### PR TITLE
Ignore Werror-maybe-uninitialized from Azure IoT Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,3 +209,8 @@ set(COMPONENT_REQUIRES spi_flash mbedtls mdns ethernet)
 set(COMPONENT_PRIV_REQUIRES fatfs nvs_flash app_update spiffs bootloader_support openssl bt)
 
 register_component()
+
+set_source_files_properties(libraries/AzureIoT/src/az_iot/iothub_client/src/iothubtransport_mqtt_common.c
+    PROPERTIES COMPILE_FLAGS
+    -Wno-maybe-uninitialized
+)


### PR DESCRIPTION
Ignore the error about a potentially uninitialized variable
in the Azure library that will occur when compiling as a component
in ESP-IDF.

See https://github.com/espressif/arduino-esp32/issues/2822