### PR TITLE
Allow chaining of methods for more concise code

### DIFF
--- a/libraries/ArduinoOTA/examples/BasicOTA/BasicOTA.ino
+++ b/libraries/ArduinoOTA/examples/BasicOTA/BasicOTA.ino
@@ -30,31 +30,34 @@ void setup() {
   // MD5(admin) = 21232f297a57a5a743894a0e4a801fc3
   // ArduinoOTA.setPasswordHash("21232f297a57a5a743894a0e4a801fc3");
 
-  ArduinoOTA.onStart([]() {
-    String type;
-    if (ArduinoOTA.getCommand() == U_FLASH)
-      type = "sketch";
-    else // U_SPIFFS
-      type = "filesystem";
+  ArduinoOTA
+    .onStart([]() {
+      String type;
+      if (ArduinoOTA.getCommand() == U_FLASH)
+        type = "sketch";
+      else // U_SPIFFS
+        type = "filesystem";
 
-    // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
-    Serial.println("Start updating " + type);
-  });
-  ArduinoOTA.onEnd([]() {
-    Serial.println("\nEnd");
-  });
-  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-    Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
-  });
-  ArduinoOTA.onError([](ota_error_t error) {
-    Serial.printf("Error[%u]: ", error);
-    if (error == OTA_AUTH_ERROR) Serial.println("Auth Failed");
-    else if (error == OTA_BEGIN_ERROR) Serial.println("Begin Failed");
-    else if (error == OTA_CONNECT_ERROR) Serial.println("Connect Failed");
-    else if (error == OTA_RECEIVE_ERROR) Serial.println("Receive Failed");
-    else if (error == OTA_END_ERROR) Serial.println("End Failed");
-  });
+      // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
+      Serial.println("Start updating " + type);
+    })
+    .onEnd([]() {
+      Serial.println("\nEnd");
+    })
+    .onProgress([](unsigned int progress, unsigned int total) {
+      Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+    })
+    .onError([](ota_error_t error) {
+      Serial.printf("Error[%u]: ", error);
+      if (error == OTA_AUTH_ERROR) Serial.println("Auth Failed");
+      else if (error == OTA_BEGIN_ERROR) Serial.println("Begin Failed");
+      else if (error == OTA_CONNECT_ERROR) Serial.println("Connect Failed");
+      else if (error == OTA_RECEIVE_ERROR) Serial.println("Receive Failed");
+      else if (error == OTA_END_ERROR) Serial.println("End Failed");
+    });
+
   ArduinoOTA.begin();
+
   Serial.println("Ready");
   Serial.print("IP address: ");
   Serial.println(WiFi.localIP());

--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -31,39 +31,45 @@ ArduinoOTAClass::~ArduinoOTAClass(){
     _udp_ota.stop();
 }
 
