### PR TITLE
Add setInterrupt method to HardwareSerial class

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -30,6 +30,13 @@ HardwareSerial Serial2(2);
 
 HardwareSerial::HardwareSerial(int uart_nr) : _uart_nr(uart_nr), _uart(NULL) {}
 
+void HardwareSerial::setInterrupt(void(*arg)() )
+{
+	uartDisableInterrupt(_uart);
+	intr = arg;
+	uartEnableInterrupt(_uart,&intr);
+}
+
 void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin, bool invert, unsigned long timeout_ms)
 {
     if(0 > _uart_nr || _uart_nr > 2) {

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -54,7 +54,7 @@ class HardwareSerial: public Stream
 {
 public:
     HardwareSerial(int uart_nr);
-
+    void setInterrupt(void (*arg)() );
     void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms = 20000UL);
     void end();
     void updateBaudRate(unsigned long baud);
@@ -93,11 +93,10 @@ public:
     void setDebugOutput(bool);
 
 protected:
+    void (*intr)() ;
     int _uart_nr;
     uart_t* _uart;
 };
-
-extern void serialEventRun(void) __attribute__((weak));
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
 extern HardwareSerial Serial;
@@ -105,4 +104,4 @@ extern HardwareSerial Serial1;
 extern HardwareSerial Serial2;
 #endif
 
-#endif // HardwareSerial_h
+#endif

--- a/cores/esp32/Stream.h
+++ b/cores/esp32/Stream.h
@@ -60,6 +60,24 @@ public:
 
     void setTimeout(unsigned long timeout);  // sets maximum milliseconds to wait for stream data, default is 1 second
     unsigned long getTimeout(void);
+    
+    bool find(char *target);   // reads data from the stream until the target string is found
+    bool find(uint8_t *target) { return find ((char *)target); }
+    // returns true if target string is found, false if timed out (see setTimeout)
+
+    bool find(char *target, size_t length);   // reads data from the stream until the target string of given length is found
+    bool find(uint8_t *target, size_t length) { return find ((char *)target, length); }
+    // returns true if target string is found, false if timed out
+
+    bool find(char target) { return find (&target, 1); }
+
+    bool findUntil(char *target, char *terminator);   // as find but search ends if the terminator string is found
+    bool findUntil(uint8_t *target, char *terminator) { return findUntil((char *)target, terminator); }
+
+    bool findUntil(char *target, size_t targetLen, char *terminate, size_t termLen);   // as above but search ends if the terminate string is found
+    bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen); }
+
+/*    
     bool find(const char *target);   // reads data from the stream until the target string is found
     bool find(uint8_t *target)
     {
@@ -90,7 +108,7 @@ public:
     {
         return findUntil((char *) target, targetLen, terminate, termLen);
     }
-
+*/
     long parseInt(); // returns the first valid (long) integer value from the current position.
     // initial characters that are not digits (or the minus sign) are skipped
     // integer is terminated by the first character that is not a digit.
@@ -123,6 +141,17 @@ protected:
     // this allows format characters (typically commas) in values to be ignored
 
     float parseFloat(char skipChar);  // as above but the given skipChar is ignored
+  
+    struct MultiTarget {
+      const char *str;  // string you're searching for
+      size_t len;       // length of string you're searching for
+      size_t index;     // index used by the search routine.
+    };
+
+  // This allows you to search for an arbitrary number of strings.
+  // Returns index of the target that is found first or -1 if timeout occurs.
+  int findMulti(struct MultiTarget *targets, int tCount);
+
 };
 
 #endif

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -81,4 +81,7 @@ bool uartRxActive(uart_t* uart);
 }
 #endif
 
+void uartDisableInterrupt(uart_t* uart);
+void uartEnableInterrupt(uart_t* uart,void * func );
+
 #endif /* MAIN_ESP32_HAL_UART_H_ */


### PR DESCRIPTION
These changes allow to add an interrupt event for Serial using an method setInterrupt. Simple and Easy!

