### PR TITLE
Addition of baudrate/upload speed options for Olimex boards

### DIFF
--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -6,10 +6,10 @@ echo "Installing Python Wheel ..."
 pip install wheel > /dev/null 2>&1
 
 echo "Installing PlatformIO ..."
-pip install -U https://github.com/platformio/platformio/archive/develop.zip > /dev/null 2>&1
+pip install -U https://github.com/platformio/platformio/archive/develop.zip
 
 echo "Installing Platform ESP32 ..."
-python -m platformio platform install https://github.com/platformio/platform-espressif32.git#feature/stage > /dev/null 2>&1
+python -m platformio platform install espressif32
 
 echo "Replacing the framework version ..."
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/boards.txt
+++ b/boards.txt
@@ -2025,8 +2025,20 @@ esp32-evb.menu.FlashFreq.40=40MHz
 esp32-evb.menu.FlashFreq.40.build.flash_freq=40m
 
 
+esp32-evb.menu.UploadSpeed.921600=921600
+esp32-evb.menu.UploadSpeed.921600.upload.speed=921600
 esp32-evb.menu.UploadSpeed.115200=115200
 esp32-evb.menu.UploadSpeed.115200.upload.speed=115200
+esp32-evb.menu.UploadSpeed.256000.windows=256000
+esp32-evb.menu.UploadSpeed.256000.upload.speed=256000
+esp32-evb.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32-evb.menu.UploadSpeed.230400=230400
+esp32-evb.menu.UploadSpeed.230400.upload.speed=230400
+esp32-evb.menu.UploadSpeed.460800.linux=460800
+esp32-evb.menu.UploadSpeed.460800.macosx=460800
+esp32-evb.menu.UploadSpeed.460800.upload.speed=460800
+esp32-evb.menu.UploadSpeed.512000.windows=512000
+esp32-evb.menu.UploadSpeed.512000.upload.speed=512000
 
 esp32-evb.menu.PartitionScheme.default=Default
 esp32-evb.menu.PartitionScheme.default.build.partitions=default
@@ -2072,9 +2084,20 @@ esp32-gateway.menu.FlashFreq.80.build.flash_freq=80m
 esp32-gateway.menu.FlashFreq.40=40MHz
 esp32-gateway.menu.FlashFreq.40.build.flash_freq=40m
 
-
+esp32-gateway.menu.UploadSpeed.921600=921600
+esp32-gateway.menu.UploadSpeed.921600.upload.speed=921600
 esp32-gateway.menu.UploadSpeed.115200=115200
 esp32-gateway.menu.UploadSpeed.115200.upload.speed=115200
+esp32-gateway.menu.UploadSpeed.256000.windows=256000
+esp32-gateway.menu.UploadSpeed.256000.upload.speed=256000
+esp32-gateway.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32-gateway.menu.UploadSpeed.230400=230400
+esp32-gateway.menu.UploadSpeed.230400.upload.speed=230400
+esp32-gateway.menu.UploadSpeed.460800.linux=460800
+esp32-gateway.menu.UploadSpeed.460800.macosx=460800
+esp32-gateway.menu.UploadSpeed.460800.upload.speed=460800
+esp32-gateway.menu.UploadSpeed.512000.windows=512000
+esp32-gateway.menu.UploadSpeed.512000.upload.speed=512000
 
 esp32-gateway.menu.PartitionScheme.default=Default
 esp32-gateway.menu.PartitionScheme.default.build.partitions=default
@@ -2114,9 +2137,20 @@ esp32-poe.menu.FlashFreq.80.build.flash_freq=80m
 esp32-poe.menu.FlashFreq.40=40MHz
 esp32-poe.menu.FlashFreq.40.build.flash_freq=40m
 
-
+esp32-poe.menu.UploadSpeed.921600=921600
+esp32-poe.menu.UploadSpeed.921600.upload.speed=921600
 esp32-poe.menu.UploadSpeed.115200=115200
 esp32-poe.menu.UploadSpeed.115200.upload.speed=115200
+esp32-poe.menu.UploadSpeed.256000.windows=256000
+esp32-poe.menu.UploadSpeed.256000.upload.speed=256000
+esp32-poe.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32-poe.menu.UploadSpeed.230400=230400
+esp32-poe.menu.UploadSpeed.230400.upload.speed=230400
+esp32-poe.menu.UploadSpeed.460800.linux=460800
+esp32-poe.menu.UploadSpeed.460800.macosx=460800
+esp32-poe.menu.UploadSpeed.460800.upload.speed=460800
+esp32-poe.menu.UploadSpeed.512000.windows=512000
+esp32-poe.menu.UploadSpeed.512000.upload.speed=512000
 
 esp32-poe.menu.PartitionScheme.default=Default
 esp32-poe.menu.PartitionScheme.default.build.partitions=default
@@ -2156,9 +2190,20 @@ esp32-poe-iso.menu.FlashFreq.80.build.flash_freq=80m
 esp32-poe-iso.menu.FlashFreq.40=40MHz
 esp32-poe-iso.menu.FlashFreq.40.build.flash_freq=40m
 
-
+esp32-poe-iso.menu.UploadSpeed.921600=921600
+esp32-poe-iso.menu.UploadSpeed.921600.upload.speed=921600
 esp32-poe-iso.menu.UploadSpeed.115200=115200
 esp32-poe-iso.menu.UploadSpeed.115200.upload.speed=115200
+esp32-poe-iso.menu.UploadSpeed.256000.windows=256000
+esp32-poe-iso.menu.UploadSpeed.256000.upload.speed=256000
+esp32-poe-iso.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32-poe-iso.menu.UploadSpeed.230400=230400
+esp32-poe-iso.menu.UploadSpeed.230400.upload.speed=230400
+esp32-poe-iso.menu.UploadSpeed.460800.linux=460800
+esp32-poe-iso.menu.UploadSpeed.460800.macosx=460800
+esp32-poe-iso.menu.UploadSpeed.460800.upload.speed=460800
+esp32-poe-iso.menu.UploadSpeed.512000.windows=512000
+esp32-poe-iso.menu.UploadSpeed.512000.upload.speed=512000
 
 esp32-poe-iso.menu.PartitionScheme.default=Default
 esp32-poe-iso.menu.PartitionScheme.default.build.partitions=default

--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -64,6 +64,7 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit)
 #endif
     if(mode1bit) {
         host.flags = SDMMC_HOST_FLAG_1BIT; //use 1-line SD mode
+        slot_config.width = 1;
     }
 
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {


### PR DESCRIPTION
Added options for 921600/115200/256000/230400/460800/512000 upload speed for the Olimex boards (ESP32-EVB, ESP32-Gateway, ESP32-PoE, ESP32-PoE-ISO)