### PR TITLE
Correct PSK length check in WiFiMulti

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -56,7 +56,7 @@ bool WiFiMulti::addAP(const char* ssid, const char *passphrase)
         return false;
     }
 
-    if(passphrase && strlen(passphrase) > 63) {
+    if(passphrase && strlen(passphrase) > 64) {
         // fail passphrase too long!
         log_e("[WIFI][APlistAdd] passphrase too long");
         return false;


### PR DESCRIPTION
Fix for https://github.com/espressif/arduino-esp32/issues/3914 by syncing with https://github.com/espressif/arduino-esp32/blob/esp32s2/libraries/WiFi/src/WiFiSTA.cpp#L161