### PR TITLE
implement FSPreferences, VSF (SD, SD_MMC, SPIFFS) compatible 'Preferences-lib' alternative

### DIFF
--- a/libraries/FSPreferences/examples/Showcase/Showcase.ino
+++ b/libraries/FSPreferences/examples/Showcase/Showcase.ino
@@ -1,0 +1,64 @@
+/*
+ ESP32 FSPreferences showcase
+
+ This is a simple demonstration of different features of the FSPreferences library
+
+ created for arduino-esp32
+ by Frederik Merz (Curclamas) <Frederik.merz@novalight.de>
+*/
+
+#include <SD.h>
+#include <SD_MMC.h>
+#include <SPIFFS.h>
+
+#include <FSPreferences.h>
+
+/* Select your FS */
+// #define MY_FS SD
+#define MY_FS SD_MMC
+// #define MY_FS SPIFFS
+
+FSPreferences preferences(MY_FS);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println();
+
+  MY_FS.begin();
+
+  preferences.begin("my-app1", false);
+  preferences.putInt("myInt", 1337);
+  preferences.putBool("myBool", true);
+  preferences.putBool("myBool2", true);
+  preferences.remove("myBool2");
+  preferences.putString("myString", "Hello World!");
+  preferences.end();
+
+  preferences.begin("my-app2", false);
+  preferences.putInt("myInt", 1337);
+  preferences.putBool("myBool", true);
+  preferences.putString("myString", "Hello World!");
+  preferences.end();
+
+  preferences.begin("my-app1", true);
+  Serial.println(preferences.getInt("myInt", -1));
+  Serial.println(preferences.getBool("myBool", false));
+  Serial.println(preferences.getString("myString", "Error!"));  
+  preferences.end();
+
+  preferences.begin("my-app2", false);
+  preferences.clear();
+  preferences.end();
+
+  // Close the FS  
+  MY_FS.end();
+
+  // Wait 10 seconds
+  Serial.println("Restarting in 10 seconds...");
+  delay(10000);
+
+  // Restart ESP
+  ESP.restart();
+}
+
+void loop() {}

--- a/libraries/FSPreferences/examples/StartCounter/StartCounter.ino
+++ b/libraries/FSPreferences/examples/StartCounter/StartCounter.ino
@@ -1,0 +1,67 @@
+/*
+ ESP32 start counter example with Preferences library
+
+ This simple example demonstrate using Preferences library to store how many times
+ was ESP32 module started. Preferences library is wrapper around Non-volatile
+ storage on ESP32 processor.
+
+ created for arduino-esp32 09 Feb 2017
+ by Martin Sloup (Arcao)
+*/
+
+#include <SD.h>
+#include <SD_MMC.h>
+#include <SPIFFS.h>
+
+#include <FSPreferences.h>
+
+/* Select your FS */
+// #define MY_FS SD
+#define MY_FS SD_MMC
+// #define MY_FS SPIFFS
+
+FSPreferences preferences(MY_FS);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println();
+
+  MY_FS.begin();
+
+  // Open Preferences with my-app namespace. Each application module, library, etc.
+  // has to use namespace name to prevent key name collisions. We will open storage in
+  // RW-mode (second parameter has to be false).
+  // Note: Namespace name is limited to 15 chars
+  preferences.begin("my-app", false);
+
+  // Remove all preferences under opened namespace
+  //preferences.clear();
+
+  // Or remove the counter key only
+  //preferences.remove("counter");
+
+  // Get a counter value, if key is not exist return default value 0
+  // Note: Key name is limited to 15 chars too
+  unsigned int counter = preferences.getUInt("counter", 0);
+
+  // Increase counter
+  counter++;
+
+  // Print counter to a Serial
+  Serial.printf("Current counter value: %u\n", counter);
+
+  // Store counter to the Preferences
+  preferences.putUInt("counter", counter);
+
+  // Close the Preferences
+  preferences.end();
+  MY_FS.end();
+  // Wait 10 seconds
+  Serial.println("Restarting in 10 seconds...");
+  delay(10000);
+
+  // Restart ESP
+  ESP.restart();
+}
+
+void loop() {}

