### PR TITLE
SPI: Fix discarded-qalifiers warning when compiling with all warnings

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -532,16 +532,6 @@ uint8_t spiTransferByte(spi_t * spi, uint8_t data)
     return data;
 }
 
-static uint32_t __spiTranslate24(uint32_t data)
-{
-    union {
-        uint32_t l;
-        uint8_t b[4];
-    } out;
-    out.l = data;
-    return out.b[2] | (out.b[1] << 8) | (out.b[0] << 16);
-}
-
 static uint32_t __spiTranslate32(uint32_t data)
 {
     union {

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -532,7 +532,7 @@ uint8_t spiTransferByte(spi_t * spi, uint8_t data)
     return data;
 }
 
-uint32_t __spiTranslate24(uint32_t data)
+static uint32_t __spiTranslate24(uint32_t data)
 {
     union {
         uint32_t l;
@@ -542,7 +542,7 @@ uint32_t __spiTranslate24(uint32_t data)
     return out.b[2] | (out.b[1] << 8) | (out.b[0] << 16);
 }
 
-uint32_t __spiTranslate32(uint32_t data)
+static uint32_t __spiTranslate32(uint32_t data)
 {
     union {
         uint32_t l;
@@ -630,7 +630,7 @@ uint32_t spiTransferLong(spi_t * spi, uint32_t data)
     return data;
 }
 
-void __spiTransferBytes(spi_t * spi, const uint8_t * data, uint8_t * out, uint32_t bytes)
+static void __spiTransferBytes(spi_t * spi, const uint8_t * data, uint8_t * out, uint32_t bytes)
 {
     if(!spi) {
         return;

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -630,7 +630,7 @@ uint32_t spiTransferLong(spi_t * spi, uint32_t data)
     return data;
 }
 
-void __spiTransferBytes(spi_t * spi, uint8_t * data, uint8_t * out, uint32_t bytes)
+void __spiTransferBytes(spi_t * spi, const uint8_t * data, uint8_t * out, uint32_t bytes)
 {
     if(!spi) {
         return;


### PR DESCRIPTION
This fixes an error introduced with changeset b847f41 which
tightened the use of const for read-only data. The helper
function __transferBytes also requires the const qualifier on
outgoing data. Without this change a warning is displayed
when compiling with the Arduino IDE set to display "All"
compiler warnings.

Local functions __transferBytes() and __spiTranslate32() are now marked as static.

Unused local function __spiTranslate24() has been removed.

Tests:
 - Build an ESP32 SPI sketch that uses static const data to send
   to an SPI device using the SPI.transferBytes() API