### PR TITLE
Add Heltec boards defintion and update board menu chooices

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2065,7 +2065,7 @@ odroid_esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 
-heltec_wifi_kit_32.name=Heltec_WIFI_Kit_32
+heltec_wifi_kit_32.name=Heltec WiFi Kit 32
 
 heltec_wifi_kit_32.upload.tool=esptool_py
 heltec_wifi_kit_32.upload.maximum_size=1310720
@@ -2078,19 +2078,74 @@ heltec_wifi_kit_32.serial.disableRTS=true
 heltec_wifi_kit_32.build.mcu=esp32
 heltec_wifi_kit_32.build.core=esp32
 heltec_wifi_kit_32.build.variant=heltec_wifi_kit_32
-heltec_wifi_kit_32.build.board=Heltec_WIFI_Kit_32
+heltec_wifi_kit_32.build.board=HELTEC_WIFI_KIT_32
 
 heltec_wifi_kit_32.build.f_cpu=240000000L
-heltec_wifi_kit_32.build.flash_mode=dio
 heltec_wifi_kit_32.build.flash_size=4MB
+heltec_wifi_kit_32.build.flash_freq=40m
+heltec_wifi_kit_32.build.flash_mode=dio
 heltec_wifi_kit_32.build.boot=dio
 heltec_wifi_kit_32.build.partitions=default
 heltec_wifi_kit_32.build.defines=
 
-heltec_wifi_kit_32.menu.FlashFreq.80=80MHz
-heltec_wifi_kit_32.menu.FlashFreq.80.build.flash_freq=80m
+heltec_wifi_kit_32.menu.PSRAM.disabled=Disabled
+heltec_wifi_kit_32.menu.PSRAM.disabled.build.defines=
+heltec_wifi_kit_32.menu.PSRAM.enabled=Enabled
+heltec_wifi_kit_32.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+
+heltec_wifi_kit_32.menu.PartitionScheme.default=Default
+heltec_wifi_kit_32.menu.PartitionScheme.default.build.partitions=default
+heltec_wifi_kit_32.menu.PartitionScheme.minimal=Minimal (2MB FLASH)
+heltec_wifi_kit_32.menu.PartitionScheme.minimal.build.partitions=minimal
+heltec_wifi_kit_32.menu.PartitionScheme.no_ota=No OTA (Large APP)
+heltec_wifi_kit_32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+heltec_wifi_kit_32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+heltec_wifi_kit_32.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA)
+heltec_wifi_kit_32.menu.PartitionScheme.huge_app.build.partitions=huge_app
+heltec_wifi_kit_32.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+heltec_wifi_kit_32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+heltec_wifi_kit_32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+heltec_wifi_kit_32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+heltec_wifi_kit_32.menu.PartitionScheme.fatflash=16M Fat
+heltec_wifi_kit_32.menu.PartitionScheme.fatflash.build.partitions=ffat
+
+heltec_wifi_kit_32.menu.CPUFreq.240=240MHz (WiFi/BT)
+heltec_wifi_kit_32.menu.CPUFreq.240.build.f_cpu=240000000L
+heltec_wifi_kit_32.menu.CPUFreq.160=160MHz (WiFi/BT)
+heltec_wifi_kit_32.menu.CPUFreq.160.build.f_cpu=160000000L
+heltec_wifi_kit_32.menu.CPUFreq.80=80MHz (WiFi/BT)
+heltec_wifi_kit_32.menu.CPUFreq.80.build.f_cpu=80000000L
+heltec_wifi_kit_32.menu.CPUFreq.26=26MHz (26MHz XTAL)
+heltec_wifi_kit_32.menu.CPUFreq.26.build.f_cpu=26000000L
+heltec_wifi_kit_32.menu.CPUFreq.13=13MHz (26MHz XTAL)
+heltec_wifi_kit_32.menu.CPUFreq.13.build.f_cpu=13000000L
+
+heltec_wifi_kit_32.menu.FlashMode.qio=QIO
+heltec_wifi_kit_32.menu.FlashMode.qio.build.flash_mode=dio
+heltec_wifi_kit_32.menu.FlashMode.qio.build.boot=qio
+heltec_wifi_kit_32.menu.FlashMode.dio=DIO
+heltec_wifi_kit_32.menu.FlashMode.dio.build.flash_mode=dio
+heltec_wifi_kit_32.menu.FlashMode.dio.build.boot=dio
+heltec_wifi_kit_32.menu.FlashMode.qout=QOUT
+heltec_wifi_kit_32.menu.FlashMode.qout.build.flash_mode=dout
+heltec_wifi_kit_32.menu.FlashMode.qout.build.boot=qout
+heltec_wifi_kit_32.menu.FlashMode.dout=DOUT
+heltec_wifi_kit_32.menu.FlashMode.dout.build.flash_mode=dout
+heltec_wifi_kit_32.menu.FlashMode.dout.build.boot=dout
+
 heltec_wifi_kit_32.menu.FlashFreq.40=40MHz
 heltec_wifi_kit_32.menu.FlashFreq.40.build.flash_freq=40m
