### PR TITLE
Correct millis() error causes by micros() overflow every about 72 minutes

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -115,7 +115,7 @@ unsigned long IRAM_ATTR micros()
 
 unsigned long IRAM_ATTR millis()
 {
-    return (unsigned long) (esp_timer_get_time() / 1000);
+    return (unsigned long) (esp_timer_get_time() / 1000ULL);
 }
 
 void delay(uint32_t ms)


### PR DESCRIPTION
Corrects issue #2430, thanks to @stickbreaker for the very easy solution found! 

This solution is very different from the ESP8266 solution, because on that controller the micros() timer used to calculate millis() is a 32 bit wide counter. On the ESP32 the micros() base counter is 64 bits wide, allowing the solution to be both fast and simple. As I understand from reading topics on the internet, the division by 1,000 needed in this solution should be optimised by the gcc compiler using the same magic number method as in the ESP8266.

The new millis() function was tested (only) one loop of 72 minutes, without an issue.