-void ArduinoOTAClass::onStart(THandlerFunction fn) {
+ArduinoOTAClass& ArduinoOTAClass::onStart(THandlerFunction fn) {
     _start_callback = fn;
+    return *this;
 }
 
-void ArduinoOTAClass::onEnd(THandlerFunction fn) {
+ArduinoOTAClass& ArduinoOTAClass::onEnd(THandlerFunction fn) {
     _end_callback = fn;
+    return *this;
 }
 
-void ArduinoOTAClass::onProgress(THandlerFunction_Progress fn) {
+ArduinoOTAClass& ArduinoOTAClass::onProgress(THandlerFunction_Progress fn) {
     _progress_callback = fn;
+    return *this;
 }
 
-void ArduinoOTAClass::onError(THandlerFunction_Error fn) {
+ArduinoOTAClass& ArduinoOTAClass::onError(THandlerFunction_Error fn) {
     _error_callback = fn;
+    return *this;
 }
 
-void ArduinoOTAClass::setPort(uint16_t port) {
+ArduinoOTAClass& ArduinoOTAClass::setPort(uint16_t port) {
     if (!_initialized && !_port && port) {
         _port = port;
     }
+    return *this;
 }
 
-void ArduinoOTAClass::setHostname(const char * hostname) {
+ArduinoOTAClass& ArduinoOTAClass::setHostname(const char * hostname) {
     if (!_initialized && !_hostname.length() && hostname) {
         _hostname = hostname;
     }
+    return *this;
 }
 
 String ArduinoOTAClass::getHostname() {
     return _hostname;
 }
 
-void ArduinoOTAClass::setPassword(const char * password) {
+ArduinoOTAClass& ArduinoOTAClass::setPassword(const char * password) {
     if (!_initialized && !_password.length() && password) {
         MD5Builder passmd5;
         passmd5.begin();
@@ -71,20 +77,24 @@ void ArduinoOTAClass::setPassword(const char * password) {
         passmd5.calculate();
         _password = passmd5.toString();
     }
+    return *this;
 }
 
-void ArduinoOTAClass::setPasswordHash(const char * password) {
+ArduinoOTAClass& ArduinoOTAClass::setPasswordHash(const char * password) {
     if (!_initialized && !_password.length() && password) {
         _password = password;
     }
+    return *this;
 }
 
-void ArduinoOTAClass::setRebootOnSuccess(bool reboot){
+ArduinoOTAClass& ArduinoOTAClass::setRebootOnSuccess(bool reboot){
     _rebootOnSuccess = reboot;
+    return *this;
 }
 
-void ArduinoOTAClass::setMdnsEnabled(bool enabled){
+ArduinoOTAClass& ArduinoOTAClass::setMdnsEnabled(bool enabled){
     _mdnsEnabled = enabled;
+    return *this;
 }
 
 void ArduinoOTAClass::begin() {

--- a/libraries/ArduinoOTA/src/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.h
@@ -33,35 +33,35 @@ class ArduinoOTAClass
     ~ArduinoOTAClass();
 
     //Sets the service port. Default 3232
-    void setPort(uint16_t port);
+    ArduinoOTAClass& setPort(uint16_t port);
 
     //Sets the device hostname. Default esp32-xxxxxx
-    void setHostname(const char *hostname);
+    ArduinoOTAClass& setHostname(const char *hostname);
     String getHostname();
 
     //Sets the password that will be required for OTA. Default NULL
-    void setPassword(const char *password);
+    ArduinoOTAClass& setPassword(const char *password);
 
     //Sets the password as above but in the form MD5(password). Default NULL
-    void setPasswordHash(const char *password);
+    ArduinoOTAClass& setPasswordHash(const char *password);
 
     //Sets if the device should be rebooted after successful update. Default true
-    void setRebootOnSuccess(bool reboot);
+    ArduinoOTAClass& setRebootOnSuccess(bool reboot);
 
     //Sets if the device should advertise itself to Arduino IDE. Default true
-    void setMdnsEnabled(bool enabled);
+    ArduinoOTAClass& setMdnsEnabled(bool enabled);
 
     //This callback will be called when OTA connection has begun
-    void onStart(THandlerFunction fn);
+    ArduinoOTAClass& onStart(THandlerFunction fn);
 
     //This callback will be called when OTA has finished
-    void onEnd(THandlerFunction fn);
+    ArduinoOTAClass& onEnd(THandlerFunction fn);
 
     //This callback will be called when OTA encountered Error
-    void onError(THandlerFunction_Error fn);
+    ArduinoOTAClass& onError(THandlerFunction_Error fn);
 
     //This callback will be called when OTA is receiving data
-    void onProgress(THandlerFunction_Progress fn);
+    ArduinoOTAClass& onProgress(THandlerFunction_Progress fn);
 
     //Starts the ArduinoOTA service
     void begin();


### PR DESCRIPTION
This change allows chaining of methods for more concise code, similar like in most JavaScript Frameworks. Should not affect previous usage patterns, as the return type was `void`.

The BasicOTA example could look like this:
```
 ArduinoOTA
    .onStart([]() {
      
    })
    .onEnd([]() {

    })
    .onProgress([](unsigned int progress, unsigned int total) {

    })
    .onError([](ota_error_t error) {
      
    });
```
