### PR TITLE
Add server connect timeout to HTTPClient

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -429,6 +429,15 @@ void HTTPClient::setAuthorization(const char * auth)
 }
 
 /**
+ * set the timeout (ms) for establishing a connection to the server
+ * @param connectTimeout int32_t
+ */
+void HTTPClient::setConnectTimeout(int32_t connectTimeout)
+{
+    _connectTimeout = connectTimeout;
+}
+
+/**
  * set the timeout for the TCP connection
  * @param timeout unsigned int
  */
@@ -442,7 +451,7 @@ void HTTPClient::setTimeout(uint16_t timeout)
 
 /**
  * use HTTP1.0
- * @param timeout
+ * @param use
  */
 void HTTPClient::useHTTP10(bool useHTTP10)
 {
@@ -966,7 +975,7 @@ bool HTTPClient::connect(void)
         return false;
     }
 
-    if(!_client->connect(_host.c_str(), _port)) {
+    if(!_client->connect(_host.c_str(), _port, _connectTimeout)) {
         log_d("failed connect to %s:%u", _host.c_str(), _port);
         return false;
     }

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -153,6 +153,7 @@ public:
     void setUserAgent(const String& userAgent);
     void setAuthorization(const char * user, const char * password);
     void setAuthorization(const char * auth);
+    void setConnectTimeout(int32_t connectTimeout);
     void setTimeout(uint16_t timeout);
 
     void useHTTP10(bool usehttp10 = true);
@@ -213,6 +214,7 @@ protected:
     /// request handling
     String _host;
     uint16_t _port = 0;
+    int32_t _connectTimeout = -1;
     bool _reuse = false;
     uint16_t _tcpTimeout = HTTPCLIENT_DEFAULT_TCP_TIMEOUT;
     bool _useHTTP10 = false;


### PR DESCRIPTION
The existing setTimeout() function is effective only once the client is already connected to the server. Therefore, if there is a problem establishing a connection to the server in the first place (eg. it is offline), connect() will block for up to ~20 seconds regardless of the value passed to setTimeout. 
See https://github.com/espressif/arduino-esp32/issues/1433

This PR introduces a separate, self-explanatory function - setConnectTimeout(int32_t connectTimeout) - to HTTPClient, which simply takes advantage of the WiFiClient connect timeout functionality recently introduced here: https://github.com/espressif/arduino-esp32/pull/2383