### PR TITLE
Fix #4046 Details below:

### DIFF
--- a/libraries/BLE/src/BLECharacteristic.cpp
+++ b/libraries/BLE/src/BLECharacteristic.cpp
@@ -219,19 +219,22 @@ void BLECharacteristic::handleGATTServerEvent(
 		// - uint8_t exec_write_flag - Either ESP_GATT_PREP_WRITE_EXEC or ESP_GATT_PREP_WRITE_CANCEL
 		//
 		case ESP_GATTS_EXEC_WRITE_EVT: {
-			if (param->exec_write.exec_write_flag == ESP_GATT_PREP_WRITE_EXEC) {
-				m_value.commit();
-				m_pCallbacks->onWrite(this); // Invoke the onWrite callback handler.
-			} else {
-				m_value.cancel();
-			}
-// ???
-			esp_err_t errRc = ::esp_ble_gatts_send_response(
-					gatts_if,
-					param->write.conn_id,
-					param->write.trans_id, ESP_GATT_OK, nullptr);
-			if (errRc != ESP_OK) {
-				log_e("esp_ble_gatts_send_response: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
+			if(m_writeEvt){
+				m_writeEvt = false;
+				if (param->exec_write.exec_write_flag == ESP_GATT_PREP_WRITE_EXEC) {
+					m_value.commit();
+					m_pCallbacks->onWrite(this); // Invoke the onWrite callback handler.
+				} else {
+					m_value.cancel();
+				}
+	// ???
+				esp_err_t errRc = ::esp_ble_gatts_send_response(
+						gatts_if,
+						param->write.conn_id,
+						param->write.trans_id, ESP_GATT_OK, nullptr);
+				if (errRc != ESP_OK) {
+					log_e("esp_ble_gatts_send_response: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
+				}
 			}
 			break;
 		} // ESP_GATTS_EXEC_WRITE_EVT
@@ -277,6 +280,7 @@ void BLECharacteristic::handleGATTServerEvent(
 			if (param->write.handle == m_handle) {
 				if (param->write.is_prep) {
 					m_value.addPart(param->write.value, param->write.len);
+					m_writeEvt = true;
 				} else {
 					setValue(param->write.value, param->write.len);
 				}

--- a/libraries/BLE/src/BLECharacteristic.h
+++ b/libraries/BLE/src/BLECharacteristic.h
@@ -107,6 +107,7 @@ private:
 	BLEService*                 m_pService;
 	BLEValue                    m_value;
 	esp_gatt_perm_t             m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
+	bool						m_writeEvt = false; // If we have started a long write, this tells the commit code that we were the target
 
 	void handleGATTServerEvent(
 			esp_gatts_cb_event_t      event,


### PR DESCRIPTION
Informed by the discussion in the bug and the code in 'that other branch'
the fix was clear.  Just set a flag if we start handling a write, and
use that flag to guard the long write complete call.