### PR TITLE
Allow PSK instead of passphrase in WiFiSTA::begin

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -110,7 +110,7 @@ wl_status_t WiFiSTAClass::begin(const char* ssid, const char *passphrase, int32_
         return WL_CONNECT_FAILED;
     }
 
-    if(passphrase && strlen(passphrase) > 63) {
+    if(passphrase && strlen(passphrase) > 64) {
         // fail passphrase too long!
         return WL_CONNECT_FAILED;
     }
@@ -119,7 +119,10 @@ wl_status_t WiFiSTAClass::begin(const char* ssid, const char *passphrase, int32_
     strcpy(reinterpret_cast<char*>(conf.sta.ssid), ssid);
 
     if(passphrase) {
-        strcpy(reinterpret_cast<char*>(conf.sta.password), passphrase);
+        if (strlen(passphrase) == 64) // it's not a passphrase, is the PSK
+            memcpy(reinterpret_cast<char*>(conf.sta.password), passphrase, 64);
+        else
+            strcpy(reinterpret_cast<char*>(conf.sta.password), passphrase);
     } else {
         *conf.sta.password = 0;
     }


### PR DESCRIPTION
Allow PSK, which generated by `wpa_passphrase` command or the PBKDF2 function.

I referred to the following the PR: https://github.com/esp8266/Arduino/pull/1850

> In WPA protocol, the maximum length of the passphrases is 64 characters in order to distinguish them from the actual PSK which is 64 ASCII characters long, so in most systems if a 64 chars string is passed, it is assumed to be a PSK, otherwise is treated as a passphrase and is used to compute the PSK.

To calc the PSK, please use http://jorisvr.nl/wpapsk.html