### PR TITLE
Copy ESP8266 String w/SSO to ESP32 repo

### DIFF
--- a/cores/esp32/StreamString.cpp
+++ b/cores/esp32/StreamString.cpp
@@ -2,6 +2,7 @@
  StreamString.cpp
 
  Copyright (c) 2015 Markus Sattler. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -22,31 +23,27 @@
 #include <Arduino.h>
 #include "StreamString.h"
 
-size_t StreamString::write(const uint8_t *data, size_t size)
-{
+size_t StreamString::write(const uint8_t *data, size_t size) {
     if(size && data) {
         if(reserve(length() + size + 1)) {
-            memcpy((void *) (buffer + len), (const void *) data, size);
-            len += size;
-            *(buffer + len) = 0x00; // add null for string end
+            memcpy((void *) (wbuffer() + len()), (const void *) data, size);
+            setLen(len() + size);
+            *(wbuffer() + len()) = 0x00; // add null for string end
             return size;
         }
     }
     return 0;
 }
 
-size_t StreamString::write(uint8_t data)
-{
+size_t StreamString::write(uint8_t data) {
     return concat((char) data);
 }
 
-int StreamString::available()
-{
+int StreamString::available() {
     return length();
 }
 
-int StreamString::read()
-{
+int StreamString::read() {
     if(length()) {
         char c = charAt(0);
         remove(0, 1);
@@ -56,8 +53,7 @@ int StreamString::read()
     return -1;
 }
 
-int StreamString::peek()
-{
+int StreamString::peek() {
     if(length()) {
         char c = charAt(0);
         return c;
@@ -65,7 +61,6 @@ int StreamString::peek()
     return -1;
 }
 
-void StreamString::flush()
-{
+void StreamString::flush() {
 }
 

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -3,8 +3,8 @@
  ...mostly rewritten by Paul Stoffregen...
  Copyright (c) 2009-10 Hernando Barragan.  All rights reserved.
  Copyright 2011, Paul Stoffregen, paul@pjrc.com
- Modified by Ivan Grokhotkov, 2014 - ESP31B support
- Modified by Michael C. Miller, 2015 - ESP31B progmem support
+ Modified by Ivan Grokhotkov, 2014 - esp8266 support
+ Modified by Michael C. Miller, 2015 - esp8266 progmem support
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -21,47 +21,43 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <Arduino.h>
 #include "WString.h"
 #include "stdlib_noniso.h"
-#include "esp32-hal-log.h"
-//extern "C" {
-//#include "esp_common.h"
-//}
 
 /*********************************************/
 /*  Constructors                             */
 /*********************************************/
 
-String::String(const char *cstr)
-{
+String::String(const char *cstr) {
     init();
-    if(cstr) {
+    if(cstr)
         copy(cstr, strlen(cstr));
-    }
 }
 
-String::String(const String &value)
-{
+String::String(const String &value) {
     init();
     *this = value;
 }
 
+String::String(const __FlashStringHelper *pstr) {
+    init();
+    *this = pstr; // see operator =
+}
+
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(String &&rval)
-{
+String::String(String &&rval) {
     init();
     move(rval);
 }
 
-String::String(StringSumHelper &&rval)
-{
+String::String(StringSumHelper &&rval) {
     init();
     move(rval);
 }
 #endif
 
-String::String(char c)
-{
+String::String(char c) {
     init();
     char buf[2];
     buf[0] = c;
@@ -69,120 +65,134 @@ String::String(char c)
     *this = buf;
 }
 
-String::String(unsigned char value, unsigned char base)
-{
+String::String(unsigned char value, unsigned char base) {
     init();
     char buf[1 + 8 * sizeof(unsigned char)];
     utoa(value, buf, base);
     *this = buf;
 }
 
-String::String(int value, unsigned char base)
-{
+String::String(int value, unsigned char base) {
     init();
     char buf[2 + 8 * sizeof(int)];
-    itoa(value, buf, base);
+    if (base == 10) {
+        sprintf(buf, "%d", value);
+    } else {
+        itoa(value, buf, base);
+    }
     *this = buf;
 }
 
-String::String(unsigned int value, unsigned char base)
-{
+String::String(unsigned int value, unsigned char base) {
     init();
     char buf[1 + 8 * sizeof(unsigned int)];
     utoa(value, buf, base);
     *this = buf;
 }
 
-String::String(long value, unsigned char base)
-{
+String::String(long value, unsigned char base) {
     init();
     char buf[2 + 8 * sizeof(long)];
-    ltoa(value, buf, base);
+    if (base==10) {
+        sprintf(buf, "%ld", value);
+    } else {
+        ltoa(value, buf, base);
+    }
     *this = buf;
 }
 
-String::String(unsigned long value, unsigned char base)
-{
+String::String(unsigned long value, unsigned char base) {
     init();
     char buf[1 + 8 * sizeof(unsigned long)];
     ultoa(value, buf, base);
     *this = buf;
 }
 
-String::String(float value, unsigned char decimalPlaces)
-{
+String::String(float value, unsigned char decimalPlaces) {
     init();
     char buf[33];
     *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 
-String::String(double value, unsigned char decimalPlaces)
-{
+String::String(double value, unsigned char decimalPlaces) {
     init();
     char buf[33];
     *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 
-String::~String()
-{
-    if(buffer) {
-        free(buffer);
-    }
-    init();
+String::~String() {
+    invalidate();
 }
 
 // /*********************************************/
 // /*  Memory Management                        */
 // /*********************************************/
 
-inline void String::init(void)
-{
-    buffer = NULL;
-    capacity = 0;
-    len = 0;
+inline void String::init(void) {
+    setSSO(false);
+    setCapacity(0);
+    setLen(0);
+    setBuffer(nullptr);
 }
 
-void String::invalidate(void)
-{
-    if(buffer) {
-        free(buffer);
-    }
+void String::invalidate(void) {
+    if(!sso() && wbuffer())
+        free(wbuffer());
     init();
 }
 
-unsigned char String::reserve(unsigned int size)
-{
-    if(buffer && capacity >= size) {
+unsigned char String::reserve(unsigned int size) {
+    if(buffer() && capacity() >= size)
         return 1;
-    }
     if(changeBuffer(size)) {
-        if(len == 0) {
-            buffer[0] = 0;
-        }
+        if(len() == 0)
+            wbuffer()[0] = 0;
         return 1;
     }
     return 0;
 }
 
-unsigned char String::changeBuffer(unsigned int maxStrLen)
-{
-    size_t newSize = ((maxStrLen + 16) & (~0xf)) - 1;
-    char *newbuffer = (char *) realloc(buffer, newSize+1);
-    if(newbuffer) {
-        if(newSize > len){
-            if(newSize > capacity){
-                memset(newbuffer+capacity, 0, newSize-capacity);
-            }
-        } else {
-            //new buffer can not fit the old len
-            newbuffer[newSize] = 0;
-            len = newSize;
+unsigned char String::changeBuffer(unsigned int maxStrLen) {
+    // Can we use SSO here to avoid allocation?
+    if (maxStrLen < sizeof(sso_buf)) {
+        if (sso() || !buffer()) {
+            // Already using SSO, nothing to do
+            setSSO(true);
+            return 1;
+        } else { // if bufptr && !sso()
+            // Using bufptr, need to shrink into sso_buff
+            char temp[sizeof(sso_buf)];
+            memcpy(temp, buffer(), maxStrLen);
+            free(wbuffer());
+            setSSO(true);
+            memcpy(wbuffer(), temp, maxStrLen);
+            return 1;
         }
-        capacity = newSize;
-        buffer = newbuffer;
+    }
+    // Fallthrough to normal allocator
+    size_t newSize = (maxStrLen + 16) & (~0xf);
+    // Make sure we can fit newsize in the buffer
+    if (newSize > CAPACITY_MAX) {
+        return false;
+    }
+    uint16_t oldLen = len();
+    char *newbuffer = (char *) realloc(sso() ? nullptr : wbuffer(), newSize);
+    if(newbuffer) {
+        size_t oldSize = capacity() + 1; // include NULL.
+        if (sso()) {
+            // Copy the SSO buffer into allocated space
+            memcpy(newbuffer, sso_buf, sizeof(sso_buf));
+        }
+        if (newSize > oldSize)
+        {
+            memset(newbuffer + oldSize, 0, newSize - oldSize);
+        }
+        setSSO(false);
+        setCapacity(newSize - 1);
+        setLen(oldLen); // Needed in case of SSO where len() never existed
+        setBuffer(newbuffer);
         return 1;
     }
-    log_e("realloc failed! Buffer unchanged");
     return 0;
 }
 
@@ -190,84 +200,88 @@ unsigned char String::changeBuffer(unsigned int maxStrLen)
 // /*  Copy and Move                            */
 // /*********************************************/
 
-String & String::copy(const char *cstr, unsigned int length)
-{
+String & String::copy(const char *cstr, unsigned int length) {
     if(!reserve(length)) {
         invalidate();
         return *this;
     }
-    len = length;
-    strcpy(buffer, cstr);
+    setLen(length);
+    strcpy(wbuffer(), cstr);
     return *this;
 }
 
-String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
-{
-    return copy(reinterpret_cast<const char *>(pstr), length);
-}
-
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
-void String::move(String &rhs)
-{
-    if(buffer) {
-        if(capacity >= rhs.len) {
-            strcpy(buffer, rhs.buffer);
-            len = rhs.len;
-            rhs.len = 0;
-            return;
-        } else {
-            free(buffer);
-        }
-    }
-    buffer = rhs.buffer;
-    capacity = rhs.capacity;
-    len = rhs.len;
-    rhs.buffer = NULL;
-    rhs.capacity = 0;
-    rhs.len = 0;
-}
-#endif
-
-String & String::operator =(const String &rhs)
-{
-    if(this == &rhs) {
+String & String::copy(const __FlashStringHelper *pstr, unsigned int length) {
+    if (!reserve(length)) {
+        invalidate();
         return *this;
     }
+    setLen(length);
+    strcpy_P(wbuffer(), (PGM_P)pstr);
+    return *this;
+}
 
-    if(rhs.buffer) {
-        copy(rhs.buffer, rhs.len);
-    } else {
-        invalidate();
+#ifdef __GXX_EXPERIMENTAL_CXX0X__
+void String::move(String &rhs) {
+    if(buffer()) {
+        if(capacity() >= rhs.len()) {
+            strcpy(wbuffer(), rhs.buffer());
+            setLen(rhs.len());
+	    rhs.invalidate();
+            return;
+        } else {
+            if (!sso()) {
+                free(wbuffer());
+                setBuffer(nullptr);
+            }
+        }
     }
+    if (rhs.sso()) {
+        setSSO(true);
+        memmove(sso_buf, rhs.sso_buf, sizeof(sso_buf));
+    } else {
+        setSSO(false);
+        setBuffer(rhs.wbuffer());
+    }
+    setCapacity(rhs.capacity());
+    setLen(rhs.len());
+    rhs.setSSO(false);
+    rhs.setCapacity(0);
+    rhs.setLen(0);
+    rhs.setBuffer(nullptr);
+}
+#endif
+
+String & String::operator =(const String &rhs) {
+    if(this == &rhs)
+        return *this;
+
+    if(rhs.buffer())
+        copy(rhs.buffer(), rhs.len());
+    else
+        invalidate();
 
     return *this;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String & String::operator =(String &&rval)
-{
-    if(this != &rval) {
+String & String::operator =(String &&rval) {
+    if(this != &rval)
         move(rval);
-    }
     return *this;
 }
 
-String & String::operator =(StringSumHelper &&rval)
-{
-    if(this != &rval) {
+String & String::operator =(StringSumHelper &&rval) {
+    if(this != &rval)
         move(rval);
-    }
     return *this;
 }
 #endif
 
-String & String::operator =(const char *cstr)
-{
-    if(cstr) {
+String & String::operator =(const char *cstr) {
+    if(cstr)
         copy(cstr, strlen(cstr));
-    } else {
+    else
         invalidate();
-    }
 
     return *this;
 }
@@ -284,196 +298,184 @@ String & String::operator = (const __FlashStringHelper *pstr)
 // /*  concat                                   */
 // /*********************************************/
 
-unsigned char String::concat(const String &s)
-{
-    return concat(s.buffer, s.len);
+unsigned char String::concat(const String &s) {
+    // Special case if we're concatting ourself (s += s;) since we may end up
+    // realloc'ing the buffer and moving s.buffer in the method called
+    if (&s == this) {
+        unsigned int newlen = 2 * len();
+        if (!s.buffer())
+            return 0;
+        if (s.len() == 0)
+            return 1;
+        if (!reserve(newlen))
+            return 0;
+        memcpy(wbuffer() + len(), buffer(), len());
+        setLen(newlen);
+        wbuffer()[len()] = 0;
+        return 1;
+    } else {
+        return concat(s.buffer(), s.len());
+    }
 }
 
-unsigned char String::concat(const char *cstr, unsigned int length)
-{
-    unsigned int newlen = len + length;
-    if(!cstr) {
+unsigned char String::concat(const char *cstr, unsigned int length) {
+    unsigned int newlen = len() + length;
+    if(!cstr)
         return 0;
-    }
-    if(length == 0) {
+    if(length == 0)
         return 1;
-    }
-    if(!reserve(newlen)) {
+    if(!reserve(newlen))
         return 0;
-    }
-    strcpy(buffer + len, cstr);
-    len = newlen;
+    strcpy(wbuffer() + len(), cstr);
+    setLen(newlen);
     return 1;
 }
 
-unsigned char String::concat(const char *cstr)
-{
-    if(!cstr) {
+unsigned char String::concat(const char *cstr) {
+    if(!cstr)
         return 0;
-    }
     return concat(cstr, strlen(cstr));
 }
 
-unsigned char String::concat(char c)
-{
+unsigned char String::concat(char c) {
     char buf[2];
     buf[0] = c;
     buf[1] = 0;
     return concat(buf, 1);
 }
 
-unsigned char String::concat(unsigned char num)
-{
+unsigned char String::concat(unsigned char num) {
     char buf[1 + 3 * sizeof(unsigned char)];
-    itoa(num, buf, 10);
+    sprintf(buf, "%d", num);
     return concat(buf, strlen(buf));
 }
 
-unsigned char String::concat(int num)
-{
+unsigned char String::concat(int num) {
     char buf[2 + 3 * sizeof(int)];
-    itoa(num, buf, 10);
+    sprintf(buf, "%d", num);
     return concat(buf, strlen(buf));
 }
 
-unsigned char String::concat(unsigned int num)
-{
+unsigned char String::concat(unsigned int num) {
     char buf[1 + 3 * sizeof(unsigned int)];
     utoa(num, buf, 10);
     return concat(buf, strlen(buf));
 }
 
-unsigned char String::concat(long num)
-{
+unsigned char String::concat(long num) {
     char buf[2 + 3 * sizeof(long)];
-    ltoa(num, buf, 10);
+    sprintf(buf, "%ld", num);
     return concat(buf, strlen(buf));
 }
 
-unsigned char String::concat(unsigned long num)
-{
+unsigned char String::concat(unsigned long num) {
     char buf[1 + 3 * sizeof(unsigned long)];
     ultoa(num, buf, 10);
     return concat(buf, strlen(buf));
 }
 
-unsigned char String::concat(float num)
-{
+unsigned char String::concat(float num) {
     char buf[20];
     char* string = dtostrf(num, 4, 2, buf);
     return concat(string, strlen(string));
 }
 
-unsigned char String::concat(double num)
-{
+unsigned char String::concat(double num) {
     char buf[20];
     char* string = dtostrf(num, 4, 2, buf);
     return concat(string, strlen(string));
 }
 
-unsigned char String::concat(const __FlashStringHelper * str)
-{
-    return concat(reinterpret_cast<const char *>(str));
+unsigned char String::concat(const __FlashStringHelper * str) {
+    if (!str) return 0;
+    int length = strlen_P((PGM_P)str);
+    if (length == 0) return 1;
+    unsigned int newlen = len() + length;
+    if (!reserve(newlen)) return 0;
+    strcpy_P(wbuffer() + len(), (PGM_P)str);
+    setLen(newlen);
+    return 1;
 }
 
 /*********************************************/
 /*  Concatenate                              */
 /*********************************************/
 
-StringSumHelper & operator +(const StringSumHelper &lhs, const String &rhs)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, const String &rhs) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(rhs.buffer, rhs.len)) {
+    if(!a.concat(rhs.buffer(), rhs.len()))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, const char *cstr)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, const char *cstr) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!cstr || !a.concat(cstr, strlen(cstr))) {
+    if(!cstr || !a.concat(cstr, strlen(cstr)))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, char c)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, char c) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(c)) {
+    if(!a.concat(c))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, unsigned char num)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, unsigned char num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(num)) {
+    if(!a.concat(num))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, int num)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, int num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(num)) {
+    if(!a.concat(num))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, unsigned int num)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, unsigned int num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(num)) {
+    if(!a.concat(num))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, long num)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, long num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(num)) {
+    if(!a.concat(num))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, unsigned long num)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, unsigned long num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(num)) {
+    if(!a.concat(num))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, float num)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, float num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(num)) {
+    if(!a.concat(num))
         a.invalidate();
-    }
     return a;
 }
 
-StringSumHelper & operator +(const StringSumHelper &lhs, double num)
-{
+StringSumHelper & operator +(const StringSumHelper &lhs, double num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if(!a.concat(num)) {
+    if(!a.concat(num))
         a.invalidate();
-    }
     return a;
 }
 
 StringSumHelper & operator + (const StringSumHelper &lhs, const __FlashStringHelper *rhs)
 {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-    if (!a.concat(rhs))	a.invalidate();
+    if (!a.concat(rhs))
+        a.invalidate();
     return a;
 }
 
@@ -481,425 +483,72 @@ StringSumHelper & operator + (const StringSumHelper &lhs, const __FlashStringHel
 // /*  Comparison                               */
 // /*********************************************/
 
-int String::compareTo(const String &s) const
-{
-    if(!buffer || !s.buffer) {
-        if(s.buffer && s.len > 0) {
-            return 0 - *(unsigned char *) s.buffer;
-        }
-        if(buffer && len > 0) {
-            return *(unsigned char *) buffer;
-        }
+int String::compareTo(const String &s) const {
+    if(!buffer() || !s.buffer()) {
+        if(s.buffer() && s.len() > 0)
+            return 0 - *(unsigned char *) s.buffer();
+        if(buffer() && len() > 0)
+            return *(unsigned char *) buffer();
         return 0;
     }
-    return strcmp(buffer, s.buffer);
+    return strcmp(buffer(), s.buffer());
 }
 
-unsigned char String::equals(const String &s2) const
-{
-    return (len == s2.len && compareTo(s2) == 0);
+unsigned char String::equals(const String &s2) const {
+    return (len() == s2.len() && compareTo(s2) == 0);
 }
 
-unsigned char String::equals(const char *cstr) const
-{
-    if(len == 0) {
+unsigned char String::equals(const char *cstr) const {
+    if(len() == 0)
         return (cstr == NULL || *cstr == 0);
-    }
-    if(cstr == NULL) {
-        return buffer[0] == 0;
-    }
-    return strcmp(buffer, cstr) == 0;
+    if(cstr == NULL)
+        return buffer()[0] == 0;
+    return strcmp(buffer(), cstr) == 0;
 }
 
-unsigned char String::operator<(const String &rhs) const
-{
+unsigned char String::operator<(const String &rhs) const {
     return compareTo(rhs) < 0;
 }
 
-unsigned char String::operator>(const String &rhs) const
-{
+unsigned char String::operator>(const String &rhs) const {
     return compareTo(rhs) > 0;
 }
 
-unsigned char String::operator<=(const String &rhs) const
-{
+unsigned char String::operator<=(const String &rhs) const {
     return compareTo(rhs) <= 0;
 }
 
-unsigned char String::operator>=(const String &rhs) const
-{
+unsigned char String::operator>=(const String &rhs) const {
     return compareTo(rhs) >= 0;
 }
 
-unsigned char String::equalsIgnoreCase(const String &s2) const
-{
-    if(this == &s2) {
+unsigned char String::equalsIgnoreCase(const String &s2) const {
+    if(this == &s2)
         return 1;
-    }
-    if(len != s2.len) {
+    if(len() != s2.len())
         return 0;
-    }
-    if(len == 0) {
+    if(len() == 0)
         return 1;
-    }
-    const char *p1 = buffer;
-    const char *p2 = s2.buffer;
+    const char *p1 = buffer();
+    const char *p2 = s2.buffer();
     while(*p1) {
-        if(tolower(*p1++) != tolower(*p2++)) {
+        if(tolower(*p1++) != tolower(*p2++))
             return 0;
-        }
     }
     return 1;
-}
-
-unsigned char String::startsWith(const String &s2) const
-{
-    if(len < s2.len) {
-        return 0;
-    }
-    return startsWith(s2, 0);
-}
-
-unsigned char String::startsWith(const String &s2, unsigned int offset) const
-{
-    if(offset > len - s2.len || !buffer || !s2.buffer) {
-        return 0;
-    }
-    return strncmp(&buffer[offset], s2.buffer, s2.len) == 0;
-}
-
-unsigned char String::endsWith(const String &s2) const
-{
-    if(len < s2.len || !buffer || !s2.buffer) {
-        return 0;
-    }
-    return strcmp(&buffer[len - s2.len], s2.buffer) == 0;
-}
-
-// /*********************************************/
-// /*  Character Access                         */
-// /*********************************************/
-
-char String::charAt(unsigned int loc) const
-{
-    return operator[](loc);
-}
-
-void String::setCharAt(unsigned int loc, char c)
-{
-    if(loc < len) {
-        buffer[loc] = c;
-    }
-}
-
-char & String::operator[](unsigned int index)
-{
-    static char dummy_writable_char;
-    if(index >= len || !buffer) {
-        dummy_writable_char = 0;
-        return dummy_writable_char;
-    }
-    return buffer[index];
-}
-
-char String::operator[](unsigned int index) const
-{
-    if(index >= len || !buffer) {
-        return 0;
-    }
-    return buffer[index];
-}
-
-void String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index) const
-{
-    if(!bufsize || !buf) {
-        return;
-    }
-    if(index >= len) {
-        buf[0] = 0;
-        return;
-    }
-    unsigned int n = bufsize - 1;
-    if(n > len - index) {
-        n = len - index;
-    }
-    strncpy((char *) buf, buffer + index, n);
-    buf[n] = 0;
-}
-
-// /*********************************************/
-// /*  Search                                   */
-// /*********************************************/
-
-int String::indexOf(char c) const
-{
-    return indexOf(c, 0);
-}
-
-int String::indexOf(char ch, unsigned int fromIndex) const
-{
-    if(fromIndex >= len) {
-        return -1;
-    }
-    const char* temp = strchr(buffer + fromIndex, ch);
-    if(temp == NULL) {
-        return -1;
-    }
-    return temp - buffer;
-}
-
-int String::indexOf(const String &s2) const
-{
-    return indexOf(s2, 0);
-}
-
-int String::indexOf(const String &s2, unsigned int fromIndex) const
-{
-    if(fromIndex >= len) {
-        return -1;
-    }
-    const char *found = strstr(buffer + fromIndex, s2.buffer);
-    if(found == NULL) {
-        return -1;
-    }
-    return found - buffer;
-}
-
-int String::lastIndexOf(char theChar) const
-{
-    return lastIndexOf(theChar, len - 1);
-}
-
-int String::lastIndexOf(char ch, unsigned int fromIndex) const
-{
-    if(fromIndex >= len) {
-        return -1;
-    }
-    char tempchar = buffer[fromIndex + 1];
-    buffer[fromIndex + 1] = '\0';
-    char* temp = strrchr(buffer, ch);
-    buffer[fromIndex + 1] = tempchar;
-    if(temp == NULL) {
-        return -1;
-    }
-    return temp - buffer;
-}
-
-int String::lastIndexOf(const String &s2) const
-{
-    return lastIndexOf(s2, len - s2.len);
-}
-
-int String::lastIndexOf(const String &s2, unsigned int fromIndex) const
-{
-    if(s2.len == 0 || len == 0 || s2.len > len) {
-        return -1;
-    }
-    if(fromIndex >= len) {
-        fromIndex = len - 1;
-    }
-    int found = -1;
-    for(char *p = buffer; p <= buffer + fromIndex; p++) {
-        p = strstr(p, s2.buffer);
-        if(!p) {
-            break;
-        }
-        if((unsigned int) (p - buffer) <= fromIndex) {
-            found = p - buffer;
-        }
-    }
-    return found;
-}
-
-String String::substring(unsigned int left, unsigned int right) const
-{
-    if(left > right) {
-        unsigned int temp = right;
-        right = left;
-        left = temp;
-    }
-    String out;
-    if(left >= len) {
-        return out;
-    }
-    if(right > len) {
-        right = len;
-    }
-    char temp = buffer[right];  // save the replaced character
-    buffer[right] = '\0';
-    out = buffer + left;  // pointer arithmetic
-    buffer[right] = temp;  //restore character
-    return out;
-}
-
-// /*********************************************/
-// /*  Modification                             */
-// /*********************************************/
-
-void String::replace(char find, char replace)
-{
-    if(!buffer) {
-        return;
-    }
-    for(char *p = buffer; *p; p++) {
-        if(*p == find) {
-            *p = replace;
-        }
-    }
-}
-
-void String::replace(const String& find, const String& replace)
-{
-    if(len == 0 || find.len == 0) {
-        return;
-    }
-    int diff = replace.len - find.len;
-    char *readFrom = buffer;
-    char *foundAt;
-    if(diff == 0) {
-        while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
-            memcpy(foundAt, replace.buffer, replace.len);
-            readFrom = foundAt + replace.len;
-        }
-    } else if(diff < 0) {
-        char *writeTo = buffer;
-        while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
-            unsigned int n = foundAt - readFrom;
-            memcpy(writeTo, readFrom, n);
-            writeTo += n;
-            memcpy(writeTo, replace.buffer, replace.len);
-            writeTo += replace.len;
-            readFrom = foundAt + find.len;
-            len += diff;
-        }
-        strcpy(writeTo, readFrom);
-    } else {
-        unsigned int size = len; // compute size needed for result
-        while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
-            readFrom = foundAt + find.len;
-            size += diff;
-        }
-        if(size == len) {
-            return;
-        }
-        if(size > capacity && !changeBuffer(size)) {
-            return;    // XXX: tell user!
-        }
-        int index = len - 1;
-        while(index >= 0 && (index = lastIndexOf(find, index)) >= 0) {
-            readFrom = buffer + index + find.len;
-            memmove(readFrom + diff, readFrom, len - (readFrom - buffer));
-            len += diff;
-            buffer[len] = 0;
-            memcpy(buffer + index, replace.buffer, replace.len);
-            index--;
-        }
-    }
-}
-
-void String::remove(unsigned int index)
-{
-    // Pass the biggest integer as the count. The remove method
-    // below will take care of truncating it at the end of the
-    // string.
-    remove(index, (unsigned int) -1);
-}
-
-void String::remove(unsigned int index, unsigned int count)
-{
-    if(index >= len) {
-        return;
-    }
-    if(count <= 0) {
-        return;
-    }
-    if(count > len - index) {
-        count = len - index;
-    }
-    char *writeTo = buffer + index;
-    len = len - count;
-    strncpy(writeTo, buffer + index + count, len - index);
-    buffer[len] = 0;
-}
-
-void String::toLowerCase(void)
-{
-    if(!buffer) {
-        return;
-    }
-    for(char *p = buffer; *p; p++) {
-        *p = tolower(*p);
-    }
-}
-
-void String::toUpperCase(void)
-{
-    if(!buffer) {
-        return;
-    }
-    for(char *p = buffer; *p; p++) {
-        *p = toupper(*p);
-    }
-}
-
-void String::trim(void)
-{
-    if(!buffer || len == 0) {
-        return;
-    }
-    char *begin = buffer;
-    while(isspace(*begin)) {
-        begin++;
-    }
-    char *end = buffer + len - 1;
-    while(isspace(*end) && end >= begin) {
-        end--;
-    }
-    len = end + 1 - begin;
-    if(begin > buffer) {
-        memcpy(buffer, begin, len);
-    }
-    buffer[len] = 0;
-}
-
-// /*********************************************/
-// /*  Parsing / Conversion                     */
-// /*********************************************/
-
-long String::toInt(void) const
-{
-    if(buffer) {
-        return atol(buffer);
-    }
-    return 0;
-}
-
-float String::toFloat(void) const
-{
-    if(buffer) {
-        return atof(buffer);
-    }
-    return 0;
-}
-
-double String::toDouble(void) const {
-    if (buffer) {
-        return atof(buffer);    
-    }
-    return 0;
 }
 
 unsigned char String::equalsConstantTime(const String &s2) const {
     // To avoid possible time-based attacks present function
     // compares given strings in a constant time.
-    if(len != s2.len)
+    if(len() != s2.len())
         return 0;
     //at this point lengths are the same
-    if(len == 0)
+    if(len() == 0)
         return 1;
     //at this point lenghts are the same and non-zero
-    const char *p1 = buffer;
-    const char *p2 = s2.buffer;
+    const char *p1 = buffer();
+    const char *p2 = s2.buffer();
     unsigned int equalchars = 0;
     unsigned int diffchars = 0;
     while(*p1) {
@@ -911,7 +560,293 @@ unsigned char String::equalsConstantTime(const String &s2) const {
         ++p2;
     }
     //the following should force a constant time eval of the condition without a compiler "logical shortcut"
-    unsigned char equalcond = (equalchars == len);
+    unsigned char equalcond = (equalchars == len());
     unsigned char diffcond = (diffchars == 0);
     return (equalcond & diffcond); //bitwise AND
 }
+
+unsigned char String::startsWith(const String &s2) const {
+    if(len() < s2.len())
+        return 0;
+    return startsWith(s2, 0);
+}
+
+unsigned char String::startsWith(const String &s2, unsigned int offset) const {
+    if(offset > (unsigned)(len() - s2.len()) || !buffer() || !s2.buffer())
+        return 0;
+    return strncmp(&buffer()[offset], s2.buffer(), s2.len()) == 0;
+}
+
+unsigned char String::endsWith(const String &s2) const {
+    if(len() < s2.len() || !buffer() || !s2.buffer())
+        return 0;
+    return strcmp(&buffer()[len() - s2.len()], s2.buffer()) == 0;
+}
+
+// /*********************************************/
+// /*  Character Access                         */
+// /*********************************************/
+
+char String::charAt(unsigned int loc) const {
+    return operator[](loc);
+}
+
+void String::setCharAt(unsigned int loc, char c) {
+    if(loc < len())
+        wbuffer()[loc] = c;
+}
+
+char & String::operator[](unsigned int index) {
+    static char dummy_writable_char;
+    if(index >= len() || !buffer()) {
+        dummy_writable_char = 0;
+        return dummy_writable_char;
+    }
+    return wbuffer()[index];
+}
+
+char String::operator[](unsigned int index) const {
+    if(index >= len() || !buffer())
+        return 0;
+    return buffer()[index];
+}
+
+void String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index) const {
+    if(!bufsize || !buf)
+        return;
+    if(index >= len()) {
+        buf[0] = 0;
+        return;
+    }
+    unsigned int n = bufsize - 1;
+    if(n > len() - index)
+        n = len() - index;
+    strncpy((char *) buf, buffer() + index, n);
+    buf[n] = 0;
+}
+
+// /*********************************************/
+// /*  Search                                   */
+// /*********************************************/
+
+int String::indexOf(char c) const {
+    return indexOf(c, 0);
+}
+
+int String::indexOf(char ch, unsigned int fromIndex) const {
+    if(fromIndex >= len())
+        return -1;
+    const char* temp = strchr(buffer() + fromIndex, ch);
+    if(temp == NULL)
+        return -1;
+    return temp - buffer();
+}
+
+int String::indexOf(const String &s2) const {
+    return indexOf(s2, 0);
+}
+
+int String::indexOf(const String &s2, unsigned int fromIndex) const {
+    if(fromIndex >= len())
+        return -1;
+    const char *found = strstr(buffer() + fromIndex, s2.buffer());
+    if(found == NULL)
+        return -1;
+    return found - buffer();
+}
+
+int String::lastIndexOf(char theChar) const {
+    return lastIndexOf(theChar, len() - 1);
+}
+
+int String::lastIndexOf(char ch, unsigned int fromIndex) const {
+    if(fromIndex >= len())
+        return -1;
+    char tempchar = buffer()[fromIndex + 1];
+    wbuffer()[fromIndex + 1] = '\0';
+    char* temp = strrchr(wbuffer(), ch);
+    wbuffer()[fromIndex + 1] = tempchar;
+    if(temp == NULL)
+        return -1;
+    return temp - buffer();
+}
+
+int String::lastIndexOf(const String &s2) const {
+    return lastIndexOf(s2, len() - s2.len());
+}
+
+int String::lastIndexOf(const String &s2, unsigned int fromIndex) const {
+    if(s2.len() == 0 || len() == 0 || s2.len() > len())
+        return -1;
+    if(fromIndex >= len())
+        fromIndex = len() - 1;
+    int found = -1;
+    for(char *p = wbuffer(); p <= wbuffer() + fromIndex; p++) {
+        p = strstr(p, s2.buffer());
+        if(!p)
+            break;
+        if((unsigned int) (p - wbuffer()) <= fromIndex)
+            found = p - buffer();
+    }
+    return found;
+}
+
+String String::substring(unsigned int left, unsigned int right) const {
+    if(left > right) {
+        unsigned int temp = right;
+        right = left;
+        left = temp;
+    }
+    String out;
+    if(left >= len())
+        return out;
+    if(right > len())
+        right = len();
+    char temp = buffer()[right];  // save the replaced character
+    wbuffer()[right] = '\0';
+    out = wbuffer() + left;  // pointer arithmetic
+    wbuffer()[right] = temp;  //restore character
+    return out;
+}
+
+// /*********************************************/
+// /*  Modification                             */
+// /*********************************************/
+
+void String::replace(char find, char replace) {
+    if(!buffer())
+        return;
+    for(char *p = wbuffer(); *p; p++) {
+        if(*p == find)
+            *p = replace;
+    }
+}
+
+void String::replace(const String& find, const String& replace) {
+    if(len() == 0 || find.len() == 0)
+        return;
+    int diff = replace.len() - find.len();
+    char *readFrom = wbuffer();
+    char *foundAt;
+    if(diff == 0) {
+        while((foundAt = strstr(readFrom, find.buffer())) != NULL) {
+            memmove(foundAt, replace.buffer(), replace.len());
+            readFrom = foundAt + replace.len();
+        }
+    } else if(diff < 0) {
+        char *writeTo = wbuffer();
+        while((foundAt = strstr(readFrom, find.buffer())) != NULL) {
+            unsigned int n = foundAt - readFrom;
+            memmove(writeTo, readFrom, n);
+            writeTo += n;
+            memmove(writeTo, replace.buffer(), replace.len());
+            writeTo += replace.len();
+            readFrom = foundAt + find.len();
+            setLen(len() + diff);
+        }
+        memmove(writeTo, readFrom, strlen(readFrom)+1);
+    } else {
+        unsigned int size = len(); // compute size needed for result
+        while((foundAt = strstr(readFrom, find.buffer())) != NULL) {
+            readFrom = foundAt + find.len();
+            size += diff;
+        }
+        if(size == len())
+            return;
+        if(size > capacity() && !changeBuffer(size))
+            return; // XXX: tell user!
+        int index = len() - 1;
+        while(index >= 0 && (index = lastIndexOf(find, index)) >= 0) {
+            readFrom = wbuffer() + index + find.len();
+            memmove(readFrom + diff, readFrom, len() - (readFrom - buffer()));
+	    int newLen = len() + diff;
+            memmove(wbuffer() + index, replace.buffer(), replace.len());
+            setLen(newLen);
+            wbuffer()[newLen] = 0;
+            index--;
+        }
+    }
+}
+
+void String::remove(unsigned int index) {
+    // Pass the biggest integer as the count. The remove method
+    // below will take care of truncating it at the end of the
+    // string.
+    remove(index, (unsigned int) -1);
+}
+
+void String::remove(unsigned int index, unsigned int count) {
+    if(index >= len()) {
+        return;
+    }
+    if(count <= 0) {
+        return;
+    }
+    if(count > len() - index) {
+        count = len() - index;
+    }
+    char *writeTo = wbuffer() + index;
+    unsigned int newlen = len() - count;
+    setLen(newlen);
+    memmove(writeTo, wbuffer() + index + count, newlen - index);
+    wbuffer()[newlen] = 0;
+}
+
+void String::toLowerCase(void) {
+    if(!buffer())
+        return;
+    for(char *p = wbuffer(); *p; p++) {
+        *p = tolower(*p);
+    }
+}
+
+void String::toUpperCase(void) {
+    if(!buffer())
+        return;
+    for(char *p = wbuffer(); *p; p++) {
+        *p = toupper(*p);
+    }
+}
+
+void String::trim(void) {
+    if(!buffer() || len() == 0)
+        return;
+    char *begin = wbuffer();
+    while(isspace(*begin))
+        begin++;
+    char *end = wbuffer() + len() - 1;
+    while(isspace(*end) && end >= begin)
+        end--;
+    unsigned int newlen = end + 1 - begin;
+    setLen(newlen);
+    if(begin > buffer())
+        memmove(wbuffer(), begin, newlen);
+    wbuffer()[newlen] = 0;
+}
+
+// /*********************************************/
+// /*  Parsing / Conversion                     */
+// /*********************************************/
+
+long String::toInt(void) const {
+    if (buffer())
+        return atol(buffer());
+    return 0;
+}
+
+float String::toFloat(void) const {
+    if (buffer())
+        return atof(buffer());
+    return 0;
+}
+
+double String::toDouble(void) const
+{
+    if (buffer())
+        return atof(buffer());
+    return 0.0;
+}
+
+// global empty string to allow returning const String& with nothing
+
+const String emptyString;

--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -35,295 +35,292 @@ class StringSumHelper;
 // an abstract class used as a means to proide a unique pointer type
 // but really has no body
 class __FlashStringHelper;
-#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
+#define FPSTR(pstr_pointer) (reinterpret_cast<const __FlashStringHelper *>(pstr_pointer))
+#define F(string_literal) (FPSTR(PSTR(string_literal)))
 
 // The string class
-class String
-{
-    // use a function pointer to allow for "if (s)" without the
-    // complications of an operator bool(). for more information, see:
-    // http://www.artima.com/cppsource/safebool.html
-    typedef void (String::*StringIfHelperType)() const;
-    void StringIfHelper() const
-    {
-    }
-
-public:
-    // constructors
-    // creates a copy of the initial value.
-    // if the initial value is null or invalid, or if memory allocation
-    // fails, the string will be marked as invalid (i.e. "if (s)" will
-    // be false).
-    String(const char *cstr = "");
-    String(const String &str);
-    String(const __FlashStringHelper *str) : String(reinterpret_cast<const char *>(str)) {};
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String(String &&rval);
-    String(StringSumHelper &&rval);
-#endif
-    explicit String(char c);
-    explicit String(unsigned char, unsigned char base = 10);
-    explicit String(int, unsigned char base = 10);
-    explicit String(unsigned int, unsigned char base = 10);
-    explicit String(long, unsigned char base = 10);
-    explicit String(unsigned long, unsigned char base = 10);
-    explicit String(float, unsigned char decimalPlaces = 2);
-    explicit String(double, unsigned char decimalPlaces = 2);
-    ~String(void);
-
-    // memory management
-    // return true on success, false on failure (in which case, the string
-    // is left unchanged).  reserve(0), if successful, will validate an
-    // invalid string (i.e., "if (s)" will be true afterwards)
-    unsigned char reserve(unsigned int size);
-    inline unsigned int length(void) const
-    {
-        if(buffer) {
-            return len;
-        } else {
-            return 0;
+class String {
+        // use a function pointer to allow for "if (s)" without the
+        // complications of an operator bool(). for more information, see:
+        // http://www.artima.com/cppsource/safebool.html
+        typedef void (String::*StringIfHelperType)() const;
+        void StringIfHelper() const {
         }
-    }
 
-    // creates a copy of the assigned value.  if the value is null or
-    // invalid, or if the memory allocation fails, the string will be
-    // marked as invalid ("if (s)" will be false).
-    String & operator =(const String &rhs);
-    String & operator =(const char *cstr);
-    String & operator = (const __FlashStringHelper *str);
+    public:
+        // constructors
+        // creates a copy of the initial value.
+        // if the initial value is null or invalid, or if memory allocation
+        // fails, the string will be marked as invalid (i.e. "if (s)" will
+        // be false).
+        String(const char *cstr = "");
+        String(const String &str);
+        String(const __FlashStringHelper *str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String & operator =(String &&rval);
-    String & operator =(StringSumHelper &&rval);
+        String(String &&rval);
+        String(StringSumHelper &&rval);
+#endif
+        explicit String(char c);
+        explicit String(unsigned char, unsigned char base = 10);
+        explicit String(int, unsigned char base = 10);
+        explicit String(unsigned int, unsigned char base = 10);
+        explicit String(long, unsigned char base = 10);
+        explicit String(unsigned long, unsigned char base = 10);
+        explicit String(float, unsigned char decimalPlaces = 2);
+        explicit String(double, unsigned char decimalPlaces = 2);
+        ~String(void);
+
+        // memory management
+        // return true on success, false on failure (in which case, the string
+        // is left unchanged).  reserve(0), if successful, will validate an
+        // invalid string (i.e., "if (s)" will be true afterwards)
+        unsigned char reserve(unsigned int size);
+        inline unsigned int length(void) const {
+            if(buffer()) {
+                return len();
+            } else {
+                return 0;
+            }
+        }
+
+        // creates a copy of the assigned value.  if the value is null or
+        // invalid, or if the memory allocation fails, the string will be
+        // marked as invalid ("if (s)" will be false).
+        String & operator =(const String &rhs);
+        String & operator =(const char *cstr);
+        String & operator = (const __FlashStringHelper *str);
+#ifdef __GXX_EXPERIMENTAL_CXX0X__
+        String & operator =(String &&rval);
+        String & operator =(StringSumHelper &&rval);
 #endif
 
-    // concatenate (works w/ built-in types)
+        // concatenate (works w/ built-in types)
 
-    // returns true on success, false on failure (in which case, the string
-    // is left unchanged).  if the argument is null or invalid, the
-    // concatenation is considered unsucessful.
-    unsigned char concat(const String &str);
-    unsigned char concat(const char *cstr);
-    unsigned char concat(char c);
-    unsigned char concat(unsigned char c);
-    unsigned char concat(int num);
-    unsigned char concat(unsigned int num);
-    unsigned char concat(long num);
-    unsigned char concat(unsigned long num);
-    unsigned char concat(float num);
-    unsigned char concat(double num);
-    unsigned char concat(const __FlashStringHelper * str);
+        // returns true on success, false on failure (in which case, the string
+        // is left unchanged).  if the argument is null or invalid, the
+        // concatenation is considered unsucessful.
+        unsigned char concat(const String &str);
+        unsigned char concat(const char *cstr);
+        unsigned char concat(char c);
+        unsigned char concat(unsigned char c);
+        unsigned char concat(int num);
+        unsigned char concat(unsigned int num);
+        unsigned char concat(long num);
+        unsigned char concat(unsigned long num);
+        unsigned char concat(float num);
+        unsigned char concat(double num);
+        unsigned char concat(const __FlashStringHelper * str);
 
-    // if there's not enough memory for the concatenated value, the string
-    // will be left unchanged (but this isn't signalled in any way)
-    String & operator +=(const String &rhs)
-    {
-        concat(rhs);
-        return (*this);
-    }
-    String & operator +=(const char *cstr)
-    {
-        concat(cstr);
-        return (*this);
-    }
-    String & operator +=(char c)
-    {
-        concat(c);
-        return (*this);
-    }
-    String & operator +=(unsigned char num)
-    {
-        concat(num);
-        return (*this);
-    }
-    String & operator +=(int num)
-    {
-        concat(num);
-        return (*this);
-    }
-    String & operator +=(unsigned int num)
-    {
-        concat(num);
-        return (*this);
-    }
-    String & operator +=(long num)
-    {
-        concat(num);
-        return (*this);
-    }
-    String & operator +=(unsigned long num)
-    {
-        concat(num);
-        return (*this);
-    }
-    String & operator +=(float num)
-    {
-        concat(num);
-        return (*this);
-    }
-    String & operator +=(double num)
-    {
-        concat(num);
-        return (*this);
-    }
-    String & operator += (const __FlashStringHelper *str)
-    {
-        concat(str);
-        return (*this);
-    }
+        // if there's not enough memory for the concatenated value, the string
+        // will be left unchanged (but this isn't signalled in any way)
+        String & operator +=(const String &rhs) {
+            concat(rhs);
+            return (*this);
+        }
+        String & operator +=(const char *cstr) {
+            concat(cstr);
+            return (*this);
+        }
+        String & operator +=(char c) {
+            concat(c);
+            return (*this);
+        }
+        String & operator +=(unsigned char num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator +=(int num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator +=(unsigned int num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator +=(long num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator +=(unsigned long num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator +=(float num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator +=(double num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator += (const __FlashStringHelper *str){
+            concat(str);
+            return (*this);
+        }
 
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, const String &rhs);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, const char *cstr);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, char c);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned char num);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, int num);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned int num);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, long num);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned long num);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, float num);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, double num);
-    friend StringSumHelper & operator +(const StringSumHelper &lhs, const __FlashStringHelper *rhs);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, const String &rhs);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, const char *cstr);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, char c);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned char num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, int num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned int num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, long num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned long num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, float num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, double num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, const __FlashStringHelper *rhs);
 
-    // comparison (only works w/ Strings and "strings")
-    operator StringIfHelperType() const
-    {
-        return buffer ? &String::StringIfHelper : 0;
-    }
-    int compareTo(const String &s) const;
-    unsigned char equals(const String &s) const;
-    unsigned char equals(const char *cstr) const;
-    unsigned char operator ==(const String &rhs) const
-    {
-        return equals(rhs);
-    }
-    unsigned char operator ==(const char *cstr) const
-    {
-        return equals(cstr);
-    }
-    unsigned char operator !=(const String &rhs) const
-    {
-        return !equals(rhs);
-    }
-    unsigned char operator !=(const char *cstr) const
-    {
-        return !equals(cstr);
-    }
-    unsigned char operator <(const String &rhs) const;
-    unsigned char operator >(const String &rhs) const;
-    unsigned char operator <=(const String &rhs) const;
-    unsigned char operator >=(const String &rhs) const;
-    unsigned char equalsIgnoreCase(const String &s) const;
-    unsigned char equalsConstantTime(const String &s) const;
-    unsigned char startsWith(const String &prefix) const;
-    unsigned char startsWith(const String &prefix, unsigned int offset) const;
-    unsigned char endsWith(const String &suffix) const;
+        // comparison (only works w/ Strings and "strings")
+        operator StringIfHelperType() const {
+            return buffer() ? &String::StringIfHelper : 0;
+        }
+        int compareTo(const String &s) const;
+        unsigned char equals(const String &s) const;
+        unsigned char equals(const char *cstr) const;
+        unsigned char operator ==(const String &rhs) const {
+            return equals(rhs);
+        }
+        unsigned char operator ==(const char *cstr) const {
+            return equals(cstr);
+        }
+        unsigned char operator !=(const String &rhs) const {
+            return !equals(rhs);
+        }
+        unsigned char operator !=(const char *cstr) const {
+            return !equals(cstr);
+        }
+        unsigned char operator <(const String &rhs) const;
+        unsigned char operator >(const String &rhs) const;
+        unsigned char operator <=(const String &rhs) const;
+        unsigned char operator >=(const String &rhs) const;
+        unsigned char equalsIgnoreCase(const String &s) const;
+        unsigned char equalsConstantTime(const String &s) const;
+        unsigned char startsWith(const String &prefix) const;
+        unsigned char startsWith(const String &prefix, unsigned int offset) const;
+        unsigned char endsWith(const String &suffix) const;
 
-    // character acccess
-    char charAt(unsigned int index) const;
-    void setCharAt(unsigned int index, char c);
-    char operator [](unsigned int index) const;
-    char& operator [](unsigned int index);
-    void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index = 0) const;
-    void toCharArray(char *buf, unsigned int bufsize, unsigned int index = 0) const
-    {
-        getBytes((unsigned char *) buf, bufsize, index);
-    }
-    const char * c_str() const
-    {
-        return buffer;
-    }
+        // character acccess
+        char charAt(unsigned int index) const;
+        void setCharAt(unsigned int index, char c);
+        char operator [](unsigned int index) const;
+        char& operator [](unsigned int index);
+        void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index = 0) const;
+        void toCharArray(char *buf, unsigned int bufsize, unsigned int index = 0) const {
+            getBytes((unsigned char *) buf, bufsize, index);
+        }
+        const char* c_str() const { return buffer(); }
+        char* begin() { return wbuffer(); }
+        char* end() { return wbuffer() + length(); }
+        const char* begin() const { return c_str(); }
+        const char* end() const { return c_str() + length(); }
 
-    // search
-    int indexOf(char ch) const;
-    int indexOf(char ch, unsigned int fromIndex) const;
-    int indexOf(const String &str) const;
-    int indexOf(const String &str, unsigned int fromIndex) const;
-    int lastIndexOf(char ch) const;
-    int lastIndexOf(char ch, unsigned int fromIndex) const;
-    int lastIndexOf(const String &str) const;
-    int lastIndexOf(const String &str, unsigned int fromIndex) const;
-    String substring(unsigned int beginIndex) const
-    {
-        return substring(beginIndex, len);
-    }
-    ;
-    String substring(unsigned int beginIndex, unsigned int endIndex) const;
+        // search
+        int indexOf(char ch) const;
+        int indexOf(char ch, unsigned int fromIndex) const;
+        int indexOf(const String &str) const;
+        int indexOf(const String &str, unsigned int fromIndex) const;
+        int lastIndexOf(char ch) const;
+        int lastIndexOf(char ch, unsigned int fromIndex) const;
+        int lastIndexOf(const String &str) const;
+        int lastIndexOf(const String &str, unsigned int fromIndex) const;
+        String substring(unsigned int beginIndex) const {
+            return substring(beginIndex, len());
+        }
+        ;
+        String substring(unsigned int beginIndex, unsigned int endIndex) const;
 
-    // modification
-    void replace(char find, char replace);
-    void replace(const String& find, const String& replace);
-    void remove(unsigned int index);
-    void remove(unsigned int index, unsigned int count);
-    void toLowerCase(void);
-    void toUpperCase(void);
-    void trim(void);
+        // modification
+        void replace(char find, char replace);
+        void replace(const String& find, const String& replace);
+        void remove(unsigned int index);
+        void remove(unsigned int index, unsigned int count);
+        void toLowerCase(void);
+        void toUpperCase(void);
+        void trim(void);
 
-    // parsing/conversion
-    long toInt(void) const;
-    float toFloat(void) const;
-    double toDouble(void) const;
+        // parsing/conversion
+        long toInt(void) const;
+        float toFloat(void) const;
+	double toDouble(void) const;
 
-protected:
-    char *buffer;	        // the actual char array
-    unsigned int capacity;  // the array length minus one (for the '\0')
-    unsigned int len;       // the String length (not counting the '\0')
-protected:
-    void init(void);
-    void invalidate(void);
-    unsigned char changeBuffer(unsigned int maxStrLen);
-    unsigned char concat(const char *cstr, unsigned int length);
+    protected:
+        // Contains the string info when we're not in SSO mode
+        struct _ptr { 
+            char *   buff;
+            uint16_t cap;
+            uint16_t len;
+        };
 
-    // copy and move
-    String & copy(const char *cstr, unsigned int length);
-    String & copy(const __FlashStringHelper *pstr, unsigned int length);
+        // SSO is handled by checking the last byte of sso_buff.
+        // When not in SSO mode, that byte is set to 0xff, while when in SSO mode it is always 0x00 (so it can serve as the string terminator as well as a flag)
+        // This allows strings up up to 12 (11 + \0 termination) without any extra space.
+        enum { SSOSIZE = sizeof(struct _ptr) + 4 }; // Characters to allocate space for SSO, must be 12 or more
+        enum { CAPACITY_MAX = 65535 }; // If size of capacity changed, be sure to update this enum
+        union {
+            struct _ptr ptr;
+            char sso_buf[SSOSIZE];
+        };
+        // Accessor functions
+        inline bool sso() const { return sso_buf[SSOSIZE - 1] == 0; }
+        inline unsigned int len() const { return sso() ? strlen(sso_buf) : ptr.len; }
+        inline unsigned int capacity() const { return sso() ? SSOSIZE - 1 : ptr.cap; }
+        inline void setSSO(bool sso) { sso_buf[SSOSIZE - 1] = sso ? 0x00 : 0xff; }
+        inline void setLen(int len) { if (!sso()) ptr.len = len; }
+        inline void setCapacity(int cap) { if (!sso()) ptr.cap = cap; }
+	inline void setBuffer(char *buff) { if (!sso()) ptr.buff = buff; }
+        // Buffer accessor functions
+        inline const char *buffer() const { return (const char *)(sso() ? sso_buf : ptr.buff); }
+        inline char *wbuffer() const { return sso() ? const_cast<char *>(sso_buf) : ptr.buff; } // Writable version of buffer
+
+    protected:
+        void init(void);
+        void invalidate(void);
+        unsigned char changeBuffer(unsigned int maxStrLen);
+        unsigned char concat(const char *cstr, unsigned int length);
+
+        // copy and move
+        String & copy(const char *cstr, unsigned int length);
+        String & copy(const __FlashStringHelper *pstr, unsigned int length);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    void move(String &rhs);
+        void move(String &rhs);
 #endif
 };
 
-class StringSumHelper: public String
-{
-public:
-    StringSumHelper(const String &s) :
-        String(s)
-    {
-    }
-    StringSumHelper(const char *p) :
-        String(p)
-    {
-    }
-    StringSumHelper(char c) :
-        String(c)
-    {
-    }
-    StringSumHelper(unsigned char num) :
-        String(num)
-    {
-    }
-    StringSumHelper(int num) :
-        String(num)
-    {
-    }
-    StringSumHelper(unsigned int num) :
-        String(num)
-    {
-    }
-    StringSumHelper(long num) :
-        String(num)
-    {
-    }
-    StringSumHelper(unsigned long num) :
-        String(num)
-    {
-    }
-    StringSumHelper(float num) :
-        String(num)
-    {
-    }
-    StringSumHelper(double num) :
-        String(num)
-    {
-    }
+class StringSumHelper: public String {
+    public:
+        StringSumHelper(const String &s) :
+                String(s) {
+        }
+        StringSumHelper(const char *p) :
+                String(p) {
+        }
+        StringSumHelper(char c) :
+                String(c) {
+        }
+        StringSumHelper(unsigned char num) :
+                String(num) {
+        }
+        StringSumHelper(int num) :
+                String(num) {
+        }
+        StringSumHelper(unsigned int num) :
+                String(num) {
+        }
+        StringSumHelper(long num) :
+                String(num) {
+        }
+        StringSumHelper(unsigned long num) :
+                String(num) {
+        }
+        StringSumHelper(float num) :
+                String(num) {
+        }
+        StringSumHelper(double num) :
+                String(num) {
+        }
 };
+
+extern const String emptyString;
 
 #endif  // __cplusplus
 #endif  // String_class_h


### PR DESCRIPTION
I redid the ESP8266 WString library to enable small string optimization
(SSO) a while back, and think it would be helpful even on the ESP32 with
its higher memory complement.

SSO avoids lots of tiny mallocs() on the heap which cause fragmentation
by using the memory in the class object itself to store the actual
string and only mallocing() for buffers that are larger than what can
fit in thie class object.  Modern C++ std::string implementations have
this optimization as well, but since we're using Arduino strings we had
to roll our own.