### PR TITLE
Additions to WiFiClient and WiFiServer

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -224,6 +224,11 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
     return res;
 }
 
+size_t WiFiClient::write_P(PGM_P buf, size_t size)
+{
+    return write(buf, size);
+}
+
 int WiFiClient::read(uint8_t *buf, size_t size)
 {
     if(!available()) {
@@ -344,6 +349,34 @@ IPAddress WiFiClient::remoteIP() const
 uint16_t WiFiClient::remotePort() const
 {
     return remotePort(fd());
+}
+
+IPAddress WiFiClient::localIP(int fd) const
+{
+    struct sockaddr_storage addr;
+    socklen_t len = sizeof addr;
+    getsockname(fd, (struct sockaddr*)&addr, &len);
+    struct sockaddr_in *s = (struct sockaddr_in *)&addr;
+    return IPAddress((uint32_t)(s->sin_addr.s_addr));
+}
+
+uint16_t WiFiClient::localPort(int fd) const
+{
+    struct sockaddr_storage addr;
+    socklen_t len = sizeof addr;
+    getsockname(fd, (struct sockaddr*)&addr, &len);
+    struct sockaddr_in *s = (struct sockaddr_in *)&addr;
+    return ntohs(s->sin_port);
+}
+
+IPAddress WiFiClient::localIP() const
+{
+    return localIP(fd());
+}
+
+uint16_t WiFiClient::localPort() const
+{
+    return localPort(fd());
 }
 
 bool WiFiClient::operator==(const WiFiClient& rhs)

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -44,6 +44,7 @@ public:
     int connect(const char *host, uint16_t port);
     size_t write(uint8_t data);
     size_t write(const uint8_t *buf, size_t size);
+    size_t write_P(PGM_P buf, size_t size);
     int available();
     int read();
     int read(uint8_t *buf, size_t size);
@@ -84,6 +85,10 @@ public:
     IPAddress remoteIP(int fd) const;
     uint16_t remotePort() const;
     uint16_t remotePort(int fd) const;
+    IPAddress localIP() const;
+    IPAddress localIP(int fd) const;
+    uint16_t localPort() const;
+    uint16_t localPort(int fd) const;
 
     //friend class WiFiServer;
     using Print::write;

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -21,6 +21,7 @@
 #include <lwip/netdb.h>
 
 #undef write
+#undef close
 
 int WiFiServer::setTimeout(uint32_t seconds){
   struct timeval tv;
@@ -103,8 +104,16 @@ bool WiFiServer::hasClient() {
 }
 
 void WiFiServer::end(){
-  close(sockfd);
+  lwip_close_r(sockfd);
   sockfd = -1;
   _listening = false;
+}
+
+void WiFiServer::close(){
+  end();
+}
+
+void WiFiServer::stop(){
+  end();
 }
 

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -50,6 +50,8 @@ class WiFiServer : public Server {
     using Print::write;
 
     void end();
+    void close();
+    void stop();
     operator bool(){return _listening;}
     int setTimeout(uint32_t seconds);
     void stopAll();


### PR DESCRIPTION
Required for WebServer and DNSServer libraries. May be use by other libraries and apps.