### PR TITLE
uartEnd: Unlock mutex before detaching rx and tx

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -197,7 +197,7 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
     uart->dev->conf0.val = config;
     #define TWO_STOP_BITS_CONF 0x3
     #define ONE_STOP_BITS_CONF 0x1
-	
+
     if ( uart->dev->conf0.stop_bit_num == TWO_STOP_BITS_CONF) {
         uart->dev->conf0.stop_bit_num = ONE_STOP_BITS_CONF;
         uart->dev->rs485_conf.dl1_en = 1;
@@ -227,12 +227,12 @@ void uartEnd(uart_t* uart)
         while(xQueueReceive(uart->queue, &c, 0));
         vQueueDelete(uart->queue);
     }
+    UART_MUTEX_UNLOCK();
 
     uartDetachRx(uart);
     uartDetachTx(uart);
 
     uart->dev->conf0.val = 0;
-    UART_MUTEX_UNLOCK();
 }
 
 uint32_t uartAvailable(uart_t* uart)
@@ -419,4 +419,3 @@ int log_printf(const char *format, ...)
     }
     return len;
 }
-

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -227,12 +227,13 @@ void uartEnd(uart_t* uart)
         while(xQueueReceive(uart->queue, &c, 0));
         vQueueDelete(uart->queue);
     }
+
+    uart->dev->conf0.val = 0;
+
     UART_MUTEX_UNLOCK();
 
     uartDetachRx(uart);
     uartDetachTx(uart);
-
-    uart->dev->conf0.val = 0;
 }
 
 uint32_t uartAvailable(uart_t* uart)


### PR DESCRIPTION
This should solve the device freezing issue when Serial.end() is called