### PR TITLE
fix uart_flush() returning early

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -333,7 +333,7 @@ void uartFlush(uart_t* uart)
     }
 
     UART_MUTEX_LOCK();
-    while(uart->dev->status.txfifo_cnt);
+    while(uart->dev->status.txfifo_cnt || uart->dev->status.st_utx_out);
 
     //Due to hardware issue, we can not use fifo_rst to reset uart fifo.
     //See description about UART_TXFIFO_RST and UART_RXFIFO_RST in <<esp32_technical_reference_manual>> v2.6 or later.


### PR DESCRIPTION
wait for UART FSM to become idle before uart_flush() returns:
current situation:
![image](https://user-images.githubusercontent.com/23474336/48157406-cc63cb80-e2cf-11e8-835a-96f8f44faf49.png)

new situation:
![image](https://user-images.githubusercontent.com/23474336/48157422-d5549d00-e2cf-11e8-94f2-efc9d8cf7f00.png)

tested with a simple sketch:
```C++
#include <Arduino.h>

void setup() {
  Serial.begin(112500);
  pinMode(26, OUTPUT);
}

void loop() {
  static uint32_t lastMillis = 0;
  if (millis() - lastMillis > 10000) {
    lastMillis = millis();
    digitalWrite(26, HIGH);
    Serial.write("Hello World!");
    Serial.flush();
    digitalWrite(26, LOW);
  }
}
```
Tested with Serial, Serial1 and Serial2.