+heltec_wifi_kit_32.menu.FlashFreq.80=80MHz
+heltec_wifi_kit_32.menu.FlashFreq.80.build.flash_freq=80m
+
+heltec_wifi_kit_32.menu.FlashSize.4M=4MB (32Mb)
+heltec_wifi_kit_32.menu.FlashSize.4M.build.flash_size=4MB
+heltec_wifi_kit_32.menu.FlashSize.2M=2MB (16Mb)
+heltec_wifi_kit_32.menu.FlashSize.2M.build.flash_size=2MB
+heltec_wifi_kit_32.menu.FlashSize.2M.build.partitions=minimal
+heltec_wifi_kit_32.menu.FlashSize.16M=16MB (128Mb)
+heltec_wifi_kit_32.menu.FlashSize.16M.build.flash_size=16MB
+heltec_wifi_kit_32.menu.FlashSize.16M.build.partitions=ffat
 
 heltec_wifi_kit_32.menu.UploadSpeed.921600=921600
 heltec_wifi_kit_32.menu.UploadSpeed.921600.upload.speed=921600
@@ -2107,9 +2162,22 @@ heltec_wifi_kit_32.menu.UploadSpeed.460800.upload.speed=460800
 heltec_wifi_kit_32.menu.UploadSpeed.512000.windows=512000
 heltec_wifi_kit_32.menu.UploadSpeed.512000.upload.speed=512000
 
+heltec_wifi_kit_32.menu.DebugLevel.none=None
+heltec_wifi_kit_32.menu.DebugLevel.none.build.code_debug=0
+heltec_wifi_kit_32.menu.DebugLevel.error=Error
+heltec_wifi_kit_32.menu.DebugLevel.error.build.code_debug=1
+heltec_wifi_kit_32.menu.DebugLevel.warn=Warn
+heltec_wifi_kit_32.menu.DebugLevel.warn.build.code_debug=2
+heltec_wifi_kit_32.menu.DebugLevel.info=Info
+heltec_wifi_kit_32.menu.DebugLevel.info.build.code_debug=3
+heltec_wifi_kit_32.menu.DebugLevel.debug=Debug
+heltec_wifi_kit_32.menu.DebugLevel.debug.build.code_debug=4
+heltec_wifi_kit_32.menu.DebugLevel.verbose=Verbose
+heltec_wifi_kit_32.menu.DebugLevel.verbose.build.code_debug=5
+
 ##############################################################
 
-heltec_wifi_lora_32.name=Heltec_WIFI_LoRa_32
+heltec_wifi_lora_32.name=Heltec WiFi LoRa 32
 
 heltec_wifi_lora_32.upload.tool=esptool_py
 heltec_wifi_lora_32.upload.maximum_size=1310720
@@ -2122,19 +2190,74 @@ heltec_wifi_lora_32.serial.disableRTS=true
 heltec_wifi_lora_32.build.mcu=esp32
 heltec_wifi_lora_32.build.core=esp32
 heltec_wifi_lora_32.build.variant=heltec_wifi_lora_32
-heltec_wifi_lora_32.build.board=Heltec_WIFI_LoRa_32
+heltec_wifi_lora_32.build.board=HELTEC_WIFI_LORA_32
 
 heltec_wifi_lora_32.build.f_cpu=240000000L
-heltec_wifi_lora_32.build.flash_mode=dio
 heltec_wifi_lora_32.build.flash_size=4MB
+heltec_wifi_lora_32.build.flash_freq=40m
+heltec_wifi_lora_32.build.flash_mode=dio
 heltec_wifi_lora_32.build.boot=dio
 heltec_wifi_lora_32.build.partitions=default
 heltec_wifi_lora_32.build.defines=
 
