### PR TITLE
Replace some WiFiMulti functions without equal comportment of ESP8266

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -47,9 +47,9 @@ uint8_t WiFiMulti::run(void)
 
     int8_t scanResult;
     uint8_t status = WiFi.status();
-    if(status == WL_DISCONNECTED || status == WL_NO_SSID_AVAIL || status == WL_IDLE_STATUS || status == WL_CONNECT_FAILED) {
+    if(status != WL_CONNECTED || status == WL_NO_SSID_AVAIL || status == WL_IDLE_STATUS || status == WL_CONNECT_FAILED) {
 
-        scanResult = WiFi.scanComplete();
+        scanResult = WiFi.scanNetworks();
         if(scanResult == WIFI_SCAN_RUNNING) {
             // scan is running
             return WL_NO_SSID_AVAIL;


### PR DESCRIPTION
Actually WiFiMulti is not working due some functions haven't equal comportment of ESP8266
Replace status == WL_DISCONNECTED => status != WL_CONNECTED
Replace scanComplete() => scanNetworks()

Maybe is more interesting, for keep the maximum compatibility, investigate why WL_DISCONNECTED and scanComplete() doesn't works in this case instead of just replace by this pull request.