### PR TITLE
Remove empty line that trips copyright detection

### DIFF
--- a/tools/sdk/include/newlib/sys/features.h
+++ b/tools/sdk/include/newlib/sys/features.h
@@ -2,7 +2,6 @@
  *  Written by Joel Sherrill <joel@OARcorp.com>.
  *
  *  COPYRIGHT (c) 1989-2000.
- *
  *  On-Line Applications Research Corporation (OAR).
  *
  *  Permission to use, copy, modify, and distribute this software for any


### PR DESCRIPTION
This file contains an empty line in the middle of its copyright
statement. This is uncommon in this codebase and in general and makes it
difficult to properly detect a copyright. It triggered a rare copyright
detection issue in scancode-toolkit. Remove this one case help users
of this codebase to better scan and comply with its licenses.

Link: https://github.com/nexB/scancode-toolkit/issues/1565
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>