### PR TITLE
Added boards constants for LED_BUILTIN and KEY_BUILTIN

### DIFF
--- a/variants/esp320/pins_arduino.h
+++ b/variants/esp320/pins_arduino.h
@@ -9,6 +9,12 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+static const uint8_t LED_BUILTIN = 5;
+static const uint8_t BUILTIN_LED = 5;
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
 static const uint8_t SDA = 2;
 static const uint8_t SCL = 14;
 

--- a/variants/esp320/pins_arduino.h
+++ b/variants/esp320/pins_arduino.h
@@ -10,7 +10,7 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 5;
-static const uint8_t BUILTIN_LED = 5;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/esp32thing/pins_arduino.h
+++ b/variants/esp32thing/pins_arduino.h
@@ -10,7 +10,7 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 5;
-static const uint8_t BUILTIN_LED = 5;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/esp32thing/pins_arduino.h
+++ b/variants/esp32thing/pins_arduino.h
@@ -9,6 +9,11 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+static const uint8_t LED_BUILTIN = 5;
+static const uint8_t BUILTIN_LED = 5;
+
+static const uint8_t KEY_BUILTIN = 0;
+
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/espea32/pins_arduino.h
+++ b/variants/espea32/pins_arduino.h
@@ -9,7 +9,10 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
-#define LED_BUILTIN             5
+static const uint8_t LED_BUILTIN = 5;
+static const uint8_t BUILTIN_LED = 5;
+
+static const uint8_t KEY_BUILTIN = 0;
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/espea32/pins_arduino.h
+++ b/variants/espea32/pins_arduino.h
@@ -10,7 +10,7 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 5;
-static const uint8_t BUILTIN_LED = 5;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/hornbill32dev/pins_arduino.h
+++ b/variants/hornbill32dev/pins_arduino.h
@@ -10,7 +10,7 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 13;
-static const uint8_t BUILTIN_LED = 13;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/hornbill32dev/pins_arduino.h
+++ b/variants/hornbill32dev/pins_arduino.h
@@ -9,7 +9,12 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
-static const uint8_t TX = 1;  
+static const uint8_t LED_BUILTIN = 13;
+static const uint8_t BUILTIN_LED = 13;
+
+static const uint8_t KEY_BUILTIN = 0;
+
+static const uint8_t TX = 1;
 static const uint8_t RX = 3;  
 
 static const uint8_t SDA = 21;  

--- a/variants/lolin32/pins_arduino.h
+++ b/variants/lolin32/pins_arduino.h
@@ -9,8 +9,10 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
-#define LED_BUILTIN 2
-#define KEY_BUILTIN 0
+static const uint8_t LED_BUILTIN = 2;
+static const uint8_t BUILTIN_LED = 2;
+
+static const uint8_t KEY_BUILTIN = 0;
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/lolin32/pins_arduino.h
+++ b/variants/lolin32/pins_arduino.h
@@ -10,7 +10,7 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 2;
-static const uint8_t BUILTIN_LED = 2;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/nano32/pins_arduino.h
+++ b/variants/nano32/pins_arduino.h
@@ -10,7 +10,7 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 16;
-static const uint8_t BUILTIN_LED = 16;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t BUILTIN_KEY = 0;
 

--- a/variants/nano32/pins_arduino.h
+++ b/variants/nano32/pins_arduino.h
@@ -9,7 +9,10 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
-#define LED_BUILTIN 16
+static const uint8_t LED_BUILTIN = 16;
+static const uint8_t BUILTIN_LED = 16;
+
+static const uint8_t BUILTIN_KEY = 0;
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/node32s/pins_arduino.h
+++ b/variants/node32s/pins_arduino.h
@@ -9,6 +9,11 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+static const uint8_t LED_BUILTIN = 2;
+static const uint8_t BUILTIN_LED = 2;
+
+static const uint8_t KEY_BUILTIN = 0;
+
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/node32s/pins_arduino.h
+++ b/variants/node32s/pins_arduino.h
@@ -10,7 +10,7 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 2;
-static const uint8_t BUILTIN_LED = 2;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t KEY_BUILTIN = 0;
 


### PR DESCRIPTION
**Sources:**
* esp320: http://wiki.sweetpeas.se/index.php?title=ESP320#Developing_using_the_Arduino_IDE
* esp32thing: https://cdn.sparkfun.com/assets/learn_tutorials/5/0/7/esp32-thing-schematic.pdf
* espea32: https://github.com/AprilBrother/ESPea32/blob/master/hardware/ESPea32-schematic.pdf
* hornbill32dev: https://github.com/ExploreEmbedded/Hornbill-ESP32-DEV/blob/master/Design%20Files/Schematic/Hornbill%20Devboard.pdf
* lolin32: values from existing header
* nano32: http://iot-bits.com/closer-look-esp32-nano32/
* node32s: https://github.com/lamloei/node32s-book/blob/master/ch01/node32s-schematic.pdf

_Note: Some board producers have not published schematics yet, so it was little digging work._