### PR TITLE
fix removeApbChangeCallback() error in spiStopBus()

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -406,7 +406,7 @@ void spiStopBus(spi_t * spi)
     removeApbChangeCallback(spi, _on_apb_change);
     
     SPI_MUTEX_LOCK();
-    spiInitbus(spi);
+    spiInitBus(spi);
     SPI_MUTEX_UNLOCK();
 }
 

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -384,12 +384,8 @@ static void _on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb
     }
 }
 
-void spiStopBus(spi_t * spi)
+static void spiInitBus(spi_t * spi)
 {
-    if(!spi) {
-        return;
-    }
-    SPI_MUTEX_LOCK();
     spi->dev->slave.trans_done = 0;
     spi->dev->slave.slave_mode = 0;
     spi->dev->pin.val = 0;
@@ -399,8 +395,19 @@ void spiStopBus(spi_t * spi)
     spi->dev->ctrl1.val = 0;
     spi->dev->ctrl2.val = 0;
     spi->dev->clock.val = 0;
-    SPI_MUTEX_UNLOCK();
+}
+
+void spiStopBus(spi_t * spi)
+{
+    if(!spi) {
+        return;
+    }
+    
     removeApbChangeCallback(spi, _on_apb_change);
+    
+    SPI_MUTEX_LOCK();
+    spiInitbus(spi);
+    SPI_MUTEX_UNLOCK();
 }
 
 spi_t * spiStartBus(uint8_t spi_num, uint32_t clockDiv, uint8_t dataMode, uint8_t bitOrder)
@@ -431,12 +438,8 @@ spi_t * spiStartBus(uint8_t spi_num, uint32_t clockDiv, uint8_t dataMode, uint8_
         DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_SPI_RST_1);
     }
 
-    spiStopBus(spi);
-    spiSetDataMode(spi, dataMode);
-    spiSetBitOrder(spi, bitOrder);
-    spiSetClockDiv(spi, clockDiv);
-
     SPI_MUTEX_LOCK();
+    spiInitBus(spi);
     spi->dev->user.usr_mosi = 1;
     spi->dev->user.usr_miso = 1;
     spi->dev->user.doutdin = 1;
@@ -446,6 +449,10 @@ spi_t * spiStartBus(uint8_t spi_num, uint32_t clockDiv, uint8_t dataMode, uint8_
         spi->dev->data_buf[i] = 0x00000000;
     }
     SPI_MUTEX_UNLOCK();
+
+    spiSetDataMode(spi, dataMode);
+    spiSetBitOrder(spi, bitOrder);
+    spiSetClockDiv(spi, clockDiv);
 
     addApbChangeCallback(spi, _on_apb_change);
     return spi;


### PR DESCRIPTION
spiStartBus() was using spiStopBus() to init the hardware, one of spiStopBus() functions is to unregister the runtime CPU clock speed change callback. But, spiStartBus() only wanted to init the hardware.  This patch separates the hardware init into a standalone function spiInitBus() that both spiStartBus() and spiStopBus() call.