### PR TITLE
Root CA of webserver has changed, minor changes

### DIFF
--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureEnterprise/WiFiClientSecureEnterprise.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureEnterprise/WiFiClientSecureEnterprise.ino
@@ -1,40 +1,51 @@
-/*|----------------------------------------------------------|*/
-/*|WORKING EXAMPLE FOR HTTPS CONNECTION                      |*/
-/*|TESTED BOARDS: Devkit v1 DOIT, Devkitc v4                 |*/
-/*|CORE: June 2018                                           |*/
-/*|----------------------------------------------------------|*/
+/*|-----------------------------------------------------------|*/
+/*|WORKING EXAMPLE FOR HTTPS CONNECTION                       |*/
+/*|Author: Bc. Martin Chlebovec                               |*/
+/*|Technical University of Košice                             |*/
+/*|TESTED BOARDS: Devkit v1 DOIT, Devkitc v4                  |*/
+/*|CORE: 0.9x, 1.0.0, 1.0.1 tested, working (newer not tested)|*/
+/*|Supported methods: PEAP + MsCHAPv2, EAP-TTLS + MsCHAPv2    |*/
+/*|-----------------------------------------------------------|*/
+
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
 #include "esp_wpa2.h"
 #include <Wire.h>
-#define EAP_IDENTITY "identity" //if connecting from another corporation, use identity@organisation.domain in Eduroam 
-#define EAP_PASSWORD "password" //your Eduroam password
-const char* ssid = "eduroam"; // Eduroam SSID
-const char* host = "arduino.php5.sk"; //external server domain for HTTP connection after authentification
+#define EAP_ANONYMOUS_IDENTITY "anonymous@example.com" //anonymous identity
+#define EAP_IDENTITY "id@example.com"                  //user identity
+#define EAP_PASSWORD "password" //eduroam user password
+const char* ssid = "eduroam"; // eduroam SSID
+const char* host = "arduino.php5.sk"; //external server domain for HTTPS connection
 int counter = 0;
-const char* test_root_ca= \
-"-----BEGIN CERTIFICATE-----\n" \
-"MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh\n" \
-"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n" \
-"d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\n" \
-"QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT\n" \
-"MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\n" \
-"b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG\n" \
-"9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB\n" \
-"CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97\n" \
-"nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt\n" \
-"43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P\n" \
-"T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4\n" \
-"gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO\n" \
-"BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR\n" \
-"TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw\n" \
-"DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr\n" \
-"hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg\n" \
-"06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF\n" \
-"PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls\n" \
-"YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\n" \
-"CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\n" \
-"-----END CERTIFICATE-----\n";
+const char* test_root_ca = \
+                           "-----BEGIN CERTIFICATE-----\n" \
+                           "MIIEsTCCA5mgAwIBAgIQCKWiRs1LXIyD1wK0u6tTSTANBgkqhkiG9w0BAQsFADBh\n" \
+                           "MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n" \
+                           "d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\n" \
+                           "QTAeFw0xNzExMDYxMjIzMzNaFw0yNzExMDYxMjIzMzNaMF4xCzAJBgNVBAYTAlVT\n" \
+                           "MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\n" \
+                           "b20xHTAbBgNVBAMTFFJhcGlkU1NMIFJTQSBDQSAyMDE4MIIBIjANBgkqhkiG9w0B\n" \
+                           "AQEFAAOCAQ8AMIIBCgKCAQEA5S2oihEo9nnpezoziDtx4WWLLCll/e0t1EYemE5n\n" \
+                           "+MgP5viaHLy+VpHP+ndX5D18INIuuAV8wFq26KF5U0WNIZiQp6mLtIWjUeWDPA28\n" \
+                           "OeyhTlj9TLk2beytbtFU6ypbpWUltmvY5V8ngspC7nFRNCjpfnDED2kRyJzO8yoK\n" \
+                           "MFz4J4JE8N7NA1uJwUEFMUvHLs0scLoPZkKcewIRm1RV2AxmFQxJkdf7YN9Pckki\n" \
+                           "f2Xgm3b48BZn0zf0qXsSeGu84ua9gwzjzI7tbTBjayTpT+/XpWuBVv6fvarI6bik\n" \
+                           "KB859OSGQuw73XXgeuFwEPHTIRoUtkzu3/EQ+LtwznkkdQIDAQABo4IBZjCCAWIw\n" \
+                           "HQYDVR0OBBYEFFPKF1n8a8ADIS8aruSqqByCVtp1MB8GA1UdIwQYMBaAFAPeUDVW\n" \
+                           "0Uy7ZvCj4hsbw5eyPdFVMA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUEFjAUBggrBgEF\n" \
+                           "BQcDAQYIKwYBBQUHAwIwEgYDVR0TAQH/BAgwBgEB/wIBADA0BggrBgEFBQcBAQQo\n" \
+                           "MCYwJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBCBgNVHR8E\n" \
+                           "OzA5MDegNaAzhjFodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vRGlnaUNlcnRHbG9i\n" \
+                           "YWxSb290Q0EuY3JsMGMGA1UdIARcMFowNwYJYIZIAYb9bAECMCowKAYIKwYBBQUH\n" \
+                           "AgEWHGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwCwYJYIZIAYb9bAEBMAgG\n" \
+                           "BmeBDAECATAIBgZngQwBAgIwDQYJKoZIhvcNAQELBQADggEBAH4jx/LKNW5ZklFc\n" \
+                           "YWs8Ejbm0nyzKeZC2KOVYR7P8gevKyslWm4Xo4BSzKr235FsJ4aFt6yAiv1eY0tZ\n" \
+                           "/ZN18bOGSGStoEc/JE4ocIzr8P5Mg11kRYHbmgYnr1Rxeki5mSeb39DGxTpJD4kG\n" \
+                           "hs5lXNoo4conUiiJwKaqH7vh2baryd8pMISag83JUqyVGc2tWPpO0329/CWq2kry\n" \
+                           "qv66OSMjwulUz0dXf4OHQasR7CNfIr+4KScc6ABlQ5RDF86PGeE6kdwSQkFiB/cQ\n" \
+                           "ysNyq0jEDQTkfa2pjmuWtMCNbBnhFXBYejfubIhaUbEv2FOQB3dCav+FPg5eEveX\n" \
+                           "TVyMnGo=\n" \
+                           "-----END CERTIFICATE-----\n";
 // You can use x.509 client certificates if you want
 //const char* test_client_key = "";   //to verify the client
 //const char* test_client_cert = "";  //to verify the client