-heltec_wifi_lora_32.menu.FlashFreq.80=80MHz
-heltec_wifi_lora_32.menu.FlashFreq.80.build.flash_freq=80m
+heltec_wifi_lora_32.menu.PSRAM.disabled=Disabled
+heltec_wifi_lora_32.menu.PSRAM.disabled.build.defines=
+heltec_wifi_lora_32.menu.PSRAM.enabled=Enabled
+heltec_wifi_lora_32.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+
+heltec_wifi_lora_32.menu.PartitionScheme.default=Default
+heltec_wifi_lora_32.menu.PartitionScheme.default.build.partitions=default
+heltec_wifi_lora_32.menu.PartitionScheme.minimal=Minimal (2MB FLASH)
+heltec_wifi_lora_32.menu.PartitionScheme.minimal.build.partitions=minimal
+heltec_wifi_lora_32.menu.PartitionScheme.no_ota=No OTA (Large APP)
+heltec_wifi_lora_32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+heltec_wifi_lora_32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+heltec_wifi_lora_32.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA)
+heltec_wifi_lora_32.menu.PartitionScheme.huge_app.build.partitions=huge_app
+heltec_wifi_lora_32.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+heltec_wifi_lora_32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+heltec_wifi_lora_32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+heltec_wifi_lora_32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+heltec_wifi_lora_32.menu.PartitionScheme.fatflash=16M Fat
+heltec_wifi_lora_32.menu.PartitionScheme.fatflash.build.partitions=ffat
+
+heltec_wifi_lora_32.menu.CPUFreq.240=240MHz (WiFi/BT)
+heltec_wifi_lora_32.menu.CPUFreq.240.build.f_cpu=240000000L
+heltec_wifi_lora_32.menu.CPUFreq.160=160MHz (WiFi/BT)
+heltec_wifi_lora_32.menu.CPUFreq.160.build.f_cpu=160000000L
+heltec_wifi_lora_32.menu.CPUFreq.80=80MHz (WiFi/BT)
+heltec_wifi_lora_32.menu.CPUFreq.80.build.f_cpu=80000000L
+heltec_wifi_lora_32.menu.CPUFreq.26=26MHz (26MHz XTAL)
+heltec_wifi_lora_32.menu.CPUFreq.26.build.f_cpu=26000000L
+heltec_wifi_lora_32.menu.CPUFreq.13=13MHz (26MHz XTAL)
+heltec_wifi_lora_32.menu.CPUFreq.13.build.f_cpu=13000000L
+
+heltec_wifi_lora_32.menu.FlashMode.qio=QIO
+heltec_wifi_lora_32.menu.FlashMode.qio.build.flash_mode=dio
+heltec_wifi_lora_32.menu.FlashMode.qio.build.boot=qio
+heltec_wifi_lora_32.menu.FlashMode.dio=DIO
+heltec_wifi_lora_32.menu.FlashMode.dio.build.flash_mode=dio
+heltec_wifi_lora_32.menu.FlashMode.dio.build.boot=dio
+heltec_wifi_lora_32.menu.FlashMode.qout=QOUT
+heltec_wifi_lora_32.menu.FlashMode.qout.build.flash_mode=dout
+heltec_wifi_lora_32.menu.FlashMode.qout.build.boot=qout
+heltec_wifi_lora_32.menu.FlashMode.dout=DOUT
+heltec_wifi_lora_32.menu.FlashMode.dout.build.flash_mode=dout
+heltec_wifi_lora_32.menu.FlashMode.dout.build.boot=dout
+
 heltec_wifi_lora_32.menu.FlashFreq.40=40MHz
 heltec_wifi_lora_32.menu.FlashFreq.40.build.flash_freq=40m
+heltec_wifi_lora_32.menu.FlashFreq.80=80MHz
+heltec_wifi_lora_32.menu.FlashFreq.80.build.flash_freq=80m
+
+heltec_wifi_lora_32.menu.FlashSize.4M=4MB (32Mb)
+heltec_wifi_lora_32.menu.FlashSize.4M.build.flash_size=4MB
+heltec_wifi_lora_32.menu.FlashSize.2M=2MB (16Mb)
+heltec_wifi_lora_32.menu.FlashSize.2M.build.flash_size=2MB
+heltec_wifi_lora_32.menu.FlashSize.2M.build.partitions=minimal
+heltec_wifi_lora_32.menu.FlashSize.16M=16MB (128Mb)
+heltec_wifi_lora_32.menu.FlashSize.16M.build.flash_size=16MB
+heltec_wifi_lora_32.menu.FlashSize.16M.build.partitions=ffat
 
 heltec_wifi_lora_32.menu.UploadSpeed.921600=921600
 heltec_wifi_lora_32.menu.UploadSpeed.921600.upload.speed=921600
