### PR TITLE
Move GH CI scripts to Python3

### DIFF
--- a/.github/scripts/install-arduino-core-esp32.sh
+++ b/.github/scripts/install-arduino-core-esp32.sh
@@ -8,11 +8,11 @@ if [ ! -d "$ARDUINO_ESP32_PATH" ]; then
 	cd "$ARDUINO_USR_PATH/hardware/espressif"
 
 	echo "Installing Python Serial ..."
-	pip install pyserial > /dev/null
+	pip3 install pyserial > /dev/null
 
 	if [ "$OS_IS_WINDOWS" == "1" ]; then
 		echo "Installing Python Requests ..."
-		pip install requests > /dev/null
+		pip3 install requests > /dev/null
 	fi
 
 	if [ "$GITHUB_REPOSITORY" == "espressif/arduino-esp32" ];  then
@@ -28,7 +28,7 @@ if [ ! -d "$ARDUINO_ESP32_PATH" ]; then
 	git submodule update --init --recursive > /dev/null 2>&1
 
 	echo "Installing Platform Tools ..."
-	cd tools && python get.py
+	cd tools && python3 get.py
 	cd $script_init_path
 
 	echo "ESP32 Arduino has been installed in '$ARDUINO_ESP32_PATH'"

--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -3,13 +3,13 @@
 export PLATFORMIO_ESP32_PATH="$HOME/.platformio/packages/framework-arduinoespressif32"
 
 echo "Installing Python Wheel ..."
-pip install wheel > /dev/null 2>&1
+pip3 install wheel > /dev/null 2>&1
 
 echo "Installing PlatformIO ..."
-pip install -U https://github.com/platformio/platformio/archive/develop.zip > /dev/null 2>&1
+pip3 install -U https://github.com/platformio/platformio/archive/develop.zip > /dev/null 2>&1
 
 echo "Installing Platform ESP32 ..."
-python -m platformio platform install https://github.com/platformio/platform-espressif32.git#feature/stage > /dev/null 2>&1
+python3 -m platformio platform install https://github.com/platformio/platform-espressif32.git#feature/stage > /dev/null 2>&1
 
 echo "Replacing the framework version ..."
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -42,7 +42,7 @@ function build_pio_sketch(){ # build_pio_sketch <board> <path-to-ino>
     local sketch_dir=$(dirname "$sketch")
     echo ""
     echo "Compiling '"$(basename "$sketch")"' ..."
-    python -m platformio ci --board "$board" "$sketch_dir" --project-option="board_build.partitions = huge_app.csv"
+    python3 -m platformio ci --board "$board" "$sketch_dir" --project-option="board_build.partitions = huge_app.csv"
 }
 
 function count_sketches() # count_sketches <examples-path>

--- a/.github/scripts/merge_packages.py
+++ b/.github/scripts/merge_packages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This script merges two Arduino Board Manager package json files.
 # Usage:
 #   python merge_packages.py package_esp8266com_index.json version/new/package_esp8266com_index.json

--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -138,7 +138,7 @@ function merge_package_json(){
 
     echo "Creating new JSON ..."
     set +e
-    stdbuf -oL python "$PACKAGE_JSON_MERGE" "$jsonOut" "$old_json" > "$merged_json"
+    stdbuf -oL python3 "$PACKAGE_JSON_MERGE" "$jsonOut" "$old_json" > "$merged_json"
     set -e
     
     set -v
@@ -354,7 +354,7 @@ releaseNotes="$RELEASE_BODY$releaseNotes"
 
 # Update release page
 echo "Updating release notes ..."
-releaseNotes=$(printf '%s' "$releaseNotes" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+releaseNotes=$(printf '%s' "$releaseNotes" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
 releaseNotes=${releaseNotes:1:-1}
 curlData="{\"body\": \"$releaseNotes\"}"
 releaseData=`curl --data "$curlData" "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID?access_token=$GITHUB_TOKEN" 2>/dev/null`

--- a/tools/espota.py
+++ b/tools/espota.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Original espota.py by Ivan Grokhotkov:
 # https://gist.github.com/igrr/d35ab8446922179dc58c
@@ -8,7 +8,7 @@
 # Modified since 2016-01-03 from Matthew O'Gorman (https://githumb.com/mogorman)
 #
 # This script will push an OTA update to the ESP
-# use it like: python espota.py -i <ESP_IP_address> -I <Host_IP_address> -p <ESP_port> -P <Host_port> [-a password] -f <sketch.bin>
+# use it like: python3 espota.py -i <ESP_IP_address> -I <Host_IP_address> -p <ESP_port> -P <Host_port> [-a password] -f <sketch.bin>
 # Or to upload SPIFFS image:
 # python espota.py -i <ESP_IP_address> -I <Host_IP_address> -p <ESP_port> -P <HOST_port> [-a password] -s -f <spiffs.bin>
 #

--- a/tools/esptool.py
+++ b/tools/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ESP8266 & ESP32 ROM Bootloader Utility
 # Copyright (C) 2014-2016 Fredrik Ahlberg, Angus Gratton, Espressif Systems (Shanghai) PTE LTD, other contributors as noted.

--- a/tools/gen_esp32part.py
+++ b/tools/gen_esp32part.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ESP32 partition table generation tool
 #

--- a/tools/get.py
+++ b/tools/get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Script to download and extract tools
 


### PR DESCRIPTION
Python2 is EOL in 12 hours, so make sure we call python3 explicitly (and
pip3) in the CI scripts.