### PR TITLE
fix can not connect to empty password wifi with MultiWiFi lib

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -168,7 +168,7 @@ static bool espWiFiStop(){
     _esp_wifi_started = false;
     err = esp_wifi_stop();
     if(err){
-        log_e("Could not stop WiFi! %u", err);
+        log_e("Could not stop WiFi! %d", err);
         _esp_wifi_started = true;
         return false;
     }
@@ -496,7 +496,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
     esp_err_t err;
     err = esp_wifi_set_mode(m);
     if(err){
-        log_e("Could not set mode! %u", err);
+        log_e("Could not set mode! %d", err);
         return false;
     }
     return true;

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -367,9 +367,7 @@ esp_err_t WiFiGenericClass::_eventCallback(void *arg, system_event_t *event)
             WiFiSTAClass::_setStatus(WL_DISCONNECTED);
         }
         clearStatusBits(STA_CONNECTED_BIT | STA_HAS_IP_BIT | STA_HAS_IP6_BIT);
-        if(((reason == WIFI_REASON_AUTH_EXPIRE) ||
-            (reason >= WIFI_REASON_BEACON_TIMEOUT && reason != WIFI_REASON_AUTH_FAIL)) &&
-            WiFi.getAutoReconnect())
+        if((reason == WIFI_REASON_AUTH_EXPIRE) && WiFi.getAutoReconnect())
         {
             WiFi.disconnect(true);
             WiFi.begin();

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -185,6 +185,8 @@ bool WiFiMulti::APlistAdd(const char* ssid, const char *passphrase)
             free(newAP.ssid);
             return false;
         }
+    } else {
+        newAP.passphrase = 0x00;
     }
 
     APlist.push_back(newAP);


### PR DESCRIPTION
1. if the passphrase is NULL, it should be initialized
```WiFiMulti.cpp:188```

2. if esp32 connected to WiFi A, and the WiFi A is turned off, the esp32 will send 
```SYSTEM_EVENT_STA_DISCONNECTED  ---reason: BEACON_TIMEOUT``` event

then, the lib will try to reconnect to WiFi A, again and again ...

so, in this case, it's better not to reconnect the original WiFi A.
```WiFiGeneric.cpp:370```

this is the test code.

