### PR TITLE
Fix BluetoothSerial crash when restart

### DIFF
--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -69,7 +69,10 @@ bool btStop(){
 			log_e("BT deint failed");
 			return false;
 		}
-		while (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED);
+		vTaskDelay(1);
+		if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_IDLE) {			
+			return false;		
+		}
         return true;
     }
     log_e("BT Stop failed");

--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -65,6 +65,11 @@ bool btStop(){
         while(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED);
     }
     if(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED){
+        if (esp_bt_controller_deinit()) {
+			log_e("BT deint failed");
+			return false;
+		}
+		while (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED);
         return true;
     }
     log_e("BT Stop failed");


### PR DESCRIPTION
Fix **BluetoothSerial crash when restart** :  this is because the BT controller remains in state  ESP_BT_CONTROLLER_STATUS_INITED instead of state  ESP_BT_CONTROLLER_STATUS_IDLE after the end() method.
in file esp_bt.h it is specified

> @brief Enable BT controller.
>                Due to a known issue, you cannot call esp_bt_controller_enable() a second time
>                 to change the controller mode dynamically. To change controller mode, call
>                esp_bt_controller_disable() and then call esp_bt_controller_enable() with the new mode.

after **esp_bt_controller_disable()** the controller remains in state INITED so we do call the **esp_bt_controller_deinit()** function to put the controller into state IDLE.