### PR TITLE
Added partition size option for Pico Kit

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -257,6 +257,15 @@ pico32.build.boot=dio
 pico32.build.partitions=default
 pico32.build.defines=
 
+pico32.menu.PartitionScheme.default=Default
+pico32.menu.PartitionScheme.default.build.partitions=default
+pico32.menu.PartitionScheme.no_ota=No OTA (Large APP)
+pico32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+pico32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+pico32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+pico32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+pico32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
 pico32.menu.UploadSpeed.921600=921600
 pico32.menu.UploadSpeed.921600.upload.speed=921600
 pico32.menu.UploadSpeed.115200=115200


### PR DESCRIPTION
The original boards.txt was missing a menu option to select the FLASH partitioning options.