```
#include <Arduino.h>
#include <WiFi.h>
#include <WiFiMulti.h>

WiFiMulti wifiMulti;

typedef struct {
  const char *name;
  const char *pwd;
} WiFiItem_t;

WiFiItem_t WiFiTable[] = {
  { "iPhone", "12345678"},
  { "Company-StaffWiFi", NULL}
};
const unsigned int WiFiCnt = sizeof(WiFiTable)/sizeof(WiFiItem_t);

void setup() {
    Serial.begin(115200);
    for(uint8_t t = 3; t > 0; t--) {
        Serial.printf("[SETUP] WAIT %d...\n", t);
        Serial.flush();
        delay(1000);
    }

    for(uint8_t i=0; i<WiFiCnt; i++) {
      //Serial.printf("Add AP %s %s\n", WiFiTable[i].name, WiFiTable[i].pwd);
      wifiMulti.addAP(WiFiTable[i].name, WiFiTable[i].pwd);
    }
}

void loop() {
    uint8_t wifi_status = wifiMulti.run();

    if((wifi_status == WL_CONNECTED)) {
      Serial.printf("WiFi connected!\n");
    } else {
      Serial.printf("WiFi not connected! wifi status %u\n", wifi_status);
    }
    delay(1000);
}
```
this is the log
```
[SETUP] WAIT 3...
[SETUP] WAIT 2...
[SETUP] WAIT 1...
[I][WiFiMulti.cpp:195] APlistAdd(): [WIFI][APlistAdd] add SSID: iPhone
[I][WiFiMulti.cpp:195] APlistAdd(): [WIFI][APlistAdd] add SSID: Company-StaffWiFi
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 0 - WIFI_READY
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 1 - SCAN_DONE
[I][WiFiMulti.cpp:65] run(): [WIFI] scan done
[I][WiFiMulti.cpp:70] run(): [WIFI] 14 networks found
[D][WiFiMulti.cpp:100] run():  --->   0: [1][3E:36:BB:C7:2E:D8] iPhone (-34) *
[D][WiFiMulti.cpp:100] run():  --->   1: [11][70:10:5C:7C:57:D2] Company-StaffWiFi (-63)  
[D][WiFiMulti.cpp:102] run():        2: [11][70:10:5C:7C:57:D1] Company-LabWiFi (-63) *
[D][WiFiMulti.cpp:102] run():        3: [11][70:10:5C:7C:57:D3] Company-GuestWiFi (-63)  
[D][WiFiMulti.cpp:100] run():  --->   4: [6][70:10:5C:F2:0B:92] Company-StaffWiFi (-83)  
[D][WiFiMulti.cpp:102] run():        5: [6][70:10:5C:F2:0B:93] Company-GuestWiFi (-83)  
[D][WiFiMulti.cpp:102] run():        6: [13][30:B4:9E:6D:63:EF] L-0257 (-83) *
[D][WiFiMulti.cpp:102] run():        7: [6][70:10:5C:F2:0B:91] Company-LabWiFi (-84) *
[D][WiFiMulti.cpp:100] run():  --->   8: [6][70:10:5C:7D:EE:62] Company-StaffWiFi (-84)  
[D][WiFiMulti.cpp:102] run():        9: [6][70:10:5C:7D:EE:61] Company-LabWiFi (-84) *
[D][WiFiMulti.cpp:102] run():        10: [6][70:10:5C:7D:EE:63] Company-GuestWiFi (-84)  
[D][WiFiMulti.cpp:100] run():  --->   11: [6][70:10:5C:F2:0D:12] Company-StaffWiFi (-84)  
[D][WiFiMulti.cpp:102] run():        12: [6][70:10:5C:F2:0D:13] Company-GuestWiFi (-85)  
[D][WiFiMulti.cpp:102] run():        13: [6][70:10:5C:F2:0D:11] Company-LabWiFi (-86) *
[I][WiFiMulti.cpp:111] run(): [WIFI] Connecting BSSID: 3E:36:BB:C7:2E:D8 SSID: iPhone Channal: 1 (-34)
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 4 - STA_CONNECTED
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 7 - STA_GOT_IP
[D][WiFiGeneric.cpp:383] _eventCallback(): STA IP: 172.20.10.14, MASK: 255.255.255.240, GW: 172.20.10.1
[I][WiFiMulti.cpp:125] run(): [WIFI] Connecting done.
[D][WiFiMulti.cpp:126] run(): [WIFI] SSID: iPhone
[D][WiFiMulti.cpp:127] run(): [WIFI] IP: 172.20.10.14
[D][WiFiMulti.cpp:128] run(): [WIFI] MAC: 3E:36:BB:C7:2E:D8
[D][WiFiMulti.cpp:129] run(): [WIFI] Channel: 1
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!
WiFi connected!

// WIFI A was turned off

[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 5 - STA_DISCONNECTED
[W][WiFiGeneric.cpp:357] _eventCallback(): Reason: 200 - BEACON_TIMEOUT   // DISCONNECTED because BEACON_TIMEOUT
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 0 - WIFI_READY
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 5 - STA_DISCONNECTED
[W][WiFiGeneric.cpp:357] _eventCallback(): Reason: 201 - NO_AP_FOUND
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 0 - WIFI_READY
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 5 - STA_DISCONNECTED
[W][WiFiGeneric.cpp:357] _eventCallback(): Reason: 201 - NO_AP_FOUND
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 0 - WIFI_READY
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 5 - STA_DISCONNECTED
[W][WiFiGeneric.cpp:357] _eventCallback(): Reason: 201 - NO_AP_FOUND
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 0 - WIFI_READY
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiGeneric.cpp:342] _eventCallback(): Event: 2 - STA_START
[D][WiFiMulti.cpp:146] run(): [WIFI] delete old wifi config...
[D][WiFiMulti.cpp:149] run(): [WIFI] start scan
WiFi not connected! wifi status 6
WiFi not connected! wifi status 1
WiFi not connected! wifi status 1
WiFi not connected! wifi status 1
WiFi not connected! wifi status 1
WiFi not connected! wifi status 1
WiFi not connected! wifi status 1
WiFi not connected! wifi status 1
WiFi not connected! wifi status 1
.....
// can not reconnected anymore
```


issue id https://github.com/espressif/arduino-esp32/issues/2374