### PR TITLE
Adds functionality allowing size of HardwareSerial's RX buffer to be changed at runtime.

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -46,6 +46,10 @@ void HardwareSerial::end()
     _uart = 0;
 }
 
+size_t HardwareSerial::setRxBufferSize(size_t new_size) {
+    return uartResizeRxBuffer(_uart, new_size);
+}
+
 void HardwareSerial::setDebugOutput(bool en)
 {
     if(_uart == 0) {

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -70,6 +70,7 @@ public:
     uint32_t baudRate();
     operator bool() const;
 
+    size_t setRxBufferSize(size_t);
     void setDebugOutput(bool);
 
 protected:

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -240,6 +240,26 @@ void uartEnd(uart_t* uart)
     uartDetachTx(uart);
 }
 
+size_t uartResizeRxBuffer(uart_t * uart, size_t new_size) {
+    if(uart == NULL) {
+        return;
+    }
+
+    UART_MUTEX_LOCK();
+    if(uart->queue != NULL) {
+        uint8_t c;
+        while(xQueueReceive(uart->queue, &c, 0));
+        vQueueDelete(uart->queue);
+        uart->queue = xQueueCreate(new_size, sizeof(uint8_t));
+        if(uart->queue == NULL) {
+            return NULL;
+        }
+    }
+    UART_MUTEX_UNLOCK();
+
+    return new_size;
+}
+
 uint32_t uartAvailable(uart_t* uart)
 {
     if(uart == NULL || uart->queue == NULL) {

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -67,6 +67,8 @@ void uartFlush(uart_t* uart);
 void uartSetBaudRate(uart_t* uart, uint32_t baud_rate);
 uint32_t uartGetBaudRate(uart_t* uart);
 
+size_t uartResizeRxBuffer(uart_t* uart, size_t new_size);
+
 void uartSetDebug(uart_t* uart);
 int uartGetDebug();
 


### PR DESCRIPTION
This adds functionality analogous to the ESP8266's Arduino core's `HardwareSerial::setRxBufferSize`, providing users functionality allowing them to increase the size of the rx buffer as a way of preventing lost characters when using high baud rates.  Given that the queue size is only 256 characters by default, it is terribly easy for fast serial connections to exceed the default buffer length.