### PR TITLE
Actually disable ssl when on windows (Cygwin)

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -71,13 +71,13 @@ def get_tool(tool):
     local_path = dist_dir + archive_name
     url = tool['url']
     #real_hash = tool['checksum'].split(':')[1]
-    if 'CYGWIN_NT' in sys_name:
+    if 'CYGWIN_NT' not in sys_name:
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
     if not os.path.isfile(local_path):
         print('Downloading ' + archive_name);
-        if 'CYGWIN_NT' in sys_name:
+        if 'CYGWIN_NT' not in sys_name:
             urlretrieve(url, local_path, report_progress,context=ctx)
         else:
             urlretrieve(url, local_path, report_progress)


### PR DESCRIPTION
https://github.com/espressif/arduino-esp32/commit/4865ed0d1382f67d7ed482edc20b81ce6835c0bb says it disables on windows but does the opposite. python in cygwin says it can't find "ssl".