### PR TITLE
Fix WifiClientEnterprise - STA mode set

### DIFF
--- a/libraries/WiFi/examples/WiFiClientEnterprise/WiFiClientEnterprise.ino
+++ b/libraries/WiFi/examples/WiFiClientEnterprise/WiFiClientEnterprise.ino
@@ -1,4 +1,4 @@
-//Sketch edited by: Martin Chlebovec
+//Sketch edited by: martinius96 (Martin Chlebovec)
 //Personal website: https://arduino.php5.sk
 #include "esp_wpa2.h"
 #include <WiFi.h>
@@ -14,6 +14,7 @@ void setup() {
   Serial.print("Connecting to network: ");
   Serial.println(ssid);
   WiFi.disconnect(true);  //disconnect form wifi to set new wifi connection
+  WiFi.mode(WIFI_STA);
   esp_wifi_sta_wpa2_ent_set_identity((uint8_t *)EAP_IDENTITY, strlen(EAP_IDENTITY)); //provide identity
   esp_wifi_sta_wpa2_ent_set_username((uint8_t *)EAP_IDENTITY, strlen(EAP_IDENTITY)); //provide username
   esp_wifi_sta_wpa2_ent_set_password((uint8_t *)EAP_PASSWORD, strlen(EAP_PASSWORD)); //provide password


### PR DESCRIPTION
Few testers let me know, they were unable with connection to Eduroam network under PEAP+MsCHAPv2 methods.
They were trying many modifications. Solution is very absurd. 
Use function Wifi.mode(); with parameter WIFI_STA for init hardware!
One tester from Italy was able to connect to Eduroam network under TTLS + MsCHAPv2 with that sketch too!

Sketch was tested and worked almost for all testers with that problem (Doesn't worked for EAP-TLS --> where system want certificate from client).

Refer to: 
https://github.com/espressif/arduino-esp32/issues/1381#issuecomment-412073401
https://github.com/espressif/arduino-esp32/issues/1381#issuecomment-414174639
https://github.com/espressif/arduino-esp32/issues/1744#issuecomment-411974121