### PR TITLE
Base64::encode : const correctness / String by reference passing

### DIFF
--- a/cores/esp32/base64.cpp
+++ b/cores/esp32/base64.cpp
@@ -31,11 +31,11 @@ extern "C" {
 
 /**
  * convert input data to base64
- * @param data uint8_t *
+ * @param data const uint8_t *
  * @param length size_t
  * @return String
  */
-String base64::encode(uint8_t * data, size_t length)
+String base64::encode(const uint8_t * data, size_t length)
 {
     size_t size = base64_encode_expected_len(length) + 1;
     char * buffer = (char *) malloc(size);
@@ -54,10 +54,10 @@ String base64::encode(uint8_t * data, size_t length)
 
 /**
  * convert input data to base64
- * @param text String
+ * @param text const String&
  * @return String
  */
-String base64::encode(String text)
+String base64::encode(const String& text)
 {
     return base64::encode((uint8_t *) text.c_str(), text.length());
 }

--- a/cores/esp32/base64.h
+++ b/cores/esp32/base64.h
@@ -4,8 +4,8 @@
 class base64
 {
 public:
-    static String encode(uint8_t * data, size_t length);
-    static String encode(String text);
+    static String encode(const uint8_t * data, size_t length);
+    static String encode(const String& text);
 private:
 };
 


### PR DESCRIPTION
Avoid passing String by-value, which is slightly less efficient
as it involves a full copy-constructor/tempstring creation.