### PR TITLE
prefer custom mac address over efuse mac address for wifi interface

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -104,7 +104,10 @@ void tcpipInit(){
         initialized = true;
 #ifdef ESP_IDF_VERSION_MAJOR
         uint8_t mac[8];
-        if(esp_efuse_mac_get_default(mac) == ESP_OK){
+        if(esp_base_mac_addr_get(mac) == ESP_OK){
+            esp_base_mac_addr_set(mac);
+        }
+        else if(esp_efuse_mac_get_default(mac) == ESP_OK){
             esp_base_mac_addr_set(mac);
         }
         esp_event_loop_create_default();


### PR DESCRIPTION
if no custom mac is set it'll read the mac from efuse storage as before

im not sure if this might also be required to be changed for other interfaces like ethernet and bluetooth (a quick search didnt find any other reference for esp_efuse_mac_get_default())