### PR TITLE
Fix upload.maximum_size as current partition size 0x140000 for esp32vn-iot-uno & heltec boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -952,7 +952,7 @@ mhetesp32minikit.menu.UploadSpeed.512000.upload.speed=512000
 esp32vn-iot-uno.name=ESP32vn IoT Uno
 
 esp32vn-iot-uno.upload.tool=esptool
-esp32vn-iot-uno.upload.maximum_size=1044464
+esp32vn-iot-uno.upload.maximum_size=1310720
 esp32vn-iot-uno.upload.maximum_data_size=294912
 esp32vn-iot-uno.upload.wait_for_upload_port=true
 
@@ -1225,7 +1225,7 @@ m5stack-core-esp32.menu.DebugLevel.verbose.build.code_debug=5
 heltec_wifi_kit_32.name=Heltec_WIFI_Kit_32
 
 heltec_wifi_kit_32.upload.tool=esptool
-heltec_wifi_kit_32.upload.maximum_size=1044464
+heltec_wifi_kit_32.upload.maximum_size=1310720
 heltec_wifi_kit_32.upload.maximum_data_size=294912
 heltec_wifi_kit_32.upload.wait_for_upload_port=true
 
@@ -1268,7 +1268,7 @@ heltec_wifi_kit_32.menu.UploadSpeed.512000.upload.speed=512000
 heltec_wifi_lora_32.name=Heltec_WIFI_LoRa_32
 
 heltec_wifi_lora_32.upload.tool=esptool
-heltec_wifi_lora_32.upload.maximum_size=1044464
+heltec_wifi_lora_32.upload.maximum_size=1310720
 heltec_wifi_lora_32.upload.maximum_data_size=294912
 heltec_wifi_lora_32.upload.wait_for_upload_port=true
 


### PR DESCRIPTION
It appears that all boards which use the current partition size of 0x140000 for apps should also have upload.maximum_size=1310720 in boards.txt

Also see: https://github.com/espressif/arduino-esp32/issues/339
