### PR TITLE
FIX - AsyncUDP joinMulticastGroup does not work if interface is not specified

### DIFF
--- a/libraries/AsyncUDP/src/AsyncUDP.cpp
+++ b/libraries/AsyncUDP/src/AsyncUDP.cpp
@@ -561,26 +561,48 @@ static esp_err_t joinMulticastGroup(const ip_addr_t *addr, bool join, tcpip_adap
             return ESP_ERR_INVALID_ARG;
         }
         netif = (struct netif *)nif;
-    }
 
-    if (addr->type == IPADDR_TYPE_V4) {
-        if(join){
-            if (igmp_joingroup_netif(netif, (const ip4_addr *)&(addr->u_addr.ip4))) {
-                return ESP_ERR_INVALID_STATE;
+        if (addr->type == IPADDR_TYPE_V4) {
+            if(join){
+                if (igmp_joingroup_netif(netif, (const ip4_addr *)&(addr->u_addr.ip4))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
+            } else {
+                if (igmp_leavegroup_netif(netif, (const ip4_addr *)&(addr->u_addr.ip4))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
             }
         } else {
-            if (igmp_leavegroup_netif(netif, (const ip4_addr *)&(addr->u_addr.ip4))) {
-                return ESP_ERR_INVALID_STATE;
+            if(join){
+                if (mld6_joingroup_netif(netif, &(addr->u_addr.ip6))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
+            } else {
+                if (mld6_leavegroup_netif(netif, &(addr->u_addr.ip6))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
             }
         }
-    } else {
-        if(join){
-            if (mld6_joingroup_netif(netif, &(addr->u_addr.ip6))) {
-                return ESP_ERR_INVALID_STATE;
+    }  else {
+        if (addr->type == IPADDR_TYPE_V4) {
+            if(join){
+                if (igmp_joingroup((const ip4_addr *)IP4_ADDR_ANY, (const ip4_addr *)&(addr->u_addr.ip4))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
+            } else {
+                if (igmp_leavegroup((const ip4_addr *)IP4_ADDR_ANY, (const ip4_addr *)&(addr->u_addr.ip4))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
             }
         } else {
-            if (mld6_leavegroup_netif(netif, &(addr->u_addr.ip6))) {
-                return ESP_ERR_INVALID_STATE;
+            if(join){
+                if (mld6_joingroup((const ip6_addr *)IP6_ADDR_ANY, &(addr->u_addr.ip6))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
+            } else {
+                if (mld6_leavegroup((const ip6_addr *)IP6_ADDR_ANY, &(addr->u_addr.ip6))) {
+                    return ESP_ERR_INVALID_STATE;
+                }
             }
         }
     }


### PR DESCRIPTION
If ```joinMulticastGroup`` is used with the default ```tcpip_if``` of ```TCPIP_ADAPTER_IF_MAX```, an ungraceful crash will occur.  This modifies ```joinMulticastGroup``` to utilize ```igmp_joingroup``` instead of ```igmp_joingroup_netif``` when ```TCPIP_ADAPTER_IF_MAX``` is passed in so that all interfaces are iterated over and joined.