### PR TITLE
Fix crash when deleting BLEClient

### DIFF
--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -302,10 +302,6 @@ std::string BLERemoteService::getValue(BLEUUID characteristicUuid) {
  * @return N/A.
  */
 void BLERemoteService::removeCharacteristics() {
-	for (auto &myPair : m_characteristicMap) {
-	   delete myPair.second;
-	   //m_characteristicMap.erase(myPair.first);  // Should be no need to delete as it will be deleted by the clear
-	}
 	m_characteristicMap.clear();   // Clear the map
 	for (auto &myPair : m_characteristicMapByHandle) {
 	   delete myPair.second;


### PR DESCRIPTION
Currently the ESP crashes when delete is called on a BLEClient instance because the BLERemoteService tries to delete its characteristics twice.

This has already been fixed here https://github.com/nkolban/esp32-snippets/blob/fe3d318acddf87c6918944f24e8b899d63c816dd/cpp_utils/BLERemoteService.cpp#L267 but somehow didn't make it into the master/current releases.