--- a/libraries/FSPreferences/keywords.txt
+++ b/libraries/FSPreferences/keywords.txt
@@ -1,0 +1,54 @@
+#######################################
+# Syntax Coloring Map NVS
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+Preferences	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+begin	KEYWORD2
+end	KEYWORD2
+
+clear	KEYWORD2
+remove	KEYWORD2
+
+putChar	KEYWORD2
+putUChar	KEYWORD2
+putShort	KEYWORD2
+putUShort	KEYWORD2
+putInt	KEYWORD2
+putUInt	KEYWORD2
+putLong	KEYWORD2
+putULong	KEYWORD2
+putLong64	KEYWORD2
+putULong64	KEYWORD2
+putFloat	KEYWORD2
+putDouble	KEYWORD2
+putBool	KEYWORD2
+putString	KEYWORD2
+putBytes	KEYWORD2
+
+getChar	KEYWORD2
+getUChar	KEYWORD2
+getShort	KEYWORD2
+getUShort	KEYWORD2
+getInt	KEYWORD2
+getUInt	KEYWORD2
+getLong	KEYWORD2
+getULong	KEYWORD2
+getLong64	KEYWORD2
+getULong64	KEYWORD2
+getFloat	KEYWORD2
+getDouble	KEYWORD2
+getBool	KEYWORD2
+getString	KEYWORD2
+getBytes	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################

--- a/libraries/FSPreferences/library.properties
+++ b/libraries/FSPreferences/library.properties
@@ -1,0 +1,9 @@
+name=FSPreferences
+version=0.1
+author=Frederik Merz <frederik.merz@novalight.de>
+maintainer=Github Community
+sentence=Provides a NVS/Preferences-like wrapper around VFS API
+paragraph=With this library you can use Preferences-like semantics to write to any VFS-API (SD-Cards, SPIFFS etc.)
+category=Data Storage
+url=
+architectures=esp32

