### PR TITLE
Add Example Code for WPS Functionality

### DIFF
--- a/libraries/WiFi/examples/WPS/README.md
+++ b/libraries/WiFi/examples/WPS/README.md
@@ -1,0 +1,104 @@
+Example Serial Logs For Various Cases
+======================================
+
+For WPS Push Button method,after the ESP32 boots up and prints that WPS has started, press the button that looks something like [this](https://www.verizon.com/supportresources/images/fqgrouter-frontview-wps-button.png) on your router. In case you dont find anything similar, check your router specs if it does really support WPS Push functionality.
+
+As for WPS Pin Mode, it will output a 8 digit Pin on the Serial Monitor that will change every 2 minutes if it hasn't connected. You need to log in to your router (generally reaching 192.168.0.1) and enter the pin shown in Serial Monitor in the WPS Settings of your router.
+
+#### WPS Push Button Failure
+
+```
+ets Jun  8 2016 00:22:57
+
+rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+configsip: 0, SPIWP:0xee
+clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
+mode:DIO, clock div:1
+load:0x3fff0010,len:4
+load:0x3fff0014,len:732
+load:0x40078000,len:0
+load:0x40078000,len:11572
+entry 0x40078a14
+
+Starting WPS
+Station Mode Started
+WPS Timedout, retrying
+WPS Timedout, retrying
+```
+
+#### WPS Push Button Successfull
+
+```
+ets Jun  8 2016 00:22:57
+
+rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+ets Jun  8 2016 00:22:57
+
+rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+configsip: 0, SPIWP:0xee
+clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
+mode:DIO, clock div:1
+load:0x3fff0010,len:4
+load:0x3fff0014,len:732
+load:0x40078000,len:0
+load:0x40078000,len:11572
+entry 0x40078a14
+
+Starting WPS
+Station Mode Started
+WPS Successfull, stopping WPS and connecting to: < Your Router SSID >
+Disconnected from station, attempting reconnection
+Connected to : < Your Router SSID >
+Got IP: 192.168.1.100
+```
+
+#### WPS PIN Failure
+
+```
+ets Jun  8 2016 00:22:57
+
+rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+ets Jun  8 2016 00:22:57
+
+rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+configsip: 0, SPIWP:0xee
+clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
+mode:DIO, clock div:1
+load:0x3fff0010,len:4
+load:0x3fff0014,len:732
+load:0x40078000,len:0
+load:0x40078000,len:11572
+entry 0x40078a14
+
+Starting WPS
+Station Mode Started
+WPS_PIN = 94842104
+WPS Timedout, retrying
+WPS_PIN = 55814171
+WPS Timedout, retrying
+WPS_PIN = 71321622
+```
+
+#### WPS PIN Successfull
+
+```
+ets Jun  8 2016 00:22:57
+
+rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+configsip: 0, SPIWP:0xee
+clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
+mode:DIO, clock div:1
+load:0x3fff0010,len:4
+load:0x3fff0014,len:732
+load:0x40078000,len:0
+load:0x40078000,len:11572
+entry 0x40078a14
+
+Starting WPS
+Station Mode Started
+WPS_PIN = 36807581
+WPS Successfull, stopping WPS and connecting to: <Your Router SSID>
+Disconnected from station, attempting reconnection
+Connected to :<Your Router SSID>
+Got IP: 192.168.1.100
+```

--- a/libraries/WiFi/examples/WPS/WPS.ino
+++ b/libraries/WiFi/examples/WPS/WPS.ino
@@ -1,0 +1,96 @@
+/*
+Example Code To Get ESP32 To Connect To A Router Using WPS
+===========================================================
+This example code provides both Push Button method and Pin
+based WPS entry to get your ESP connected to your WiFi router.
+
+Hardware Requirements
+========================
+ESP32 and a Router having atleast one WPS functionality
+
+This code is under Public Domain License.
+
+Author:
+Pranav Cherukupalli <cherukupallip@gmail.com>
+*/
+
+#include "WiFi.h"
+#include "esp_wps.h"
+
+/*
+Change the definition of the WPS mode
+from WPS_TYPE_PBC to WPS_TYPE_PIN in
+the case that you are using pin type
+WPS
+*/
+#define ESP_WPS_MODE WPS_TYPE_PBC
+
+esp_wps_config_t config = WPS_CONFIG_INIT_DEFAULT(ESP_WPS_MODE);
+
+String wpspin2string(uint8_t a[]){
+  char wps_pin[9];
+  for(int i=0;i<8;i++){
+    wps_pin[i] = a[i];
+  }
+  wps_pin[8] = '\0';
+  return (String)wps_pin;
+}
+
+void WiFiEvent(WiFiEvent_t event, system_event_info_t info){
+  switch(event){
+    case SYSTEM_EVENT_STA_START:
+    Serial.println("Station Mode Started");
+    break;
+    case SYSTEM_EVENT_STA_GOT_IP:
+    Serial.println("Connected to :" + String(WiFi.SSID()));
+    Serial.print("Got IP: ");
+    Serial.println(WiFi.localIP());
+    break;
+    case SYSTEM_EVENT_STA_DISCONNECTED:
+    Serial.println("Disconnected from station, attempting reconnection");
+    WiFi.reconnect();
+    break;
+    case SYSTEM_EVENT_STA_WPS_ER_SUCCESS:
+    Serial.println("WPS Successfull, stopping WPS and connecting to: " + String(WiFi.SSID()));
+    esp_wifi_wps_disable();
+    delay(10);
+    WiFi.begin();
+    break;
+    case SYSTEM_EVENT_STA_WPS_ER_FAILED:
+    Serial.println("WPS Failed, retrying");
+    esp_wifi_wps_disable();
+    esp_wifi_wps_enable(&config);
+    esp_wifi_wps_start(0);
+    break;
+    case SYSTEM_EVENT_STA_WPS_ER_TIMEOUT:
+    Serial.println("WPS Timedout, retrying");
+    esp_wifi_wps_disable();
+    esp_wifi_wps_enable(&config);
+    esp_wifi_wps_start(0);
+    break;
+    case SYSTEM_EVENT_STA_WPS_ER_PIN:
+    Serial.println("WPS_PIN = " + wpspin2string(info.sta_er_pin.pin_code));
+    break;
+    default:
+    break;
+  }
+}
+
+void setup(){
+  Serial.begin(115200);
+  delay(10);
+
+  Serial.println();
+
+  WiFi.onEvent(WiFiEvent);
+  WiFi.mode(WIFI_MODE_STA);
+
+  Serial.println("Starting WPS");
+
+  esp_wifi_wps_enable(&config);
+  esp_wifi_wps_start(0);
+}
+
+void loop(){
+  //nothing to do here
+}


### PR DESCRIPTION
This example shows how WPS can be used to connect an ESP32 to a router that has the required functionality.