### PR TITLE
Undo the redefinition of FPSTR from 8266 merge

### DIFF
--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -35,8 +35,7 @@ class StringSumHelper;
 // an abstract class used as a means to proide a unique pointer type
 // but really has no body
 class __FlashStringHelper;
-#define FPSTR(pstr_pointer) (reinterpret_cast<const __FlashStringHelper *>(pstr_pointer))
-#define F(string_literal) (FPSTR(PSTR(string_literal)))
+#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
 
 // The string class
 class String {


### PR DESCRIPTION
Fixes Arduino.h redefinition errors, as found by @dok-net 