### PR TITLE
not Validated.  I2C, UART mods to support Cpu freq Changes

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -116,23 +116,17 @@ int HardwareSerial::availableForWrite(void)
 
 int HardwareSerial::peek(void)
 {
-    if (available()) {
-        return uartPeek(_uart);
-    }
-    return -1;
+    return uartPeek(_uart);
 }
 
 int HardwareSerial::read(void)
 {
-    if(available()) {
-        return uartRead(_uart);
-    }
-    return -1;
+    return uartRead(_uart);
 }
 
 void HardwareSerial::flush()
 {
-    uartFlush(_uart);
+    uartDrain(_uart);
 }
 
 size_t HardwareSerial::write(uint8_t c)

--- a/cores/esp32/esp32-hal-cpu.h
+++ b/cores/esp32/esp32-hal-cpu.h
@@ -25,6 +25,11 @@ extern "C" {
 
 typedef enum { APB_BEFORE_CHANGE, APB_AFTER_CHANGE, APB_ABORT_CHANGE} apb_change_ev_t;
 
+/* apb_change_cb callback can refuse the requested change by returning false while processing APB_BEFORE_CHANGE
+  cycle.  If any callback refuses the change, all callbacks that successfully prepared for the change
+  will receive APB_ABORT_CHANGE, the callback must then restore to the old_apb frequency, when this happens
+  APB_AFTER_CHANGE will not be sent.
+  */
 typedef bool (* apb_change_cb_t)(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb);
 
 bool addApbChangeCallback(void * arg, apb_change_cb_t cb);
@@ -40,11 +45,6 @@ bool setCpuFrequency(uint32_t cpu_freq_mhz);
 
 uint32_t getCpuFrequencyMHz(); // In MHz
 uint32_t getApbFrequency(); // In Hz
-
-#define D_A 18
-#define D_B 19
- 
-void twiddle( const char* pattern);
 
 #ifdef __cplusplus
 }

--- a/cores/esp32/esp32-hal-cpu.h
+++ b/cores/esp32/esp32-hal-cpu.h
@@ -23,12 +23,13 @@ extern "C" {
 #include <stdbool.h>
 #include <stdlib.h>
 
-typedef enum { APB_BEFORE_CHANGE, APB_AFTER_CHANGE } apb_change_ev_t;
+typedef enum { APB_BEFORE_CHANGE, APB_AFTER_CHANGE, APB_ABORT_CHANGE} apb_change_ev_t;
 
-typedef void (* apb_change_cb_t)(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb);
+typedef bool (* apb_change_cb_t)(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb);
 
 bool addApbChangeCallback(void * arg, apb_change_cb_t cb);
 bool removeApbChangeCallback(void * arg, apb_change_cb_t cb);
+bool runCallbackList(void);
 
 //function takes the following frequencies as valid values:
 //  240, 160, 80                     <<< For all XTAL types
@@ -37,8 +38,13 @@ bool removeApbChangeCallback(void * arg, apb_change_cb_t cb);
 //  24, 12, 8, 6, 4, 3, 2, 1         <<< For 24MHz XTAL
 bool setCpuFrequency(uint32_t cpu_freq_mhz);
 
-uint32_t getCpuFrequency(); // In MHz
+uint32_t getCpuFrequencyMHz(); // In MHz
 uint32_t getApbFrequency(); // In Hz
+
+#define D_A 18
+#define D_B 19
+ 
+void twiddle( const char* pattern);
 
 #ifdef __cplusplus
 }

--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -24,7 +24,7 @@
 #include "soc/i2c_struct.h"
 #include "soc/dport_reg.h"
 #include "esp_attr.h"
-
+#include "esp32-hal-cpu.h" // cpu clock change support 31DEC2018
 //#define I2C_DEV(i)   (volatile i2c_dev_t *)((i)?DR_REG_I2C1_EXT_BASE:DR_REG_I2C_EXT_BASE)
 //#define I2C_DEV(i)   ((i2c_dev_t *)(REG_I2C_BASE(i)))
 #define I2C_SCL_IDX(p)  ((p==0)?I2CEXT0_SCL_OUT_IDX:((p==1)?I2CEXT1_SCL_OUT_IDX:0))
@@ -206,8 +206,8 @@ static i2c_t _i2c_bus_array[2] = {
     {(volatile i2c_dev_t *)(DR_REG_I2C1_EXT_BASE_FIXED), 1, -1, -1,I2C_NONE,I2C_NONE,I2C_ERROR_OK,NULL,NULL,NULL,0,0,0,0,0}
 };
 #else
