### PR TITLE
First commit of FFat library

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -8,6 +8,104 @@ menu.PSRAM=PSRAM
 
 ##############################################################
 
+esp32.name=ESP32 Dev Module
+
+esp32.upload.tool=esptool
+esp32.upload.maximum_size=1310720
+esp32.upload.maximum_data_size=327680
+esp32.upload.wait_for_upload_port=true
+
+esp32.serial.disableDTR=true
+esp32.serial.disableRTS=true
+
+esp32.build.mcu=esp32
+esp32.build.core=esp32
+esp32.build.variant=esp32
+esp32.build.board=ESP32_DEV
+
+esp32.build.f_cpu=240000000L
+esp32.build.flash_size=4MB
+esp32.build.flash_freq=40m
+esp32.build.flash_mode=dio
+esp32.build.boot=dio
+esp32.build.partitions=default
+esp32.build.defines=
+
+esp32.menu.PSRAM.disabled=Disabled
+esp32.menu.PSRAM.disabled.build.defines=
+esp32.menu.PSRAM.enabled=Enabled
+esp32.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+
+esp32.menu.PartitionScheme.default=Default
+esp32.menu.PartitionScheme.default.build.partitions=default
+esp32.menu.PartitionScheme.minimal=Minimal (2MB FLASH)
+esp32.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32.menu.PartitionScheme.no_ota=No OTA (Large APP)
+esp32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+esp32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32.menu.PartitionScheme.fatflash=16M Fat
+esp32.menu.PartitionScheme.fatflash.build.partitions=ffat
+
+esp32.menu.FlashMode.qio=QIO
+esp32.menu.FlashMode.qio.build.flash_mode=dio
+esp32.menu.FlashMode.qio.build.boot=qio
+esp32.menu.FlashMode.dio=DIO
+esp32.menu.FlashMode.dio.build.flash_mode=dio
+esp32.menu.FlashMode.dio.build.boot=dio
+esp32.menu.FlashMode.qout=QOUT
+esp32.menu.FlashMode.qout.build.flash_mode=dout
+esp32.menu.FlashMode.qout.build.boot=qout
+esp32.menu.FlashMode.dout=DOUT
+esp32.menu.FlashMode.dout.build.flash_mode=dout
+esp32.menu.FlashMode.dout.build.boot=dout
+
+esp32.menu.FlashFreq.80=80MHz
+esp32.menu.FlashFreq.80.build.flash_freq=80m
+esp32.menu.FlashFreq.40=40MHz
+esp32.menu.FlashFreq.40.build.flash_freq=40m
+
+esp32.menu.FlashSize.4M=4MB (32Mb)
+esp32.menu.FlashSize.4M.build.flash_size=4MB
+esp32.menu.FlashSize.2M=2MB (16Mb)
+esp32.menu.FlashSize.2M.build.flash_size=2MB
+esp32.menu.FlashSize.2M.build.partitions=minimal
+esp32.menu.FlashSize.16M=16MB (128Mb)
+esp32.menu.FlashSize.16M.build.flash_size=16MB
+esp32.menu.FlashSize.2M.build.partitions=ffat
+
+esp32.menu.UploadSpeed.921600=921600
+esp32.menu.UploadSpeed.921600.upload.speed=921600
+esp32.menu.UploadSpeed.115200=115200
+esp32.menu.UploadSpeed.115200.upload.speed=115200
+esp32.menu.UploadSpeed.256000.windows=256000
+esp32.menu.UploadSpeed.256000.upload.speed=256000
+esp32.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32.menu.UploadSpeed.230400=230400
+esp32.menu.UploadSpeed.230400.upload.speed=230400
+esp32.menu.UploadSpeed.460800.linux=460800
+esp32.menu.UploadSpeed.460800.macosx=460800
+esp32.menu.UploadSpeed.460800.upload.speed=460800
+esp32.menu.UploadSpeed.512000.windows=512000
+esp32.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32.menu.DebugLevel.none=None
+esp32.menu.DebugLevel.none.build.code_debug=0
+esp32.menu.DebugLevel.error=Error
+esp32.menu.DebugLevel.error.build.code_debug=1
+esp32.menu.DebugLevel.warn=Warn
+esp32.menu.DebugLevel.warn.build.code_debug=2
+esp32.menu.DebugLevel.info=Info
+esp32.menu.DebugLevel.info.build.code_debug=3
+esp32.menu.DebugLevel.debug=Debug
+esp32.menu.DebugLevel.debug.build.code_debug=4
+esp32.menu.DebugLevel.verbose=Verbose
+esp32.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 ttgo-lora32-v1.name=TTGO LoRa32-OLED V1
 
 ttgo-lora32-v1.upload.tool=esptool
