### PR TITLE
Fix handling of registerForNotify in BLERemoteCharacteristic.cpp

### DIFF
--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -467,7 +467,8 @@ void BLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, 
 		uint8_t val[] = {0x01, 0x00};
 		if(!notifications) val[0] = 0x02;
 		BLERemoteDescriptor* desc = getDescriptor(BLEUUID((uint16_t)0x2902));
-		desc->writeValue(val, 2);
+		if (desc != nullptr)
+			desc->writeValue(val, 2);
 	} // End Register
 	else {   // If we weren't passed a callback function, then this is an unregistration.
 		esp_err_t errRc = ::esp_ble_gattc_unregister_for_notify(
@@ -482,7 +483,8 @@ void BLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, 
 
 		uint8_t val[] = {0x00, 0x00};
 		BLERemoteDescriptor* desc = getDescriptor((uint16_t)0x2902);
-		desc->writeValue(val, 2);
+		if (desc != nullptr)
+			desc->writeValue(val, 2);
 	} // End Unregister
 
 	m_semaphoreRegForNotifyEvt.wait("registerForNotify");


### PR DESCRIPTION
Some devices (eg some cheap iTag buttons) don't have descriptor 0x2902. Make it optional instead. For these devices, notify still works.

Debugged with ESP Exception Decoder:

```
PC: 0x400d56ff: BLERemoteDescriptor::writeValue(unsigned char*, unsigned int, bool) at /home/bb/Desktop/Arduino/libraries/ESP32_BLE_Arduino/src/BLERemoteDescriptor.cpp line 40
EXCVADDR: 0x00000030

Decoding stack results
0x400d56ff: BLERemoteDescriptor::writeValue(unsigned char*, unsigned int, bool) at /home/bb/Desktop/Arduino/libraries/ESP32_BLE_Arduino/src/BLERemoteDescriptor.cpp line 40
0x400d4d6f: BLERemoteCharacteristic::registerForNotify(void (*)(BLERemoteCharacteristic*, unsigned char*, unsigned int, bool), bool) at /home/bb/Desktop/Arduino/libraries/ESP32_BLE_Arduino/src/BLERemoteCharacteristic.cpp line 485
0x400d19ea: connectToServer(BLEAddress) at /home/bb/Desktop/Arduino/itag-test/itag-test.ino line 104
0x400d1bbe: loop() at /home/bb/Desktop/Arduino/itag-test/itag-test.ino line 120
0x400d90c9: loopTask(void*) at /home/bb/.arduino15/packages/esp32/hardware/esp32/1.0.2/cores/esp32/main.cpp line 19
0x40092c55: vPortTaskWrapper at /Users/ficeto/Desktop/ESP32/ESP32/esp-idf-public/components/freertos/port.c line 143

```