### PR TITLE
remove useless condition in if statement

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -168,7 +168,7 @@ static bool espWiFiStop(){
     _esp_wifi_started = false;
     err = esp_wifi_stop();
     if(err){
-        log_e("Could not stop WiFi! %u", err);
+        log_e("Could not stop WiFi! %d", err);
         _esp_wifi_started = true;
         return false;
     }
@@ -496,7 +496,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
     esp_err_t err;
     err = esp_wifi_set_mode(m);
     if(err){
-        log_e("Could not set mode! %u", err);
+        log_e("Could not set mode! %d", err);
         return false;
     }
     return true;

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -47,108 +47,110 @@ uint8_t WiFiMulti::run(uint32_t connectTimeout)
 
     int8_t scanResult;
     uint8_t status = WiFi.status();
-    if(status != WL_CONNECTED || status == WL_NO_SSID_AVAIL || status == WL_IDLE_STATUS || status == WL_CONNECT_FAILED) {
+    if(status == WL_CONNECTED) {
+        return status;
+    }
 
-        scanResult = WiFi.scanNetworks();
-        if(scanResult == WIFI_SCAN_RUNNING) {
-            // scan is running
-            return WL_NO_SSID_AVAIL;
-        } else if(scanResult > 0) {
-            // scan done analyze
-            WifiAPlist_t bestNetwork { NULL, NULL };
-            int bestNetworkDb = INT_MIN;
-            uint8_t bestBSSID[6];
-            int32_t bestChannel = 0;
+    scanResult = WiFi.scanNetworks();
+    if(scanResult == WIFI_SCAN_RUNNING) {
+        // scan is running
+        return WL_NO_SSID_AVAIL;
+    } else if(scanResult > 0) {
+        // scan done analyze
+        WifiAPlist_t bestNetwork { NULL, NULL };
+        int bestNetworkDb = INT_MIN;
+        uint8_t bestBSSID[6];
+        int32_t bestChannel = 0;
 
-            log_i("[WIFI] scan done");
+        log_i("[WIFI] scan done");
 
-            if(scanResult <= 0) {
-                log_e("[WIFI] no networks found");
-            } else {
-                log_i("[WIFI] %d networks found", scanResult);
-                for(int8_t i = 0; i < scanResult; ++i) {
+        if(scanResult <= 0) {
+            log_e("[WIFI] no networks found");
+        } else {
+            log_i("[WIFI] %d networks found", scanResult);
+            for(int8_t i = 0; i < scanResult; ++i) {
 
-                    String ssid_scan;
-                    int32_t rssi_scan;
-                    uint8_t sec_scan;
-                    uint8_t* BSSID_scan;
-                    int32_t chan_scan;
+                String ssid_scan;
+                int32_t rssi_scan;
+                uint8_t sec_scan;
+                uint8_t* BSSID_scan;
+                int32_t chan_scan;
 
-                    WiFi.getNetworkInfo(i, ssid_scan, sec_scan, rssi_scan, BSSID_scan, chan_scan);
+                WiFi.getNetworkInfo(i, ssid_scan, sec_scan, rssi_scan, BSSID_scan, chan_scan);
 
-                    bool known = false;
-                    for(uint32_t x = 0; x < APlist.size(); x++) {
-                        WifiAPlist_t entry = APlist[x];
+                bool known = false;
+                for(uint32_t x = 0; x < APlist.size(); x++) {
+                    WifiAPlist_t entry = APlist[x];
 
-                        if(ssid_scan == entry.ssid) { // SSID match
-                            known = true;
-                            if(rssi_scan > bestNetworkDb) { // best network
-                                if(sec_scan == WIFI_AUTH_OPEN || entry.passphrase) { // check for passphrase if not open wlan
-                                    bestNetworkDb = rssi_scan;
-                                    bestChannel = chan_scan;
-                                    memcpy((void*) &bestNetwork, (void*) &entry, sizeof(bestNetwork));
-                                    memcpy((void*) &bestBSSID, (void*) BSSID_scan, sizeof(bestBSSID));
-                                }
+                    if(ssid_scan == entry.ssid) { // SSID match
+                        known = true;
+                        if(rssi_scan > bestNetworkDb) { // best network
+                            if(sec_scan == WIFI_AUTH_OPEN || entry.passphrase) { // check for passphrase if not open wlan
+                                bestNetworkDb = rssi_scan;
+                                bestChannel = chan_scan;
+                                memcpy((void*) &bestNetwork, (void*) &entry, sizeof(bestNetwork));
+                                memcpy((void*) &bestBSSID, (void*) BSSID_scan, sizeof(bestBSSID));
                             }
-                            break;
                         }
+                        break;
                     }
+                }
 
-                    if(known) {
-                        log_d(" --->   %d: [%d][%02X:%02X:%02X:%02X:%02X:%02X] %s (%d) %c", i, chan_scan, BSSID_scan[0], BSSID_scan[1], BSSID_scan[2], BSSID_scan[3], BSSID_scan[4], BSSID_scan[5], ssid_scan.c_str(), rssi_scan, (sec_scan == WIFI_AUTH_OPEN) ? ' ' : '*');
-                    } else {
-                        log_d("       %d: [%d][%02X:%02X:%02X:%02X:%02X:%02X] %s (%d) %c", i, chan_scan, BSSID_scan[0], BSSID_scan[1], BSSID_scan[2], BSSID_scan[3], BSSID_scan[4], BSSID_scan[5], ssid_scan.c_str(), rssi_scan, (sec_scan == WIFI_AUTH_OPEN) ? ' ' : '*');
-                    }
+                if(known) {
+                    log_d(" --->   %d: [%d][%02X:%02X:%02X:%02X:%02X:%02X] %s (%d) %c", i, chan_scan, BSSID_scan[0], BSSID_scan[1], BSSID_scan[2], BSSID_scan[3], BSSID_scan[4], BSSID_scan[5], ssid_scan.c_str(), rssi_scan, (sec_scan == WIFI_AUTH_OPEN) ? ' ' : '*');
+                } else {
+                    log_d("       %d: [%d][%02X:%02X:%02X:%02X:%02X:%02X] %s (%d) %c", i, chan_scan, BSSID_scan[0], BSSID_scan[1], BSSID_scan[2], BSSID_scan[3], BSSID_scan[4], BSSID_scan[5], ssid_scan.c_str(), rssi_scan, (sec_scan == WIFI_AUTH_OPEN) ? ' ' : '*');
                 }
             }
+        }
 
-            // clean up ram
-            WiFi.scanDelete();
+        // clean up ram
+        WiFi.scanDelete();
 
-            if(bestNetwork.ssid) {
-                log_i("[WIFI] Connecting BSSID: %02X:%02X:%02X:%02X:%02X:%02X SSID: %s Channal: %d (%d)", bestBSSID[0], bestBSSID[1], bestBSSID[2], bestBSSID[3], bestBSSID[4], bestBSSID[5], bestNetwork.ssid, bestChannel, bestNetworkDb);
+        if(bestNetwork.ssid) {
+            log_i("[WIFI] Connecting BSSID: %02X:%02X:%02X:%02X:%02X:%02X SSID: %s Channal: %d (%d)", bestBSSID[0], bestBSSID[1], bestBSSID[2], bestBSSID[3], bestBSSID[4], bestBSSID[5], bestNetwork.ssid, bestChannel, bestNetworkDb);
 
-                WiFi.begin(bestNetwork.ssid, bestNetwork.passphrase, bestChannel, bestBSSID);
+            WiFi.begin(bestNetwork.ssid, bestNetwork.passphrase, bestChannel, bestBSSID);
+            status = WiFi.status();
+            
+            auto startTime = millis();
+            // wait for connection, fail, or timeout
+            while(status != WL_CONNECTED && status != WL_NO_SSID_AVAIL && status != WL_CONNECT_FAILED && (millis() - startTime) <= connectTimeout) {
+                delay(10);
                 status = WiFi.status();
-                
-                auto startTime = millis();
-                // wait for connection, fail, or timeout
-                while(status != WL_CONNECTED && status != WL_NO_SSID_AVAIL && status != WL_CONNECT_FAILED && (millis() - startTime) <= connectTimeout) {
-                    delay(10);
-                    status = WiFi.status();
-                }
+            }
 
-                switch(status) {
-                case 3:
-                    log_i("[WIFI] Connecting done.");
-                    log_d("[WIFI] SSID: %s", WiFi.SSID().c_str());
-                    log_d("[WIFI] IP: %s", WiFi.localIP().toString().c_str());
-                    log_d("[WIFI] MAC: %s", WiFi.BSSIDstr().c_str());
-                    log_d("[WIFI] Channel: %d", WiFi.channel());
-                    break;
-                case 1:
-                    log_e("[WIFI] Connecting Failed AP not found.");
-                    break;
-                case 4:
-                    log_e("[WIFI] Connecting Failed.");
-                    break;
-                default:
-                    log_e("[WIFI] Connecting Failed (%d).", status);
-                    break;
-                }
-            } else {
-                log_e("[WIFI] no matching wifi found!");
+            switch(status) {
+            case 3:
+                log_i("[WIFI] Connecting done.");
+                log_d("[WIFI] SSID: %s", WiFi.SSID().c_str());
+                log_d("[WIFI] IP: %s", WiFi.localIP().toString().c_str());
+                log_d("[WIFI] MAC: %s", WiFi.BSSIDstr().c_str());
+                log_d("[WIFI] Channel: %d", WiFi.channel());
+                break;
+            case 1:
+                log_e("[WIFI] Connecting Failed AP not found.");
+                break;
+            case 4:
+                log_e("[WIFI] Connecting Failed.");
+                break;
+            default:
+                log_e("[WIFI] Connecting Failed (%d).", status);
+                break;
             }
         } else {
-            // start scan
-            log_d("[WIFI] delete old wifi config...");
-            WiFi.disconnect();
-
-            log_d("[WIFI] start scan");
-            // scan wifi async mode
-            WiFi.scanNetworks(true);
+            log_e("[WIFI] no matching wifi found!");
         }
+    } else {
+        // start scan
+        log_d("[WIFI] delete old wifi config...");
+        WiFi.disconnect();
+
+        log_d("[WIFI] start scan");
+        // scan wifi async mode
+        WiFi.scanNetworks(true);
     }
+
     return status;
 }
 


### PR DESCRIPTION
```
uint8_t run() {
    if(status != WL_CONNECTED || status == WL_NO_SSID_AVAIL || status == WL_IDLE_STATUS || status == WL_CONNECT_FAILED) {
        // ...
    }
}
```
these code are equal to
```
uint8_t run() {
    if(status != WL_CONNECTED) {
        // ...
    }
}
```
and equal to

```
uint8_t run() {
    if(status == WL_CONNECTED) {
        return status;
    }

    // ...
}

```