### PR TITLE
Added timeout to WiFiScan.cpp to prevent getting stuck at WIFI_SCAN_RUNNING

### DIFF
--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -60,7 +60,7 @@ int16_t WiFiScanClass::scanNetworks(bool async, bool show_hidden, bool passive, 
         return WIFI_SCAN_RUNNING;
     }
 
-    WiFiScanClass::_scanTimeout = max_ms_per_chan * 20
+    WiFiScanClass::_scanTimeout = max_ms_per_chan * 20;
     WiFiScanClass::_scanAsync = async;
 
     WiFi.enableSTA(true);

--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -83,8 +83,8 @@ int16_t WiFiScanClass::scanNetworks(bool async, bool show_hidden, bool passive, 
     if(esp_wifi_scan_start(&config, false) == ESP_OK) {
         _scanStarted = millis();
         if (!_scanStarted) { //Prevent 0 from millis overflow
-		    ++_scanStarted;
-	    }
+	    ++_scanStarted;
+	}
 
         WiFiGenericClass::clearStatusBits(WIFI_SCAN_DONE_BIT);
         WiFiGenericClass::setStatusBits(WIFI_SCANNING_BIT);
@@ -143,8 +143,8 @@ int16_t WiFiScanClass::scanComplete()
 {
     if (WiFiScanClass::_scanStarted && (millis()-WiFiScanClass::_scanStarted) > WiFiScanClass::_scanTimeout) { //Check is scan was started and if the delay expired, return WIFI_SCAN_FAILED in this case 
     	WiFiGenericClass::clearStatusBits(WIFI_SCANNING_BIT);
-		return WIFI_SCAN_FAILED;
-	}
+	return WIFI_SCAN_FAILED;
+    }
 
     if(WiFiGenericClass::getStatusBits() & WIFI_SCAN_DONE_BIT) {
         return WiFiScanClass::_scanCount;

--- a/libraries/WiFi/src/WiFiScan.h
+++ b/libraries/WiFi/src/WiFiScan.h
@@ -50,8 +50,11 @@ public:
 protected:
 
     static bool _scanAsync;
-
+    
+    static uint32_t _scanStarted;
+    static uint32_t _scanTimeout;
     static uint16_t _scanCount;
+    
     static void* _scanResult;
 
     static void * _getScanInfoByIndex(int i);


### PR DESCRIPTION
If you start a scan for networks if the esp is connecting to an ap the scan request is aborted by the sdk without returning an error. See here espressif/esp-idf#3044 for reference.

In my case the scan routine is running in its own thread so i can't assume when the scanNetworks is triggered. If it gets triggered while the esp is connecting the connect has priority and the SYSTEM_EVENT_SCAN_DONE event is never triggered. In that particular case the WIFI_SCANNING_BIT is never cleared and you're not able to scan for networks without a reset.

To prevent that case i modified the WiFiScan.ccp to include a timeout mechanism to reset a failed scan. So I added a define SCAN_ERROR_DELAY with a value of 10000 for 10s as timeout and the parameter _scanStarted.

If the SYSTEM_EVENT_SCAN_DONE event is not fired within the SCAN_ERROR_DELAY the scanComplete method returns WIFI_SCAN_FAILED to indicate that the scan failed.