### PR TITLE
EEPROM.readstring was returning an extra character

### DIFF
--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -296,9 +296,9 @@ String EEPROMClass::readString (int address)
   if (address + len > _size)
     return String(0);
 
-  char value[len + 1];
+  char value[len];
   memcpy((uint8_t*) value, _data + address, len);
-  value[len + 1] = 0;
+  value[len] = 0;
   return String(value);
 }
 


### PR DESCRIPTION
Fixes #1608 