### PR TITLE
Camera pin mappings for the M5Stack ESP32CAM device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tools/mkspiffs/mkspiffs.exe
 .vs/
 __vm/
 *.vcxproj*
+.vscode/

--- a/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
@@ -12,7 +12,8 @@
 //#define CAMERA_MODEL_ESP_EYE // Has PSRAM
 //#define CAMERA_MODEL_M5STACK_PSRAM // Has PSRAM
 //#define CAMERA_MODEL_M5STACK_V2_PSRAM // M5Camera version B Has PSRAM
-//#define CAMERA_MODEL_M5STACK_WIDE	// Has PSRAM
+//#define CAMERA_MODEL_M5STACK_WIDE // Has PSRAM
+//#define CAMERA_MODEL_M5STACK_ESP32CAM // No PSRAM
 //#define CAMERA_MODEL_AI_THINKER // Has PSRAM
 //#define CAMERA_MODEL_TTGO_T_JOURNAL // No PSRAM
 
@@ -84,7 +85,7 @@ void setup() {
   // drop down frame size for higher initial frame rate
   s->set_framesize(s, FRAMESIZE_QVGA);
 
-#if defined(CAMERA_MODEL_M5STACK_WIDE)
+#if defined(CAMERA_MODEL_M5STACK_WIDE) || defined(CAMERA_MODEL_M5STACK_ESP32CAM)
   s->set_vflip(s, 1);
   s->set_hmirror(s, 1);
 #endif

--- a/libraries/ESP32/examples/Camera/CameraWebServer/camera_pins.h
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/camera_pins.h
@@ -94,6 +94,25 @@
 #define HREF_GPIO_NUM     26
 #define PCLK_GPIO_NUM     21
 
+#elif defined(CAMERA_MODEL_M5STACK_ESP32CAM)
+#define PWDN_GPIO_NUM     -1
+#define RESET_GPIO_NUM    15
+#define XCLK_GPIO_NUM     27
+#define SIOD_GPIO_NUM     25
+#define SIOC_GPIO_NUM     23
+
+#define Y9_GPIO_NUM       19
+#define Y8_GPIO_NUM       36
+#define Y7_GPIO_NUM       18
+#define Y6_GPIO_NUM       39
+#define Y5_GPIO_NUM        5
+#define Y4_GPIO_NUM       34
+#define Y3_GPIO_NUM       35
+#define Y2_GPIO_NUM       17
+#define VSYNC_GPIO_NUM    22
+#define HREF_GPIO_NUM     26
+#define PCLK_GPIO_NUM     21
+
 #elif defined(CAMERA_MODEL_AI_THINKER)
 #define PWDN_GPIO_NUM     32
 #define RESET_GPIO_NUM    -1


### PR DESCRIPTION
M5Stack's product offering includes various ESP32-based camera devices. They are all broadly similar, all being based on the ESP32-D0WD core, but have some subtle differences between variants around PSRAM inclusion and camera pin mappings.

The ESP32CAM "unit" product (SKU: U007) has no PSRAM and maps the "Pixel Data 0" (Y2 GPIO/OV2640 D2) camera pin to IO17 rather than IO32 as is the case with most other M5Stack ESP32 camera devices.

The ESP32CAM also requires the "hmirror" and "vflip" camera configuration bits setting in order to capture a true image.

The relevant M5Stack pin configuration documentation can be found [here](https://docs.m5stack.com/#/en/unit/esp32cam?id=pinmap).