### PR TITLE
add board TTGO T-Display

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -4838,12 +4838,12 @@ ttgo-t-display.build.flash_freq=40m
 ttgo-t-display.build.flash_mode=dio
 ttgo-t-display.build.boot=dio
 ttgo-t-display.build.partitions=default
-ttgo-t-display.build.defines=
+ttgo-t-display.build.commondefs=-DARDUINO_TTGO_Display -DUSER_SETUP_LOADED=1 -DST7789_DRIVER=1 -DTFT_WIDTH=135 -DTFT_HEIGHT=240 -DCGRAM_OFFSET=1 -DTFT_MOSI=19 -DTFT_SCLK=18 -DTFT_CS=5 -DTFT_DC=16 -DTFT_RST=23 -DTFT_BL=4 -DTFT_BACKLIGHT_ON=HIGH -DLOAD_GLCD=1 -DLOAD_FONT2=1 -DLOAD_FONT4=1 -DLOAD_FONT6=1 -DLOAD_FONT7=1 -DLOAD_FONT8=1 -DLOAD_GFXFF=1 -DSMOOTH_FONT=1 -DSPI_FREQUENCY=40000000 -DSPI_READ_FREQUENCY=6000000
 
 ttgo-t-display.menu.PSRAM.disabled=Disabled
-ttgo-t-display.menu.PSRAM.disabled.build.defines=
+ttgo-t-display.menu.PSRAM.disabled.build.defines={build.commondefs}
 ttgo-t-display.menu.PSRAM.enabled=Enabled
-ttgo-t-display.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+ttgo-t-display.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue {build.commondefs}
 
 ttgo-t-display.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 ttgo-t-display.menu.PartitionScheme.default.build.partitions=default

--- a/boards.txt
+++ b/boards.txt
@@ -4816,3 +4816,141 @@ sensesiot_weizen.menu.UploadSpeed.460800.upload.speed=460800
 sensesiot_weizen.menu.UploadSpeed.512000.windows=512000
 sensesiot_weizen.menu.UploadSpeed.512000.upload.speed=512000
 ##############################################################
