### PR TITLE
Greatly reduced error rate of WMath map() roundtrip

### DIFF
--- a/cores/esp32/WMath.cpp
+++ b/cores/esp32/WMath.cpp
@@ -66,11 +66,11 @@ long random(long howsmall, long howbig)
 }
 
 long map(long x, long in_min, long in_max, long out_min, long out_max) {
-    long divisor = (in_max - in_min);
-    if(divisor == 0){
-        return -1; //AVR returns -1, SAM returns 0
-    }
-    return (x - in_min) * (out_max - out_min) / divisor + out_min;
+    const long dividend = out_max - out_min;
+    const long divisor = in_max - in_min;
+    const long delta = x - in_min;
+
+    return (delta * dividend + (divisor / 2)) / divisor + out_min;
 }
 
 unsigned int makeWord(unsigned int w)


### PR DESCRIPTION
Half, or zero errors, depending on in/out…… ranges, for round-trip mapping at the same performance.
(Based on "improved_map" from ESP8266's Servo.cpp)