### PR TITLE
Workaround strict-aliasing warnings

### DIFF
--- a/cores/esp32/pgmspace.h
+++ b/cores/esp32/pgmspace.h
@@ -37,18 +37,33 @@ typedef unsigned long prog_uint32_t;
 #define _SFR_BYTE(n)  (n)
 
 #define pgm_read_byte(addr)   (*(const unsigned char *)(addr))
-#define pgm_read_word(addr)   (*(const unsigned short *)(addr))
-#define pgm_read_dword(addr)  (*(const unsigned long *)(addr))
-#define pgm_read_float(addr)  (*(const float *)(addr))
+#define pgm_read_word(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned short *)(_addr); \
+})
+#define pgm_read_dword(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const unsigned long *)(_addr); \
+})
+#define pgm_read_float(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(const float *)(_addr); \
+})
+#define pgm_read_ptr(addr) ({ \
+  typeof(addr) _addr = (addr); \
+  *(void * const *)(_addr); \
+})
 
 #define pgm_read_byte_near(addr)  pgm_read_byte(addr)
 #define pgm_read_word_near(addr)  pgm_read_word(addr)
 #define pgm_read_dword_near(addr) pgm_read_dword(addr)
 #define pgm_read_float_near(addr) pgm_read_float(addr)
+#define pgm_read_ptr_near(addr)   pgm_read_ptr(addr)
 #define pgm_read_byte_far(addr)   pgm_read_byte(addr)
 #define pgm_read_word_far(addr)   pgm_read_word(addr)
 #define pgm_read_dword_far(addr)  pgm_read_dword(addr)
 #define pgm_read_float_far(addr)  pgm_read_float(addr)
+#define pgm_read_ptr_far(addr)    pgm_read_ptr(addr)
 
 #define memcmp_P      memcmp
 #define memccpy_P     memccpy


### PR DESCRIPTION
Also added missing pgm_read_ptr define

See: https://travis-ci.org/felis/USB_Host_Shield_2.0/jobs/328511332 and https://github.com/PaulStoffregen/cores/commit/8a02ea67f577c1798b50c38da9b74296a861b45a#diff-6e1ff9551639ac89d99617863bf84e10