### PR TITLE
Added Olimex ESP32-PoE board definitions

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1665,6 +1665,39 @@ esp32-gateway.menu.UploadSpeed.115200.upload.speed=115200
 
 ##############################################################
 
+esp32-poe.name=OLIMEX ESP32-PoE
+
+esp32-poe.upload.tool=esptool
+esp32-poe.upload.maximum_size=1310720
+esp32-poe.upload.maximum_data_size=327680
+esp32-poe.upload.wait_for_upload_port=true
+
+esp32-poe.serial.disableDTR=true
+esp32-poe.serial.disableRTS=true
+
+esp32-poe.build.mcu=esp32
+esp32-poe.build.core=esp32
+esp32-poe.build.variant=esp32-poe
+esp32-poe.build.board=ESP32_POE
+
+esp32-poe.build.f_cpu=240000000L
+esp32-poe.build.flash_mode=dio
+esp32-poe.build.flash_size=4MB
+esp32-poe.build.boot=dio
+esp32-poe.build.partitions=default
+esp32-poe.build.defines=
+
+esp32-poe.menu.FlashFreq.80=80MHz
+esp32-poe.menu.FlashFreq.80.build.flash_freq=80m
+esp32-poe.menu.FlashFreq.40=40MHz
+esp32-poe.menu.FlashFreq.40.build.flash_freq=40m
+
+
+esp32-poe.menu.UploadSpeed.115200=115200
+esp32-poe.menu.UploadSpeed.115200.upload.speed=115200
+
+##############################################################
+
 espino32.name=ThaiEasyElec's ESPino32
 
 espino32.upload.tool=esptool

--- a/variants/esp32-poe/pins_arduino.h
+++ b/variants/esp32-poe/pins_arduino.h
@@ -1,0 +1,28 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+
+static const uint8_t KEY_BUILTIN = 34;
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 13;
+static const uint8_t SCL = 16;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 2;
+static const uint8_t MISO  = 15;
+static const uint8_t SCK   = 14;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Added Olimex board ESP32-PoE. pins_arduino header file based on the ESP32-EVB with changed SS pin and removed BOARD_HAS_1BIT_SDMMC macro. Added the board description in boards.txt file in the same pattern like ESP32-EVB.