### PR TITLE
bit_num->duty_resolution, div_num->clock_divider

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -68,8 +68,8 @@ static void _ledcSetupTimer(uint8_t chan, uint32_t div_num, uint8_t bit_num, boo
 #endif
     }
     LEDC_MUTEX_LOCK();
-    LEDC_TIMER(group, timer).conf.div_num = div_num;//18 bit (10.8) This register is used to configure parameter for divider in timer the least significant eight bits represent the decimal part.
-    LEDC_TIMER(group, timer).conf.bit_num = bit_num;//5 bit This register controls the range of the counter in timer. the counter range is [0 2**bit_num] the max bit width for counter is 20.
+    LEDC_TIMER(group, timer).conf.clock_divider = div_num;//18 bit (10.8) This register is used to configure parameter for divider in timer the least significant eight bits represent the decimal part.
+    LEDC_TIMER(group, timer).conf.duty_resolution = bit_num;//5 bit This register controls the range of the counter in timer. the counter range is [0 2**bit_num] the max bit width for counter is 20.
     LEDC_TIMER(group, timer).conf.tick_sel = apb_clk;//apb clock
     if(group) {
         LEDC_TIMER(group, timer).conf.low_speed_update = 1;//This bit is only useful for low speed timer channels, reserved for high speed timers
@@ -111,8 +111,8 @@ static double _ledcTimerRead(uint8_t chan)
     bool apb_clk;
     uint8_t group=(chan/8), timer=((chan/2)%4);
     LEDC_MUTEX_LOCK();
-    div_num = LEDC_TIMER(group, timer).conf.div_num;//18 bit (10.8) This register is used to configure parameter for divider in timer the least significant eight bits represent the decimal part.
-    bit_num = LEDC_TIMER(group, timer).conf.bit_num;//5 bit This register controls the range of the counter in timer. the counter range is [0 2**bit_num] the max bit width for counter is 20.
+    div_num = LEDC_TIMER(group, timer).conf.clock_divider;//18 bit (10.8) This register is used to configure parameter for divider in timer the least significant eight bits represent the decimal part.
+    bit_num = LEDC_TIMER(group, timer).conf.duty_resolution;//5 bit This register controls the range of the counter in timer. the counter range is [0 2**bit_num] the max bit width for counter is 20.
     apb_clk = LEDC_TIMER(group, timer).conf.tick_sel;//apb clock
     LEDC_MUTEX_UNLOCK();
     uint64_t clk_freq = 1000000;


### PR DESCRIPTION
Needed after d488bb7bacca80e6089bdf070bb1e10324d31dbb merged to esp-idf.

Fixes issue #895.