### PR TITLE
Increase UART concurrency

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -111,18 +111,12 @@ int HardwareSerial::availableForWrite(void)
 
 int HardwareSerial::peek(void)
 {
-    if (available()) {
-        return uartPeek(_uart);
-    }
-    return -1;
+    return uartPeek(_uart);
 }
 
 int HardwareSerial::read(void)
 {
-    if(available()) {
-        return uartRead(_uart);
-    }
-    return -1;
+    return uartRead(_uart);
 }
 
 void HardwareSerial::flush()

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -77,7 +77,7 @@ static void _uart_rx_flush( uart_t * uart){
         c = uart->dev->fifo.rw_byte;
         xQueueSend(uart->queue, &c,0);
     }
-	UART_MUTEX_UNLOCK();
+    UART_MUTEX_UNLOCK();
 }
 
 static void IRAM_ATTR _uart_isr(void *arg)

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -306,7 +306,7 @@ uint32_t uartAvailableForWrite(uart_t* uart)
     return 0x7f - uart->dev->status.txfifo_cnt;
 }
 
-int16_t uartRead(uart_t* uart)
+int uartRead(uart_t* uart)
 {
     if(uart == NULL || uart->queue == NULL) {
         return -1;
@@ -323,7 +323,7 @@ int16_t uartRead(uart_t* uart)
     return -1;
 }
 
-int16_t uartPeek(uart_t* uart)
+int uartPeek(uart_t* uart)
 {
     if(uart == NULL || uart->queue == NULL) {
         return -1;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -306,10 +306,10 @@ uint32_t uartAvailableForWrite(uart_t* uart)
     return 0x7f - uart->dev->status.txfifo_cnt;
 }
 
-uint8_t uartRead(uart_t* uart)
+int16_t uartRead(uart_t* uart)
 {
     if(uart == NULL || uart->queue == NULL) {
-        return 0;
+        return -1;
     }
     uint8_t c;
     if(xQueueReceive(uart->queue, &c, 0)) {
@@ -320,13 +320,13 @@ uint8_t uartRead(uart_t* uart)
             return c;
         }
     }
-    return 0;
+    return -1;
 }
 
-uint8_t uartPeek(uart_t* uart)
+int16_t uartPeek(uart_t* uart)
 {
     if(uart == NULL || uart->queue == NULL) {
-        return 0;
+        return -1;
     }
     uint8_t c;
     if(xQueuePeek(uart->queue, &c, 0)) {
@@ -337,7 +337,7 @@ uint8_t uartPeek(uart_t* uart)
             return c;
         }
     }
-    return 0;
+    return -1;
 }
 
 void uartWrite(uart_t* uart, uint8_t c)

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -91,12 +91,12 @@ static void IRAM_ATTR _uart_isr(void *arg)
         if(uart->intr_handle == NULL){
             continue;
         }
-		while(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
-			c = uart->dev->fifo.rw_byte;
-       		if(uart->queue != NULL && !xQueueIsQueueFullFromISR(uart->queue)) {
-        		xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
-       		}
-		}
+        while(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)){
+            c = uart->dev->fifo.rw_byte;
+            if(uart->queue != NULL && !xQueueIsQueueFullFromISR(uart->queue)) {
+                xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
+            }
+        }
         uart->dev->int_clr.rxfifo_full = 1;
         uart->dev->int_clr.frm_err = 1;
         uart->dev->int_clr.rxfifo_tout = 1;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -66,7 +66,7 @@ static uart_t _uart_bus_array[3] = {
 };
 #endif
 
-static void _uart_rx_flush( uart_t * uart){
+static void _uart_rx_read_fifo( uart_t * uart){
     uint8_t c;
     UART_MUTEX_LOCK();
     UBaseType_t spaces=0;
@@ -100,7 +100,7 @@ static void IRAM_ATTR _uart_isr(void *arg)
         uart->dev->int_clr.rxfifo_full = 1;
         uart->dev->int_clr.frm_err = 1;
         uart->dev->int_clr.rxfifo_tout = 1;
- 	}
+    }
 
     if (xHigherPriorityTaskWoken) {
         portYIELD_FROM_ISR();
@@ -294,7 +294,7 @@ uint32_t uartAvailable(uart_t* uart)
     if(uart == NULL || uart->queue == NULL) {
         return 0;
     }
-    _uart_rx_flush(uart);
+    _uart_rx_read_fifo(uart);
     return uxQueueMessagesWaiting(uart->queue);
 }
 
@@ -315,7 +315,7 @@ uint8_t uartRead(uart_t* uart)
     if(xQueueReceive(uart->queue, &c, 0)) {
         return c;
     } else {
-        _uart_rx_flush(uart);
+        _uart_rx_read_fifo(uart);
         if(xQueueReceive(uart->queue, &c, 0)) {
             return c;
         }
@@ -332,7 +332,7 @@ uint8_t uartPeek(uart_t* uart)
     if(xQueuePeek(uart->queue, &c, 0)) {
         return c;
     } else {
-        _uart_rx_flush(uart);
+        _uart_rx_read_fifo(uart);
         if(xQueuePeek(uart->queue, &c, 0)) {
             return c;
         }

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -91,16 +91,16 @@ static void IRAM_ATTR _uart_isr(void *arg)
         if(uart->intr_handle == NULL){
             continue;
         }
-	while(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
-        	c = uart->dev->fifo.rw_byte;
-        	if(uart->queue != NULL && !xQueueIsQueueFullFromISR(uart->queue)) {
-        	    	xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
-        	}
+		while(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
+			c = uart->dev->fifo.rw_byte;
+       		if(uart->queue != NULL && !xQueueIsQueueFullFromISR(uart->queue)) {
+        		xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
+       		}
+		}
         uart->dev->int_clr.rxfifo_full = 1;
         uart->dev->int_clr.frm_err = 1;
         uart->dev->int_clr.rxfifo_tout = 1;
-    	}
-    }
+ 	}
 
     if (xHigherPriorityTaskWoken) {
         portYIELD_FROM_ISR();

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -56,8 +56,8 @@ void uartEnd(uart_t* uart);
 
 uint32_t uartAvailable(uart_t* uart);
 uint32_t uartAvailableForWrite(uart_t* uart);
-uint8_t uartRead(uart_t* uart);
-uint8_t uartPeek(uart_t* uart);
+int16_t uartRead(uart_t* uart);
+int16_t uartPeek(uart_t* uart);
 
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -56,8 +56,8 @@ void uartEnd(uart_t* uart);
 
 uint32_t uartAvailable(uart_t* uart);
 uint32_t uartAvailableForWrite(uart_t* uart);
-int16_t uartRead(uart_t* uart);
-int16_t uartPeek(uart_t* uart);
+int uartRead(uart_t* uart);
+int uartPeek(uart_t* uart);
 
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);


### PR DESCRIPTION
While data is beginning received, it is stuck in the RX Fifo until the fifo fills to `rxfifo_full_thrhd`, or there is a break in the continuous data stream longer than the configured `rx_tout_thrhd`.  This fix changes processing so that if a `read()` sees an empty queue, or `available()` is called, the RX fifo is flushed.  This will decrease any latency between reception at the port and data handling in `Serial()`.

This mod has not been exhaustively tested, but I have encountered no issues with my per-existing code.