### PR TITLE
allow component projects to compile with CONFIG_DISABLE_HAL_LOCKS

### DIFF
--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -46,8 +46,8 @@
 #define _INT_THR_EVNT(channel)  ((__INT_THR_EVNT)<<(channel))
 
 #if CONFIG_DISABLE_HAL_LOCKS
-# define UART_MUTEX_LOCK(channel)
-# define UART_MUTEX_UNLOCK(channel)
+# define RMT_MUTEX_LOCK(channel)
+# define RMT_MUTEX_UNLOCK(channel)
 #else
 # define RMT_MUTEX_LOCK(channel)    do {} while (xSemaphoreTake(g_rmt_objlocks[channel], portMAX_DELAY) != pdPASS)
 # define RMT_MUTEX_UNLOCK(channel)  xSemaphoreGive(g_rmt_objlocks[channel])


### PR DESCRIPTION
Small fix to esp32-hal-rmt.c allows as-component projects to compile with locks disabled.