### PR TITLE
Update pins_arduino.h for Firebeetle32

### DIFF
--- a/variants/firebeetle32/pins_arduino.h
+++ b/variants/firebeetle32/pins_arduino.h
@@ -11,6 +11,8 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+typedef unsigned char uint8_t;
+
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
@@ -28,21 +30,34 @@ static const uint8_t MISO  = 19;
 static const uint8_t SCK   = 18;
 
 static const uint8_t A0 = 36;
-static const uint8_t A3 = 39;
-static const uint8_t A4 = 32;
-static const uint8_t A5 = 33;
-static const uint8_t A6 = 34;
-static const uint8_t A7 = 35;
-static const uint8_t A10 = 4;
-static const uint8_t A11 = 0;
-static const uint8_t A12 = 2;
-static const uint8_t A13 = 15;
-static const uint8_t A14 = 13;
-static const uint8_t A15 = 12;
-static const uint8_t A16 = 14;
-static const uint8_t A17 = 27;
-static const uint8_t A18 = 25;
-static const uint8_t A19 = 26;
+static const uint8_t A1 = 39;
+static const uint8_t A2 = 34;
+static const uint8_t A3 = 35;
+static const uint8_t A4 = 15;
+static const uint8_t A5 = 35;
+static const uint8_t A6 = 4;
+static const uint8_t A7 = 0;
+static const uint8_t A8 = 2;
+static const uint8_t A9 = 13;
+static const uint8_t A10 = 12;
+static const uint8_t A11 = 14;
+static const uint8_t A12 = 27;
+static const uint8_t A13 = 25;
+static const uint8_t A14 = 26;
+
+
+
+static const uint8_t D0 = 3;
+static const uint8_t D1 = 1;
+static const uint8_t D2 = 25;
+static const uint8_t D3 = 26;
+static const uint8_t D4 = 27;
+static const uint8_t D5 = 9;
+static const uint8_t D6 = 10;
+static const uint8_t D7 = 13;
+static const uint8_t D8 = 5;
+static const uint8_t D9 = 2;
+static const uint8_t D10 = 0;
 
 static const uint8_t T0 = 4;
 static const uint8_t T1 = 0;


### PR DESCRIPTION
Update in accordance with Firebeetle's official firebeetle32 pins_arduino.h. Without it, digital pins weren't definable, and analogue pins didnt line up.

Taken from http://download.dfrobot.top/FireBeetle/DFRobot_FireBeetle-ESP32-0.0.9.zip