### PR TITLE
Add support of unified provisioning to Arduino v4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(LIBRARY_SRCS
   libraries/WiFi/src/WiFi.cpp
   libraries/WiFi/src/WiFiGeneric.cpp
   libraries/WiFi/src/WiFiMulti.cpp
+  libraries/WiFi/src/WiFiProv.cpp
   libraries/WiFi/src/WiFiScan.cpp
   libraries/WiFi/src/WiFiServer.cpp
   libraries/WiFi/src/WiFiSTA.cpp

--- a/libraries/WiFi/examples/WiFiProv/README.md
+++ b/libraries/WiFi/examples/WiFiProv/README.md
@@ -1,0 +1,130 @@
+# Provisioning for Arduino
+
+This sketch implements provisioning using various IDF components
+
+# Description
+
+This example allows Arduino user to choose either BLE or SOFTAP as a mode of transport, over which the provisioning related communication is to take place, between the device (to be provisioned) and the client (owner of the device).
+
+# APIs introduced for provisioning
+
+## WiFi.onEvent()
+
+Using this API user can register to receive WiFi Events and Provisioning Events
+
+#### Parameters passed
+
+A function with following signature
+* void SysProvEvent(system_event_t * , wifi_prov_event_t * );
+ 
+#### structure [ wifi_prov_event_t ]
+
+* wifi_prov_cb_event_t event;
+* void * event_data;
+
+## WiFi.beginProvision()
+
+WiFi.beginProvision(scheme prov_scheme, wifi_prov_scheme_event_handler_t scheme_event_handler, wifi_prov_security_t security, char * pop, char * service_name, char * service_key, uint8_t * uuid);
+
+#### Parameters passed
+
+* prov_scheme : choose the mode of transfer
+    * WIFI_PROV_SCHEME_BLE - Using BLE
+    * WIFI_PROV_SCHEME_SOFTAP - Using SoftAP
+        
+* security : choose security type
+    * WIFI_PROV_SECURITY_1 - It allows secure communication which consists of secure handshake using key exchange and proof of possession (pop) and encryption/decryption of messages.
+
+    * WIFI_PROV_SECURITY_0 - It do not provide application level security, it involve simply plain text communication.
+
+* scheme_event_handler : specify the handlers according to the mode chosen
+    * BLE :
+        - WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BTDM - This scheme event handler is used when application doesn't need BT and BLE after provisioning is finised
+        - WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BLE - This scheme event handler is used when application doesn't need BLE to be active after provisioning is finised
+        - WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BT - This scheme event handler is used when application doesn't need BT to be active after provisioning is finised
+
+    * SoftAp :
+        - WIFI_PROV_EVENT_HANDLER_NONE
+
+* pop : It is the string that is used to provide the authentication.
+
+* service_name : Specify service name for the device, if it is not specified then default chosen name via SoftAP is WIFI_XXX and via BLE is BLE_XXX where XXX are the last 3 bytes of the MAC address. 
+
+* service_key : Specify service key, if chosen mode of provisioning is BLE then service_key is always NULL
+
+* uuid : user can specify there own 128 bit UUID while provisioning using BLE, if not specified then default value taken is
+        - {  0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf,
+             0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02, }
+
+# NOTE
+
+* If none of the parameters are specified in beginProvision then default provisioning takes place using SoftAP with
+    * scheme = WIFI_PROV_SCHEME_SOFTAP
+    * scheme_event_handler = WIFI_PROV_EVENT_HANDLER_NONE
+    * security = WIFI_PROV_SECURITY_1
+    * pop = "abcd1234"
+    * service_name = "WiFi_XXX"
+    * service_key = NULL
+    * uuid = NULL
+
+# Log Output
+* Enable debuger : [ Tools -> Core Debug Level -> Info ] 
+
+# Provisioning Tools
+https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/provisioning/wifi_provisioning.html#provisioning-tools
+
+# Example output
+
+## Provisioning using SoftAP
+
+```
+[I][WiFiProv.cpp:117] beginProvision(): Starting AP using SOFTAP
+ service_name : WIFI_XXX
+ password : 123456789
+ pop : abcd1234
+
+Provisioning started
+Give Credentials of your access point using " Android app "
+
+Received Wi-Fi credentials
+	SSID : GIONEE M2
+	Password : 123456789
+
+Provisioning Successful
+
+Connected IP address : 192.168.43.120
+
+Provisioning Ends
+
+```
+
+## Provisioning using BLE
+
+```
+[I][WiFiProv.cpp:115] beginProvision(): Starting AP using BLE
+ service_name : BLE_XXX
+ pop : abcd1234
+
+Provisioning started
+Give Credentials of your access point using " Android app "
+
+Received Wi-Fi credentials
+	SSID : GIONEE M2
+	Password : 123456789
+
+Provisioning Successful
+
+Connected IP address : 192.168.43.120
+
+Provisioning Ends
+
+```
+
+## Credentials are available on device
+
+```
+[I][WiFiProv.cpp:125] beginProvision(): Aleardy Provisioned, starting Wi-Fi STA
+[I][WiFiProv.cpp:126] beginProvision(): CONNECTING ACCESS POINT CREDENTIALS : 
+[I][WiFiProv.cpp:126] beginProvision(): SSID : GIONEE M2
+
+```

--- a/libraries/WiFi/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFi/examples/WiFiProv/WiFiProv.ino
@@ -1,0 +1,63 @@
+#include "WiFi.h"
+void SysProvEvent(system_event_t *sys_event,wifi_prov_event_t *prov_event)
+{
+    if(sys_event) {
+      switch (sys_event->event_id) {
+      case SYSTEM_EVENT_STA_GOT_IP:
+          Serial.print("\nConnected IP address : ");
+          Serial.println(ip4addr_ntoa(&sys_event->event_info.got_ip.ip_info.ip));
+          break;
+      case SYSTEM_EVENT_STA_DISCONNECTED:
+          Serial.println("\nDisconnected. Connecting to the AP again... ");
+          break;
+      default:
+          break;
+      }      
+    }
+
+    if(prov_event) {
+        switch (prov_event->event) {
+        case WIFI_PROV_START:
+            Serial.println("\nProvisioning started\nGive Credentials of your access point using \" Android app \"");
+            break;
+        case WIFI_PROV_CRED_RECV: { 
+            Serial.println("\nReceived Wi-Fi credentials");
+            wifi_sta_config_t *wifi_sta_cfg = (wifi_sta_config_t *)prov_event->event_data;
+            Serial.print("\tSSID : ");
+            Serial.println((const char *) wifi_sta_cfg->ssid);
+            Serial.print("\tPassword : ");
+            Serial.println((char const *) wifi_sta_cfg->password);
+            break;
+        }
+        case WIFI_PROV_CRED_FAIL: { 
+            wifi_prov_sta_fail_reason_t *reason = (wifi_prov_sta_fail_reason_t *)prov_event->event_data;
+            Serial.println("\nProvisioning failed!\nPlease reset to factory and retry provisioning\n");
+            if(*reason == WIFI_PROV_STA_AUTH_ERROR) 
+                Serial.println("\nWi-Fi AP password incorrect");
+            else
+                Serial.println("\nWi-Fi AP not found....Add API \" nvs_flash_erase() \" before beginProvision()");        
+            break;
+        }
+        case WIFI_PROV_CRED_SUCCESS:
+            Serial.println("\nProvisioning Successful");
+            break;
+        case WIFI_PROV_END:
+            Serial.println("\nProvisioning Ends");
+            break;
+        default:
+            break;
+        }      
+    }
+}
+
+void setup() {
+  Serial.begin(115200);
+  //Sample uuid that user can pass during provisioning using BLE
+  /* uint8_t uuid[16] = {0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf,
+                   0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02 };*/
+  WiFi.onEvent(SysProvEvent);
+  WiFi.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, "abcd1234", "BLE_XXX", NULL, NULL);
+}
+
+void loop() {
+}

