### PR TITLE
Fix Werror in WebServer that prevents compiling using idf.py

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -39,7 +39,8 @@ static const char Content_Length[] = "Content-Length";
 
 
 WebServer::WebServer(IPAddress addr, int port)
-: _server(addr, port)
+: _corsEnabled(false)
+, _server(addr, port)
 , _currentMethod(HTTP_ANY)
 , _currentVersion(0)
 , _currentStatus(HC_NONE)
@@ -55,12 +56,12 @@ WebServer::WebServer(IPAddress addr, int port)
 , _currentHeaders(nullptr)
 , _contentLength(0)
 , _chunked(false)
-, _corsEnabled(false)
 {
 }
 
 WebServer::WebServer(int port)
-: _server(port)
+: _corsEnabled(false)
+, _server(port)
 , _currentMethod(HTTP_ANY)
 , _currentVersion(0)
 , _currentStatus(HC_NONE)
@@ -76,7 +77,6 @@ WebServer::WebServer(int port)
 , _currentHeaders(nullptr)
 , _contentLength(0)
 , _chunked(false)
-, _corsEnabled(false)
 {
 }
 


### PR DESCRIPTION
This PR addresses the GCC `reorder` warning caused by [a recent commit that adds CORS support to `WebServer`](https://github.com/espressif/arduino-esp32/commit/672e4faa92b0560352f34fd99f67ff388e05d413). This error prevents compiling using the default `idf.py build` workflow which, for some reason, sets `-Werror`. 