### PR TITLE
Allow sketches to have custom partitions

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -61,6 +61,31 @@ compiler.ar.extra_flags=
 compiler.objcopy.eep.extra_flags=
 compiler.elf2hex.extra_flags=
 
+# Build Dir: {build.path}
+# Sketch Dir: {build.source.path}
+# recipe.hooks.prebuild.1.pattern=ls "{build.source.path}"
+# recipe.hooks.prebuild.1.pattern.windows=dir "{build.source.path}"
+# recipe.hooks.sketch.prebuild.NUMBER.pattern (called before sketch compilation)
+# recipe.hooks.sketch.postbuild.NUMBER.pattern (called after sketch compilation)
+# recipe.hooks.libraries.prebuild.NUMBER.pattern (called before libraries compilation)
+# recipe.hooks.libraries.postbuild.NUMBER.pattern (called after libraries compilation)
+# recipe.hooks.core.prebuild.NUMBER.pattern (called before core compilation)
+# recipe.hooks.core.postbuild.NUMBER.pattern (called after core compilation)
+# recipe.hooks.linking.prelink.NUMBER.pattern (called before linking)
+# recipe.hooks.linking.postlink.NUMBER.pattern (called after linking)
+# recipe.hooks.objcopy.preobjcopy.NUMBER.pattern (called before objcopy recipes execution)
+# recipe.hooks.objcopy.postobjcopy.NUMBER.pattern (called after objcopy recipes execution)
+# recipe.hooks.savehex.presavehex.NUMBER.pattern (called before savehex recipe execution)
+# recipe.hooks.savehex.postsavehex.NUMBER.pattern (called after savehex recipe execution)
+
+recipe.hooks.prebuild.1.pattern=bash -c "[ -f {build.source.path}/partitions.csv ] && cp {build.source.path}/partitions.csv {build.path}/partitions.csv"
+recipe.hooks.prebuild.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
+recipe.hooks.prebuild.3.pattern=cat "{build.path}/partitions.csv"
+
+recipe.hooks.prebuild.1.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" copy "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
+recipe.hooks.prebuild.2.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" copy "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
+recipe.hooks.prebuild.3.pattern.windows=type "{build.path}/partitions.csv"
+
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" -DARDUINO_VARIANT="{build.variant}" {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
@@ -77,7 +102,10 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -Wl,--start-group {object_files} "{archive_file_path}" {compiler.c.elf.libs} -Wl,--end-group -Wl,-EL -o "{build.path}/{build.project_name}.elf"
 
 ## Create eeprom
-recipe.objcopy.eep.pattern={tools.gen_esp32part.cmd} -q "{runtime.platform.path}/tools/partitions/{build.partitions}.csv" "{build.path}/{build.project_name}.partitions.bin"
+# recipe.hooks.objcopy.preobjcopy.1.pattern=bash -c "[ -f {build.source.path}/partitions.csv ] && cp {build.source.path}/partitions.csv {build.path}/partitions.csv"
+# recipe.hooks.objcopy.preobjcopy.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
+# recipe.hooks.objcopy.preobjcopy.3.pattern=cat "{build.path}/partitions.csv"
+recipe.objcopy.eep.pattern={tools.gen_esp32part.cmd} -q "{build.path}/partitions.csv" "{build.path}/{build.project_name}.partitions.bin"
 
 ## Create hex
 recipe.objcopy.hex.pattern="{tools.esptool_py.path}/{tools.esptool_py.cmd}" --chip esp32 elf2image --flash_mode "{build.flash_mode}" --flash_freq "{build.flash_freq}" --flash_size "{build.flash_size}" -o "{build.path}/{build.project_name}.bin" "{build.path}/{build.project_name}.elf"

--- a/platform.txt
+++ b/platform.txt
@@ -78,14 +78,6 @@ compiler.elf2hex.extra_flags=
 # recipe.hooks.savehex.presavehex.NUMBER.pattern (called before savehex recipe execution)
 # recipe.hooks.savehex.postsavehex.NUMBER.pattern (called after savehex recipe execution)
 
-recipe.hooks.prebuild.1.pattern=bash -c "[ -f {build.source.path}/partitions.csv ] && cp {build.source.path}/partitions.csv {build.path}/partitions.csv || exit 0"
-recipe.hooks.prebuild.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
-recipe.hooks.prebuild.3.pattern=cat "{build.path}/partitions.csv"
-
-recipe.hooks.prebuild.1.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" copy "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
-recipe.hooks.prebuild.2.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" copy "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
-recipe.hooks.prebuild.3.pattern.windows=type "{build.path}/partitions.csv"
-
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" -DARDUINO_VARIANT="{build.variant}" {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
@@ -102,9 +94,10 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -Wl,--start-group {object_files} "{archive_file_path}" {compiler.c.elf.libs} -Wl,--end-group -Wl,-EL -o "{build.path}/{build.project_name}.elf"
 
 ## Create eeprom
