### PR TITLE
uartResizeRxBuffer() returns no value

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -242,7 +242,7 @@ void uartEnd(uart_t* uart)
 
 size_t uartResizeRxBuffer(uart_t * uart, size_t new_size) {
     if(uart == NULL) {
-        return;
+        return 0;
     }
 
     UART_MUTEX_LOCK();


### PR DESCRIPTION
uartResizeRxBuffer() is declared to return a size_t but does not return anything when uart is not defined