### PR TITLE
fix #4071

### DIFF
--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -113,7 +113,7 @@ public:
         }
 
         File f = _fs.open(path, "r");
-        if (!f)
+        if (!f || !f.available())
             return false;
 
         if (_cache_header.length() != 0)


### PR DESCRIPTION
SPIFFS File object evaluates as true even if the file could not be opened.