--- a/libraries/FSPreferences/src/FSPreferences.cpp
+++ b/libraries/FSPreferences/src/FSPreferences.cpp
@@ -1,0 +1,485 @@
+#include "FSPreferences.h"
+
+enum FSItemType : uint8_t {
+    ERR = 0,
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    U64,
+    I64,
+    FLO,
+    DOB,
+    BOO,
+    STR,
+    BLOB    
+};
+
+FSPreferences::FSPreferences(fs::FS &_handle) : _handle(_handle) {
+    //this._handle = _handle;
+    _namespacePath = nullptr;
+    _filePath = nullptr;
+    _started = false;
+}
+
+FSPreferences::~FSPreferences(){
+    end();
+}
+
+bool FSPreferences::begin(const char * name, bool readOnly){
+    if(_started){
+        return false;
+    }
+    _started = true;
+    _readOnly = readOnly;
+
+    const char * base = "/FSPreferences";
+
+    if(!_handle.mkdir(base)) {
+        log_e("mkdir '%s' failed!", base);
+        end();
+        return false;
+    }
+
+    _namespacePath = (char *)malloc( strlen(base) + strlen(name) + 2 );
+    
+    if(!_namespacePath) {
+        log_e("malloc failed!");
+        end();
+        return false;
+    }
+
+    sprintf(_namespacePath,"%s/%s", base, name);
+
+    if(!_handle.mkdir(_namespacePath)) {
+        log_e("mkdir '%s' failed!", _namespacePath);
+        end();
+        return false;
+    }
+
+    return true;
+}
+
+void FSPreferences::end(){
+    if(!_started){
+        return;
+    }
+    free(_namespacePath);
+    _namespacePath = nullptr;
+    free(_filePath);
+    _filePath = nullptr;
+    _started = false;
+}
+
+bool FSPreferences::clear() {
+    if(!_started || _readOnly){
+        return false;
+    }
+
+    File root = _handle.open(_namespacePath);
+    if(!root || !root.isDirectory()){
+        log_e("failed to open namespace directory!");
+        return false;
+    }
+
+    bool success;
+    File file = root.openNextFile();
+    while(file){
+        String filePath = String(file.name());
+        bool isFile = !file.isDirectory();
+        file.close();
+
+        
+        if(isFile){
+            success = _handle.remove(filePath.c_str());
+        } else {
+            success = _handle.rmdir(filePath.c_str());
+        }
+        
+        if(!success){
+            log_e("there was an error deleting namespace entry '%s'!", filePath.c_str());
+            break;
+        }
+        
+        file = root.openNextFile();
+    }
+    root.close();
+
+    return success;
+}
+
+bool FSPreferences::setFilePath(const char * key) {
+    if(!_namespacePath || !key){
+        log_e("key and namespace paths must not be NULL");
+        free(_filePath);
+        _filePath = nullptr;
+        return false;
+    }
+
+    char * tempFilePath = (char *)realloc(_filePath, strlen(_namespacePath) + strlen(key) + 2 );
+    if(tempFilePath == nullptr) {
+        free(_filePath);
+        _filePath = nullptr;
+        log_e("realloc failed!");        
+    } else {
+        sprintf(tempFilePath,"%s/%s", _namespacePath, key);
+    }
+    _filePath = tempFilePath;
+
+    return (_filePath != nullptr);
+}
+
+bool FSPreferences::remove(const char * key) {
+    if(!_started || !key || _readOnly){
+        return false;
+    }
+
+    if(!setFilePath(key)) {
+        return false;
+    }
+
+    if(!_handle.exists(_filePath)) {
+        log_e("key does not exist!"); 
+        return false;
+    }
+
+    if(!_handle.remove(_filePath)) {
+        log_e("key could not be removed!"); 
+        return false;
+    }
+
+    return true;
+}
+
+size_t FSPreferences::putBytes(const char* key, uint8_t type, const void* value, size_t len) {
+    if(!_started || !key || _readOnly || !type || !len){
+        return 0;
+    }
+
+    if(!setFilePath(key)) {
+        return 0;
+    }
+
+    if(_handle.exists(_filePath)) {
+        File existing = _handle.open(_filePath, FILE_READ);
+
+        if(!existing) {
+            log_e("existing file '%s' could not be opened!", _filePath); 
+            return 0;
+        }
+
+        if(existing.isDirectory()) {
+            log_e("existing file '%s' is a directory!", _filePath); 
+            existing.close();
+            return 0;
+        }
+
+        uint8_t existingType = existing.available() ? (FSItemType)existing.peek() : FSItemType::ERR;
+        existing.close();
+
+        if(existingType != type) {
+            log_e("existing file '%s' type is: %u, expected: %u", _filePath, existingType, type); 
+            return 0;
+        }
+    }
+
+    File newItem = _handle.open(_filePath, FILE_WRITE);
+
+    if(!newItem) {
+        log_e("new file '%s' could not be opened!", _filePath); 
+        return 0;
+    }
+
+    if(!newItem.write(type) || !newItem.write((uint8_t*)value, len)) {
+        log_e("new file '%s' could not be written to!", _filePath); 
+        newItem.close();
+        return 0;
+    }
+
+    newItem.close();
+    return len;
+}
+
+size_t FSPreferences::getBytes(const char* key, uint8_t type, void* buf, size_t maxLen, size_t minLen) {
+    if(!_started || !key || !type || !maxLen){
+        return 0;
+    }
+
+    if(!setFilePath(key)) {
+        return 0;
+    }
+
+    if(!_handle.exists(_filePath)) {
+        log_w("Key '%s' could not be found at '%s'", key, _filePath); 
+        return 0;
+    }
+
+    File existing = _handle.open(_filePath, FILE_READ);
+    
+    if(!existing) {
+        log_e("existing file '%s' could not be opened!", _filePath); 
+        return 0;
+    }
+
+    if(existing.isDirectory()) {
+        log_e("existing file '%s' is a directory!", _filePath); 
+        existing.close();
+        return 0;
+    }
+
+    size_t fileSize = existing.size();
+
+    if(fileSize < minLen + 1) {
+        log_e("existing file '%s' size is: %zu, expected minimum: %zu", _filePath, fileSize, minLen + 1); 
+        existing.close();
+        return 0;
+    }    
+
+    uint8_t existingType = existing.available() ? (FSItemType)existing.read() : FSItemType::ERR;
+
+    if(existingType != type) {
+        log_e("existing file '%s' type is: %u, expected: %u", _filePath, existingType, type); 
+        existing.close();
+        return 0;
+    }
+
+    size_t recordSize = fileSize - 1;
+    const size_t len = maxLen ? std::min(recordSize, maxLen) : recordSize;
+
+    char data[len]{0};
+
+    const size_t resLen = existing.read((uint8_t*)data, len);
+    existing.close();
+
+    if (resLen != len) {
+        log_e("existing file '%s' read  '%zu' bytes, expected '%zu' ", _filePath, resLen, len); 
+        return 0;
+    }
+
+    memcpy(buf, data, len);
+    return len;
+}
+
+size_t FSPreferences::putChar(const char* key, int8_t value) {
+    return putBytes(key, FSItemType::I8, &value, sizeof(value));
+}
+
+size_t FSPreferences::putUChar(const char* key, uint8_t value) {
+    return putBytes(key, FSItemType::U8, &value, sizeof(value));
+}
+
+size_t FSPreferences::putShort(const char* key, int16_t value) {
+    return putBytes(key, FSItemType::I16, &value, sizeof(value));
+}
+
+size_t FSPreferences::putUShort(const char* key, uint16_t value) {
+    return putBytes(key, FSItemType::U16, &value, sizeof(value));
+}
+
+size_t FSPreferences::putInt(const char* key, int32_t value) {
+    return putBytes(key, FSItemType::I32, &value, sizeof(value));
+}
+
+size_t FSPreferences::putUInt(const char* key, uint32_t value) {
+    return putBytes(key, FSItemType::U32, &value, sizeof(value));
+}
+
+size_t FSPreferences::putLong(const char* key, int32_t value) {
+    return putBytes(key, FSItemType::I32, &value, sizeof(value));
+}
+
+size_t FSPreferences::putULong(const char* key, uint32_t value) {
+    return putBytes(key, FSItemType::U32, &value, sizeof(value));
+}
+
+size_t FSPreferences::putLong64(const char* key, int64_t value) {
+    return putBytes(key, FSItemType::I64, &value, sizeof(value));
+}
+
+size_t FSPreferences::putULong64(const char* key, uint64_t value) {
+    return putBytes(key, FSItemType::U64, &value, sizeof(value));
+}
+
+size_t FSPreferences::putFloat(const char* key, float_t value) {
+    return putBytes(key, FSItemType::FLO, &value, sizeof(value));
+}
+
+size_t FSPreferences::putDouble(const char* key, double_t value) {
+    return putBytes(key, FSItemType::DOB, &value, sizeof(value));
+}
+
+size_t FSPreferences::putBool(const char* key, bool value) {
+    return putBytes(key, FSItemType::BOO, &value, sizeof(value));
+}
+
+size_t FSPreferences::putString(const char* key, const char* value) {
+    return putBytes(key, FSItemType::STR, value, strlen(value) + 1);
+}
+
+size_t FSPreferences::putString(const char* key, const String& value) {
+    return putString(key, value.c_str());
+}
+
+size_t FSPreferences::putBytes(const char* key, const void* value, size_t len) {
+    return putBytes(key, FSItemType::BLOB, value, len);
+}
+
+int8_t FSPreferences::getChar(const char* key, int8_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::I8, (void*) &result, len, len);
+    return result;
+}
+
+uint8_t FSPreferences::getUChar(const char* key, uint8_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::U8, (void*) &result, len, len);
+    return result;
+}
+
+int16_t FSPreferences::getShort(const char* key, int16_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::I16, (void*) &result, len, len);
+    return result;
+}
+
+uint16_t FSPreferences::getUShort(const char* key, uint16_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::U16, (void*) &result, len, len);
+    return result;
+}
+
+int32_t FSPreferences::getInt(const char* key, int32_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::I32, (void*) &result, len, len);
+    return result;
+}
+
+uint32_t FSPreferences::getUInt(const char* key, uint32_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::U32, (void*) &result, len, len);
+    return result;
+}
+
+int32_t FSPreferences::getLong(const char* key, int32_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::I32, (void*) &result, len, len);
+    return result;
+}
+
+uint32_t FSPreferences::getULong(const char* key, uint32_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::U32, (void*) &result, len, len);
+    return result;
+}
+
+int64_t FSPreferences::getLong64(const char* key, int64_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::I64, (void*) &result, len, len);
+    return result;
+}
+
+uint64_t FSPreferences::getULong64(const char* key, uint64_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::U64, (void*) &result, len, len);
+    return result;
+}
+
+float_t FSPreferences::getFloat(const char* key, float_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::FLO, (void*) &result, len, len);
+    return result;
+}
+
+double_t FSPreferences::getDouble(const char* key, double_t defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::DOB, (void*) &result, len, len);
+    return result;
+}
+
+bool FSPreferences::getBool(const char* key, bool defaultValue) {
+    auto result = defaultValue;
+    size_t len = sizeof(defaultValue);
+    getBytes(key, FSItemType::BOO, (void*) &result, len, len);
+    return result;
+}
+
+size_t FSPreferences::getBytes(const char* key, void * buf, size_t maxLen) {
+    return getBytes(key, FSItemType::BLOB, buf, maxLen);
+}
+
+
+size_t FSPreferences::getString(const char* key, char* value, size_t maxLen) {    
+    return getBytes(key, FSItemType::STR, (void*) value, maxLen);
+}
+
+String FSPreferences::getString(const char* key, String defaultValue) {
+    if(!_started || !key){
+        return defaultValue;
+    }
+
+    if(!setFilePath(key)) {
+        return defaultValue;
+    }
+
+    if(!_handle.exists(_filePath)) {
+        log_w("Key '%s' could not be found at '%s'", key, _filePath); 
+        return defaultValue;
+    }
+
+    File existing = _handle.open(_filePath, FILE_READ);
+    
+    if(!existing) {
+        log_e("existing file '%s' could not be opened!", _filePath); 
+        return defaultValue;
+    }
+
+    if(existing.isDirectory()) {
+        log_e("existing file '%s' is a directory!", _filePath); 
+        existing.close();
+        return defaultValue;
+    }
+
+    size_t fileSize = existing.size();
+
+    if(fileSize < 2) {
+        log_e("existing file '%s' size is: %zu, expected minimum: 2", _filePath, fileSize); 
+        existing.close();
+        return defaultValue;
+    }    
+
+    uint8_t existingType = existing.available() ? (FSItemType)existing.read() : FSItemType::ERR;
+
+    if(existingType != FSItemType::STR) {
+        log_e("existing file '%s' type is: %u, expected: %u", _filePath, existingType, FSItemType::STR); 
+        existing.close();
+        return defaultValue;
+    }
+
+    size_t recordSize = fileSize - 1;
+
+    char data[recordSize + 1]{0};
+
+    const size_t resLen = existing.read((uint8_t*)data, recordSize);
+    existing.close();
+
+    if (resLen != recordSize) {
+        log_e("existing file '%s' read  '%zu' bytes, expected '%zu' ", _filePath, resLen, recordSize); 
+        return defaultValue;
+    }
+
+    return String(data);
+}

