### PR TITLE
EEPROM library: Move #include of Arduino.h to header file

### DIFF
--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -24,7 +24,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "Arduino.h"
 #include "EEPROM.h"
 
 #include <esp_log.h>

--- a/libraries/EEPROM/EEPROM.h
+++ b/libraries/EEPROM/EEPROM.h
@@ -29,6 +29,7 @@
 #ifndef EEPROM_FLASH_PARTITION_NAME
 #define EEPROM_FLASH_PARTITION_NAME "eeprom"
 #endif
+#include <Arduino.h>
 extern "C" {
 
 #include <stddef.h>


### PR DESCRIPTION
EEPROM.h uses data types which are declared through Arduino.h but that file does not contain an `#include` directive for Arduino.h. This does not cause any problems when the EEPROM library is `#included` from a .ino file because the Arduino IDE automatically adds an `#include` directive for Arduino.h but this is not the case for .cpp files. If a .cpp file has an `#include` directive for EEPROM.h that does not follow an `#include` directive for Arduino.h then compilation fails:
```
E:\arduino\hardware\espressif\esp32\libraries\EEPROM/EEPROM.h:91:5: error: 'float_t' does not name a type

     float_t readFloat(int address);

     ^

E:\arduino\hardware\espressif\esp32\libraries\EEPROM/EEPROM.h:92:5: error: 'double_t' does not name a type

     double_t readDouble(int address);

     ^

E:\arduino\hardware\espressif\esp32\libraries\EEPROM/EEPROM.h:95:5: error: 'String' does not name a type

     String readString(int address);

     ^

E:\arduino\hardware\espressif\esp32\libraries\EEPROM/EEPROM.h:110:36: error: 'float_t' has not been declared

     size_t writeFloat(int address, float_t value);

                                    ^

E:\arduino\hardware\espressif\esp32\libraries\EEPROM/EEPROM.h:111:37: error: 'double_t' has not been declared

     size_t writeDouble(int address, double_t value);

                                     ^

E:\arduino\hardware\espressif\esp32\libraries\EEPROM/EEPROM.h:114:37: error: 'String' has not been declared

     size_t writeString(int address, String value);
```

Fixes https://github.com/espressif/arduino-esp32/issues/1614