### PR TITLE
fix WiFiClient.connected()

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -495,7 +495,7 @@ uint8_t WiFiClient::connected()
         int res = recv(fd(), &dummy, 0, MSG_DONTWAIT);
         // avoid unused var warning by gcc
         (void)res;
-        // recv only sets errno if res is -1
+        // recv only sets errno if res is <= 0
         if (res <= 0){
           switch (errno) {
               case EWOULDBLOCK:

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -496,7 +496,7 @@ uint8_t WiFiClient::connected()
         // avoid unused var warning by gcc
         (void)res;
         // recv only sets errno if res is -1
-        if (res < 0){
+        if (res <= 0){
           switch (errno) {
               case EWOULDBLOCK:
               case ENOENT: //caused by vfs


### PR DESCRIPTION
WiFiClient.connected() was hanging thinking there was still a connection when the remote had already closed. The one-liner in this patch addresses recv() returning 0 and errno==128. I couldn't find the corresponding errno for 128 but its caught by the case statement which includes EPIPE, ENOTCONN, ECONNRESET and ECONNABORTED so I assume its one of those. Broken pipe maybe?
```c
[D][WiFiClient.cpp:511] connected(): Disconnected: RES: 0, ERR: 128
```
EDIT: added comment to reflect that recv() can set errno when it returns 0.