### PR TITLE
Fix compilation against recent IDF (DDR for SD_MMC)

### DIFF
--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -50,6 +50,7 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit)
         .init = &sdmmc_host_init,
         .set_bus_width = &sdmmc_host_set_bus_width,
         .get_bus_width = &sdmmc_host_get_slot_width,
+        .set_bus_ddr_mode = &sdmmc_host_set_bus_ddr_mode,
         .set_card_clk = &sdmmc_host_set_card_clk,
         .do_transaction = &sdmmc_host_do_transaction,
         .deinit = &sdmmc_host_deinit,


### PR DESCRIPTION
Hi. Compiling current Arduino-ESP32 (a0f0bd930c) against current ESP-IDF (espressif/esp-idf@e54f3d9) fails due to the newly added SD_MMC DDR support on ESP-IDF: https://github.com/espressif/esp-idf/commit/78fab8a0f .

Error:

```
C:/msys32/home/muo/esp/blink/components/arduino/libraries/SD_MMC/src/SD_MMC.cpp: In member function 'bool fs::SDMMCFS::begin(const char*, bool)':
C:/msys32/home/muo/esp/blink/components/arduino/libraries/SD_MMC/src/SD_MMC.cpp:59:5: sorry, unimplemented: non-trivial designated initializers not supported
     };
     ^
<snip>
C:/msys32/home/muo/esp/blink/components/arduino/libraries/SD_MMC/src/SD_MMC.cpp:59:5: warning: missing initializer for member 'sdmmc_host_t::command_timeout_ms' [-Wmissing-field-initializers]
```

This pull-req is a simple fix for this issue which syncs initializers with current code.