### PR TITLE
Reduce flash usage up to 214k in one click

### DIFF
--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -84,8 +84,9 @@ esp_bd_addr_t *BLEAddress::getNative() {
  * @return The string representation of the address.
  */
 std::string BLEAddress::toString() {
-	char *res = (char*)malloc(18);
-	snprintf(res, 18, "%02x:%02x:%02x:%02x:%02x:%02x", m_address[0], m_address[1], m_address[2], m_address[3], m_address[4], m_address[5]);
+	auto size = 18;
+	char *res = (char*)malloc(size);
+	snprintf(res, size, "%02x:%02x:%02x:%02x:%02x:%02x", m_address[0], m_address[1], m_address[2], m_address[3], m_address[4], m_address[5]);
 	std::string ret(res);
 	free(res);
 	return ret;

--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -13,6 +13,7 @@
 #include <iomanip>
 #include <string.h>
 #include <stdio.h>
+#include <malloc.h>
 #ifdef ARDUINO_ARCH_ESP32
 #include "esp32-hal-log.h"
 #endif
@@ -83,13 +84,10 @@ esp_bd_addr_t *BLEAddress::getNative() {
  * @return The string representation of the address.
  */
 std::string BLEAddress::toString() {
-	std::stringstream stream;
-	stream << std::setfill('0') << std::setw(2) << std::hex << (int) ((uint8_t*) (m_address))[0] << ':';
-	stream << std::setfill('0') << std::setw(2) << std::hex << (int) ((uint8_t*) (m_address))[1] << ':';
-	stream << std::setfill('0') << std::setw(2) << std::hex << (int) ((uint8_t*) (m_address))[2] << ':';
-	stream << std::setfill('0') << std::setw(2) << std::hex << (int) ((uint8_t*) (m_address))[3] << ':';
-	stream << std::setfill('0') << std::setw(2) << std::hex << (int) ((uint8_t*) (m_address))[4] << ':';
-	stream << std::setfill('0') << std::setw(2) << std::hex << (int) ((uint8_t*) (m_address))[5];
-	return stream.str();
+	char *res = (char*)malloc(18);
+	snprintf(res, 18, "%02x:%02x:%02x:%02x:%02x:%02x", m_address[0], m_address[1], m_address[2], m_address[3], m_address[4], m_address[5]);
+	std::string ret(res);
+	free(res);
+	return ret;
 } // toString
 #endif

--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -484,23 +484,29 @@ void BLEAdvertisedDevice::setTXPower(int8_t txPower) {
  * @return A string representation of this device.
  */
 std::string BLEAdvertisedDevice::toString() {
-	std::stringstream ss;
-	ss << "Name: " << getName() << ", Address: " << getAddress().toString();
+	std::string res = "Name: " + getName() + ", Address: " + getAddress().toString();
 	if (haveAppearance()) {
-		ss << ", appearance: " << getAppearance();
+		char val[6];
+		snprintf(val, sizeof(val), "%d", getAppearance());
+		res += ", appearance: ";
+		res += val;
 	}
 	if (haveManufacturerData()) {
 		char *pHex = BLEUtils::buildHexData(nullptr, (uint8_t*)getManufacturerData().data(), getManufacturerData().length());
-		ss << ", manufacturer data: " << pHex;
+		res += ", manufacturer data: ";
+		res += pHex;
 		free(pHex);
 	}
 	if (haveServiceUUID()) {
-		ss << ", serviceUUID: " << getServiceUUID().toString();
+		res += ", serviceUUID: " + getServiceUUID().toString();
 	}
 	if (haveTXPower()) {
-		ss << ", txPower: " << (int)getTXPower();
+		char val[4];
+		snprintf(val, sizeof(val), "%d", getTXPower());
+		res += ", txPower: ";
+		res += val;
 	}
-	return ss.str();
+	return res;
 } // toString
 
 uint8_t* BLEAdvertisedDevice::getPayload() {

--- a/libraries/BLE/src/BLECharacteristic.cpp
+++ b/libraries/BLE/src/BLECharacteristic.cpp
@@ -717,17 +717,18 @@ void BLECharacteristic::setWriteProperty(bool value) {
  * @return A string representation of the characteristic.
  */
 std::string BLECharacteristic::toString() {
-	std::stringstream stringstream;
-	stringstream << std::hex << std::setfill('0');
-	stringstream << "UUID: " << m_bleUUID.toString() + ", handle: 0x" << std::setw(2) << m_handle;
-	stringstream << " " <<
-		((m_properties & ESP_GATT_CHAR_PROP_BIT_READ) ? "Read " : "") <<
-		((m_properties & ESP_GATT_CHAR_PROP_BIT_WRITE) ? "Write " : "") <<
-		((m_properties & ESP_GATT_CHAR_PROP_BIT_WRITE_NR) ? "WriteNoResponse " : "") <<
-		((m_properties & ESP_GATT_CHAR_PROP_BIT_BROADCAST) ? "Broadcast " : "") <<
-		((m_properties & ESP_GATT_CHAR_PROP_BIT_NOTIFY) ? "Notify " : "") <<
-		((m_properties & ESP_GATT_CHAR_PROP_BIT_INDICATE) ? "Indicate " : "");
-	return stringstream.str();
+	std::string res = "UUID: " + m_bleUUID.toString() + ", handle : 0x";
+	char hex[5];
+	snprintf(hex, sizeof(hex), "%04x", m_handle);
+	res += hex;
+	res += " ";
+	if (m_properties & ESP_GATT_CHAR_PROP_BIT_READ) res += "Read ";
+	if (m_properties & ESP_GATT_CHAR_PROP_BIT_WRITE) res += "Write ";
+	if (m_properties & ESP_GATT_CHAR_PROP_BIT_WRITE_NR) res += "WriteNoResponse ";
+	if (m_properties & ESP_GATT_CHAR_PROP_BIT_BROADCAST) res += "Broadcast ";
+	if (m_properties & ESP_GATT_CHAR_PROP_BIT_NOTIFY) res += "Notify ";
+	if (m_properties & ESP_GATT_CHAR_PROP_BIT_INDICATE) res += "Indicate ";
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLECharacteristicMap.cpp
+++ b/libraries/BLE/src/BLECharacteristicMap.cpp
@@ -116,17 +116,18 @@ void BLECharacteristicMap::setByUUID(BLECharacteristic* pCharacteristic, BLEUUID
  * @return A string representation of the characteristic map.
  */
 std::string BLECharacteristicMap::toString() {
-	std::stringstream stringStream;
-	stringStream << std::hex << std::setfill('0');
+	std::string res;
 	int count = 0;
+	char hex[5];
 	for (auto &myPair: m_uuidMap) {
-		if (count > 0) {
-			stringStream << "\n";
-		}
+		if (count > 0) {res += "\n";}
+		snprintf(hex, sizeof(hex), "%04x", myPair.first->getHandle());
 		count++;
-		stringStream << "handle: 0x" << std::setw(2) << myPair.first->getHandle() << ", uuid: " + myPair.first->getUUID().toString();
+		res += "handle: 0x";
+		res += hex;
+		res += ", uuid: " + myPair.first->getUUID().toString();
 	}
-	return stringStream.str();
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -515,14 +515,13 @@ uint16_t BLEClient::getMTU() {
  * @return A string representation of this client.
  */
 std::string BLEClient::toString() {
-	std::ostringstream ss;
-	ss << "peer address: " << m_peerAddress.toString();
-	ss << "\nServices:\n";
+	std::string res = "peer address: " + m_peerAddress.toString();
+	res += "\nServices:\n";
 	for (auto &myPair : m_servicesMap) {
-		ss << myPair.second->toString() << "\n";
+		res += myPair.second->toString() + "\n";
 	  // myPair.second is the value
 	}
-	return ss.str();
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLEClient.h
+++ b/libraries/BLE/src/BLEClient.h
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <map>
 #include <string>
-#include "BLEExceptions.h"
+//#include "BLEExceptions.h"
 #include "BLERemoteService.h"
 #include "BLEService.h"
 #include "BLEAddress.h"

--- a/libraries/BLE/src/BLEDescriptor.cpp
+++ b/libraries/BLE/src/BLEDescriptor.cpp
@@ -255,10 +255,10 @@ void BLEDescriptor::setAccessPermissions(esp_gatt_perm_t perm) {
  * @return A string representation of the descriptor.
  */
 std::string BLEDescriptor::toString() {
-	std::stringstream stringstream;
-	stringstream << std::hex << std::setfill('0');
-	stringstream << "UUID: " << m_bleUUID.toString() + ", handle: 0x" << std::setw(2) << m_handle;
-	return stringstream.str();
+	char hex[5];
+	snprintf(hex, sizeof(hex), "%04x", m_handle);
+	std::string res = "UUID: " + m_bleUUID.toString() + ", handle: 0x" + hex;
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLEDescriptorMap.cpp
+++ b/libraries/BLE/src/BLEDescriptorMap.cpp
@@ -95,7 +95,7 @@ std::string BLEDescriptorMap::toString() {
 	int count = 0;
 	for (auto &myPair : m_uuidMap) {
 		if (count > 0) {res += "\n";}
-		snprintf(hex, 3, "%04x", myPair.first->getHandle());
+		snprintf(hex, sizeof(hex), "%04x", myPair.first->getHandle());
 		count++;
 		res += "handle: 0x";
 		res += hex;

--- a/libraries/BLE/src/BLEDescriptorMap.cpp
+++ b/libraries/BLE/src/BLEDescriptorMap.cpp
@@ -90,17 +90,18 @@ void BLEDescriptorMap::setByHandle(uint16_t handle, BLEDescriptor* pDescriptor) 
  * @return A string representation of the descriptor map.
  */
 std::string BLEDescriptorMap::toString() {
-	std::stringstream stringStream;
-	stringStream << std::hex << std::setfill('0');
+	std::string res;
+	char hex[5];
 	int count = 0;
 	for (auto &myPair : m_uuidMap) {
-		if (count > 0) {
-			stringStream << "\n";
-		}
+		if (count > 0) {res += "\n";}
+		snprintf(hex, 3, "%04x", myPair.first->getHandle());
 		count++;
-		stringStream << "handle: 0x" << std::setw(2) << myPair.first->getHandle() << ", uuid: " + myPair.first->getUUID().toString();
+		res += "handle: 0x";
+		res += hex;
+		res += ", uuid: " + myPair.first->getUUID().toString();
 	}
-	return stringStream.str();
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -479,9 +479,8 @@ gatts_event_handler BLEDevice::m_customGattsHandler = nullptr;
  * @return A string representation of the nature of this device.
  */
 /* STATIC */ std::string BLEDevice::toString() {
-	std::ostringstream oss;
-	oss << "BD Address: " << getAddress().toString();
-	return oss.str();
+	std::string res = "BD Address: " + getAddress().toString();
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLEEddystoneTLM.cpp
+++ b/libraries/BLE/src/BLEEddystoneTLM.cpp
@@ -56,7 +56,6 @@ uint32_t BLEEddystoneTLM::getTime() {
 std::string BLEEddystoneTLM::toString() {
   std::string out = "";
   uint32_t rawsec = ENDIAN_CHANGE_U32(m_eddystoneData.tmil);
-  float temp = (float)m_eddystoneData.temp;
   char val[6];
 
   out += "Version " + m_eddystoneData.version;
@@ -65,12 +64,9 @@ std::string BLEEddystoneTLM::toString() {
   out += " mV\n";
 
   out += "Temperature ";
-  snprintf(val, sizeof(val), "%d", (int)m_eddystoneData.temp);
+  snprintf(val, sizeof(val), "%d", m_eddystoneData.temp);
   out += val;
-  out += ".";
-  snprintf(val, sizeof(val), "%d", ((int)(m_eddystoneData.temp * 100)) % 100);
-  out += val;
-  out += " °C\n";
+  out += ".0 °C\n";
 
   out += "Adv. Count ";
   snprintf(val, sizeof(val), "%d", ENDIAN_CHANGE_U32(m_eddystoneData.advCount));

--- a/libraries/BLE/src/BLEEddystoneTLM.cpp
+++ b/libraries/BLE/src/BLEEddystoneTLM.cpp
@@ -7,7 +7,7 @@
 #include "sdkconfig.h"
 #if defined(CONFIG_BT_ENABLED)
 #include <string.h>
-#include <sstream>
+#include <stdio.h>
 #include "esp32-hal-log.h"
 #include "BLEEddystoneTLM.h"
 
@@ -54,62 +54,48 @@ uint32_t BLEEddystoneTLM::getTime() {
 } // getTime
 
 std::string BLEEddystoneTLM::toString() {
-	std::stringstream ss;
-	std::string out = "";
-  uint32_t rawsec;
-  ss << "Version ";
-  ss << std::dec << m_eddystoneData.version;
-  ss << "\n";
+  std::string out = "";
+  uint32_t rawsec = ENDIAN_CHANGE_U32(m_eddystoneData.tmil);
+  float temp = (float)m_eddystoneData.temp;
+  char val[6];
 
-  ss << "Battery Voltage ";
-  ss << std::dec << ENDIAN_CHANGE_U16(m_eddystoneData.volt);
-  ss << " mV\n";
+  out += "Version " + m_eddystoneData.version;
+  out += "\n";
+  out += "Battery Voltage " + ENDIAN_CHANGE_U16(m_eddystoneData.volt);
+  out += " mV\n";
 
-  ss << "Temperature ";
-  ss << (float) m_eddystoneData.temp;
-  ss << " °C\n";
+  out += "Temperature ";
+  snprintf(val, sizeof(val), "%d", (int)m_eddystoneData.temp);
+  out += val;
+  out += ".";
+  snprintf(val, sizeof(val), "%d", ((int)(m_eddystoneData.temp * 100)) % 100);
+  out += val;
+  out += " °C\n";
 
-  ss << "Adv. Count ";
-  ss << std::dec << ENDIAN_CHANGE_U32(m_eddystoneData.advCount);
+  out += "Adv. Count ";
+  snprintf(val, sizeof(val), "%d", ENDIAN_CHANGE_U32(m_eddystoneData.advCount));
+  out += val;
+  out += "\n";
 
-  ss << "\n";
+  out += "Time ";
 
-  ss << "Time ";
+  snprintf(val, sizeof(val), "%04d", rawsec / 864000);
+  out += val;
+  out += ".";
 
-  rawsec = ENDIAN_CHANGE_U32(m_eddystoneData.tmil);
-  std::stringstream buffstream;
-  buffstream << "0000";
-  buffstream << std::dec << rawsec / 864000;
-  std::string buff = buffstream.str();
+  snprintf(val, sizeof(val), "%02d", (rawsec / 36000) % 24);
+  out += val;
+  out += ":";
 
-  ss << buff.substr(buff.length() - 4, buff.length());
-  ss << ".";
+  snprintf(val, sizeof(val), "%02d", (rawsec / 600) % 60);
+  out += val;
+  out += ":";
 
-  buffstream.str("");
-  buffstream.clear();
-  buffstream << "00";
-  buffstream << std::dec << (rawsec / 36000) % 24;
-  buff = buffstream.str();
-  ss << buff.substr(buff.length()-2, buff.length());
-  ss << ":";
+  snprintf(val, sizeof(val), "%02d", (rawsec / 10) % 60);
+  out += val;
+  out += "\n";
 
-  buffstream.str("");
-  buffstream.clear();
-  buffstream << "00";
-  buffstream << std::dec << (rawsec / 600) % 60;
-  buff = buffstream.str();
-  ss << buff.substr(buff.length() - 2, buff.length());
-  ss << ":";
-
-  buffstream.str("");
-  buffstream.clear();
-  buffstream << "00";
-  buffstream << std::dec << (rawsec / 10) % 60;
-  buff = buffstream.str();
-  ss << buff.substr(buff.length() - 2, buff.length());
-  ss << "\n";
-
-  return ss.str();
+  return out;
 } // toString
 
 /**

--- a/libraries/BLE/src/BLEExceptions.cpp
+++ b/libraries/BLE/src/BLEExceptions.cpp
@@ -5,5 +5,5 @@
  *      Author: kolban
  */
 
-#include "BLEExceptions.h"
+//#include "BLEExceptions.h"
 

--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -400,7 +400,8 @@ std::string BLERemoteCharacteristic::readValue() {
 	// Check to see that we are connected.
 	if (!getRemoteService()->getClient()->isConnected()) {
 		log_e("Disconnected");
-//		throw BLEDisconnectedException();
+//		throw BLEDisconnectedException(); TODO:: think about error reporting mechanism
+		return std::string();
 	}
 
 	m_semaphoreReadCharEvt.take("readValue");

--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -14,7 +14,7 @@
 #include <esp_err.h>
 
 #include <sstream>
-#include "BLEExceptions.h"
+//#include "BLEExceptions.h"
 #include "BLEUtils.h"
 #include "GeneralUtils.h"
 #include "BLERemoteDescriptor.h"
@@ -400,7 +400,7 @@ std::string BLERemoteCharacteristic::readValue() {
 	// Check to see that we are connected.
 	if (!getRemoteService()->getClient()->isConnected()) {
 		log_e("Disconnected");
-		throw BLEDisconnectedException();
+//		throw BLEDisconnectedException();
 	}
 
 	m_semaphoreReadCharEvt.take("readValue");
@@ -501,11 +501,16 @@ void BLERemoteCharacteristic::removeDescriptors() {
  * @return a String representation.
  */
 std::string BLERemoteCharacteristic::toString() {
-	std::ostringstream ss;
-	ss << "Characteristic: uuid: " << m_uuid.toString() <<
-		", handle: " << getHandle() << " 0x" << std::hex << getHandle() <<
-		", props: " << BLEUtils::characteristicPropertiesToString(m_charProp);
-	return ss.str();
+	std::string res = "Characteristic: uuid: " + m_uuid.toString();
+	char val[6];
+	res += ", handle: ";
+	snprintf(val, sizeof(val), "%d", getHandle());
+	res += val;
+	res += " 0x";
+	snprintf(val, sizeof(val), "%04x", getHandle());
+	res += val;
+	res += ", props: " + BLEUtils::characteristicPropertiesToString(m_charProp);
+	return res;
 } // toString
 
 
@@ -546,7 +551,7 @@ void BLERemoteCharacteristic::writeValue(uint8_t* data, size_t length, bool resp
 	// Check to see that we are connected.
 	if (!getRemoteService()->getClient()->isConnected()) {
 		log_e("Disconnected");
-		throw BLEDisconnectedException();
+//		throw BLEDisconnectedException();
 	}
 
 	m_semaphoreWriteCharEvt.take("writeValue");

--- a/libraries/BLE/src/BLERemoteDescriptor.cpp
+++ b/libraries/BLE/src/BLERemoteDescriptor.cpp
@@ -55,7 +55,7 @@ std::string BLERemoteDescriptor::readValue() {
 	// Check to see that we are connected.
 	if (!getRemoteCharacteristic()->getRemoteService()->getClient()->isConnected()) {
 		log_e("Disconnected");
-		throw BLEDisconnectedException();
+//		throw BLEDisconnectedException();
 	}
 
 	m_semaphoreReadDescrEvt.take("readValue");
@@ -113,9 +113,12 @@ uint32_t BLERemoteDescriptor::readUInt32() {
  * @retun A string representation of this BLE Remote Descriptor.
  */
 std::string BLERemoteDescriptor::toString() {
-	std::stringstream ss;
-	ss << "handle: " << getHandle() << ", uuid: " << getUUID().toString();
-	return ss.str();
+	char val[6];
+	snprintf(val, sizeof(val), "%d", getHandle());
+	std::string res = "handle: ";
+	res += val;
+	res += ", uuid: " + getUUID().toString();
+	return res;
 } // toString
 
 
@@ -130,7 +133,7 @@ void BLERemoteDescriptor::writeValue(uint8_t* data, size_t length, bool response
 	// Check to see that we are connected.
 	if (!getRemoteCharacteristic()->getRemoteService()->getClient()->isConnected()) {
 		log_e("Disconnected");
-		throw BLEDisconnectedException();
+//		throw BLEDisconnectedException();
 	}
 
 	esp_err_t errRc = ::esp_ble_gattc_write_char_descr(

--- a/libraries/BLE/src/BLERemoteDescriptor.cpp
+++ b/libraries/BLE/src/BLERemoteDescriptor.cpp
@@ -55,7 +55,8 @@ std::string BLERemoteDescriptor::readValue() {
 	// Check to see that we are connected.
 	if (!getRemoteCharacteristic()->getRemoteService()->getClient()->isConnected()) {
 		log_e("Disconnected");
-//		throw BLEDisconnectedException();
+//		throw BLEDisconnectedException(); TODO:: think about error reporting mechanism
+		return std::string();
 	}
 
 	m_semaphoreReadDescrEvt.take("readValue");
@@ -133,7 +134,8 @@ void BLERemoteDescriptor::writeValue(uint8_t* data, size_t length, bool response
 	// Check to see that we are connected.
 	if (!getRemoteCharacteristic()->getRemoteService()->getClient()->isConnected()) {
 		log_e("Disconnected");
-//		throw BLEDisconnectedException();
+//		throw BLEDisconnectedException(); TODO:: think about error reporting mechanism
+		return;
 	}
 
 	esp_err_t errRc = ::esp_ble_gattc_write_char_descr(

--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -317,15 +317,25 @@ void BLERemoteService::setValue(BLEUUID characteristicUuid, std::string value) {
  * @return A string representation of this remote service.
  */
 std::string BLERemoteService::toString() {
-	std::ostringstream ss;
-	ss << "Service: uuid: " + m_uuid.toString();
-	ss << ", start_handle: " << std::dec << m_startHandle << " 0x" << std::hex << m_startHandle <<
-			", end_handle: " << std::dec << m_endHandle << " 0x" << std::hex << m_endHandle;
+	std::string res = "Service: uuid: " + m_uuid.toString();
+	char val[6];
+	res += ", start_handle: ";
+	snprintf(val, sizeof(val), "%d", m_startHandle);
+	res += val;
+	snprintf(val, sizeof(val), "%04x", m_startHandle);
+	res += " 0x";
+	res += val;
+	res += ", end_handle: ";
+	snprintf(val, sizeof(val), "%d", m_endHandle);
+	res += val;
+	snprintf(val, sizeof(val), "%04x", m_endHandle);
+	res += " 0x";
+	res += val;
 	for (auto &myPair : m_characteristicMap) {
-		ss << "\n" << myPair.second->toString();
+		res += "\n" + myPair.second->toString();
 	   // myPair.second is the value
 	}
-	return ss.str();
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLEService.cpp
+++ b/libraries/BLE/src/BLEService.cpp
@@ -381,10 +381,12 @@ BLECharacteristic* BLEService::getCharacteristic(BLEUUID uuid) {
  * @return A string representation of this service.
  */
 std::string BLEService::toString() {
-	std::stringstream stringStream;
-	stringStream << "UUID: " << getUUID().toString() <<
-		", handle: 0x" << std::hex << std::setfill('0') << std::setw(2) << getHandle();
-	return stringStream.str();
+	std::string res = "UUID: " + getUUID().toString();
+	char hex[5];
+	snprintf(hex, sizeof(hex), "%04x", getHandle());
+	res += ", handle: 0x";
+	res += hex;
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/BLEServiceMap.cpp
+++ b/libraries/BLE/src/BLEServiceMap.cpp
@@ -6,7 +6,7 @@
  */
 #include "sdkconfig.h"
 #if defined(CONFIG_BT_ENABLED)
-#include <sstream>
+#include <stdio.h>
 #include <iomanip>
 #include "BLEService.h"
 
@@ -73,12 +73,15 @@ void BLEServiceMap::setByHandle(uint16_t handle, BLEService* service) {
  * @return A string representation of the service map.
  */
 std::string BLEServiceMap::toString() {
-	std::stringstream stringStream;
-	stringStream << std::hex << std::setfill('0');
+	std::string res;
+	char hex[5];
 	for (auto &myPair: m_handleMap) {
-		stringStream << "handle: 0x" << std::setw(2) << myPair.first << ", uuid: " + myPair.second->getUUID().toString() << "\n";
+		res += "handle: 0x";
+		snprintf(hex, sizeof(hex), "%04x", myPair.first);
+		res += hex;
+		res += ", uuid: " + myPair.second->getUUID().toString() + "\n";
 	}
-	return stringStream.str();
+	return res;
 } // toString
 
 void BLEServiceMap::handleGATTServerEvent(

--- a/libraries/BLE/src/BLEUUID.cpp
+++ b/libraries/BLE/src/BLEUUID.cpp
@@ -349,51 +349,37 @@ BLEUUID BLEUUID::to128() {
  */
 std::string BLEUUID::toString() {
 	if (!m_valueSet) return "<NULL>";   // If we have no value, nothing to format.
-
 	// If the UUIDs are 16 or 32 bit, pad correctly.
-	std::stringstream ss;
 
 	if (m_uuid.len == ESP_UUID_LEN_16) {  // If the UUID is 16bit, pad correctly.
-		ss << "0000" <<
-			std::hex <<
-			std::setfill('0') <<
-			std::setw(4) <<
-			m_uuid.uuid.uuid16 <<
-			"-0000-1000-8000-00805f9b34fb";
-		return ss.str();                    // Return the string
+		char hex[5];
+		snprintf(hex, sizeof(hex), "%04x", m_uuid.uuid.uuid16);
+		return std::string(hex) + "-0000-1000-8000-00805f9b34fb";
 	} // End 16bit UUID
 
 	if (m_uuid.len == ESP_UUID_LEN_32) {  // If the UUID is 32bit, pad correctly.
-		ss << std::hex <<
-			std::setfill('0') <<
-			std::setw(8) <<
-			m_uuid.uuid.uuid32 <<
-			"-0000-1000-8000-00805f9b34fb";
-		return ss.str();                    // return the string
+		char hex[9];
+		snprintf(hex, sizeof(hex), "%08x", m_uuid.uuid.uuid32);
+		return std::string(hex) + "-0000-1000-8000-00805f9b34fb";
 	} // End 32bit UUID
 
 	// The UUID is not 16bit or 32bit which means that it is 128bit.
 	//
 	// UUID string format:
 	// AABBCCDD-EEFF-GGHH-IIJJ-KKLLMMNNOOPP
-	ss << std::hex << std::setfill('0') <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[15] <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[14] <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[13] <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[12] << "-" <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[11] <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[10] << "-" <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[9]  <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[8]  << "-" <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[7]  <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[6]  << "-" <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[5]  <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[4]  <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[3]  <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[2]  <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[1]  <<
-		std::setw(2) << (int) m_uuid.uuid.uuid128[0];
-	return ss.str();
+	char *hex = (char *)malloc(35);
+	snprintf(hex, 35, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+			m_uuid.uuid.uuid128[15], m_uuid.uuid.uuid128[14],
+			m_uuid.uuid.uuid128[13], m_uuid.uuid.uuid128[12],
+			m_uuid.uuid.uuid128[11], m_uuid.uuid.uuid128[10],
+			m_uuid.uuid.uuid128[9], m_uuid.uuid.uuid128[8],
+			m_uuid.uuid.uuid128[7], m_uuid.uuid.uuid128[6],
+			m_uuid.uuid.uuid128[5], m_uuid.uuid.uuid128[4],
+			m_uuid.uuid.uuid128[3], m_uuid.uuid.uuid128[2],
+			m_uuid.uuid.uuid128[1], m_uuid.uuid.uuid128[0]);
+	std::string res(hex);
+	free(hex);
+	return res;
 } // toString
 
 #endif /* CONFIG_BT_ENABLED */

--- a/libraries/BLE/src/BLEUUID.cpp
+++ b/libraries/BLE/src/BLEUUID.cpp
@@ -367,8 +367,9 @@ std::string BLEUUID::toString() {
 	//
 	// UUID string format:
 	// AABBCCDD-EEFF-GGHH-IIJJ-KKLLMMNNOOPP
-	char *hex = (char *)malloc(35);
-	snprintf(hex, 35, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+	auto size = 35;
+	char *hex = (char *)malloc(size);
+	snprintf(hex, size, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
 			m_uuid.uuid.uuid128[15], m_uuid.uuid.uuid128[14],
 			m_uuid.uuid.uuid128[13], m_uuid.uuid.uuid128[12],
 			m_uuid.uuid.uuid128[11], m_uuid.uuid.uuid128[10],

--- a/libraries/BLE/src/BLEUtils.cpp
+++ b/libraries/BLE/src/BLEUtils.cpp
@@ -604,26 +604,32 @@ static const gattService_t g_gattServices[] = {
  * @return A string representation of characteristic properties.
  */
 std::string BLEUtils::characteristicPropertiesToString(esp_gatt_char_prop_t prop) {
-	std::stringstream stream;
-	stream <<
-			"broadcast: "  << ((prop & ESP_GATT_CHAR_PROP_BIT_BROADCAST)?"1":"0") <<
-			", read: "     << ((prop & ESP_GATT_CHAR_PROP_BIT_READ)?"1":"0") <<
-			", write_nr: " << ((prop & ESP_GATT_CHAR_PROP_BIT_WRITE_NR)?"1":"0") <<
-			", write: "    << ((prop & ESP_GATT_CHAR_PROP_BIT_WRITE)?"1":"0") <<
-			", notify: "   << ((prop & ESP_GATT_CHAR_PROP_BIT_NOTIFY)?"1":"0") <<
-			", indicate: " << ((prop & ESP_GATT_CHAR_PROP_BIT_INDICATE)?"1":"0") <<
-			", auth: "     << ((prop & ESP_GATT_CHAR_PROP_BIT_AUTH)?"1":"0");
-	return stream.str();
+	std::string res = "broadcast: ";
+	res += ((prop & ESP_GATT_CHAR_PROP_BIT_BROADCAST)?"1":"0");
+	res += ", read: ";
+	res += ((prop & ESP_GATT_CHAR_PROP_BIT_READ)?"1":"0");
+	res += ", write_nr: ";
+	res += ((prop & ESP_GATT_CHAR_PROP_BIT_WRITE_NR)?"1":"0");
+	res += ", write: ";
+	res += ((prop & ESP_GATT_CHAR_PROP_BIT_WRITE)?"1":"0");
+	res += ", notify: ";
+	res += ((prop & ESP_GATT_CHAR_PROP_BIT_NOTIFY)?"1":"0");
+	res += ", indicate: ";
+	res += ((prop & ESP_GATT_CHAR_PROP_BIT_INDICATE)?"1":"0");
+	res += ", auth: ";
+	res += ((prop & ESP_GATT_CHAR_PROP_BIT_AUTH)?"1":"0");
+	return res;
 } // characteristicPropertiesToString
 
 /**
  * @brief Convert an esp_gatt_id_t to a string.
  */
 static std::string gattIdToString(esp_gatt_id_t gattId) {
-	std::stringstream stream;
-	stream << "uuid: " << BLEUUID(gattId.uuid).toString() << ", inst_id: " << (int)gattId.inst_id;
-	//sprintf(buffer, "uuid: %s, inst_id: %d", uuidToString(gattId.uuid).c_str(), gattId.inst_id);
-	return stream.str();
+	std::string res = "uuid: " + BLEUUID(gattId.uuid).toString() + ", inst_id: ";
+	char val[8];
+	snprintf(val, sizeof(val), "%d", (int)gattId.inst_id);
+	res += val;
+	return res;
 } // gattIdToString
 
 
@@ -654,23 +660,23 @@ const char* BLEUtils::addressTypeToString(esp_ble_addr_type_t type) {
  * @return std::string A string representation of the advertising flags.
  */
 std::string BLEUtils::adFlagsToString(uint8_t adFlags) {
-	std::stringstream ss;
+	std::string res;
 	if (adFlags & (1 << 0)) {
-		ss << "[LE Limited Discoverable Mode] ";
+		res += "[LE Limited Discoverable Mode] ";
 	}
 	if (adFlags & (1 << 1)) {
-		ss << "[LE General Discoverable Mode] ";
+		res += "[LE General Discoverable Mode] ";
 	}
 	if (adFlags & (1 << 2)) {
-		ss << "[BR/EDR Not Supported] ";
+		res += "[BR/EDR Not Supported] ";
 	}
 	if (adFlags & (1 << 3)) {
-		ss << "[Simultaneous LE and BR/EDR to Same Device Capable (Controller)] ";
+		res += "[Simultaneous LE and BR/EDR to Same Device Capable (Controller)] ";
 	}
 	if (adFlags & (1 << 4)) {
-		ss << "[Simultaneous LE and BR/EDR to Same Device Capable (Host)] ";
+		res += "[Simultaneous LE and BR/EDR to Same Device Capable (Host)] ";
 	}
-	return ss.str();
+	return res;
 } // adFlagsToString
 
 
@@ -802,13 +808,13 @@ char* BLEUtils::buildHexData(uint8_t* target, uint8_t* source, uint8_t length) {
  * @return A string representation of a piece of memory.
  */
 std::string BLEUtils::buildPrintData(uint8_t* source, size_t length) {
-	std::ostringstream ss;
+	std::string res;
 	for (int i = 0; i < length; i++) {
 		char c = *source;
-		ss << (isprint(c) ? c : '.');
+		res += (isprint(c) ? c : '.');
 		source++;
 	}
-	return ss.str();
+	return res;
 } // buildPrintData
 
 
@@ -1848,14 +1854,22 @@ std::string BLEUtils::gattDescriptorUUIDToString(uint32_t descriptorUUID) {
  * @return A string representation of an esp_gattc_service_elem_t.
  */
 std::string BLEUtils::gattcServiceElementToString(esp_gattc_service_elem_t* pGATTCServiceElement) {
-	std::stringstream ss;
-
-	ss << "[uuid: " << BLEUUID(pGATTCServiceElement->uuid).toString() <<
-		", start_handle: " << pGATTCServiceElement->start_handle <<
-			" 0x" << std::hex << pGATTCServiceElement->start_handle <<
-		", end_handle: " << std::dec << pGATTCServiceElement->end_handle <<
-		  " 0x" << std::hex << pGATTCServiceElement->end_handle << "]";
-	return ss.str();
+	std::string res;
+	char val[6];
+	res += "[uuid: " + BLEUUID(pGATTCServiceElement->uuid).toString() + ", start_handle: ";
+	snprintf(val, sizeof(val), "%d", pGATTCServiceElement->start_handle);
+	res += val;
+	res += " 0x";
+	snprintf(val, sizeof(val), "%04x", pGATTCServiceElement->start_handle);
+	res += val;
+	res += ", end_handle: ";
+	snprintf(val, sizeof(val), "%d", pGATTCServiceElement->end_handle);
+	res += val;
+	res += " 0x";
+	snprintf(val, sizeof(val), "%04x", pGATTCServiceElement->end_handle);
+	res += val;
+	res += "]";
+	return res;
 } // gattcServiceElementToString
 
 

--- a/libraries/BLE/src/FreeRTOS.cpp
+++ b/libraries/BLE/src/FreeRTOS.cpp
@@ -202,9 +202,12 @@ bool FreeRTOS::Semaphore::take(uint32_t timeoutMs, std::string owner) {
  * @return A string representation of the semaphore.
  */
 std::string FreeRTOS::Semaphore::toString() {
-	std::stringstream stringStream;
-	stringStream << "name: "<< m_name << " (0x" << std::hex << std::setfill('0') << (uint32_t)m_semaphore << "), owner: " << m_owner;
-	return stringStream.str();
+	char hex[9];
+	std::string res = "name: " + m_name + " (0x";
+	snprintf(hex, sizeof(hex), "%08x", (uint32_t)m_semaphore);
+	res += hex;
+	res += "), owner: " + m_owner;
+	return res;
 } // toString
 
 

--- a/libraries/BLE/src/GeneralUtils.cpp
+++ b/libraries/BLE/src/GeneralUtils.cpp
@@ -332,12 +332,12 @@ void GeneralUtils::hexDump(const uint8_t* pData, uint32_t length) {
  * @return A string representation of the IP address.
  */
 std::string GeneralUtils::ipToString(uint8_t *ip) {
-	char *val = (char*)malloc(16);
-	snprintf(val, 16, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	auto size = 16;
+	char *val = (char*)malloc(size);
+	snprintf(val, size, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
 	std::string res(val);
 	free(val);
 	return res;
-	return std::string();
 } // ipToString
 
 

--- a/libraries/BLE/src/GeneralUtils.cpp
+++ b/libraries/BLE/src/GeneralUtils.cpp
@@ -332,9 +332,12 @@ void GeneralUtils::hexDump(const uint8_t* pData, uint32_t length) {
  * @return A string representation of the IP address.
  */
 std::string GeneralUtils::ipToString(uint8_t *ip) {
-	std::stringstream s;
-	s << (int) ip[0] << '.' << (int) ip[1] << '.' << (int) ip[2] << '.' << (int) ip[3];
-	return s.str();
+	char *val = (char*)malloc(16);
+	snprintf(val, 16, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	std::string res(val);
+	free(val);
+	return res;
+	return std::string();
 } // ipToString
 
 
@@ -347,11 +350,14 @@ std::string GeneralUtils::ipToString(uint8_t *ip) {
 std::vector<std::string> GeneralUtils::split(std::string source, char delimiter) {
 	// See also: https://stackoverflow.com/questions/5167625/splitting-a-c-stdstring-using-tokens-e-g
 	std::vector<std::string> strings;
-	std::istringstream iss(source);
-	std::string s;
-	while (std::getline(iss, s, delimiter)) {
-		strings.push_back(trim(s));
+	std::size_t current, previous = 0;
+	current = source.find(delimiter);
+	while (current != std::string::npos) {
+		strings.push_back(trim(source.substr(previous, current - previous)));
+		previous = current + 1;
+		current = source.find(delimiter, previous);
 	}
+	strings.push_back(trim(source.substr(previous, current - previous)));
 	return strings;
 } // split
 


### PR DESCRIPTION
This PR gets rid of stringstream and exception usage in @nkolban  BLE library. While stringstream itself is a good and safe thing on mature desktop platforms, using it in embedded world mostly for debugging purposes has its impact. In this case we can save about **214k**.

Here's a metrics of my test image build.
----
* Stringsream=y
* Exceptions in idf toolchain=y
* Exceptions in library=y
```
$ ls -al build/
-rw-r--r--   1 user  staff    628288 25 июн 16:45 firmware_.bin
```
-----
* Stringsream=n
* Exceptions in library=n
* Exceptions in idf toolchain=y

***Note**: by default exceptions seems to be enabled in Arduino build configuration. So, actual flash size benefit from this PR on most platforms can be about **137k**.*

-----
```
$ ls -al build/
-rw-r--r--   1 user  staff    491184 25 июн 16:49 firmware_.bin
```
----

* Stringsream=n
* Exceptions in library=n
* Exceptions in idf toolchain=n

```
$ ls -al build/
-rw-r--r--   1 user  staff   413616 25 июн 16:38 firmware_.bin
```
