### PR TITLE
add support for TXT records in mDNS query responses

### DIFF
--- a/libraries/ESPmDNS/src/ESPmDNS.cpp
+++ b/libraries/ESPmDNS/src/ESPmDNS.cpp
@@ -285,4 +285,51 @@ uint16_t MDNSResponder::port(int idx) {
     return result->port;
 }
 
+int MDNSResponder::numTxt(int idx) {
+    mdns_result_t * result = _getResult(idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return 0;
+    }
+    return result->txt_count;
+}
+
+bool MDNSResponder::hasTxt(int idx, const char * key) {
+    mdns_result_t * result = _getResult(idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return false;
+    }
+    int i = 0;
+    while(i < result->txt_count) {
+        if (strcmp(result->txt[i].key, key) == 0) return true;
+        i++;
+    }
+    return false;
+}
+
+String MDNSResponder::txt(int idx, const char * key) {
+    mdns_result_t * result = _getResult(idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return "";
+    }
+    int i = 0;
+    while(i < result->txt_count) {
+        if (strcmp(result->txt[i].key, key) == 0) return result->txt[i].value;
+        i++;
+    }
+    return "";
+}
+
+String MDNSResponder::txt(int idx, int txtIdx) {
+    mdns_result_t * result = _getResult(idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return "";
+    }
+    if (txtIdx >= result->txt_count) return "";
+    return result->txt[txtIdx].value;
+}
+
 MDNSResponder MDNS;

--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -107,6 +107,10 @@ public:
   IPAddress IP(int idx);
   IPv6Address IPv6(int idx);
   uint16_t port(int idx);
+  int numTxt(int idx);
+  bool hasTxt(int idx, const char * key);
+  String txt(int idx, const char * key);
+  String txt(int idx, int txtIdx);
   
 private:
   String _hostname;


### PR DESCRIPTION
This patch is for adding methods which get TXT record values from mDNS result.