### PR TITLE
Fix missing declaration of __bswap64 in endian.h

### DIFF
--- a/tools/sdk/include/wpa_supplicant/endian.h
+++ b/tools/sdk/include/wpa_supplicant/endian.h
@@ -85,6 +85,7 @@ typedef	__uint64_t	uint64_t;
 #if 1 //BYTE_ORDER == _LITTLE_ENDIAN
 #define __bswap16     __bswap_16
 #define __bswap32     __bswap_32
+#define __bswap64     __bswap_64
 #define	htobe16(x)	bswap16((x))
 #define	htobe32(x)	bswap32((x))
 #define	htobe64(x)	bswap64((x))


### PR DESCRIPTION
This is the equivalent of https://github.com/espressif/esp-idf/pull/2983 in the arduino core.
Without this line, code that uses htobe64 causes a compilation error:
```
/home/openlcb/snap/arduino-mhall119/5/.arduino15/packages/esp32/hardware/esp32/1.0.1/tools/sdk/include/wpa_supplicant/endian.h:79:31: error: '__bswap64' was not declared in this scope
 #define bswap64(x) __bswap64(x)
                               ^
/home/openlcb/snap/arduino-mhall119/5/.arduino15/packages/esp32/hardware/esp32/1.0.1/tools/sdk/include/wpa_supplicant/endian.h:97:20: note: in expansion of macro 'bswap64'
 #define be64toh(x) bswap64((x))
                    ^
/home/openlcb/snap/arduino-mhall119/5/Arduino/libraries/OpenMRN/src/openlcb/If.hxx:96:12: note: in expansion of macro 'be64toh'
     return be64toh(ret);
```