### PR TITLE
Add single quotes to fix bash error when there is a space in either paths {build.source.path} or {build.path}

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -63,8 +63,8 @@ compiler.elf2hex.extra_flags=
 
 # Build Dir: {build.path}
 # Sketch Dir: {build.source.path}
-recipe.hooks.prebuild.1.pattern=bash -c "[ ! -f {build.source.path}/partitions.csv ] || cp -f {build.source.path}/partitions.csv {build.path}/partitions.csv"
-recipe.hooks.prebuild.2.pattern=bash -c "[ -f {build.path}/partitions.csv ] || cp {runtime.platform.path}/tools/partitions/{build.partitions}.csv {build.path}/partitions.csv"
+recipe.hooks.prebuild.1.pattern=bash -c "[ ! -f '{build.source.path}'/partitions.csv ] || cp -f '{build.source.path}'/partitions.csv '{build.path}'/partitions.csv"
+recipe.hooks.prebuild.2.pattern=bash -c "[ -f '{build.path}'/partitions.csv ] || cp '{runtime.platform.path}'/tools/partitions/'{build.partitions}'.csv '{build.path}'/partitions.csv"
 recipe.hooks.prebuild.1.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" copy /y "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
 recipe.hooks.prebuild.2.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" copy "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
 


### PR DESCRIPTION
Using Ubuntu as operating system, and the latest Arduino IDE (1.8.10), I have a space in the path to the source directory resulting in the following error during compilation:

```
bash: line 0: [: too many arguments
cp: target 'partitions.csv' is not a directory
exit status 1
Error compiling for board Node32s.
```

Adding single quotes to the paths {build.source.path} and {build.path} fixes the error.