### PR TITLE
move message to closecomment instead of unmark comment.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -38,12 +38,12 @@ markComment: >
   for your contributions.
 
 # Comment to post when removing the stale label.
-unmarkComment: >
-  This stale issue has been automatically closed. Thank you for your contributions.
+#unmarkComment: >
+#  This stale issue has been automatically closed. Thank you for your contributions.
 
 # Comment to post when closing a stale Issue or Pull Request.
-# closeComment: >
-#   Your comment here.
+closeComment: >
+  This stale issue has been automatically closed. Thank you for your contributions.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30


### PR DESCRIPTION
https://github.com/espressif/arduino-esp32/issues/1264#issuecomment-517154820

In the above comment Bot says it closes the issue, but actually it removes stale label.
 