### PR TITLE
Webserver: Add content length check

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -167,6 +167,10 @@ bool WebServer::_parseRequest(WiFiClient& client) {
 
     if (!isForm){
       size_t plainLength;
+      if (contentLength > HTTP_MAX_CONTENT_SIZE) {
+        log_e("'Content-Length' was larger than max content size (%d bytes)", HTTP_MAX_CONTENT_SIZE);
+        return false;
+      }
       char* plainBuf = readBytesWithTimeout(client, contentLength, plainLength, HTTP_MAX_POST_WAIT);
       if (plainLength < contentLength) {
       	free(plainBuf);

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -45,6 +45,7 @@ enum HTTPAuthMethod { BASIC_AUTH, DIGEST_AUTH };
 #define HTTP_MAX_POST_WAIT 5000 //ms to wait for POST data to arrive
 #define HTTP_MAX_SEND_WAIT 5000 //ms to wait for data chunk to be ACKed
 #define HTTP_MAX_CLOSE_WAIT 2000 //ms to wait for the client to close the connection
+#define HTTP_MAX_CONTENT_SIZE 16384 // Max content size supported, unless chunked
 
 #define CONTENT_LENGTH_UNKNOWN ((size_t) -1)
 #define CONTENT_LENGTH_NOT_SET ((size_t) -2)


### PR DESCRIPTION
Without having a Content-Length check, sending a payload bigger than 512kB would crash the application and force a restart, In other words it prevents this type of DoS attack.