### PR TITLE
fixing incorrect clean-up in BLERemoteService::removeCharacteristics()

### DIFF
--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -304,12 +304,8 @@ std::string BLERemoteService::getValue(BLEUUID characteristicUuid) {
 void BLERemoteService::removeCharacteristics() {
 	for (auto &myPair : m_characteristicMap) {
 	   delete myPair.second;
-	   //m_characteristicMap.erase(myPair.first);  // Should be no need to delete as it will be deleted by the clear
 	}
 	m_characteristicMap.clear();   // Clear the map
-	for (auto &myPair : m_characteristicMapByHandle) {
-	   delete myPair.second;
-	}
 	m_characteristicMapByHandle.clear();   // Clear the map
 } // removeCharacteristics
 


### PR DESCRIPTION
fixing incorrect clean-up in BLERemoteService::removeCharacteristics(), causing heap corruption crash when deleting BLEClient instances, possible as reported by issue #3966