+
+ttgo-t-display.name=TTGO Display
+
+ttgo-t-display.upload.tool=esptool_py
+ttgo-t-display.upload.maximum_size=1310720
+ttgo-t-display.upload.maximum_data_size=327680
+ttgo-t-display.upload.wait_for_upload_port=true
+
+ttgo-t-display.serial.disableDTR=true
+ttgo-t-display.serial.disableRTS=true
+
+ttgo-t-display.build.mcu=esp32
+ttgo-t-display.build.core=esp32
+ttgo-t-display.build.variant=ttgo-display
+ttgo-t-display.build.board=TTGO_Display
+
+ttgo-t-display.build.f_cpu=240000000L
+ttgo-t-display.build.flash_size=4MB
+ttgo-t-display.build.flash_freq=40m
+ttgo-t-display.build.flash_mode=dio
+ttgo-t-display.build.boot=dio
+ttgo-t-display.build.partitions=default
+ttgo-t-display.build.defines=
+
+ttgo-t-display.menu.PSRAM.disabled=Disabled
+ttgo-t-display.menu.PSRAM.disabled.build.defines=
+ttgo-t-display.menu.PSRAM.enabled=Enabled
+ttgo-t-display.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+
+ttgo-t-display.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+ttgo-t-display.menu.PartitionScheme.default.build.partitions=default
+ttgo-t-display.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+ttgo-t-display.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+ttgo-t-display.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+ttgo-t-display.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+ttgo-t-display.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+ttgo-t-display.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+ttgo-t-display.menu.PartitionScheme.minimal.build.partitions=minimal
+ttgo-t-display.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+ttgo-t-display.menu.PartitionScheme.no_ota.build.partitions=no_ota
+ttgo-t-display.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+ttgo-t-display.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+ttgo-t-display.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+ttgo-t-display.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+ttgo-t-display.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+ttgo-t-display.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+ttgo-t-display.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+ttgo-t-display.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+ttgo-t-display.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+ttgo-t-display.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+ttgo-t-display.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+ttgo-t-display.menu.PartitionScheme.huge_app.build.partitions=huge_app
+ttgo-t-display.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+ttgo-t-display.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+ttgo-t-display.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+ttgo-t-display.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+ttgo-t-display.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FAT)
+ttgo-t-display.menu.PartitionScheme.fatflash.build.partitions=ffat
+ttgo-t-display.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+ttgo-t-display.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
+ttgo-t-display.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+ttgo-t-display.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+ttgo-t-display.menu.CPUFreq.240=240MHz (WiFi/BT)
+ttgo-t-display.menu.CPUFreq.240.build.f_cpu=240000000L
+ttgo-t-display.menu.CPUFreq.160=160MHz (WiFi/BT)
+ttgo-t-display.menu.CPUFreq.160.build.f_cpu=160000000L
+ttgo-t-display.menu.CPUFreq.80=80MHz (WiFi/BT)
+ttgo-t-display.menu.CPUFreq.80.build.f_cpu=80000000L
+ttgo-t-display.menu.CPUFreq.40=40MHz (40MHz XTAL)
+ttgo-t-display.menu.CPUFreq.40.build.f_cpu=40000000L
+ttgo-t-display.menu.CPUFreq.26=26MHz (26MHz XTAL)
+ttgo-t-display.menu.CPUFreq.26.build.f_cpu=26000000L
+ttgo-t-display.menu.CPUFreq.20=20MHz (40MHz XTAL)
+ttgo-t-display.menu.CPUFreq.20.build.f_cpu=20000000L
+ttgo-t-display.menu.CPUFreq.13=13MHz (26MHz XTAL)
+ttgo-t-display.menu.CPUFreq.13.build.f_cpu=13000000L
+ttgo-t-display.menu.CPUFreq.10=10MHz (40MHz XTAL)
+ttgo-t-display.menu.CPUFreq.10.build.f_cpu=10000000L
+
+ttgo-t-display.menu.FlashMode.qio=QIO
+ttgo-t-display.menu.FlashMode.qio.build.flash_mode=dio
+ttgo-t-display.menu.FlashMode.qio.build.boot=qio
+ttgo-t-display.menu.FlashMode.dio=DIO
+ttgo-t-display.menu.FlashMode.dio.build.flash_mode=dio
+ttgo-t-display.menu.FlashMode.dio.build.boot=dio
+ttgo-t-display.menu.FlashMode.qout=QOUT
+ttgo-t-display.menu.FlashMode.qout.build.flash_mode=dout
+ttgo-t-display.menu.FlashMode.qout.build.boot=qout
+ttgo-t-display.menu.FlashMode.dout=DOUT
+ttgo-t-display.menu.FlashMode.dout.build.flash_mode=dout
+ttgo-t-display.menu.FlashMode.dout.build.boot=dout
+
+ttgo-t-display.menu.FlashFreq.80=80MHz
+ttgo-t-display.menu.FlashFreq.80.build.flash_freq=80m
+ttgo-t-display.menu.FlashFreq.40=40MHz
+ttgo-t-display.menu.FlashFreq.40.build.flash_freq=40m
+
+ttgo-t-display.menu.FlashSize.4M=4MB (32Mb)
+ttgo-t-display.menu.FlashSize.4M.build.flash_size=4MB
+ttgo-t-display.menu.FlashSize.8M=8MB (64Mb)
+ttgo-t-display.menu.FlashSize.8M.build.flash_size=8MB
+ttgo-t-display.menu.FlashSize.8M.build.partitions=default_8MB
+ttgo-t-display.menu.FlashSize.2M=2MB (16Mb)
+ttgo-t-display.menu.FlashSize.2M.build.flash_size=2MB
+ttgo-t-display.menu.FlashSize.2M.build.partitions=minimal
+ttgo-t-display.menu.FlashSize.16M=16MB (128Mb)
+ttgo-t-display.menu.FlashSize.16M.build.flash_size=16MB
+
+ttgo-t-display.menu.UploadSpeed.921600=921600
+ttgo-t-display.menu.UploadSpeed.921600.upload.speed=921600
+ttgo-t-display.menu.UploadSpeed.115200=115200
+ttgo-t-display.menu.UploadSpeed.115200.upload.speed=115200
+ttgo-t-display.menu.UploadSpeed.256000.windows=256000
+ttgo-t-display.menu.UploadSpeed.256000.upload.speed=256000
+ttgo-t-display.menu.UploadSpeed.230400.windows.upload.speed=256000
+ttgo-t-display.menu.UploadSpeed.230400=230400
+ttgo-t-display.menu.UploadSpeed.230400.upload.speed=230400
+ttgo-t-display.menu.UploadSpeed.460800.linux=460800
+ttgo-t-display.menu.UploadSpeed.460800.macosx=460800
+ttgo-t-display.menu.UploadSpeed.460800.upload.speed=460800
+ttgo-t-display.menu.UploadSpeed.512000.windows=512000
+ttgo-t-display.menu.UploadSpeed.512000.upload.speed=512000
+
+ttgo-t-display.menu.DebugLevel.none=None
+ttgo-t-display.menu.DebugLevel.none.build.code_debug=0
+ttgo-t-display.menu.DebugLevel.error=Error
+ttgo-t-display.menu.DebugLevel.error.build.code_debug=1
+ttgo-t-display.menu.DebugLevel.warn=Warn
+ttgo-t-display.menu.DebugLevel.warn.build.code_debug=2
+ttgo-t-display.menu.DebugLevel.info=Info
+ttgo-t-display.menu.DebugLevel.info.build.code_debug=3
+ttgo-t-display.menu.DebugLevel.debug=Debug
+ttgo-t-display.menu.DebugLevel.debug.build.code_debug=4
+ttgo-t-display.menu.DebugLevel.verbose=Verbose
+ttgo-t-display.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -4838,12 +4838,12 @@ ttgo-t-display.build.flash_freq=40m
 ttgo-t-display.build.flash_mode=dio
 ttgo-t-display.build.boot=dio
 ttgo-t-display.build.partitions=default
