### PR TITLE
Fix warning -Wempty-body by adding braces to 'if' stmt body

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -333,7 +333,9 @@ const char * system_event_reasons[] = { "UNSPECIFIED", "AUTH_EXPIRE", "AUTH_LEAV
 #endif
 esp_err_t WiFiGenericClass::_eventCallback(void *arg, system_event_t *event)
 {
-    if(event->event_id < 26) log_d("Event: %d - %s", event->event_id, system_event_names[event->event_id]);
+    if(event->event_id < 26) {
+        log_d("Event: %d - %s", event->event_id, system_event_names[event->event_id]);
+    }
     if(event->event_id == SYSTEM_EVENT_SCAN_DONE) {
         WiFiScanClass::_scanDone();
 


### PR DESCRIPTION
This resolves the following build warning when using WiFi:

```
[...]\hardware\espressif\esp32\libraries\WiFi\src\WiFiGeneric.cpp: In static member function 'static esp_err_t WiFiGenericClass::_eventCallback(void*, system_event_t*)':

[...]\hardware\espressif\esp32\libraries\WiFi\src\WiFiGeneric.cpp:336:107: warning: suggest braces around empty body in an 'if' statement [-Wempty-body]

     if(event->event_id < 26) log_d("Event: %d - %s", event->event_id, system_event_names[event->event_id]);
```
