### PR TITLE
Add submodule of Azure IoT library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libraries/BLE"]
 	path = libraries/BLE
 	url = https://github.com/nkolban/ESP32_BLE_Arduino.git
+[submodule "libraries/AzureIoT"]
+	path = libraries/AzureIoT
+	url = https://github.com/VSChina/ESP32_AzureIoT_Arduino


### PR DESCRIPTION
This library is a port of the Microsoft Azure IoT device SDK for C to Arduino for esp32 devices. It allows user to use several Arduino compatible ESP32 boards with Azure IoT Hub.