### PR TITLE
Add guard to handle to check for _initialized

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -370,6 +370,9 @@ void ArduinoOTAClass::end() {
 }
 
 void ArduinoOTAClass::handle() {
+    if (!_initialized) {
+        return; 
+    }
     if (_state == OTA_RUNUPDATE) {
         _runUpdate();
         _state = OTA_IDLE;


### PR DESCRIPTION
The wifi stack initialisation must be complete before calling  `_udp_ota.parsePacket()` otherwise you just get a screen filled with 
```
```
and due to the more async methods in ESP32 `handle()` may be called before this can occur.