### PR TITLE
Make yield() overridable

### DIFF
--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -97,6 +97,8 @@ protected:
     uart_t* _uart;
 };
 
+extern void serialEventRun(void) __attribute__((weak));
+
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
 extern HardwareSerial Serial;
 extern HardwareSerial Serial1;

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -105,4 +105,4 @@ extern HardwareSerial Serial1;
 extern HardwareSerial Serial2;
 #endif
 
-#endif
+#endif // HardwareSerial_h

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -144,7 +144,6 @@ unsigned long IRAM_ATTR millis()
 void delay(uint32_t ms)
 {
     vTaskDelay(ms / portTICK_PERIOD_MS);
-    if (yield != __yield) yield();
 }
 
 void IRAM_ATTR delayMicroseconds(uint32_t us)

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -144,7 +144,7 @@ unsigned long IRAM_ATTR millis()
 void delay(uint32_t ms)
 {
     vTaskDelay(ms / portTICK_PERIOD_MS);
-    yield();
+    if (yield != __yield) yield();
 }
 
 void IRAM_ATTR delayMicroseconds(uint32_t us)

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -141,12 +141,10 @@ unsigned long IRAM_ATTR millis()
     return (unsigned long) (esp_timer_get_time() / 1000ULL);
 }
 
-void __delay(uint32_t ms)
+void delay(uint32_t ms)
 {
     vTaskDelay(ms / portTICK_PERIOD_MS);
 }
-
-void delay(uint32_t ms) __attribute__ ((weak, alias("__delay"))); 
 
 void IRAM_ATTR delayMicroseconds(uint32_t us)
 {

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -144,6 +144,7 @@ unsigned long IRAM_ATTR millis()
 void delay(uint32_t ms)
 {
     vTaskDelay(ms / portTICK_PERIOD_MS);
+    yield();
 }
 
 void IRAM_ATTR delayMicroseconds(uint32_t us)

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -44,10 +44,12 @@ float temperatureRead()
     return (temprature_sens_read() - 32) / 1.8;
 }
 
-void yield()
+void __yield()
 {
     vPortYield();
 }
+
+void yield() __attribute__ ((weak, alias("__yield")));
 
 #if CONFIG_AUTOSTART_ARDUINO
 
@@ -139,10 +141,12 @@ unsigned long IRAM_ATTR millis()
     return (unsigned long) (esp_timer_get_time() / 1000ULL);
 }
 
-void delay(uint32_t ms)
+void __delay(uint32_t ms)
 {
     vTaskDelay(ms / portTICK_PERIOD_MS);
 }
+
+void delay(uint32_t ms) __attribute__ ((weak, alias("__delay"))); 
 
 void IRAM_ATTR delayMicroseconds(uint32_t us)
 {

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -9,6 +9,13 @@ TaskHandle_t loopTaskHandle = NULL;
 
 bool loopTaskWDTEnabled;
 
+extern "C" void __loop_end(void)
+{
+    /* do nothing by default */
+}
+
+extern "C" void loop_end(void) __attribute__((weak, alias("__loop_end")));
+
 void loopTask(void *pvParameters)
 {
     setup();
@@ -17,6 +24,7 @@ void loopTask(void *pvParameters)
             esp_task_wdt_reset();
         }
         loop();
+        loop_end();
     }
 }
 

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -9,12 +9,10 @@ TaskHandle_t loopTaskHandle = NULL;
 
 bool loopTaskWDTEnabled;
 
-extern "C" void __loop_end(void)
-{
-    /* do nothing by default */
+extern "C" void esp_loop(void) __attribute__((weak));
+extern "C" void esp_loop(void) {
+    loop();
 }
-
-extern "C" void loop_end(void) __attribute__((weak, alias("__loop_end")));
 
 void loopTask(void *pvParameters)
 {
@@ -23,8 +21,7 @@ void loopTask(void *pvParameters)
         if(loopTaskWDTEnabled){
             esp_task_wdt_reset();
         }
-        loop();
-        loop_end();
+        esp_loop();
     }
 }
 

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -9,11 +9,6 @@ TaskHandle_t loopTaskHandle = NULL;
 
 bool loopTaskWDTEnabled;
 
-extern "C" void esp_loop(void) __attribute__((weak));
-extern "C" void esp_loop(void) {
-    loop();
-}
-
 void loopTask(void *pvParameters)
 {
     setup();
@@ -21,7 +16,8 @@ void loopTask(void *pvParameters)
         if(loopTaskWDTEnabled){
             esp_task_wdt_reset();
         }
-        esp_loop();
+        loop();
+        if (serialEventRun) serialEventRun();
     }
 }
 


### PR DESCRIPTION
Hi @me-no-dev!
As I've a fully portable co-op scheduler running on ESP8266, ESP32 and Arduino (physically the ATmega 328P - Arduino Pro or Pro Mini) now [https://github.com/dok-net/CoopTask], here is another request to allow nice integration into the loop() with `yield()` (and, later, optionally, `delay()`). AVR Arduino et cetera have this, because `yield()` is overridable and `delay()` cyclically calls `yield()`, but as you know, the scheduling on the Espressif SOC is different.
I just hope that this very small adjustment is agreeable to you, even if you don't think that cooperative MT is useful on FreeRTOS, but users should implement OS tasks instead...