-#define I2C_MUTEX_LOCK()    do {} while (xSemaphoreTake(i2c->lock, portMAX_DELAY) != pdPASS)
-#define I2C_MUTEX_UNLOCK()  xSemaphoreGive(i2c->lock)
+#define I2C_MUTEX_LOCK()    do {} while (xSemaphoreTakeRecursive(i2c->lock, portMAX_DELAY) != pdPASS)
+#define I2C_MUTEX_UNLOCK()  xSemaphoreGiveRecursive(i2c->lock)
 
 static i2c_t _i2c_bus_array[2] = {
     {(volatile i2c_dev_t *)(DR_REG_I2C_EXT_BASE_FIXED), NULL, 0, -1, -1, I2C_NONE,I2C_NONE,I2C_ERROR_OK,NULL,NULL,NULL,0,0,0,0,0,0},
@@ -445,6 +445,45 @@ static void IRAM_ATTR i2cTriggerDumps(i2c_t * i2c, uint8_t trigger, const char l
 }
  // end of debug support routines
  
+/* Start of CPU Clock change Support
+*/
+
+static bool i2cApbChangeCallback(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb){
+    i2c_t* i2c = (i2c_t*) arg; // recover data
+    if(i2c == NULL) {  // point to peripheral control block does not exits
+        return false;
+    }
+    bool success = true;
+    uint32_t oldFreq=0;
+    switch(ev_type){
+        case APB_BEFORE_CHANGE : 
+            if(new_apb < 3000000) {// too slow
+                success=false;
+                break;
+            }
+            I2C_MUTEX_LOCK(); // lock will spin until current transaction is completed
+            break;
+        case APB_ABORT_CHANGE :
+            I2C_MUTEX_UNLOCK();
+            break;
+        case APB_AFTER_CHANGE :
+//            twiddle("1000111");
+            oldFreq = (i2c->dev->scl_low_period.period+i2c->dev->scl_high_period.period); //read old apbCycles 
+            if(oldFreq>0) { // was configured with value
+                oldFreq = old_apb / oldFreq;
+                i2cSetFrequency(i2c,oldFreq);
+            }
+            log_d("after %d",oldFreq);
+            I2C_MUTEX_UNLOCK();
+            break;
+        default : 
+            log_e("unk ev %u",ev_type);
+            I2C_MUTEX_UNLOCK();
+    }
+    return success;
+}
+/* End of CPU Clock change Support
+*/ 
 static void IRAM_ATTR i2cSetCmd(i2c_t * i2c, uint8_t index, uint8_t op_code, uint8_t byte_num, bool ack_val, bool ack_exp, bool ack_check)
 {
     I2C_COMMAND_t cmd;
@@ -1221,6 +1260,12 @@ i2c_err_t i2cProcQueue(i2c_t * i2c, uint32_t *readCount, uint16_t timeOutMillis)
             I2C_MUTEX_UNLOCK();
             return I2C_ERROR_MEMORY;
         }
+        if( !addApbChangeCallback( i2c, i2cApbChangeCallback)) {
+            log_e("install apb Callback failed");
+            I2C_MUTEX_UNLOCK();
+            return I2C_ERROR_DEV;
+        }
+
     }
     //hang until it completes.
 
@@ -1352,6 +1397,9 @@ static void i2cReleaseISR(i2c_t * i2c)
     if(i2c->intr_handle) {
         esp_intr_free(i2c->intr_handle);
         i2c->intr_handle=NULL;
+        if (!removeApbChangeCallback( i2c, i2cApbChangeCallback)) {
+            log_e("unable to release apbCallback");
+        }
     }
 }
 
@@ -1437,8 +1485,7 @@ i2c_err_t i2cDetachSDA(i2c_t * i2c, int8_t sda)
  * PUBLIC API
  * */
 // 24Nov17 only supports Master Mode