@@ -2150,6 +2273,253 @@ heltec_wifi_lora_32.menu.UploadSpeed.460800.macosx=460800
 heltec_wifi_lora_32.menu.UploadSpeed.460800.upload.speed=460800
 heltec_wifi_lora_32.menu.UploadSpeed.512000.windows=512000
 heltec_wifi_lora_32.menu.UploadSpeed.512000.upload.speed=512000
+
+heltec_wifi_lora_32.menu.DebugLevel.none=None
+heltec_wifi_lora_32.menu.DebugLevel.none.build.code_debug=0
+heltec_wifi_lora_32.menu.DebugLevel.error=Error
+heltec_wifi_lora_32.menu.DebugLevel.error.build.code_debug=1
+heltec_wifi_lora_32.menu.DebugLevel.warn=Warn
+heltec_wifi_lora_32.menu.DebugLevel.warn.build.code_debug=2
+heltec_wifi_lora_32.menu.DebugLevel.info=Info
+heltec_wifi_lora_32.menu.DebugLevel.info.build.code_debug=3
+heltec_wifi_lora_32.menu.DebugLevel.debug=Debug
+heltec_wifi_lora_32.menu.DebugLevel.debug.build.code_debug=4
+heltec_wifi_lora_32.menu.DebugLevel.verbose=Verbose
+heltec_wifi_lora_32.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
+heltec_wifi_lora_32_V2.name=Heltec WiFi LoRa 32(V2)
+
+heltec_wifi_lora_32_V2.upload.tool=esptool_py
+heltec_wifi_lora_32_V2.upload.maximum_size=1310720
+heltec_wifi_lora_32_V2.upload.maximum_data_size=327680
+heltec_wifi_lora_32_V2.upload.wait_for_upload_port=true
+
+heltec_wifi_lora_32_V2.serial.disableDTR=true
+heltec_wifi_lora_32_V2.serial.disableRTS=true
+
+heltec_wifi_lora_32_V2.build.mcu=esp32
+heltec_wifi_lora_32_V2.build.core=esp32
+heltec_wifi_lora_32_V2.build.variant=heltec_wifi_lora_32_V2
+heltec_wifi_lora_32_V2.build.board=HELTEC_WIFI_LORA_32_V2
+
+heltec_wifi_lora_32_V2.build.f_cpu=240000000L
+heltec_wifi_lora_32_V2.build.flash_size=8MB
+heltec_wifi_lora_32_V2.build.flash_freq=40m
+heltec_wifi_lora_32_V2.build.flash_mode=dio
+heltec_wifi_lora_32_V2.build.boot=dio
+heltec_wifi_lora_32_V2.build.partitions=default_8MB
+heltec_wifi_lora_32_V2.build.defines=
+
+heltec_wifi_lora_32_V2.menu.PSRAM.disabled=Disabled
+heltec_wifi_lora_32_V2.menu.PSRAM.disabled.build.defines=
+heltec_wifi_lora_32_V2.menu.PSRAM.enabled=Enabled
+heltec_wifi_lora_32_V2.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+
+heltec_wifi_lora_32_V2.menu.PartitionScheme.default=default_8MB
+heltec_wifi_lora_32_V2.menu.PartitionScheme.default.build.partitions=default_8MB
+heltec_wifi_lora_32_V2.menu.PartitionScheme.minimal=Minimal (2MB FLASH)
+heltec_wifi_lora_32_V2.menu.PartitionScheme.minimal.build.partitions=minimal
+heltec_wifi_lora_32_V2.menu.PartitionScheme.no_ota=No OTA (Large APP)
+heltec_wifi_lora_32_V2.menu.PartitionScheme.no_ota.build.partitions=no_ota
+heltec_wifi_lora_32_V2.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+heltec_wifi_lora_32_V2.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA)
+heltec_wifi_lora_32_V2.menu.PartitionScheme.huge_app.build.partitions=huge_app
+heltec_wifi_lora_32_V2.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+heltec_wifi_lora_32_V2.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+heltec_wifi_lora_32_V2.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+heltec_wifi_lora_32_V2.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+heltec_wifi_lora_32_V2.menu.PartitionScheme.fatflash=16M Fat
+heltec_wifi_lora_32_V2.menu.PartitionScheme.fatflash.build.partitions=ffat
+
+heltec_wifi_lora_32_V2.menu.CPUFreq.240=240MHz (WiFi/BT)
+heltec_wifi_lora_32_V2.menu.CPUFreq.240.build.f_cpu=240000000L
+heltec_wifi_lora_32_V2.menu.CPUFreq.160=160MHz (WiFi/BT)
+heltec_wifi_lora_32_V2.menu.CPUFreq.160.build.f_cpu=160000000L
+heltec_wifi_lora_32_V2.menu.CPUFreq.80=80MHz (WiFi/BT)
+heltec_wifi_lora_32_V2.menu.CPUFreq.80.build.f_cpu=80000000L
+heltec_wifi_lora_32_V2.menu.CPUFreq.40=40MHz (40MHz XTAL)
+heltec_wifi_lora_32_V2.menu.CPUFreq.40.build.f_cpu=40000000L
+heltec_wifi_lora_32_V2.menu.CPUFreq.20=20MHz (40MHz XTAL)
+heltec_wifi_lora_32_V2.menu.CPUFreq.20.build.f_cpu=20000000L
+heltec_wifi_lora_32_V2.menu.CPUFreq.10=10MHz (40MHz XTAL)
+heltec_wifi_lora_32_V2.menu.CPUFreq.10.build.f_cpu=10000000L
+
+heltec_wifi_lora_32_V2.menu.FlashMode.qio=QIO
+heltec_wifi_lora_32_V2.menu.FlashMode.qio.build.flash_mode=dio
+heltec_wifi_lora_32_V2.menu.FlashMode.qio.build.boot=qio
+heltec_wifi_lora_32_V2.menu.FlashMode.dio=DIO
+heltec_wifi_lora_32_V2.menu.FlashMode.dio.build.flash_mode=dio
+heltec_wifi_lora_32_V2.menu.FlashMode.dio.build.boot=dio
+heltec_wifi_lora_32_V2.menu.FlashMode.qout=QOUT
+heltec_wifi_lora_32_V2.menu.FlashMode.qout.build.flash_mode=dout
+heltec_wifi_lora_32_V2.menu.FlashMode.qout.build.boot=qout
+heltec_wifi_lora_32_V2.menu.FlashMode.dout=DOUT
+heltec_wifi_lora_32_V2.menu.FlashMode.dout.build.flash_mode=dout
+heltec_wifi_lora_32_V2.menu.FlashMode.dout.build.boot=dout
+
+heltec_wifi_lora_32_V2.menu.FlashFreq.80=80MHz
+heltec_wifi_lora_32_V2.menu.FlashFreq.80.build.flash_freq=80m
+heltec_wifi_lora_32_V2.menu.FlashFreq.40=40MHz
+heltec_wifi_lora_32_V2.menu.FlashFreq.40.build.flash_freq=40m
+
+heltec_wifi_lora_32_V2.menu.FlashSize.8M=8MB (64Mb)
+heltec_wifi_lora_32_V2.menu.FlashSize.8M.build.flash_size=8MB
+heltec_wifi_lora_32_V2.menu.FlashSize.2M.build.partitions=default_8MB
+heltec_wifi_lora_32_V2.menu.FlashSize.4M=4MB (32Mb)
+heltec_wifi_lora_32_V2.menu.FlashSize.4M.build.flash_size=4MB
+heltec_wifi_lora_32_V2.menu.FlashSize.2M=2MB (16Mb)
+heltec_wifi_lora_32_V2.menu.FlashSize.2M.build.flash_size=2MB
+heltec_wifi_lora_32_V2.menu.FlashSize.2M.build.partitions=minimal
+heltec_wifi_lora_32_V2.menu.FlashSize.16M=16MB (128Mb)
+heltec_wifi_lora_32_V2.menu.FlashSize.16M.build.flash_size=16MB
+heltec_wifi_lora_32_V2.menu.FlashSize.16M.build.partitions=ffat
+
+heltec_wifi_lora_32_V2.menu.UploadSpeed.921600=921600
+heltec_wifi_lora_32_V2.menu.UploadSpeed.921600.upload.speed=921600
+heltec_wifi_lora_32_V2.menu.UploadSpeed.115200=115200
+heltec_wifi_lora_32_V2.menu.UploadSpeed.115200.upload.speed=115200
+heltec_wifi_lora_32_V2.menu.UploadSpeed.256000.windows=256000
+heltec_wifi_lora_32_V2.menu.UploadSpeed.256000.upload.speed=256000
+heltec_wifi_lora_32_V2.menu.UploadSpeed.230400.windows.upload.speed=256000
+heltec_wifi_lora_32_V2.menu.UploadSpeed.230400=230400
+heltec_wifi_lora_32_V2.menu.UploadSpeed.230400.upload.speed=230400
+heltec_wifi_lora_32_V2.menu.UploadSpeed.460800.linux=460800
+heltec_wifi_lora_32_V2.menu.UploadSpeed.460800.macosx=460800
+heltec_wifi_lora_32_V2.menu.UploadSpeed.460800.upload.speed=460800
+heltec_wifi_lora_32_V2.menu.UploadSpeed.512000.windows=512000
+heltec_wifi_lora_32_V2.menu.UploadSpeed.512000.upload.speed=512000
+
+heltec_wifi_lora_32_V2.menu.DebugLevel.none=None
+heltec_wifi_lora_32_V2.menu.DebugLevel.none.build.code_debug=0
+heltec_wifi_lora_32_V2.menu.DebugLevel.error=Error
+heltec_wifi_lora_32_V2.menu.DebugLevel.error.build.code_debug=1
+heltec_wifi_lora_32_V2.menu.DebugLevel.warn=Warn
+heltec_wifi_lora_32_V2.menu.DebugLevel.warn.build.code_debug=2
+heltec_wifi_lora_32_V2.menu.DebugLevel.info=Info
+heltec_wifi_lora_32_V2.menu.DebugLevel.info.build.code_debug=3
+heltec_wifi_lora_32_V2.menu.DebugLevel.debug=Debug
+heltec_wifi_lora_32_V2.menu.DebugLevel.debug.build.code_debug=4
+heltec_wifi_lora_32_V2.menu.DebugLevel.verbose=Verbose
+heltec_wifi_lora_32_V2.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
+heltec_wireless_stick.name=Heltec Wireless Stick
+
+heltec_wireless_stick.upload.tool=esptool_py
+heltec_wireless_stick.upload.maximum_size=1310720
+heltec_wireless_stick.upload.maximum_data_size=327680
+heltec_wireless_stick.upload.wait_for_upload_port=true
+
+heltec_wireless_stick.serial.disableDTR=true
+heltec_wireless_stick.serial.disableRTS=true
+
+heltec_wireless_stick.build.mcu=esp32
+heltec_wireless_stick.build.core=esp32
+heltec_wireless_stick.build.variant=heltec_wireless_stick
+heltec_wireless_stick.build.board=HELTEC_WIRELESS_STICK
+
+heltec_wireless_stick.build.f_cpu=240000000L
+heltec_wireless_stick.build.flash_size=8MB
+heltec_wireless_stick.build.flash_freq=40m
+heltec_wireless_stick.build.flash_mode=dio
+heltec_wireless_stick.build.boot=dio
+heltec_wireless_stick.build.partitions=default_8MB
+heltec_wireless_stick.build.defines=
+
+heltec_wireless_stick.menu.PSRAM.disabled=Disabled
+heltec_wireless_stick.menu.PSRAM.disabled.build.defines=
+heltec_wireless_stick.menu.PSRAM.enabled=Enabled
+heltec_wireless_stick.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+
+heltec_wireless_stick.menu.PartitionScheme.default=default_8MB
+heltec_wireless_stick.menu.PartitionScheme.default.build.partitions=default_8MB
+heltec_wireless_stick.menu.PartitionScheme.minimal=Minimal (2MB FLASH)
+heltec_wireless_stick.menu.PartitionScheme.minimal.build.partitions=minimal
+heltec_wireless_stick.menu.PartitionScheme.no_ota=No OTA (Large APP)
+heltec_wireless_stick.menu.PartitionScheme.no_ota.build.partitions=no_ota
+heltec_wireless_stick.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+heltec_wireless_stick.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA)
+heltec_wireless_stick.menu.PartitionScheme.huge_app.build.partitions=huge_app
+heltec_wireless_stick.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+heltec_wireless_stick.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+heltec_wireless_stick.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+heltec_wireless_stick.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+heltec_wireless_stick.menu.PartitionScheme.fatflash=16M Fat
+heltec_wireless_stick.menu.PartitionScheme.fatflash.build.partitions=ffat
+
+heltec_wireless_stick.menu.CPUFreq.240=240MHz (WiFi/BT)
+heltec_wireless_stick.menu.CPUFreq.240.build.f_cpu=240000000L
+heltec_wireless_stick.menu.CPUFreq.160=160MHz (WiFi/BT)
+heltec_wireless_stick.menu.CPUFreq.160.build.f_cpu=160000000L
+heltec_wireless_stick.menu.CPUFreq.80=80MHz (WiFi/BT)
+heltec_wireless_stick.menu.CPUFreq.80.build.f_cpu=80000000L
+heltec_wireless_stick.menu.CPUFreq.40=40MHz (40MHz XTAL)
+heltec_wireless_stick.menu.CPUFreq.40.build.f_cpu=40000000L
+heltec_wireless_stick.menu.CPUFreq.20=20MHz (40MHz XTAL)
+heltec_wireless_stick.menu.CPUFreq.20.build.f_cpu=20000000L
+heltec_wireless_stick.menu.CPUFreq.10=10MHz (40MHz XTAL)
+heltec_wireless_stick.menu.CPUFreq.10.build.f_cpu=10000000L
+
+heltec_wireless_stick.menu.FlashMode.qio=QIO
+heltec_wireless_stick.menu.FlashMode.qio.build.flash_mode=dio
+heltec_wireless_stick.menu.FlashMode.qio.build.boot=qio
+heltec_wireless_stick.menu.FlashMode.dio=DIO
+heltec_wireless_stick.menu.FlashMode.dio.build.flash_mode=dio
+heltec_wireless_stick.menu.FlashMode.dio.build.boot=dio
+heltec_wireless_stick.menu.FlashMode.qout=QOUT
+heltec_wireless_stick.menu.FlashMode.qout.build.flash_mode=dout
+heltec_wireless_stick.menu.FlashMode.qout.build.boot=qout
+heltec_wireless_stick.menu.FlashMode.dout=DOUT
+heltec_wireless_stick.menu.FlashMode.dout.build.flash_mode=dout
+heltec_wireless_stick.menu.FlashMode.dout.build.boot=dout
+
+heltec_wireless_stick.menu.FlashFreq.80=80MHz
+heltec_wireless_stick.menu.FlashFreq.80.build.flash_freq=80m
+heltec_wireless_stick.menu.FlashFreq.40=40MHz
+heltec_wireless_stick.menu.FlashFreq.40.build.flash_freq=40m
+
+heltec_wireless_stick.menu.FlashSize.8M=8MB (64Mb)
+heltec_wireless_stick.menu.FlashSize.8M.build.flash_size=8MB
+heltec_wireless_stick.menu.FlashSize.2M.build.partitions=default_8MB
+heltec_wireless_stick.menu.FlashSize.4M=4MB (32Mb)
+heltec_wireless_stick.menu.FlashSize.4M.build.flash_size=4MB
+heltec_wireless_stick.menu.FlashSize.2M=2MB (16Mb)
+heltec_wireless_stick.menu.FlashSize.2M.build.flash_size=2MB
+heltec_wireless_stick.menu.FlashSize.2M.build.partitions=minimal
+heltec_wireless_stick.menu.FlashSize.16M=16MB (128Mb)
+heltec_wireless_stick.menu.FlashSize.16M.build.flash_size=16MB
+heltec_wireless_stick.menu.FlashSize.16M.build.partitions=ffat
+
+heltec_wireless_stick.menu.UploadSpeed.921600=921600
+heltec_wireless_stick.menu.UploadSpeed.921600.upload.speed=921600
+heltec_wireless_stick.menu.UploadSpeed.115200=115200
+heltec_wireless_stick.menu.UploadSpeed.115200.upload.speed=115200
+heltec_wireless_stick.menu.UploadSpeed.256000.windows=256000
+heltec_wireless_stick.menu.UploadSpeed.256000.upload.speed=256000
+heltec_wireless_stick.menu.UploadSpeed.230400.windows.upload.speed=256000
+heltec_wireless_stick.menu.UploadSpeed.230400=230400
+heltec_wireless_stick.menu.UploadSpeed.230400.upload.speed=230400
+heltec_wireless_stick.menu.UploadSpeed.460800.linux=460800
+heltec_wireless_stick.menu.UploadSpeed.460800.macosx=460800
+heltec_wireless_stick.menu.UploadSpeed.460800.upload.speed=460800
+heltec_wireless_stick.menu.UploadSpeed.512000.windows=512000
+heltec_wireless_stick.menu.UploadSpeed.512000.upload.speed=512000
+
+heltec_wireless_stick.menu.DebugLevel.none=None
+heltec_wireless_stick.menu.DebugLevel.none.build.code_debug=0
+heltec_wireless_stick.menu.DebugLevel.error=Error
+heltec_wireless_stick.menu.DebugLevel.error.build.code_debug=1
+heltec_wireless_stick.menu.DebugLevel.warn=Warn
+heltec_wireless_stick.menu.DebugLevel.warn.build.code_debug=2
+heltec_wireless_stick.menu.DebugLevel.info=Info
+heltec_wireless_stick.menu.DebugLevel.info.build.code_debug=3
+heltec_wireless_stick.menu.DebugLevel.debug=Debug
+heltec_wireless_stick.menu.DebugLevel.debug.build.code_debug=4
+heltec_wireless_stick.menu.DebugLevel.verbose=Verbose
+heltec_wireless_stick.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 

