### PR TITLE
Removed pragme in BLERemoteService.cpp

### DIFF
--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -228,7 +228,6 @@ std::map<std::string, BLERemoteCharacteristic*>* BLERemoteService::getCharacteri
  * @brief This function is designed to get characteristics map when we have multiple characteristics with the same UUID
  */
 void BLERemoteService::getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic*>* pCharacteristicMap) {
-#pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
 	pCharacteristicMap = &m_characteristicMapByHandle;
 }  // Get the characteristics map.
 


### PR DESCRIPTION
This fixes the bug that the GCC compiler ignores the pragma.