### PR TITLE
OTA success reporting fix

### DIFF
--- a/tools/espota.py
+++ b/tools/espota.py
@@ -205,7 +205,7 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
         data = connection.recv(32).decode()
         logging.info('Result: %s' ,data)
 
-        if data == "OK":
+        if "OK" in data:
           logging.info('Success')
           connection.close()
           f.close()


### PR DESCRIPTION
This PR piggybacks on #1695.  @Gei0r originally reported that while the update was successful, it was reported erroneous by espota.py.  I've run into another similar condition, where the expected "OK" is coming concatenated with another recv.

```
07:38:54 [DEBUG]: Options: {'timeout': 10, 'esp_ip': '10.4.20.20', 'host_port': 13414, 'image': '.pioenvs/esp12e_0/firmware.bin', 'host_ip': '0.0.0.0', 'auth': '', 'esp_port': 8266, 'spiffs': False, 'debug': True, 'progress': True}
07:38:54 [INFO]: Starting on 0.0.0.0:13414
07:38:54 [INFO]: Upload size: 293792
Sending invitation to 10.4.20.20
07:38:54 [INFO]: Waiting for device...
Uploading: [============================================================] 100% Done...

07:39:00 [INFO]: Waiting for result...
07:39:00 [INFO]: Result: 536
07:39:00 [INFO]: Result: 392OK
07:39:00 [INFO]: Result:
07:39:00 [INFO]: Result:
07:39:00 [INFO]: Result:
07:39:00 [ERROR]: Error response from device
*** [upload] Error 1
```
