### PR TITLE
python2 get.py does not work behind proxy

### DIFF
--- a/docs/arduino-ide/debian_ubuntu.md
+++ b/docs/arduino-ide/debian_ubuntu.md
@@ -16,7 +16,7 @@ Installation instructions for Debian / Ubuntu OS
   cd esp32 && \
   git submodule update --init --recursive && \
   cd tools && \
-  python2 get.py
+  python3 get.py
   ```
 - Restart Arduino IDE
 
@@ -32,5 +32,5 @@ Installation instructions for Debian / Ubuntu OS
   cd esp32 && \
   git submodule update --init --recursive && \
   cd tools && \
-  python2 get.py
+  python3 get.py
   ```


### PR DESCRIPTION
Executing python2 get.py behind proxy give error "IOError: [Errno socket error] [SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:590)"