### PR TITLE
Fix WebServer hang on client disconnect during upload

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -303,6 +303,7 @@ void WebServer::_uploadWriteByte(uint8_t b){
 }
 
 int WebServer::_uploadReadByte(WiFiClient& client){
+  if (!client.connected()) return -1;
   int res = client.read();
   if(res < 0) {
     // keep trying until you either read a valid byte or timeout


### PR DESCRIPTION
This tiny PR fixes endless loop inside WebServer library if file upload is interrupted by the browser