### PR TITLE
[OTA Timeout] Added ability set OTA timeout in the OTA client

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -261,7 +261,7 @@ void ArduinoOTAClass::_runUpdate() {
 
     uint32_t written = 0, total = 0, tried = 0;
     while (!Update.isFinished() && client.connected()) {
-        size_t waited = 1000;
+        size_t waited = OTA_TIMEOUT_DURATION_MS;
         size_t available = client.available();
         while (!available && waited){
             delay(1);

--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -9,7 +9,7 @@
 #include "Update.h"
 
 
-//#define OTA_DEBUG Serial
+// #define OTA_DEBUG Serial
 
 ArduinoOTAClass::ArduinoOTAClass()
 : _port(0)
@@ -20,6 +20,7 @@ ArduinoOTAClass::ArduinoOTAClass()
 , _size(0)
 , _cmd(0)
 , _ota_port(0)
+, _ota_timeout(1000)
 , _start_callback(NULL)
 , _end_callback(NULL)
 , _error_callback(NULL)
@@ -260,8 +261,9 @@ void ArduinoOTAClass::_runUpdate() {
     }
 
     uint32_t written = 0, total = 0, tried = 0;
+
     while (!Update.isFinished() && client.connected()) {
-        size_t waited = OTA_TIMEOUT_DURATION_MS;
+        size_t waited = _ota_timeout;
         size_t available = client.available();
         while (!available && waited){
             delay(1);
@@ -385,6 +387,10 @@ void ArduinoOTAClass::handle() {
 
 int ArduinoOTAClass::getCommand() {
     return _cmd;
+}
+
+void ArduinoOTAClass::setTimeout(int timeoutInMillis) {
+    _ota_timeout = timeoutInMillis;
 }
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ARDUINOOTA)

--- a/libraries/ArduinoOTA/src/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.h
@@ -7,10 +7,6 @@
 
 #define INT_BUFFER_SIZE 16
 
-#ifndef OTA_TIMEOUT_DURATION_MS
-#define OTA_TIMEOUT_DURATION_MS 1000
-#endif
-
 typedef enum {
   OTA_IDLE,
   OTA_WAITAUTH,
@@ -28,9 +24,9 @@ typedef enum {
 class ArduinoOTAClass
 {
   public:
-	typedef std::function<void(void)> THandlerFunction;
-	typedef std::function<void(ota_error_t)> THandlerFunction_Error;
-	typedef std::function<void(unsigned int, unsigned int)> THandlerFunction_Progress;
+    typedef std::function<void(void)> THandlerFunction;
+    typedef std::function<void(ota_error_t)> THandlerFunction_Error;
+    typedef std::function<void(unsigned int, unsigned int)> THandlerFunction_Progress;
 
     ArduinoOTAClass();
     ~ArduinoOTAClass();
@@ -78,6 +74,8 @@ class ArduinoOTAClass
     //Gets update command type after OTA has started. Either U_FLASH or U_SPIFFS
     int getCommand();
 
+    void setTimeout(int timeoutInMillis);
+
   private:
     int _port;
     String _password;
@@ -91,6 +89,7 @@ class ArduinoOTAClass
     int _size;
     int _cmd;
     int _ota_port;
+    int _ota_timeout;
     IPAddress _ota_ip;
     String _md5;
 

--- a/libraries/ArduinoOTA/src/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.h
@@ -7,6 +7,9 @@
 
 #define INT_BUFFER_SIZE 16
 
+#ifndef OTA_TIMEOUT_DURATION_MS
+#define OTA_TIMEOUT_DURATION_MS 1000
+#endif
 
 typedef enum {
   OTA_IDLE,


### PR DESCRIPTION
Currently the timeout for OTA packets is set as 1 sec, which is not good enough in a slower connection. This PR enables the clients to set custom timeout for OTA packets.