### PR TITLE
Selective compilation

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -106,8 +106,147 @@ config AUTOCONNECT_WIFI
     bool "Autoconnect WiFi on boot"
     default "n"
     depends on AUTOSTART_ARDUINO
+    depends on ARDUINO_SELECTIVE_WiFi
     help
         If enabled, WiFi will connect to the last used SSID (if station was enabled),
         else connection will be started only after calling WiFi.begin(ssid, password)
+
+config ARDUINO_SELECTIVE_COMPILATION
+    bool "Include only specific Arduino libraries"
+    default n
+
+config ARDUINO_SELECTIVE_ArduinoOTA
+    bool "Enable ArduinoOTA"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_WiFi
+    select ARDUINO_SELECTIVE_ESPmDNS
+    default y
+
+config ARDUINO_SELECTIVE_AsyncUDP
+    bool "Enable AsyncUDP"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_AzureIoT
+    bool "Enable AzureIoT"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_HTTPClient
+    default y
+
+config ARDUINO_SELECTIVE_BLE
+    bool "Enable BLE"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_BluetoothSerial
+    bool "Enable BluetoothSerial"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_DNSServer
+    bool "Enable DNSServer"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_WiFi
+    default y
+
+config ARDUINO_SELECTIVE_EEPROM
+    bool "Enable EEPROM"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_ESP32
+    bool "Enable ESP32"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_ESPmDNS
+    bool "Enable ESPmDNS"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_WiFi
+    default y
+
+config ARDUINO_SELECTIVE_FS
+    bool "Enable FS"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_HTTPClient
+    bool "Enable HTTPClient"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_WiFi
+    select ARDUINO_SELECTIVE_WiFiClientSecure
+    default y
+
+config ARDUINO_SELECTIVE_NetBIOS
+    bool "Enable NetBIOS"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_WiFi
+    default y
+
+config ARDUINO_SELECTIVE_Preferences
+    bool "Enable Preferences"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_SD
+    bool "Enable SD"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_FS
+    default y
+
+config ARDUINO_SELECTIVE_SD_MMC
+    bool "Enable SD_MMC"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_FS
+    default y
+
+config ARDUINO_SELECTIVE_SimpleBLE
+    bool "Enable SimpleBLE"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_SPI
+    bool "Enable SPI"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_SPIFFS
+    bool "Enable SPIFFS"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_FS
+    default y
+
+config ARDUINO_SELECTIVE_Ticker
+    bool "Enable Ticker"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_Update
+    bool "Enable Update"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_WebServer
+    bool "Enable WebServer"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+    select ARDUINO_SELECTIVE_FS
+
+config ARDUINO_SELECTIVE_WiFi
+    bool "Enable WiFi"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
+config ARDUINO_SELECTIVE_WiFiClientSecure
+    bool "Enable WiFiClientSecure"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_WiFi
+    default y
+
+config ARDUINO_SELECTIVE_Wire
+    bool "Enable Wire"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
 
 endmenu

--- a/component.mk
+++ b/component.mk
@@ -1,4 +1,128 @@
-ARDUINO_CORE_LIBS := $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/))))
+ARDUINO_CORE_LIBS := $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/*/*/*/*/*/*/))))
+
+SPECIFIC_LIBS :=
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_ArduinoOTA)"
+MODULE := ArduinoOTA
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_AsyncUDP)"
+MODULE := AsyncUDP
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_AzureIoT)"
+MODULE := AzureIoT
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_BLE)"
+MODULE := BLE
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_BluetoothSerial)"
+MODULE := BluetoothSerial
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_DNSServer)"
+MODULE := DNSServer
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_EEPROM)"
+MODULE := EEPROM
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_ESP32)"
+MODULE := ESP32
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_ESPmDNS)"
+MODULE := ESPmDNS
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_FS)"
+MODULE := FS
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_HTTPClient)"
+MODULE := HTTPClient
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_NetBIOS)"
+MODULE := NetBIOS
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_Preferences)"
+MODULE := Preferences
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_SD)"
+MODULE := SD
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_SD_MMC)"
+MODULE := SD_MMC
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_SimpleBLE)"
+MODULE := SimpleBLE
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_SPI)"
+MODULE := SPI
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_SPIFFS)"
+MODULE := SPIFFS
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_Ticker)"
+MODULE := Ticker
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_Update)"
+MODULE := Update
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_WebServer)"
+MODULE := WebServer
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_WiFi)"
+MODULE := WiFi
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_WiFiClientSecure)"
+MODULE := WiFiClientSecure
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ifneq "y" "$(CONFIG_ARDUINO_SELECTIVE_Wire)"
+MODULE := Wire
+SPECIFIC_LIBS += $(patsubst $(COMPONENT_PATH)/%,%,$(sort $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/)) $(dir $(wildcard $(COMPONENT_PATH)/libraries/$(MODULE)/*/*/*/*/*/))))
+endif
+
+ARDUINO_CORE_LIBS := $(filter-out $(SPECIFIC_LIBS),$(ARDUINO_CORE_LIBS))
 
 COMPONENT_ADD_INCLUDEDIRS := cores/esp32 variants/esp32 $(ARDUINO_CORE_LIBS)
 COMPONENT_PRIV_INCLUDEDIRS := cores/esp32/libb64


### PR DESCRIPTION
1. This allows to unselect specific modules from build. Enables speedup of compilation time and also enables and reduces size where whole archive is needed for late linking, e.g. when using something like `COMPONENT_ADD_LDFLAGS := -Wl,--whole-archive -larduino-esp32 -Wl,--no-whole-archive` 
2. Some modules (e.g. Azure IoT) will not eventually build, as the source path wildcards are not deep enough. This is fixed in this code.