### PR TITLE
Set HSPI ports by default when HSPI is selected

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -49,10 +49,17 @@ void SPIClass::begin(int8_t sck, int8_t miso, int8_t mosi, int8_t ss)
         return;
     }
 
-    _sck = sck;
-    _miso = miso;
-    _mosi = mosi;
-    _ss = ss;
+    if(sck == -1 && miso == -1 && mosi == -1 && ss == -1) {
+        _sck = (_spi_num == VSPI) ? SCK : 14;
+        _miso = (_spi_num == VSPI) ? MISO : 12;
+        _mosi = (_spi_num == VSPI) ? MOSI : 13;
+        _ss = (_spi_num == VSPI) ? SS : 15;
+    } else {
+        _sck = sck;
+        _miso = miso;
+        _mosi = mosi;
+        _ss = ss;
+    }
 
     spiAttachSCK(_spi, _sck);
     spiAttachMISO(_spi, _miso);

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -52,7 +52,7 @@ private:
 
 public:
     SPIClass(uint8_t spi_bus=HSPI);
-    void begin(int8_t sck=SCK, int8_t miso=MISO, int8_t mosi=MOSI, int8_t ss=-1);
+    void begin(int8_t sck=-1, int8_t miso=-1, int8_t mosi=-1, int8_t ss=-1);
     void end();
 
     void setHwCs(bool use);


### PR DESCRIPTION
When user selected HSPI with SPIClass name(HSPI) ESP was, by default,
still using VSPI ports (the ones defined in pins_arduino.h).
With this change when user selects HSPI then HSPI default ports will be
used.
If user won't specify HSPI then VSPI default ports will be used.
If user will specify SCLK, MOSI, MISO and SS with SPI.begin() then user
defined ports will be used no matter if VSPI or HSPI is selected.
With this change fe. SD library can use default HSPI ports. It was
possible to
pass HSPI SPI instance to SD lib, however even then it was using VSPI
ports which were (probably) GPIO matrixed to HSPI.