### PR TITLE
Fix for regression of millis(). It wraps back to zero every 4295 seconds otherwise.

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -145,7 +145,7 @@ unsigned long IRAM_ATTR micros()
 
 unsigned long IRAM_ATTR millis()
 {
-    return (unsigned long) (micros() / 1000);
+    return (unsigned long) (esp_timer_get_time() * _sys_time_multiplier / 1000);
 }
 
 void delay(uint32_t ms)


### PR DESCRIPTION
Regression has been noticed in between release 1.0.0 and current git version of the Core.
When millis() is in use for system uptime measurement, it now wraps every 1+ hour  (4295 seconds) -
which is not good for this purpose.
This fix brings the maximum calculated uptime value (based on millis())  back to 1000+ hours.
