### PR TITLE
Fixes for zero length packet bug, buffer overflow in parseInt(), added end() method

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -122,11 +122,11 @@ void ArduinoOTAClass::begin() {
 }
 
 int ArduinoOTAClass::parseInt(){
-    char data[16];
+    char data[INT_BUFFER_SIZE];
     uint8_t index = 0;
     char value;
     while(_udp_ota.peek() == ' ') _udp_ota.read();
-    while(true){
+    while(index < INT_BUFFER_SIZE - 1){
         value = _udp_ota.peek();
         if(value < '0' || value > '9'){
             data[index++] = '\0';
@@ -347,6 +347,16 @@ void ArduinoOTAClass::_runUpdate() {
     }
 }
 
+void ArduinoOTAClass::end() {
+    _initialized = false;
+    _udp_ota.stop();
+    MDNS.end();
+    _state = OTA_IDLE;
+#ifdef OTA_DEBUG
+    OTA_DEBUG.println("OTA server stopped.");
+#endif
+}
+
 void ArduinoOTAClass::handle() {
     if (_state == OTA_RUNUPDATE) {
         _runUpdate();
@@ -354,8 +364,8 @@ void ArduinoOTAClass::handle() {
     }
     if(_udp_ota.parsePacket()){
         _onRx();
-        _udp_ota.flush();
     }
+    _udp_ota.flush(); // always flush, even zero length packets must be flushed.
 }
 
 int ArduinoOTAClass::getCommand() {

--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -350,7 +350,9 @@ void ArduinoOTAClass::_runUpdate() {
 void ArduinoOTAClass::end() {
     _initialized = false;
     _udp_ota.stop();
-    MDNS.end();
+    if(_mdnsEnabled){
+        MDNS.end();
+    }
     _state = OTA_IDLE;
 #ifdef OTA_DEBUG
     OTA_DEBUG.println("OTA server stopped.");

--- a/libraries/ArduinoOTA/src/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.h
@@ -5,6 +5,9 @@
 #include <functional>
 #include "Update.h"
 
+#define INT_BUFFER_SIZE 16
+
+
 typedef enum {
   OTA_IDLE,
   OTA_WAITAUTH,
@@ -62,6 +65,9 @@ class ArduinoOTAClass
 
     //Starts the ArduinoOTA service
     void begin();
+
+    //Ends the ArduinoOTA service
+    void end();
 
     //Call this in loop() to run the service
     void handle();


### PR DESCRIPTION
Previously, ArduinoOTA would stop receiving any packets if the port received a zero-length UDP packet, commonly sent by network scanners like nmap. Fixed to flush() after every call to parsePacket(), even if read length is 0.

Additionally, added length checking to fix a potential buffer overflow in parseInt().

Finally, added an end() method that stops the OTA listener and releases resources.