### PR TITLE
Missing xcrun fix.

### DIFF
--- a/docs/arduino-ide/mac.md
+++ b/docs/arduino-ide/mac.md
@@ -11,4 +11,11 @@ Installation instructions for Mac OS
   cd esp32/tools/ && \
   python get.py
   ```
+- If you get the error below. Install the command line dev tools with xcode-select --install and try the command above again:
+  
+```xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun```
+
+```xcode-select --install```
+
 - Restart Arduino IDE
+


### PR DESCRIPTION
Had to run "xcode-select --install" before your script worked.

More info here: https://stackoverflow.com/questions/32893412/command-line-tools-not-working-os-x-el-capitan-macos-sierra