### PR TITLE
Disable SimpleBLE when BT not enabled

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -1,4 +1,25 @@
-ARDUINO_CORE_LIBS := $(patsubst $(COMPONENT_PATH)/%,%,$(wildcard $(COMPONENT_PATH)/libraries/*/src))
+ARDUINO_CORE_LIBS := libraries/ArduinoOTA/src  \
+    libraries/ESP32/src \
+    libraries/ESPmDNS/src \
+    libraries/FS/src  \
+    libraries/HTTPClient/src \
+    libraries/Preferences/src \
+    libraries/SD/src \
+    libraries/SD_MMC/src \
+    libraries/SPI/src \
+    libraries/Update/src \
+    libraries/Wire/src
+
+ifdef CONFIG_BT_ENABLED
+ifdef CONFIG_BLUEDROID_ENABLED
+ARDUINO_CORE_LIBS += libraries/SimpleBLE/src
+endif
+endif
+
+ifdef CONFIG_WIFI_ENABLED
+ARDUINO_CORE_LIBS += libraries/WiFi/src \
+		     libraries/WiFiClientSecure/src
+endif
 
 COMPONENT_ADD_INCLUDEDIRS := cores/esp32 variants/esp32 $(ARDUINO_CORE_LIBS)
 COMPONENT_PRIV_INCLUDEDIRS := cores/esp32/libb64

--- a/component.mk
+++ b/component.mk
@@ -1,26 +1,18 @@
-ARDUINO_CORE_LIBS := libraries/ArduinoOTA/src  \
-    libraries/ESP32/src \
-    libraries/ESPmDNS/src \
-    libraries/FS/src  \
-    libraries/HTTPClient/src \
-    libraries/Preferences/src \
-    libraries/SD/src \
-    libraries/SD_MMC/src \
-    libraries/SPI/src \
-    libraries/Update/src \
-    libraries/Wire/src
+ARDUINO_CORE_LIBS := $(patsubst $(COMPONENT_PATH)/%,%,$(wildcard $(COMPONENT_PATH)/libraries/*/src))
+FILTER_LIBS :=
 
-ifdef CONFIG_BT_ENABLED
-ifdef CONFIG_BLUEDROID_ENABLED
-ARDUINO_CORE_LIBS += libraries/SimpleBLE/src
+ifndef CONFIG_BT_ENABLED
+ifndef CONFIG_BLUEDROID_ENABLED
+FILTER_LIBS += libraries/SimpleBLE/src
 endif
 endif
 
-ifdef CONFIG_WIFI_ENABLED
-ARDUINO_CORE_LIBS += libraries/WiFi/src \
-		     libraries/WiFiClientSecure/src
+ifndef CONFIG_WIFI_ENABLED
+FILTER_LIBS += libraries/WiFi/src  \
+	       libraries/WiFiClientSecure/src
 endif
 
+ARDUINO_CORE_LIBS := $(filter-out $(FILTER_LIBS),$(ARDUINO_CORE_LIBS))
 COMPONENT_ADD_INCLUDEDIRS := cores/esp32 variants/esp32 $(ARDUINO_CORE_LIBS)
 COMPONENT_PRIV_INCLUDEDIRS := cores/esp32/libb64
 COMPONENT_SRCDIRS := cores/esp32/libb64 cores/esp32 variants/esp32 $(ARDUINO_CORE_LIBS)


### PR DESCRIPTION
SimpleBLE would otherwise require a bt header file to be reachable in the include paths.
This forces people to enable bt even when not needed. Which is a pity because that also disables a memory region for BT exclusive use.

Signed-off-by: Andreas Pokorny <andreas.pokorny@siemens.com>