### PR TITLE
fix for BLE Library Compile Error #2866

### DIFF
--- a/libraries/BLE/src/BLEAdvertising.cpp
+++ b/libraries/BLE/src/BLEAdvertising.cpp
@@ -262,7 +262,7 @@ void BLEAdvertising::stop() {
 
 void BLEAdvertising::setDeviceAddress(esp_bd_addr_t addr, esp_ble_addr_type_t type)
 {
-	log_v(">> setPrivateAddress")
+	log_v(">> setPrivateAddress");
 
 	m_advParams.own_addr_type = type;
 	esp_err_t errRc = esp_ble_gap_set_rand_addr((uint8_t*)addr);
@@ -271,7 +271,7 @@ void BLEAdvertising::setDeviceAddress(esp_bd_addr_t addr, esp_ble_addr_type_t ty
 		log_e("esp_ble_gap_set_rand_addr: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 		return;
 	}
-	log_v("<< setPrivateAddress")
+	log_v("<< setPrivateAddress");
 } // setPrivateAddress
 
 /**


### PR DESCRIPTION
Simple fix for missing ';' in the file libraries/BLE/src/BLEAdvertising.cpp.