### PR TITLE
Error Handling for Window10 without CygWin

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -80,7 +80,15 @@ def get_tool(tool):
         if 'CYGWIN_NT' in sys_name:
             urlretrieve(url, local_path, report_progress,context=ctx)
         else:
-            urlretrieve(url, local_path, report_progress)
+            try:
+                urlretrieve(url, local_path, report_progress)
+            except Exception,e:
+                print()
+                print("!!! TLS Failed !!! Download the following file manually and put it in the 'dist' folder:")
+                print(url)
+                print("... then run this script again.")
+                print()
+                raise Exception('Aborting')
         sys.stdout.write("\rDone\n")
         sys.stdout.flush()
     else:


### PR DESCRIPTION
Added an Exception handling to the offending urlretrieve() call for the issue https://github.com/espressif/arduino-esp32/issues/108

It's not really a fix but the failure message is much more elegant than the initial stack trace as it hints at the solution to the setup problem rather than confusing the user into Windows problems.