### PR TITLE
Fix WiFiGeneric event handler

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -54,10 +54,10 @@ static TaskHandle_t _network_event_task_handle = NULL;
 static EventGroupHandle_t _network_event_group = NULL;
 
 static void _network_event_task(void * arg){
-    system_event_t *event = NULL;
+    system_event_t event;
     for (;;) {
         if(xQueueReceive(_network_event_queue, &event, portMAX_DELAY) == pdTRUE){
-            WiFiGenericClass::_eventCallback(arg, event);
+            WiFiGenericClass::_eventCallback(arg, &event);
         }
     }
     vTaskDelete(NULL);
@@ -65,7 +65,7 @@ static void _network_event_task(void * arg){
 }
 
 static esp_err_t _network_event_cb(void *arg, system_event_t *event){
-    if (xQueueSend(_network_event_queue, &event, portMAX_DELAY) != pdPASS) {
+    if (xQueueSend(_network_event_queue, event, portMAX_DELAY) != pdPASS) {
         log_w("Network Event Queue Send Failed!");
         return ESP_FAIL;
     }
@@ -82,7 +82,7 @@ static bool _start_network_event_task(){
         xEventGroupSetBits(_network_event_group, WIFI_DNS_IDLE_BIT);
     }
     if(!_network_event_queue){
-        _network_event_queue = xQueueCreate(32, sizeof(system_event_t *));
+        _network_event_queue = xQueueCreate(32, sizeof(system_event_t));
         if(!_network_event_queue){
             log_e("Network Event Queue Create Failed!");
             return false;


### PR DESCRIPTION
Hi.

**Summary**

Currently `_network_event_cb` pass pointer to `system_event_t` into `_network_event_queue`, instead of value.
I think this wrong. And this pull request fix that.

**Description**

Method `esp_event_loop_task` that calls `_network_event_cb` stores `system_event_t` in stack:

```
static void esp_event_loop_task(void *pvParameters)
{
    while (1) {
        system_event_t evt;
        if (xQueueReceive(s_event_queue, &evt, portMAX_DELAY) == pdPASS) {
            esp_err_t ret = esp_event_process_default(&evt);
            if (ret != ESP_OK) {
                ESP_LOGE(TAG, "default event handler failed!");
            }
            ret = esp_event_post_to_user(&evt);
            if (ret != ESP_OK) {
                ESP_LOGE(TAG, "post event to user fail!");
            }
        }
    }
}
```

So when `_network_event_cb` sent pointer in `_network_event_queue` it stores pointer to stack in queue. And if several events occurs it send the same value of pointer to `_network_event_queue`. It is not that we want.

And more, when `_network_event_task` reads this pointer, value of `system_event_t` may be corrupt, because in this time in parallel task method `esp_event_loop_task` calls `xQueueReceive` that replacing `system_event_t`.
