### PR TITLE
Reset retry counter upon successful WiFiClient::write

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -358,6 +358,7 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
                 } else {
                     buf += res;
                     bytesRemaining -= res;
+                    retry = WIFI_CLIENT_MAX_WRITE_RETRY;
                 }
             }
             else if(res < 0) {


### PR DESCRIPTION
Currently  WiFiClient::write is unable to send messages over 25Kb, because of the hard-coded retry limit of 10, that is getting decremented on every successful send. Since we cannot send more than 2*MTU bytes in one go, and have only 10 retries, write() is limited to approximately 25Kb. Technically it is not a bug, as it correctly returns the number of sent bytes and the caller can set up futher retries. But not all libs are aware of this behavior, for example, WebServer is not.
I suggest improving current behavior by resetting retry counter every time we had a successful write, so the limit of 10 retries will apply to Failed writes only, and will not apply to Successful writes. This will allow to write() blobs of arbitrary sizes.