### PR TITLE
SDK headers: Use new esp-idf signal name VSPICLK_OUT_IDX

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -27,7 +27,7 @@
 #include "soc/gpio_sig_map.h"
 #include "soc/dport_reg.h"
 
-#define SPI_CLK_IDX(p)  ((p==0)?SPICLK_OUT_IDX:((p==1)?SPICLK_OUT_IDX:((p==2)?HSPICLK_OUT_IDX:((p==3)?VSPICLK_OUT_MUX_IDX:0))))
+#define SPI_CLK_IDX(p)  ((p==0)?SPICLK_OUT_IDX:((p==1)?SPICLK_OUT_IDX:((p==2)?HSPICLK_OUT_IDX:((p==3)?VSPICLK_OUT_IDX:0))))
 #define SPI_MISO_IDX(p) ((p==0)?SPIQ_OUT_IDX:((p==1)?SPIQ_OUT_IDX:((p==2)?HSPIQ_OUT_IDX:((p==3)?VSPIQ_OUT_IDX:0))))
 #define SPI_MOSI_IDX(p) ((p==0)?SPID_IN_IDX:((p==1)?SPID_IN_IDX:((p==2)?HSPID_IN_IDX:((p==3)?VSPID_IN_IDX:0))))
 

--- a/tools/sdk/include/esp32/soc/gpio_sig_map.h
+++ b/tools/sdk/include/esp32/soc/gpio_sig_map.h
@@ -135,7 +135,7 @@
 #define HSPICS2_IN_IDX			62
 #define HSPICS2_OUT_IDX			62
 #define VSPICLK_IN_IDX			63
-#define VSPICLK_OUT_MUX_IDX			63
+#define VSPICLK_OUT_IDX			63
 #define VSPIQ_IN_IDX			64
 #define VSPIQ_OUT_IDX			64
 #define VSPID_IN_IDX			65


### PR DESCRIPTION
Hi @me-no-dev,

esp-idf commit esp-idf/23455de4 renamed VSPICLK_OUT_MUX_IDX to VSPICLK_OUT_IDX. This PR updates the name to avoid compilation errors when using arduino as an esp-idf component.

FWIW I think this should be safe to change even without rebuilding the binary libraries, as there's no object file difference. But it will break anyone compiling arduino as a submodule in older esp-idf. 

Angus