### PR TITLE
Add LED_BUILTIN pin

### DIFF
--- a/variants/esp32/pins_arduino.h
+++ b/variants/esp32/pins_arduino.h
@@ -11,6 +11,9 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+static const uint8_t LED_BUILTIN = 1;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 


### PR DESCRIPTION
On my dev module, the built in led was on pin 1, and this also appears to be the case for the one from adafruit as well.