### PR TITLE
 Fix - LoadProhibited exception occurs when an unknown event occurred

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -339,7 +339,7 @@ const char * system_event_reasons[] = { "UNSPECIFIED", "AUTH_EXPIRE", "AUTH_LEAV
 #endif
 esp_err_t WiFiGenericClass::_eventCallback(void *arg, system_event_t *event)
 {
-    log_d("Event: %d - %s", event->event_id, system_event_names[event->event_id]);
+    log_d("Event: %d - %s", event->event_id, event->event_id >= sizeof(system_event_names) / sizeof(const char *) ? "Unknown" : system_event_names[event->event_id]);
     if(event->event_id == SYSTEM_EVENT_SCAN_DONE) {
         WiFiScanClass::_scanDone();
 


### PR DESCRIPTION
When an unknown event occurs with "Core Debug Level" higher than "Debug", LoadProhibited exception is raised with log_printf. This change avoids the occurrence of an exception. #2334 