### PR TITLE
bugfix(i2c): fix signal glitch on sda and scl  pin

### DIFF
--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -72,7 +72,9 @@ i2c_err_t i2cAttachSCL(i2c_t * i2c, int8_t scl)
     if(i2c == NULL){
         return I2C_ERROR_DEV;
     }
+    // digitalWrite(scl, HIGH); // optional before
     pinMode(scl, OUTPUT_OPEN_DRAIN | PULLUP);
+    digitalWrite(scl, HIGH); // tested 
     pinMatrixOutAttach(scl, I2C_SCL_IDX(i2c->num), false, false);
     pinMatrixInAttach(scl, I2C_SCL_IDX(i2c->num), false);
     return I2C_ERROR_OK;
@@ -94,7 +96,9 @@ i2c_err_t i2cAttachSDA(i2c_t * i2c, int8_t sda)
     if(i2c == NULL){
         return I2C_ERROR_DEV;
     }
+    // digitalWrite(sda, HIGH);  // optional before
     pinMode(sda, OUTPUT_OPEN_DRAIN | PULLUP);
+    digitalWrite(sda, HIGH); // tested
     pinMatrixOutAttach(sda, I2C_SDA_IDX(i2c->num), false, false);
     pinMatrixInAttach(sda, I2C_SDA_IDX(i2c->num), false);
     return I2C_ERROR_OK;


### PR DESCRIPTION
see https://github.com/espressif/arduino-esp32/issues/1061
here a tested version and an optional suggestion