### PR TITLE
Fix for issue_3209.

### DIFF
--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -32,13 +32,7 @@
 #include "esp32-hal-bt.h"
 #endif
 
-#if defined(CONFIG_ARDUHAL_ESP_LOG)
 #include "esp32-hal-log.h"
-
-#else
-#include "esp_log.h"
-static const char* LOG_TAG = "BLEDevice";
-#endif
 
 
 /**


### PR DESCRIPTION
#include "esp32-hal-log.h" is mandatory is order to build BLEDevice.cpp.
It can't be left up to a compiler variable.