### PR TITLE
HardwareSerial::write(const char*, ...) API compatibility to AVR, ESP8266, et al

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -137,13 +137,13 @@ int HardwareSerial::read(void)
 // the buffer is NOT null terminated.
 size_t HardwareSerial::read(uint8_t *buffer, size_t size)
 {
+    size_t avail = available();
+    if (size < avail) {
+        avail = size;
+    }
     size_t count = 0;
-    while(count < size) {
-        int c = read();
-        if(c < 0) {
-            break;
-        }
-        *buffer++ = (char) c;
+    while(count < avail) {
+        *buffer++ = uartRead(_uart);
         count++;
     }
     return count;

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -131,6 +131,24 @@ int HardwareSerial::read(void)
     return -1;
 }
 
+// read characters into buffer
+// terminates if size characters have been read, or no further are pending
+// returns the number of characters placed in the buffer
+// the buffer is NOT null terminated.
+size_t HardwareSerial::read(uint8_t *buffer, size_t size)
+{
+    size_t count = 0;
+    while(count < size) {
+        int c = read();
+        if(c < 0) {
+            break;
+        }
+        *buffer++ = (char) c;
+        count++;
+    }
+    return count;
+}
+
 void HardwareSerial::flush(void)
 {
     uartFlush(_uart);

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -62,6 +62,11 @@ public:
     int availableForWrite(void);
     int peek(void);
     int read(void);
+    size_t read(uint8_t *buffer, size_t size);
+    inline size_t read(char * buffer, size_t size)
+    {
+        return read((uint8_t*) buffer, size);
+    }
     void flush(void);
     void flush( bool txOnly);
     size_t write(uint8_t);
@@ -70,7 +75,6 @@ public:
     {
         return write((uint8_t*) buffer, size);
     }
-
     inline size_t write(const char * s)
     {
         return write((uint8_t*) s, strlen(s));

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -66,6 +66,10 @@ public:
     void flush( bool txOnly);
     size_t write(uint8_t);
     size_t write(const uint8_t *buffer, size_t size);
+    inline size_t write(const char * buffer, size_t size)
+    {
+        return write((uint8_t*) buffer, size);
+    }
 
     inline size_t write(const char * s)
     {


### PR DESCRIPTION
The ESP32 Arduino implementation of `HardwareSerial.h` is missing
```c++
write(const char * buffer, size_t size);
```
Additionally, this PR adds the `read(buffer, size)` extension from ESP8266, also in `EspSoftwareSerial`, that complements the inherited `Stream::readBytes()` with a non-blocking variant.