### PR TITLE
use libbase64 macro to calculate base64 length

### DIFF
--- a/cores/esp32/base64.cpp
+++ b/cores/esp32/base64.cpp
@@ -37,8 +37,7 @@ extern "C" {
  */
 String base64::encode(uint8_t * data, size_t length)
 {
-    // base64 needs more size then the source data
-    size_t size = ((length * 1.6f) + 1);
+    size_t size = base64_encode_expected_len(length) + 1;
     char * buffer = (char *) malloc(size);
     if(buffer) {
         base64_encodestate _state;

--- a/cores/esp32/libb64/cencode.c
+++ b/cores/esp32/libb64/cencode.c
@@ -7,13 +7,10 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include "cencode.h"
 
-const int CHARS_PER_LINE = 72;
-
 void base64_init_encodestate(base64_encodestate* state_in)
 {
     state_in->step = step_A;
     state_in->result = 0;
-    state_in->stepcount = 0;
 }
 
 char base64_encode_value(char value_in)
@@ -68,12 +65,6 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
             *codechar++ = base64_encode_value(result);
             result  = (fragment & 0x03f) >> 0;
             *codechar++ = base64_encode_value(result);
-
-            ++(state_in->stepcount);
-            if (state_in->stepcount == CHARS_PER_LINE/4) {
-                *codechar++ = '\n';
-                state_in->stepcount = 0;
-            }
         }
     }
     /* control should not reach here */


### PR DESCRIPTION
The calculation of the base64 encoded string length is incorrect as pointed out in #827. libbase64 already provides a macro that can be used to calculate the base64 encoded string length.

You also have to increment the calculated size by 1 for the trailing zero character.