--- a/libraries/FSPreferences/src/FSPreferences.h
+++ b/libraries/FSPreferences/src/FSPreferences.h
@@ -1,0 +1,64 @@
+#ifndef _FSPREFERENCES_H_
+#define _FSPREFERENCES_H_
+
+#include "Arduino.h"
+#include "FS.h"
+
+class FSPreferences {
+    protected:
+        fs::FS &_handle;
+        bool _started;
+        bool _readOnly;
+        char * _namespacePath;
+        char * _filePath;
+
+        bool setFilePath(const char* key);
+
+        size_t putBytes(const char* key, uint8_t type, const void* value, size_t len);
+        size_t getBytes(const char* key, uint8_t type, void* buf, size_t maxLen = 0, size_t minLen = 0);        
+    public:
+        FSPreferences(fs::FS &_handle);
+        ~FSPreferences();
+
+        bool begin(const char * name, bool readOnly=false);
+        void end();
+
+        bool clear();
+        bool remove(const char * key);
+
+        size_t putChar(const char* key, int8_t value);
+        size_t putUChar(const char* key, uint8_t value);
+        size_t putShort(const char* key, int16_t value);
+        size_t putUShort(const char* key, uint16_t value);
+        size_t putInt(const char* key, int32_t value);
+        size_t putUInt(const char* key, uint32_t value);
+        size_t putLong(const char* key, int32_t value);
+        size_t putULong(const char* key, uint32_t value);
+        size_t putLong64(const char* key, int64_t value);
+        size_t putULong64(const char* key, uint64_t value);
+        size_t putFloat(const char* key, float_t value);
+        size_t putDouble(const char* key, double_t value);
+        size_t putBool(const char* key, bool value);
+        size_t putString(const char* key, const char* value);
+        size_t putString(const char* key, const String& value);
+        size_t putBytes(const char* key, const void* value, size_t len);
+
+        int8_t getChar(const char* key, int8_t defaultValue = 0);
+        uint8_t getUChar(const char* key, uint8_t defaultValue = 0);
+        int16_t getShort(const char* key, int16_t defaultValue = 0);
+        uint16_t getUShort(const char* key, uint16_t defaultValue = 0);
+        int32_t getInt(const char* key, int32_t defaultValue = 0);
+        uint32_t getUInt(const char* key, uint32_t defaultValue = 0);
+        int32_t getLong(const char* key, int32_t defaultValue = 0);
+        uint32_t getULong(const char* key, uint32_t defaultValue = 0);
+        int64_t getLong64(const char* key, int64_t defaultValue = 0);
+        uint64_t getULong64(const char* key, uint64_t defaultValue = 0);
+        float_t getFloat(const char* key, float_t defaultValue = NAN);
+        double_t getDouble(const char* key, double_t defaultValue = NAN);
+        bool getBool(const char* key, bool defaultValue = false);
+        size_t getString(const char* key, char* value, size_t maxLen);
+        String getString(const char* key, String defaultValue = String());
+        size_t getBytes(const char* key, void * buf, size_t maxLen);
+};
+
+#endif


### PR DESCRIPTION
## Background
Preferences.h lib is very useful but has some shortcomings. To name two: limited space and likely limited wear leveling. When we are able to use 8GB or 16GB SD-Cards space and wear leveling become much less of a problem.

## Possible side-effects
None that I know, it's a separate library that maps the Preferences functions on top of VSF API.

## What to test
Different memory devices should be tested, I confirmed it with 8GB and 16GB cards as SD and SD_MMC.

## Where to start reviewing
First look at the constructors and destructors. Then one should definitely look at the private functions:
```cpp
        size_t putBytes(const char* key, uint8_t type, const void* value, size_t len);
        size_t getBytes(const char* key, uint8_t type, void* buf, size_t maxLen = 0, size_t minLen = 0);     
```
These are used to write to the VFS API, the other functions merely call these with different type/length params.

One exception is:
```arduino
String getString(const char* key, String defaultValue)
```

because I wanted to avoid unnecessary double buffering. The double buffering is used in the other functions so that we only write to the provided buffer/pointer when everything was read successfully. This could lead to stack overflow when reading very large chunks of data. To mitigate this, one could also implement a non-buffered method in the future.