### PR TITLE
std::functioanl for WFIF event + Minor fix

### DIFF
--- a/cores/esp32/pgmspace.h
+++ b/cores/esp32/pgmspace.h
@@ -71,7 +71,7 @@ typedef unsigned long prog_uint32_t;
 #define memcpy_P      memcpy
 #define strcpy_P      strcpy
 #define strncpy_P     strncpy
-#define strcat_p      strcat
+#define strcat_P      strcat
 #define strncat_P     strncat
 #define strcmp_P      strcmp
 #define strncmp_P     strncmp

--- a/libraries/WiFi/examples/WiFiClientEvents/WiFiClientEvents.ino
+++ b/libraries/WiFi/examples/WiFiClientEvents/WiFiClientEvents.ino
@@ -1,7 +1,37 @@
 /*
  *  This sketch shows the WiFi event usage
  *
- */
+*/
+
+/* 
+* WiFi Events
+
+SYSTEM_EVENT_WIFI_READY               < ESP32 WiFi ready
+SYSTEM_EVENT_SCAN_DONE                < ESP32 finish scanning AP
+SYSTEM_EVENT_STA_START                < ESP32 station start
+SYSTEM_EVENT_STA_STOP                 < ESP32 station stop
+SYSTEM_EVENT_STA_CONNECTED            < ESP32 station connected to AP
+SYSTEM_EVENT_STA_DISCONNECTED         < ESP32 station disconnected from AP
+SYSTEM_EVENT_STA_AUTHMODE_CHANGE      < the auth mode of AP connected by ESP32 station changed
+SYSTEM_EVENT_STA_GOT_IP               < ESP32 station got IP from connected AP
+SYSTEM_EVENT_STA_LOST_IP              < ESP32 station lost IP and the IP is reset to 0
+SYSTEM_EVENT_STA_WPS_ER_SUCCESS       < ESP32 station wps succeeds in enrollee mode
+SYSTEM_EVENT_STA_WPS_ER_FAILED        < ESP32 station wps fails in enrollee mode
+SYSTEM_EVENT_STA_WPS_ER_TIMEOUT       < ESP32 station wps timeout in enrollee mode
+SYSTEM_EVENT_STA_WPS_ER_PIN           < ESP32 station wps pin code in enrollee mode
+SYSTEM_EVENT_AP_START                 < ESP32 soft-AP start
+SYSTEM_EVENT_AP_STOP                  < ESP32 soft-AP stop
+SYSTEM_EVENT_AP_STACONNECTED          < a station connected to ESP32 soft-AP
+SYSTEM_EVENT_AP_STADISCONNECTED       < a station disconnected from ESP32 soft-AP
+SYSTEM_EVENT_AP_PROBEREQRECVED        < Receive probe request packet in soft-AP interface
+SYSTEM_EVENT_GOT_IP6                  < ESP32 station or ap or ethernet interface v6IP addr is preferred
+SYSTEM_EVENT_ETH_START                < ESP32 ethernet start
+SYSTEM_EVENT_ETH_STOP                 < ESP32 ethernet stop
+SYSTEM_EVENT_ETH_CONNECTED            < ESP32 ethernet phy link up
+SYSTEM_EVENT_ETH_DISCONNECTED         < ESP32 ethernet phy link down
+SYSTEM_EVENT_ETH_GOT_IP               < ESP32 ethernet got IP from connected AP
+SYSTEM_EVENT_MAX
+*/
 
 #include <WiFi.h>
 
@@ -13,7 +43,8 @@ void WiFiEvent(WiFiEvent_t event)
 {
     Serial.printf("[WiFi-event] event: %d\n", event);
 
-    switch(event) {
+    switch (event)
+    {
     case SYSTEM_EVENT_STA_GOT_IP:
         Serial.println("WiFi connected");
         Serial.println("IP address: ");
@@ -25,6 +56,13 @@ void WiFiEvent(WiFiEvent_t event)
     }
 }
 
+void WiFiGotIP(WiFiEvent_t event, WiFiEventInfo_t info)
+{
+    Serial.println("WiFi connected");
+    Serial.println("IP address: ");
+    Serial.println(IPAddress(info.got_ip.ip_info.ip.addr));
+}
+
 void setup()
 {
     Serial.begin(115200);
@@ -34,7 +72,18 @@ void setup()
 
     delay(1000);
 
+    // Examples of diffrent ways to register wifi events
     WiFi.onEvent(WiFiEvent);
+    WiFi.onEvent(WiFiGotIP, WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP);
+    WiFiEventId_t eventID = WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info){
+        Serial.print("WiFi lost connection. Reason: ");
+        Serial.println(info.disconnected.reason);
+    }, WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
+
+    // Remove WiFi event
+    Serial.print("WiFi Event ID: ");
+    Serial.println(eventID);
+    // WiFi.removeEvent(eventID);
 
     WiFi.begin(ssid, password);
 
@@ -43,9 +92,7 @@ void setup()
     Serial.println("Wait for WiFi... ");
 }
 
