### PR TITLE
Defined BLE setPrivateAddress()

### DIFF
--- a/libraries/BLE/src/BLEAdvertising.cpp
+++ b/libraries/BLE/src/BLEAdvertising.cpp
@@ -254,6 +254,27 @@ void BLEAdvertising::stop() {
 } // stop
 
 /**
+ * @brief Set BLE address.
+ * @param [in] Bluetooth address.
+ * @param [in] Bluetooth address type.
+ * Set BLE address.
+ */
+
+void BLEAdvertising::setDeviceAddress(esp_bd_addr_t addr, esp_ble_addr_type_t type)
+{
+	log_v(">> setPrivateAddress")
+
+	m_advParams.own_addr_type = type;
+	esp_err_t errRc = esp_ble_gap_set_rand_addr((uint8_t*)addr);
+	if (errRc != ESP_OK)
+	{
+		log_e("esp_ble_gap_set_rand_addr: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
+		return;
+	}
+	log_v("<< setPrivateAddress")
+} // setPrivateAddress
+
+/**
  * @brief Add data to the payload to be advertised.
  * @param [in] data The data to be added to the payload.
  */

--- a/libraries/BLE/src/BLEAdvertising.h
+++ b/libraries/BLE/src/BLEAdvertising.h
@@ -58,6 +58,7 @@ public:
 	void setScanFilter(bool scanRequertWhitelistOnly, bool connectWhitelistOnly);
 	void setScanResponseData(BLEAdvertisementData& advertisementData);
 	void setPrivateAddress(esp_ble_addr_type_t type = BLE_ADDR_TYPE_RANDOM);
+	void setDeviceAddress(esp_bd_addr_t addr, esp_ble_addr_type_t type = BLE_ADDR_TYPE_RANDOM);
 
 	void handleGAPEvent(esp_gap_ble_cb_event_t  event, esp_ble_gap_cb_param_t* param);
 	void setMinPreferred(uint16_t);


### PR DESCRIPTION
Implemented the function used to change the advertised BLE address.

As per the specification, there are multiple address types that can be user set (Random, Static, etc.). Currently this library only uses the address issued to the device during manufacture. This pull request adds the functionality of user changeable BLE addresses.

There is currently no implementation of this function that I am aware of, so use in projects should be minimal, if at all. Changing the functions signature should not break any significant number of projects.