--- a/tools/partitions/default_8MB.csv
+++ b/tools/partitions/default_8MB.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x330000,
+app1,     app,  ota_1,   0x340000,0x330000,
+eeprom,   data, 0x99,    0x670000,0x1000,
+spiffs,   data, spiffs,  0x671000,0x18F000,

--- a/variants/heltec_wifi_kit_32/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32/pins_arduino.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#define WIFI_Kit_32	true
+#define DISPLAY_HEIGHT 64
+#define DISPLAY_WIDTH  128
+
 #define EXTERNAL_NUM_INTERRUPTS 16
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
@@ -60,5 +64,11 @@ static const uint8_t T9 = 32;
 
 static const uint8_t DAC1 = 25;
 static const uint8_t DAC2 = 26;
+
+static const uint8_t Vext = 21;
+static const uint8_t LED  = 25;
+static const uint8_t RST_OLED = 16;
+static const uint8_t SCL_OLED = 15;
+static const uint8_t SDA_OLED = 4;
 
 #endif /* Pins_Arduino_h */

--- a/variants/heltec_wifi_lora_32_V2/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V2/pins_arduino.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#define WIFI_LoRa_32
+#define WIFI_LoRa_32_V2
 #define DISPLAY_HEIGHT 64
 #define DISPLAY_WIDTH  128
 
