### PR TITLE
Code linking with Arduino1.8.5 failed

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -3,7 +3,7 @@ version=0.0.1
 
 runtime.tools.xtensa-esp32-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32-elf
 
-tools.esptool.path={runtime.platform.path}/tools/esptool
+tools.esptool.path={runtime.platform.path}/tools
 tools.esptool.cmd=esptool
 tools.esptool.cmd.linux=esptool.py
 tools.esptool.cmd.windows=esptool.exe


### PR DESCRIPTION
While linking the code, it invoking esptool.exe from esptool folder ( tools/esptool/esptool.exe). However, there is no folder "esptool" under "tools" folder in the code package. We getting an error exec: "C:\\Users\\Username\\Documents\\Arduino\\hardware\\espressif\\esp32\\tools\\esptool\\esptool.exe" file doesn't exist. Kindly check the issue.
OS: Windows 10