### PR TITLE
Make 1bit SDMMC interface work

### DIFF
--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -64,6 +64,7 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit)
 #endif
     if(mode1bit) {
         host.flags = SDMMC_HOST_FLAG_1BIT; //use 1-line SD mode
+	slot_config.width = 1;
     }
 
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {


### PR DESCRIPTION
According to ESP-IDF API
https://github.com/espressif/esp-idf/blob/dc14d027cec49260b78efb1c3724b1710f2f3ec0/docs/en/api-reference/peripherals/sdmmc_host.rst :

"To configure the bus width, set the width field of :cpp:class:`sdmmc_slot_config_t`. For example, to set 1-line mode:

sdmmc_slot_config_t slot = SDMMC_SLOT_CONFIG_DEFAULT();
slot.width = 1;
"

E.g. necessary on Olimex ESP32-POE, because this board is using GPIO12 for other purpose (switching PoE power). GPIO12 ususally is used in 4 bit SDMMC interface. Thus, should be disabled in 1bit mode to avoid conflicts if GPIO12 is used for other purpose.