### PR TITLE
Abortable Arduino delay()

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -54,6 +54,12 @@ void yield()
 extern TaskHandle_t loopTaskHandle;
 extern bool loopTaskWDTEnabled;
 
+void IRAM_ATTR abortLoopDelay(){
+    if(loopTaskHandle != NULL){
+        vTaskNotifyGiveFromISR(loopTaskHandle, NULL);
+    }
+}
+
 void enableLoopWDT(){
     if(loopTaskHandle != NULL){
         if(esp_task_wdt_add(loopTaskHandle) != ESP_OK){
@@ -141,7 +147,7 @@ unsigned long IRAM_ATTR millis()
 
 void delay(uint32_t ms)
 {
-    vTaskDelay(ms / portTICK_PERIOD_MS);
+    ulTaskNotifyTake(pdTRUE, ms / portTICK_PERIOD_MS);
 }
 
 void IRAM_ATTR delayMicroseconds(uint32_t us)

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -56,7 +56,11 @@ extern bool loopTaskWDTEnabled;
 
 void IRAM_ATTR abortLoopDelay(){
     if(loopTaskHandle != NULL){
-        vTaskNotifyGiveFromISR(loopTaskHandle, NULL);
+        if (xPortInIsrContext()){
+            vTaskNotifyGiveFromISR(loopTaskHandle, NULL);
+        } else {
+            xTaskNotifyGive(loopTaskHandle);
+        }
     }
 }
 

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -74,6 +74,7 @@ void yield(void);
 float temperatureRead();
 
 #if CONFIG_AUTOSTART_ARDUINO
+void abortLoopDelay();
 //enable/disable WDT for Arduino's setup and loop functions
 void enableLoopWDT();
 void disableLoopWDT();


### PR DESCRIPTION
Currently, there is (seems to be?) no way to break out of the Arduino `delay()` equivalent implementation on ESP32 Arduino core.
This PR proposes a different FreeRTOS method of implementing task delay, that allows resuming the loop() task (or any other task using Arduino-style sketches with `delay()`).
Measured timings for very short delay values, that is 0, 1, 2µs, are identical to the replaced code.