### PR TITLE
Sync flags with platform.txt; Custom partitions per board

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -36,16 +36,19 @@ assert isdir(FRAMEWORK_DIR)
 
 env.Prepend(
     CPPDEFINES=[
-        ("ARDUINO", 10610),
-        "ARDUINO_ARCH_ESP32"
+        ("ARDUINO", 10805),
+        "ARDUINO_ARCH_ESP32",
+        ("ARDUINO_BOARD", '\\"%s\\"' % env.BoardConfig().get("name").replace('"', ""))
     ],
 
     CFLAGS=["-Wno-old-style-declaration"],
 
     CCFLAGS=[
         "-Wno-error=deprecated-declarations",
+        "-Wno-error=unused-function",
         "-Wno-unused-parameter",
-        "-Wno-sign-compare"
+        "-Wno-sign-compare",
+        # "-fstack-protector",
     ],
 
     CPPPATH=[
@@ -115,7 +118,7 @@ def _get_board_flash_mode(env):
 
 env.Append(
     __get_board_flash_mode=_get_board_flash_mode,
-    
+
     LIBSOURCE_DIRS=[
         join(FRAMEWORK_DIR, "libraries")
     ],

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -48,7 +48,7 @@ env.Prepend(
         "-Wno-error=unused-function",
         "-Wno-unused-parameter",
         "-Wno-sign-compare",
-        # "-fstack-protector",
+        "-fstack-protector"
     ],
 
     CPPPATH=[

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -177,11 +177,11 @@ env.Prepend(LIBS=libs)
 #
 # Generate partition table
 #
-
 partition_table = env.Command(
     join("$BUILD_DIR", "partitions.bin"),
-    join(FRAMEWORK_DIR, "tools", "partitions", "default.csv"),
-    env.VerboseAction('"$PYTHONEXE" "%s" -q $SOURCE $TARGET' %
-                      join(FRAMEWORK_DIR, "tools", "gen_esp32part.py"),
+    join(FRAMEWORK_DIR, "tools", "partitions",
+         "%s.csv" % env.BoardConfig().get("build.partitions", "default")),
+    env.VerboseAction('"$PYTHONEXE" "%s" -q $SOURCE $TARGET' % join(
+        FRAMEWORK_DIR, "tools", "gen_esp32part.py"),
                       "Generating partitions $TARGET"))
 env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", partition_table)


### PR DESCRIPTION
Do you have ideas why `-fstack-protector` generates a warning? Should be it removed from platform.txt?

```
cores/esp32/IPv6Address.cpp:1:0: warning: -fstack-protector not supported for this target
```