### PR TITLE
Add from original Arduino.h

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -145,6 +145,12 @@ typedef unsigned int word;
 #define _min(a,b) ((a)<(b)?(a):(b))
 #define _max(a,b) ((a)>(b)?(a):(b))
 
+// WMath prototypes
+long random(long);
+long random(long, long);
+void randomSeed(unsigned long);
+long map(long, long, long, long, long);
+
 #include "pins_arduino.h"
 
 #endif /* _ESP32_CORE_ARDUINO_H_ */


### PR DESCRIPTION
The defines are needed by library [Adafruit_SSD1306](https://github.com/adafruit/Adafruit_SSD1306/blob/master/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino)