### PR TITLE
StreamString SSO fix

### DIFF
--- a/cores/esp32/StreamString.cpp
+++ b/cores/esp32/StreamString.cpp
@@ -25,10 +25,11 @@
 
 size_t StreamString::write(const uint8_t *data, size_t size) {
     if(size && data) {
-        if(reserve(length() + size + 1)) {
+        const unsigned int newlen = length() + size;
+        if(reserve(newlen + 1)) {
             memcpy((void *) (wbuffer() + len()), (const void *) data, size);
-            setLen(len() + size);
-            *(wbuffer() + len()) = 0x00; // add null for string end
+            setLen(newlen);
+            *(wbuffer() + newlen) = 0x00; // add null for string end
             return size;
         }
     }


### PR DESCRIPTION
Sorry, @me-no-dev, I thought we'd hammered out the issues in the SSO conversion, but there's one more but just found.

As found by @mongozmaki in https://github.com/esp8266/Arduino/pull/6035

With SSO implementation in String, StreamString::write generates wrong
strings under some circumstances.  Reason is that String::len() returns
strlen(sso_buf) if SSO=true but with newly written data
(in StreamString::write) the null-termination missing at the time len()
is called.

Furthermore, len() is called twice which is inefficient if SSO=true.