-i2c_t * i2cInit(uint8_t i2c_num, int8_t sda, int8_t scl, uint32_t frequency) //before this is called, pins should be detached, else glitch
-{
+i2c_t * i2cInit(uint8_t i2c_num, int8_t sda, int8_t scl, uint32_t frequency) {
   log_v("num=%d sda=%d scl=%d freq=%d",i2c_num, sda, scl, frequency);
     if(i2c_num > 1) {
         return NULL;
@@ -1446,6 +1493,7 @@ i2c_t * i2cInit(uint8_t i2c_num, int8_t sda, int8_t scl, uint32_t frequency) //b
 
     i2c_t * i2c = &_i2c_bus_array[i2c_num];
 
+    // pins should be detached, else glitch
     if(i2c->sda >= 0){
         i2cDetachSDA(i2c, i2c->sda);
     }
@@ -1457,7 +1505,7 @@ i2c_t * i2cInit(uint8_t i2c_num, int8_t sda, int8_t scl, uint32_t frequency) //b
 
 #if !CONFIG_DISABLE_HAL_LOCKS
     if(i2c->lock == NULL) {
-        i2c->lock = xSemaphoreCreateMutex();
+        i2c->lock = xSemaphoreCreateRecursiveMutex();
         if(i2c->lock == NULL) {
             return NULL;
         }
@@ -1604,7 +1652,8 @@ i2c_err_t i2cRead(i2c_t * i2c, uint16_t address, uint8_t* buff, uint16_t size, b
     return last_error;
 }
 
-#define MIN_I2C_CLKS 100
+#define MIN_I2C_CLKS 100              // minimum ratio between cpu and i2c Bus clocks
+#define INTERRUPT_CYCLE_OVERHEAD 16000 // number of cpu clocks necessary to respond to interrupt
 i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed)
 {
     if(i2c == NULL) {
@@ -1614,17 +1663,18 @@ i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed)
     uint32_t period = (apb/clk_speed) / 2;
 
     if((apb/8192 > clk_speed)||(apb/MIN_I2C_CLKS < clk_speed)){ //out of bounds
-        log_w("i2c freq(%d) out of bounds.vs APB Clock(%d), min=%d, max=%d",clk_speed,apb,(apb/8192),(apb/MIN_I2C_CLKS));
+        log_d("i2c freq(%d) out of bounds.vs APB Clock(%d), min=%d, max=%d",clk_speed,apb,(apb/8192),(apb/MIN_I2C_CLKS));
     }
     if(period < (MIN_I2C_CLKS/2) ){
         period = (MIN_I2C_CLKS/2);
         clk_speed = apb/(period*2);
-        log_w("APB Freq too slow, Reducing i2c Freq to %d Hz",clk_speed);
+        log_d("APB Freq too slow, Reducing i2c Freq to %d Hz",clk_speed);
     } else if ( period> 4095) {
         period = 4095;
         clk_speed = apb/(period*2);
-        log_w("APB Freq too fast, Increasing i2c Freq to %d Hz",clk_speed);
+        log_d("APB Freq too fast, Increasing i2c Freq to %d Hz",clk_speed);
     }
+    log_d("freq=%dHz",clk_speed);
       
     uint32_t halfPeriod = period/2;
     uint32_t quarterPeriod = period/4;
@@ -1633,14 +1683,19 @@ i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed)
 
     I2C_FIFO_CONF_t f;
 
-    // Adjust Fifo thresholds based on frequency
     f.val    = i2c->dev->fifo_conf.val;
-    uint32_t a = (clk_speed / 50000L )+1; 
-    if (a > 24) a=24;   
-    f.rx_fifo_full_thrhd = 32 - a;
-    f.tx_fifo_empty_thrhd = a;
+/*  Adjust Fifo thresholds based on differential between cpu frequency and bus clock.
+    The fifo_delta is calculated such that at least INTERRUPT_CYCLE_OVERHEAD cpu clocks are
+    available when a Fifo interrupt is triggered.  This allows enough room in the Fifo so that
+    interrupt latency does not cause a Fifo overflow/underflow event.
+*/
+    log_d("cpu Freq=%dMhz, i2c Freq=%dHz",getCpuFrequencyMHz(),clk_speed);
+    uint32_t fifo_delta = (INTERRUPT_CYCLE_OVERHEAD/((getCpuFrequencyMHz()*1000000 / clk_speed)*10))+1; 
+    if (fifo_delta > 24) fifo_delta=24;   
+    f.rx_fifo_full_thrhd = 32 - fifo_delta;
+    f.tx_fifo_empty_thrhd = fifo_delta;
     i2c->dev->fifo_conf.val = f.val; // set thresholds
-    log_v("Fifo threshold=%d",a);
+    log_v("Fifo delta=%d",fifo_delta);
 
     //the clock num during SCL is low level
     i2c->dev->scl_low_period.period = period;
@@ -1696,6 +1751,8 @@ uint32_t i2cGetStatus(i2c_t * i2c){
     }
     else return 0;
 }
+
+
 /* todo
   22JUL18
     need to add multi-thread capability, use dq.queueEvent as the group marker. When multiple threads

--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -467,7 +467,6 @@ static bool i2cApbChangeCallback(void * arg, apb_change_ev_t ev_type, uint32_t o
             I2C_MUTEX_UNLOCK();
             break;
         case APB_AFTER_CHANGE :
-//            twiddle("1000111");
             oldFreq = (i2c->dev->scl_low_period.period+i2c->dev->scl_high_period.period); //read old apbCycles 
             if(oldFreq>0) { // was configured with value
                 oldFreq = old_apb / oldFreq;

--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -1674,7 +1674,7 @@ i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed)
         clk_speed = apb/(period*2);
         log_d("APB Freq too fast, Increasing i2c Freq to %d Hz",clk_speed);
     }
-    log_d("freq=%dHz",clk_speed);
+    log_v("freq=%dHz",clk_speed);
       
     uint32_t halfPeriod = period/2;
     uint32_t quarterPeriod = period/4;
@@ -1689,7 +1689,7 @@ i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed)
     available when a Fifo interrupt is triggered.  This allows enough room in the Fifo so that
     interrupt latency does not cause a Fifo overflow/underflow event.
 */
-    log_d("cpu Freq=%dMhz, i2c Freq=%dHz",getCpuFrequencyMHz(),clk_speed);
+    log_v("cpu Freq=%dMhz, i2c Freq=%dHz",getCpuFrequencyMHz(),clk_speed);
     uint32_t fifo_delta = (INTERRUPT_CYCLE_OVERHEAD/((getCpuFrequencyMHz()*1000000 / clk_speed)*10))+1; 
     if (fifo_delta > 24) fifo_delta=24;   
     f.rx_fifo_full_thrhd = 32 - fifo_delta;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -45,6 +45,8 @@ struct uart_struct_t {
     uint8_t num;
     xQueueHandle queue;
     intr_handle_t intr_handle;
+    int8_t rx_pin;
+    bool invertedLogic;
 };
 
 #if CONFIG_DISABLE_HAL_LOCKS
@@ -52,43 +54,84 @@ struct uart_struct_t {
 #define UART_MUTEX_UNLOCK()
 
 static uart_t _uart_bus_array[3] = {
-    {(volatile uart_dev_t *)(DR_REG_UART_BASE), 0, NULL, NULL},
-    {(volatile uart_dev_t *)(DR_REG_UART1_BASE), 1, NULL, NULL},
-    {(volatile uart_dev_t *)(DR_REG_UART2_BASE), 2, NULL, NULL}
+    {(volatile uart_dev_t *)(DR_REG_UART_BASE), 0, NULL, NULL,-1,false},
+    {(volatile uart_dev_t *)(DR_REG_UART1_BASE), 1, NULL, NULL,-1,false},
+    {(volatile uart_dev_t *)(DR_REG_UART2_BASE), 2, NULL, NULL,-1,false}
 };
 #else
-#define UART_MUTEX_LOCK()    do {} while (xSemaphoreTake(uart->lock, portMAX_DELAY) != pdPASS)
-#define UART_MUTEX_UNLOCK()  xSemaphoreGive(uart->lock)
+#define UART_MUTEX_LOCK()    do {} while (xSemaphoreTakeRecursive(uart->lock, portMAX_DELAY) != pdPASS)
+#define UART_MUTEX_UNLOCK()  xSemaphoreGiveRecursive(uart->lock)
 
 static uart_t _uart_bus_array[3] = {
-    {(volatile uart_dev_t *)(DR_REG_UART_BASE), NULL, 0, NULL, NULL},
-    {(volatile uart_dev_t *)(DR_REG_UART1_BASE), NULL, 1, NULL, NULL},
-    {(volatile uart_dev_t *)(DR_REG_UART2_BASE), NULL, 2, NULL, NULL}
+    {(volatile uart_dev_t *)(DR_REG_UART_BASE), NULL, 0, NULL, NULL,-1,false},
+    {(volatile uart_dev_t *)(DR_REG_UART1_BASE), NULL, 1, NULL, NULL,-1,false},
+    {(volatile uart_dev_t *)(DR_REG_UART2_BASE), NULL, 2, NULL, NULL,-1,false}
 };
 #endif
 
-static void uart_on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb);
+//#define DEBUG_RX
+
+static bool uart_on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb);
+
+static void _uart_rx_read_fifo( uart_t * uart){
+    uint8_t c;
+    UART_MUTEX_LOCK();
+    UBaseType_t count=0, spaces=0;
+    // wr_addr, rd_addr are circular buffer pointers, wrapping is controlled by UART config,
+    // standard fifo is 128 byte, but address is 11bits (1024byte buffer, allocated into 6 128byte buffers rx/tx)
+    
+    count = (uart->dev->mem_rx_status.wr_addr - uart->dev->mem_rx_status.rd_addr)% 0x80;
+    if(uart->queue != NULL) {
+        spaces=uxQueueSpacesAvailable( uart->queue);
+    
+        while((spaces >0)&&(count-- > 0)){
+        //(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr))) {
+            c = uart->dev->fifo.rw_byte;
+            xQueueSend(uart->queue, &c,0);
+            spaces--;
+        }
+    }  
+    if(spaces == 0){ // disable rxFifo_full interrupt, no room in Queue or queue does not exit
+        uart->dev->int_ena.rxfifo_full = 0;
+        uart->dev->int_ena.rxfifo_tout = 0;
+#ifdef DEBUG_RX
+        digitalWrite(25,HIGH);
+#endif
+    }
+    UART_MUTEX_UNLOCK();
+}
 
 static void IRAM_ATTR _uart_isr(void *arg)
 {
     uint8_t i, c;
-    BaseType_t xHigherPriorityTaskWoken;
-    uart_t* uart;
+    BaseType_t xHigherPriorityTaskWoken=pdFALSE;
+    uart_t* uart =(uart_t *)arg;
+    if( uart != NULL){
+        UBaseType_t spaces=0,count=0;
+        count = (uart->dev->mem_rx_status.wr_addr - uart->dev->mem_rx_status.rd_addr)%0x80;
+        if(uart->queue != NULL) {
+            spaces=uxQueueSpacesAvailable( uart->queue);
+        
+     
+            while((spaces > 0 )&&( (count--) > 0 )){ // if room in queue move from fifo to queue
+          // store it
+                c = uart->dev->fifo.rw_byte;
+                xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
+                spaces--;
+            }
+        }
 
-    for(i=0;i<3;i++){
-        uart = &_uart_bus_array[i];
-        if(uart->intr_handle == NULL){
-            continue;
+        if(spaces==0) { // disable interrupts until space exists in queue
+        // if fifo overflows then, characters are lost.  But which characters? top of fifo or bottom?
+           uart->dev->int_ena.rxfifo_full = 0;
+           uart->dev->int_ena.rxfifo_tout = 0;
+#ifdef DEBUG_RX
+           digitalWrite(25,HIGH);
+#endif
         }
         uart->dev->int_clr.rxfifo_full = 1;
         uart->dev->int_clr.frm_err = 1;
         uart->dev->int_clr.rxfifo_tout = 1;
-        while(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
-            c = uart->dev->fifo.rw_byte;
-            if(uart->queue != NULL && !xQueueIsQueueFullFromISR(uart->queue)) {
-                xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
-            }
-        }
     }
 
     if (xHigherPriorityTaskWoken) {
@@ -96,22 +139,32 @@ static void IRAM_ATTR _uart_isr(void *arg)
     }
 }
 
-void uartEnableInterrupt(uart_t* uart)
+static void uartEnableInterrupt(uart_t* uart)
 {
     UART_MUTEX_LOCK();
-    uart->dev->conf1.rxfifo_full_thrhd = 112;
-    uart->dev->conf1.rx_tout_thrhd = 2;
+    uart->dev->conf1.rxfifo_full_thrhd = 112; // needs speed compensation?
+    uart->dev->conf1.rx_tout_thrhd = 32; // no need to force rxFiFo empty, because uartRead() will empty if necessary
     uart->dev->conf1.rx_tout_en = 1;
     uart->dev->int_ena.rxfifo_full = 1;
     uart->dev->int_ena.frm_err = 1;
     uart->dev->int_ena.rxfifo_tout = 1;
     uart->dev->int_clr.val = 0xffffffff;
-
-    esp_intr_alloc(UART_INTR_SOURCE(uart->num), (int)ESP_INTR_FLAG_IRAM, _uart_isr, NULL, &uart->intr_handle);
+#ifdef DEBUG_RX
+    digitalWrite(25,LOW);
+#endif
+// can this share an interrupt?
+    uint32_t flags = ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED | ESP_INTR_FLAG_LOWMED;
+//    esp_intr_alloc(UART_INTR_SOURCE(uart->num), (int)ESP_INTR_FLAG_IRAM, _uart_isr, uart, &uart->intr_handle);
+    uint32_t ret = 0;
+    uint32_t interrupts_enabled = uart->dev->int_ena.val;
+    ret = esp_intr_alloc_intrstatus(UART_INTR_SOURCE(uart->num), flags, (uint32_t)&uart->dev->int_st.val, interrupts_enabled, _uart_isr,uart, &uart->intr_handle);
+    if(ret != ESP_OK ){
+        log_e("unable to configure interrupt %u",ret);
+    }
     UART_MUTEX_UNLOCK();
 }
 
-void uartDisableInterrupt(uart_t* uart)
+static void uartDisableInterrupt(uart_t* uart)
 {
     UART_MUTEX_LOCK();
     uart->dev->conf1.val = 0;
@@ -124,16 +177,17 @@ void uartDisableInterrupt(uart_t* uart)
     UART_MUTEX_UNLOCK();
 }
 
-void uartDetachRx(uart_t* uart)
+static void uartDetachRx(uart_t* uart)
 {
     if(uart == NULL) {
         return;
     }
     pinMatrixInDetach(UART_RXD_IDX(uart->num), false, false);
     uartDisableInterrupt(uart);
+    uart->rx_pin = -1;
 }
 
-void uartDetachTx(uart_t* uart)
+static void uartDetachTx(uart_t* uart)
 {
     if(uart == NULL) {
         return;
@@ -141,17 +195,18 @@ void uartDetachTx(uart_t* uart)
     pinMatrixOutDetach(UART_TXD_IDX(uart->num), false, false);
 }
 
-void uartAttachRx(uart_t* uart, uint8_t rxPin, bool inverted)
+static void uartAttachRx(uart_t* uart, uint8_t rxPin, bool inverted)
 {
     if(uart == NULL || rxPin > 39) {
         return;
     }
-    pinMode(rxPin, INPUT);
+    uart->rx_pin = rxPin;
+    pinMode(rxPin, INPUT_PULLUP);
     pinMatrixInAttach(rxPin, UART_RXD_IDX(uart->num), inverted);
     uartEnableInterrupt(uart);
 }
 
-void uartAttachTx(uart_t* uart, uint8_t txPin, bool inverted)
+static void uartAttachTx(uart_t* uart, uint8_t txPin, bool inverted)
 {
     if(uart == NULL || txPin > 39) {
         return;
@@ -174,12 +229,14 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
 
 #if !CONFIG_DISABLE_HAL_LOCKS
     if(uart->lock == NULL) {
-        uart->lock = xSemaphoreCreateMutex();
+        uart->lock = xSemaphoreCreateRecursiveMutex();
         if(uart->lock == NULL) {
             return NULL;
         }
     }
 #endif
+    UART_MUTEX_LOCK();
+    uart->invertedLogic = inverted;
 
     if(queueLen && uart->queue == NULL) {
         uart->queue = xQueueCreate(queueLen, sizeof(uint8_t)); //initialize the queue
@@ -187,20 +244,26 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
             return NULL;
         }
     }
+    uartDetachRx(uart); // release ISR
+    uartDetachTx(uart);
+    
     if(uart_nr == 1){
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART1_RST);
         DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_UART1_CLK_EN);
         DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART1_RST);
     } else if(uart_nr == 2){
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART2_RST);
         DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_UART2_CLK_EN);
         DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART2_RST);
     } else {
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART_RST);
         DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_UART_CLK_EN);
         DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART_RST);
     }
