### PR TITLE
Port UART reset fix from ESP-IDF

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -315,11 +315,14 @@ void uartFlush(uart_t* uart)
     UART_MUTEX_LOCK();
     while(uart->dev->status.txfifo_cnt);
 
-    uart->dev->conf0.txfifo_rst = 1;
-    uart->dev->conf0.txfifo_rst = 0;
+    //Due to hardware issue, we can not use fifo_rst to reset uart fifo.
+    //See description about UART_TXFIFO_RST and UART_RXFIFO_RST in <<esp32_technical_reference_manual>> v2.6 or later.
 
-    uart->dev->conf0.rxfifo_rst = 1;
-    uart->dev->conf0.rxfifo_rst = 0;
+    // we read the data out and make `fifo_len == 0 && rd_addr == wr_addr`.
+    while(uart->dev->status.rxfifo_cnt != 0 || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
+        READ_PERI_REG(UART_FIFO_REG(uart->num));
+    }
+
     UART_MUTEX_UNLOCK();
 }
 


### PR DESCRIPTION
`uartFlush()` does not work after soft reset due to a hardware bug in ESP32. This was fixed in ESP-IDF by reading out all data from the buffers instead of using reset bits.

Using reset bits on UART1 also corrupts data in UART2. From technical reference manual:
> UART2 doesn’t have any register to reset Tx_FIFO or Rx_FIFO, and the UART1_TXFIFO_RST and UART1_RXFIFO_RST in UART1 may impact the functioning of UART2. Therefore, these two registers in UART1 should only be used when the Tx_FIFO and Rx_FIFO in UART2 do not have any data. (R/W)

Hence UART should only be flushed by reading out.

ESP-IDF commits:
https://github.com/espressif/esp-idf/commit/4052803e161ba06d1cae8d36bc66dde15b3fc8c7
https://github.com/espressif/esp-idf/commit/492db0591d0c5643cb863b76600ab0bf5a204b64

Fixes: #662 