### PR TITLE
fix Arduino component build when CONFIG_ARDUHAL_ESP_LOG is turned off

### DIFF
--- a/cores/esp32/esp32-hal-log.h
+++ b/cores/esp32/esp32-hal-log.h
@@ -107,9 +107,9 @@ int log_printf(const char *fmt, ...);
 #define log_e(format, ...)
 #endif
 
-#ifdef CONFIG_ARDUHAL_ESP_LOG
 #include "esp_log.h"
 
+#ifdef CONFIG_ARDUHAL_ESP_LOG
 #undef ESP_LOGE
 #undef ESP_LOGW
 #undef ESP_LOGI


### PR DESCRIPTION
I'm trying to build the IDF A2DP source example, and the Arduino core is getting pulled in.

BluetoothSerial uses ESP_LOGI/E/W but esp32-hal-log.h doesn't define those because esp_log.h is hidden behind an #ifdef.

```
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp: In function 'void esp_spp_cb(esp_spp_cb_event_t, esp_spp_cb_param_t*)':
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:48:45: error: 'ESP_LOGI' was not declared in this scope
         ESP_LOGI(SPP_TAG, "ESP_SPP_INIT_EVT");
                                             ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:69:111: error: 'ESP_LOGV' was not declared in this scope
         ESP_LOGV(SPP_TAG, "ESP_SPP_DATA_IND_EVT len=%d handle=%d", param->data_ind.len, param->data_ind.handle);
                                                                                                               ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:77:52: error: 'ESP_LOGE' was not declared in this scope
             ESP_LOGE(SPP_TAG, "SerialQueueBT ERROR");
                                                    ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp: In function 'bool _init_bt(const char*)':
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:98:72: error: 'ESP_LOGE' was not declared in this scope
         ESP_LOGE(SPP_TAG, "%s initialize controller failed\n", __func__);
                                                                        ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:105:75: error: 'ESP_LOGE' was not declared in this scope
             ESP_LOGE(SPP_TAG, "%s initialize bluedroid failed\n", __func__);
                                                                           ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:112:71: error: 'ESP_LOGE' was not declared in this scope
             ESP_LOGE(SPP_TAG, "%s enable bluedroid failed\n", __func__);
                                                                       ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:118:63: error: 'ESP_LOGE' was not declared in this scope
         ESP_LOGE(SPP_TAG, "%s spp register failed\n", __func__);
                                                               ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:123:59: error: 'ESP_LOGE' was not declared in this scope
         ESP_LOGE(SPP_TAG, "%s spp init failed\n", __func__);
                                                           ^
/Users/george/esp/esp-idf/components/arduino/libraries/BluetoothSerial/src//BluetoothSerial.cpp:129:64: error: 'ESP_LOGE' was not declared in this scope
         ESP_LOGE(SPP_TAG, "%s Queue creation error\n", __func__);
                                                                ^
```