### PR TITLE
Fix support for some arduino libraries which don't put source files under a src directory

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -1,5 +1,4 @@
-ARDUINO_CORE_LIBS := $(patsubst $(COMPONENT_PATH)/%,%,$(wildcard $(COMPONENT_PATH)/libraries/*/src))
-ARDUINO_CORE_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/))))
+ARDUINO_CORE_LIBS := $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/))))
 
 COMPONENT_ADD_INCLUDEDIRS := cores/esp32 variants/esp32 $(ARDUINO_CORE_LIBS)
 COMPONENT_PRIV_INCLUDEDIRS := cores/esp32/libb64

--- a/component.mk
+++ b/component.mk
@@ -1,4 +1,5 @@
 ARDUINO_CORE_LIBS := $(patsubst $(COMPONENT_PATH)/%,%,$(wildcard $(COMPONENT_PATH)/libraries/*/src))
+ARDUINO_CORE_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/))))
 
 COMPONENT_ADD_INCLUDEDIRS := cores/esp32 variants/esp32 $(ARDUINO_CORE_LIBS)
 COMPONENT_PRIV_INCLUDEDIRS := cores/esp32/libb64


### PR DESCRIPTION
There are many libraries which don't put their source files under *src* directory.
For example, nearly all sensor libraries from Adafruit don't have a *src* directory.
In order to compile with these libraries, we should manually create a *src* directory and move all source files into it, which is really annoying.
If the library also includes source files under sub directories, it would result in linker errors.
**However, only changing a line in *component.mk* can solve all these issues.**