### PR TITLE
Fix bug in PR #2148: correcting available() introduced an bug!

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -398,6 +398,10 @@ int WiFiClient::peek()
 
 int WiFiClient::available()
 {
+    if(!_rxBuffer)
+    {
+        return 0;
+    }
     int res = _rxBuffer->available();
     if(_rxBuffer->failed()) {
         log_e("%d", errno);


### PR DESCRIPTION
If ::available() is called before ::connect() _rxBuffer is not initialised