### PR TITLE
Port SSL fingerprint checking from ESP8266 WiFiClientSecure to ESP32

### DIFF
--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -210,6 +210,14 @@ void WiFiClientSecure::setPrivateKey (const char *private_key)
     _private_key = private_key;
 }
 
+bool WiFiClientSecure::verify(const char* fp, const char* domain_name)
+{
+    if (!sslclient)
+        return false;
+
+    return verify_ssl_fingerprint(sslclient, fp, domain_name);
+}
+
 int WiFiClientSecure::lastError(char *buf, const size_t size)
 {
     if (!_lastError) {

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.h
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.h
@@ -58,6 +58,7 @@ public:
     void setCACert(const char *rootCA);
     void setCertificate(const char *client_ca);
     void setPrivateKey (const char *private_key);
+    bool verify(const char* fingerprint, const char* domain_name);
 
     operator bool()
     {

--- a/libraries/WiFiClientSecure/src/ssl_client.h
+++ b/libraries/WiFiClientSecure/src/ssl_client.h
@@ -32,5 +32,7 @@ void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, cons
 int data_to_read(sslclient_context *ssl_client);
 int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, uint16_t len);
 int get_ssl_receive(sslclient_context *ssl_client, uint8_t *data, int length);
+bool verify_ssl_fingerprint(sslclient_context *ssl_client, const char* fp, const char* domain_name);
+bool verify_ssl_dn(sslclient_context *ssl_client, const char* domain_name);
 
 #endif


### PR DESCRIPTION
This PR ports `verify` function from ESP8266 WiFiClientSecure which verifies remote certificate fingerprint.

Since sha1 is no longer secure, I switched to sha256.

Fixes #278