### PR TITLE
Spi pattern fix

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -1,9 +1,9 @@
-/*
+/* 
  SPI.cpp - SPI library for esp8266
 
  Copyright (c) 2015 Hristo Gochkov. All rights reserved.
  This file is part of the esp8266 core for Arduino environment.
-
+ 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -1,9 +1,9 @@
-/* 
+/*
  SPI.cpp - SPI library for esp8266
 
  Copyright (c) 2015 Hristo Gochkov. All rights reserved.
  This file is part of the esp8266 core for Arduino environment.
- 
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
@@ -242,11 +242,12 @@ void SPIClass::writePattern(uint8_t * data, uint8_t size, uint32_t repeat)
 
     uint32_t byte = (size * repeat);
     uint8_t r = (64 / size);
+    const uint8_t max_bytes_FIFO = r * size;    // Max number of whole patterns (in bytes) that can fit into the hardware FIFO
 
     while(byte) {
-        if(byte > 64) {
+        if(byte > max_bytes_FIFO) {
             writePattern_(data, size, r);
-            byte -= 64;
+            byte -= max_bytes_FIFO;
         } else {
             writePattern_(data, size, (byte / size));
             byte = 0;


### PR DESCRIPTION
Fixes problem where not enough data is sent when sending a repeating pattern via SPI that doesn't evenly divide into the hardware FIFO size (64 bytes).

For example, I was sending a 3-byte pattern (RGB data) for a 320 x 480 display, which fits 21 times into the hardware FIFO (3 * 21 = 63 bytes), and by the end of the routine 1/64th of the data (and therefore the image) was missing.  This happened because for every 63 bytes sent, this routine decremented the byte count by 64.