### PR TITLE
WebServer Speed Up

### DIFF
--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -147,7 +147,7 @@ protected:
   bool _parseForm(WiFiClient& client, String boundary, uint32_t len);
   bool _parseFormUploadAborted();
   void _uploadWriteByte(uint8_t b);
-  uint8_t _uploadReadByte(WiFiClient& client);
+  int _uploadReadByte(WiFiClient& client);
   void _prepareHeader(String& response, int code, const char* content_type, size_t contentLength);
   bool _collectHeader(const char* headerName, const char* headerValue);
  


### PR DESCRIPTION
Functions _uploadReadByte and _parseForm were modified in order to speed up uploading data. 
Now there is no need to call time consuming client.connected() method.