### PR TITLE
Additional partition scheme min_spiffs

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -90,6 +90,8 @@ config ARDUHAL_PARTITION_SCHEME_MINIMAL
     bool "Minimal (for 2MB FLASH)"
 config ARDUHAL_PARTITION_SCHEME_NO_OTA
     bool "No OTA (for large apps)"
+config ARDUHAL_PARTITION_SCHEME_MIN_SPIFFS
+    bool "Minimal SPIFFS (for large apps with OTA)"
 endchoice
 
 config ARDUHAL_PARTITION_SCHEME
@@ -97,6 +99,7 @@ config ARDUHAL_PARTITION_SCHEME
     default "default" if ARDUHAL_PARTITION_SCHEME_DEFAULT
     default "minimal" if ARDUHAL_PARTITION_SCHEME_MINIMAL
     default "no_ota" if ARDUHAL_PARTITION_SCHEME_NO_OTA
+    default "min_spiffs" if ARDUHAL_PARTITION_SCHEME_MIN_SPIFFS
 
 
 config AUTOCONNECT_WIFI

--- a/boards.txt
+++ b/boards.txt
@@ -35,6 +35,8 @@ esp32.menu.PartitionScheme.minimal=Minimal (2MB FLASH)
 esp32.menu.PartitionScheme.minimal.build.partitions=minimal
 esp32.menu.PartitionScheme.no_ota=No OTA (Large APP)
 esp32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+esp32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
 
 esp32.menu.FlashMode.qio=QIO
 esp32.menu.FlashMode.qio.build.flash_mode=dio

--- a/tools/partitions/min_spiffs.csv
+++ b/tools/partitions/min_spiffs.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1E0000,
+app1,     app,  ota_1,   0x1F0000,0x1E0000,
+eeprom,   data, 0x99,    0x3F0000,0x1000,
+spiffs,   data, spiffs,  0x3F1000,0xF000,


### PR DESCRIPTION
with minimal SPIFFS partition size for bigger apps and OTA support 

useful for problems:
https://github.com/espressif/arduino-esp32/issues/1194
https://github.com/espressif/arduino-esp32/issues/1282
but leaving the OTA functionality available (unlike no_ota scheme)

addition for:
https://github.com/espressif/arduino-esp32/pull/1296/commits/535a55dd4ca19d7fa10d10e47367ed8edd7b866b
https://github.com/espressif/arduino-esp32/pull/1296/commits/75b08d542f560d1b588f47a43100acd43a869064

P.S. is there a possibility to add partitions select for all available boards? (not only for esp32 dev board)