### PR TITLE
SNI support

### DIFF
--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -97,7 +97,12 @@ int WiFiClientSecure::connect(const char *host, uint16_t port)
 
 int WiFiClientSecure::connect(IPAddress ip, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
 {
-    int ret = start_ssl_client(sslclient, ip, port, _CA_cert, _cert, _private_key);
+    return connect(ip.toString().c_str(), port, _CA_cert, _cert, _private_key);
+}
+
+int WiFiClientSecure::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
+{
+    int ret = start_ssl_client(sslclient, host, port, _CA_cert, _cert, _private_key);
     if (ret < 0) {
         log_e("lwip_connect_r: %d", errno);
         stop();
@@ -106,18 +111,6 @@ int WiFiClientSecure::connect(IPAddress ip, uint16_t port, const char *_CA_cert,
     _connected = true;
     return 1;
 }
-
-int WiFiClientSecure::connect(const char *host, uint16_t port, const char *_CA_cert, const char *_cert, const char *_private_key)
-{
-    struct hostent *server;
-    server = gethostbyname(host);
-    if (server == NULL) {
-        return 0;
-    }
-    IPAddress srv((const uint8_t *)(server->h_addr));
-    return connect(srv, port, _CA_cert, _cert, _private_key);
-}
-
 
 size_t WiFiClientSecure::write(uint8_t data)
 {

--- a/libraries/WiFiClientSecure/src/ssl_client.h
+++ b/libraries/WiFiClientSecure/src/ssl_client.h
@@ -27,7 +27,7 @@ typedef struct sslclient_context {
 
 
 void ssl_init(sslclient_context *ssl_client);
-int start_ssl_client(sslclient_context *ssl_client, uint32_t ipAddress, uint32_t port, const char *rootCABuff, const char *cli_cert, const char *cli_key);
+int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t port, const char *rootCABuff, const char *cli_cert, const char *cli_key);
 void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key);
 int data_to_read(sslclient_context *ssl_client);
 int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, uint16_t len);


### PR DESCRIPTION
Server Name Indication (SNI) support for WiFiClientSecure

Fix https://github.com/espressif/arduino-esp32/issues/571 and https://github.com/espressif/arduino-esp32/issues/550