-    uartFlush(uart);
     uartSetBaudRate(uart, baudrate);
-    UART_MUTEX_LOCK();
     uart->dev->conf0.val = config;
+    uart->dev->mem_conf.mem_pd=0; // power up Fifo memory
+    uartFlush(uart);
     #define TWO_STOP_BITS_CONF 0x3
     #define ONE_STOP_BITS_CONF 0x1
 
@@ -208,17 +271,18 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
         uart->dev->conf0.stop_bit_num = ONE_STOP_BITS_CONF;
         uart->dev->rs485_conf.dl1_en = 1;
     }
-    UART_MUTEX_UNLOCK();
-
-    if(rxPin != -1) {
-        uartAttachRx(uart, rxPin, inverted);
-    }
 
     if(txPin != -1) {
         uartAttachTx(uart, txPin, inverted);
     }
 
+    if(rxPin != -1) {
+        uartAttachRx(uart, rxPin, inverted); //Attach ISR interrupt also
+    }
+
+    UART_MUTEX_UNLOCK();
     addApbChangeCallback(uart, uart_on_apb_change);
+
     return uart;
 }
 
@@ -227,20 +291,74 @@ void uartEnd(uart_t* uart)
     if(uart == NULL) {
         return;
     }
-    removeApbChangeCallback(uart, uart_on_apb_change);
 
     UART_MUTEX_LOCK();
