### PR TITLE
Changed Python version in Debian/Ubuntu install instructions

### DIFF
--- a/docs/arduino-ide/debian_ubuntu.md
+++ b/docs/arduino-ide/debian_ubuntu.md
@@ -16,7 +16,7 @@ Installation instructions for Debian / Ubuntu OS
   cd esp32 && \
   git submodule update --init --recursive && \
   cd tools && \
-  python get.py
+  python2 get.py
   ```
 - Restart Arduino IDE
 
@@ -32,4 +32,4 @@ Installation instructions for Debian / Ubuntu OS
   cd esp32 && \
   git submodule update --init --recursive && \
   cd tools && \
-  python get.py```
+  python2 get.py```


### PR DESCRIPTION
As discussed in #1042.

FIXED: The script currently tries to run Python 2 with the command `python`. To run Python 2, the command `python2` should be used.