### PR TITLE
fix for "realtime uart" in esp32-hal-uart.c

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -96,7 +96,8 @@ static void IRAM_ATTR _uart_isr(void *arg)
 void uartEnableInterrupt(uart_t* uart)
 {
     UART_MUTEX_LOCK();
-    uart->dev->conf1.rxfifo_full_thrhd = 112;
+    //uart->dev->conf1.rxfifo_full_thrhd = 112; //original
+    uart->dev->conf1.rxfifo_full_thrhd = 1; //fix for "realtime" uart
     uart->dev->conf1.rx_tout_thrhd = 2;
     uart->dev->conf1.rx_tout_en = 1;
     uart->dev->int_ena.rxfifo_full = 1;


### PR DESCRIPTION
if you are doing uart stuff that depends on timing, the original code will leave you in the "blind" (Serial.availabe() reads ZERO) until 112 bytes have been received.
Setting this value to 1 will cause 112 times more interrupts, but still use the buffer and not leave your code blind in regards of timing.

i'm aware that his is no real solution, ideally someone (@me-no-dev, @igrr ?) would add some code to HardwareSerial and esp32-hal-uart to expose a new method or optional parameter for serial.begin which could affect this setting.

i'm happy for my project with it and did not encounter side-issues with other projects - there's enough cpu resources left to handle the 112 times higher rx-interrupt rate...

