### PR TITLE
std::shared_ptr Memory Leak

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -188,9 +188,7 @@ WiFiClient::~WiFiClient()
 WiFiClient & WiFiClient::operator=(const WiFiClient &other)
 {
     stop();
-    clientSocketHandle.reset();
     clientSocketHandle = other.clientSocketHandle;
-    _rxBuffer.reset();
     _rxBuffer = other._rxBuffer;
     _connected = other._connected;
     return *this;

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -188,8 +188,10 @@ WiFiClient::~WiFiClient()
 WiFiClient & WiFiClient::operator=(const WiFiClient &other)
 {
     stop();
-    clientSocketHandle.reset( other.clientSocketHandle ); // clientSocketHandle = other.clientSocketHandle;
-    _rxBuffer.reset( other._rxBuffer); // _rxBuffer = other._rxBuffer;
+    clientSocketHandle.reset();
+    clientSocketHandle = other.clientSocketHandle;
+    _rxBuffer.reset();
+    _rxBuffer = other._rxBuffer;
     _connected = other._connected;
     return *this;
 }

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -188,16 +188,16 @@ WiFiClient::~WiFiClient()
 WiFiClient & WiFiClient::operator=(const WiFiClient &other)
 {
     stop();
-    clientSocketHandle = other.clientSocketHandle;
-    _rxBuffer = other._rxBuffer;
+    clientSocketHandle.reset( other.clientSocketHandle ); // clientSocketHandle = other.clientSocketHandle;
+    _rxBuffer.reset( other._rxBuffer); // _rxBuffer = other._rxBuffer;
     _connected = other._connected;
     return *this;
 }
 
 void WiFiClient::stop()
 {
-    clientSocketHandle = NULL;
-    _rxBuffer = NULL;
+    clientSocketHandle.reset(); // clientSocketHandle = NULL;
+    _rxBuffer.reset(); // _rxBuffer = NULL;
     _connected = false;
 }
 


### PR DESCRIPTION
clientSocketHande and _rxBuffer are std::shared_ptr, the stop() call was not correctly releasing them and the operator= had similar problems fix for #3679