### PR TITLE
Fix HTTPClient persistance issue for HTTP1.1 see ESP8266 issue #6152

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1080,6 +1080,8 @@ int HTTPClient::handleHeaderResponse()
         return HTTPC_ERROR_NOT_CONNECTED;
     }
 
+    _canReuse = !_useHTTP10;
+
     String transferEncoding;
     _returnCode = -1;
     _size = -1;
@@ -1098,6 +1100,7 @@ int HTTPClient::handleHeaderResponse()
 
             if(headerLine.startsWith("HTTP/1.")) {
                 _returnCode = headerLine.substring(9, headerLine.indexOf(' ', 9)).toInt();
+                _canReuse = (_returnCode != '0');
             } else if(headerLine.indexOf(':')) {
                 String headerName = headerLine.substring(0, headerLine.indexOf(':'));
                 String headerValue = headerLine.substring(headerLine.indexOf(':') + 1);

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -217,7 +217,7 @@ protected:
     String _host;
     uint16_t _port = 0;
     int32_t _connectTimeout = -1;
-    bool _reuse = false;
+    bool _reuse = true;
     uint16_t _tcpTimeout = HTTPCLIENT_DEFAULT_TCP_TIMEOUT;
     bool _useHTTP10 = false;
     bool _secure = false;


### PR DESCRIPTION
HTTPClient's Persistence support does not follow the RFC 2068 standard for HTTP 1.1 but follows HTTP 1.0 instead. This [issue](https://github.com/esp8266/Arduino/issues/6152) was found by @jpboucher for the **ESP8266**. With this PR it is fixed for the **ESP32** too.