### PR TITLE
Fix WiFiClient error handling

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -313,7 +313,7 @@ uint8_t WiFiClient::connected()
     if (_connected) {
         uint8_t dummy;
         int res = recv(fd(), &dummy, 0, MSG_DONTWAIT);
-        if (res <= 0) {
+        if (res < 0) {
             switch (errno) {
                 case ENOTCONN:
                 case EPIPE:
@@ -328,7 +328,6 @@ uint8_t WiFiClient::connected()
             }
         }
         else {
-            // Should never happen since requested 0 bytes
             _connected = true;
         }
     }


### PR DESCRIPTION
`WiFiClient::connected()` incorrectly checks `errno`. If any other function before this call sets `errno`, the `connected()` returns false even though `recv()` result was 0. This is because `recv` function does not reset `errno` variable on successful operation and old unknown value is used in switch.

This behaviour can be observed when using multiple `WiFiClient` objects and one of them disconnects with an error. Subsequent `connected()` call on a healthy connection would return false due to a previous set `errno`.

I propose a change to only check for `errno` if `recv()` call fails.