@@ -62,15 +62,15 @@ static const uint8_t T9 = 32;
 static const uint8_t DAC1 = 25;
 static const uint8_t DAC2 = 26;
 
-static const uint8_t Vext  = 21;
+static const uint8_t Vext = 21;
 static const uint8_t LED  = 25;
 static const uint8_t RST_OLED = 16;
 static const uint8_t SCL_OLED = 15;
 static const uint8_t SDA_OLED = 4;
 static const uint8_t RST_LoRa = 14;
 static const uint8_t DIO0 = 26;
-static const uint8_t DIO1 = 33;
-static const uint8_t DIO2 = 32;
+static const uint8_t DIO1 = 35;
+static const uint8_t DIO2 = 34;
 
 
 #endif /* Pins_Arduino_h */

--- a/variants/heltec_wireless_stick/pins_arduino.h
+++ b/variants/heltec_wireless_stick/pins_arduino.h
@@ -3,9 +3,9 @@
 
 #include <stdint.h>
 
-#define WIFI_LoRa_32
-#define DISPLAY_HEIGHT 64
-#define DISPLAY_WIDTH  128
+#define Wireless_Stick
+#define DISPLAY_HEIGHT 32
+#define DISPLAY_WIDTH  64
 
 #define EXTERNAL_NUM_INTERRUPTS 16
 #define NUM_DIGITAL_PINS        40
@@ -62,15 +62,14 @@ static const uint8_t T9 = 32;
 static const uint8_t DAC1 = 25;
 static const uint8_t DAC2 = 26;
 
-static const uint8_t Vext  = 21;
+static const uint8_t Vext = 21;
 static const uint8_t LED  = 25;
 static const uint8_t RST_OLED = 16;
 static const uint8_t SCL_OLED = 15;
 static const uint8_t SDA_OLED = 4;
 static const uint8_t RST_LoRa = 14;
 static const uint8_t DIO0 = 26;
-static const uint8_t DIO1 = 33;
-static const uint8_t DIO2 = 32;
-
+static const uint8_t DIO1 = 35;
+static const uint8_t DIO2 = 34;
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
- Added Heltec Automation(TM) newest boards defintion, include WiFi_Kit_32, WiFi_LoRa_32, WiFi_LoRa_32_V2, Wireless_Stick defintions;

- Added 8MB SPI FLASH partition map;

- Update board menu chooices.