### PR TITLE
Broke HTTP_Method out into a separate header for reuse in ESPAsyncWe…

### DIFF
--- a/libraries/WebServer/src/HTTP_Method.h
+++ b/libraries/WebServer/src/HTTP_Method.h
@@ -1,0 +1,15 @@
+#ifndef _HTTP_Method_H_
+#define _HTTP_Method_H_
+
+typedef enum {
+  HTTP_GET     = 0b00000001,
+  HTTP_POST    = 0b00000010,
+  HTTP_DELETE  = 0b00000100,
+  HTTP_PUT     = 0b00001000,
+  HTTP_PATCH   = 0b00010000,
+  HTTP_HEAD    = 0b00100000,
+  HTTP_OPTIONS = 0b01000000,
+  HTTP_ANY     = 0b01111111,
+} HTTPMethod;
+
+#endif /* _HTTP_Method_H_ */

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -27,8 +27,8 @@
 #include <functional>
 #include <memory>
 #include <WiFi.h>
+#include "HTTP_Method.h"
 
-enum HTTPMethod { HTTP_ANY, HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_PATCH, HTTP_DELETE, HTTP_OPTIONS };
 enum HTTPUploadStatus { UPLOAD_FILE_START, UPLOAD_FILE_WRITE, UPLOAD_FILE_END,
                         UPLOAD_FILE_ABORTED };
 enum HTTPClientStatus { HC_NONE, HC_WAIT_READ, HC_WAIT_CLOSE };


### PR DESCRIPTION
ESPAsyncWebServer uses some bitmasking on this structure, so it needs to have the specific numeric values.  WebServer doesn't seem to care.