### PR TITLE
feature(BluetoothSerial): add pinCode function

### DIFF
--- a/libraries/BluetoothSerial/examples/SerialToSerialBT/SerialToSerialBT.ino
+++ b/libraries/BluetoothSerial/examples/SerialToSerialBT/SerialToSerialBT.ino
@@ -6,15 +6,12 @@
 
 #include "BluetoothSerial.h"
 
-#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
-#error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
-#endif
-
 BluetoothSerial SerialBT;
 
 void setup() {
   Serial.begin(115200);
   SerialBT.begin("ESP32test"); //Bluetooth device name
+  SerialBT.pinCode("1234"); //Bluetooth device password
   Serial.println("The device started, now you can pair it with bluetooth!");
 }
 

--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -235,7 +235,7 @@ static void esp_spp_cb(esp_spp_cb_event_t event, esp_spp_cb_param_t *param)
     if(custom_spp_callback)(*custom_spp_callback)(event, param);
 }
 
-static bool _init_bt(const char *deviceName)
+static bool _init_bt(const char *deviceName, const char *pswd)
 {
     if(!_spp_event_group){
         _spp_event_group = xEventGroupCreate();
@@ -319,6 +319,11 @@ static bool _init_bt(const char *deviceName)
         return false;
     }
 
+    if (esp_bt_gap_set_pin(ESP_BT_PIN_TYPE_FIXED, strlen(pswd), (uint8_t *)pswd) != ESP_OK) {
+        log_e("set pincode failed");
+        return false;
+    }
+
     return true;
 }
 
@@ -369,6 +374,7 @@ static bool _stop_bt()
 BluetoothSerial::BluetoothSerial()
 {
     local_name = "ESP32"; //default bluetooth name
+    pin_code = "0000"; //default bluetooth password
 }
 
 BluetoothSerial::~BluetoothSerial(void)
@@ -381,7 +387,17 @@ bool BluetoothSerial::begin(String localName)
     if (localName.length()){
         local_name = localName;
     }
-    return _init_bt(local_name.c_str());
+    return _init_bt(local_name.c_str(), pin_code.c_str());
+}
+
+bool BluetoothSerial::pinCode(String pswd)
+{
+    if (pswd.length() == 0 || pswd.length() > ESP_BT_PIN_CODE_LEN) {
+        return false;
+    }
+    
+    esp_bt_gap_set_pin(ESP_BT_PIN_TYPE_FIXED, pswd.length(), (uint8_t *)pswd.c_str());
+    return true;
 }
 
 int BluetoothSerial::available(void)

--- a/libraries/BluetoothSerial/src/BluetoothSerial.h
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.h
@@ -22,6 +22,7 @@
 #include "Arduino.h"
 #include "Stream.h"
 #include <esp_spp_api.h>
+#include "esp_gap_bt_api.h"   
 
 class BluetoothSerial: public Stream
 {
@@ -31,6 +32,7 @@ class BluetoothSerial: public Stream
         ~BluetoothSerial(void);
 
         bool begin(String localName=String());
+        bool pinCode(String pswd);
         int available(void);
         int peek(void);
         bool hasClient(void);
@@ -43,6 +45,7 @@ class BluetoothSerial: public Stream
 
     private:
         String local_name;
+        String pin_code;
 
 };
 


### PR DESCRIPTION
@me-no-dev 

Hi，
* This change enables Bluetooth Serial to use password pairing.
* libbt.a requires you to recompile the build library to support simple pairing.

* kconfig: // SSP (Secure Simple Pairing ) disable

