### PR TITLE
Fixes for zero length packet bug, buffer overflow in parseInt(), added end() method

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.h
@@ -5,6 +5,9 @@
 #include <functional>
 #include "Update.h"
 
+#define INT_BUFFER_SIZE 16
+
+
 typedef enum {
   OTA_IDLE,
   OTA_WAITAUTH,
@@ -62,6 +65,9 @@ class ArduinoOTAClass
 
     //Starts the ArduinoOTA service
     void begin();
+    
+    //Ends the ArduinoOTA service
+    void end();
 
     //Call this in loop() to run the service
     void handle();


### PR DESCRIPTION
ArduinoOTA would stop receiving any packets if the port received a zero-length UDP packet, commonly sent by network scanners like nmap. Fixed to flush() after every call to parsePacket(), even if read length is 0.

Additionally, added length checking to fix a potential buffer overflow in parseInt().

Finally, added an end() method that stops the OTA listener and releases resources.