### PR TITLE
Add hooks for sketches/libraries to perform work on each yield() and completed loop()

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -130,6 +130,9 @@ void init(void);
 void initVariant(void);
 void initArduino(void);
 
+void yield_completed(void);
+void loop_completed(void);
+
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout);
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout);
 

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -134,6 +134,22 @@ unsigned long IRAM_ATTR millis()
     return (unsigned long) (esp_timer_get_time() / 1000ULL);
 }
 
+void IRAM_ATTR delayMicroseconds(uint32_t us)
+{
+    uint32_t m = micros();
+    if(us){
+        uint32_t e = (m + us);
+        if(m > e){ //overflow
+            while(micros() > e){
+                NOP();
+            }
+        }
+        while(micros() < e){
+            NOP();
+        }
+    }
+}
+
 void initVariant() __attribute__((weak));
 void initVariant() {}
 
@@ -154,30 +170,14 @@ bool btInUse() { return false; }
 
 void yield()
 {
-	vPortYield();
-	yield_completed();
+    vPortYield();
+    yield_completed();
 }
 
 void delay(uint32_t ms)
 {
-	vTaskDelay(ms / portTICK_PERIOD_MS);
-	yield_completed();
-}
-
-void IRAM_ATTR delayMicroseconds(uint32_t us)
-{
-    uint32_t m = micros();
-    if(us){
-        uint32_t e = (m + us);
-        if(m > e){ //overflow
-            while(micros() > e){
-                NOP();
-            }
-        }
-        while(micros() < e){
-            NOP();
-        }
-    }
+    vTaskDelay(ms / portTICK_PERIOD_MS);
+    yield_completed();
 }
 
 void initArduino()

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -17,6 +17,7 @@ void loopTask(void *pvParameters)
             esp_task_wdt_reset();
         }
         loop();
+        loop_completed();
     }
 }
 
@@ -26,5 +27,8 @@ extern "C" void app_main()
     initArduino();
     xTaskCreateUniversal(loopTask, "loopTask", 8192, NULL, 1, &loopTaskHandle, CONFIG_ARDUINO_RUNNING_CORE);
 }
+
+extern "C" void loop_completed() __attribute__((weak));
+extern "C" void loop_completed() {}
 
 #endif


### PR DESCRIPTION
For periodic workloads, as in some libraries, being able perform on each yield() and after each loop without modifications to the main sketch code, is very useful, sometimes even necessary. Full multi-tasking / threading may sometimes not be an option due to data atomicity and other concurrency considerations.