### PR TITLE
Add an error message in case of invalid configured dependency mbedTLS.

### DIFF
--- a/libraries/WiFiClientSecure/src/ssl_client.cpp
+++ b/libraries/WiFiClientSecure/src/ssl_client.cpp
@@ -19,6 +19,9 @@
 #include "ssl_client.h"
 #include "WiFi.h"
 
+#ifndef MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED
+#  error "Please configure IDF framework to include mbedTLS -> Enable pre-shared-key ciphersuites and activate at least one cipher"
+#endif
 
 const char *pers = "esp32-tls";
 


### PR DESCRIPTION
Especially if the user wants to use the library as component in IDF,
there are some pitfalls while doing make menuconfig. One is this missing
dependency which will now fail with a better error message with a hint to
the user how to fix it.

refs #2154 #3215