### PR TITLE
Update board file for LOPY4

### DIFF
--- a/variants/lopy4/pins_arduino.h
+++ b/variants/lopy4/pins_arduino.h
@@ -20,7 +20,6 @@
 #define LORA_IO0 LORA_IRQ  // alias
 #define LORA_IO1 LORA_IRQ   // tied by diode to IO0
 #define LORA_IO2 LORA_IRQ   // tied by diode to IO0
-#define LORA_RST NOT_A_PIN
 
 static const uint8_t LED_BUILTIN = 0; // ->2812 RGB !!!
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility


### PR DESCRIPTION
removed #define LORA_RST NOT_A_PIN because this runs on an error with LMIC stack (NOT_A_PIN resolves to -1 in Arduino)