### PR TITLE
Added missing wifi_provisioning dependency (#3971).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
 
 set(COMPONENT_PRIV_INCLUDEDIRS cores/esp32/libb64)
 
-set(COMPONENT_REQUIRES spi_flash mbedtls mdns ethernet esp_adc_cal)
+set(COMPONENT_REQUIRES spi_flash mbedtls mdns ethernet esp_adc_cal wifi_provisioning)
 set(COMPONENT_PRIV_REQUIRES fatfs nvs_flash app_update spiffs bootloader_support openssl bt)
 
 register_component()


### PR DESCRIPTION
This addresses issue #3971 where build failed when building as a component because the include directory for wifi_provisioning was missing. 