@@ -61,99 +159,6 @@ ttgo-lora32-v1.menu.DebugLevel.debug=Debug
 ttgo-lora32-v1.menu.DebugLevel.debug.build.code_debug=4
 ttgo-lora32-v1.menu.DebugLevel.verbose=Verbose
 ttgo-lora32-v1.menu.DebugLevel.verbose.build.code_debug=5
-
-##############################################################
-
-esp32.name=ESP32 Dev Module
-
-esp32.upload.tool=esptool
-esp32.upload.maximum_size=1310720
-esp32.upload.maximum_data_size=327680
-esp32.upload.wait_for_upload_port=true
-
-esp32.serial.disableDTR=true
-esp32.serial.disableRTS=true
-
-esp32.build.mcu=esp32
-esp32.build.core=esp32
-esp32.build.variant=esp32
-esp32.build.board=ESP32_DEV
-
-esp32.build.f_cpu=240000000L
-esp32.build.flash_size=4MB
-esp32.build.flash_freq=40m
-esp32.build.flash_mode=dio
-esp32.build.boot=dio
-esp32.build.partitions=default
-esp32.build.defines=
-
-esp32.menu.PSRAM.disabled=Disabled
-esp32.menu.PSRAM.disabled.build.defines=
-esp32.menu.PSRAM.enabled=Enabled
-esp32.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
-
-esp32.menu.PartitionScheme.default=Default
-esp32.menu.PartitionScheme.default.build.partitions=default
-esp32.menu.PartitionScheme.minimal=Minimal (2MB FLASH)
-esp32.menu.PartitionScheme.minimal.build.partitions=minimal
-esp32.menu.PartitionScheme.no_ota=No OTA (Large APP)
-esp32.menu.PartitionScheme.no_ota.build.partitions=no_ota
-esp32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-esp32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
-esp32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-esp32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-
-esp32.menu.FlashMode.qio=QIO
-esp32.menu.FlashMode.qio.build.flash_mode=dio
-esp32.menu.FlashMode.qio.build.boot=qio
-esp32.menu.FlashMode.dio=DIO
-esp32.menu.FlashMode.dio.build.flash_mode=dio
-esp32.menu.FlashMode.dio.build.boot=dio
-esp32.menu.FlashMode.qout=QOUT
-esp32.menu.FlashMode.qout.build.flash_mode=dout
-esp32.menu.FlashMode.qout.build.boot=qout
-esp32.menu.FlashMode.dout=DOUT
-esp32.menu.FlashMode.dout.build.flash_mode=dout
-esp32.menu.FlashMode.dout.build.boot=dout
-
-esp32.menu.FlashFreq.80=80MHz
-esp32.menu.FlashFreq.80.build.flash_freq=80m
-esp32.menu.FlashFreq.40=40MHz
-esp32.menu.FlashFreq.40.build.flash_freq=40m
-
-esp32.menu.FlashSize.4M=4MB (32Mb)
-esp32.menu.FlashSize.4M.build.flash_size=4MB
-esp32.menu.FlashSize.2M=2MB (16Mb)
-esp32.menu.FlashSize.2M.build.flash_size=2MB
-esp32.menu.FlashSize.2M.build.partitions=minimal
-
-esp32.menu.UploadSpeed.921600=921600
-esp32.menu.UploadSpeed.921600.upload.speed=921600
-esp32.menu.UploadSpeed.115200=115200
-esp32.menu.UploadSpeed.115200.upload.speed=115200
-esp32.menu.UploadSpeed.256000.windows=256000
-esp32.menu.UploadSpeed.256000.upload.speed=256000
-esp32.menu.UploadSpeed.230400.windows.upload.speed=256000
-esp32.menu.UploadSpeed.230400=230400
-esp32.menu.UploadSpeed.230400.upload.speed=230400
-esp32.menu.UploadSpeed.460800.linux=460800
-esp32.menu.UploadSpeed.460800.macosx=460800
-esp32.menu.UploadSpeed.460800.upload.speed=460800
-esp32.menu.UploadSpeed.512000.windows=512000
-esp32.menu.UploadSpeed.512000.upload.speed=512000
-
-esp32.menu.DebugLevel.none=None
-esp32.menu.DebugLevel.none.build.code_debug=0
-esp32.menu.DebugLevel.error=Error
-esp32.menu.DebugLevel.error.build.code_debug=1
-esp32.menu.DebugLevel.warn=Warn
-esp32.menu.DebugLevel.warn.build.code_debug=2
-esp32.menu.DebugLevel.info=Info
-esp32.menu.DebugLevel.info.build.code_debug=3
-esp32.menu.DebugLevel.debug=Debug
-esp32.menu.DebugLevel.debug.build.code_debug=4
-esp32.menu.DebugLevel.verbose=Verbose
-esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 

