### PR TITLE
File with more than 32,767 characters

### DIFF
--- a/libraries/Update/examples/AWS_S3_OTA_Update/AWS_S3_OTA_Update.ino
+++ b/libraries/Update/examples/AWS_S3_OTA_Update/AWS_S3_OTA_Update.ino
@@ -26,7 +26,7 @@ WiFiClient client;
 
 // Variables to validate
 // response from S3
-int contentLength = 0;
+long contentLength = 0;
 bool isValidContentType = false;
 
 // Your SSID and PSWD that the chip needs
@@ -120,7 +120,7 @@ void execOTA() {
       // extract headers here
       // Start with content length
       if (line.startsWith("Content-Length: ")) {
-        contentLength = atoi((getHeaderValue(line, "Content-Length: ")).c_str());
+        contentLength = atol((getHeaderValue(line, "Content-Length: ")).c_str());
         Serial.println("Got " + String(contentLength) + " bytes from server");
       }
 


### PR DESCRIPTION
When the file.bin is more than 32767 characters. 
I change "int" in "long" for contentLength.