### PR TITLE
Rework WiFiClient

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -29,11 +29,25 @@
 #undef write
 #undef read
 
+class WiFiClientSocketHandle {
+private:
+    int sockfd;
 
-WiFiClientSocketHandle::~WiFiClientSocketHandle()
-{
-    close(sockfd);
-}
+public:
+    WiFiClientSocketHandle(int fd):sockfd(fd)
+    {
+    }
+
+    ~WiFiClientSocketHandle()
+    {
+        close(sockfd);
+    }
+
+    int fd()
+    {
+        return sockfd;
+    }
+};
 
 WiFiClient::WiFiClient():_connected(false),next(NULL)
 {
@@ -276,3 +290,13 @@ bool WiFiClient::operator==(const WiFiClient& rhs)
 {
     return clientSocketHandle == rhs.clientSocketHandle && remotePort() == rhs.remotePort() && remoteIP() == rhs.remoteIP();
 }
+
+int WiFiClient::fd() const
+{
+    if (clientSocketHandle == NULL) {
+        return -1;
+    } else {
+        return clientSocketHandle->fd();
+    }
+}
+

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -25,22 +25,7 @@
 #include "Client.h"
 #include <memory>
 
-class WiFiClientSocketHandle {
-private:
-    int sockfd;
-
-public:
-    WiFiClientSocketHandle(int fd):sockfd(fd)
-    {
-    }
-
-    ~WiFiClientSocketHandle();
-
-    int fd()
-    {
-        return sockfd;
-    }
-};
+class WiFiClientSocketHandle;
 
 class WiFiClient : public Client
 {
@@ -87,14 +72,7 @@ public:
         return !this->operator==(rhs);
     };
 
-    int fd() const
-    {
-        if (clientSocketHandle == NULL) {
-            return -1;
-        } else {
-            return clientSocketHandle->fd();
-        }
-    }
+    int fd() const;
 
     int setSocketOption(int option, char* value, size_t len);
     int setOption(int option, int *value);

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -20,30 +20,21 @@
 #ifndef _WIFICLIENT_H_
 #define _WIFICLIENT_H_
 
+
 #include "Arduino.h"
 #include "Client.h"
+#include <memory>
 
 class WiFiClientSocketHandle {
 private:
     int sockfd;
-    int refCount;
 
 public:
-    WiFiClientSocketHandle(int fd):sockfd(fd), refCount(1)
+    WiFiClientSocketHandle(int fd):sockfd(fd)
     {
     }
-    ;
+
     ~WiFiClientSocketHandle();
-
-    int ref()
-    {
-        return ++refCount;
-    }
-
-    int unref()
-    {
-        return --refCount;
-    }
 
     int fd()
     {
@@ -54,14 +45,13 @@ public:
 class WiFiClient : public Client
 {
 protected:
-    WiFiClientSocketHandle *clientSocketHandle;
+    std::shared_ptr<WiFiClientSocketHandle> clientSocketHandle;
     bool _connected;
 
 public:
     WiFiClient *next;
     WiFiClient();
     WiFiClient(int fd);
-    WiFiClient(const WiFiClient &other);
     ~WiFiClient();
     int connect(IPAddress ip, uint16_t port);
     int connect(const char *host, uint16_t port);


### PR DESCRIPTION
Rework WiFiClient to correct error where making a copy of a WiFiClient object resulted in the socket being closed prematurely.

Added loop and select to write to handle/prevent EAGAIN errors.