### PR TITLE
add lolin32 CPU freq choice

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -879,6 +879,23 @@ lolin32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
 lolin32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
 lolin32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
+lolin32.menu.CPUFreq.240=240MHz (WiFi/BT)
+lolin32.menu.CPUFreq.240.build.f_cpu=240000000L
+lolin32.menu.CPUFreq.160=160MHz (WiFi/BT)
+lolin32.menu.CPUFreq.160.build.f_cpu=160000000L
+lolin32.menu.CPUFreq.80=80MHz (WiFi/BT)
+lolin32.menu.CPUFreq.80.build.f_cpu=80000000L
+lolin32.menu.CPUFreq.40=40MHz (40MHz XTAL)
+lolin32.menu.CPUFreq.40.build.f_cpu=40000000L
+lolin32.menu.CPUFreq.26=26MHz (26MHz XTAL)
+lolin32.menu.CPUFreq.26.build.f_cpu=26000000L
+lolin32.menu.CPUFreq.20=20MHz (40MHz XTAL)
+lolin32.menu.CPUFreq.20.build.f_cpu=20000000L
+lolin32.menu.CPUFreq.13=13MHz (26MHz XTAL)
+lolin32.menu.CPUFreq.13.build.f_cpu=13000000L
+lolin32.menu.CPUFreq.10=10MHz (40MHz XTAL)
+lolin32.menu.CPUFreq.10.build.f_cpu=10000000L
+
 lolin32.menu.UploadSpeed.921600=921600
 lolin32.menu.UploadSpeed.921600.upload.speed=921600
 lolin32.menu.UploadSpeed.115200=115200


### PR DESCRIPTION
With a little bit of copy, paste and rename I added cpu frequency to the arduino IDE menu.
Tested with 240, 160 and 80 MHz.

I am not sure if the plan is to add this to all of the board definitions, so feel free to reject or close this PR.