### PR TITLE
Move _STREAM_BOUNDARY before _STREAM_PART

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
@@ -404,14 +404,14 @@ static esp_err_t stream_handler(httpd_req_t *req){
             }
         }
         if(res == ESP_OK){
+            res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
+        }
+        if(res == ESP_OK){
             size_t hlen = snprintf((char *)part_buf, 64, _STREAM_PART, _jpg_buf_len);
             res = httpd_resp_send_chunk(req, (const char *)part_buf, hlen);
         }
         if(res == ESP_OK){
             res = httpd_resp_send_chunk(req, (const char *)_jpg_buf, _jpg_buf_len);
-        }
-        if(res == ESP_OK){
-            res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
         }
         if(fb){
             esp_camera_fb_return(fb);


### PR DESCRIPTION
The boundary delimiter (_STREAM_BOUNDARY) needs to be send before the body part (_STREAM_PART) too follow RFC2046. This caused `ffplay`/`ffmpeg` to fail to open the MJPEG stream.

[RFC2046: 5.1. Multipart Media Type](https://tools.ietf.org/html/rfc2046#section-5.1)
"... The body must then contain one or more body parts, **each preceded by a boundary delimiter line**, and the last one followed by a closing boundary delimiter line. ..."

After the change `ffplay`, `ffmpeg` and `mplayer` worked fine with the MJPEG stream. 
