### PR TITLE
[OTA] Fix "Error response from device" if OK response comes to early

### DIFF
--- a/tools/espota.py
+++ b/tools/espota.py
@@ -179,6 +179,7 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
       try:
         connection.sendall(chunk)
         res = connection.recv(10)
+        lastResponseContainedOK = 'OK' in res.decode()
       except:
         sys.stderr.write('\n')
         logging.error('Error Uploading')
@@ -186,6 +187,13 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
         f.close()
         sock.close()
         return 1
+
+    if lastResponseContainedOK:
+      logging.info('Success')
+      connection.close()
+      f.close()
+      sock.close()
+      return 0
 
     sys.stderr.write('\n')
     logging.info('Waiting for result...')


### PR DESCRIPTION
Using OTA with platformio, I sometimes get an error like this:

    20:14:21 [DEBUG]: Options: {'timeout': 10, 'esp_ip': '192.168.178.45', 'host_port': 44255, 'image': '.pioenvs\\d1_mini\\spiffs.bin', 'host_ip': '0.0.0.0', 'auth': '', 'esp_port': 8266, 'spiffs': True, 'debug': True, 'progress': True}
    20:14:21 [INFO]: Starting on 0.0.0.0:44255
    20:14:21 [INFO]: Upload size: 1028096
    Sending invitation to 192.168.178.45
    20:14:21 [INFO]: Waiting for device...
    Uploading: [============================================================] 100% Done...
    
    20:14:39 [INFO]: Waiting for result...
    20:14:39 [INFO]: Result:
    20:14:39 [INFO]: Result:
    20:14:39 [INFO]: Result:
    20:14:39 [INFO]: Result:
    20:14:39 [INFO]: Result:
    20:14:39 [ERROR]: Error response from device
    *** [uploadfs] Error 1

On investigation I found that the target does send "OK" via TCP. However, `espota.py` does not receive the OK, because it has been "swallowed up" by an earlier call to `recv()`.

This pull request skips the "wait for OK response" if "OK" has already been received in the last call to `recv()`.