+
+    uartDetachRx(uart); // release pin, disable interrupt
+    uartDetachTx(uart); // release pin
+
+
+    uart->dev->conf0.val = 0;
+    // power down uart, disable clocking
+    uart->dev->mem_conf.mem_pd=1; // power down Fifo memory
+    if(uart->num == 1){
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART1_RST);
+        DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_UART1_CLK_EN);
+    } else if(uart->num == 2){
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART2_RST);
+        DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_UART2_CLK_EN);
+    } else {
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_UART_RST);
+        DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_UART_CLK_EN);
+    }
     if(uart->queue != NULL) {
+        uint8_t c;
+        while(xQueueReceive(uart->queue, &c, 0));
         vQueueDelete(uart->queue);
         uart->queue = NULL;
     }
-
-    uart->dev->conf0.val = 0;
+    removeApbChangeCallback(uart, uart_on_apb_change);
 
     UART_MUTEX_UNLOCK();
 
-    uartDetachRx(uart);
-    uartDetachTx(uart);
+}
+
+static bool uart_on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb)
+{
+    uart_t* uart = (uart_t*)arg;
+    bool success=true;
+    int8_t saveRxPin;
+    uint32_t clk_div,baud_rate;
+    switch (ev_type){
+        case APB_BEFORE_CHANGE:
+            if(new_apb < 3000000) {
+                success=false;
+                break;
+            }
+            UART_MUTEX_LOCK();
+            saveRxPin = uart->rx_pin;
+            uartDetachRx(uart); // release pin, disable interrupt
+            uart->rx_pin =saveRxPin;
+            uartDrain(uart);
+            break;
+        case APB_ABORT_CHANGE:
+            uartAttachRx(uart,uart->rx_pin,uart->invertedLogic);
+            UART_MUTEX_UNLOCK();
+            break;
+        case APB_AFTER_CHANGE:
+        // set baudrate
+            clk_div = (uart->dev->clk_div.div_int << 4) | (uart->dev->clk_div.div_frag & 0x0F);
+            baud_rate = ((old_apb<<4)/clk_div);
+            clk_div = ((new_apb<<4)/baud_rate);
+            uart->dev->clk_div.div_int = clk_div>>4 ;
+            uart->dev->clk_div.div_frag = clk_div & 0xf;
+        // attach rx
+            uartAttachRx(uart,uart->rx_pin,uart->invertedLogic);
+            UART_MUTEX_UNLOCK();
+            break;
+        default : ;
+    }
+    return success;
 }
 
 size_t uartResizeRxBuffer(uart_t * uart, size_t new_size) {
@@ -250,11 +368,27 @@ size_t uartResizeRxBuffer(uart_t * uart, size_t new_size) {
 
     UART_MUTEX_LOCK();
     if(uart->queue != NULL) {
+        uart->dev->int_ena.rxfifo_full = 0; // shut off interrupt
+        uart->dev->int_ena.rxfifo_tout = 0;
+#ifdef DEBUG_RX
+        digitalWrite(25,HIGH);
+#endif
+        uint8_t c;
+        while(xQueueReceive(uart->queue, &c, 0));
         vQueueDelete(uart->queue);
+    }
+    if( new_size > 0){
         uart->queue = xQueueCreate(new_size, sizeof(uint8_t));
         if(uart->queue == NULL) {
             return NULL;
+        } else { // reEnable interrupt
+            uart->dev->int_ena.rxfifo_full = 1;
+            uart->dev->int_ena.rxfifo_tout = 1;
+#ifdef DEBUG_RX
+            digitalWrite(25,LOW);
+#endif
         }
+    
     }
     UART_MUTEX_UNLOCK();
 
@@ -263,10 +397,19 @@ size_t uartResizeRxBuffer(uart_t * uart, size_t new_size) {
 
 uint32_t uartAvailable(uart_t* uart)
 {
-    if(uart == NULL || uart->queue == NULL) {
+    if(uart == NULL ){
         return 0;
     }
-    return uxQueueMessagesWaiting(uart->queue);
+    UART_MUTEX_LOCK();
+    uint32_t count = 0;
+    if(uart->queue){
+        _uart_rx_read_fifo(uart);
+        count = uxQueueMessagesWaiting(uart->queue);
+    }
+    // include direct from FiFo
+    count += (uart->dev->mem_rx_status.wr_addr - uart->dev->mem_rx_status.rd_addr)% 0x80;
+    UART_MUTEX_UNLOCK();
+    return count;
 }
 
 uint32_t uartAvailableForWrite(uart_t* uart)
@@ -277,28 +420,50 @@ uint32_t uartAvailableForWrite(uart_t* uart)
     return 0x7f - uart->dev->status.txfifo_cnt;
 }
 
-uint8_t uartRead(uart_t* uart)
+int16_t uartRead(uart_t* uart)
 {
-    if(uart == NULL || uart->queue == NULL) {
-        return 0;
+    if(uart == NULL ) {
+        return -1;
     }
     uint8_t c;
-    if(xQueueReceive(uart->queue, &c, 0)) {
-        return c;
+    uart->dev->int_ena.rxfifo_full = 1;
+    uart->dev->int_ena.rxfifo_tout = 1;
+#ifdef DEBUG_RX
+    digitalWrite(25,LOW);
+#endif
+    if(uart->queue != NULL){
+        if(xQueueReceive(uart->queue, &c, 0)) {
+            return c;
+        } else {
+            _uart_rx_read_fifo(uart);
+            if(xQueueReceive(uart->queue, &c, 0)) {
+                return c;
+            }
+        }
+    } else { // direct from fifo
+        if( ((uart->dev->mem_rx_status.wr_addr - uart->dev->mem_rx_status.rd_addr)% 0x80)>0){
+            c = uart->dev->fifo.rw_byte;
+            return c;
+        }
     }
-    return 0;
+    return -1;
 }
 
-uint8_t uartPeek(uart_t* uart)
+int16_t uartPeek(uart_t* uart) // peek cannot work without Queue
 {
     if(uart == NULL || uart->queue == NULL) {
-        return 0;
+        return -1;
     }
     uint8_t c;
     if(xQueuePeek(uart->queue, &c, 0)) {
         return c;
+    } else {
+        _uart_rx_read_fifo(uart);
+        if(xQueuePeek(uart->queue, &c, 0)) {
+            return c;
+        }
     }
-    return 0;
+    return -1;
 }
 
 void uartWrite(uart_t* uart, uint8_t c)
@@ -306,8 +471,12 @@ void uartWrite(uart_t* uart, uint8_t c)
     if(uart == NULL) {
         return;
     }
+    
     UART_MUTEX_LOCK();
-    while(uart->dev->status.txfifo_cnt == 0x7F);
+    while(uart->dev->status.txfifo_cnt == 0x7F){
+      digitalWrite(25,HIGH);
+    }
+    digitalWrite(25,LOW);
     uart->dev->fifo.rw_byte = c;
     UART_MUTEX_UNLOCK();
 }
@@ -319,10 +488,13 @@ void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len)
     }
     UART_MUTEX_LOCK();
     while(len) {
-        while(uart->dev->status.txfifo_cnt == 0x7F);
-        uart->dev->fifo.rw_byte = *data++;
-        len--;
+        while(len && uart->dev->status.txfifo_cnt < 0x7F) {
+            uart->dev->fifo.rw_byte = *data++;
+            len--;
+        }
+        if (len) digitalWrite(25,HIGH);
     }
+    digitalWrite(25,LOW);
     UART_MUTEX_UNLOCK();
 }
 
@@ -339,6 +511,7 @@ void uartFlush(uart_t* uart)
     //See description about UART_TXFIFO_RST and UART_RXFIFO_RST in <<esp32_technical_reference_manual>> v2.6 or later.
 
     // we read the data out and make `fifo_len == 0 && rd_addr == wr_addr`.
+
     while(uart->dev->status.rxfifo_cnt != 0 || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
         READ_PERI_REG(UART_FIFO_REG(uart->num));
     }
@@ -346,47 +519,40 @@ void uartFlush(uart_t* uart)
     UART_MUTEX_UNLOCK();
 }
 