--- a/libraries/FFat/examples/FFat_Test/FFat_Test.ino
+++ b/libraries/FFat/examples/FFat_Test/FFat_Test.ino
@@ -1,0 +1,183 @@
+#include "FS.h"
+#include "FFat.h"
+
+/* You only need to format FFat the first time you run a
+   test or else use the FFat plugin to create a partition
+   https://github.com/me-no-dev/arduino-esp32fs-plugin */
+#define FORMAT_FFAT true
+
+void listDir(fs::FS &fs, const char * dirname, uint8_t levels){
+    Serial.printf("Listing directory: %s\r\n", dirname);
+
+    File root = fs.open(dirname);
+    if(!root){
+        Serial.println("- failed to open directory");
+        return;
+    }
+    if(!root.isDirectory()){
+        Serial.println(" - not a directory");
+        return;
+    }
+
+    File file = root.openNextFile();
+    while(file){
+        if(file.isDirectory()){
+            Serial.print("  DIR : ");
+            Serial.println(file.name());
+            if(levels){
+                listDir(fs, file.name(), levels -1);
+            }
+        } else {
+            Serial.print("  FILE: ");
+            Serial.print(file.name());
+            Serial.print("\tSIZE: ");
+            Serial.println(file.size());
+        }
+        file = root.openNextFile();
+    }
+}
+
+void readFile(fs::FS &fs, const char * path){
+    Serial.printf("Reading file: %s\r\n", path);
+
+    File file = fs.open(path);
+    if(!file || file.isDirectory()){
+        Serial.println("- failed to open file for reading");
+        return;
+    }
+
+    Serial.println("- read from file:");
+    while(file.available()){
+        Serial.write(file.read());
+    }
+}
+
+void writeFile(fs::FS &fs, const char * path, const char * message){
+    Serial.printf("Writing file: %s\r\n", path);
+
+    File file = fs.open(path, FILE_WRITE);
+    if(!file){
+        Serial.println("- failed to open file for writing");
+        return;
+    }
+    if(file.print(message)){
+        Serial.println("- file written");
+    } else {
+        Serial.println("- frite failed");
+    }
+}
+
+void appendFile(fs::FS &fs, const char * path, const char * message){
+    Serial.printf("Appending to file: %s\r\n", path);
+
+    File file = fs.open(path, FILE_APPEND);
+    if(!file){
+        Serial.println("- failed to open file for appending");
+        return;
+    }
+    if(file.print(message)){
+        Serial.println("- message appended");
+    } else {
+        Serial.println("- append failed");
+    }
+}
+
+void renameFile(fs::FS &fs, const char * path1, const char * path2){
+    Serial.printf("Renaming file %s to %s\r\n", path1, path2);
+    if (fs.rename(path1, path2)) {
+        Serial.println("- file renamed");
+    } else {
+        Serial.println("- rename failed");
+    }
+}
+
+void deleteFile(fs::FS &fs, const char * path){
+    Serial.printf("Deleting file: %s\r\n", path);
+    if(fs.remove(path)){
+        Serial.println("- file deleted");
+    } else {
+        Serial.println("- delete failed");
+    }
+}
+
+void testFileIO(fs::FS &fs, const char * path){
+    Serial.printf("Testing file I/O with %s\r\n", path);
+
+    static uint8_t buf[512];
+    size_t len = 0;
+    File file = fs.open(path, FILE_WRITE);
+    if(!file){
+        Serial.println("- failed to open file for writing");
+        return;
+    }
+
+    size_t i;
+    Serial.print("- writing" );
+    uint32_t start = millis();
+    for(i=0; i<2048; i++){
+        if ((i & 0x001F) == 0x001F){
+          Serial.print(".");
+        }
+        file.write(buf, 512);
+    }
+    Serial.println("");
+    uint32_t end = millis() - start;
+    Serial.printf(" - %u bytes written in %u ms\r\n", 2048 * 512, end);
+    file.close();
+
+    file = fs.open(path);
+    start = millis();
+    end = start;
+    i = 0;
+    if(file && !file.isDirectory()){
+        len = file.size();
+        size_t flen = len;
+        start = millis();
+        Serial.print("- reading" );
+        while(len){
+            size_t toRead = len;
+            if(toRead > 512){
+                toRead = 512;
+            }
+            file.read(buf, toRead);
+            if ((i++ & 0x001F) == 0x001F){
+              Serial.print(".");
+            }
+            len -= toRead;
+        }
+        Serial.println("");
+        end = millis() - start;
+        Serial.printf("- %u bytes read in %u ms\r\n", flen, end);
+        file.close();
+    } else {
+        Serial.println("- failed to open file for reading");
+    }
+}
+
+void setup(){
+    Serial.begin(115200);
+    Serial.setDebugOutput(true);
+    if (FORMAT_FFAT) FFat.format();
+    if(!FFat.begin()){
+        Serial.println("FFat Mount Failed");
+        return;
+    }
+    
+    Serial.printf("Total space: %10lu\n", FFat.totalBytes());
+    Serial.printf("Free space: %10lu\n", FFat.freeBytes());
+    listDir(FFat, "/", 0);
+    writeFile(FFat, "/hello.txt", "Hello ");
+    appendFile(FFat, "/hello.txt", "World!\r\n");
+    readFile(FFat, "/hello.txt");
+    renameFile(FFat, "/hello.txt", "/foo.txt");
+    readFile(FFat, "/foo.txt");
+    deleteFile(FFat, "/foo.txt");
+    testFileIO(FFat, "/test.txt");
+    Serial.printf("Free space: %10lu\n", FFat.freeBytes());
+    deleteFile(FFat, "/test.txt");
+    Serial.println( "Test complete" );
+}
+
+void loop(){
+
+}

