### PR TITLE
FIXED "heap != NULL && "free() target pointer is outside heap areas" on BLERemoteCharacteristic::readValue()

### DIFF
--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -39,6 +39,7 @@ BLERemoteCharacteristic::BLERemoteCharacteristic(
 	m_charProp       = charProp;
 	m_pRemoteService = pRemoteService;
 	m_notifyCallback = nullptr;
+	m_rawData = nullptr;
 
 	retrieveDescriptors(); // Get the descriptors for this characteristic
 	log_v("<< BLERemoteCharacteristic");


### PR DESCRIPTION
When calling the function `BLERemoteCharacteristic::readValue()` sometimes it gave this error:

[D][FreeRTOS.cpp:158] take(): Semaphore taking: name: ReadCharEvt (0x3fff8f00), owner: <N/A> for readValue
[D][FreeRTOS.cpp:167] take(): Semaphore taken:  name: ReadCharEvt (0x3fff8f00), owner: readValue
[D][BLEDevice.cpp:154] gattClientEventHandler(): gattClientEventHandler [esp_gatt_if: 4] ... Unknown
[D][BLEClient.cpp:158] gattClientEventHandler(): gattClientEventHandler [esp_gatt_if: 4] ... Unknown
assertion "heap != NULL && "free() target pointer is outside heap areas"" failed: file "/Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/heap/heap_caps.c", line 267, function: heap_caps_free
abort() was called at PC 0x4016a1cf on core 0

Backtrace: 0x40093d80:0x3ffe2310 0x40093fb1:0x3ffe2330 0x4016a1cf:0x3ffe2350 0x40086903:0x3ffe2380 0x4008c985:0x3ffe23a0 0x4000bec7:0x3ffe23c0 0x400e4036:0x3ffe23e0 0x400e4981:0x3ffe2420 0x400e30c5:0x3ffe2440 0x400e3bfd:0x3ffe24f0 0x40100179:0x3ffe2560 0x400fc13e:0x3ffe25b0 0x4008f9e5:0x3ffe25e0

This error is generated on free on row 185
`if(m_rawData != nullptr) free(m_rawData);`
