### PR TITLE
Add WiFiClient localIP and localPort

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -346,6 +346,34 @@ uint16_t WiFiClient::remotePort() const
     return remotePort(fd());
 }
 
+IPAddress WiFiClient::localIP(int fd) const
+{
+    struct sockaddr_storage addr;
+    socklen_t len = sizeof addr;
+    getsockname(fd, (struct sockaddr*)&addr, &len);
+    struct sockaddr_in *s = (struct sockaddr_in *)&addr;
+    return IPAddress((uint32_t)(s->sin_addr.s_addr));
+}
+
+uint16_t WiFiClient::localPort(int fd) const
+{
+    struct sockaddr_storage addr;
+    socklen_t len = sizeof addr;
+    getsockname(fd, (struct sockaddr*)&addr, &len);
+    struct sockaddr_in *s = (struct sockaddr_in *)&addr;
+    return ntohs(s->sin_port);
+}
+
+IPAddress WiFiClient::localIP() const
+{
+    return localIP(fd());
+}
+
+uint16_t WiFiClient::localPort() const
+{
+    return localPort(fd());
+}
+
 bool WiFiClient::operator==(const WiFiClient& rhs)
 {
     return clientSocketHandle == rhs.clientSocketHandle && remotePort() == rhs.remotePort() && remoteIP() == rhs.remoteIP();

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -85,6 +85,11 @@ public:
     uint16_t remotePort() const;
     uint16_t remotePort(int fd) const;
 
+    IPAddress localIP() const;
+    IPAddress localIP(int fd) const;
+    uint16_t localPort() const;
+    uint16_t localPort(int fd) const;
+
     //friend class WiFiServer;
     using Print::write;
 };


### PR DESCRIPTION
Implement methods from ESP8266WiFiClient but use sockets API. The methods are used in the DNSServer library CaptivePortAdvanced example as well as in the WiFiManager library.