--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -94,7 +94,7 @@ void ETHClass::eth_event_handler(void *arg, esp_event_base_t event_base, int32_t
     default:
         break;
     }
-    WiFi._eventCallback(arg, &event);
+    WiFi._eventCallback(arg, &event,NULL);
 }
 
 

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -37,8 +37,9 @@
 #include "WiFiClient.h"
 #include "WiFiServer.h"
 #include "WiFiUdp.h"
+#include "WiFiProv.h"
 
-class WiFiClass : public WiFiGenericClass, public WiFiSTAClass, public WiFiScanClass, public WiFiAPClass
+class WiFiClass : public WiFiGenericClass, public WiFiSTAClass, public WiFiScanClass, public WiFiAPClass, public WiFiProvClass
 {
 public:
     using WiFiGenericClass::channel;

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -42,7 +42,6 @@ extern "C" {
 #include "lwip/dns.h"
 #include "esp_ipc.h"
 
-
 } //extern "C"
 
 #include "esp32-hal-log.h"
@@ -53,20 +52,42 @@ static xQueueHandle _network_event_queue;
 static TaskHandle_t _network_event_task_handle = NULL;
 static EventGroupHandle_t _network_event_group = NULL;
 
+esp_err_t postToSysQueue(system_prov_event_t *data)
+{
+    if (xQueueSend(_network_event_queue, &data, portMAX_DELAY) != pdPASS) {
+        log_w("Network Event Queue Send Failed!");
+            return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
 static void _network_event_task(void * arg){
-    system_event_t event;
+    system_prov_event_t *data;
     for (;;) {
-        if(xQueueReceive(_network_event_queue, &event, portMAX_DELAY) == pdTRUE){
-            WiFiGenericClass::_eventCallback(arg, &event);
-        }
+        if(xQueueReceive(_network_event_queue, &data, portMAX_DELAY) == pdTRUE){
+            if(data->prov_event != NULL){
+                WiFiGenericClass::_eventCallback(arg, data->sys_event, data->prov_event);
+                free(data->sys_event);
+                free(data->prov_event);
+            } else {
+                WiFiGenericClass::_eventCallback(arg, data->sys_event, NULL);
+            }
+            free(data);
+        }        
     }
     vTaskDelete(NULL);
     _network_event_task_handle = NULL;
 }
 
-static esp_err_t _network_event_cb(void *arg, system_event_t *event){
-    if (xQueueSend(_network_event_queue, event, portMAX_DELAY) != pdPASS) {
-        log_w("Network Event Queue Send Failed!");
+static esp_err_t _network_event_cb(void *arg, system_event_t *event){ 
+    system_prov_event_t *sys_prov_data = (system_prov_event_t *)malloc(sizeof(system_prov_event_t));
+    if(sys_prov_data == NULL) {
+        return ESP_FAIL;
+    }
+    sys_prov_data->sys_event = event;
+    sys_prov_data->prov_event = NULL;
+    if (postToSysQueue(sys_prov_data) != ESP_OK){
+        free(sys_prov_data);
         return ESP_FAIL;
     }
     return ESP_OK;
@@ -82,7 +103,7 @@ static bool _start_network_event_task(){
         xEventGroupSetBits(_network_event_group, WIFI_DNS_IDLE_BIT);
     }
     if(!_network_event_queue){
-        _network_event_queue = xQueueCreate(32, sizeof(system_event_t));
+        _network_event_queue = xQueueCreate(32, sizeof(system_prov_event_t));
         if(!_network_event_queue){
             log_e("Network Event Queue Create Failed!");
             return false;
@@ -151,7 +172,7 @@ static bool espWiFiStart(){
     _esp_wifi_started = true;
     system_event_t event;
     event.event_id = SYSTEM_EVENT_WIFI_READY;
-    WiFiGenericClass::_eventCallback(nullptr, &event);
+    WiFiGenericClass::_eventCallback(nullptr, &event, NULL);
     return true;
 }
 
@@ -180,9 +201,10 @@ typedef struct WiFiEventCbList {
     WiFiEventCb cb;
     WiFiEventFuncCb fcb;
     WiFiEventSysCb scb;
+    WiFiProvEventCb provcb;
     system_event_id_t event;
 
-    WiFiEventCbList() : id(current_id++), cb(NULL), fcb(NULL), scb(NULL), event(SYSTEM_EVENT_WIFI_READY) {}
+    WiFiEventCbList() : id(current_id++), cb(NULL), fcb(NULL), scb(NULL), provcb(NULL), event(SYSTEM_EVENT_WIFI_READY) {}
 } WiFiEventCbList_t;
 wifi_event_id_t WiFiEventCbList::current_id = 1;
 
@@ -237,6 +259,20 @@ int WiFiGenericClass::waitStatusBits(int bits, uint32_t timeout_ms){
  * @param cbEvent WiFiEventCb
  * @param event optional filter (WIFI_EVENT_MAX is all events)
  */
+wifi_event_id_t WiFiGenericClass::onEvent(WiFiProvEventCb cbEvent, system_event_id_t event)
+{
+    if(!cbEvent){
+        return 0;
+    }
+    WiFiEventCbList_t newEventHandler;
+    newEventHandler.cb = NULL;
+    newEventHandler.fcb = NULL;
+    newEventHandler.scb = NULL;
+    newEventHandler.provcb = cbEvent;
+    newEventHandler.event = event;
+    cbEventList.push_back(newEventHandler);
+    return newEventHandler.id;
+}
 wifi_event_id_t WiFiGenericClass::onEvent(WiFiEventCb cbEvent, system_event_id_t event)
 {
     if(!cbEvent) {
@@ -246,6 +282,7 @@ wifi_event_id_t WiFiGenericClass::onEvent(WiFiEventCb cbEvent, system_event_id_t
     newEventHandler.cb = cbEvent;
     newEventHandler.fcb = NULL;
     newEventHandler.scb = NULL;
+    newEventHandler.provcb = NULL;
     newEventHandler.event = event;
     cbEventList.push_back(newEventHandler);
     return newEventHandler.id;
@@ -260,6 +297,7 @@ wifi_event_id_t WiFiGenericClass::onEvent(WiFiEventFuncCb cbEvent, system_event_
     newEventHandler.cb = NULL;
     newEventHandler.fcb = cbEvent;
     newEventHandler.scb = NULL;
+    newEventHandler.provcb = NULL;
     newEventHandler.event = event;
     cbEventList.push_back(newEventHandler);
     return newEventHandler.id;
@@ -274,6 +312,7 @@ wifi_event_id_t WiFiGenericClass::onEvent(WiFiEventSysCb cbEvent, system_event_i
     newEventHandler.cb = NULL;
     newEventHandler.fcb = NULL;
     newEventHandler.scb = cbEvent;
+    newEventHandler.provcb = NULL;
     newEventHandler.event = event;
     cbEventList.push_back(newEventHandler);
     return newEventHandler.id;
@@ -333,7 +372,7 @@ const char * system_event_names[] = { "WIFI_READY", "SCAN_DONE", "STA_START", "S
 const char * system_event_reasons[] = { "UNSPECIFIED", "AUTH_EXPIRE", "AUTH_LEAVE", "ASSOC_EXPIRE", "ASSOC_TOOMANY", "NOT_AUTHED", "NOT_ASSOCED", "ASSOC_LEAVE", "ASSOC_NOT_AUTHED", "DISASSOC_PWRCAP_BAD", "DISASSOC_SUPCHAN_BAD", "UNSPECIFIED", "IE_INVALID", "MIC_FAILURE", "4WAY_HANDSHAKE_TIMEOUT", "GROUP_KEY_UPDATE_TIMEOUT", "IE_IN_4WAY_DIFFERS", "GROUP_CIPHER_INVALID", "PAIRWISE_CIPHER_INVALID", "AKMP_INVALID", "UNSUPP_RSN_IE_VERSION", "INVALID_RSN_IE_CAP", "802_1X_AUTH_FAILED", "CIPHER_SUITE_REJECTED", "BEACON_TIMEOUT", "NO_AP_FOUND", "AUTH_FAIL", "ASSOC_FAIL", "HANDSHAKE_TIMEOUT", "CONNECTION_FAIL" };
 #define reason2str(r) ((r>176)?system_event_reasons[r-176]:system_event_reasons[r-1])
 #endif
-esp_err_t WiFiGenericClass::_eventCallback(void *arg, system_event_t *event)
+esp_err_t WiFiGenericClass::_eventCallback(void *arg, system_event_t *event, wifi_prov_event_t *prov_event)
 {
     if(event->event_id < 26) {
         log_d("Event: %d - %s", event->event_id, system_event_names[event->event_id]);
@@ -442,6 +481,9 @@ esp_err_t WiFiGenericClass::_eventCallback(void *arg, system_event_t *event)
                     entry.scb(event);
                 }
             }
+        }
+        if(entry.provcb) {
+            entry.provcb(event,prov_event);
         }
     }
     return ESP_OK;

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -27,10 +27,24 @@
 #include <esp_event_loop.h>
 #include <functional>
 #include "WiFiType.h"
+#include <wifi_provisioning/manager.h>
+
+typedef struct
+{
+     wifi_prov_cb_event_t event;
+     void *event_data;
+}wifi_prov_event_t;
+
+typedef struct
+{
+    wifi_prov_event_t *prov_event;
+    system_event_t *sys_event;
+}system_prov_event_t;
 
 typedef void (*WiFiEventCb)(system_event_id_t event);
 typedef std::function<void(system_event_id_t event, system_event_info_t info)> WiFiEventFuncCb;
 typedef void (*WiFiEventSysCb)(system_event_t *event);
+typedef void (*WiFiProvEventCb)(system_event_t *sys_event, wifi_prov_event_t *prov_event);
 
 typedef size_t wifi_event_id_t;
 
@@ -73,6 +87,7 @@ class WiFiGenericClass
     wifi_event_id_t onEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     wifi_event_id_t onEvent(WiFiEventFuncCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     wifi_event_id_t onEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
+    wifi_event_id_t onEvent(WiFiProvEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(WiFiEventCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(WiFiEventSysCb cbEvent, system_event_id_t event = SYSTEM_EVENT_MAX);
     void removeEvent(wifi_event_id_t id);
@@ -97,7 +112,7 @@ class WiFiGenericClass
     bool setTxPower(wifi_power_t power);
     wifi_power_t getTxPower();
 
-    static esp_err_t _eventCallback(void *arg, system_event_t *event);
+    static esp_err_t _eventCallback(void *arg, system_event_t *event, wifi_prov_event_t *prov_event);
 
   protected:
     static bool _persistent;

--- a/libraries/WiFi/src/WiFiProv.cpp
+++ b/libraries/WiFi/src/WiFiProv.cpp
@@ -1,0 +1,149 @@
+/*
+    WiFiProv.cpp - WiFiProv class for provisioning
+    All rights reserved.
+ 
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+  
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+  
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+    
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <esp_err.h>
+#include <esp_wifi.h>
+#include <esp_event_loop.h>
+#include <esp32-hal.h>
+
+#include <nvs_flash.h>
+#include <wifi_provisioning/scheme_ble.h>
+#include <wifi_provisioning/scheme_softap.h>
+#include <wifi_provisioning/manager.h>
+#undef IPADDR_NONE
+#include "WiFi.h"
+
+extern esp_err_t postToSysQueue(system_prov_event_t *);
+static const uint8_t custom_service_uuid[16] = {  0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf,
+                                                  0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02, };
+
+#define SERV_NAME_PREFIX_BLE "BLE_"
+#define SERV_NAME_PREFIX_WIFI "WIFI_"
+
+static void event_handler(void* arg, esp_event_base_t event_base, int event_id, void* event_data)
+{
+     system_prov_event_t *sys_prov = (system_prov_event_t *)malloc(sizeof(system_prov_event_t));
+     if(sys_prov == NULL) {
+         log_e("Malloc Failed");
+         return;
+     }
+
+     sys_prov->prov_event = (wifi_prov_event_t *)malloc(sizeof(wifi_prov_event_t));
+     if(sys_prov->prov_event == NULL) {
+         log_e("Malloc Failed");
+         free(sys_prov);
+         return;
+     }
+
+     sys_prov->sys_event = (system_event_t *)malloc(sizeof(system_event_t));
+     if(sys_prov->sys_event == NULL) {
+         log_e("Malloc Failed");
+         free(sys_prov->prov_event);
+         free(sys_prov);
+         return;
+     }
+
+     sys_prov->prov_event->event = (wifi_prov_cb_event_t)event_id;
+     sys_prov->prov_event->event_data = event_data;
+     sys_prov->sys_event->event_id = SYSTEM_EVENT_MAX;
+     esp_err_t check = postToSysQueue(sys_prov);
+     if(check == ESP_FAIL) {
+         log_e("Provisioning event not send to queue");
+         free(sys_prov->sys_event);
+         free(sys_prov->prov_event);
+         free(sys_prov);
+     }
+}
+
+static void get_device_service_name(scheme prov_scheme, char *service_name, size_t max)
+{
+    uint8_t eth_mac[6];
+    WiFi.macAddress(eth_mac);
+    if(prov_scheme == WIFI_PROV_SCHEME_BLE) {
+        snprintf(service_name, max, "%s%02X%02X%02X",SERV_NAME_PREFIX_BLE, eth_mac[3], eth_mac[4], eth_mac[5]);
+    } else {
+         snprintf(service_name, max, "%s%02X%02X%02X",SERV_NAME_PREFIX_WIFI, eth_mac[3], eth_mac[4], eth_mac[5]);  
+    }
+}
+
+void WiFiProvClass :: beginProvision(scheme prov_scheme, wifi_prov_event_handler_t scheme_event_handler, wifi_prov_security_t security, const char * pop, const char *service_name, const char *service_key, uint8_t * uuid)
+{
+    bool provisioned = false;
+    esp_event_loop_create_default();
+    wifi_prov_mgr_config_t config;
+    config.scheme_event_handler = scheme_event_handler; 
+    config.app_event_handler = {
+            .event_cb = NULL,
+            .user_data = NULL
+            };
+    if(prov_scheme == WIFI_PROV_SCHEME_BLE) {
+        config.scheme = wifi_prov_scheme_ble;        
+    } else {
+    	config.scheme = wifi_prov_scheme_softap;
+    }
+    wifi_prov_mgr_init(config);
+    WiFi.mode(WIFI_MODE_AP);
+    wifi_prov_mgr_is_provisioned(&provisioned);
+    if(provisioned == false) {
+        if(esp_event_handler_register(WIFI_PROV_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL)!=ESP_OK) {
+            log_e("Event Handler Register fail");
+        }
+        if(prov_scheme == WIFI_PROV_SCHEME_BLE) {
+            service_key = NULL;
+            if(uuid == NULL) {
+                uuid=(uint8_t *)custom_service_uuid;
+            }
+            wifi_prov_scheme_ble_set_service_uuid(uuid);
+        }
+
+        if(service_name == NULL) {
+            char service_name_temp[12];
+            get_device_service_name(prov_scheme,service_name_temp,sizeof(service_name_temp));
+            service_name = (const char *)service_name_temp;
+        }
+
+        if(prov_scheme == WIFI_PROV_SCHEME_BLE) {
+            log_i("Starting AP using BLE\n service_name : %s\n pop : %s",service_name,pop);
+        } else {
+            if(service_key == NULL) {
+               log_i("Starting AP using SOFTAP\n service_name : %s\n pop : %s",service_name,pop); 
+            } else { 
+               log_i("Starting AP using SOFTAP\n service_name : %s\n password : %s\n pop : %s",service_name,service_key,pop); 
+            }
+        }
+
+        wifi_prov_mgr_start_provisioning(security,pop,service_name,service_key);
+    } else {
+        wifi_prov_mgr_deinit();
+        WiFi.mode(WIFI_MODE_STA);
+        log_i("Aleardy Provisioned, starting Wi-Fi STA");
+        log_i("CONNECTING ACCESS POINT CREDENTIALS : "); 
+#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
+        wifi_config_t conf;
+        esp_wifi_get_config(WIFI_IF_STA,&conf);
+        log_i("SSID : %s\n",conf.sta.ssid);
+#endif
+    }
+}
+

--- a/libraries/WiFi/src/WiFiProv.h
+++ b/libraries/WiFi/src/WiFiProv.h
@@ -1,0 +1,47 @@
+/*
+    WiFiProv.h - Base class for provisioning support
+    All right reserved.
+ 
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+  
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+  
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "wifi_provisioning/manager.h"
+#include "wifi_provisioning/scheme_ble.h"
+#include "esp_wifi.h"
+#include "nvs_flash.h"
+#include "SimpleBLE.h"
+//Select the scheme using which you want to provision
+enum scheme
+{
+    WIFI_PROV_SCHEME_BLE,
+    WIFI_PROV_SCHEME_SOFTAP,
+    WIFI_PROV_SCHEME_CONSOLE
+};
+//Provisioning class 
+class WiFiProvClass
+{
+    public:
+        void beginProvision(scheme prov_scheme = WIFI_PROV_SCHEME_SOFTAP, wifi_prov_event_handler_t scheme_event_handler = WIFI_PROV_EVENT_HANDLER_NONE, wifi_prov_security_t security = WIFI_PROV_SECURITY_1, const char * pop = "abcd1234", const char * service_name = NULL, const char * service_key = NULL, uint8_t *uuid = NULL);
+};
+
+/*
+ Event Handler for BLE
+      - WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BTDM
+      - WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BLE
+      - WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BT
+Event Handler for SOFTAP
+      - WIFI_PROV_EVENT_HANDLER_NONE
+*/
+


### PR DESCRIPTION
Here 1. WiFiProv.ino sketch is added that allows arduino users to do provisioning via SoftAP or BLE. WiFi.beginProvision( ) API is designed for provisioning in Arduino.
2. In WiFiProv.h provisioning class is defined.
3. WiFiProv.cpp contains implementation for provisioning class.
4. README.md file is added which contains detail information for working.