+void uartDrain(uart_t * uart)
+{
+    if(uart == NULL) {
+        return;
+    }
+
+    UART_MUTEX_LOCK(); 
+    //wait for txFifo to empty
+    while(uart->dev->status.txfifo_cnt || uart->dev->status.st_utx_out){
+        digitalWrite(25,HIGH);
+    }
+    digitalWrite(25,LOW);
+    //empty rxFifo, save rx characters so reset of UART doesn't cause problem
+    _uart_rx_read_fifo(uart);
+
+    UART_MUTEX_UNLOCK();
+}
+  
+
 void uartSetBaudRate(uart_t* uart, uint32_t baud_rate)
 {
     if(uart == NULL) {
         return;
     }
     UART_MUTEX_LOCK();
+    int8_t oldPin = uart->rx_pin;
+    uartDetachRx(uart);  // detach RX pin
+    uartDrain(uart); // empty tx,rxFifo
+    // attach RX pin
     uint32_t clk_div = ((getApbFrequency()<<4)/baud_rate);
     uart->dev->clk_div.div_int = clk_div>>4 ;
     uart->dev->clk_div.div_frag = clk_div & 0xf;
+    uartAttachRx(uart,oldPin,uart->invertedLogic);
     UART_MUTEX_UNLOCK();
-}
-
-static void uart_on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb)
-{
-    uart_t* uart = (uart_t*)arg;
-    if(ev_type == APB_BEFORE_CHANGE){
-        //todo:
-        UART_MUTEX_LOCK();
-        // detach RX
-        // read RX fifo
-        uint8_t c;
-        BaseType_t xHigherPriorityTaskWoken;
-        while(uart->dev->status.rxfifo_cnt != 0 || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
-            c = uart->dev->fifo.rw_byte;
-            if(uart->queue != NULL && !xQueueIsQueueFullFromISR(uart->queue)) {
-                xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
-            }
-        }
-        // wait TX empty
-        while(uart->dev->status.txfifo_cnt || uart->dev->status.st_utx_out);
-    } else {
-        //todo:
-        // set baudrate
-        uint32_t clk_div = (uart->dev->clk_div.div_int << 4) | (uart->dev->clk_div.div_frag & 0x0F);
-        uint32_t baud_rate = ((old_apb<<4)/clk_div);
-        clk_div = ((new_apb<<4)/baud_rate);
-        uart->dev->clk_div.div_int = clk_div>>4 ;
-        uart->dev->clk_div.div_frag = clk_div & 0xf;
-        // attach rx
-        UART_MUTEX_UNLOCK();
-    }
 }
 
 uint32_t uartGetBaudRate(uart_t* uart)
