### PR TITLE
update board files for LoPy, LoPy4, T-Beam

### DIFF
--- a/variants/lopy/pins_arduino.h
+++ b/variants/lopy/pins_arduino.h
@@ -18,6 +18,7 @@
 #define LORA_CS 17      // GPIO17 - SX1276 CS
 #define LORA_RST 18     // GPIO18 - SX1276 RST
 #define LORA_IRQ 23     // GPIO23 - SX1276 IO0
+#define LORA_IO0 23     // GPIO23 - SX1276 IO0
 #define LORA_IO1 23     // GPIO23 - SX1276 IO1 tied by diode to IO0
 #define LORA_IO2 23     // GPIO23 - SX1276 IO2 tied by diode to IO0
 

--- a/variants/lopy/pins_arduino.h
+++ b/variants/lopy/pins_arduino.h
@@ -18,9 +18,9 @@
 #define LORA_CS 17      // GPIO17 - SX1276 CS
 #define LORA_RST 18     // GPIO18 - SX1276 RST
 #define LORA_IRQ 23     // GPIO23 - SX1276 IO0
-#define LORA_IO0 23     // GPIO23 - SX1276 IO0
-#define LORA_IO1 23     // GPIO23 - SX1276 IO1 tied by diode to IO0
-#define LORA_IO2 23     // GPIO23 - SX1276 IO2 tied by diode to IO0
+#define LORA_IO0 LORA_IRQ  // alias
+#define LORA_IO1 LORA_IRQ  // tied by diode to IO0
+#define LORA_IO2 LORA_IRQ  // tied by diode to IO0
 
 static const uint8_t LED_BUILTIN = 0; // ->2812 RGB !!!
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility

--- a/variants/lopy4/pins_arduino.h
+++ b/variants/lopy4/pins_arduino.h
@@ -17,9 +17,9 @@
 #define LORA_MOSI 27    // GPIO27 - SX1276 MOSI
 #define LORA_CS 18      // GPIO18 - SX1276 CS
 #define LORA_IRQ 23     // GPIO23 - SX1276 IO0
-#define LORA_IO0 23     // GPIO23 - SX1276 IO0
-#define LORA_IO1 23     // GPIO23 - SX1276 IO1 tied by diode to IO0
-#define LORA_IO2 23     // GPIO23 - SX1276 IO2 tied by diode to IO0
+#define LORA_IO0 LORA_IRQ  // alias
+#define LORA_IO1 LORA_IRQ   // tied by diode to IO0
+#define LORA_IO2 LORA_IRQ   // tied by diode to IO0
 #define LORA_RST NOT_A_PIN
 
 static const uint8_t LED_BUILTIN = 0; // ->2812 RGB !!!

--- a/variants/lopy4/pins_arduino.h
+++ b/variants/lopy4/pins_arduino.h
@@ -17,6 +17,7 @@
 #define LORA_MOSI 27    // GPIO27 - SX1276 MOSI
 #define LORA_CS 18      // GPIO18 - SX1276 CS
 #define LORA_IRQ 23     // GPIO23 - SX1276 IO0
+#define LORA_IO0 23     // GPIO23 - SX1276 IO0
 #define LORA_IO1 23     // GPIO23 - SX1276 IO1 tied by diode to IO0
 #define LORA_IO2 23     // GPIO23 - SX1276 IO2 tied by diode to IO0
 #define LORA_RST NOT_A_PIN

--- a/variants/t-beam/pins_arduino.h
+++ b/variants/t-beam/pins_arduino.h
@@ -18,7 +18,7 @@
 #define LORA_CS 18      // GPIO18 - SX1276 CS
 #define LORA_RST 23     // GPIO23 - SX1276 RST
 #define LORA_IRQ 26     // GPIO26 - SX1276 IO0
-#define LORA_IO0 26     // GPIO26 - SX1276 IO0
+#define LORA_IO0 LORA_IRQ  // alias
 #define LORA_IO1 33     // GPIO33 - SX1276 IO1
 #define LORA_IO2 32     // GPIO32 - SX1276 IO2
 

--- a/variants/t-beam/pins_arduino.h
+++ b/variants/t-beam/pins_arduino.h
@@ -18,6 +18,7 @@
 #define LORA_CS 18      // GPIO18 - SX1276 CS
 #define LORA_RST 23     // GPIO23 - SX1276 RST
 #define LORA_IRQ 26     // GPIO26 - SX1276 IO0
+#define LORA_IO0 26     // GPIO26 - SX1276 IO0
 #define LORA_IO1 33     // GPIO33 - SX1276 IO1
 #define LORA_IO2 32     // GPIO32 - SX1276 IO2
 


### PR DESCRIPTION
small fixes in pin definitions:
- changed LORA_IO0 to LORA_IRQ
- added missing SS line for LoPy4
- added missing LORA_RST definition for LoPy4