### PR TITLE
HardwareSerial - add changeBaudRate method

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -73,6 +73,14 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
     }
 }
 
+void HardwareSerial::updateBaudRate(unsigned long baud)
+{
+	uartFlush(_uart);
+
+	uartSetBaudRate(_uart, baud);
+	uartFlush(_uart);
+}
+
 void HardwareSerial::end()
 {
     if(uartGetDebug() == _uart_nr) {

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -75,10 +75,7 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
 
 void HardwareSerial::updateBaudRate(unsigned long baud)
 {
-	uartFlush(_uart);
-
 	uartSetBaudRate(_uart, baud);
-	uartFlush(_uart);
 }
 
 void HardwareSerial::end()

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -57,6 +57,7 @@ public:
 
     void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms = 20000UL);
     void end();
+	void updateBaudRate(unsigned long baud);
     int available(void);
     int availableForWrite(void);
     int peek(void);

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -57,7 +57,7 @@ public:
 
     void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms = 20000UL);
     void end();
-	void updateBaudRate(unsigned long baud);
+    void updateBaudRate(unsigned long baud);
     int available(void);
     int availableForWrite(void);
     int peek(void);


### PR DESCRIPTION
 - This method will be useful for libraries that attempt to find current baud rate of device connected via Serial, for example GSM modems
 - Please be aware that some garbage on Serial may occur(an most of times it does) after baud rate is changed

Fixes:
#441