### PR TITLE
Missing include gpio.h in esp32-hal-dac.h

### DIFF
--- a/cores/esp32/esp32-hal-dac.h
+++ b/cores/esp32/esp32-hal-dac.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 #include "esp32-hal.h"
+#include "driver/gpio.h"
 
 void dacWrite(uint8_t pin, uint8_t value);
 


### PR DESCRIPTION
Missing include gpio.h in esp32-hal-dac.h. Fixes https://github.com/espressif/arduino-esp32/issues/1500