--- a/libraries/FFat/library.properties
+++ b/libraries/FFat/library.properties
@@ -1,0 +1,9 @@
+name=FFat
+version=1.0
+author=Hristo Gochkov, Ivan Grokhtkov, Larry Bernstone
+maintainer=Hristo Gochkov <hristo@espressif.com>
+sentence=ESP32 FAT on Flash File System
+paragraph=
+category=Data Storage
+url=
+architectures=esp32

--- a/libraries/FFat/src/FFat.cpp
+++ b/libraries/FFat/src/FFat.cpp
@@ -1,0 +1,132 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vfs_api.h"
+
+extern "C" {
+#include <sys/unistd.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include "esp_vfs_fat.h"
+#include "diskio.h"
+#include "diskio_wl.h"
+#include "vfs_fat_internal.h"
+}
+#include "FFat.h"
+
+using namespace fs;
+
+F_Fat::F_Fat(FSImplPtr impl)
+    : FS(impl)
+{}
+
+bool F_Fat::begin(bool formatOnFail, const char * basePath, uint8_t maxOpenFiles, const char * partitionLabel)
+{
+    if(_wl_handle){
+        log_w("Already Mounted!");
+        return true;
+    }     
+    esp_vfs_fat_mount_config_t conf = {
+      .format_if_mount_failed = formatOnFail,
+      .max_files = maxOpenFiles
+    };
+
+    esp_err_t err = esp_vfs_fat_spiflash_mount(basePath, partitionLabel, &conf, &_wl_handle);
+    if(err){
+        log_e("Mounting FatFlash failed! Error: %d", err);
+        return false;
+    }
+    _impl->mountpoint(basePath);
+    return true;
+}
+
+void F_Fat::end()
+{
+    if(_wl_handle){
+        esp_err_t err = esp_vfs_fat_spiflash_unmount(_impl->mountpoint(), _wl_handle);
+        if(err){
+            log_e("Unmounting FatFlash failed! Error: %d", err);
+            return;
+        }
+        _wl_handle = NULL;
+        _impl->mountpoint(NULL);
+    }
+}
+
+bool F_Fat::format(bool full_wipe, char* partitionLabel)
+{
+    esp_err_t result;
+    wl_handle_t temp_handle;
+    esp_vfs_fat_mount_config_t conf = {
+      .format_if_mount_failed = false,
+      .max_files = 1
+    };
+// Attempt to mount to see if there is already data
+    esp_partition_subtype_t subtype = ESP_PARTITION_SUBTYPE_DATA_FAT;
+    const esp_partition_t *ffat_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, subtype, partitionLabel);
+    result = wl_mount(ffat_partition, &temp_handle);
+
+    if (result == ESP_OK) {
+// Wipe disk- quick just wipes the FAT. Full zeroes the whole disk
+        //result = esp_vfs_fat_spiflash_mount("/format_ffat", partitionLabel, &conf, &temp_handle);
+        uint32_t wipe_size = full_wipe ? wl_size(temp_handle) : 16384;
+        wl_erase_range(temp_handle, 0, wipe_size);
+        esp_vfs_fat_spiflash_unmount("/format_ffat", temp_handle);
+    }
+    conf.format_if_mount_failed = true;
+    result = esp_vfs_fat_spiflash_mount("/format_ffat", partitionLabel, &conf, &temp_handle);
+    esp_vfs_fat_spiflash_unmount("/format_ffat", temp_handle);
+    return result;
+}
+
+size_t F_Fat::totalBytes()
+{
+    FATFS *fs;
+    DWORD free_clust, tot_sect, sect_size;
+
+    BYTE pdrv = ff_diskio_get_pdrv_wl(_wl_handle);
+    char drv[3] = {(char)'0' + pdrv, ':', 0};
+    FRESULT res = f_getfree(drv, &free_clust, &fs);
+    tot_sect = (fs->n_fatent - 2) * fs->csize;
+    sect_size=CONFIG_WL_SECTOR_SIZE;
+    return tot_sect * sect_size;
+}
+
+size_t F_Fat::freeBytes()
+{
+
+    FATFS *fs;
+    DWORD free_clust, free_sect, sect_size;
+
+    BYTE pdrv = ff_diskio_get_pdrv_wl(_wl_handle);
+    char drv[3] = {(char)'0' + pdrv, ':', 0};
+    FRESULT res = f_getfree(drv, &free_clust, &fs);
+    free_sect = free_clust * fs->csize;
+    sect_size=CONFIG_WL_SECTOR_SIZE;
+    return free_sect * sect_size;
+}
+
+bool F_Fat::exists(const char* path)
+{
+    File f = open(path, "r");
+    return (f == true) && !f.isDirectory();
+}
+
+bool F_Fat::exists(const String& path)
+{
+    return exists(path.c_str());
+}
+
+
+F_Fat FFat = F_Fat(FSImplPtr(new VFSImpl()));

