### PR TITLE
Webserver: Add warning about library being unsafe

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -93,6 +93,7 @@ WebServer::~WebServer() {
 }
 
 void WebServer::begin() {
+  log_e("This Webserver is only for educational purposes, and should NEVER be used in production of any sort!\n");
   close();
   _server.begin();
   _server.setNoDelay(true);


### PR DESCRIPTION
The Webserver code:
* Lacks tests
* Low code quality
* It's handling client requests in serial, which means by design it's easy to DoS
* Lacks an error reporting interface for users of the library

In my opinion, we should rather recommend and ship a battle tested embedded HTTP library than writing one ourself. For example https://github.com/cesanta/mongoose might be an option.