### PR TITLE
Properly allocate string and remove warning

### DIFF
--- a/libraries/ESP32/examples/ESPNow/Basic/Slave/Slave.ino
+++ b/libraries/ESP32/examples/ESPNow/Basic/Slave/Slave.ino
@@ -51,7 +51,7 @@ void InitESPNow() {
 
 // config AP SSID
 void configDeviceAP() {
-  char SSID[] = "Slave_1";
+  const char *SSID = "Slave_1";
   bool result = WiFi.softAP(SSID, "Slave_1_Password", CHANNEL, 0);
   if (!result) {
     Serial.println("AP Config failed.");

--- a/libraries/ESP32/examples/ESPNow/Basic/Slave/Slave.ino
+++ b/libraries/ESP32/examples/ESPNow/Basic/Slave/Slave.ino
@@ -51,7 +51,7 @@ void InitESPNow() {
 
 // config AP SSID
 void configDeviceAP() {
-  char* SSID = "Slave_1";
+  char SSID[] = "Slave_1";
   bool result = WiFi.softAP(SSID, "Slave_1_Password", CHANNEL, 0);
   if (!result) {
     Serial.println("AP Config failed.");


### PR DESCRIPTION
The former way generates the following warning:
ISO C++ forbids converting a string constant to 'char*'

This change makes a character array the size of the string with null ending. It's clearer and gets rid of the warning.