### PR TITLE
Change - to _ in build.board names

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1037,7 +1037,7 @@ esp32vn-iot-uno.serial.disableRTS=true
 esp32vn-iot-uno.build.mcu=esp32
 esp32vn-iot-uno.build.core=esp32
 esp32vn-iot-uno.build.variant=esp32vn-iot-uno
-esp32vn-iot-uno.build.board=esp32vn-iot-uno
+esp32vn-iot-uno.build.board=esp32vn_iot_uno
 
 esp32vn-iot-uno.build.f_cpu=240000000L
 esp32vn-iot-uno.build.flash_mode=dio
@@ -1134,7 +1134,7 @@ esp32-evb.serial.disableRTS=true
 esp32-evb.build.mcu=esp32
 esp32-evb.build.core=esp32
 esp32-evb.build.variant=esp32-evb
-esp32-evb.build.board=ESP32-EVB
+esp32-evb.build.board=ESP32_EVB
 
 esp32-evb.build.f_cpu=240000000L
 esp32-evb.build.flash_mode=dio
@@ -1166,7 +1166,7 @@ esp32-gateway.serial.disableRTS=true
 esp32-gateway.build.mcu=esp32
 esp32-gateway.build.core=esp32
 esp32-gateway.build.variant=esp32-gateway
-esp32-gateway.build.board=ESP32-GATEWAY
+esp32-gateway.build.board=ESP32_GATEWAY
 
 esp32-gateway.build.f_cpu=240000000L
 esp32-gateway.build.flash_mode=dio


### PR DESCRIPTION
`build.board` is used to define a macro but `-` is not a permitted character in macro names. This causes the macro name to actually be only everything up to the first `-` and also many warnings when compiling for one of these boards:
```
<command-line>:0:14: warning: ISO C++11 requires whitespace after the macro name

<command-line>:0:14: warning: ISO C99 requires whitespace after the macro name
```
I have followed the convention of the other `build.board` names by replacing `-` with `_`.

Related:
https://github.com/espressif/arduino-esp32/pull/812
https://github.com/espressif/arduino-esp32/pull/1187
