### PR TITLE
Fix BananaPi-BIT and T-Beam pin definitions

### DIFF
--- a/variants/bpi-bit/pins_arduino.h
+++ b/variants/bpi-bit/pins_arduino.h
@@ -56,7 +56,7 @@ static const uint8_t P16 = 5;
 static const uint8_t P19 = 22;
 static const uint8_t P20 = 21;
 
-static const uint8_t DAC1 = 26;
-static const uint8_t DAC2 = 25;
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
 
 #endif /* Pins_Arduino_h */

--- a/variants/t-beam/pins_arduino.h
+++ b/variants/t-beam/pins_arduino.h
@@ -54,9 +54,9 @@ static const uint8_t T1 = 0;
 static const uint8_t T2 = 2;
 static const uint8_t T4 = 13;
 static const uint8_t T6 = 14;
-static const uint8_t T8 = 32;
-static const uint8_t T9 = 33;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
 
-static const uint8_t DAC2 = 25;
+static const uint8_t DAC2 = 26;
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
This came up in https://github.com/OttoWinter/esphomeyaml/pull/355

The BananaPi-BIT and TTGO T-Beam pin definitions seem to have a copy and paste error (like this one: https://github.com/espressif/arduino-esp32/pull/1949)

Original BananaPi PR: https://github.com/espressif/arduino-esp32/pull/1810
Original T-Beam PR: https://github.com/espressif/arduino-esp32/pull/1852

Disclaimer: I don't own any of these boards, the pin definitions just look *a lot* like a copy and paste error that has been copied through (and fixed in #1949) - also I don't think it's possible to re-map the touch & DAC pins :)

CC @yelvlab, @lewisxhe