This is a resume of patch:
esp32-hal-uart.h
change function to allow one second parameter
void uartEnableInterrupt(uart_t* uart,void * func );
.
.
.
.
#ifdef __cplusplus
}
#endif

void uartDisableInterrupt(uart_t* uart);
void uartEnableInterrupt(uart_t* uart,void * func );

#endif /* MAIN_ESP32_HAL_UART_H_ */

esp32-hal-uart.h
changes on function _uart_isr
and
uartEnableInterrupt(uart_t* uart,void * func );
static void IRAM_ATTR _uart_isr(void arg)
{
uint8_t i, c;
BaseType_t xHigherPriorityTaskWoken;
uart_t uart;

if(arg != NULL) {
  (*((void(**)())arg))();
}

for(i=0;i<3;i++){
    uart = &_uart_bus_array[i];
    if(uart->intr_handle == NULL){
        continue;
    }
    uart->dev->int_clr.rxfifo_full = 1;
    uart->dev->int_clr.frm_err = 1;
    uart->dev->int_clr.rxfifo_tout = 1;
    while(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
        c = uart->dev->fifo.rw_byte;
        if(uart->queue != NULL && !xQueueIsQueueFullFromISR(uart->queue)) {
            xQueueSendFromISR(uart->queue, &c, &xHigherPriorityTaskWoken);
        }
    }
}

if (xHigherPriorityTaskWoken) {
    portYIELD_FROM_ISR();
}
}

void uartEnableInterrupt(uart_t* uart,void * func)
{
UART_MUTEX_LOCK();
uart->dev->conf1.rxfifo_full_thrhd = 112;
uart->dev->conf1.rx_tout_thrhd = 2;
uart->dev->conf1.rx_tout_en = 1;
uart->dev->int_ena.rxfifo_full = 1;
uart->dev->int_ena.frm_err = 1;
uart->dev->int_ena.rxfifo_tout = 1;
uart->dev->int_clr.val = 0xffffffff;

esp_intr_alloc(UART_INTR_SOURCE(uart->num), (int)ESP_INTR_FLAG_IRAM, _uart_isr, func, &uart->intr_handle);
UART_MUTEX_UNLOCK();
}

HardwareSerial.h
add public function
void setInterrupt(void (*arg)() );
and
protected
void (*intr)() ;
class HardwareSerial: public Stream
{
public:
HardwareSerial(int uart_nr);
void setInterrupt(void (*arg)() );
void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms = 20000UL);
void end();
void updateBaudRate(unsigned long baud);
int available(void);
int availableForWrite(void);
int peek(void);
int read(void);
void flush(void);
size_t write(uint8_t);
size_t write(const uint8_t *buffer, size_t size);

inline size_t write(const char * s)
{
    return write((uint8_t*) s, strlen(s));
}
inline size_t write(unsigned long n)
{
    return write((uint8_t) n);
}
inline size_t write(long n)
{
    return write((uint8_t) n);
}
inline size_t write(unsigned int n)
{
    return write((uint8_t) n);
}
inline size_t write(int n)
{
    return write((uint8_t) n);
}
uint32_t baudRate();
operator bool() const;

size_t setRxBufferSize(size_t);
void setDebugOutput(bool);
protected:
void (intr)() ;
int _uart_nr;
uart_t _uart;
};

#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
extern HardwareSerial Serial;
extern HardwareSerial Serial1;
extern HardwareSerial Serial2;
#endif

#endif

HardwareSerial.c
add function
void setInterrupt(void (*arg)() );
void HardwareSerial::setInterrupt(void(*arg)() )
{
uartDisableInterrupt(_uart);
intr = arg;
uartEnableInterrupt(_uart,&intr);
}

FINISH!!!
Example of USE

      Serial1.begin(9600,SERIAL_8N1, 17, 16); //RX,TX
      Serial1.setInterrupt(&SerialEvent1);
void IRAM_ATTR SerialEvent1(){ // ocorre quando o arduino recebe uma transmissão no RX1
while (Serial1.available()>0) {
Serial.print(Serial1.read());
}
Serial.println();
}