### PR TITLE
bugfix(uart + i2c): fix signal glitch on tx , i2c sda and i2c scl pin

### DIFF
--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -73,7 +73,8 @@ i2c_err_t i2cAttachSCL(i2c_t * i2c, int8_t scl)
         return I2C_ERROR_DEV;
     }
     digitalWrite(scl, HIGH); // optional, tested successful in actually version 
-    pinMode(scl, OUTPUT_OPEN_DRAIN | PULLUP);
+    // pinMode(scl, OUTPUT_OPEN_DRAIN | PULLUP);
+    pinMode(scl, OPEN_DRAIN | PULLUP); // open for a test on weekend
     // digitalWrite(scl, HIGH); // successful tested in a prev version, but fails in the actually so use optional!
     pinMatrixOutAttach(scl, I2C_SCL_IDX(i2c->num), false, false);
     pinMatrixInAttach(scl, I2C_SCL_IDX(i2c->num), false);
@@ -97,7 +98,8 @@ i2c_err_t i2cAttachSDA(i2c_t * i2c, int8_t sda)
         return I2C_ERROR_DEV;
     }
     digitalWrite(sda, HIGH); // optional, tested successful in actually version
-    pinMode(sda, OUTPUT_OPEN_DRAIN | PULLUP);
+    // pinMode(sda, OUTPUT_OPEN_DRAIN | PULLUP);
+    pinMode(sda, OPEN_DRAIN | PULLUP); // open for a test on weekend
     // digitalWrite(sda, HIGH); // successful tested in a prev version, but fails in the actually so use optional!
     pinMatrixOutAttach(sda, I2C_SDA_IDX(i2c->num), false, false);
     pinMatrixInAttach(sda, I2C_SDA_IDX(i2c->num), false);

--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -72,7 +72,9 @@ i2c_err_t i2cAttachSCL(i2c_t * i2c, int8_t scl)
     if(i2c == NULL){
         return I2C_ERROR_DEV;
     }
+    digitalWrite(scl, HIGH); // optional, tested successful in actually version 
     pinMode(scl, OUTPUT_OPEN_DRAIN | PULLUP);
+    // digitalWrite(scl, HIGH); // successful tested in a prev version, but fails in the actually so use optional!
     pinMatrixOutAttach(scl, I2C_SCL_IDX(i2c->num), false, false);
     pinMatrixInAttach(scl, I2C_SCL_IDX(i2c->num), false);
     return I2C_ERROR_OK;
@@ -94,7 +96,9 @@ i2c_err_t i2cAttachSDA(i2c_t * i2c, int8_t sda)
     if(i2c == NULL){
         return I2C_ERROR_DEV;
     }
+    digitalWrite(sda, HIGH); // optional, tested successful in actually version
     pinMode(sda, OUTPUT_OPEN_DRAIN | PULLUP);
+    // digitalWrite(sda, HIGH); // successful tested in a prev version, but fails in the actually so use optional!
     pinMatrixOutAttach(sda, I2C_SDA_IDX(i2c->num), false, false);
     pinMatrixInAttach(sda, I2C_SDA_IDX(i2c->num), false);
     return I2C_ERROR_OK;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -154,6 +154,7 @@ void uartAttachTx(uart_t* uart, uint8_t txPin, bool inverted)
         return;
     }
     pinMode(txPin, OUTPUT);
+    digitalWrite(txPin, HIGH);
     pinMatrixOutAttach(txPin, UART_TXD_IDX(uart->num), inverted, false);
 }
 


### PR DESCRIPTION
see https://github.com/espressif/arduino-esp32/issues/1061