### PR TITLE
RMT: Fix in bitshift of NeoPixel example project

### DIFF
--- a/libraries/ESP32/examples/RMT/RMTWriteNeoPixel/RMTWriteNeoPixel.ino
+++ b/libraries/ESP32/examples/RMT/RMTWriteNeoPixel/RMTWriteNeoPixel.ino
@@ -62,7 +62,7 @@ void loop()
     for (led=0; led<NR_OF_LEDS; led++) {
         for (col=0; col<3; col++ ) {
             for (bit=0; bit<8; bit++){
-                if ( (color[col] & (1<<(8-bit))) && (led == led_index) ) {
+                if ( (color[col] & (1<<(7-bit))) && (led == led_index) ) {
                     led_data[i].level0 = 1;
                     led_data[i].duration0 = 8;
                     led_data[i].level1 = 0;


### PR DESCRIPTION
Fixed bit shift in demo application of using RMT peripheral. Init data array to be transmitted was off by one, as for the first iteration (i==0) the mask was 1<<8, which resulted in shifted RGB value in `color[]` variable
Closes https://github.com/espressif/arduino-esp32/issues/2921