### PR TITLE
Add generic IP utilities

### DIFF
--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -197,6 +197,33 @@ IPAddress ETHClass::dnsIP(uint8_t dns_no)
     return IPAddress(dns_ip.u_addr.ip4.addr);
 }
 
+IPAddress ETHClass::broadcastIP()
+{
+    tcpip_adapter_ip_info_t ip;
+    if(tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &ip)){
+        return IPAddress();
+    }
+    return WiFiGenericClass::calculateBroadcast(IPAddress(ip.gw.addr), IPAddress(ip.netmask.addr));
+}
+
+IPAddress ETHClass::networkID()
+{
+    tcpip_adapter_ip_info_t ip;
+    if(tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &ip)){
+        return IPAddress();
+    }
+    return WiFiGenericClass::calculateNetworkID(IPAddress(ip.gw.addr), IPAddress(ip.netmask.addr));
+}
+
+uint8_t ETHClass::subnetCIDR()
+{
+    tcpip_adapter_ip_info_t ip;
+    if(tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &ip)){
+        return (uint8_t)0;
+    }
+    return WiFiGenericClass::calculateSubnetCIDR(IPAddress(ip.netmask.addr));
+}
+
 const char * ETHClass::getHostname()
 {
     const char * hostname;

--- a/libraries/WiFi/src/ETH.h
+++ b/libraries/WiFi/src/ETH.h
@@ -79,6 +79,10 @@ class ETHClass {
         IPAddress gatewayIP();
         IPAddress dnsIP(uint8_t dns_no = 0);
 
+        IPAddress broadcastIP();
+        IPAddress networkID();
+        uint8_t subnetCIDR();
+
         uint8_t * macAddress(uint8_t* mac);
         String macAddress();
 

--- a/libraries/WiFi/src/WiFiAP.cpp
+++ b/libraries/WiFi/src/WiFiAP.cpp
@@ -253,7 +253,7 @@ IPAddress WiFiAPClass::softAPBroadcastIP()
  * Get the softAP network ID.
  * @return IPAddress softAP networkID
  */
-IPAddress WiFiAPClass::softAPNetwrokID()
+IPAddress WiFiAPClass::softAPNetworkID()
 {
     tcpip_adapter_ip_info_t ip;
     if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){

--- a/libraries/WiFi/src/WiFiAP.cpp
+++ b/libraries/WiFi/src/WiFiAP.cpp
@@ -235,6 +235,47 @@ IPAddress WiFiAPClass::softAPIP()
     return IPAddress(ip.ip.addr);
 }
 
+/**
+ * Get the softAP broadcast IP address.
+ * @return IPAddress softAP broadcastIP
+ */
+IPAddress WiFiAPClass::softAPBroadcastIP()
+{
+    tcpip_adapter_ip_info_t ip;
+    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
+        return IPAddress();
+    }
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
+    return WiFiGenericClass::calculateBroadcast(IPAddress(ip.gw.addr), IPAddress(ip.netmask.addr));
+}
+
+/**
+ * Get the softAP network ID.
+ * @return IPAddress softAP networkID
+ */
+IPAddress WiFiAPClass::softAPNetwrokID()
+{
+    tcpip_adapter_ip_info_t ip;
+    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
+        return IPAddress();
+    }
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
+    return WiFiGenericClass::calculateNetworkID(IPAddress(ip.gw.addr), IPAddress(ip.netmask.addr));
+}
+
+/**
+ * Get the softAP subnet CIDR.
+ * @return uint8_t softAP subnetCIDR
+ */
+uint8_t WiFiAPClass::softAPSubnetCIDR()
+{
+    tcpip_adapter_ip_info_t ip;
+    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
+        return (uint8_t)0;
+    }
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
+    return WiFiGenericClass::calculateSubnetCIDR(IPAddress(ip.netmask.addr));
+}
 
 /**
  * Get the softAP interface MAC address.

--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -45,6 +45,10 @@ public:
 
     IPAddress softAPIP();
 
+    IPAddress softAPBroadcastIP();
+    IPAddress softAPNetwrokID();
+    uint8_t softAPSubnetCIDR();
+
     bool softAPenableIpV6();
     IPv6Address softAPIPv6();
 

--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -46,7 +46,7 @@ public:
     IPAddress softAPIP();
 
     IPAddress softAPBroadcastIP();
-    IPAddress softAPNetwrokID();
+    IPAddress softAPNetworkID();
     uint8_t softAPSubnetCIDR();
 
     bool softAPenableIpV6();

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -656,3 +656,45 @@ int WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult)
     return (uint32_t)aResult != 0;
 }
 
+IPAddress WiFiGenericClass::calculateNetworkID(IPAddress ip, IPAddress subnet) {
+	IPAddress networkID;
+
+	for (size_t i = 0; i < 4; i++)
+		networkID[i] = subnet[i] & ip[i];
+
+	return networkID;
+}
+
+IPAddress WiFiGenericClass::calculateBroadcast(IPAddress ip, IPAddress subnet) {
+    IPAddress broadcastIp;
+    
+    for (int i = 0; i < 4; i++)
+        broadcastIp[i] = ~subnet[i] | ip[i];
+
+    return broadcastIp;
+}
+
+uint8_t WiFiGenericClass::calculateSubnetCIDR(IPAddress subnetMask) {
+	uint8_t CIDR = 0;
+
+	for (uint8_t i = 0; i < 4; i++) {
+		if (subnetMask[i] == 0x80)  // 128
+			CIDR += 1;
+		else if (subnetMask[i] == 0xC0)  // 192
+			CIDR += 2;
+		else if (subnetMask[i] == 0xE0)  // 224
+			CIDR += 3;
+		else if (subnetMask[i] == 0xF0)  // 242
+			CIDR += 4;
+		else if (subnetMask[i] == 0xF8)  // 248
+			CIDR += 5;
+		else if (subnetMask[i] == 0xFC)  // 252
+			CIDR += 6;
+		else if (subnetMask[i] == 0xFE)  // 254
+			CIDR += 7;
+		else if (subnetMask[i] == 0xFF)  // 255
+			CIDR += 8;
+	}
+
+	return CIDR;
+}

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -108,6 +108,10 @@ class WiFiGenericClass
   public:
     static int hostByName(const char *aHostname, IPAddress &aResult);
 
+    static IPAddress calculateNetworkID(IPAddress ip, IPAddress subnet);
+    static IPAddress calculateBroadcast(IPAddress ip, IPAddress subnet);
+    static uint8_t calculateSubnetCIDR(IPAddress subnetMask);
+
   protected:
     friend class WiFiSTAClass;
     friend class WiFiScanClass;

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -508,9 +508,9 @@ IPAddress WiFiSTAClass::broadcastIP()
 
 /**
  * Get the network id.
- * @return IPAddress netwrokID
+ * @return IPAddress networkID
  */
