### PR TITLE
Fix HTTPUpdate flash size check and add SPIFFS size check

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -169,7 +169,12 @@ uint32_t EspClass::getSketchSize () {
 }
 
 uint32_t EspClass::getFreeSketchSpace () {
-    return sketchSize(SKETCH_SIZE_FREE);
+    const esp_partition_t* _partition = esp_ota_get_next_update_partition(NULL);
+    if(!_partition){
+        return 0;
+    }
+
+    return _partition->size;
 }
 
 uint8_t EspClass::getChipRevision(void)

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -251,14 +251,14 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient& http, const String& curren
                     startUpdate = false;
                 }
             } else {
-                const esp_partition_t* _partition = esp_ota_get_next_update_partition(NULL);
-                if(!_partition){
+                int sketchFreeSpace = ESP.getFreeSketchSpace();
+                if(!sketchFreeSpace){
                     _lastError = HTTP_UE_NO_PARTITION;
                     return HTTP_UPDATE_FAILED;
                 }
 
-                if(len > _partition->size) {
-                    log_e("FreeSketchSpace to low (%d) needed: %d\n", _partition->size, len);
+                if(len > sketchFreeSpace) {
+                    log_e("FreeSketchSpace to low (%d) needed: %d\n", sketchFreeSpace, len);
                     startUpdate = false;
                 }
             }
@@ -389,8 +389,6 @@ bool HTTPUpdate::runUpdate(Stream& in, uint32_t size, String md5, int command)
     }
 
 // To do: the SHA256 could be checked if the server sends it
-
-    delay(0);
 
     if(Update.writeStream(in) != size) {
         _lastError = Update.getError();

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -42,6 +42,7 @@
 #define HTTP_UE_SERVER_FAULTY_MD5           (-105)
 #define HTTP_UE_BIN_VERIFY_HEADER_FAILED    (-106)
 #define HTTP_UE_BIN_FOR_WRONG_FLASH         (-107)
+#define HTTP_UE_NO_PARTITION                (-108)
 
 enum HTTPUpdateResult {
     HTTP_UPDATE_FAILED,

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -398,6 +398,10 @@ int WiFiClient::peek()
 
 int WiFiClient::available()
 {
+    if(!_rxBuffer)
+    {
+        return 0;
+    }
     int res = _rxBuffer->available();
     if(_rxBuffer->failed()) {
         log_e("%d", errno);


### PR DESCRIPTION
HTTPUpdate checked if the new sketch would fit into the _current_ partition free space, which was wrong. Now it checks if it fits into the _next_ flash partition.

A size check for a SPIFFS update is added, this was stil 'to do' from the previous PR.

Still to do: the SHA256 hash could be checked if a server sends it in the request header.

This PR includes PR #2155.