### PR TITLE
Fix compiler flags to be compatible with ESP8622/Arduino

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -830,7 +830,7 @@ nodemcu-32s.serial.disableRTS=true
 nodemcu-32s.build.mcu=esp32
 nodemcu-32s.build.core=esp32
 nodemcu-32s.build.variant=nodemcu-32s
-nodemcu-32s.build.board=NodeMCU-32S
+nodemcu-32s.build.board=NodeMCU_32S
 
 nodemcu-32s.build.f_cpu=240000000L
 nodemcu-32s.build.flash_mode=dio

--- a/boards.txt
+++ b/boards.txt
@@ -830,7 +830,7 @@ nodemcu-32s.serial.disableRTS=true
 nodemcu-32s.build.mcu=esp32
 nodemcu-32s.build.core=esp32
 nodemcu-32s.build.variant=nodemcu-32s
-nodemcu-32s.build.board=NodeMCU_32S
+nodemcu-32s.build.board=NodeMCU-32S
 
 nodemcu-32s.build.f_cpu=240000000L
 nodemcu-32s.build.flash_mode=dio

--- a/platform.txt
+++ b/platform.txt
@@ -61,13 +61,13 @@ compiler.objcopy.eep.extra_flags=
 compiler.elf2hex.extra_flags=
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpreprocessor.flags} {compiler.cpp.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpreprocessor.flags} {compiler.cpp.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.S.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.S.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/arduino.ar" "{object_file}"


### PR DESCRIPTION
see also "fix NodeMCU-32S .build.board property" (https://github.com/espressif/arduino-esp32/pull/812#issuecomment-341990261)

`-DARDUINO_BOARD={build.board}` is missing

With this fix you get a macro `ARDUINO_BOARD` with the name of the selected board (e.g. `"NodeMCU-32S"`).

https://github.com/esp8266/Arduino/blob/master/platform.txt#L75
https://github.com/esp8266/Arduino/blob/master/platform.txt#L78
https://github.com/esp8266/Arduino/blob/master/platform.txt#L81