### PR TITLE
Fixed Arduino SPI/Ethernet compile issue as described in issue #1623

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -214,6 +214,11 @@ void SPIClass::writeBytes(uint8_t * data, uint32_t size)
     spiEndTransaction(_spi);
 }
 
+void SPIClass::transfer(uint8_t * data, uint32_t size) 
+{ 
+	transferBytes(data, data, size); 
+}
+
 /**
  * @param data void *
  * @param size uint32_t

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -65,10 +65,11 @@ public:
 
     void beginTransaction(SPISettings settings);
     void endTransaction(void);
-
+    void transfer(uint8_t * data, uint32_t size);
     uint8_t transfer(uint8_t data);
     uint16_t transfer16(uint16_t data);
     uint32_t transfer32(uint32_t data);
+  
     void transferBytes(uint8_t * data, uint8_t * out, uint32_t size);
     void transferBits(uint32_t data, uint32_t * out, uint8_t bits);
 


### PR DESCRIPTION
Hi,
implemented missing SPI.transfer, required to compile Arduino SPI based Ethernet (W5500)
Splitted the suggested change in Issue #1623, in a header and source part. It compiles, works, but i'm not completely confident with exact location, and if this would be the best solution.
Please review, and accept the proposal. 
Not completely feeling confident with providing the data parameter twice to the transferBytes function, please, just copied it form the suggested solution in #1623 . 

Regards,

Arjan