### PR TITLE
Fix failing Updater with https (WifiClientSecure)

### DIFF
--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -346,7 +346,7 @@ size_t UpdateClass::writeStream(Stream &data) {
             // toRead timeout
             if(toRead == 0) {
                 fail++;
-                if (fail > 20) {
+                if (fail > 30) {
                     log_d("timeout %d", fail);
                     _abort(UPDATE_ERROR_STREAM);
                     return written;

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -352,6 +352,8 @@ size_t UpdateClass::writeStream(Stream &data) {
                     return written;
                 }
                 delay(1000);
+             } else {
+             	fail = 0; // reset timeout
              }
         }
 


### PR DESCRIPTION
In arduino code

>        size_t written = Update.writeStream(client2);

Current code often fails with error "Error Occurred. Error #: 6", with this patch this error doesn't appear.
I tested it on my side, but it should be unit tested on other scenarios, if possible.
