### PR TITLE
ESP8266 => ESP32 tidyup, set correct default port

### DIFF
--- a/tools/espota.py
+++ b/tools/espota.py
@@ -236,7 +236,7 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
 def parser(unparsed_args):
   parser = optparse.OptionParser(
     usage = "%prog [options]",
-    description = "Transmit image over the air to the esp8266 module with OTA support."
+    description = "Transmit image over the air to the esp32 module with OTA support."
   )
 
   # destination ip and port
@@ -244,7 +244,7 @@ def parser(unparsed_args):
   group.add_option("-i", "--ip",
     dest = "esp_ip",
     action = "store",
-    help = "ESP8266 IP Address.",
+    help = "ESP32 IP Address.",
     default = False
   )
   group.add_option("-I", "--host_ip",
@@ -256,8 +256,8 @@ def parser(unparsed_args):
   group.add_option("-p", "--port",
     dest = "esp_port",
     type = "int",
-    help = "ESP8266 ota Port. Default 8266",
-    default = 8266
+    help = "ESP32 ota Port. Default 3232",
+    default = 3232
   )
   group.add_option("-P", "--host_port",
     dest = "host_port",
@@ -310,7 +310,7 @@ def parser(unparsed_args):
   group.add_option("-t", "--timeout",
     dest = "timeout",
     type = "int",
-    help = "Timeout to wait for the ESP8266 to accept invitation",
+    help = "Timeout to wait for the ESP32 to accept invitation",
     default = 10
   )
   parser.add_option_group(group)


### PR DESCRIPTION
Tidied up references to the ESP8266, and set the correct default port for the ESP32.

The latter point is the main reason for this PR - I discovered that when you run the `espota.py` tool from this repo against a ESP32 _without_ overriding the default port it would not work... but it was being overridden when run via the Arduino IDE. 

I'm hoping this is just leftovers, and can be corrected?