### PR TITLE
Update get.py

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -24,7 +24,14 @@ else:
 if 'Windows' in platform.system():
     import requests
 
-current_dir = os.path.dirname(os.path.realpath(unicode(__file__)))
+def ensureUtf(s):
+  try:
+      if type(s) == unicode:
+        return s.encode('utf8', 'ignore')
+  except: 
+    return str(s)
+
+current_dir = os.path.dirname(os.path.realpath(ensureUtf(__file__)))
 dist_dir = current_dir + '/dist/'
 
 def sha256sum(filename, blocksize=65536):


### PR DESCRIPTION
crude solution to Python3.6 error: 

> 
> Traceback (most recent call last):
>   File "get.py", line 27, in <module>
>     current_dir = os.path.dirname(os.path.realpath(unicode(__file__)))
> NameError: name 'unicode' is not defined
