### PR TITLE
FIX: getEfuseMac can return random data

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -218,7 +218,7 @@ bool EspClass::flashRead(uint32_t offset, uint32_t *data, size_t size)
 
 uint64_t EspClass::getEfuseMac(void)
 {
-    uint64_t _chipmacid;
+    uint64_t _chipmacid = 0LL;
     esp_efuse_mac_get_default((uint8_t*) (&_chipmacid));
     return _chipmacid;
 }


### PR DESCRIPTION
esp_efuse_mac_get_default() only stores into the bottom 6 bytes of it's 8-byte argument, so must initialize the arg to zero to avoid trash on the stack.