### PR TITLE
Change board name

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -4040,7 +4040,7 @@ ttgo-t-watch.serial.disableRTS=true
 ttgo-t-watch.build.mcu=esp32
 ttgo-t-watch.build.core=esp32
 ttgo-t-watch.build.variant=twatch
-ttgo-t-watch.build.board=T-Watch
+ttgo-t-watch.build.board=TWatch
 
 ttgo-t-watch.build.f_cpu=240000000L
 ttgo-t-watch.build.flash_size=16MB


### PR DESCRIPTION
The original definition of T-Watch will eventually be defined as ARDUINO_T-Twatch. This is a useless macro. Now modify it to TWatch.