### PR TITLE
Fix build error on MacOSX

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -3,7 +3,7 @@ version=0.0.1
 
 runtime.tools.xtensa-esp32-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32-elf
 
-tools.esptool.cmd="{runtime.platform.path}/tools/esptool"
+tools.esptool.cmd="{runtime.platform.path}/tools/esptool.py"
 tools.esptool.cmd.windows="{runtime.platform.path}/tools/esptool.exe"
 
 tools.gen_esp32part.cmd=python "{runtime.platform.path}/tools/gen_esp32part.py"


### PR DESCRIPTION
I fixed build error on MacOSX.
Please consider merge.

build-log comparison
------

* befor 

```
"/path/to/Arduino/hardware/espressif/esp32/tools/esptool" --chip esp32 elf2image --flash_mode "dio" --flash_freq "80m" --flash_size "4MB" -o "/var/folders/XXXXXXXX/esp32_hello_world3.ino.bin" "/var/folders/XXXXXXXX/esp32_hello_world3.ino.elf"
```

* after

```
"/path/to/Arduino/hardware/espressif/esp32/tools/esptool.py" --chip esp32 elf2image --flash_mode "dio" --flash_freq "80m" --flash_size "4MB" -o "/var/folders/XXXXXXXX/esp32_hello_world3.ino.bin" "/var/folders/XXXXXXXX/esp32_hello_world3.ino.elf"
```