### PR TITLE
Add hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,8 @@ Using make instead of the Arduino IDE makes it easier to do automated and produc
 ## ESP32Dev Board PINMAP
 
 ![Pin Functions](doc/esp32_pinmap.png)
+
+## Hint
+
+To programm ESP32 via serial you must keep GPIO0 LOW during the hole programming process
+

--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ Using make instead of the Arduino IDE makes it easier to do automated and produc
 
 ## Hint
 
-To programm ESP32 via serial you must keep GPIO0 LOW during the hole programming process
+To program ESP32 via serial you must keep GPIO0 LOW during the hole programming process
 

--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ Using make instead of the Arduino IDE makes it easier to do automated and produc
 
 ## Hint
 
-Sometimes to program ESP32 via serial you must keep GPIO0 LOW during the hole programming process
+Sometimes to program ESP32 via serial you must keep GPIO0 LOW during the programming process
 

--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ Using make instead of the Arduino IDE makes it easier to do automated and produc
 
 ## Hint
 
-To program ESP32 via serial you must keep GPIO0 LOW during the hole programming process
+Sometimes to program ESP32 via serial you must keep GPIO0 LOW during the hole programming process
 


### PR DESCRIPTION
I had a problem when I first try to program ESP32 via serial. You helped me quickly.
I think others will have this problem too, because on ESP8266 you must keep GPIO0 LOW only on boot.
I add this hint at the end of readme.md file.