### PR TITLE
Allow using custom linker scripts in PlatformIO build script

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -184,6 +184,9 @@ env.Append(
     ]
 )
 
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(LDSCRIPT_PATH=env.BoardConfig().get("build.arduino.ldscript", ""))
+
 #
 # Target: Build Core Library
 #


### PR DESCRIPTION
This will allow users to set any linker script from `platformio.ini` file using the following syntax:
```ini
[env:esp32dev]
platform = espressif32
framework = arduino
board = esp32dev
board_build.ldscript = custom_ldscript.ld
```
This is a more correct way of specifying it in comparison with using the `-Wl,-T` flag.
