### PR TITLE
Fixes issue-3153 - Allocating enough memory to construct the entire UUID as a String

### DIFF
--- a/libraries/BLE/src/BLEUUID.cpp
+++ b/libraries/BLE/src/BLEUUID.cpp
@@ -367,7 +367,7 @@ std::string BLEUUID::toString() {
 	//
 	// UUID string format:
 	// AABBCCDD-EEFF-GGHH-IIJJ-KKLLMMNNOOPP
-	auto size = 35;
+	auto size = 37; // 32 for UUID data, 4 for '-' delimiters and one for a terminator == 37 chars
 	char *hex = (char *)malloc(size);
 	snprintf(hex, size, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
 			m_uuid.uuid.uuid128[15], m_uuid.uuid.uuid128[14],


### PR DESCRIPTION
Fix for https://github.com/espressif/arduino-esp32/issues/3153