### PR TITLE
Fix SS pin for Adafruit Feather variant of the ESP32 board

### DIFF
--- a/variants/feather_esp32/pins_arduino.h
+++ b/variants/feather_esp32/pins_arduino.h
@@ -20,7 +20,7 @@ static const uint8_t RX = 16;
 static const uint8_t SDA = 23;
 static const uint8_t SCL = 22;
 
-static const uint8_t SS    = 2;
+static const uint8_t SS    = 33;
 static const uint8_t MOSI  = 18;
 static const uint8_t MISO  = 19;
 static const uint8_t SCK   = 5;


### PR DESCRIPTION
Pin 2 is not found on the [Adafruit docs](https://learn.adafruit.com/adafruit-huzzah32-esp32-feather) for this board and 33 was suggested in #1586 as a fix. I've tried this locally on my board and it is working correctly.