### PR TITLE
Feature/http update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(LIBRARY_SRCS
   libraries/FS/src/FS.cpp
   libraries/FS/src/vfs_api.cpp
   libraries/HTTPClient/src/HTTPClient.cpp
+  libraries/HTTPUpdate/src/HTTPUpdate.cpp
   libraries/NetBIOS/src/NetBIOS.cpp
   libraries/Preferences/src/Preferences.cpp
   libraries/SD_MMC/src/SD_MMC.cpp
@@ -181,6 +182,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
   libraries/FFat/src
   libraries/FS/src
   libraries/HTTPClient/src
+  libraries/HTTPUpdate/src
   libraries/NetBIOS/src
   libraries/Preferences/src
   libraries/SD_MMC/src

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -434,8 +434,8 @@ void HTTPClient::setAuthorization(const char * auth)
 void HTTPClient::setTimeout(uint16_t timeout)
 {
     _tcpTimeout = timeout;
-    if(connected() && !_secure) {
-        _client->setTimeout(timeout);
+    if(connected()) {
+        _client->setTimeout((timeout + 500) / 1000);
     }
 }
 
@@ -686,7 +686,7 @@ int HTTPClient::getSize(void)
  */
 WiFiClient& HTTPClient::getStream(void)
 {
-    if (connected() && !_secure) {
+    if (connected()) {
         return *_client;
     }
 
@@ -965,7 +965,8 @@ bool HTTPClient::connect(void)
         return false;
     }
 
-    _client->setTimeout(_tcpTimeout);	
+    // set Timeout for WiFiClient and for Stream::readBytesUntil() and Stream::readStringUntil()
+    _client->setTimeout((_tcpTimeout + 500) / 1000);	
 
     if(!_client->connect(_host.c_str(), _port)) {
         log_d("failed connect to %s:%u", _host.c_str(), _port);
@@ -983,8 +984,6 @@ bool HTTPClient::connect(void)
 #endif
 
 
-    // set Timeout for readBytesUntil and readStringUntil
-//    setTimeout(_tcpTimeout);
 /*
 #ifdef ESP8266
     _client->setNoDelay(true);

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -121,20 +121,26 @@ void HTTPClient::clear()
  * @return success bool
  */
 bool HTTPClient::begin(WiFiClient &client, String url) {
-//    end();	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
+    if(_tcpDeprecated) {
+        log_d("mix up of new and deprecated api");
+        _canReuse = false;
+        end();
+    }
+#endif
 
     _client = &client;
 
     // check for : (http: or https:)
     int index = url.indexOf(':');
     if(index < 0) {
-        log_d("failed to parse protocol\n");
+        log_d("failed to parse protocol");
         return false;
     }
 
     String protocol = url.substring(0, index);
     if(protocol != "http" && protocol != "https") {
-        log_d("unknown protocol '%s'\n", protocol.c_str());
+        log_d("unknown protocol '%s'", protocol.c_str());
         return false;
     }
 
@@ -154,7 +160,13 @@ bool HTTPClient::begin(WiFiClient &client, String url) {
  */
 bool HTTPClient::begin(WiFiClient &client, String host, uint16_t port, String uri, bool https)
 {
-//    end(); !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
+    if(_tcpDeprecated) {
+        log_d("mix up of new and deprecated api");
+        _canReuse = false;
+        end();
+    }
+#endif
 
     _client = &client;
 
@@ -170,7 +182,12 @@ bool HTTPClient::begin(WiFiClient &client, String host, uint16_t port, String ur
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
 bool HTTPClient::begin(String url, const char* CAcert)
 {
-    _transportTraits.reset(nullptr);
+    if(_client && !_tcpDeprecated) {
+        log_d("mix up of new and deprecated api");
+        _canReuse = false;
+        end();
+    }
+
     _port = 443;
     if (!beginInternal(url, "https")) {
         return false;
@@ -186,8 +203,12 @@ bool HTTPClient::begin(String url, const char* CAcert)
  */
 bool HTTPClient::begin(String url)
 {
+    if(_client && !_tcpDeprecated) {
+        log_d("mix up of new and deprecated api");
+        _canReuse = false;
+        end();
+    }
 
-    _transportTraits.reset(nullptr);
     _port = 80;
     if (!beginInternal(url, "http")) {
         return begin(url, (const char*)NULL);
@@ -247,6 +268,12 @@ bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
 bool HTTPClient::begin(String host, uint16_t port, String uri)
 {
+    if(_client && !_tcpDeprecated) {
+        log_d("mix up of new and deprecated api");
+        _canReuse = false;
+        end();
+    }
+
     clear();
     _host = host;
     _port = port;
@@ -258,6 +285,12 @@ bool HTTPClient::begin(String host, uint16_t port, String uri)
 
 bool HTTPClient::begin(String host, uint16_t port, String uri, const char* CAcert)
 {
+    if(_client && !_tcpDeprecated) {
+        log_d("mix up of new and deprecated api");
+        _canReuse = false;
+        end();
+    }
+
     clear();
     _host = host;
     _port = port;
@@ -273,6 +306,12 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, const char* CAcer
 
 bool HTTPClient::begin(String host, uint16_t port, String uri, const char* CAcert, const char* cli_cert, const char* cli_key)
 {
+    if(_client && !_tcpDeprecated) {
+        log_d("mix up of new and deprecated api");
+        _canReuse = false;
+        end();
+    }
+
     clear();
     _host = host;
     _port = port;

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -26,13 +26,18 @@
 
 #include <Arduino.h>
 #include <esp32-hal-log.h>  
+
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
+#endif
+
 #include <StreamString.h>
 #include <base64.h>
 
 #include "HTTPClient.h"
 
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
 class TransportTraits
 {
 public:
@@ -78,6 +83,7 @@ protected:
     const char* _clicert;
     const char* _clikey;
 };
+#endif // HTTPCLIENT_1_1_COMPATIBLE
 
 /**
  * constructor
@@ -91,8 +97,8 @@ HTTPClient::HTTPClient()
  */
 HTTPClient::~HTTPClient()
 {
-    if(_tcp) {
-        _tcp->stop();
+    if(_client) {
+        _client->stop();
     }
     if(_currentHeaders) {
         delete[] _currentHeaders;
@@ -107,6 +113,61 @@ void HTTPClient::clear()
 }
 
 
+/**
+ * parsing the url for all needed parameters
+ * @param client Client&
+ * @param url String
+ * @param https bool
+ * @return success bool
+ */
+bool HTTPClient::begin(WiFiClient &client, String url) {
+//    end();	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    _client = &client;
+
+    // check for : (http: or https:)
+    int index = url.indexOf(':');
+    if(index < 0) {
+        log_d("failed to parse protocol\n");
+        return false;
+    }
+
+    String protocol = url.substring(0, index);
+    if(protocol != "http" && protocol != "https") {
+        log_d("unknown protocol '%s'\n", protocol.c_str());
+        return false;
+    }
+
+    _port = (protocol == "https" ? 443 : 80);
+    return beginInternal(url, protocol.c_str());
+}
+
+
+/**
+ * directly supply all needed parameters
+ * @param client Client&
+ * @param host String
+ * @param port uint16_t
+ * @param uri String
+ * @param https bool
+ * @return success bool
+ */
+bool HTTPClient::begin(WiFiClient &client, String host, uint16_t port, String uri, bool https)
+{
+//    end(); !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    _client = &client;
+
+     clear();
+    _host = host;
+    _port = port;
+    _uri = uri;
+    _protocol = (https ? "https" : "http");
+    return true;
+}
+
+
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
 bool HTTPClient::begin(String url, const char* CAcert)
 {
     _transportTraits.reset(nullptr);
@@ -134,6 +195,7 @@ bool HTTPClient::begin(String url)
     _transportTraits = TransportTraitsPtr(new TransportTraits());
     return true;
 }
+#endif // HTTPCLIENT_1_1_COMPATIBLE
 
 bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
 {
@@ -182,6 +244,7 @@ bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
     return true;
 }
 
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
 bool HTTPClient::begin(String host, uint16_t port, String uri)
 {
     clear();
@@ -222,6 +285,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, const char* CAcer
     _transportTraits = TransportTraitsPtr(new TLSTraits(CAcert, cli_cert, cli_key));
     return true;
 }
+#endif // HTTPCLIENT_1_1_COMPATIBLE
 
 /**
  * end
@@ -229,21 +293,43 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, const char* CAcer
  */
 void HTTPClient::end(void)
 {
+    disconnect();
+}
+
+
+
+/**
+ * disconnect
+ * close the TCP socket
+ */
+void HTTPClient::disconnect()
+{
     if(connected()) {
-        if(_tcp->available() > 0) {
-            log_d("still data in buffer (%d), clean up.", _tcp->available());
-            _tcp->flush();
+        if(_client->available() > 0) {
+            log_d("still data in buffer (%d), clean up.\n", _client->available());
+            while(_client->available() > 0) {
+                _client->read();
+            }
         }
+
         if(_reuse && _canReuse) {
-            log_d("tcp keep open for reuse");
+            log_d("tcp keep open for reuse\n");
         } else {
-            log_d("tcp stop");
-            _tcp->stop();
+            log_d("tcp stop\n");
+            _client->stop();
+            _client = nullptr;
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
+            if(_tcpDeprecated) {
+                _transportTraits.reset(nullptr);
+                _tcpDeprecated.reset(nullptr);
+            }
+#endif
         }
     } else {
-        log_v("tcp is closed");
+        log_d("tcp is closed\n");
     }
 }
+
 
 /**
  * connected
@@ -251,8 +337,8 @@ void HTTPClient::end(void)
  */
 bool HTTPClient::connected()
 {
-    if(_tcp) {
-        return ((_tcp->available() > 0) || _tcp->connected());
+    if(_client) {
+        return ((_client->available() > 0) || _client->connected());
     }
     return false;
 }
@@ -310,7 +396,7 @@ void HTTPClient::setTimeout(uint16_t timeout)
 {
     _tcpTimeout = timeout;
     if(connected() && !_secure) {
-        _tcp->setTimeout(timeout);
+        _client->setTimeout(timeout);
     }
 }
 
@@ -398,7 +484,7 @@ int HTTPClient::sendRequest(const char * type, uint8_t * payload, size_t size)
 
     // send Payload if needed
     if(payload && size > 0) {
-        if(_tcp->write(&payload[0], size) != size) {
+        if(_client->write(&payload[0], size) != size) {
             return returnError(HTTPC_ERROR_SEND_PAYLOAD_FAILED);
         }
     }
@@ -477,7 +563,7 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
                 int bytesRead = stream->readBytes(buff, readBytes);
 
                 // write it to Stream
-                int bytesWrite = _tcp->write((const uint8_t *) buff, bytesRead);
+                int bytesWrite = _client->write((const uint8_t *) buff, bytesRead);
                 bytesWritten += bytesWrite;
 
                 // are all Bytes a writen to stream ?
@@ -485,11 +571,11 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
                     log_d("short write, asked for %d but got %d retry...", bytesRead, bytesWrite);
 
                     // check for write error
-                    if(_tcp->getWriteError()) {
-                        log_d("stream write error %d", _tcp->getWriteError());
+                    if(_client->getWriteError()) {
+                        log_d("stream write error %d", _client->getWriteError());
 
                         //reset write error for retry
-                        _tcp->clearWriteError();
+                        _client->clearWriteError();
                     }
 
                     // some time for the stream
@@ -498,7 +584,7 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
                     int leftBytes = (readBytes - bytesWrite);
 
                     // retry to send the missed bytes
-                    bytesWrite = _tcp->write((const uint8_t *) (buff + bytesWrite), leftBytes);
+                    bytesWrite = _client->write((const uint8_t *) (buff + bytesWrite), leftBytes);
                     bytesWritten += bytesWrite;
 
                     if(bytesWrite != leftBytes) {
@@ -510,8 +596,8 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
                 }
 
                 // check for write error
-                if(_tcp->getWriteError()) {
-                    log_d("stream write error %d", _tcp->getWriteError());
+                if(_client->getWriteError()) {
+                    log_d("stream write error %d", _client->getWriteError());
                     free(buff);
                     return returnError(HTTPC_ERROR_SEND_PAYLOAD_FAILED);
                 }
@@ -562,7 +648,7 @@ int HTTPClient::getSize(void)
 WiFiClient& HTTPClient::getStream(void)
 {
     if (connected() && !_secure) {
-        return *_tcp;
+        return *_client;
     }
 
     log_w("getStream: not connected");
@@ -577,7 +663,7 @@ WiFiClient& HTTPClient::getStream(void)
 WiFiClient* HTTPClient::getStreamPtr(void)
 {
     if(connected()) {
-        return _tcp.get();
+        return _client;
     }
 
     log_w("getStreamPtr: not connected");
@@ -617,7 +703,7 @@ int HTTPClient::writeToStream(Stream * stream)
             if(!connected()) {
                 return returnError(HTTPC_ERROR_CONNECTION_LOST);
             }
-            String chunkHeader = _tcp->readStringUntil('\n');
+            String chunkHeader = _client->readStringUntil('\n');
 
             if(chunkHeader.length() <= 0) {
                 return returnError(HTTPC_ERROR_READ_TIMEOUT);
@@ -654,7 +740,7 @@ int HTTPClient::writeToStream(Stream * stream)
 
             // read trailing \r\n at the end of the chunk
             char buf[2];
-            auto trailing_seq_len = _tcp->readBytes((uint8_t*)buf, 2);
+            auto trailing_seq_len = _client->readBytes((uint8_t*)buf, 2);
             if (trailing_seq_len != 2 || buf[0] != '\r' || buf[1] != '\n') {
                 return returnError(HTTPC_ERROR_READ_TIMEOUT);
             }
@@ -822,38 +908,47 @@ bool HTTPClient::connect(void)
 
     if(connected()) {
         log_d("already connected, try reuse!");
-        while(_tcp->available() > 0) {
-            _tcp->read();
+        while(_client->available() > 0) {
+            _client->read();
         }
         return true;
     }
 
-    if (!_transportTraits) {
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
+     if(!_client) {
+        _tcpDeprecated = _transportTraits->create();
+        _client = _tcpDeprecated.get();
+     }
+#endif
+
+    if (!_client) {
         log_d("HTTPClient::begin was not called or returned error");
         return false;
     }
 
-    _tcp = _transportTraits->create();
-	
+    _client->setTimeout(_tcpTimeout);	
 
-    if (!_transportTraits->verify(*_tcp, _host.c_str())) {
-        log_d("transport level verify failed");
-        _tcp->stop();
-        return false;
-    }	
-
-    if(!_tcp->connect(_host.c_str(), _port)) {
+    if(!_client->connect(_host.c_str(), _port)) {
         log_d("failed connect to %s:%u", _host.c_str(), _port);
         return false;
     }
 
     log_d(" connected to %s:%u", _host.c_str(), _port);
 
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
+    if (_tcpDeprecated && !_transportTraits->verify(*_client, _host.c_str())) {
+        log_d("transport level verify failed");
+        _client->stop();
+        return false;
+    }	
+#endif
+
+
     // set Timeout for readBytesUntil and readStringUntil
-    setTimeout(_tcpTimeout);
+//    setTimeout(_tcpTimeout);
 /*
 #ifdef ESP8266
-    _tcp->setNoDelay(true);
+    _client->setNoDelay(true);
 #endif
  */
  return connected();
@@ -907,7 +1002,7 @@ bool HTTPClient::sendHeader(const char * type)
 
     header += _headers + "\r\n";
 
-    return (_tcp->write((const uint8_t *) header.c_str(), header.length()) == header.length());
+    return (_client->write((const uint8_t *) header.c_str(), header.length()) == header.length());
 }
 
 /**
@@ -928,9 +1023,9 @@ int HTTPClient::handleHeaderResponse()
     unsigned long lastDataTime = millis();
 
     while(connected()) {
-        size_t len = _tcp->available();
+        size_t len = _client->available();
         if(len > 0) {
-            String headerLine = _tcp->readStringUntil('\n');
+            String headerLine = _client->readStringUntil('\n');
             headerLine.trim(); // remove \r
 
             lastDataTime = millis();
@@ -1026,7 +1121,7 @@ int HTTPClient::writeToStreamDataBlock(Stream * stream, int size)
         while(connected() && (len > 0 || len == -1)) {
 
             // get available data size
-            size_t sizeAvailable = _tcp->available();
+            size_t sizeAvailable = _client->available();
 
             if(sizeAvailable) {
 
@@ -1043,7 +1138,7 @@ int HTTPClient::writeToStreamDataBlock(Stream * stream, int size)
                 }
 
                 // read data
-                int bytesRead = _tcp->readBytes(buff, readBytes);
+                int bytesRead = _client->readBytes(buff, readBytes);
 
                 // write it to Stream
                 int bytesWrite = stream->write(buff, bytesRead);
@@ -1124,7 +1219,7 @@ int HTTPClient::returnError(int error)
         log_w("error(%d): %s", error, errorToString(error).c_str());
         if(connected()) {
             log_d("tcp stop");
-            _tcp->stop();
+            _client->stop();
         }
     }
     return error;

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -22,6 +22,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
+ * Adapted in October 2018
  */
 
 #include <Arduino.h>

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -27,6 +27,8 @@
 #ifndef HTTPClient_H_
 #define HTTPClient_H_
 
+#define HTTPCLIENT_1_1_COMPATIBLE
+
 #include <memory>
 #include <Arduino.h>
 #include <WiFiClient.h>
@@ -117,8 +119,10 @@ typedef enum {
     HTTPC_TE_CHUNKED
 } transferEncoding_t;
 
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
 class TransportTraits;
 typedef std::unique_ptr<TransportTraits> TransportTraitsPtr;
+#endif
 
 class HTTPClient
 {
@@ -126,11 +130,20 @@ public:
     HTTPClient();
     ~HTTPClient();
 
+/*
+ * Since both begin() functions take a reference to client as a parameter, you need to 
+ * ensure the client object lives the entire time of the HTTPClient
+ */
+    bool begin(WiFiClient &client, String url);
+    bool begin(WiFiClient &client, String host, uint16_t port, String uri = "/", bool https = false);
+
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
     bool begin(String url);
     bool begin(String url, const char* CAcert);
     bool begin(String host, uint16_t port, String uri = "/");
     bool begin(String host, uint16_t port, String uri, const char* CAcert);
     bool begin(String host, uint16_t port, String uri, const char* CAcert, const char* cli_cert, const char* cli_key);
+#endif
 
     void end(void);
 
@@ -181,6 +194,7 @@ protected:
     };
 
     bool beginInternal(String url, const char* expectedProtocol);
+    void disconnect();
     void clear();
     int returnError(int error);
     bool connect(void);
@@ -189,8 +203,12 @@ protected:
     int writeToStreamDataBlock(Stream * stream, int len);
 
 
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
     TransportTraitsPtr _transportTraits;
-    std::unique_ptr<WiFiClient> _tcp;
+    std::unique_ptr<WiFiClient> _tcpDeprecated;
+#endif
+
+    WiFiClient* _client;
 
     /// request handling
     String _host;

--- a/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
@@ -1,0 +1,74 @@
+/**
+   httpUpdate.ino
+
+    Created on: 27.11.2015
+
+*/
+
+#include <Arduino.h>
+
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+
+#include <ESP8266HTTPClient.h>
+#include <ESP8266httpUpdate.h>
+
+#define USE_SERIAL Serial
+
+ESP8266WiFiMulti WiFiMulti;
+
+void setup() {
+
+  USE_SERIAL.begin(115200);
+  // USE_SERIAL.setDebugOutput(true);
+
+  USE_SERIAL.println();
+  USE_SERIAL.println();
+  USE_SERIAL.println();
+
+  for (uint8_t t = 4; t > 0; t--) {
+    USE_SERIAL.printf("[SETUP] WAIT %d...\n", t);
+    USE_SERIAL.flush();
+    delay(1000);
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFiMulti.addAP("SSID", "PASSWORD");
+
+
+}
+
+void loop() {
+  // wait for WiFi connection
+  if ((WiFiMulti.run() == WL_CONNECTED)) {
+
+    WiFiClient client;
+
+    // The line below is optional. It can be used to blink the LED on the board during flashing
+    // The LED will be on during download of one buffer of data from the network. The LED will
+    // be off during writing that buffer to flash
+    // On a good connection the LED should flash regularly. On a bad connection the LED will be
+    // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
+    // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
+    ESPhttpUpdate.setLedPin(LED_BUILTIN, LOW);
+
+    t_httpUpdate_return ret = ESPhttpUpdate.update(client, "http://server/file.bin");
+    // Or:
+    //t_httpUpdate_return ret = ESPhttpUpdate.update(client, "server", 80, "file.bin");
+
+    switch (ret) {
+      case HTTP_UPDATE_FAILED:
+        USE_SERIAL.printf("HTTP_UPDATE_FAILD Error (%d): %s\n", ESPhttpUpdate.getLastError(), ESPhttpUpdate.getLastErrorString().c_str());
+        break;
+
+      case HTTP_UPDATE_NO_UPDATES:
+        USE_SERIAL.println("HTTP_UPDATE_NO_UPDATES");
+        break;
+
+      case HTTP_UPDATE_OK:
+        USE_SERIAL.println("HTTP_UPDATE_OK");
+        break;
+    }
+  }
+}
+

--- a/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
@@ -48,7 +48,7 @@ void loop() {
     // On a good connection the LED should flash regularly. On a bad connection the LED will be
     // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
     // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
-    httpUpdate.setLedPin(LED_BUILTIN, LOW);
+    // httpUpdate.setLedPin(LED_BUILTIN, LOW);
 
     t_httpUpdate_return ret = httpUpdate.update(client, "http://server/file.bin");
     // Or:

--- a/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
@@ -7,28 +7,26 @@
 
 #include <Arduino.h>
 
-#include <ESP8266WiFi.h>
-#include <ESP8266WiFiMulti.h>
+#include <WiFi.h>
+#include <WiFiMulti.h>
 
-#include <ESP8266HTTPClient.h>
-#include <ESP8266httpUpdate.h>
+#include <HTTPClient.h>
+#include <HTTPUpdate.h>
 
-#define USE_SERIAL Serial
-
-ESP8266WiFiMulti WiFiMulti;
+WiFiMulti WiFiMulti;
 
 void setup() {
 
-  USE_SERIAL.begin(115200);
-  // USE_SERIAL.setDebugOutput(true);
+  Serial.begin(115200);
+  // Serial.setDebugOutput(true);
 
-  USE_SERIAL.println();
-  USE_SERIAL.println();
-  USE_SERIAL.println();
+  Serial.println();
+  Serial.println();
+  Serial.println();
 
   for (uint8_t t = 4; t > 0; t--) {
-    USE_SERIAL.printf("[SETUP] WAIT %d...\n", t);
-    USE_SERIAL.flush();
+    Serial.printf("[SETUP] WAIT %d...\n", t);
+    Serial.flush();
     delay(1000);
   }
 
@@ -50,23 +48,23 @@ void loop() {
     // On a good connection the LED should flash regularly. On a bad connection the LED will be
     // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
     // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
-    ESPhttpUpdate.setLedPin(LED_BUILTIN, LOW);
+    httpUpdate.setLedPin(LED_BUILTIN, LOW);
 
-    t_httpUpdate_return ret = ESPhttpUpdate.update(client, "http://server/file.bin");
+    t_httpUpdate_return ret = httpUpdate.update(client, "http://server/file.bin");
     // Or:
-    //t_httpUpdate_return ret = ESPhttpUpdate.update(client, "server", 80, "file.bin");
+    //t_httpUpdate_return ret = httpUpdate.update(client, "server", 80, "file.bin");
 
     switch (ret) {
       case HTTP_UPDATE_FAILED:
-        USE_SERIAL.printf("HTTP_UPDATE_FAILD Error (%d): %s\n", ESPhttpUpdate.getLastError(), ESPhttpUpdate.getLastErrorString().c_str());
+        Serial.printf("HTTP_UPDATE_FAILD Error (%d): %s\n", httpUpdate.getLastError(), httpUpdate.getLastErrorString().c_str());
         break;
 
       case HTTP_UPDATE_NO_UPDATES:
-        USE_SERIAL.println("HTTP_UPDATE_NO_UPDATES");
+        Serial.println("HTTP_UPDATE_NO_UPDATES");
         break;
 
       case HTTP_UPDATE_OK:
-        USE_SERIAL.println("HTTP_UPDATE_OK");
+        Serial.println("HTTP_UPDATE_OK");
         break;
     }
   }

--- a/libraries/HTTPUpdate/examples/httpUpdateSPIFFS/httpUpdateSPIFFS.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdateSPIFFS/httpUpdateSPIFFS.ino
@@ -1,0 +1,77 @@
+/**
+   httpUpdateSPIFFS.ino
+
+    Created on: 05.12.2015
+
+*/
+
+#include <Arduino.h>
+
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+
+#include <ESP8266HTTPClient.h>
+#include <ESP8266httpUpdate.h>
+
+#define USE_SERIAL Serial
+
+ESP8266WiFiMulti WiFiMulti;
+
+void setup() {
+
+  USE_SERIAL.begin(115200);
+  // USE_SERIAL.setDebugOutput(true);
+
+  USE_SERIAL.println();
+  USE_SERIAL.println();
+  USE_SERIAL.println();
+
+  for (uint8_t t = 4; t > 0; t--) {
+    USE_SERIAL.printf("[SETUP] WAIT %d...\n", t);
+    USE_SERIAL.flush();
+    delay(1000);
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFiMulti.addAP("SSID", "PASSWORD");
+
+}
+
+void loop() {
+  // wait for WiFi connection
+  if ((WiFiMulti.run() == WL_CONNECTED)) {
+
+    USE_SERIAL.println("Update SPIFFS...");
+
+    WiFiClient client;
+
+    // The line below is optional. It can be used to blink the LED on the board during flashing
+    // The LED will be on during download of one buffer of data from the network. The LED will
+    // be off during writing that buffer to flash
+    // On a good connection the LED should flash regularly. On a bad connection the LED will be
+    // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
+    // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
+    ESPhttpUpdate.setLedPin(LED_BUILTIN, LOW);
+
+    t_httpUpdate_return ret = ESPhttpUpdate.updateSpiffs(client, "http://server/spiffs.bin");
+    if (ret == HTTP_UPDATE_OK) {
+      USE_SERIAL.println("Update sketch...");
+      ret = ESPhttpUpdate.update(client, "http://server/file.bin");
+
+      switch (ret) {
+        case HTTP_UPDATE_FAILED:
+          USE_SERIAL.printf("HTTP_UPDATE_FAILED Error (%d): %s", ESPhttpUpdate.getLastError(), ESPhttpUpdate.getLastErrorString().c_str());
+          break;
+
+        case HTTP_UPDATE_NO_UPDATES:
+          USE_SERIAL.println("HTTP_UPDATE_NO_UPDATES");
+          break;
+
+        case HTTP_UPDATE_OK:
+          USE_SERIAL.println("HTTP_UPDATE_OK");
+          break;
+      }
+    }
+  }
+}
+

--- a/libraries/HTTPUpdate/examples/httpUpdateSPIFFS/httpUpdateSPIFFS.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdateSPIFFS/httpUpdateSPIFFS.ino
@@ -7,28 +7,26 @@
 
 #include <Arduino.h>
 
-#include <ESP8266WiFi.h>
-#include <ESP8266WiFiMulti.h>
+#include <WiFi.h>
+#include <WiFiMulti.h>
 
-#include <ESP8266HTTPClient.h>
-#include <ESP8266httpUpdate.h>
+#include <HTTPClient.h>
+#include <HTTPUpdate.h>
 
-#define USE_SERIAL Serial
-
-ESP8266WiFiMulti WiFiMulti;
+WiFiMulti WiFiMulti;
 
 void setup() {
 
-  USE_SERIAL.begin(115200);
-  // USE_SERIAL.setDebugOutput(true);
+  Serial.begin(115200);
+  // Serial.setDebugOutput(true);
 
-  USE_SERIAL.println();
-  USE_SERIAL.println();
-  USE_SERIAL.println();
+  Serial.println();
+  Serial.println();
+  Serial.println();
 
   for (uint8_t t = 4; t > 0; t--) {
-    USE_SERIAL.printf("[SETUP] WAIT %d...\n", t);
-    USE_SERIAL.flush();
+    Serial.printf("[SETUP] WAIT %d...\n", t);
+    Serial.flush();
     delay(1000);
   }
 
@@ -41,7 +39,7 @@ void loop() {
   // wait for WiFi connection
   if ((WiFiMulti.run() == WL_CONNECTED)) {
 
-    USE_SERIAL.println("Update SPIFFS...");
+    Serial.println("Update SPIFFS...");
 
     WiFiClient client;
 
@@ -51,24 +49,24 @@ void loop() {
     // On a good connection the LED should flash regularly. On a bad connection the LED will be
     // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
     // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
-    ESPhttpUpdate.setLedPin(LED_BUILTIN, LOW);
+    // httpUpdate.setLedPin(LED_BUILTIN, LOW);
 
-    t_httpUpdate_return ret = ESPhttpUpdate.updateSpiffs(client, "http://server/spiffs.bin");
+    t_httpUpdate_return ret = httpUpdate.updateSpiffs(client, "http://server/spiffs.bin");
     if (ret == HTTP_UPDATE_OK) {
-      USE_SERIAL.println("Update sketch...");
-      ret = ESPhttpUpdate.update(client, "http://server/file.bin");
+      Serial.println("Update sketch...");
+      ret = httpUpdate.update(client, "http://server/file.bin");
 
       switch (ret) {
         case HTTP_UPDATE_FAILED:
-          USE_SERIAL.printf("HTTP_UPDATE_FAILED Error (%d): %s", ESPhttpUpdate.getLastError(), ESPhttpUpdate.getLastErrorString().c_str());
+          Serial.printf("HTTP_UPDATE_FAILED Error (%d): %s", httpUpdate.getLastError(), httpUpdate.getLastErrorString().c_str());
           break;
 
         case HTTP_UPDATE_NO_UPDATES:
-          USE_SERIAL.println("HTTP_UPDATE_NO_UPDATES");
+          Serial.println("HTTP_UPDATE_NO_UPDATES");
           break;
 
         case HTTP_UPDATE_OK:
-          USE_SERIAL.println("HTTP_UPDATE_OK");
+          Serial.println("HTTP_UPDATE_OK");
           break;
       }
     }

--- a/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
@@ -104,7 +104,7 @@ void loop() {
     // On a good connection the LED should flash regularly. On a bad connection the LED will be
     // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
     // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
-    httpUpdate.setLedPin(LED_BUILTIN, HIGH);
+    // httpUpdate.setLedPin(LED_BUILTIN, HIGH);
 
     t_httpUpdate_return ret = httpUpdate.update(client, "https://server/file.bin");
     // Or:

--- a/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
@@ -1,0 +1,128 @@
+/**
+   httpUpdateSecure.ino
+
+    Created on: 16.10.2018 as an adaptation of the ESP8266 version of httpUpdate.ino
+
+*/
+
+#include <WiFi.h>
+#include <WiFiMulti.h>
+
+#include <HTTPClient.h>
+#include <HTTPUpdate.h>
+
+#include <time.h>
+
+WiFiMulti WiFiMulti;
+
+// Set time via NTP, as required for x.509 validation
+void setClock() {
+  configTime(0, 0, "pool.ntp.org", "time.nist.gov");  // UTC
+
+  Serial.print(F("Waiting for NTP time sync: "));
+  time_t now = time(nullptr);
+  while (now < 8 * 3600 * 2) {
+    yield();
+    delay(500);
+    Serial.print(F("."));
+    now = time(nullptr);
+  }
+
+  Serial.println(F(""));
+  struct tm timeinfo;
+  gmtime_r(&now, &timeinfo);
+  Serial.print(F("Current time: "));
+  Serial.print(asctime(&timeinfo));
+}
+
+/**
+ * This is lets-encrypt-x3-cross-signed.pem
+ */
+const char* rootCACertificate = \
+"-----BEGIN CERTIFICATE-----\n" \
+"MIIEkjCCA3qgAwIBAgIQCgFBQgAAAVOFc2oLheynCDANBgkqhkiG9w0BAQsFADA/\n" \
+"MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT\n" \
+"DkRTVCBSb290IENBIFgzMB4XDTE2MDMxNzE2NDA0NloXDTIxMDMxNzE2NDA0Nlow\n" \
+"SjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUxldCdzIEVuY3J5cHQxIzAhBgNVBAMT\n" \
+"GkxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzMIIBIjANBgkqhkiG9w0BAQEFAAOC\n" \
+"AQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EF\n" \
+"q6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8\n" \
+"SMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0\n" \
+"Z8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWA\n" \
+"a6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj\n" \
+"/PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQABo4IBfTCCAXkwEgYDVR0T\n" \
+"AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwfwYIKwYBBQUHAQEEczBxMDIG\n" \
+"CCsGAQUFBzABhiZodHRwOi8vaXNyZy50cnVzdGlkLm9jc3AuaWRlbnRydXN0LmNv\n" \
+"bTA7BggrBgEFBQcwAoYvaHR0cDovL2FwcHMuaWRlbnRydXN0LmNvbS9yb290cy9k\n" \
+"c3Ryb290Y2F4My5wN2MwHwYDVR0jBBgwFoAUxKexpHsscfrb4UuQdf/EFWCFiRAw\n" \
+"VAYDVR0gBE0wSzAIBgZngQwBAgEwPwYLKwYBBAGC3xMBAQEwMDAuBggrBgEFBQcC\n" \
+"ARYiaHR0cDovL2Nwcy5yb290LXgxLmxldHNlbmNyeXB0Lm9yZzA8BgNVHR8ENTAz\n" \
+"MDGgL6AthitodHRwOi8vY3JsLmlkZW50cnVzdC5jb20vRFNUUk9PVENBWDNDUkwu\n" \
+"Y3JsMB0GA1UdDgQWBBSoSmpjBH3duubRObemRWXv86jsoTANBgkqhkiG9w0BAQsF\n" \
+"AAOCAQEA3TPXEfNjWDjdGBX7CVW+dla5cEilaUcne8IkCJLxWh9KEik3JHRRHGJo\n" \
+"uM2VcGfl96S8TihRzZvoroed6ti6WqEBmtzw3Wodatg+VyOeph4EYpr/1wXKtx8/\n" \
+"wApIvJSwtmVi4MFU5aMqrSDE6ea73Mj2tcMyo5jMd6jmeWUHK8so/joWUoHOUgwu\n" \
+"X4Po1QYz+3dszkDqMp4fklxBwXRsW10KXzPMTZ+sOPAveyxindmjkW8lGy+QsRlG\n" \
+"PfZ+G6Z6h7mjem0Y+iWlkYcV4PIWL1iwBi8saCbGS5jN2p8M+X+Q7UNKEkROb3N6\n" \
+"KOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==\n" \
+"-----END CERTIFICATE-----\n";
+
+void setup() {
+
+  Serial.begin(115200);
+  // Serial.setDebugOutput(true);
+
+  Serial.println();
+  Serial.println();
+  Serial.println();
+
+  for (uint8_t t = 4; t > 0; t--) {
+    Serial.printf("[SETUP] WAIT %d...\n", t);
+    Serial.flush();
+    delay(1000);
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFiMulti.addAP("SSID", "PASSWORD");
+}
+
+void loop() {
+  // wait for WiFi connection
+  if ((WiFiMulti.run() == WL_CONNECTED)) {
+
+    setClock();
+
+    WiFiClientSecure client;
+    client.setCACert(rootCACertificate);
+
+    // Reading data over SSL may be slow, use an adequate timeout
+    client.setTimeout(12000);
+
+    // The line below is optional. It can be used to blink the LED on the board during flashing
+    // The LED will be on during download of one buffer of data from the network. The LED will
+    // be off during writing that buffer to flash
+    // On a good connection the LED should flash regularly. On a bad connection the LED will be
+    // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
+    // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
+    httpUpdate.setLedPin(LED_BUILTIN, HIGH);
+
+    t_httpUpdate_return ret = httpUpdate.update(client, "https://server/file.bin");
+    // Or:
+    //t_httpUpdate_return ret = httpUpdate.update(client, "server", 443, "file.bin");
+
+
+    switch (ret) {
+      case HTTP_UPDATE_FAILED:
+        Serial.printf("HTTP_UPDATE_FAILED Error (%d): %s\n", httpUpdate.getLastError(), httpUpdate.getLastErrorString().c_str());
+        break;
+
+      case HTTP_UPDATE_NO_UPDATES:
+        Serial.println("HTTP_UPDATE_NO_UPDATES");
+        break;
+
+      case HTTP_UPDATE_OK:
+        Serial.println("HTTP_UPDATE_OK");
+        break;
+    }
+  }
+}

--- a/libraries/HTTPUpdate/keywords.txt
+++ b/libraries/HTTPUpdate/keywords.txt
@@ -1,0 +1,42 @@
+#######################################
+# Syntax Coloring Map For ESP8266httpUpdate
+#######################################
+
+#######################################
+# Library (KEYWORD3)
+#######################################
+
+ESP8266httpUpdate	KEYWORD3		RESERVED_WORD
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+HTTPUpdateResult	KEYWORD1		DATA_TYPE
+ESPhttpUpdate	KEYWORD1		DATA_TYPE
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+rebootOnUpdate	KEYWORD2
+update	KEYWORD2
+updateSpiffs	KEYWORD2
+getLastError	KEYWORD2
+getLastErrorString	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+HTTP_UE_TOO_LESS_SPACE	LITERAL1		RESERVED_WORD_2
+HTTP_UE_SERVER_NOT_REPORT_SIZE	LITERAL1		RESERVED_WORD_2
+HTTP_UE_SERVER_FILE_NOT_FOUND	LITERAL1		RESERVED_WORD_2
+HTTP_UE_SERVER_FORBIDDEN	LITERAL1		RESERVED_WORD_2
+HTTP_UE_SERVER_WRONG_HTTP_CODE	LITERAL1		RESERVED_WORD_2
+HTTP_UE_SERVER_FAULTY_MD5	LITERAL1		RESERVED_WORD_2
+HTTP_UE_BIN_VERIFY_HEADER_FAILED	LITERAL1		RESERVED_WORD_2
+HTTP_UE_BIN_FOR_WRONG_FLASH	LITERAL1		RESERVED_WORD_2
+HTTP_UPDATE_FAILED	LITERAL1		RESERVED_WORD_2
+HTTP_UPDATE_NO_UPDATES	LITERAL1		RESERVED_WORD_2
+HTTP_UPDATE_OK	LITERAL1		RESERVED_WORD_2

--- a/libraries/HTTPUpdate/library.properties
+++ b/libraries/HTTPUpdate/library.properties
@@ -1,0 +1,9 @@
+name=HTTPUpdate
+version=1.3
+author=Markus Sattler
+maintainer=Markus Sattler
+sentence=Http Update for ESP32
+paragraph=
+category=Data Processing
+url=https://github.com/Links2004/Arduino/tree/esp8266/hardware/esp8266com/esp8266/libraries/ESP8266httpUpdate
+architectures=esp32

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -1,0 +1,356 @@
+/**
+ *
+ * @file HTTPUpdate.cpp based om ESP8266HTTPUpdate.cpp
+ * @date 16.10.2018
+ * @author Markus Sattler
+ *
+ * Copyright (c) 2015 Markus Sattler. All rights reserved.
+ * This file is part of the ESP32 Http Updater.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "HTTPUpdate.h"
+#include <StreamString.h>
+
+// To do extern "C" uint32_t _SPIFFS_start;
+// To do extern "C" uint32_t _SPIFFS_end;
+
+HTTPUpdate::HTTPUpdate(void)
+        : _httpClientTimeout(8000), _ledPin(-1)
+{
+}
+
+HTTPUpdate::HTTPUpdate(int httpClientTimeout)
+        : _httpClientTimeout(httpClientTimeout), _ledPin(-1)
+{
+}
+
+HTTPUpdate::~HTTPUpdate(void)
+{
+}
+
+HTTPUpdateResult HTTPUpdate::update(WiFiClient& client, const String& url, const String& currentVersion)
+{
+    HTTPClient http;
+    http.begin(client, url);
+    return handleUpdate(http, currentVersion, false);
+}
+
+HTTPUpdateResult HTTPUpdate::updateSpiffs(WiFiClient& client, const String& url, const String& currentVersion)
+{
+    HTTPClient http;
+    http.begin(client, url);
+    return handleUpdate(http, currentVersion, true);
+}
+
+HTTPUpdateResult HTTPUpdate::update(WiFiClient& client, const String& host, uint16_t port, const String& uri,
+        const String& currentVersion)
+{
+    HTTPClient http;
+    http.begin(client, host, port, uri);
+    return handleUpdate(http, currentVersion, false);
+}
+
+/**
+ * return error code as int
+ * @return int error code
+ */
+int HTTPUpdate::getLastError(void)
+{
+    return _lastError;
+}
+
+/**
+ * return error code as String
+ * @return String error
+ */
+String HTTPUpdate::getLastErrorString(void)
+{
+
+    if(_lastError == 0) {
+        return String(); // no error
+    }
+
+    // error from Update class
+    if(_lastError > 0) {
+        StreamString error;
+        Update.printError(error);
+        error.trim(); // remove line ending
+        return String(F("Update error: ")) + error;
+    }
+
+    // error from http client
+    if(_lastError > -100) {
+        return String(F("HTTP error: ")) + HTTPClient::errorToString(_lastError);
+    }
+
+    switch(_lastError) {
+    case HTTP_UE_TOO_LESS_SPACE:
+        return F("Not Enough space");
+    case HTTP_UE_SERVER_NOT_REPORT_SIZE:
+        return F("Server Did Not Report Size");
+    case HTTP_UE_SERVER_FILE_NOT_FOUND:
+        return F("File Not Found (404)");
+    case HTTP_UE_SERVER_FORBIDDEN:
+        return F("Forbidden (403)");
+    case HTTP_UE_SERVER_WRONG_HTTP_CODE:
+        return F("Wrong HTTP Code");
+    case HTTP_UE_SERVER_FAULTY_MD5:
+        return F("Wrong MD5");
+    case HTTP_UE_BIN_VERIFY_HEADER_FAILED:
+        return F("Verify Bin Header Failed");
+    case HTTP_UE_BIN_FOR_WRONG_FLASH:
+        return F("New Binary Does Not Fit Flash Size");
+    }
+
+    return String();
+}
+
+
+/**
+ *
+ * @param http HTTPClient *
+ * @param currentVersion const char *
+ * @return HTTPUpdateResult
+ */
+HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient& http, const String& currentVersion, bool spiffs)
+{
+
+    HTTPUpdateResult ret = HTTP_UPDATE_FAILED;
+
+    // use HTTP/1.0 for update since the update handler not support any transfer Encoding
+    http.useHTTP10(true);
+    http.setTimeout(_httpClientTimeout);
+    http.setUserAgent(F("ESP32-http-Update"));
+    http.addHeader(F("Cache-Control"), F("no-cache"));
+    http.addHeader(F("x-ESP32-STA-MAC"), WiFi.macAddress());
+    http.addHeader(F("x-ESP32-AP-MAC"), WiFi.softAPmacAddress());
+// To do    http.addHeader(F("x-ESP32-free-space"), String(ESP.getFreeSketchSpace()));
+// To do    http.addHeader(F("x-ESP32-sketch-size"), String(ESP.getSketchSize()));
+// To do    http.addHeader(F("x-ESP32-sketch-md5"), String(ESP.getSketchMD5()));
+// To do    http.addHeader(F("x-ESP32-chip-size"), String(ESP.getFlashChipRealSize()));
+    http.addHeader(F("x-ESP32-sdk-version"), ESP.getSdkVersion());
+
+    if(spiffs) {
+        http.addHeader(F("x-ESP32-mode"), F("spiffs"));
+    } else {
+        http.addHeader(F("x-ESP32-mode"), F("sketch"));
+    }
+
+    if(currentVersion && currentVersion[0] != 0x00) {
+        http.addHeader(F("x-ESP32-version"), currentVersion);
+    }
+
+    const char * headerkeys[] = { "x-MD5" };
+    size_t headerkeyssize = sizeof(headerkeys) / sizeof(char*);
+
+    // track these headers
+    http.collectHeaders(headerkeys, headerkeyssize);
+
+
+    int code = http.GET();
+    int len = http.getSize();
+
+    if(code <= 0) {
+        log_e("HTTP error: %s\n", http.errorToString(code).c_str());
+        _lastError = code;
+        http.end();
+        return HTTP_UPDATE_FAILED;
+    }
+
+
+    log_d("Header read fin.\n");
+    log_d("Server header:\n");
+    log_d(" - code: %d\n", code);
+    log_d(" - len: %d\n", len);
+
+    if(http.hasHeader("x-MD5")) {
+        log_d(" - MD5: %s\n", http.header("x-MD5").c_str());
+    }
+
+    log_d("ESP32 info:\n");
+// To do    log_d(" - free Space: %d\n", ESP.getFreeSketchSpace());
+// To do    log_d(" - current Sketch Size: %d\n", ESP.getSketchSize());
+
+    if(currentVersion && currentVersion[0] != 0x00) {
+        log_d(" - current version: %s\n", currentVersion.c_str() );
+    }
+
+    switch(code) {
+    case HTTP_CODE_OK:  ///< OK (Start Update)
+        if(len > 0) {
+            bool startUpdate = true;
+            if(spiffs) {
+// To do                size_t spiffsSize = ((size_t) &_SPIFFS_end - (size_t) &_SPIFFS_start);
+// To do                if(len > (int) spiffsSize) {
+// To do                    log_e("spiffsSize to low (%d) needed: %d\n", spiffsSize, len);
+// To do                    startUpdate = false;
+// To do                }
+            } else {
+// To do                if(len > (int) ESP.getFreeSketchSpace()) {
+// To do                    log_e("FreeSketchSpace to low (%d) needed: %d\n", ESP.getFreeSketchSpace(), len);
+// To do                    startUpdate = false;
+// To do                }
+            }
+
+            if(!startUpdate) {
+                _lastError = HTTP_UE_TOO_LESS_SPACE;
+                ret = HTTP_UPDATE_FAILED;
+            } else {
+
+                WiFiClient * tcp = http.getStreamPtr();
+
+// To do?                WiFiUDP::stopAll();
+// To do?                WiFiClient::stopAllExcept(tcp);
+
+                delay(100);
+
+                int command;
+
+                if(spiffs) {
+                    command = U_SPIFFS;
+                    log_d("runUpdate spiffs...\n");
+                } else {
+                    command = U_FLASH;
+                    log_d("runUpdate flash...\n");
+                }
+
+                if(!spiffs) {
+/* To check
+                    uint8_t buf[4];
+                    if(tcp->peekBytes(&buf[0], 4) != 4) {
+                        log_e("peekBytes magic header failed\n");
+                        _lastError = HTTP_UE_BIN_VERIFY_HEADER_FAILED;
+                        http.end();
+                        return HTTP_UPDATE_FAILED;
+                    }
+*/
+
+                    // check for valid first magic byte
+//                    if(buf[0] != 0xE9) {
+                    if(tcp->peek() != 0xE9) {
+                        log_e("Magic header does not start with 0xE9\n");
+                        _lastError = HTTP_UE_BIN_VERIFY_HEADER_FAILED;
+                        http.end();
+                        return HTTP_UPDATE_FAILED;
+
+                    }
+/* To do
+                    uint32_t bin_flash_size = ESP.magicFlashChipSize((buf[3] & 0xf0) >> 4);
+
+                    // check if new bin fits to SPI flash
+                    if(bin_flash_size > ESP.getFlashChipRealSize()) {
+                        log_e("New binary does not fit SPI Flash size\n");
+                        _lastError = HTTP_UE_BIN_FOR_WRONG_FLASH;
+                        http.end();
+                        return HTTP_UPDATE_FAILED;
+                    }
+*/
+                }
+                if(runUpdate(*tcp, len, http.header("x-MD5"), command)) {
+                    ret = HTTP_UPDATE_OK;
+                    log_d("Update ok\n");
+                    http.end();
+
+                    if(_rebootOnUpdate && !spiffs) {
+                        ESP.restart();
+                    }
+
+                } else {
+                    ret = HTTP_UPDATE_FAILED;
+                    log_e("Update failed\n");
+                }
+            }
+        } else {
+            _lastError = HTTP_UE_SERVER_NOT_REPORT_SIZE;
+            ret = HTTP_UPDATE_FAILED;
+            log_e("Content-Length was 0 or wasn't set by Server?!\n");
+        }
+        break;
+    case HTTP_CODE_NOT_MODIFIED:
+        ///< Not Modified (No updates)
+        ret = HTTP_UPDATE_NO_UPDATES;
+        break;
+    case HTTP_CODE_NOT_FOUND:
+        _lastError = HTTP_UE_SERVER_FILE_NOT_FOUND;
+        ret = HTTP_UPDATE_FAILED;
+        break;
+    case HTTP_CODE_FORBIDDEN:
+        _lastError = HTTP_UE_SERVER_FORBIDDEN;
+        ret = HTTP_UPDATE_FAILED;
+        break;
+    default:
+        _lastError = HTTP_UE_SERVER_WRONG_HTTP_CODE;
+        ret = HTTP_UPDATE_FAILED;
+        log_e("HTTP Code is (%d)\n", code);
+        break;
+    }
+
+    http.end();
+    return ret;
+}
+
+/**
+ * write Update to flash
+ * @param in Stream&
+ * @param size uint32_t
+ * @param md5 String
+ * @return true if Update ok
+ */
+bool HTTPUpdate::runUpdate(Stream& in, uint32_t size, String md5, int command)
+{
+
+    StreamString error;
+
+    if(!Update.begin(size, command, _ledPin, _ledOn)) {
+        _lastError = Update.getError();
+        Update.printError(error);
+        error.trim(); // remove line ending
+        log_e("Update.begin failed! (%s)\n", error.c_str());
+        return false;
+    }
+
+    if(md5.length()) {
+        if(!Update.setMD5(md5.c_str())) {
+            _lastError = HTTP_UE_SERVER_FAULTY_MD5;
+            log_e("Update.setMD5 failed! (%s)\n", md5.c_str());
+            return false;
+        }
+    }
+
+    if(Update.writeStream(in) != size) {
+        _lastError = Update.getError();
+        Update.printError(error);
+        error.trim(); // remove line ending
+        log_e("Update.writeStream failed! (%s)\n", error.c_str());
+        return false;
+    }
+
+    if(!Update.end()) {
+        _lastError = Update.getError();
+        Update.printError(error);
+        error.trim(); // remove line ending
+        log_e("Update.end failed! (%s)\n", error.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_HTTPUPDATE)
+HTTPUpdate httpUpdate;
+#endif

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -230,7 +230,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient& http, const String& curren
                 }
 
                 if(!spiffs) {
-/* To check
+/* To do
                     uint8_t buf[4];
                     if(tcp->peekBytes(&buf[0], 4) != 4) {
                         log_e("peekBytes magic header failed\n");

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -1,0 +1,100 @@
+/**
+ *
+ * @file HTTPUpdate.h based on ESP8266HTTPUpdate.h
+ * @date 16.10.2018
+ * @author Markus Sattler
+ *
+ * Copyright (c) 2015 Markus Sattler. All rights reserved.
+ * This file is part of the ESP32 Http Updater.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef ___HTTP_UPDATE_H___
+#define ___HTTP_UPDATE_H___
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <WiFiUdp.h>
+#include <HTTPClient.h>
+#include <Update.h>
+
+/// note we use HTTP client errors too so we start at 100
+#define HTTP_UE_TOO_LESS_SPACE              (-100)
+#define HTTP_UE_SERVER_NOT_REPORT_SIZE      (-101)
+#define HTTP_UE_SERVER_FILE_NOT_FOUND       (-102)
+#define HTTP_UE_SERVER_FORBIDDEN            (-103)
+#define HTTP_UE_SERVER_WRONG_HTTP_CODE      (-104)
+#define HTTP_UE_SERVER_FAULTY_MD5           (-105)
+#define HTTP_UE_BIN_VERIFY_HEADER_FAILED    (-106)
+#define HTTP_UE_BIN_FOR_WRONG_FLASH         (-107)
+
+enum HTTPUpdateResult {
+    HTTP_UPDATE_FAILED,
+    HTTP_UPDATE_NO_UPDATES,
+    HTTP_UPDATE_OK
+};
+
+typedef HTTPUpdateResult t_httpUpdate_return; // backward compatibility
+
+class HTTPUpdate
+{
+public:
+    HTTPUpdate(void);
+    HTTPUpdate(int httpClientTimeout);
+    ~HTTPUpdate(void);
+
+    void rebootOnUpdate(bool reboot)
+    {
+        _rebootOnUpdate = reboot;
+    }
+
+    void setLedPin(int ledPin = -1, uint8_t ledOn = HIGH)
+    {
+        _ledPin = ledPin;
+        _ledOn = ledOn;
+    }
+
+    t_httpUpdate_return update(WiFiClient& client, const String& url, const String& currentVersion = "");
+
+    t_httpUpdate_return update(WiFiClient& client, const String& host, uint16_t port, const String& uri = "/",
+                               const String& currentVersion = "");
+
+    t_httpUpdate_return updateSpiffs(WiFiClient& client, const String& url, const String& currentVersion = "");
+
+
+    int getLastError(void);
+    String getLastErrorString(void);
+
+protected:
+    t_httpUpdate_return handleUpdate(HTTPClient& http, const String& currentVersion, bool spiffs = false);
+    bool runUpdate(Stream& in, uint32_t size, String md5, int command = U_FLASH);
+
+    int _lastError;
+    bool _rebootOnUpdate = true;
+private:
+    int _httpClientTimeout;
+
+    int _ledPin;
+    uint8_t _ledOn;
+};
+
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_HTTPUPDATE)
+extern HTTPUpdate httpUpdate;
+#endif
+
+#endif /* ___HTTP_UPDATE_H___ */

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -41,7 +41,7 @@ class UpdateClass {
       Call this to check the space needed for the update
       Will return false if there is not enough space
     */
-    bool begin(size_t size=UPDATE_SIZE_UNKNOWN, int command = U_FLASH);
+    bool begin(size_t size=UPDATE_SIZE_UNKNOWN, int command = U_FLASH, int ledPin = -1, uint8_t ledOn = LOW);
 
     /*
       Writes a buffer to the flash and increments the address
@@ -174,6 +174,9 @@ class UpdateClass {
 
     String _target_md5;
     MD5Builder _md5;
+
+    int _ledPin;
+    uint8_t _ledOn;
 };
 
 extern UpdateClass Update;

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -88,6 +88,10 @@ void UpdateClass::_reset() {
     _progress = 0;
     _size = 0;
     _command = U_FLASH;
+
+    if(_ledPin != -1) {
+      digitalWrite(_ledPin, !_ledOn); // off
+    }
 }
 
 bool UpdateClass::canRollBack(){
@@ -106,11 +110,14 @@ bool UpdateClass::rollBack(){
     return _partitionIsBootable(partition) && !esp_ota_set_boot_partition(partition);
 }
 
-bool UpdateClass::begin(size_t size, int command) {
+bool UpdateClass::begin(size_t size, int command, int ledPin, uint8_t ledOn) {
     if(_size > 0){
         log_w("already running");
         return false;
     }
+
+    _ledPin = ledPin;
+    _ledOn = !!ledOn; // 0(LOW) or 1(HIGH)
 
     _reset();
     _error = 0;
@@ -315,15 +322,31 @@ size_t UpdateClass::writeStream(Stream &data) {
     if (_progress_callback) {
         _progress_callback(0, _size);
     }
+
+    if(_ledPin != -1) {
+        pinMode(_ledPin, OUTPUT);
+    }
+
     while(remaining()) {
-        toRead = data.readBytes(_buffer + _bufferLen,  (SPI_FLASH_SEC_SIZE - _bufferLen));
+        if(_ledPin != -1) {
+            digitalWrite(_ledPin, _ledOn); // Switch LED on
+        }
+        size_t bytesToRead = SPI_FLASH_SEC_SIZE - _bufferLen;
+        if(bytesToRead > remaining()) {
+            bytesToRead = remaining();
+        }
+
+        toRead = data.readBytes(_buffer + _bufferLen,  bytesToRead);
         if(toRead == 0) { //Timeout
             delay(100);
-            toRead = data.readBytes(_buffer + _bufferLen, (SPI_FLASH_SEC_SIZE - _bufferLen));
+            toRead = data.readBytes(_buffer + _bufferLen, bytesToRead);
             if(toRead == 0) { //Timeout
                 _abort(UPDATE_ERROR_STREAM);
                 return written;
             }
+        }
+        if(_ledPin != -1) {
+            digitalWrite(_ledPin, !_ledOn); // Switch LED off
         }
         _bufferLen += toRead;
         if((_bufferLen == remaining() || _bufferLen == SPI_FLASH_SEC_SIZE) && !_writeBuffer())

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -240,6 +240,7 @@ int WiFiClient::setSocketOption(int option, char* value, size_t len)
 
 int WiFiClient::setTimeout(uint32_t seconds)
 {
+    Client::setTimeout(seconds * 1000);
     struct timeval tv;
     tv.tv_sec = seconds;
     tv.tv_usec = 0;


### PR DESCRIPTION
Added HTTPUpdate class for downloading sketches from a server. It is somewhat similar to AWS_S3_OTA_update.ino from the libraries/Update/examples, however the adapted HTTPClient from PR #1973 is used in stead of printing HTTP headers directly to the client.

An example usage httpUpdateSecure.ino is given. This updates a firmware over a **secure** connection using the WiFiClientSecure class and a CA certificate. Of course a non secure WiFiClient may also be used.

The good thing is: it works. A bad thing might be that a few features that are present in the similar library for the ESP8266 are not present in this library. The reason for this is that these features rely on functions not (yet) implemented in the ESP32 libraries. However, these features are not essential to the functionality of the HTTPUpdate library. The missing features are:
- The HTTP Request Headers for free sketch space, sketch size, sketch MD5 and flash chip real size are not set due to missing functions in the ESP class. These headers are not essential for serving an update, the server hosting the binaries just should not expect these headers
- Log information showing sizes is also missing. This is also unessential
- The HTTPUpdate library does not check _beforehand_ if the binaries fit into either flash or spiffs, also because the needed ESP functions are missing. However the UpdateClass::begin() function is called at the start of the update and this function _does check if the binary fits_.
- Because peekBytes() is not implemented in WiFiClient, only the magic header byte 0xE9 is checked. After this magic byte follow bytes that indicate the length of the sketch to be uploaded. This length could be checked with the available length, but the available length could also not be determined (see bullit 2). This is also not essential, the library checks if it fits in another step (at Updater::begin())
- WiFiUDP::stopAll()and WiFiClient::stopAllExcept(tcp) are not called, also because these functions are not implemented (yet). As I recall correctly these functions were introduced due to issues with the ESP8266 WiFi chip. I did not encounter any issues on my ESP32 not calling these functions
- The code for all above missing features is still present in the library but commented out with _// To do_

The Update class is also changed:
- A small bug is solved: the UpdateClass::writeStream() function always tries to read a full buffer at the end of the stream. But at the end the last buffer is almost never full, and readBytes() exits on a timeout. With the fix the correct number of bytes is read, and the unneeded waiting is removed
- Two optional parameters ledPin and ledOn are added to UpdateClass::begin(). Settng the ledPin to LED_BUILTIN and ledOn to HIGH causes the built in LED to flash. The LED is on while reading a buffer from the internet and it is off during writing that buffer to flash. In this way visual feedback of the update process may be given. Passing -1 for LedPin causes this feature to be disabled. The included example makes use of this feature.

The HTTPClient from PR #1973 is included in this PR, because HTTPUpdate depends on it