### PR TITLE
Fix a esp32-hal-misc.c compilation error if Bluetooth not enabled

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -21,7 +21,9 @@
 #include "esp_partition.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#ifdef CONFIG_BT_ENABLED
 #include "esp_bt.h"
+#endif //CONFIG_BT_ENABLED
 #include <sys/time.h>
 #include "esp32-hal.h"
 


### PR DESCRIPTION
The file `cores/esp32/esp32-hal-misc.c` attempts to `#include "esp_bt.h"` regardless if Bluetooth is enabled or not (typically via sdkconfig) which causes a compilation error. The actual logic in `esp32-hal-misc.c` is guarded by the `CONFIG_BT_ENABLED` flag so all we have to do is wrap the include with the same flag.

### Currently
Config with `CONFIG_BT_ENABLED` not set to true will fail compilation with the following error:
```
../components/arduino/cores/esp32/esp32-hal-misc.c:24:20: fatal error: esp_bt.h: No such file or directory
```
This is because `esp_bt.h` isn't added to the CMake includes unless the `CONFIG_BT_ENABLED` flag is set to true. https://github.com/espressif/esp-idf/blob/ae5df5d6ce7c9abd9c8c4731ced96031c29f7fc1/components/bt/CMakeLists.txt#L1-L4

### After the fix
Successful compilation with the `CONFIG_BT_ENABLED` flag set to a falsey value