### PR TITLE
Include hidden SSID's, scan lists of APs

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.h
+++ b/libraries/WiFi/src/WiFiMulti.h
@@ -42,7 +42,7 @@ public:
 
     bool addAP(const char* ssid, const char *passphrase = NULL);
 
-    uint8_t run(uint32_t connectTimeout=5000);
+    uint8_t run(uint32_t connectTimeout=5000, bool scanHidden=false);
 
 private:
     std::vector<WifiAPlist_t> APlist;


### PR DESCRIPTION
Please consider this refactoring of the WiFiMulti.cpp library to better support lists of APs including those with hidden SSID's. The selection and retry logic has been modified and tested in an environment with multiple AP's hidden and visible. 
