### PR TITLE
Update Server.h for arduino core compatibility

### DIFF
--- a/cores/esp32/Server.h
+++ b/cores/esp32/Server.h
@@ -25,7 +25,7 @@
 class Server: public Print
 {
 public:
-    virtual void begin(uint16_t port=0) =0;
+    virtual void begin() =0;
 };
 
 #endif


### PR DESCRIPTION
https://github.com/arduino/ArduinoCore-API/blob/master/api/Server.h
The ArduinoCore uses virtual void begin() =0;  Changing this allowed me to compile a project using the Ethernet library.  Otherwise I would get the following compile error:
```
src\main.cpp:35:16: error: cannot declare variable 'server' to be of abstract type 'EthernetServer'
 EthernetServer server(80);
                ^
In file included from src\main.cpp:21:0:
.pio\libdeps\featheresp32\Ethernet_ID872\src/Ethernet.h:253:7: note:   because the following virtual functions are pure within 'EthernetServer':
 class EthernetServer : public Server {
       ^
In file included from C:\users\orvis\.platformio\packages\framework-arduinoespressif32\cores\esp32/Arduino.h:152:0,
                 from .pio\libdeps\featheresp32\Ethernet_ID872\src/Ethernet.h:51,
                 from src\main.cpp:21:
C:\users\orvis\.platformio\packages\framework-arduinoespressif32\cores\esp32/Server.h:28:18: note:      virtual void Server::begin(uint16_t)
     virtual void begin(uint16_t port = 0) = 0;
```