### PR TITLE
HTTPClient: make clean up faster (fixes #828)

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -232,9 +232,7 @@ void HTTPClient::end(void)
     if(connected()) {
         if(_tcp->available() > 0) {
             log_d("still data in buffer (%d), clean up.", _tcp->available());
-            while(_tcp->available() > 0) {
-                _tcp->read();
-            }
+            _tcp->flush();
         }
         if(_reuse && _canReuse) {
             log_d("tcp keep open for reuse");


### PR DESCRIPTION
If the unread data is very large, cleaning up byte by byte will take a long time.
on a http radio stream easily >=60s observed.

so just flush tcp buffer instead of reading it byte by byte.

thanks to @xiruilin and @Uksa007