```
#
# Bluetooth
#
CONFIG_BT_ENABLED=y

#
# Bluetooth controller
#
CONFIG_BTDM_CONTROLLER_MODE_BLE_ONLY=
CONFIG_BTDM_CONTROLLER_MODE_BR_EDR_ONLY=
CONFIG_BTDM_CONTROLLER_MODE_BTDM=y
CONFIG_BTDM_CONTROLLER_BLE_MAX_CONN=3
CONFIG_BTDM_CONTROLLER_BR_EDR_MAX_ACL_CONN=2
CONFIG_BTDM_CONTROLLER_BR_EDR_MAX_SYNC_CONN=0
CONFIG_BTDM_CONTROLLER_BLE_MAX_CONN_EFF=3
CONFIG_BTDM_CONTROLLER_BR_EDR_MAX_ACL_CONN_EFF=2
CONFIG_BTDM_CONTROLLER_BR_EDR_MAX_SYNC_CONN_EFF=0
CONFIG_BTDM_CONTROLLER_PINNED_TO_CORE_0=y
CONFIG_BTDM_CONTROLLER_PINNED_TO_CORE_1=
CONFIG_BTDM_CONTROLLER_PINNED_TO_CORE=0
CONFIG_BTDM_CONTROLLER_HCI_MODE_VHCI=y
CONFIG_BTDM_CONTROLLER_HCI_MODE_UART_H4=

#
# MODEM SLEEP Options
#
CONFIG_BTDM_CONTROLLER_MODEM_SLEEP=y
CONFIG_BTDM_MODEM_SLEEP_MODE_ORIG=y
CONFIG_BTDM_MODEM_SLEEP_MODE_EVED=
CONFIG_BTDM_LPCLK_SEL_MAIN_XTAL=y
CONFIG_BLE_SCAN_DUPLICATE=y
CONFIG_SCAN_DUPLICATE_BY_DEVICE_ADDR=y
CONFIG_SCAN_DUPLICATE_BY_ADV_DATA=
CONFIG_SCAN_DUPLICATE_BY_ADV_DATA_AND_DEVICE_ADDR=
CONFIG_SCAN_DUPLICATE_TYPE=0
CONFIG_DUPLICATE_SCAN_CACHE_SIZE=20
CONFIG_BLE_MESH_SCAN_DUPLICATE_EN=
CONFIG_BLUEDROID_ENABLED=y
CONFIG_BLUEDROID_PINNED_TO_CORE_0=y
CONFIG_BLUEDROID_PINNED_TO_CORE_1=
CONFIG_BLUEDROID_PINNED_TO_CORE=0
CONFIG_BTC_TASK_STACK_SIZE=8192
CONFIG_BTU_TASK_STACK_SIZE=4096
CONFIG_BLUEDROID_MEM_DEBUG=
CONFIG_CLASSIC_BT_ENABLED=y
CONFIG_A2DP_ENABLE=y
CONFIG_A2DP_SINK_TASK_STACK_SIZE=2048
CONFIG_A2DP_SOURCE_TASK_STACK_SIZE=2048
CONFIG_BT_SPP_ENABLED=y
CONFIG_HFP_ENABLE=y
CONFIG_HFP_CLIENT_ENABLE=y
CONFIG_HFP_AUDIO_DATA_PATH_PCM=y
CONFIG_HFP_AUDIO_DATA_PATH_HCI=
CONFIG_BT_SSP_ENABLED=
CONFIG_GATTS_ENABLE=y
CONFIG_GATTS_SEND_SERVICE_CHANGE_MANUAL=
CONFIG_GATTS_SEND_SERVICE_CHANGE_AUTO=y
CONFIG_GATTS_SEND_SERVICE_CHANGE_MODE=0
CONFIG_GATTC_ENABLE=y
CONFIG_GATTC_CACHE_NVS_FLASH=
CONFIG_BLE_SMP_ENABLE=y
CONFIG_BT_STACK_NO_LOG=y
CONFIG_BT_ACL_CONNECTIONS=4
CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST=y
CONFIG_BT_BLE_DYNAMIC_ENV_MEMORY=y
CONFIG_BLE_HOST_QUEUE_CONGESTION_CHECK=
CONFIG_SMP_ENABLE=y
CONFIG_BT_RESERVE_DRAM=0xdb5c
```