-# recipe.hooks.objcopy.preobjcopy.1.pattern=bash -c "[ -f {build.source.path}/partitions.csv ] && cp {build.source.path}/partitions.csv {build.path}/partitions.csv"
-# recipe.hooks.objcopy.preobjcopy.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
-# recipe.hooks.objcopy.preobjcopy.3.pattern=cat "{build.path}/partitions.csv"
+recipe.hooks.objcopy.preobjcopy.1.pattern=bash -c "[ ! -f {build.source.path}/partitions.csv ] || cp {build.source.path}/partitions.csv {build.path}/partitions.csv"
+recipe.hooks.objcopy.preobjcopy.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
+recipe.hooks.objcopy.preobjcopy.1.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" copy "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
+recipe.hooks.objcopy.preobjcopy.2.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" copy "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
 recipe.objcopy.eep.pattern={tools.gen_esp32part.cmd} -q "{build.path}/partitions.csv" "{build.path}/{build.project_name}.partitions.bin"
 
 ## Create hex

--- a/platform.txt
+++ b/platform.txt
@@ -78,7 +78,7 @@ compiler.elf2hex.extra_flags=
 # recipe.hooks.savehex.presavehex.NUMBER.pattern (called before savehex recipe execution)
 # recipe.hooks.savehex.postsavehex.NUMBER.pattern (called after savehex recipe execution)
 
-recipe.hooks.prebuild.1.pattern=bash -c "[ -f {build.source.path}/partitions.csv ] && cp {build.source.path}/partitions.csv {build.path}/partitions.csv"
+recipe.hooks.prebuild.1.pattern=bash -c "[ -f {build.source.path}/partitions.csv ] && cp {build.source.path}/partitions.csv {build.path}/partitions.csv || exit 0"
 recipe.hooks.prebuild.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
 recipe.hooks.prebuild.3.pattern=cat "{build.path}/partitions.csv"
 

--- a/platform.txt
+++ b/platform.txt
@@ -63,20 +63,10 @@ compiler.elf2hex.extra_flags=
 
 # Build Dir: {build.path}
 # Sketch Dir: {build.source.path}
-# recipe.hooks.prebuild.1.pattern=ls "{build.source.path}"
-# recipe.hooks.prebuild.1.pattern.windows=dir "{build.source.path}"
-# recipe.hooks.sketch.prebuild.NUMBER.pattern (called before sketch compilation)
-# recipe.hooks.sketch.postbuild.NUMBER.pattern (called after sketch compilation)
-# recipe.hooks.libraries.prebuild.NUMBER.pattern (called before libraries compilation)
-# recipe.hooks.libraries.postbuild.NUMBER.pattern (called after libraries compilation)
-# recipe.hooks.core.prebuild.NUMBER.pattern (called before core compilation)
-# recipe.hooks.core.postbuild.NUMBER.pattern (called after core compilation)
-# recipe.hooks.linking.prelink.NUMBER.pattern (called before linking)
-# recipe.hooks.linking.postlink.NUMBER.pattern (called after linking)
-# recipe.hooks.objcopy.preobjcopy.NUMBER.pattern (called before objcopy recipes execution)
-# recipe.hooks.objcopy.postobjcopy.NUMBER.pattern (called after objcopy recipes execution)
-# recipe.hooks.savehex.presavehex.NUMBER.pattern (called before savehex recipe execution)
-# recipe.hooks.savehex.postsavehex.NUMBER.pattern (called after savehex recipe execution)
+recipe.hooks.prebuild.1.pattern=bash -c "[ ! -f {build.source.path}/partitions.csv ] || cp -f {build.source.path}/partitions.csv {build.path}/partitions.csv"
+recipe.hooks.prebuild.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
+recipe.hooks.prebuild.1.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" copy /y "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
+recipe.hooks.prebuild.2.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" copy "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
 
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" -DARDUINO_VARIANT="{build.variant}" {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
@@ -94,10 +84,6 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -Wl,--start-group {object_files} "{archive_file_path}" {compiler.c.elf.libs} -Wl,--end-group -Wl,-EL -o "{build.path}/{build.project_name}.elf"
 
 ## Create eeprom
-recipe.hooks.objcopy.preobjcopy.1.pattern=bash -c "[ ! -f {build.source.path}/partitions.csv ] || cp {build.source.path}/partitions.csv {build.path}/partitions.csv"
-recipe.hooks.objcopy.preobjcopy.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
-recipe.hooks.objcopy.preobjcopy.1.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" copy "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
-recipe.hooks.objcopy.preobjcopy.2.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" copy "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
 recipe.objcopy.eep.pattern={tools.gen_esp32part.cmd} -q "{build.path}/partitions.csv" "{build.path}/{build.project_name}.partitions.bin"
 
 ## Create hex


### PR DESCRIPTION
Add a file named `partitions.csv` to your sketch folder and define the partitions inside. In order to not get `Sketch too big`, please select appropriate partition scheme from the board menu