### PR TITLE
Updater.cpp support for encrypted flash

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -309,6 +309,20 @@ bool EspClass::flashRead(uint32_t offset, uint32_t *data, size_t size)
     return spi_flash_read(offset, (uint32_t*) data, size) == ESP_OK;
 }
 
+bool EspClass::partitionEraseRange(const esp_partition_t *partition, uint32_t offset, size_t size) 
+{
+    return esp_partition_erase_range(partition, offset, size) == ESP_OK;
+}
+
+bool EspClass::partitionWrite(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size) 
+{
+    return esp_partition_write(partition, offset, data, size) == ESP_OK;
+}
+
+bool EspClass::partitionRead(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size) 
+{
+    return esp_partition_read(partition, offset, data, size) == ESP_OK;
+}
 
 uint64_t EspClass::getEfuseMac(void)
 {

--- a/cores/esp32/Esp.h
+++ b/cores/esp32/Esp.h
@@ -21,6 +21,7 @@
 #define ESP_H
 
 #include <Arduino.h>
+#include <esp_partition.h>
 
 /**
  * AVR macros for WDT managment
@@ -96,6 +97,10 @@ public:
     bool flashEraseSector(uint32_t sector);
     bool flashWrite(uint32_t offset, uint32_t *data, size_t size);
     bool flashRead(uint32_t offset, uint32_t *data, size_t size);
+
+    bool partitionEraseRange(const esp_partition_t *partition, uint32_t offset, size_t size);
+    bool partitionWrite(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size);
+    bool partitionRead(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size);
 
     uint64_t getEfuseMac();
 

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -26,6 +26,8 @@
 #define U_SPIFFS  100
 #define U_AUTH    200
 
+#define ENCRYPTED_BLOCK_SIZE 16
+
 class UpdateClass {
   public:
     typedef std::function<void(size_t, size_t)> THandlerFunction_Progress;
@@ -163,10 +165,12 @@ class UpdateClass {
     bool _writeBuffer();
     bool _verifyHeader(uint8_t data);
     bool _verifyEnd();
+    bool _enablePartition(const esp_partition_t* partition);
 
 
     uint8_t _error;
     uint8_t *_buffer;
+    uint8_t *_skipBuffer;
     size_t _bufferLen;
     size_t _size;
     THandlerFunction_Progress _progress_callback;


### PR DESCRIPTION
### Background
The current implementation of `Update()` uses the `spi_flash_*` api to write and read from flash. These functions ignore the `partition->encrypted` flag and always write raw data to flash even if the partition is marked as encrypted.

### Changes in this PR
1. `Update()` now uses the `esp_partition_*` api.
2. Wrapper functions for `esp_partition_*` added to `ESP.cpp`. This was done to maintain a consistent approach to the way the `spi_flash_*` functions were used. I note though that not all of the esp-idf functions are used are wrapped, for example `esp_ota_get_next_update_partition()` so it may be that these should not be added?
3. The current implementation of Update() changes the first (magic) byte of firmware to `0xFF` on write, and then when the firmware is completely written changes it back to `ESP_IMAGE_HEADER_MAGIC`. This works without erasing the sector because flash bits can be changed from 1->0 (but not 0->1). If the flash is encrypted then the actual data written to flash will not be all ones, so this approach will not work. In addition, encrypted flash must be written in 16 byte blocks. So, instead of changing the first byte the changed code stashes the first 16 bytes, and starts writing at the 17th byte, leaving the first 16 bytes as `0xFF`. Then, in `_enablePartition()` the stashed bytes can be successfully written.

### Benefits
1. Whilst it's not possible to use encrypted flash directly from either the Arduino IDE or PIO it's reasonably straightforward to compile and flash a bootloader with the necessary support from a simple esp-idf project and then use ArduinoOTA for subsequent updates. This PR enables the use of this workflow until such time as encrypted flash is supported, and is a first (small) step toward adding support.
2. Regardless of the above, the `esp_partition_*` api is [recommended](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/spi_flash.html) over the `api_flash_*` api.  
> Application code should mostly use these esp_partition_* API functions instead of lower level spi_flash_* API functions. Partition table API functions do bounds checking and calculate correct offsets in flash, based on data stored in a partition table.

### Questions
1. IDF-4.0 makes the flash APIs non-atomic in some circumstances. How will this be handled in the Arduino core, and does this affect this PR?