### PR TITLE
BLE Library onRead Callback fix and Client disconnect feature

### DIFF
--- a/libraries/BLE/src/BLECharacteristic.cpp
+++ b/libraries/BLE/src/BLECharacteristic.cpp
@@ -378,6 +378,10 @@ void BLECharacteristic::handleGATTServerEvent(
 						}
 					} else { // read.is_long == false
 
+						if (m_pCallbacks != nullptr) {  // If is.long is false then this is the first (or only) request to read data, so invoke the callback
+							m_pCallbacks->onRead(this);   // Invoke the read callback.
+						}
+
 						std::string value = m_value.getValue();
 
 						if (value.length() + 1 > maxOffset) {
@@ -391,10 +395,6 @@ void BLECharacteristic::handleGATTServerEvent(
 							rsp.attr_value.len    = value.length();
 							rsp.attr_value.offset = 0;
 							memcpy(rsp.attr_value.value, value.data(), rsp.attr_value.len);
-						}
-
-						if (m_pCallbacks != nullptr) {  // If is.long is false then this is the first (or only) request to read data, so invoke the callback
-							m_pCallbacks->onRead(this);   // Invoke the read callback.
 						}
 					}
 					rsp.attr_value.handle   = param->read.handle;

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -412,4 +412,9 @@ void BLEServer::updateConnParams(esp_bd_addr_t remote_bda, uint16_t minInterval,
 	conn_params.timeout = timeout;    // timeout = 400*10ms = 4000ms
 	esp_ble_gap_update_conn_params(&conn_params); 
 }
+
+void BLEServer::disconnect(uint16_t connId) {
+	esp_ble_gatts_close(m_gatts_if, connId);
+}
+
 #endif // CONFIG_BT_ENABLED

--- a/libraries/BLE/src/BLEServer.h
+++ b/libraries/BLE/src/BLEServer.h
@@ -72,6 +72,7 @@ public:
 	BLEService* 	getServiceByUUID(const char* uuid);
 	BLEService* 	getServiceByUUID(BLEUUID uuid);
 	bool 			connect(BLEAddress address);
+	void 			disconnect(uint16_t connId);
 	uint16_t		m_appId;
 	void			updateConnParams(esp_bd_addr_t remote_bda, uint16_t minInterval, uint16_t maxInterval, uint16_t latency, uint16_t timeout);
 


### PR DESCRIPTION
`onRead` callback is called after the actual data is sent over BLE read response.

Possibly fix of #1982

Also brings useful capability to gracefully disconnect client from BLEServer