### PR TITLE
Ensure errors are generated if the wrong method is called to retrieve the SSL data stream.

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -203,6 +203,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, const char* CAcer
     if (strlen(CAcert) == 0) {
         return false;
     }
+    _secure = true;
     _transportTraits = TransportTraitsPtr(new TLSTraits(CAcert));
     return true;
 }
@@ -217,6 +218,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, const char* CAcer
     if (strlen(CAcert) == 0) {
         return false;
     }
+    _secure = true;
     _transportTraits = TransportTraitsPtr(new TLSTraits(CAcert, cli_cert, cli_key));
     return true;
 }
@@ -561,18 +563,18 @@ int HTTPClient::getSize(void)
  */
 WiFiClient& HTTPClient::getStream(void)
 {
-    if(connected()) {
+    if (connected() && !_secure) {
         return *_tcp;
     }
 
-    log_d("getStream: not connected");
+    log_w("getStream: not connected");
     static WiFiClient empty;
     return empty;
 }
 
 /**
- * returns the stream of the tcp connection
- * @return WiFiClient *
+ * returns a pointer to the stream of the tcp connection
+ * @return WiFiClient*
  */
 WiFiClient* HTTPClient::getStreamPtr(void)
 {
@@ -580,7 +582,7 @@ WiFiClient* HTTPClient::getStreamPtr(void)
         return _tcp.get();
     }
 
-    log_d("getStreamPtr: not connected");
+    log_w("getStreamPtr: not connected");
     return nullptr;
 }
 

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <Arduino.h>
 #include <WiFiClient.h>
+#include <WiFiClientSecure.h>
 
 #define HTTPCLIENT_DEFAULT_TCP_TIMEOUT (5000)
 

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -134,7 +134,6 @@ size_t WiFiClientSecure::write(const uint8_t *buf, size_t size)
     }
     int res = send_ssl_data(sslclient, buf, size);
     if (res < 0) {
-						   
         stop();
         res = 0;
     }
@@ -148,7 +147,6 @@ int WiFiClientSecure::read(uint8_t *buf, size_t size)
     }
     int res = get_ssl_receive(sslclient, buf, size);
     if (res < 0) {
-							
         stop();
     }
     return res;

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.h
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.h
@@ -28,7 +28,6 @@
 class WiFiClientSecure : public WiFiClient
 {
 protected:
-    bool _connected;
     sslclient_context *sslclient;
 
     const char *_CA_cert;


### PR DESCRIPTION
Currently, the getStream() function on the httpClient will return the stream for the non-SSL without generating errors and this will cause problems when someone tries to read the stream as there is nothing to read. The changes check whether the SSL mode is in use or not and generate an error if the method is called while SSL is in use.