### PR TITLE
Add new target u-blox nina-w10

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -122,6 +122,44 @@ esp32thing.menu.UploadSpeed.512000.upload.speed=512000
 
 ##############################################################
 
+nina_w10.name=u-blox NINA-W10 series (ESP32)
+
+nina_w10.upload.tool=esptool
+nina_w10.upload.maximum_size=1310720
+nina_w10.upload.maximum_data_size=294912
+nina_w10.upload.wait_for_upload_port=true
+
+nina_w10.serial.disableDTR=true
+nina_w10.serial.disableRTS=true
+
+nina_w10.build.mcu=esp32
+nina_w10.build.core=esp32
+nina_w10.build.variant=nina_w10
+nina_w10.build.board=UBLOX_NINA_W10
+nina_w10.build.f_cpu=240000000L
+nina_w10.build.boot=bootloader
+nina_w10.build.partitions=default
+nina_w10.build.flash_mode=dio
+nina_w10.build.flash_size=2MB
+nina_w10.build.flash_freq=40m
+
+nina_w10.menu.UploadSpeed.921600=921600
+nina_w10.menu.UploadSpeed.921600.upload.speed=921600
+nina_w10.menu.UploadSpeed.115200=115200
+nina_w10.menu.UploadSpeed.115200.upload.speed=115200
+nina_w10.menu.UploadSpeed.256000.windows=256000
+nina_w10.menu.UploadSpeed.256000.upload.speed=256000
+nina_w10.menu.UploadSpeed.230400.windows.upload.speed=256000
+nina_w10.menu.UploadSpeed.230400=230400
+nina_w10.menu.UploadSpeed.230400.upload.speed=230400
+nina_w10.menu.UploadSpeed.460800.linux=460800
+nina_w10.menu.UploadSpeed.460800.macosx=460800
+nina_w10.menu.UploadSpeed.460800.upload.speed=460800
+nina_w10.menu.UploadSpeed.512000.windows=512000
+nina_w10.menu.UploadSpeed.512000.upload.speed=512000
+
+##############################################################
+
 widora-air.name=Widora AIR
 
 widora-air.upload.tool=esptool

--- a/variants/nina_w10/pins_arduino.h
+++ b/variants/nina_w10/pins_arduino.h
@@ -1,0 +1,84 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t LED_GREEN = 33;
+static const uint8_t LED_RED = 23;
+static const uint8_t LED_BLUE = 21;
+static const uint8_t SW1 = 33;
+static const uint8_t SW2 = 27;
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 12;
+static const uint8_t SCL = 13;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t D0 = 3;
+static const uint8_t D1 = 1;
+static const uint8_t D2 = 26;
+static const uint8_t D3 = 25;
+static const uint8_t D4 = 35;
+static const uint8_t D5 = 27;
+static const uint8_t D6 = 22;
+static const uint8_t D7 = 0;
+static const uint8_t D8 = 15;
+static const uint8_t D9 = 14;
+static const uint8_t D10 = 5;
+static const uint8_t D11 = 19;
+static const uint8_t D12 = 23;
+static const uint8_t D13 = 18;
+static const uint8_t D14 = 13;
+static const uint8_t D15 = 12;
+
+static const uint8_t D16 = 32;
+static const uint8_t D17 = 33;
+static const uint8_t D18 = 21;
+static const uint8_t D19 = 34;
+static const uint8_t D20 = 36;
+static const uint8_t D21 = 39;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
This was implemented according to section 1.3 and 2.4 of the system integration manual: 
https://www.u-blox.com/sites/default/files/NINA-W1_SIM_%28UBX-17005730%29_2.pdf

This target can for example be used on the following products:
- https://www.u-blox.com/en/product/evk-nina-w10
- https://www.u-blox.com/en/product/nina-w10-series