### PR TITLE
fix #2232 and #2033

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -456,7 +456,7 @@ int log_printf(const char *format, ...)
     ets_printf("%s", temp);
 #endif
     va_end(arg);
-    if(len > 64){
+    if(len > sizeof(loc_buf)){
         free(temp);
     }
     return len;


### PR DESCRIPTION
@felixstorm reported one more location where a buffer is created but not freed when the size is exactly 64 bytes.