-
 void loop()
 {
     delay(1000);
 }
-

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -23,6 +23,7 @@
 #ifndef ESP32WIFIGENERIC_H_
 #define ESP32WIFIGENERIC_H_
 
+#include <functional>
 #include "WiFiType.h"
 #include <esp_err.h>
 #include <esp_event_loop.h>
@@ -30,6 +31,7 @@
 typedef void (*WiFiEventCb)(system_event_id_t event);
 typedef void (*WiFiEventFullCb)(system_event_id_t event, system_event_info_t info);
 typedef void (*WiFiEventSysCb)(system_event_t *event);
+typedef std::function<void(system_event_id_t event, system_event_info_t info)> WiFiEventFuncCb;
 
 class WiFiGenericClass
 {
@@ -37,12 +39,14 @@ public:
 
     WiFiGenericClass();
 
-    void onEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
-    void onEvent(WiFiEventFullCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
-    void onEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    size_t onEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    size_t onEvent(WiFiEventFullCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    size_t onEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    size_t onEvent(WiFiEventFuncCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(WiFiEventFullCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    void removeEvent(size_t id);
 
     int32_t channel(void);
 

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -23,30 +23,28 @@
 #ifndef ESP32WIFIGENERIC_H_
 #define ESP32WIFIGENERIC_H_
 
-#include <functional>
-#include "WiFiType.h"
 #include <esp_err.h>
 #include <esp_event_loop.h>
+#include <functional>
+#include "WiFiType.h"
 
 typedef void (*WiFiEventCb)(system_event_id_t event);
-typedef void (*WiFiEventFullCb)(system_event_id_t event, system_event_info_t info);
-typedef void (*WiFiEventSysCb)(system_event_t *event);
 typedef std::function<void(system_event_id_t event, system_event_info_t info)> WiFiEventFuncCb;
+typedef void (*WiFiEventSysCb)(system_event_t *event);
+
+typedef size_t wifi_event_id_t;
 
 class WiFiGenericClass
 {
-public:
-
+  public:
     WiFiGenericClass();
 
-    size_t onEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
-    size_t onEvent(WiFiEventFullCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
-    size_t onEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
-    size_t onEvent(WiFiEventFuncCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    wifi_event_id_t onEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    wifi_event_id_t onEvent(WiFiEventFuncCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    wifi_event_id_t onEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
-    void removeEvent(WiFiEventFullCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
-    void removeEvent(size_t id);
+    void removeEvent(wifi_event_id_t id);
 
     int32_t channel(void);
 
@@ -60,16 +58,14 @@ public:
 
     static esp_err_t _eventCallback(void *arg, system_event_t *event);
 
-protected:
+  protected:
     static bool _persistent;
     static wifi_mode_t _forceSleepLastMode;
 
-public:
+  public:
+    int hostByName(const char *aHostname, IPAddress &aResult);
 
-    int hostByName(const char* aHostname, IPAddress& aResult);
-
-protected:
-
+  protected:
     friend class WiFiSTAClass;
     friend class WiFiScanClass;
     friend class WiFiAPClass;

--- a/libraries/WiFi/src/WiFiType.h
+++ b/libraries/WiFi/src/WiFiType.h
@@ -33,7 +33,8 @@
 #define WIFI_AP_STA  WIFI_MODE_APSTA
 
 #define WiFiEvent_t  system_event_id_t
-#define WiFiEvent_id_t wifi_event_id_t;
+#define WiFiEventInfo_t system_event_info_t
+#define WiFiEventId_t wifi_event_id_t
 
 
 typedef enum {

--- a/libraries/WiFi/src/WiFiType.h
+++ b/libraries/WiFi/src/WiFiType.h
@@ -33,6 +33,8 @@
 #define WIFI_AP_STA  WIFI_MODE_APSTA
 
 #define WiFiEvent_t  system_event_id_t
+#define WiFiEvent_id_t wifi_event_id_t;
+
 
 typedef enum {
     WL_NO_SHIELD        = 255,   // for compatibility with WiFi Shield library


### PR DESCRIPTION
+ Fix for WiFi onEvent std::functional #1174
+ Minor fix for #1185 strcat_P

I couldnt work out how to remove the wifif event like how the other functions do, using a std::functional since i cant equate functionals as the same (ie the == operater doesnt work), thus i had to use an id work around, which IMHO isnt a bad thing, Please review and tell me how i can improve :) (my fist PR here....)