### PR TITLE
EEPROM return empty string instead of "0"

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -286,7 +286,7 @@ size_t EEPROMClass::readString (int address, char* value, size_t maxLen)
 String EEPROMClass::readString (int address)
 {
   if (address < 0 || address > _size)
-    return String(0);
+    return String();
 
   uint16_t len;
   for (len = 0; len <= _size; len++)
@@ -294,7 +294,7 @@ String EEPROMClass::readString (int address)
       break;
 
   if (address + len > _size)
-    return String(0);
+    return String();
 
   char value[len];
   memcpy((uint8_t*) value, _data + address, len);


### PR DESCRIPTION
String EEPROMClass::readString (int address) returns **"0"** instead of empty string **""**


> ```String thisString = String(13);```
> gives you the String "13". 

[source](https://www.arduino.cc/reference/en/language/variables/data-types/stringobject/)


