### PR TITLE
Expand gitignore to cover files created by Visual Micro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ tools/esptool.exe
 tools/mkspiffs/mkspiffs
 tools/mkspiffs/mkspiffs.exe
 .DS_Store
+ 
+#Ignore files built by Visual Studio/Visual Micro
+[Dd]ebug*/
+[Rr]elease*/
+.vs/
+__vm/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tools/mkspiffs/mkspiffs.exe
 [Rr]elease*/
 .vs/
 __vm/
+*.vcxproj*


### PR DESCRIPTION
The Arduino IDE for Visual Studio in part uses the standard MS Visual Studio project layout.