### PR TITLE
Two Stop Bit Workaround

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -195,6 +195,13 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
     uartSetBaudRate(uart, baudrate);
     UART_MUTEX_LOCK();
     uart->dev->conf0.val = config;
+    #define TWO_STOP_BITS_CONF 0x3
+	#define ONE_STOP_BITS_CONF 0x1
+	
+	if ( uart->dev->conf0.stop_bit_num == TWO_STOP_BITS_CONF) {
+		uart->dev->conf0.stop_bit_num = ONE_STOP_BITS_CONF;
+		uart->dev->rs485_conf.dl1_en = 1;
+	}
     UART_MUTEX_UNLOCK();
 
     if(rxPin != -1) {

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -196,12 +196,12 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
     UART_MUTEX_LOCK();
     uart->dev->conf0.val = config;
     #define TWO_STOP_BITS_CONF 0x3
-	#define ONE_STOP_BITS_CONF 0x1
+    #define ONE_STOP_BITS_CONF 0x1
 	
-	if ( uart->dev->conf0.stop_bit_num == TWO_STOP_BITS_CONF) {
-		uart->dev->conf0.stop_bit_num = ONE_STOP_BITS_CONF;
-		uart->dev->rs485_conf.dl1_en = 1;
-	}
+    if ( uart->dev->conf0.stop_bit_num == TWO_STOP_BITS_CONF) {
+        uart->dev->conf0.stop_bit_num = ONE_STOP_BITS_CONF;
+        uart->dev->rs485_conf.dl1_en = 1;
+    }
     UART_MUTEX_UNLOCK();
 
     if(rxPin != -1) {


### PR DESCRIPTION
This incorporates a fix from the latest IDF for the two stop bit issue.
See:
https://github.com/espressif/esp-idf/blob/master/components/driver/uart.c  lines 118-127