### PR TITLE
Add XinaBox CW02 to supported boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -101,6 +101,82 @@ esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 
+cw02.name=XinaBox CW02
+
+cw02.upload.tool=esptool
+cw02.upload.maximum_size=1310720
+cw02.upload.maximum_data_size=294912
+cw02.upload.wait_for_upload_port=true
+
+cw02.serial.disableDTR=true
+cw02.serial.disableRTS=true
+
+cw02.build.mcu=esp32
+cw02.build.core=esp32
+cw02.build.variant=xinabox
+cw02.build.board=ESP32_DEV
+
+cw02.build.f_cpu=240000000L
+cw02.build.flash_size=4MB
+cw02.build.flash_freq=40m
+cw02.build.flash_mode=dio
+cw02.build.boot=dio
+cw02.build.partitions=default
+
+cw02.menu.FlashMode.qio=QIO
+cw02.menu.FlashMode.qio.build.flash_mode=dio
+cw02.menu.FlashMode.qio.build.boot=qio
+cw02.menu.FlashMode.dio=DIO
+cw02.menu.FlashMode.dio.build.flash_mode=dio
+cw02.menu.FlashMode.dio.build.boot=dio
+cw02.menu.FlashMode.qout=QOUT
+cw02.menu.FlashMode.qout.build.flash_mode=dout
+cw02.menu.FlashMode.qout.build.boot=qout
+cw02.menu.FlashMode.dout=DOUT
+cw02.menu.FlashMode.dout.build.flash_mode=dout
+cw02.menu.FlashMode.dout.build.boot=dout
+
+cw02.menu.FlashFreq.80=80MHz
+cw02.menu.FlashFreq.80.build.flash_freq=80m
+cw02.menu.FlashFreq.40=40MHz
+cw02.menu.FlashFreq.40.build.flash_freq=40m
+
+cw02.menu.FlashSize.4M=4MB (32Mb)
+cw02.menu.FlashSize.4M.build.flash_size=4MB
+cw02.menu.FlashSize.2M=2MB (16Mb)
+cw02.menu.FlashSize.2M.build.flash_size=2MB
+cw02.menu.FlashSize.2M.build.partitions=minimal
+
+cw02.menu.UploadSpeed.921600=921600
+cw02.menu.UploadSpeed.921600.upload.speed=921600
+cw02.menu.UploadSpeed.115200=115200
+cw02.menu.UploadSpeed.115200.upload.speed=115200
+cw02.menu.UploadSpeed.256000.windows=256000
+cw02.menu.UploadSpeed.256000.upload.speed=256000
+cw02.menu.UploadSpeed.230400.windows.upload.speed=256000
+cw02.menu.UploadSpeed.230400=230400
+cw02.menu.UploadSpeed.230400.upload.speed=230400
+cw02.menu.UploadSpeed.460800.linux=460800
+cw02.menu.UploadSpeed.460800.macosx=460800
+cw02.menu.UploadSpeed.460800.upload.speed=460800
+cw02.menu.UploadSpeed.512000.windows=512000
+cw02.menu.UploadSpeed.512000.upload.speed=512000
+
+cw02.menu.DebugLevel.none=None
+cw02.menu.DebugLevel.none.build.code_debug=0
+cw02.menu.DebugLevel.error=Error
+cw02.menu.DebugLevel.error.build.code_debug=1
+cw02.menu.DebugLevel.warn=Warn
+cw02.menu.DebugLevel.warn.build.code_debug=2
+cw02.menu.DebugLevel.info=Info
+cw02.menu.DebugLevel.info.build.code_debug=3
+cw02.menu.DebugLevel.debug=Debug
+cw02.menu.DebugLevel.debug.build.code_debug=4
+cw02.menu.DebugLevel.verbose=Verbose
+cw02.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 esp32wrover.name=ESP32 Wrover Module
 
 esp32wrover.upload.tool=esptool

--- a/variants/xinabox/pins_arduino.h
+++ b/variants/xinabox/pins_arduino.h
@@ -1,0 +1,58 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t LED_BUILTIN = 27;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */

--- a/variants/xinabox/pins_arduino.h
+++ b/variants/xinabox/pins_arduino.h
@@ -25,34 +25,4 @@ static const uint8_t MOSI  = 23;
 static const uint8_t MISO  = 19;
 static const uint8_t SCK   = 18;
 
-static const uint8_t A0 = 36;
-static const uint8_t A3 = 39;
-static const uint8_t A4 = 32;
-static const uint8_t A5 = 33;
-static const uint8_t A6 = 34;
-static const uint8_t A7 = 35;
-static const uint8_t A10 = 4;
-static const uint8_t A11 = 0;
-static const uint8_t A12 = 2;
-static const uint8_t A13 = 15;
-static const uint8_t A14 = 13;
-static const uint8_t A15 = 12;
-static const uint8_t A16 = 14;
-static const uint8_t A18 = 25;
-static const uint8_t A19 = 26;
-
-static const uint8_t T0 = 4;
-static const uint8_t T1 = 0;
-static const uint8_t T2 = 2;
-static const uint8_t T3 = 15;
-static const uint8_t T4 = 13;
-static const uint8_t T5 = 12;
-static const uint8_t T6 = 14;
-static const uint8_t T7 = 27;
-static const uint8_t T8 = 33;
-static const uint8_t T9 = 32;
-
-static const uint8_t DAC1 = 25;
-static const uint8_t DAC2 = 26;
-
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
We have a product based off the ESP32 WROOM-32 module.  
Information of the product can be found on our [store](https://xinabox.cc/products/cw02).
Additional info can be found on our [wiki](https://wiki.xinabox.cc/CW02_-_Wi-Fi_%26_Bluetooth_Core).