### PR TITLE
Allow update to function over HTTPS due to peek() missing from mbedTLS.

### DIFF
--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -200,18 +200,6 @@ bool UpdateClass::_writeBuffer(){
     return true;
 }
 
-bool UpdateClass::_verifyHeader(uint8_t data) {
-    if(_command == U_FLASH) {
-        if(data != ESP_IMAGE_HEADER_MAGIC) {
-            _abort(UPDATE_ERROR_MAGIC_BYTE);
-            return false;
-        }
-        return true;
-    } else if(_command == U_SPIFFS) {
-        return true;
-    }
-    return false;
-}
 
 bool UpdateClass::_verifyEnd() {
     if(_command == U_FLASH) {
@@ -308,10 +296,6 @@ size_t UpdateClass::writeStream(Stream &data) {
     if(hasError() || !isRunning())
         return 0;
 
-    if(!_verifyHeader(data.peek())) {
-        _reset();
-        return 0;
-    }
     if (_progress_callback) {
         _progress_callback(0, _size);
     }


### PR DESCRIPTION
Removed redundant check of magic byte from writeStream()

* The magic byte is checked in _writeBuffer() before any flash is altered.
* The check using peek() earlier will at best only save a wasted read of one buffer length of data being read if data is missing the magic byte
* As we are already prepared to read an entire buffers worth of data anyway this saving doesn't matter.