### PR TITLE
Added support for TinyPICO in the boards list

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -279,6 +279,64 @@ pico32.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 
+tinypico.name=TinyPICO
+
+tinypico.upload.tool=esptool_py
+tinypico.upload.maximum_size=1310720
+tinypico.upload.maximum_data_size=327680
+tinypico.upload.wait_for_upload_port=true
+
+tinypico.serial.disableDTR=true
+tinypico.serial.disableRTS=true
+
+tinypico.build.mcu=esp32
+tinypico.build.core=esp32
+tinypico.build.variant=pico32
+tinypico.build.board=ESP32_PICO
+
+tinypico.build.f_cpu=240000000L
+tinypico.build.flash_size=4MB
+tinypico.build.flash_freq=80m
+tinypico.build.flash_mode=dio
+tinypico.build.boot=dio
+tinypico.build.partitions=default
+tinypico.build.defines=
+
+tinypico.menu.UploadSpeed.921600=921600
+tinypico.menu.UploadSpeed.921600.upload.speed=921600
+tinypico.menu.UploadSpeed.115200=115200
+tinypico.menu.UploadSpeed.115200.upload.speed=115200
+tinypico.menu.UploadSpeed.256000.windows=256000
+tinypico.menu.UploadSpeed.256000.upload.speed=256000
+tinypico.menu.UploadSpeed.230400.windows.upload.speed=256000
+tinypico.menu.UploadSpeed.230400=230400
+tinypico.menu.UploadSpeed.230400.upload.speed=230400
+tinypico.menu.UploadSpeed.460800.linux=460800
+tinypico.menu.UploadSpeed.460800.macosx=460800
+tinypico.menu.UploadSpeed.460800.upload.speed=460800
+tinypico.menu.UploadSpeed.512000.windows=512000
+tinypico.menu.UploadSpeed.512000.upload.speed=512000
+
+tinypico.menu.PSRAM.enabled=Enabled
+tinypico.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+tinypico.menu.PSRAM.disabled=Disabled
+tinypico.menu.PSRAM.disabled.build.defines=
+
+tinypico.menu.DebugLevel.none=None
+tinypico.menu.DebugLevel.none.build.code_debug=0
+tinypico.menu.DebugLevel.error=Error
+tinypico.menu.DebugLevel.error.build.code_debug=1
+tinypico.menu.DebugLevel.warn=Warn
+tinypico.menu.DebugLevel.warn.build.code_debug=2
+tinypico.menu.DebugLevel.info=Info
+tinypico.menu.DebugLevel.info.build.code_debug=3
+tinypico.menu.DebugLevel.debug=Debug
+tinypico.menu.DebugLevel.debug.build.code_debug=4
+tinypico.menu.DebugLevel.verbose=Verbose
+tinypico.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 turta_iot_node.name=Turta IoT Node
 
 turta_iot_node.upload.tool=esptool_py

--- a/variants/tinypico/pins_arduino.h
+++ b/variants/tinypico/pins_arduino.h
@@ -1,0 +1,60 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+static const uint8_t APA_POWER = 13;
+static const uint8_t APA_DATA = 2;
+static const uint8_t APA_CLK = 12;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
I have added support for the ESP32 PICO-D4 based TinyPICO in the boards list, so users can select that board when using their TinyPICO.