--- a/libraries/FFat/src/FFat.h
+++ b/libraries/FFat/src/FFat.h
@@ -1,0 +1,47 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef _FFAT_H_
+#define _FFAT_H_
+
+#include "FS.h"
+#include "wear_levelling.h"
+
+#define FFAT_WIPE_QUICK 0
+#define FFAT_WIPE_FULL 1
+#define FFAT_PARTITION_LABEL "ffat"
+
+namespace fs
+{
+
+class F_Fat : public FS
+{
+public:
+    F_Fat(FSImplPtr impl);
+    bool begin(bool formatOnFail=false, const char * basePath="/ffat", uint8_t maxOpenFiles=10, const char * partitionLabel = FFAT_PARTITION_LABEL);
+    bool format(bool full_wipe = FFAT_WIPE_QUICK, char* partitionLabel = FFAT_PARTITION_LABEL);
+    size_t totalBytes();
+    size_t freeBytes();
+    void end();
+    bool exists(const char* path);
+    bool exists(const String& path);
+
+private:
+    wl_handle_t _wl_handle;
+};
+
+}
+
+extern fs::F_Fat FFat;
+
+#endif /* _FAT_FLASH_H_ */

--- a/tools/partitions/ffat.csv
+++ b/tools/partitions/ffat.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x200000,
+app1,     app,  ota_1,   0x210000,0x200000,
+eeprom,   data, 0x99,    0x410000,0x1000,
+ffat,     data, fat,     0x411000,0xBEE000,


### PR DESCRIPTION
First commit of the FFat library which provides a wrapper to use standard FS functionality on a FAT partition located on the SPI Flash.  All functions available in SPIFFS have been exposed.
I have also included a new partition scheme and csv which will create a 12MB partition along with good sized OTA partitions. The WebServer/FSBrowser.ino example was updated to allow use of SPIFFS or FFat.