### PR TITLE
Fix BLEClient disconnect bug

### DIFF
--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -178,6 +178,8 @@ void BLEClient::gattClientEventHandler(
 		// - uint16_t          conn_id
 		// - esp_bd_addr_t     remote_bda
 		case ESP_GATTC_DISCONNECT_EVT: {
+				if (evtParam->disconnect.conn_id != m_conn_id)
+					break;
 				// If we receive a disconnect event, set the class flag that indicates that we are
 				// no longer connected.
 				m_isConnected = false;


### PR DESCRIPTION
By default the disconnect is broadcasted to every clients. So if you call disconnect on one connected client, they'll all be disconnected if we don't filter the event by conn_id.

I'm not sure if other esp_gattc_cb_event_t events should do the same thing to prevent similar bugs.