-IPAddress WiFiSTAClass::netwrokID()
+IPAddress WiFiSTAClass::networkID()
 {
     if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
         return IPAddress();
@@ -522,7 +522,7 @@ IPAddress WiFiSTAClass::netwrokID()
 
 /**
  * Get the network id.
- * @return uint8_t netwrokID
+ * @return uint8_t subnetCIDR
  */
 uint8_t WiFiSTAClass::subnetCIDR()
 {

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -493,6 +493,48 @@ IPAddress WiFiSTAClass::dnsIP(uint8_t dns_no)
 }
 
 /**
+ * Get the broadcast ip address.
+ * @return IPAddress broadcastIP
+ */
+IPAddress WiFiSTAClass::broadcastIP()
+{
+    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
+        return IPAddress();
+    }
+    tcpip_adapter_ip_info_t ip;
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip);
+    return WiFiGenericClass::calculateBroadcast(IPAddress(ip.gw.addr), IPAddress(ip.netmask.addr));
+}
+
+/**
+ * Get the network id.
+ * @return IPAddress netwrokID
+ */
+IPAddress WiFiSTAClass::netwrokID()
+{
+    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
+        return IPAddress();
+    }
+    tcpip_adapter_ip_info_t ip;
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip);
+    return WiFiGenericClass::calculateNetworkID(IPAddress(ip.gw.addr), IPAddress(ip.netmask.addr));
+}
+
+/**
+ * Get the network id.
+ * @return uint8_t netwrokID
+ */
+uint8_t WiFiSTAClass::subnetCIDR()
+{
+    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
+        return (uint8_t)0;
+    }
+    tcpip_adapter_ip_info_t ip;
+    tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip);
+    return WiFiGenericClass::calculateSubnetCIDR(IPAddress(ip.netmask.addr));
+}
+
+/**
  * Return the current SSID associated with the network
  * @return SSID
  */

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -521,7 +521,7 @@ IPAddress WiFiSTAClass::networkID()
 }
 
 /**
- * Get the network id.
+ * Get the subnet CIDR.
  * @return uint8_t subnetCIDR
  */
 uint8_t WiFiSTAClass::subnetCIDR()

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -64,6 +64,10 @@ public:
     IPAddress subnetMask();
     IPAddress gatewayIP();
     IPAddress dnsIP(uint8_t dns_no = 0);
+
+    IPAddress broadcastIP();
+    IPAddress netwrokID();
+    uint8_t subnetCIDR();
     
     bool enableIpV6();
     IPv6Address localIPv6();

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -66,7 +66,7 @@ public:
     IPAddress dnsIP(uint8_t dns_no = 0);
 
     IPAddress broadcastIP();
-    IPAddress netwrokID();
+    IPAddress networkID();
     uint8_t subnetCIDR();
     
     bool enableIpV6();


### PR DESCRIPTION
WiFiGeneric:
calculateNetworkID(IPAddress ip, IPAddress subnet) => Calculate the network id using the IP and subnet (e.g. 192.168.0.0)
calculateBroadcast(IPAddress ip, IPAddress subnet) => Calculate the broadcast IP using the IP and subnet (e.g. 192.168.0.255)
calculateSubnetCIDR(IPAddress subnetMask) => Calculate the subnet CIDR using the subnet (e.g. 24)

WiFiAP:
softAPBroadcastIP() => Retrieve the network id (e.g. 192.168.0.0)
softAPNetwrokID() => Retrieve the broadcast IP (e.g. 192.168.0.15)
softAPSubnetCIDR() => Retrieve the subnet CIDR (e.g. 28)

WiFiSTA:
broadcastIP() => Retrieve the network id (e.g. 192.168.0.0)
netwrokID() => Retrieve the broadcast IP (e.g. 192.168.0.255)
subnetCIDR() => Retrieve the subnet CIDR (e.g. 24)

ETH:
broadcastIP() => Retrieve the network id (e.g. 172.16.0.0)
netwrokID() => Retrieve the broadcast IP (e.g. 172.16.255.255)
subnetCIDR() => Retrieve the subnet CIDR (e.g. 16)