### PR TITLE
Fix commit d8b2098 (PR #3377) which includes esp_adc_cal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
 
 set(COMPONENT_PRIV_INCLUDEDIRS cores/esp32/libb64)
 
-set(COMPONENT_REQUIRES spi_flash mbedtls mdns ethernet)
+set(COMPONENT_REQUIRES spi_flash mbedtls mdns ethernet esp_adc_cal)
 set(COMPONENT_PRIV_REQUIRES fatfs nvs_flash app_update spiffs bootloader_support openssl bt)
 
 register_component()


### PR DESCRIPTION
Fix recent commit d8b2098 (PR #3377) which includes `esp_adc_cal` component but does not update `CMakeLists.txt`.