### PR TITLE
Change disconnect function

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -255,6 +255,13 @@ bool WiFiSTAClass::reconnect()
 bool WiFiSTAClass::disconnect(bool wifioff)
 {
     bool ret;
+    wifi_config_t conf;
+    *conf.sta.ssid = 0;
+    *conf.sta.password = 0;
+
+    WiFi.getMode();
+    esp_wifi_start();
+    esp_wifi_set_config(WIFI_IF_STA, &conf);
     ret = esp_wifi_disconnect() == ESP_OK;
 
     if(wifioff) {

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -255,14 +255,7 @@ bool WiFiSTAClass::reconnect()
 bool WiFiSTAClass::disconnect(bool wifioff)
 {
     bool ret;
-    wifi_config_t conf;
-    *conf.sta.ssid = 0;
-    *conf.sta.password = 0;
-
-    WiFi.getMode();
-    esp_wifi_start();
-    esp_wifi_set_config(WIFI_IF_STA, &conf);
-    ret = esp_wifi_set_config(WIFI_IF_STA, &conf) == ESP_OK;
+    ret = esp_wifi_disconnect() == ESP_OK;
 
     if(wifioff) {
         WiFi.enableSTA(false);


### PR DESCRIPTION
Current implementation does not disconnect the WiFi. Use of `esp_wifi_disconnect()` does.