### PR TITLE
Non-functional deinit/init in BLEDevice.cpp

### DIFF
--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -625,7 +625,7 @@ void BLEDevice::removePeerDevice(uint16_t conn_id, bool _client) {
     esp_bluedroid_deinit();
     esp_bt_controller_disable();
     esp_bt_controller_deinit();
-#ifndef ARDUINO_ARCH_ESP32
+#ifdef ARDUINO_ARCH_ESP32
     if (release_memory) {
         esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);  // <-- require tests because we released classic BT memory and this can cause crash (most likely not, esp-idf takes care of it)
     } else {


### PR DESCRIPTION
Pretty sure this was a typo as the deinit doesn't actually allow for reinit if that is an ifndef.  Changed in my local copy and can now deinit and reinit just fine.  Also, not sure why we are checking for the architecture here.  Just curious.