### PR TITLE
New version of the Olimex boards ESP32-EVB/Gateway/PoE

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -6,6 +6,7 @@ menu.FlashSize=Flash Size
 menu.PartitionScheme=Partition Scheme
 menu.DebugLevel=Core Debug Level
 menu.PSRAM=PSRAM
+menu.Revision=Board Revision
 
 ##############################################################
 
@@ -1697,6 +1698,15 @@ esp32-evb.menu.FlashFreq.40.build.flash_freq=40m
 esp32-evb.menu.UploadSpeed.115200=115200
 esp32-evb.menu.UploadSpeed.115200.upload.speed=115200
 
+esp32-evb.menu.PartitionScheme.default=Default
+esp32-evb.menu.PartitionScheme.default.build.partitions=default
+esp32-evb.menu.PartitionScheme.no_ota=No OTA (Large APP)
+esp32-evb.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32-evb.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32-evb.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+esp32-evb.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32-evb.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
 ##############################################################
 
 esp32-gateway.name=OLIMEX ESP32-GATEWAY
@@ -1712,7 +1722,13 @@ esp32-gateway.serial.disableRTS=true
 esp32-gateway.build.mcu=esp32
 esp32-gateway.build.core=esp32
 esp32-gateway.build.variant=esp32-gateway
-esp32-gateway.build.board=ESP32_GATEWAY
+#esp32-gateway.build.board=ESP32_GATEWAY
+esp32-gateway.menu.Revision.RevC=Revision C or older
+esp32-gateway.menu.Revision.RevC.build.board=ESP32_GATEWAY='C'
+esp32-gateway.menu.Revision.RevE=Revision E
+esp32-gateway.menu.Revision.RevE.build.board=ESP32_GATEWAY='E'
+esp32-gateway.menu.Revision.RevF=Revision F
+esp32-gateway.menu.Revision.RevF.build.board=ESP32_GATEWAY='F'
 
 esp32-gateway.build.f_cpu=240000000L
 esp32-gateway.build.flash_mode=dio
@@ -1729,6 +1745,15 @@ esp32-gateway.menu.FlashFreq.40.build.flash_freq=40m
 
 esp32-gateway.menu.UploadSpeed.115200=115200
 esp32-gateway.menu.UploadSpeed.115200.upload.speed=115200
+
+esp32-gateway.menu.PartitionScheme.default=Default
+esp32-gateway.menu.PartitionScheme.default.build.partitions=default
+esp32-gateway.menu.PartitionScheme.no_ota=No OTA (Large APP)
+esp32-gateway.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32-gateway.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32-gateway.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+esp32-gateway.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32-gateway.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
 ##############################################################
 
@@ -1762,6 +1787,15 @@ esp32-poe.menu.FlashFreq.40.build.flash_freq=40m
 
 esp32-poe.menu.UploadSpeed.115200=115200
 esp32-poe.menu.UploadSpeed.115200.upload.speed=115200
+
+esp32-poe.menu.PartitionScheme.default=Default
+esp32-poe.menu.PartitionScheme.default.build.partitions=default
+esp32-poe.menu.PartitionScheme.no_ota=No OTA (Large APP)
+esp32-poe.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32-poe.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32-poe.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+esp32-poe.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32-poe.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
 ##############################################################
 

--- a/variants/esp32-gateway/pins_arduino.h
+++ b/variants/esp32-gateway/pins_arduino.h
@@ -11,6 +11,11 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+#if	ARDUINO_ESP32_GATEWAY >= 'D'
+#define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
+#define ETH_PHY_POWER 5
+#endif
+
 static const uint8_t LED_BUILTIN = 33;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
@@ -34,5 +39,9 @@ static const uint8_t A4 = 32;
 static const uint8_t A7 = 35;
 
 static const uint8_t T9 = 32;
+
+#if	ARDUINO_ESP32_GATEWAY >= 'F'
+#define BOARD_HAS_1BIT_SDMMC
+#endif
 
 #endif /* Pins_Arduino_h */

--- a/variants/esp32-poe/pins_arduino.h
+++ b/variants/esp32-poe/pins_arduino.h
@@ -11,6 +11,8 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+#define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
+#define ETH_PHY_POWER 12
 
 static const uint8_t KEY_BUILTIN = 34;
 
@@ -24,5 +26,7 @@ static const uint8_t SS    = 5;
 static const uint8_t MOSI  = 2;
 static const uint8_t MISO  = 15;
 static const uint8_t SCK   = 14;
+
+#define BOARD_HAS_1BIT_SDMMC
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
In Board.txt file added board revision submenu for different revisions of the same board. By selecting different revision in the Arduino menu different value of the predefined macro will be applied which is used inside the pins_arduino.h file to make different defines and values for the specific revision.

Added PartitionScheme submenu to our 3 boards, similar to the other ESP32 boards.

In esp32-gateway pin defintions preprocessor conditions added to distingiush different revisions.

In esp32-poe pin definitions is added ethernet power enable pin and also defined macro: BOARD_HAS_1BIT_SDMMC.