### PR TITLE
UDP Packet with zero data length

### DIFF
--- a/libraries/WiFi/src/WiFiUdp.cpp
+++ b/libraries/WiFi/src/WiFiUdp.cpp
@@ -221,6 +221,7 @@ int WiFiUDP::parsePacket(){
   }
   remote_ip = IPAddress(si_other.sin_addr.s_addr);
   remote_port = ntohs(si_other.sin_port);
+  if (len == 0) return 0;
   rx_buffer = new cbuf(len);
   rx_buffer->write(buf, len);
   delete[] buf;
@@ -264,6 +265,7 @@ int WiFiUDP::peek(){
 }
 
 void WiFiUDP::flush(){
+  if(!rx_buffer) return;
   cbuf *b = rx_buffer;
   rx_buffer = 0;
   delete b;


### PR DESCRIPTION
If you receive a package with a data length of zero, parsePacket returns zero, but rx_buffer will be created. So if you perform another parsePacket you will get a zero, even if something could be read. This example would not work: https://www.arduino.cc/en/Reference/EthernetUDPParsePacket

Also I added a check if rx_buffer exist when you try to flush it.