### PR TITLE
heltec_wireless_stick_lite: Add pin definition

### DIFF
--- a/variants/heltec_wireless_stick_lite/pins_arduino.h
+++ b/variants/heltec_wireless_stick_lite/pins_arduino.h
@@ -1,0 +1,72 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define Wireless_Stick_Lite true
+#define DISPLAY_HEIGHT 0
+#define DISPLAY_WIDTH 0
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS 40
+#define NUM_ANALOG_INPUTS 16
+
+#define analogInputToDigitalPin(p) (((p) < 20) ? (esp32_adc2gpio[(p)]) : -1)
+#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < 34)
+
+static const uint8_t LED_BUILTIN = 25;
+#define BUILTIN_LED LED_BUILTIN // backward compatibility
+
+static const uint8_t KEY_BUILTIN = 0;
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS = 18;
+static const uint8_t MOSI = 27;
+static const uint8_t MISO = 19;
+static const uint8_t SCK = 5;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+static const uint8_t Vext = 21;
+static const uint8_t LED = 25;
+static const uint8_t RST_LoRa = 14;
+static const uint8_t DIO0 = 26;
+static const uint8_t DIO1 = 35;
+static const uint8_t DIO2 = 34;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Add the pins_arduino.h definitions for Heltecs Wireless Stick Lite.
Product: https://heltec.org/project/wireless-stick-lite/

The patch is based on @brunohorta82 previous work.