-ttgo-t-display.build.commondefs=-DARDUINO_TTGO_Display -DUSER_SETUP_LOADED=1 -DST7789_DRIVER=1 -DTFT_WIDTH=135 -DTFT_HEIGHT=240 -DCGRAM_OFFSET=1 -DTFT_MOSI=19 -DTFT_SCLK=18 -DTFT_CS=5 -DTFT_DC=16 -DTFT_RST=23 -DTFT_BL=4 -DTFT_BACKLIGHT_ON=HIGH -DLOAD_GLCD=1 -DLOAD_FONT2=1 -DLOAD_FONT4=1 -DLOAD_FONT6=1 -DLOAD_FONT7=1 -DLOAD_FONT8=1 -DLOAD_GFXFF=1 -DSMOOTH_FONT=1 -DSPI_FREQUENCY=40000000 -DSPI_READ_FREQUENCY=6000000
+ttgo-t-display.build.defines=
 
 ttgo-t-display.menu.PSRAM.disabled=Disabled
-ttgo-t-display.menu.PSRAM.disabled.build.defines={build.commondefs}
+ttgo-t-display.menu.PSRAM.disabled.build.defines=
 ttgo-t-display.menu.PSRAM.enabled=Enabled
-ttgo-t-display.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue {build.commondefs}
+ttgo-t-display.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
 
 ttgo-t-display.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 ttgo-t-display.menu.PartitionScheme.default.build.partitions=default

--- a/variants/ttgo-display/pins_arduino.h
+++ b/variants/ttgo-display/pins_arduino.h
@@ -1,0 +1,62 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+static const uint8_t VBAT = 34;
+
+static const uint8_t RIGHT_BUTTON = 35;
+static const uint8_t LEFT_BUTTON = 0;
+
+
+#endif /* Pins_Arduino_h */

--- a/variants/ttgo-display/pins_arduino.h
+++ b/variants/ttgo-display/pins_arduino.h
@@ -58,5 +58,4 @@ static const uint8_t VBAT = 34;
 static const uint8_t RIGHT_BUTTON = 35;
 static const uint8_t LEFT_BUTTON = 0;
 
-
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
This adds a new board TTGO T-Display.
This also requires related changes in platform-espressif32. See my pull request there.

This board is like a base ESP32 dev board with integrated display.
Hence, the additions are modified copies from the ESP32 DEV board.
