### PR TITLE
Make a selective menuconfig option for FFat

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -232,6 +232,12 @@ config ARDUINO_SELECTIVE_ESPmDNS
     select ARDUINO_SELECTIVE_WiFi
     default y
 
+config ARDUINO_SELECTIVE_FFat
+    bool "Enable FFat"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    select ARDUINO_SELECTIVE_FS
+    default y
+
 config ARDUINO_SELECTIVE_FS
     bool "Enable FS"
     depends on ARDUINO_SELECTIVE_COMPILATION


### PR DESCRIPTION
I think FFat went into core at the same time as the selective menuconfig, so it did not get an option in there.