@@ -416,8 +582,17 @@ static void IRAM_ATTR uart2_write_char(char c)
     ESP_REG(DR_REG_UART2_BASE) = c;
 }
 
-void uart_install_putc()
+void uartSetDebug(uart_t* uart)
 {
+    if(uart == NULL || uart->num > 2) {
+        s_uart_debug_nr = -1;
+        ets_install_putc1(NULL);
+        return;
+    }
+    if(s_uart_debug_nr == uart->num) {
+        return;
+    }
+    s_uart_debug_nr = uart->num;
     switch(s_uart_debug_nr) {
     case 0:
         ets_install_putc1((void (*)(char)) &uart0_write_char);
@@ -432,20 +607,6 @@ void uart_install_putc()
         ets_install_putc1(NULL);
         break;
     }
-}
-
-void uartSetDebug(uart_t* uart)
-{
-    if(uart == NULL || uart->num > 2) {
-        s_uart_debug_nr = -1;
-        //ets_install_putc1(NULL);
-        //return;
-    } else
-    if(s_uart_debug_nr == uart->num) {
-        return;
-    } else
-    s_uart_debug_nr = uart->num;
-    uart_install_putc();
 }
 
 int uartGetDebug()
@@ -476,9 +637,9 @@ int log_printf(const char *format, ...)
     vsnprintf(temp, len+1, format, arg);
 #if !CONFIG_DISABLE_HAL_LOCKS
     if(_uart_bus_array[s_uart_debug_nr].lock){
-        while (xSemaphoreTake(_uart_bus_array[s_uart_debug_nr].lock, portMAX_DELAY) != pdPASS);
+        while (xSemaphoreTakeRecursive(_uart_bus_array[s_uart_debug_nr].lock, portMAX_DELAY) != pdPASS);
         ets_printf("%s", temp);
-        xSemaphoreGive(_uart_bus_array[s_uart_debug_nr].lock);
+        xSemaphoreGiveRecursive(_uart_bus_array[s_uart_debug_nr].lock);
     } else {
         ets_printf("%s", temp);
     }
