### PR TITLE
Update HardwareSerial.h

### DIFF
--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -86,6 +86,10 @@ public:
     {
         return write((uint8_t) n);
     }
+    void setBaudRate(uint32_t baud) 
+    {
+        uartSetBaudRate(_uart, baud);
+    }
     uint32_t baudRate();
     operator bool() const;
 


### PR DESCRIPTION
This should resolve issue #476 and easily allows access to the uartSetBaudRate function in the HAL