### PR TITLE
Correct comment in SPI_Multiple_Buses.ino

### DIFF
--- a/libraries/SPI/examples/SPI_Multiple_Buses/SPI_Multiple_Buses.ino
+++ b/libraries/SPI/examples/SPI_Multiple_Buses/SPI_Multiple_Buses.ino
@@ -2,7 +2,7 @@
 
 /* The ESP32 has four SPi buses, however as of right now only two of
  * them are available to use, HSPI and VSPI. Simply using the SPI API 
- * as illustrated in Arduino examples will use HSPI, leaving VSPI unused.
+ * as illustrated in Arduino examples will use VSPI, leaving HSPI unused.
  * 
  * However if we simply intialise two instance of the SPI class for both
  * of these buses both can be used. However when just using these the Arduino


### PR DESCRIPTION
The default SPI bus is VSPI (see libraries/SPI/src/SPI.cpp). This change corrects a misleading comment in a code example which was stating wrongly that HSPI would be the default one.