### PR TITLE
Fix WiFiClientRxBuffer::fillBuffer() error, likely solves issue #2212

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "libraries/BLE"]
-	path = libraries/BLE
-	url = https://github.com/nkolban/ESP32_BLE_Arduino.git
 [submodule "libraries/AzureIoT"]
 	path = libraries/AzureIoT
 	url = https://github.com/VSChina/ESP32_AzureIoT_Arduino

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -58,6 +58,10 @@ private:
         {
             if(!_buffer){
                 _buffer = (uint8_t *)malloc(_size);
+                if(!_buffer) {
+                    _failed = true;
+                    return 0;
+                }
             }
             if(_fill && _pos == _fill){
                 _fill = 0;
@@ -67,8 +71,10 @@ private:
                 return 0;
             }
             int res = recv(_fd, _buffer + _fill, _size - _fill, MSG_DONTWAIT);
-            if(res < 0 && errno != EWOULDBLOCK) {
-                _failed = true;
+            if(res < 0) {
+                if(errno != EWOULDBLOCK) {
+                    _failed = true;
+                }
                 return 0;
             }
             _fill += res;

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -59,6 +59,7 @@ private:
             if(!_buffer){
                 _buffer = (uint8_t *)malloc(_size);
                 if(!_buffer) {
+                    log_e("Not enough memory to allocate buffer");
                     _failed = true;
                     return 0;
                 }


### PR DESCRIPTION
Fix WiFiClientRxBuffer::fillBuffer() error in handing a negative res from the call to recv()

In https://github.com/espressif/arduino-esp32/blob/229d9b7366deee0d8a90fb69c19119f7287c9d1d/libraries/WiFi/src/WiFiClient.cpp#L70 if res is negative and errno equals EWOULDBLOCK then the if() condition is false causing _fill to be decremented. 
The condition res < 0 && errno == EWOULDBLOCK simply means that the socket has no data available (yet), so _fill should not change and, since nothing is read, the return value of fillBuffer should be zero.

This most likely solves the complete #2212 issue, at least it solves the minimum sketch reproducing the error as posted in that issue by @lbernstone. This could also be the root cause of other issues, since on slow connections it is likely that the socket not always has data available.

I also added an extra test on https://github.com/espressif/arduino-esp32/blob/229d9b7366deee0d8a90fb69c19119f7287c9d1d/libraries/WiFi/src/WiFiClient.cpp#L60 by setting _failed to true if the malloc() fails. I am not sure and did not check if the _failed condition is checked in the other functions, but it should not do any harm. Moreover, this did not cause the error.

Happy New Year to everyone!