### PR TITLE
Fixed bug where mutex would not be unlocked

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -257,6 +257,7 @@ size_t uartResizeRxBuffer(uart_t * uart, size_t new_size) {
         vQueueDelete(uart->queue);
         uart->queue = xQueueCreate(new_size, sizeof(uint8_t));
         if(uart->queue == NULL) {
+            UART_MUTEX_UNLOCK();
             return NULL;
         }
     }


### PR DESCRIPTION
Fixed bug where uartResizeRxBuffer() did not unlock mutex if creation of queue failed.