### PR TITLE
Expose setTimeZone to Arduino IDE

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -169,6 +169,7 @@ uint16_t makeWord(byte h, byte l);
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 
+extern "C" void setTimeZone(long offset, int daylight);
 extern "C" bool getLocalTime(struct tm * info, uint32_t ms = 5000);
 extern "C" void configTime(long gmtOffset_sec, int daylightOffset_sec,
         const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);

--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -16,7 +16,7 @@
 #include "lwip/apps/sntp.h"
 #include "tcpip_adapter.h"
 
-static void setTimeZone(long offset, int daylight)
+void setTimeZone(long offset, int daylight)
 {
     char cst[17] = {0};
     char cdt[17] = "DST";


### PR DESCRIPTION
Allow to set time zone to get time from RTC without network connectivity.