### PR TITLE
Fix long Ticker period conversion: cast ms to uint64_t when calculating us

### DIFF
--- a/libraries/Ticker/src/Ticker.cpp
+++ b/libraries/Ticker/src/Ticker.cpp
@@ -43,9 +43,9 @@ void Ticker::_attach_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t 
   }
   esp_timer_create(&_timerConfig, &_timer);
   if (repeat) {
-    esp_timer_start_periodic(_timer, milliseconds * 1000);
+    esp_timer_start_periodic(_timer, ((uint64_t)milliseconds) * 1000);
   } else {
-    esp_timer_start_once(_timer, milliseconds * 1000);
+    esp_timer_start_once(_timer, ((uint64_t)milliseconds) * 1000);
   }
 }
 

--- a/libraries/Ticker/src/Ticker.cpp
+++ b/libraries/Ticker/src/Ticker.cpp
@@ -43,9 +43,9 @@ void Ticker::_attach_ms(uint32_t milliseconds, bool repeat, callback_with_arg_t 
   }
   esp_timer_create(&_timerConfig, &_timer);
   if (repeat) {
-    esp_timer_start_periodic(_timer, ((uint64_t)milliseconds) * 1000);
+    esp_timer_start_periodic(_timer, milliseconds * 1000ULL);
   } else {
-    esp_timer_start_once(_timer, ((uint64_t)milliseconds) * 1000);
+    esp_timer_start_once(_timer, milliseconds * 1000ULL);
   }
 }
 


### PR DESCRIPTION
Long duration was truncated when calculating milliseconds * 1000. ESP32 only: functions esp_timer_start_* require microseconds as uint64_t. ESP8266 is not affected as it uses a different API.