### PR TITLE
Add setNoDelay and getNoDelay to WiFiServer class

### DIFF
--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -45,8 +45,11 @@ WiFiClient WiFiServer::available(){
   int client_sock = accept(sockfd, (struct sockaddr *)&_client, (socklen_t*)&cs);
   if(client_sock >= 0){
     int val = 1;
-    if(setsockopt(client_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&val, sizeof(int)) == ESP_OK)
-      return WiFiClient(client_sock);
+    if(setsockopt(client_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&val, sizeof(int)) == ESP_OK) {
+      val = _noDelay;
+      if(setsockopt(client_sock, IPPROTO_TCP, TCP_NODELAY, (char*)&val, sizeof(int)) == ESP_OK)
+        return WiFiClient(client_sock);
+    }
   }
   return WiFiClient();
 }
@@ -67,6 +70,14 @@ void WiFiServer::begin(){
     return;
   fcntl(sockfd, F_SETFL, O_NONBLOCK);
   _listening = true;
+}
+
+void WiFiServer::setNoDelay(bool nodelay) {
+    _noDelay = nodelay;
+}
+
+bool WiFiServer::getNoDelay() {
+    return _noDelay;
 }
 
 void WiFiServer::end(){

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -29,6 +29,7 @@ class WiFiServer : public Server {
     uint16_t _port;
     uint8_t _max_clients;
     bool _listening;
+    bool _noDelay = false;
 
   public:
     void listenOnLocalhost(){}
@@ -38,6 +39,8 @@ class WiFiServer : public Server {
     WiFiClient available();
     WiFiClient accept(){return available();}
     void begin();
+    void setNoDelay(bool nodelay);
+    bool getNoDelay();
     size_t write(const uint8_t *data, size_t len);
     size_t write(uint8_t data){
       return write(&data, 1);


### PR DESCRIPTION
setNoDelay/getNoDelay are implemented in the ESP8266 version of WiFiServer so patch adds them to ESP32. See #379 for discussion.