### PR TITLE
Remove unused variable

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -126,7 +126,6 @@ uint8_t WiFiMulti::run(uint32_t connectTimeout)
                 }
 
                 IPAddress ip;
-                uint8_t * mac;
                 switch(status) {
                 case 3:
                     ip = WiFi.localIP();


### PR DESCRIPTION
From platformio:

WiFiMulti.cpp:129:27: warning: variable 'mac' set but not used [-Wunused-but-set-variable]