### PR TITLE
WPA2 connection fix (significant improvement to connection time)

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -162,6 +162,8 @@ wl_status_t WiFiSTAClass::begin(const char* ssid, const char *passphrase, int32_
         esp_wifi_set_config(WIFI_IF_STA, &conf);
     } else if(status() == WL_CONNECTED){
         return WL_CONNECTED;
+    } else {
+        esp_wifi_set_config(WIFI_IF_STA, &conf);
     }
 
     if(!_useStaticIp) {

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -198,6 +198,12 @@ wl_status_t WiFiSTAClass::begin()
         return WL_CONNECT_FAILED;
     }
 
+    wifi_config_t current_conf;
+    if(esp_wifi_get_config(WIFI_IF_STA, &current_conf) != ESP_OK || esp_wifi_set_config(WIFI_IF_STA, &current_conf) != ESP_OK) {
+        log_e("config failed");
+        return WL_CONNECT_FAILED;
+    }
+
     if(!_useStaticIp) {
         if(tcpip_adapter_dhcpc_start(TCPIP_ADAPTER_IF_STA) == ESP_ERR_TCPIP_ADAPTER_DHCPC_START_FAILED){
             log_e("dhcp client start failed!");


### PR DESCRIPTION
This seems to finally fix/workaround the bug that has been plaguing WPA2 connections.
In my testing (home network, WPA2 Personal), connection time has improved from **~1200ms to ~300-350ms**.

The issue seems to be that the underlying WiFi API needs esp_wifi_set_config() to be explicitly called. Perhaps some lwIP settings aren't applied. It might even be a clash with the ARP check config specifically.

This is not specific to Arduino, but it is a band-aid for now. Also tested with esp-idf (PlatformIO) , esp-idf + Arduino component (PlatformIO), Arduino (IDE and PlatformIO). 
I'll create an issue on the esp-idf repo soon.

Hopefully helps with #1675, #2798, etc