### PR TITLE
SPI_MODE2 and SPI_MODE3 configurations inverted

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -332,11 +332,11 @@ void spiSetDataMode(spi_t * spi, uint8_t dataMode)
         break;
     case SPI_MODE2:
         spi->dev->pin.ck_idle_edge = 1;
-        spi->dev->user.ck_out_edge = 0;
+        spi->dev->user.ck_out_edge = 1;
         break;
     case SPI_MODE3:
         spi->dev->pin.ck_idle_edge = 1;
-        spi->dev->user.ck_out_edge = 1;
+        spi->dev->user.ck_out_edge = 0;
         break;
     case SPI_MODE0:
     default:


### PR DESCRIPTION
It appears that the configurations for `ck_out_edge` were inverted for `SPI_MODE2` and `SPI_MODE3`. You can check the technical reference manual on page 76, table 23 "Clock Polarity and Phase, and Corresponding SPI Register Values for SPI Master".

![screen shot 2017-05-01 at 15 59 44](https://cloud.githubusercontent.com/assets/222161/25593126/5b70a052-2e89-11e7-8198-8b57e399b012.png)

I've check with my oscilloscope that the current configuration is wrong and this fix corrects the issue.

Here are some examples writing `0x8F` with the `SCK` line in red and the `MOSI` line in yellow

`SPI_MODE2` before the change:
![spi_mode2_before](https://cloud.githubusercontent.com/assets/222161/25593465/aa32be90-2e8a-11e7-811d-2a16c689a2f2.png)

`SPI_MODE2` after the change:
![spi_mode2_after](https://cloud.githubusercontent.com/assets/222161/25593469/b023aa12-2e8a-11e7-97de-a1bc6879bf36.png)

`SPI_MODE3` before the change:
![spi_mode3_before](https://cloud.githubusercontent.com/assets/222161/25593477/b919211a-2e8a-11e7-818e-5f90001b5e9d.png)

`SPI_MODE3` after the change:
![spi_mode3_after](https://cloud.githubusercontent.com/assets/222161/25593491/c705f258-2e8a-11e7-9f05-55c59a720212.png)