### PR TITLE
Add default pin mapping for Serial1 and Serial2

### DIFF
--- a/variants/wesp32/pins_arduino.h
+++ b/variants/wesp32/pins_arduino.h
@@ -11,6 +11,11 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+#define TX1   13
+#define RX1   12
+#define TX2   33
+#define RX2   39
+
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
@@ -39,6 +44,6 @@ static const uint8_t T9 = 32;
 #define ETH_PHY_MDC   16
 #define ETH_PHY_MDIO  17
 #define ETH_PHY_TYPE  ETH_PHY_LAN8720
-#define ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
+#define ETH_CLK_MODE  ETH_CLOCK_GPIO0_IN
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
This sets the default pin assignments for Serial1 and Serial2 correctly for the wESP32.