### PR TITLE
Changed WeMosBat.name

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1191,7 +1191,7 @@ pocket_32.menu.UploadSpeed.512000.upload.speed=512000
 
 ##############################################################
 
-WeMosBat.name="WeMos" WiFi&Bluetooth Battery
+WeMosBat.name=WeMos WiFi&Bluetooth Battery
 
 WeMosBat.upload.tool=esptool_py
 WeMosBat.upload.maximum_size=1310720


### PR DESCRIPTION
The old version would crash the Stino plugin, which appears not to support quotes in board names