### PR TITLE
Added loadCert methods to WiFiClientSecure

### DIFF
--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -230,6 +230,51 @@ bool WiFiClientSecure::verify(const char* fp, const char* domain_name)
     return verify_ssl_fingerprint(sslclient, fp, domain_name);
 }
 
+char *WiFiClientSecure::_streamLoad(Stream& stream, size_t size) {
+  char *dest = (char*)malloc(size);
+  if (!dest) {
+    return nullptr;
+  }
+  if (size != stream.readBytes(dest, size)) {
+    free(dest);
+    return nullptr;
+  }
+  char ret[size+1];
+  snprintf(ret, size, "%s", dest);
+  free(dest);
+  return ret;
+}
+
+bool WiFiClientSecure::loadCACert(Stream& stream, size_t size) {
+  char *dest = _streamLoad(stream, size);
+  bool ret = false;
+  if (dest) {
+    setCACert(dest);
+    ret = true;
+  }
+  return ret;
+}
+
+bool WiFiClientSecure::loadCertificate(Stream& stream, size_t size) {
+  char *dest = _streamLoad(stream, size);
+  bool ret = false;
+  if (dest) {
+    setCertificate(dest);
+    ret = true;
+  }
+  return ret;
+}
+
+bool WiFiClientSecure::loadPrivateKey(Stream& stream, size_t size) {
+  char *dest = _streamLoad(stream, size);
+  bool ret = false;
+  if (dest) {
+    setPrivateKey(dest);
+    ret = true;
+  }
+  return ret;
+}
+
 int WiFiClientSecure::lastError(char *buf, const size_t size)
 {
     if (!_lastError) {

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.h
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.h
@@ -58,6 +58,9 @@ public:
     void setCACert(const char *rootCA);
     void setCertificate(const char *client_ca);
     void setPrivateKey (const char *private_key);
+    bool loadCACert(Stream& stream, size_t size);
+    bool loadCertificate(Stream& stream, size_t size);
+    bool loadPrivateKey(Stream& stream, size_t size);
     bool verify(const char* fingerprint, const char* domain_name);
 
     operator bool()
@@ -83,6 +86,9 @@ public:
     {
         return sslclient->socket = -1;
     }
+
+private:
+    char *_streamLoad(Stream& stream, size_t size);
 
     //friend class WiFiServer;
     using Print::write;


### PR DESCRIPTION
Fixes #1957.
Allows a file object to be used as a certificate in WiFiClientSecure.