### PR TITLE
Fix WiFi.persistent(false); having no effect.

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -108,7 +108,7 @@ void tcpipInit(){
     }
 }
 
-static bool wifiLowLevelInit(){
+static bool wifiLowLevelInit(bool persistent){
     static bool lowLevelInitDone = false;
     if(!lowLevelInitDone){
         tcpipInit();
@@ -118,7 +118,9 @@ static bool wifiLowLevelInit(){
             log_e("esp_wifi_init %d", err);
             return false;
         }
-        esp_wifi_set_storage(WIFI_STORAGE_FLASH);
+        if(!persistent){
+          esp_wifi_set_storage(WIFI_STORAGE_RAM);
+        }
         esp_wifi_set_mode(WIFI_MODE_NULL);
         lowLevelInitDone = true;
     }
@@ -133,11 +135,11 @@ static bool wifiLowLevelDeinit(){
 
 static bool _esp_wifi_started = false;
 
-static bool espWiFiStart(){
+static bool espWiFiStart(bool persistent){
     if(_esp_wifi_started){
         return true;
     }
-    if(!wifiLowLevelInit()){
+    if(!wifiLowLevelInit(persistent)){
         return false;
     }
     esp_err_t err = esp_wifi_start();
@@ -383,7 +385,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
         return false;
     }
     if(m){
-        return espWiFiStart();
+        return espWiFiStart(_persistent);
     }
     return espWiFiStop();
 }
@@ -394,7 +396,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
  */
 wifi_mode_t WiFiGenericClass::getMode()
 {
-    if(!wifiLowLevelInit()){
+    if(!wifiLowLevelInit(_persistent)){
         return WIFI_MODE_MAX;
     }
     uint8_t mode;


### PR DESCRIPTION
  This PR calls `esp_wifi_set_storage(WIFI_STORAGE_RAM);` when persistent WiFi configuration is not desired.

according to the ESP32 API reference guide the default is to store WiFi configuration in NVS.

esp_err_t esp_wifi_set_storage(wifi_storage_tstorage)
Set the WiFi API configuration storage type.

Attention
1. The default value is WIFI_STORAGE_FLASH