### PR TITLE
Wire endTransmission() fix for issue #1725

### DIFF
--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -1,5 +1,5 @@
 name=Wire
-version=1.0
+version=1.0.1
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Allows the communication between devices or sensors connected via Two Wire Interface Bus. For esp8266 boards. 

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -308,11 +308,6 @@ uint8_t TwoWire::endTransmission(void)
     return endTransmission(true);
 }
 
-uint8_t TwoWire::endTransmission(uint8_t sendStop)
-{
-    return endTransmission(static_cast<bool>(sendStop));
-}
-
 /* stickbreaker Nov2017 better error reporting
  */
 uint8_t TwoWire::lastError()

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -87,7 +87,6 @@ public:
     void beginTransmission(int address);
 
     uint8_t endTransmission(bool sendStop);
-    uint8_t endTransmission(uint8_t sendStop);
     uint8_t endTransmission(void);
 
     uint8_t requestFrom(uint16_t address, uint8_t size, bool sendStop);


### PR DESCRIPTION
This patch will fix issue #1725 
There is no need to have the uint8_t version of the endTransmission() function.
Having both endTransmission(uint8_t) and endTransmission(bool) creates problems. The biggest problem being that endTransmission(0) and endTransmission(1) won't compile like it does on all the other cores.
Simply removing endTransmission(uint8_t) solves the problem.