### PR TITLE
fix NodeMCU-32S .build.board property

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -830,7 +830,7 @@ nodemcu-32s.serial.disableRTS=true
 nodemcu-32s.build.mcu=esp32
 nodemcu-32s.build.core=esp32
 nodemcu-32s.build.variant=nodemcu-32s
-nodemcu-32s.build.board=NodeMCU-32S
+nodemcu-32s.build.board=NodeMCU_32S
 
 nodemcu-32s.build.f_cpu=240000000L
 nodemcu-32s.build.flash_mode=dio


### PR DESCRIPTION
The .build.board=xx proptery is used for generating a macro named "ARDUINO_xxx".

C macro names should never have a "-" sign.

* current: ARDUINO_NodeMCU-32S
* should be: ARDUINO_=NodeMCU_32S