### PR TITLE
make ESP32_PHY_CALIBRATION_AND_DATA_STORAGE optional

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -5,7 +5,6 @@ config ENABLE_ARDUINO_DEPENDS
     select LWIP_SO_RCVBUF
     select ETHERNET
     select WIFI_ENABLED
-    select ESP32_PHY_CALIBRATION_AND_DATA_STORAGE
     select MEMMAP_SMP
     default "y"
 


### PR DESCRIPTION
### Background
When using arduino-esp32 as IDF component we would like to disable `ESP32_PHY_CALIBRATION_AND_DATA_STORAGE` since we sometimes have different antennae on our boards and we would like to perform a full calibration on default.