@@ -47,42 +58,42 @@ void setup() {
   Serial.println(ssid);
   WiFi.disconnect(true);  //disconnect form wifi to set new wifi connection
   WiFi.mode(WIFI_STA); //init wifi mode
-  esp_wifi_sta_wpa2_ent_set_identity((uint8_t *)EAP_IDENTITY, strlen(EAP_IDENTITY)); //provide identity
-  esp_wifi_sta_wpa2_ent_set_username((uint8_t *)EAP_IDENTITY, strlen(EAP_IDENTITY)); //provide username --> identity and username is same
+  esp_wifi_sta_wpa2_ent_set_identity((uint8_t *)EAP_ANONYMOUS_IDENTITY, strlen(EAP_ANONYMOUS_IDENTITY)); //provide identity
+  esp_wifi_sta_wpa2_ent_set_username((uint8_t *)EAP_IDENTITY, strlen(EAP_IDENTITY)); //provide username
   esp_wifi_sta_wpa2_ent_set_password((uint8_t *)EAP_PASSWORD, strlen(EAP_PASSWORD)); //provide password
-  esp_wpa2_config_t config = WPA2_CONFIG_INIT_DEFAULT(); //set config settings to default
-  esp_wifi_sta_wpa2_ent_enable(&config); //set config settings to enable function
+  esp_wpa2_config_t config = WPA2_CONFIG_INIT_DEFAULT();
+  esp_wifi_sta_wpa2_ent_enable(&config);
   WiFi.begin(ssid); //connect to wifi
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");
     counter++;
-    if(counter>=60){ //after 30 seconds timeout - reset board
+    if (counter >= 60) { //after 30 seconds timeout - reset board (on unsucessful connection)
       ESP.restart();
     }
   }
   client.setCACert(test_root_ca);
-  //client.setCertificate(test_client_key); // for client verification
-  //client.setPrivateKey(test_client_cert);  // for client verification
+  //client.setCertificate(test_client_key); // for client verification - certificate
+  //client.setPrivateKey(test_client_cert);  // for client verification - private key
   Serial.println("");
   Serial.println("WiFi connected");
-  Serial.println("IP address set: "); 
+  Serial.println("IP address set: ");
   Serial.println(WiFi.localIP()); //print LAN IP
 }
 void loop() {
-  if (WiFi.status() == WL_CONNECTED) { //if we are connected to Eduroam network
+  if (WiFi.status() == WL_CONNECTED) { //if we are connected to eduroam network
     counter = 0; //reset counter
-    Serial.println("Wifi is still connected with IP: "); 
+    Serial.println("Wifi is still connected with IP: ");
     Serial.println(WiFi.localIP());   //inform user about his IP address
-  }else if (WiFi.status() != WL_CONNECTED) { //if we lost connection, retry
-    WiFi.begin(ssid);      
+  } else if (WiFi.status() != WL_CONNECTED) { //if we lost connection, retry
+    WiFi.begin(ssid);
   }
   while (WiFi.status() != WL_CONNECTED) { //during lost connection, print dots
     delay(500);
     Serial.print(".");
     counter++;
-    if(counter>=60){ //30 seconds timeout - reset board
-    ESP.restart();
+    if (counter >= 60) { //30 seconds timeout - reset board
+      ESP.restart();
     }
   }
   Serial.print("Connecting to website: ");
@@ -98,9 +109,9 @@ void loop() {
       }
     }
     String line = client.readStringUntil('\n');
-   Serial.println(line);
-  }else{
-      Serial.println("Connection unsucessful");
-    }
+    Serial.println(line);
+  } else {
+    Serial.println("Connection unsucessful");
+  }
   delay(5000);
 }


### PR DESCRIPTION
Root CA certificate of my webserver that was used in example for HTTPS connection with eduroam connectivity has changed.
There were deleted and added a few comments, added a new header  with info about example. Tested, under core 1.0.1 (currently using) working, screenshot attached.
Added anonymous identity option to set in variable.
![Sucessful connection with new root CA certificate](https://i.imgur.com/5s5nRXb.png)
