### PR TITLE
Enable creation of static libs. Task creation and app_main() separated in two different files.

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -187,4 +187,6 @@ long random(long);
 
 #include "pins_arduino.h"
 
+void arduino_task(void);
+
 #endif /* _ESP32_CORE_ARDUINO_H_ */

--- a/cores/esp32/arduino.cpp
+++ b/cores/esp32/arduino.cpp
@@ -19,7 +19,7 @@ void loopTask(void *pvParameters)
     }
 }
 
-extern "C" void app_main()
+extern "C" void arduino_task()
 {
     initArduino();
     xTaskCreatePinnedToCore(loopTask, "loopTask", 8192, NULL, 1, NULL, ARDUINO_RUNNING_CORE);

--- a/cores/esp32/main.c
+++ b/cores/esp32/main.c
@@ -1,0 +1,5 @@
+#include "Arduino.h"
+
+void app_main() {
+	arduino_task();
+}


### PR DESCRIPTION
Hi,

I'm building an enhanced esp-idf-template where I'd like to use both C and micropython. In order to get this result I need for both the frameworks to not seize app_main(). In other words, I need the app_main() to be in a separate file so that in case can be excluded from linking. Enabling the creation of static libs.
I've already requested a similar pull to the Micropython repo. Here is the one for arduino-esp32.

Please send this patch upstream.

Thank you