### PR TITLE
ESP.getCpuFreqMHz fix

### DIFF
--- a/cores/esp32/Esp.h
+++ b/cores/esp32/Esp.h
@@ -75,7 +75,7 @@ public:
     uint32_t getMaxAllocPsram();
 
     uint8_t getChipRevision();
-    uint8_t getCpuFreqMHz(){ return getCpuFrequencyMhz(); }
+    uint32_t getCpuFreqMHz(){ return getCpuFrequencyMhz(); }
     uint32_t getCycleCount();
     const char * getSdkVersion();
 

--- a/cores/esp32/Esp.h
+++ b/cores/esp32/Esp.h
@@ -75,7 +75,7 @@ public:
     uint32_t getMaxAllocPsram();
 
     uint8_t getChipRevision();
-    uint8_t getCpuFreqMHz(){ return CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ; }
+    uint8_t getCpuFreqMHz(){ return getCpuFrequencyMhz(); }
     uint32_t getCycleCount();
     const char * getSdkVersion();
 


### PR DESCRIPTION
ESP.getCpuFreqMHz was returning the CONFIG_ variable.  Now calls the getCpuFrequencyMhz function.