### PR TITLE
After a client disconnects, we need to restart advertising or else...

### DIFF
--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -214,6 +214,8 @@ void BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t 
 			if(removePeerDevice(param->disconnect.conn_id, false)) {
                 m_connectedCount--;                          // Decrement the number of connected devices count.
             }
+
+			startAdvertising();
             break;
 		} // ESP_GATTS_DISCONNECT_EVT
 


### PR DESCRIPTION
any reconnects by the client will not happen for a very long time.

## Steps to reproduce problem
1. BLE client (talking to my ESP32 server) gracefully disconnected from the server (either because the user disabled bluetooth on their phone or the app chose to talk to a different BLE server)
2. User decides to try and reconnect to this ESP32 server, the user would no longer see the device in the list of BLE devices nearby
3. It seems that starting a GATT server implicitly stops advertising at the ESP32 core bluetooth level.

This change restarts advertising (which is harmless if it was already running) when we receive a BLE disconnect event.

Tested and works great on my device, but I'll leave this PR draft until I hear back from our [alpha testers](https://meshtastic.discourse.group/t/alpha-tester-thread-please-try-0-7-8-device-and-0-7-80-android-see-thread/298/89?u=geeksville).
