### PR TITLE
Generate `SYSTEM_EVENT_WIFI_READY` event

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -147,6 +147,9 @@ static bool espWiFiStart(){
         return false;
     }
     _esp_wifi_started = true;
+    system_event_t event; 
+    event.event_id = SYSTEM_EVENT_WIFI_READY; 
+    WiFiGenericClass::_eventCallback(nullptr, &event); 
     return true;
 }
 


### PR DESCRIPTION
For what ever reason the `SYSTEM_EVENT_WIFI_READY` event is never generated by the sdk. 
This is a pain for services that require its init prior to begin started. 
This generates the event via `WiFi` class to allow services to hook in.