### PR TITLE
add microseconds

### DIFF
--- a/libraries/Ticker/src/Ticker.cpp
+++ b/libraries/Ticker/src/Ticker.cpp
@@ -1,8 +1,8 @@
-/* 
+/*
   Ticker.cpp - esp32 library that calls functions periodically
 
   Copyright (c) 2017 Bert Melis. All rights reserved.
-  
+
   Based on the original work of:
   Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
   The original version is part of the esp8266 core for Arduino environment.
@@ -31,7 +31,7 @@ Ticker::~Ticker() {
   detach();
 }
 
-void Ticker::_attach_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t callback, uint32_t arg) {
+void Ticker::_attach_us(uint64_t microseconds, bool repeat, callback_with_arg_t callback, uint32_t arg) {
   esp_timer_create_args_t _timerConfig;
   _timerConfig.arg = reinterpret_cast<void*>(arg);
   _timerConfig.callback = callback;
@@ -43,9 +43,9 @@ void Ticker::_attach_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t 
   }
   esp_timer_create(&_timerConfig, &_timer);
   if (repeat) {
-    esp_timer_start_periodic(_timer, milliseconds * 1000);
+    esp_timer_start_periodic(_timer, microseconds);
   } else {
-    esp_timer_start_once(_timer, milliseconds * 1000);
+    esp_timer_start_once(_timer, microseconds);
   }
 }
 

--- a/libraries/Ticker/src/Ticker.h
+++ b/libraries/Ticker/src/Ticker.h
@@ -1,8 +1,8 @@
-/* 
+/*
   Ticker.h - esp32 library that calls functions periodically
 
   Copyright (c) 2017 Bert Melis. All rights reserved.
-  
+
   Based on the original work of:
   Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
   The original version is part of the esp8266 core for Arduino environment.
@@ -39,12 +39,17 @@ public:
 
   void attach(float seconds, callback_t callback)
   {
-    _attach_ms(seconds * 1000, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
+    _attach_us(1000000L * seconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
   }
 
   void attach_ms(uint32_t milliseconds, callback_t callback)
   {
-    _attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
+    _attach_us(1000L * milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
+  }
+
+  void attach_us(uint64_t microseconds, callback_t callback)
+  {
+    _attach_us(microseconds, true, reinterpret_cast<callback_with_arg_t>(callback), 0);
   }
 
   template<typename TArg>
@@ -55,7 +60,7 @@ public:
     // static_cast for smaller integer types,
     // reinterpret_cast + const_cast for pointer types
     uint32_t arg32 = (uint32_t)arg;
-    _attach_ms(seconds * 1000, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+  _attach_us(1000000L * seconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
   }
 
   template<typename TArg>
@@ -63,25 +68,38 @@ public:
   {
     static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_ms() callback argument size must be <= 4 bytes");
     uint32_t arg32 = (uint32_t)arg;
-    _attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+    _attach_us(1000L * milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+  }
+
+  template<typename TArg>
+  void attach_ms(uint64_t microseconds, void (*callback)(TArg), TArg arg)
+  {
+    static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_ms() callback argument size must be <= 4 bytes");
+    uint32_t arg32 = (uint32_t)arg;
+    _attach_us(microseconds, true, reinterpret_cast<callback_with_arg_t>(callback), arg32);
   }
 
   void once(float seconds, callback_t callback)
   {
-    _attach_ms(seconds * 1000, false, reinterpret_cast<callback_with_arg_t>(callback), 0);
+    _attach_us(1000000L * seconds, false, reinterpret_cast<callback_with_arg_t>(callback), 0);
   }
 
   void once_ms(uint32_t milliseconds, callback_t callback)
   {
-    _attach_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), 0);	
+    _attach_us(1000L * milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), 0);
   }
 
+  void once_us(uint64_t microseconds, callback_t callback)
+  {
+    _attach_us(microseconds, false, reinterpret_cast<callback_with_arg_t>(callback), 0);
+  }
+ 
   template<typename TArg>
   void once(float seconds, void (*callback)(TArg), TArg arg)
   {
     static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach() callback argument size must be <= 4 bytes");
     uint32_t arg32 = (uint32_t)(arg);
-    _attach_ms(seconds * 1000, false, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+    _attach_us(1000000L * seconds, false, reinterpret_cast<callback_with_arg_t>(callback), arg32);
   }
 
   template<typename TArg>
@@ -89,19 +107,25 @@ public:
   {
     static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_ms() callback argument size must be <= 4 bytes");
     uint32_t arg32 = (uint32_t)(arg);
-    _attach_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+    _attach_us(1000L * milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), arg32);
+  }
+
+  template<typename TArg>
+  void once_us(uint64_t microseconds, void (*callback)(TArg), TArg arg)
+  {
+    static_assert(sizeof(TArg) <= sizeof(uint32_t), "attach_ms() callback argument size must be <= 4 bytes");
+    uint32_t arg32 = (uint32_t)(arg);
+    _attach_us(microseconds, false, reinterpret_cast<callback_with_arg_t>(callback), arg32);
   }
 
   void detach();
   bool active();
 
-protected:	
-  void _attach_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
-
+protected:
+  void _attach_us(uint64_t microseconds, bool repeat, callback_with_arg_t callback, uint32_t arg);
 
 protected:
   esp_timer_handle_t _timer;
 };
-
 
 #endif  // TICKER_H


### PR DESCRIPTION
Add microseconds to the ticker library. Usefull for example for DAC/audio projects.