### PR TITLE
Unicode support in get.py

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -24,7 +24,7 @@ else:
 if 'Windows' in platform.system():
     import requests
 
-current_dir = os.path.dirname(os.path.realpath(__file__))
+current_dir = os.path.dirname(os.path.realpath(unicode(__file__)))
 dist_dir = current_dir + '/dist/'
 
 def sha256sum(filename, blocksize=65536):


### PR DESCRIPTION
Localized versions of Linux systems use Unicode characters in the names of standard directories like "Downloads".