### PR TITLE
allow configTime() to handle timezone and dst begin/end info

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -166,7 +166,7 @@ unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 100000
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 
 extern "C" bool getLocalTime(struct tm * info, uint32_t ms = 5000);
-extern "C" void configTime(long gmtOffset_sec, int daylightOffset_sec,
+extern "C" void configTime(const char* tz,
         const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 
 // WMath prototypes

--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -15,35 +15,11 @@
 #include "esp32-hal.h"
 #include "apps/sntp/sntp.h"
 
-static void setTimeZone(long offset, int daylight)
-{
-    char cst[16] = {0};
-    char cdt[16] = "CDT";
-    char tz[32] = {0};
-
-    if(offset % 3600){
-        sprintf(cst, "CST%ld:%02u:%02u", offset / 3600, abs((offset % 3600) / 60), abs(offset % 60));
-    } else {
-        sprintf(cst, "CST%ld", offset / 3600);
-    }
-    if(daylight != 3600){
-        long tz_dst = offset - daylight;
-        if(tz_dst % 3600){
-            sprintf(cdt, "CDT%ld:%02u:%02u", tz_dst / 3600, abs((tz_dst % 3600) / 60), abs(tz_dst % 60));
-        } else {
-            sprintf(cdt, "CDT%ld", tz_dst / 3600);
-        }
-    }
-    sprintf(tz, "%s%s", cst, cdt);
-    setenv("TZ", tz, 1);
-    tzset();
-}
-
 /*
  * configTime
  * Source: https://github.com/esp8266/Arduino/blob/master/cores/esp8266/time.c
  * */
-void configTime(long gmtOffset_sec, int daylightOffset_sec, const char* server1, const char* server2, const char* server3)
+void configTime(const char *tz, const char* server1, const char* server2, const char* server3)
 {
 
     if(sntp_enabled()){
@@ -54,7 +30,8 @@ void configTime(long gmtOffset_sec, int daylightOffset_sec, const char* server1,
     sntp_setservername(1, (char*)server2);
     sntp_setservername(2, (char*)server3);
     sntp_init();
-    setTimeZone(gmtOffset_sec, daylightOffset_sec);
+    setenv("TZ", tz, 1);
+    tzset();
 }
 
 bool getLocalTime(struct tm * info, uint32_t ms)


### PR DESCRIPTION
This allows configTime() to use timezone info in the same manner as esp-idf. configTime() can now be called with a character array describing the timezone and daylight saving time begin and end.

configTime("EST5EDT4,M3.2.0/02:00:00,M11.1.0/02:00:00", "my.ntp.server", NULL, NULL);

