### PR TITLE
Change to retry setting up I2C command rather than waiting indefinitely

### DIFF
--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -445,7 +445,8 @@ void i2cInitFix(i2c_t * i2c){
     i2c->dev->fifo_data.data = 0;
     i2cSetCmd(i2c, 1, I2C_CMD_WRITE, 1, false, false, false);
     i2cSetCmd(i2c, 2, I2C_CMD_STOP, 0, false, false, false);
-    i2c->dev->ctr.trans_start = 1;
-    while(!i2c->dev->command[2].done);
+    do {
+        i2c->dev->ctr.trans_start = 1;
+    } while(!i2c->dev->command[2].done);
     I2C_MUTEX_UNLOCK();
 }


### PR DESCRIPTION
With a large I2C bus, I encountered a situation where the following line in esp32-hal-i2c.c, method i2cInitFix hung indefinitely.

`
    while(!i2c->dev->command[2].done);
`

Adding the included changes resolved the problem in my situation, by allowing a retry.