### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/libraries/ArduinoOTA/keywords.txt
+++ b/libraries/ArduinoOTA/keywords.txt
@@ -15,10 +15,10 @@ ArduinoOTA	KEYWORD1
 begin	KEYWORD2
 setup	KEYWORD2
 handle	KEYWORD2
-onStart KEYWORD2
-onEnd   KEYWORD2
-onError KEYWORD2
-onProgress KEYWORD2
+onStart	KEYWORD2
+onEnd	KEYWORD2
+onError	KEYWORD2
+onProgress	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/ESPmDNS/keywords.txt
+++ b/libraries/ESPmDNS/keywords.txt
@@ -14,10 +14,10 @@ MDNS	KEYWORD1
 #######################################
 
 begin	KEYWORD2
-end KEYWORD2
+end	KEYWORD2
 addService	KEYWORD2
 enableArduino	KEYWORD2
-disableArduino   KEYWORD2
+disableArduino	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/Ticker/keywords.txt
+++ b/libraries/Ticker/keywords.txt
@@ -9,6 +9,6 @@ Ticker	KEYWORD1
 #######################################
 
 attach	KEYWORD2
-attach_ms KEYWORD2
-once  KEYWORD2
-detach  KEYWORD2
+attach_ms	KEYWORD2
+once	KEYWORD2
+detach	KEYWORD2

--- a/libraries/Update/keywords.txt
+++ b/libraries/Update/keywords.txt
@@ -13,10 +13,10 @@ Update	KEYWORD1
 #######################################
 
 begin	KEYWORD2
-end KEYWORD2
+end	KEYWORD2
 write	KEYWORD2
 writeStream	KEYWORD2
-printError   KEYWORD2
+printError	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords