### PR TITLE
Implement Tx only Flush

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -133,12 +133,12 @@ int HardwareSerial::read(void)
 
 void HardwareSerial::flush(void)
 {
-    uartFlush(_uart, false);
+    uartFlush(_uart);
 }
 
 void HardwareSerial::flush(bool txOnly)
 {
-    uartFlush(_uart, txOnly);
+    uartFlushTxOnly(_uart, txOnly);
 }
 
 size_t HardwareSerial::write(uint8_t c)

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -131,9 +131,9 @@ int HardwareSerial::read(void)
     return -1;
 }
 
-void HardwareSerial::flush()
+void HardwareSerial::flush(bool txOnly)
 {
-    uartFlush(_uart);
+    uartFlush(_uart, txOnly);
 }
 
 size_t HardwareSerial::write(uint8_t c)

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -131,6 +131,11 @@ int HardwareSerial::read(void)
     return -1;
 }
 
+void HardwareSerial::flush(void)
+{
+    uartFlush(_uart, false);
+}
+
 void HardwareSerial::flush(bool txOnly)
 {
     uartFlush(_uart, txOnly);

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -62,7 +62,7 @@ public:
     int availableForWrite(void);
     int peek(void);
     int read(void);
-    void flush(void);
+    void flush( bool txOnly = false);
     size_t write(uint8_t);
     size_t write(const uint8_t *buffer, size_t size);
 

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -62,7 +62,8 @@ public:
     int availableForWrite(void);
     int peek(void);
     int read(void);
-    void flush( bool txOnly = false);
+    void flush(void);
+    void flush( bool txOnly);
     size_t write(uint8_t);
     size_t write(const uint8_t *buffer, size_t size);
 

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -326,7 +326,7 @@ void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len)
     UART_MUTEX_UNLOCK();
 }
 
-void uartFlush(uart_t* uart)
+void uartFlush(uart_t* uart, bool txOnly)
 {
     if(uart == NULL) {
         return;
@@ -334,17 +334,19 @@ void uartFlush(uart_t* uart)
 
     UART_MUTEX_LOCK();
     while(uart->dev->status.txfifo_cnt || uart->dev->status.st_utx_out);
+    
+    if( !txOnly ){
+        //Due to hardware issue, we can not use fifo_rst to reset uart fifo.
+        //See description about UART_TXFIFO_RST and UART_RXFIFO_RST in <<esp32_technical_reference_manual>> v2.6 or later.
 
-    //Due to hardware issue, we can not use fifo_rst to reset uart fifo.
-    //See description about UART_TXFIFO_RST and UART_RXFIFO_RST in <<esp32_technical_reference_manual>> v2.6 or later.
+        // we read the data out and make `fifo_len == 0 && rd_addr == wr_addr`.
+        while(uart->dev->status.rxfifo_cnt != 0 || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
+            READ_PERI_REG(UART_FIFO_REG(uart->num));
+        }
 
-    // we read the data out and make `fifo_len == 0 && rd_addr == wr_addr`.
-    while(uart->dev->status.rxfifo_cnt != 0 || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
-        READ_PERI_REG(UART_FIFO_REG(uart->num));
+        xQueueReset(uart->queue);
     }
-
-    xQueueReset(uart->queue);
-
+    
     UART_MUTEX_UNLOCK();
 }
 

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -328,10 +328,10 @@ void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len)
 
 vois uartFlush(uart_t* uart)
 {
-    uartFlush(uart,false);
+    uartFlushTxOnly(uart,false);
 }
 
-void uartFlush(uart_t* uart, bool txOnly)
+void uartFlushTxOnly(uart_t* uart, bool txOnly)
 {
     if(uart == NULL) {
         return;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -326,7 +326,7 @@ void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len)
     UART_MUTEX_UNLOCK();
 }
 
-vois uartFlush(uart_t* uart)
+void uartFlush(uart_t* uart)
 {
     uartFlushTxOnly(uart,false);
 }

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -326,6 +326,11 @@ void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len)
     UART_MUTEX_UNLOCK();
 }
 
+vois uartFlush(uart_t* uart)
+{
+    uartFlush(uart,false);
+}
+
 void uartFlush(uart_t* uart, bool txOnly)
 {
     if(uart == NULL) {

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -62,7 +62,7 @@ uint8_t uartPeek(uart_t* uart);
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 
-void uartFlush(uart_t* uart);
+void uartFlush(uart_t* uart, bool txOnly = false);
 
 void uartSetBaudRate(uart_t* uart, uint32_t baud_rate);
 uint32_t uartGetBaudRate(uart_t* uart);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -62,7 +62,8 @@ uint8_t uartPeek(uart_t* uart);
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 
-void uartFlush(uart_t* uart, bool txOnly = false);
+void uartFlush(uart_t* uart);
+void uartFlush(uart_t* uart, bool txOnly );
 
 void uartSetBaudRate(uart_t* uart, uint32_t baud_rate);
 uint32_t uartGetBaudRate(uart_t* uart);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -63,7 +63,7 @@ void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 
 void uartFlush(uart_t* uart);
-void uartFlush(uart_t* uart, bool txOnly );
+void uartFlushTxOnly(uart_t* uart );
 
 void uartSetBaudRate(uart_t* uart, uint32_t baud_rate);
 uint32_t uartGetBaudRate(uart_t* uart);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -63,7 +63,7 @@ void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 
 void uartFlush(uart_t* uart);
-void uartFlushTxOnly(uart_t* uart );
+void uartFlushTxOnly(uart_t* uart, bool txOnly );
 
 void uartSetBaudRate(uart_t* uart, uint32_t baud_rate);
 uint32_t uartGetBaudRate(uart_t* uart);


### PR DESCRIPTION
Second attempt to create a `Serial.flush()` that does not affect the rx data queue or rxFifo.

`Serial.flush(true);` will hang until all tx Data has been sent out the UART.  It will not clear the rx data queue.
