### PR TITLE
SPI: Ensure all read-only data pointers are marked as const

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -459,7 +459,7 @@ void spiWaitReady(spi_t * spi)
     while(spi->dev->cmd.usr);
 }
 
-void spiWrite(spi_t * spi, uint32_t *data, uint8_t len)
+void spiWrite(spi_t * spi, const uint32_t *data, uint8_t len)
 {
     if(!spi) {
         return;
@@ -671,7 +671,7 @@ void __spiTransferBytes(spi_t * spi, uint8_t * data, uint8_t * out, uint32_t byt
     }
 }
 
-void spiTransferBytes(spi_t * spi, uint8_t * data, uint8_t * out, uint32_t size)
+void spiTransferBytes(spi_t * spi, const uint8_t * data, uint8_t * out, uint32_t size)
 {
     if(!spi) {
         return;
@@ -861,7 +861,7 @@ uint32_t spiTransferLongNL(spi_t * spi, uint32_t data)
     return data;
 }
 
-void spiWriteNL(spi_t * spi, const void * data_in, size_t len){
+void spiWriteNL(spi_t * spi, const void * data_in, uint32_t len){
     size_t longs = len >> 2;
     if(len & 3){
         longs++;
@@ -887,7 +887,7 @@ void spiWriteNL(spi_t * spi, const void * data_in, size_t len){
     }
 }
 
-void spiTransferBytesNL(spi_t * spi, const void * data_in, uint8_t * data_out, size_t len){
+void spiTransferBytesNL(spi_t * spi, const void * data_in, uint8_t * data_out, uint32_t len){
     if(!spi) {
         return;
     }
@@ -974,7 +974,7 @@ void spiTransferBitsNL(spi_t * spi, uint32_t data, uint32_t * out, uint8_t bits)
     }
 }
 
-void IRAM_ATTR spiWritePixelsNL(spi_t * spi, const void * data_in, size_t len){
+void IRAM_ATTR spiWritePixelsNL(spi_t * spi, const void * data_in, uint32_t len){
     size_t longs = len >> 2;
     if(len & 3){
         longs++;

--- a/cores/esp32/esp32-hal-spi.h
+++ b/cores/esp32/esp32-hal-spi.h
@@ -96,7 +96,7 @@ void spiSetClockDiv(spi_t * spi, uint32_t clockDiv);
 void spiSetDataMode(spi_t * spi, uint8_t dataMode);
 void spiSetBitOrder(spi_t * spi, uint8_t bitOrder);
 
-void spiWrite(spi_t * spi, uint32_t *data, uint8_t len);
+void spiWrite(spi_t * spi, const uint32_t *data, uint8_t len);
 void spiWriteByte(spi_t * spi, uint8_t data);
 void spiWriteWord(spi_t * spi, uint16_t data);
 void spiWriteLong(spi_t * spi, uint32_t data);
@@ -105,7 +105,7 @@ void spiTransfer(spi_t * spi, uint32_t *out, uint8_t len);
 uint8_t spiTransferByte(spi_t * spi, uint8_t data);
 uint16_t spiTransferWord(spi_t * spi, uint16_t data);
 uint32_t spiTransferLong(spi_t * spi, uint32_t data);
-void spiTransferBytes(spi_t * spi, uint8_t * data, uint8_t * out, uint32_t size);
+void spiTransferBytes(spi_t * spi, const uint8_t * data, uint8_t * out, uint32_t size);
 void spiTransferBits(spi_t * spi, uint32_t data, uint32_t * out, uint8_t bits);
 
 /*
@@ -115,11 +115,11 @@ void spiTransaction(spi_t * spi, uint32_t clockDiv, uint8_t dataMode, uint8_t bi
 void spiSimpleTransaction(spi_t * spi);
 void spiEndTransaction(spi_t * spi);
 
-void spiWriteNL(spi_t * spi, const void * data, uint32_t len);
+void spiWriteNL(spi_t * spi, const void * data_in, uint32_t len);
 void spiWriteByteNL(spi_t * spi, uint8_t data);
 void spiWriteShortNL(spi_t * spi, uint16_t data);
 void spiWriteLongNL(spi_t * spi, uint32_t data);
-void spiWritePixelsNL(spi_t * spi, const void * data, uint32_t len);
+void spiWritePixelsNL(spi_t * spi, const void * data_in, uint32_t len);
 
 #define spiTransferNL(spi, data, len) spiTransferBytesNL(spi, data, data, len)
 uint8_t spiTransferByteNL(spi_t * spi, uint8_t data);

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -238,7 +238,7 @@ void SPIClass::writePixels(const void * data, uint32_t size)
  * @param out  uint8_t * output buffer. can be NULL for Write Only operation
  * @param size uint32_t
  */
-void SPIClass::transferBytes(uint8_t * data, uint8_t * out, uint32_t size)
+void SPIClass::transferBytes(const uint8_t * data, uint8_t * out, uint32_t size)
 {
     if(_inTransaction){
         return spiTransferBytesNL(_spi, data, out, size);
@@ -251,7 +251,7 @@ void SPIClass::transferBytes(uint8_t * data, uint8_t * out, uint32_t size)
  * @param size uint8_t  max for size is 64Byte
  * @param repeat uint32_t
  */
-void SPIClass::writePattern(uint8_t * data, uint8_t size, uint32_t repeat)
+void SPIClass::writePattern(const uint8_t * data, uint8_t size, uint32_t repeat)
 {
     if(size > 64) {
         return;    //max Hardware FIFO
@@ -272,12 +272,12 @@ void SPIClass::writePattern(uint8_t * data, uint8_t size, uint32_t repeat)
     }
 }
 
-void SPIClass::writePattern_(uint8_t * data, uint8_t size, uint8_t repeat)
+void SPIClass::writePattern_(const uint8_t * data, uint8_t size, uint8_t repeat)
 {
     uint8_t bytes = (size * repeat);
     uint8_t buffer[64];
     uint8_t * bufferPtr = &buffer[0];
-    uint8_t * dataPtr;
+    const uint8_t * dataPtr;
     uint8_t dataSize = bytes;
     for(uint8_t i = 0; i < repeat; i++) {
         dataSize = size;

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -48,7 +48,7 @@ private:
     uint32_t _div;
     uint32_t _freq;
     bool _inTransaction;
-    void writePattern_(uint8_t * data, uint8_t size, uint8_t repeat);
+    void writePattern_(const uint8_t * data, uint8_t size, uint8_t repeat);
 
 public:
     SPIClass(uint8_t spi_bus=HSPI);
@@ -70,7 +70,7 @@ public:
     uint16_t transfer16(uint16_t data);
     uint32_t transfer32(uint32_t data);
   
-    void transferBytes(uint8_t * data, uint8_t * out, uint32_t size);
+    void transferBytes(const uint8_t * data, uint8_t * out, uint32_t size);
     void transferBits(uint32_t data, uint32_t * out, uint8_t bits);
 
     void write(uint8_t data);
@@ -78,7 +78,7 @@ public:
     void write32(uint32_t data);
     void writeBytes(const uint8_t * data, uint32_t size);
     void writePixels(const void * data, uint32_t size);//ili9341 compatible
-    void writePattern(uint8_t * data, uint8_t size, uint32_t repeat);
+    void writePattern(const uint8_t * data, uint8_t size, uint32_t repeat);
 
     spi_t * bus(){ return _spi; }
 };


### PR DESCRIPTION
This changes all SPI functions that take data pointers which are
not modified so that the declaration is const. This allows them
to be used with const data (i.e. held in flash). No functional
changes are required.

The defnitions of spiWrite() and spiTransferBytes()  in
esp-hal-spi.h/c have been updated to be consistent.

Tests:
 - Build a simple sketch using SPI.writePattern() and
   SPI.transferBytes()  which uses const data and verify that the
   attached device functions as expected.