### PR TITLE
Update RMTLoopback.ino

### DIFF
--- a/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
+++ b/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
@@ -11,7 +11,7 @@ rmt_data_t data[256];
 rmt_obj_t* rmt_send = NULL;
 rmt_obj_t* rmt_recv = NULL;
 
-static EventGroupHandle_t events;
+static EventGroupHandle_t events = xEventGroupCreate();
 
 void setup() 
 {

--- a/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
+++ b/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
@@ -11,11 +11,12 @@ rmt_data_t data[256];
 rmt_obj_t* rmt_send = NULL;
 rmt_obj_t* rmt_recv = NULL;
 
-static EventGroupHandle_t events = xEventGroupCreate();
+static EventGroupHandle_t events;
 
 void setup() 
 {
     Serial.begin(115200);
+    events = xEventGroupCreate();
     
     if ((rmt_send = rmtInit(18, true, RMT_MEM_64)) == NULL)
     {


### PR DESCRIPTION
BUGFIX: avoids assertion in xEventGroupWaitBits()
(/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/event_groups.c:350 (xEventGroupWaitBits)- assert failed!)