### PR TITLE
Minimize HardwareSerial Receive and Transmit delays

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -208,6 +208,11 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
         uart->dev->conf0.stop_bit_num = ONE_STOP_BITS_CONF;
         uart->dev->rs485_conf.dl1_en = 1;
     }
+
+    // tx_idle_num : idle interval after tx FIFO is empty(unit: the time it takes to send one bit under current baudrate)
+    // Setting it to 0 prevents line idle time/delays when sending messages with small intervals
+    uart->dev->idle_conf.tx_idle_num = 0;  //
+
     UART_MUTEX_UNLOCK();
 
     if(rxPin != -1) {
@@ -265,7 +270,7 @@ uint32_t uartAvailable(uart_t* uart)
     if(uart == NULL || uart->queue == NULL) {
         return 0;
     }
-    return uxQueueMessagesWaiting(uart->queue);
+    return (uxQueueMessagesWaiting(uart->queue) + uart->dev->status.rxfifo_cnt) ;
 }
 
 uint32_t uartAvailableForWrite(uart_t* uart)
@@ -276,12 +281,27 @@ uint32_t uartAvailableForWrite(uart_t* uart)
     return 0x7f - uart->dev->status.txfifo_cnt;
 }
 
+void uartRxFifoToQueue(uart_t* uart)
+{
+	uint8_t c;
+    UART_MUTEX_LOCK();
+    while(uart->dev->status.rxfifo_cnt || (uart->dev->mem_rx_status.wr_addr != uart->dev->mem_rx_status.rd_addr)) {
+        c = uart->dev->fifo.rw_byte;
+        xQueueSend(uart->queue, &c, 0);
+    }
+    UART_MUTEX_UNLOCK();
+}
+
 uint8_t uartRead(uart_t* uart)
 {
     if(uart == NULL || uart->queue == NULL) {
         return 0;
     }
     uint8_t c;
+    if ((uxQueueMessagesWaiting(uart->queue) == 0) && (uart->dev->status.rxfifo_cnt > 0))
+    {
+    	uartRxFifoToQueue(uart);
+    }
     if(xQueueReceive(uart->queue, &c, 0)) {
         return c;
     }
@@ -294,6 +314,10 @@ uint8_t uartPeek(uart_t* uart)
         return 0;
     }
     uint8_t c;
+    if ((uxQueueMessagesWaiting(uart->queue) == 0) && (uart->dev->status.rxfifo_cnt > 0))
+    {
+    	uartRxFifoToQueue(uart);
+    }
     if(xQueuePeek(uart->queue, &c, 0)) {
         return c;
     }

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -59,8 +59,6 @@ uint32_t uartAvailableForWrite(uart_t* uart);
 uint8_t uartRead(uart_t* uart);
 uint8_t uartPeek(uart_t* uart);
 
-void uartRxFifoToQueue(uart_t* uart);
-
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -59,6 +59,8 @@ uint32_t uartAvailableForWrite(uart_t* uart);
 uint8_t uartRead(uart_t* uart);
 uint8_t uartPeek(uart_t* uart);
 
+void uartRxFifoToQueue(uart_t* uart);
+
 void uartWrite(uart_t* uart, uint8_t c);
 void uartWriteBuf(uart_t* uart, const uint8_t * data, size_t len);
 


### PR DESCRIPTION
In current HardwareSerial/esp-uart-hal 
- on Transmit
In the uart configutarion setting there is a parameter tx_idle_num.
tx_idle_num is : idle interval after tx FIFO is empty(unit: the time it takes to send one bit under current baudrate)
This tx_idle_num is set to 256.
Resulting in a forced transmit idle time after txFifo empty to next.

This PR sets the tx_idle_num value to zero at uartBegin(). 
Result is an immediate start of transmission when a char is send.

- On Receive
The chars are first received in rxFifo buffer which is transfered to HardwareSerial Queue on either fifo filled with 112 chars or 2 bytes idle time. 
Resulting in a delay at application level processing the incoming messages.

This PR takes the characters in rxFifo into account when calling available(), read() and peek().
Result is an immediate transfer from queue and/or fifo when application requests data.

To demonstrate/test I have an application doing message transfer at 19200 baud
- send a 6 byte message
- receives a 6 bytes message
- responds to that with a 6 byte message.

Running with Master : duration 19.3 ms
Running with PR : duration 9.3 ms

![SerialMaster](https://user-images.githubusercontent.com/4587225/73084843-023da180-3ece-11ea-8eab-6fe3f55e2d5a.JPG)

![SerialPR](https://user-images.githubusercontent.com/4587225/73084856-0a95dc80-3ece-11ea-9a8e-317762c0f5fd.JPG)
