### PR TITLE
Cleanup on README and boards_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Arduino core for ESP32 WiFi chip
-
-[![Build Status](https://travis-ci.org/espressif/arduino-esp32.svg?branch=master)](https://travis-ci.org/espressif/arduino-esp32)
+# Arduino core for ESP32 WiFi chip    [![Build Status](https://travis-ci.org/espressif/arduino-esp32.svg?branch=master)](https://travis-ci.org/espressif/arduino-esp32)
 
 ### Need help or have a question? Join the chat at [![https://gitter.im/espressif/arduino-esp32](https://badges.gitter.im/espressif/arduino-esp32.svg)](https://gitter.im/espressif/arduino-esp32?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -12,15 +10,16 @@
 - [ESP32Dev Board PINMAP](#esp32dev-board-pinmap)
 
 ## Development Status
+[Latest stable release ![Release Version](https://img.shields.io/github/release/espressif/arduino-esp32.svg?style=plastic) ![Release Date](https://img.shields.io/github/release-date/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/)
+
+[Latest development release ![Development Version](https://img.shields.io/github/release/espressif/arduino-esp32/all.svg?style=plastic) ![Development Date](https://img.shields.io/github/release-date-pre/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/)
+
 Most of the framework is implemented. Most noticable is the missing analogWrite. While analogWrite is on it's way, there are a few other options that you can use:
 - 16 channels [LEDC](cores/esp32/esp32-hal-ledc.h) which is PWM
 - 8 channels [SigmaDelta](cores/esp32/esp32-hal-sigmadelta.h) which uses SigmaDelta modulation
 - 2 channels [DAC](cores/esp32/esp32-hal-dac.h) which gives real analog output
 
 ## Installation Instructions
-
-#### [Latest release ![Release Version](https://img.shields.io/github/release/espressif/arduino-esp32/all.svg?style=plastic) ![Release Date](https://img.shields.io/github/release-date/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/)
-
 - Using Arduino IDE Boards Manager (preferred)
   + [Instructions for Boards Manager](docs/arduino-ide/boards_manager.md)
 - Using Arduino IDE with the development repository

--- a/docs/arduino-ide/boards_manager.md
+++ b/docs/arduino-ide/boards_manager.md
@@ -8,8 +8,6 @@ Starting with 1.6.4, Arduino allows installation of third-party platform package
 - Enter ```https://dl.espressif.com/dl/package_esp32_index.json``` into *Additional Board Manager URLs* field. You can add multiple URLs, separating them with commas.
 - Open Boards Manager from Tools > Board menu and install *esp32* platform (and don't forget to select your ESP32 board from Tools > Board menu after installation).
 
-#### [Latest stable release ![Release Version](https://img.shields.io/github/release/espressif/arduino-esp32.svg?style=plastic) ![Release Date](https://img.shields.io/github/release-date/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/)
 Stable release link: `https://dl.espressif.com/dl/package_esp32_index.json`
 
-#### [Latest development release ![Development Version](https://img.shields.io/github/release/espressif/arduino-esp32/all.svg?style=plastic) ![Development Date](https://img.shields.io/github/release-date-pre/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/)
 Development release link: `https://dl.espressif.com/dl/package_esp32_dev_index.json`


### PR DESCRIPTION
Removed links to releases page from boards_manager.md to make it less confusing.  They are on the main README.md now.