### PR TITLE
Fix semaphores in IDF & std::string assert

### DIFF
--- a/libraries/BLE/src/FreeRTOS.cpp
+++ b/libraries/BLE/src/FreeRTOS.cpp
@@ -61,14 +61,14 @@ uint32_t FreeRTOS::getTimeSinceStart() {
  */
 uint32_t FreeRTOS::Semaphore::wait(std::string owner) {
 	log_v(">> wait: Semaphore waiting: %s for %s", toString().c_str(), owner.c_str());
-
-	m_owner = owner;
 	
 	if (m_usePthreads) {
 		pthread_mutex_lock(&m_pthread_mutex);
 	} else {
 		xSemaphoreTake(m_semaphore, portMAX_DELAY);
 	}
+	
+	m_owner = owner;
 
 	if (m_usePthreads) {
 		pthread_mutex_unlock(&m_pthread_mutex);
@@ -77,6 +77,7 @@ uint32_t FreeRTOS::Semaphore::wait(std::string owner) {
 	}
 
 	log_v("<< wait: Semaphore released: %s", toString().c_str());
+	m_owner = std::string("<N/A>");
 	return m_value;
 } // wait
 

--- a/libraries/BLE/src/FreeRTOS.cpp
+++ b/libraries/BLE/src/FreeRTOS.cpp
@@ -62,13 +62,13 @@ uint32_t FreeRTOS::getTimeSinceStart() {
 uint32_t FreeRTOS::Semaphore::wait(std::string owner) {
 	log_v(">> wait: Semaphore waiting: %s for %s", toString().c_str(), owner.c_str());
 
+	m_owner = owner;
+	
 	if (m_usePthreads) {
 		pthread_mutex_lock(&m_pthread_mutex);
 	} else {
 		xSemaphoreTake(m_semaphore, portMAX_DELAY);
 	}
-
-	m_owner = owner;
 
 	if (m_usePthreads) {
 		pthread_mutex_unlock(&m_pthread_mutex);
@@ -77,7 +77,6 @@ uint32_t FreeRTOS::Semaphore::wait(std::string owner) {
 	}
 
 	log_v("<< wait: Semaphore released: %s", toString().c_str());
-	m_owner = std::string("<N/A>");
 	return m_value;
 } // wait
 
@@ -87,7 +86,8 @@ FreeRTOS::Semaphore::Semaphore(std::string name) {
 	if (m_usePthreads) {
 		pthread_mutex_init(&m_pthread_mutex, nullptr);
 	} else {
-		m_semaphore = xSemaphoreCreateMutex();
+		m_semaphore = xSemaphoreCreateBinary();
+		xSemaphoreGive(m_semaphore);
 	}
 
 	m_name      = name;

--- a/libraries/BLE/src/FreeRTOS.cpp
+++ b/libraries/BLE/src/FreeRTOS.cpp
@@ -67,8 +67,6 @@ uint32_t FreeRTOS::Semaphore::wait(std::string owner) {
 	} else {
 		xSemaphoreTake(m_semaphore, portMAX_DELAY);
 	}
-	
-	m_owner = owner;
 
 	if (m_usePthreads) {
 		pthread_mutex_unlock(&m_pthread_mutex);
@@ -77,7 +75,6 @@ uint32_t FreeRTOS::Semaphore::wait(std::string owner) {
 	}
 
 	log_v("<< wait: Semaphore released: %s", toString().c_str());
-	m_owner = std::string("<N/A>");
 	return m_value;
 } // wait
 
@@ -112,6 +109,8 @@ FreeRTOS::Semaphore::~Semaphore() {
  */
 void FreeRTOS::Semaphore::give() {
 	log_v("Semaphore giving: %s", toString().c_str());
+	m_owner = std::string("<N/A>");
+	
 	if (m_usePthreads) {
 		pthread_mutex_unlock(&m_pthread_mutex);
 	} else {
@@ -121,7 +120,6 @@ void FreeRTOS::Semaphore::give() {
 // 	FreeRTOS::sleep(10);
 // #endif
 
-	m_owner = std::string("<N/A>");
 } // Semaphore::give
 
 


### PR DESCRIPTION
Fixes the problem of giving a mutex from a callback with the latest IDF. Also addresses an occasional assert that happens when the btc_task callback gives the semaphore and causes an assert due to both cores potentially writing m_owner concurrently.