@@ -486,7 +647,7 @@ int log_printf(const char *format, ...)
     ets_printf("%s", temp);
 #endif
     va_end(arg);
-    if(len > sizeof(loc_buf)){
+    if(len >= sizeof(loc_buf)){
         free(temp);
     }
     return len;

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -56,15 +56,16 @@ void uartEnd(uart_t* uart);
 
 uint32_t uartAvailable(uart_t* uart);
 uint32_t uartAvailableForWrite(uart_t* uart);
-uint8_t uartRead(uart_t* uart);
-uint8_t uartPeek(uart_t* uart);
+int16_t uartRead(uart_t* uart);
+int16_t uartPeek(uart_t* uart);
 
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 
-void uartFlush(uart_t* uart);
+void uartFlush(uart_t* uart); //wait for txFifo to empty, then Discard anything left in RxFifo, Queue contents left alone?
+void uartDrain(uart_t* uart); //wait for txFifo to empty, the add anything in rxFifo to Queue
 
-void uartSetBaudRate(uart_t* uart, uint32_t baud_rate);
+void uartSetBaudRate(uart_t* uart, uint32_t baud_rate); 
 uint32_t uartGetBaudRate(uart_t* uart);
 
 size_t uartResizeRxBuffer(uart_t* uart, size_t new_size);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -54,10 +54,10 @@ typedef struct uart_struct_t uart_t;
 uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t queueLen, bool inverted);
 void uartEnd(uart_t* uart);
 
-uint32_t uartAvailable(uart_t* uart);
-uint32_t uartAvailableForWrite(uart_t* uart);
-int16_t uartRead(uart_t* uart);
-int16_t uartPeek(uart_t* uart);
+int uartAvailable(uart_t* uart);
+int uartAvailableForWrite(uart_t* uart);
+int uartRead(uart_t* uart);
+int uartPeek(uart_t* uart);
 
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -62,7 +62,7 @@ int uartPeek(uart_t* uart);
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 
-void uartFlush(uart_t* uart); //wait for txFifo to empty, then Discard anything left in RxFifo, Queue contents left alone?
+void uartFlush(uart_t* uart); //wait for txFifo to empty, then Discard anything left in RxFifo, empty rx Queue contents?
 void uartDrain(uart_t* uart); //wait for txFifo to empty, the add anything in rxFifo to Queue
 
 void uartSetBaudRate(uart_t* uart, uint32_t baud_rate); 

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -1,9 +1,9 @@
 name=Wire
-version=1.0.1
-author=Hristo Gochkov
-maintainer=Hristo Gochkov <hristo@espressif.com>
-sentence=Allows the communication between devices or sensors connected via Two Wire Interface Bus. For esp8266 boards. 
-paragraph=
+version=1.1.0
+author=Hristo Gochkov<hristo@espressif.com>;stickbreaker@github
+maintainer=stickbreaker@github
+sentence=Allows the communication between devices or sensors connected via Two Wire Interface Bus. For esp32 boards. 
+paragraph=Supports I2C communication using both hardware peripherals, default 128byte read/write buffers. Direct transmission/reception into local buffer up to 64k-1 bytes. Cpu frequency changing supported. 
 category=Signal Input/Output
-url=http://arduino.cc/en/Reference/Wire
+url=http://arduino.cc/en/Reference/Wire;http://https://github.com/espressif/arduino-esp32
 architectures=esp32

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -30,7 +30,7 @@
 #include "freertos/queue.h"
 #include "Stream.h"
 
-#define STICKBREAKER V1.0.1
+#define STICKBREAKER 'V1.1.0'
 #define I2C_BUFFER_LENGTH 128
 typedef void(*user_onRequest)(void);
 typedef void(*user_onReceive)(uint8_t*, int);
@@ -138,6 +138,7 @@ extern TwoWire Wire1;
 
 
 /*
+V1.1.0 04JAN2019 Add support for cpu frequency changes.
 V1.0.2 30NOV2018 stop returning I2C_ERROR_CONTINUE on ReSTART operations, regain compatibility with Arduino libs
 V1.0.1 02AUG2018 First Fix after release, Correct ReSTART handling, change Debug control, change begin()
   to a function, this allow reporting if bus cannot be initialized, Wire.begin() can be used to recover


### PR DESCRIPTION

#  UNTESTED 
## Development testing code 
## debug coding still active 


**hal-uart modifications**
* changed to support naked receive(operation without FreeRTOS queue)
* changed to improve realtime concurrency
  read(),peek() will access rxFifo if necessary,
  available() will include rxFifo content in the count.
  read(),peek() will return -1 if no data available
* will compensate for cpufrequency changes to maintain configured Baud rate
  Baudrate is NOT validated
* hal-uart supports 3mhz minimum cpu clock rate.

**hal-i2c modifications**
* supports 3mhz minimum cpu clock rate
* reduce i2c bus clock when cpu clock decreases
  Will NOT increase bus clock when cpu freq increases.

**hal-cpu modifications**
* change callback list to double link, to support unwind
* add APB_ABORT_CHANGE ev_type to allow drivers to refuse change request
* change callback to bool