### PR TITLE
Add connect timeout to WiFiClient

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -25,6 +25,7 @@
 
 #define WIFI_CLIENT_MAX_WRITE_RETRY   (10)
 #define WIFI_CLIENT_SELECT_TIMEOUT_US (1000000)
+#define WIFI_CLIENT_CONNECT_TIMEOUT_MS (60000)
 #define WIFI_CLIENT_FLUSH_BUFFER_SIZE (1024)
 
 #undef connect
@@ -203,11 +204,16 @@ void WiFiClient::stop()
 
 int WiFiClient::connect(IPAddress ip, uint16_t port)
 {
+    return connect(ip,port,WIFI_CLIENT_CONNECT_TIMEOUT_MS);
+}
+int WiFiClient::connect(IPAddress ip, uint16_t port, uint32_t timeout)
+{
     int sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0) {
         log_e("socket: %d", errno);
         return 0;
     }
+    fcntl( sockfd, F_SETFL, fcntl( sockfd, F_GETFL, 0 ) | O_NONBLOCK );
 
     uint32_t ip_addr = ip;
     struct sockaddr_in serveraddr;
@@ -215,12 +221,21 @@ int WiFiClient::connect(IPAddress ip, uint16_t port)
     serveraddr.sin_family = AF_INET;
     bcopy((const void *)(&ip_addr), (void *)&serveraddr.sin_addr.s_addr, 4);
     serveraddr.sin_port = htons(port);
-    int res = lwip_connect_r(sockfd, (struct sockaddr*)&serveraddr, sizeof(serveraddr));
-    if (res < 0) {
-        log_e("lwip_connect_r: %d", errno);
+    fd_set fdset;
+    struct timeval tv;
+    FD_ZERO(&fdset);
+    FD_SET(sockfd, &fdset);
+    tv.tv_sec = 0;
+    tv.tv_usec = timeout * 1000;
+    lwip_connect_r(sockfd, (struct sockaddr*)&serveraddr, sizeof(serveraddr));
+    int res = select(sockfd + 1, NULL, &fdset, NULL, &tv);
+    if (res != 1)
+    {
+        log_e("select: %d",errno);
         close(sockfd);
         return 0;
     }
+    fcntl( sockfd, F_SETFL, fcntl( sockfd, F_GETFL, 0 ) & (~O_NONBLOCK) );
     clientSocketHandle.reset(new WiFiClientSocketHandle(sockfd));
     _rxBuffer.reset(new WiFiClientRxBuffer(sockfd));
     _connected = true;
@@ -229,11 +244,15 @@ int WiFiClient::connect(IPAddress ip, uint16_t port)
 
 int WiFiClient::connect(const char *host, uint16_t port)
 {
+    return connect(host,port,WIFI_CLIENT_CONNECT_TIMEOUT_MS);
+}
+int WiFiClient::connect(const char *host, uint16_t port, uint32_t timeout)
+{
     IPAddress srv((uint32_t)0);
     if(!WiFiGenericClass::hostByName(host, srv)){
         return 0;
     }
-    return connect(srv, port);
+    return connect(srv, port, timeout);
 }
 
 int WiFiClient::setSocketOption(int option, char* value, size_t len)

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -25,7 +25,6 @@
 
 #define WIFI_CLIENT_MAX_WRITE_RETRY   (10)
 #define WIFI_CLIENT_SELECT_TIMEOUT_US (1000000)
-#define WIFI_CLIENT_CONNECT_TIMEOUT_MS (60000)
 #define WIFI_CLIENT_FLUSH_BUFFER_SIZE (1024)
 
 #undef connect
@@ -204,9 +203,9 @@ void WiFiClient::stop()
 
 int WiFiClient::connect(IPAddress ip, uint16_t port)
 {
-    return connect(ip,port,WIFI_CLIENT_CONNECT_TIMEOUT_MS);
+    return connect(ip,port,-1);
 }
-int WiFiClient::connect(IPAddress ip, uint16_t port, uint32_t timeout)
+int WiFiClient::connect(IPAddress ip, uint16_t port, int32_t timeout)
 {
     int sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0) {
@@ -228,7 +227,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, uint32_t timeout)
     tv.tv_sec = 0;
     tv.tv_usec = timeout * 1000;
     lwip_connect_r(sockfd, (struct sockaddr*)&serveraddr, sizeof(serveraddr));
-    int res = select(sockfd + 1, NULL, &fdset, NULL, &tv);
+    int res = select(sockfd + 1, nullptr, &fdset, nullptr, timeout<0 ? nullptr : &tv);
     if (res != 1)
     {
         log_e("select: %d",errno);
@@ -244,9 +243,9 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, uint32_t timeout)
 
 int WiFiClient::connect(const char *host, uint16_t port)
 {
-    return connect(host,port,WIFI_CLIENT_CONNECT_TIMEOUT_MS);
+    return connect(host,port,-1);
 }
-int WiFiClient::connect(const char *host, uint16_t port, uint32_t timeout)
+int WiFiClient::connect(const char *host, uint16_t port, int32_t timeout)
 {
     IPAddress srv((uint32_t)0);
     if(!WiFiGenericClass::hostByName(host, srv)){

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -41,9 +41,9 @@ public:
     WiFiClient(int fd);
     ~WiFiClient();
     int connect(IPAddress ip, uint16_t port);
-    int connect(IPAddress ip, uint16_t port, uint32_t timeout);
+    int connect(IPAddress ip, uint16_t port, int32_t timeout);
     int connect(const char *host, uint16_t port);
-    int connect(const char *host, uint16_t port, uint32_t timeout);
+    int connect(const char *host, uint16_t port, int32_t timeout);
     size_t write(uint8_t data);
     size_t write(const uint8_t *buf, size_t size);
     size_t write_P(PGM_P buf, size_t size);

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -41,7 +41,9 @@ public:
     WiFiClient(int fd);
     ~WiFiClient();
     int connect(IPAddress ip, uint16_t port);
+    int connect(IPAddress ip, uint16_t port, uint32_t timeout);
     int connect(const char *host, uint16_t port);
+    int connect(const char *host, uint16_t port, uint32_t timeout);
     size_t write(uint8_t data);
     size_t write(const uint8_t *buf, size_t size);
     size_t write_P(PGM_P buf, size_t size);


### PR DESCRIPTION
Allows a timeout, in milliseconds, to be passed as an optional parameter to WiFiClient.connect().

Currently this is a blocking function which can take up to 20 seconds to return if the server isn't responding. 

- Incidentally, the 'normal' timeout will trigger an error at the usual time so behaviour is unchanged if a timeout isn't provided! (Unfortunately, it will also trigger if the provided timeout is longer; timeout duration is therefore effectively capped at whatever it is normally.) Ideally this would be overriden. Also, a defined default value might be more a better approach (see initial commit for eg.).

- Perhaps using setTimeout would be a better way to set the value. That would leave signatures unchanged and only require setting the value once, instead of tacking it on to every connect().