### PR TITLE
Fixed multi_heap_free failed during setting the value of the characte…

### DIFF
--- a/libraries/BLE/src/BLECharacteristic.cpp
+++ b/libraries/BLE/src/BLECharacteristic.cpp
@@ -628,7 +628,9 @@ void BLECharacteristic::setValue(uint8_t* data, size_t length) {
 		log_e("Size %d too large, must be no bigger than %d", length, ESP_GATT_MAX_ATTR_LEN);
 		return;
 	}
+  m_semaphoreSetValue.take();
 	m_value.setValue(data, length);
+  m_semaphoreSetValue.give();
 	log_v("<< setValue");
 } // setValue
 

--- a/libraries/BLE/src/BLECharacteristic.h
+++ b/libraries/BLE/src/BLECharacteristic.h
@@ -117,6 +117,7 @@ private:
 	void                 setHandle(uint16_t handle);
 	FreeRTOS::Semaphore m_semaphoreCreateEvt = FreeRTOS::Semaphore("CreateEvt");
 	FreeRTOS::Semaphore m_semaphoreConfEvt   = FreeRTOS::Semaphore("ConfEvt");
+  FreeRTOS::Semaphore m_semaphoreSetValue  = FreeRTOS::Semaphore("SetValue");
 }; // BLECharacteristic
 
 


### PR DESCRIPTION
…ristic in BLE Library.

It's fixed that multi_heap_free failed like below. It sometimes happen when esp32 recevied ble data fast from another device so I added semaphore so It was fixed.


assertion "head != NULL" failed: file "/Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/heap/multi_heap_poisoning.c", line 214, function: multi_heap_free

ELF file SHA256: 0000000000000000000000000000000000000000000000000000000000000000

Backtrace: 0x4008faf8:0x3ffd1d60 0x4008fd75:0x3ffd1d80 0x40157317:0x3ffd1da0 0x400954cd:0x3ffd1dd0 0x40085d82:0x3ffd1df0 0x4008c131:0x3ffd1e10 0x4000bec7:0x3ffd1e30 0x401889d5:0x3ffd1e50 0x4018c05e:0x3ffd1e70 0x400ddcb6:0x3ffd1e90 0x400d99ba:0x3ffd1ed0 0x400d9a5d:0x3ffd1ef0 0x400da2fd:0x3ffd21a0 0x400dd105:0x3ffd21c0 0x400dd539:0x3ffd2210 0x400dcaa2:0x3ffd2230 0x400dae35:0x3ffd2290 0x400f0211:0x3ffd22b0 0x400eb28e:0x3ffd22f0 0x400920ed:0x3ffd2320



Decoding stack results
0x4008faf8: invoke_abort at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/esp32/panic.c line 156
0x4008fd75: abort at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/esp32/panic.c line 171
0x40157317: __assert_func at ../../../.././newlib/libc/stdlib/assert.c line 63
0x400954cd: multi_heap_free at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/heap/multi_heap_poisoning.c line 214
0x40085d82: heap_caps_free at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/heap/heap_caps.c line 269
0x4008c131: _free_r at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/newlib/syscalls.c line 42
0x401889d5: operator delete(void*) at /builds/idf/crosstool-NG/.build/src/gcc-5.2.0/libstdc++-v3/libsupc++/del_op.cc line 46
0x4018c05e: std::__cxx11::basic_string  , std::allocator  >::_M_dispose() at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/build/build-cc-gcc-final/xtensa-esp32-elf/libstdc++-v3/include/ext/new_allocator.h line 110
0x400ddcb6: BLEValue::setValue(unsigned char*, unsigned int) at c:\users\baram\appdata\local\arduino15\packages\esp32\tools\xtensa-esp32-elf-gcc\1.22.0-80-g6c4433a-5.2.0\xtensa-esp32-elf\include\c++\5.2.0\bits/basic_string.h line 544
0x400d99ba: BLECharacteristic::setValue(unsigned char*, unsigned int) at C:\Users\Baram\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.2-rc1\libraries\BLE\src\BLECharacteristic.cpp line 633
0x400d9a5d: BLECharacteristic::handleGATTServerEvent(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at C:\Users\Baram\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.2-rc1\libraries\BLE\src\BLECharacteristic.cpp line 283
0x400da2fd: BLECharacteristicMap::handleGATTServerEvent(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at C:\Users\Baram\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.2-rc1\libraries\BLE\src\BLECharacteristicMap.cpp line 87
0x400dd105: BLEService::handleGATTServerEvent(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at C:\Users\Baram\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.2-rc1\libraries\BLE\src\BLEService.cpp line 362
0x400dd539: BLEServiceMap::handleGATTServerEvent(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at C:\Users\Baram\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.2-rc1\libraries\BLE\src\BLEServiceMap.cpp line 90
0x400dcaa2: BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at C:\Users\Baram\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.2-rc1\libraries\BLE\src\BLEServer.cpp line 269
0x400dae35: BLEDevice::gattServerEventHandler(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at C:\Users\Baram\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.2-rc1\libraries\BLE\src\BLEDevice.cpp line 129
0x400f0211: btc_gatts_cb_handler at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/bt/bluedroid/btc/profile/std/gatt/btc_gatts.c line 54
0x400eb28e: btc_task at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/bt/bluedroid/btc/core/btc_task.c line 110
0x400920ed: vPortTaskWrapper at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/freertos/port.c line 143


