### PR TITLE
Use std::abs for a float-compatible abs() function

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -68,12 +68,6 @@
 #define __STRINGIFY(a) #a
 #endif
 
-// undefine stdlib's abs if encountered
-#ifdef abs
-#undef abs
-#endif
-
-#define abs(x) ((x)>0?(x):-(x))
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define radians(deg) ((deg)*DEG_TO_RAD)
 #define degrees(rad) ((rad)*RAD_TO_DEG)
@@ -160,6 +154,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 #include "HardwareSerial.h"
 #include "Esp.h"
 
+using std::abs;
 using std::isinf;
 using std::isnan;
 using std::max;


### PR DESCRIPTION
* Other Arduino cores uses a macro to redefine libc abs() to take any  type, meaning `abs(-3.3) == 3.3` not the normal libc result of 3.

* 1e4bf14a3 (#1783) replaced similar `min`, `max` macros with c++ stdlib. However this change includes `<algorithm>` after the line which defines the abs() macro. `<algorithm>` includes `<cstdlib>` which undefines `abs()` and re-defines it.

* As a result, current esp32 Arduino core has a bug compared to other Arduino cores: `abs()` is now the plain libc version which only takes integers, so `abs(-3.3) == 3`. As reported here: https://github.com/espressif/esp-idf/issues/3405

This fix tries to keep in the spirit of #1783 by using libstdc++ rather than a macro, for the same effect (abs can take any compatible type). The other option would be to include `<cstdlib>` before defining the `abs()` macro, so it doesn't get undef-ed again later on.

This will probably also fix https://github.com/espressif/arduino-esp32/issues/2128 as the `abs()` macro is no longer defined.