### PR TITLE
Fix Werror=reorder for idf.py build

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -28,10 +28,10 @@
 #include <esp_log.h>
 
 EEPROMClass::EEPROMClass(void)
-  : _data(0)
+  : _handle(NULL)
+  , _data(0)
   , _size(0)
   , _dirty(false)
-  , _handle(NULL)
   , _name("eeprom")
   , _user_defined_size(0)
 {
@@ -39,20 +39,20 @@ EEPROMClass::EEPROMClass(void)
 
 EEPROMClass::EEPROMClass(uint32_t sector)
 // Only for compatiility, no sectors in nvs!
-  : _data(0)
+  : _handle(NULL)
+  , _data(0)
   , _size(0)
   , _dirty(false)
-  , _handle(NULL)
   , _name("eeprom")
   , _user_defined_size(0)
 {
 }
 
 EEPROMClass::EEPROMClass(const char* name, uint32_t user_defined_size)
-  : _data(0)
+  : _handle(NULL)
+  , _data(0)
   , _size(0)
   , _dirty(false)
-  , _handle(NULL)
   , _name(name)
   , _user_defined_size(user_defined_size)
 {

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -59,7 +59,8 @@ env.Append(
         "-Wno-unused-parameter",
         "-Wno-sign-compare",
         "-fstack-protector",
-        "-fexceptions"
+        "-fexceptions",
+        "-Werror=reorder"
     ],
 
     CXXFLAGS=[


### PR DESCRIPTION
Like #2700 except for https://github.com/espressif/arduino-esp32/commit/619568db5bcc219091c653a5ced5e378b3a5643b. Hopefully adding the CFLAG to CI will prevent this from happening (yet) again?