### PR TITLE
[Updater.cpp] Increasing stream timeout to avoid read timeout during OTA flash write

### DIFF
--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -303,6 +303,7 @@ size_t UpdateClass::write(uint8_t *data, size_t len) {
 }
 
 size_t UpdateClass::writeStream(Stream &data) {
+    data.setTimeout(10000);
     size_t written = 0;
     size_t toRead = 0;
     if(hasError() || !isRunning())


### PR DESCRIPTION
If using a nginx webserver to feed a https OTA write flash stream with ~1,5MB binary data, i'm getting reproducely _error #6 (stream read timeout) on a ESP32 Pycom LoPy with CPU revision 0.

I was able to stable fix this by applying a patch to `Updater.cpp`, following a hint for ESP 8266 Update.cpp, found at the end of this issue: 

https://github.com/esp8266/Arduino/issues/1157

This PR is a quick&dirty fix. Problem should be further analysed and then solved at the root cause. Eventually this is a TCP related issue.