### PR TITLE
Adding debug flag to PIO build script

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -44,6 +44,7 @@ env.Append(
 
     CCFLAGS=[
         "-Os",
+        "-g3",
         "-Wall",
         "-nostdlib",
         "-Wpointer-arith",


### PR DESCRIPTION
Adding the -g3 flag that was omitted in the PIO build script but is present in Arduino IDE build scripts. This flag restores the ability to get line numbers from stack traces for elf files generated in PlatformIO IDE.