### PR TITLE
Python 3 fails,  unicode is not needed or supplied

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -17,6 +17,7 @@ import zipfile
 import re
 if sys.version_info[0] == 3:
     from urllib.request import urlretrieve
+    unicode = lambda s: str(s)
 else:
     # Not Python 3 - today, it is most likely to be Python 2
     from urllib import urlretrieve


### PR DESCRIPTION
See  https://stackoverflow.com/questions/6812031/how-to-make-unicode-string-with-python3

May unicode an alias for str()