### PR TITLE
Hide log_v behind conditional define, reduce excessive logging

### DIFF
--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -1480,7 +1480,9 @@ i2c_err_t i2cDetachSDA(i2c_t * i2c, int8_t sda)
  * */
 // 24Nov17 only supports Master Mode
 i2c_t * i2cInit(uint8_t i2c_num, int8_t sda, int8_t scl, uint32_t frequency) {
+#ifdef ENABLE_I2C_DEBUG_BUFFER
   log_v("num=%d sda=%d scl=%d freq=%d",i2c_num, sda, scl, frequency);
+#endif
     if(i2c_num > 1) {
         return NULL;
     }
@@ -1674,8 +1676,9 @@ i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed)
         clk_speed = apb/(period*2);
         log_d("APB Freq too fast, Increasing i2c Freq to %d Hz",clk_speed);
     }
+#ifdef ENABLE_I2C_DEBUG_BUFFER
     log_v("freq=%dHz",clk_speed);
-      
+#endif      
     uint32_t halfPeriod = period/2;
     uint32_t quarterPeriod = period/4;
 
@@ -1689,14 +1692,17 @@ i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed)
     available when a Fifo interrupt is triggered.  This allows enough room in the Fifo so that
     interrupt latency does not cause a Fifo overflow/underflow event.
 */
+#ifdef ENABLE_I2C_DEBUG_BUFFER
     log_v("cpu Freq=%dMhz, i2c Freq=%dHz",getCpuFrequencyMhz(),clk_speed);
+#endif
     uint32_t fifo_delta = (INTERRUPT_CYCLE_OVERHEAD/((getCpuFrequencyMhz()*1000000 / clk_speed)*10))+1; 
     if (fifo_delta > 24) fifo_delta=24;   
     f.rx_fifo_full_thrhd = 32 - fifo_delta;
     f.tx_fifo_empty_thrhd = fifo_delta;
     i2c->dev->fifo_conf.val = f.val; // set thresholds
+#ifdef ENABLE_I2C_DEBUG_BUFFER
     log_v("Fifo delta=%d",fifo_delta);
-
+#endif
     //the clock num during SCL is low level
     i2c->dev->scl_low_period.period = period;
     //the clock num during SCL is high level


### PR DESCRIPTION
@cyberman54 from #2250 recommended reducing unnecessary logging.  There have not been any reported problems with i2c and cpu frequency changes since it was implemented in the 1.0.1 release. This pr hides these verbose log reported behind the `ENABLE_I2C_DEBUG_BUFFER` define.  They will be available if necessary, but normally will not be included in compiled code.

Chuck.
