### PR TITLE
Fix issue #3522 (WiFi does not restart after stopped)

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -574,7 +574,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
  */
 wifi_mode_t WiFiGenericClass::getMode()
 {
-    if(!lowLevelInitDone){
+    if(!lowLevelInitDone || !_esp_wifi_started){
         return WIFI_MODE_NULL;
     }
     wifi_mode_t mode;


### PR DESCRIPTION
This commit fixes issue https://github.com/espressif/arduino-esp32/issues/3522 where WiFi service fails to start after a WiFi.disconnect(true) or a WiFi.mode(WIFI_OFF).

I'm just doing the PR. Initial fix found by @rob58329 and modified by @lbernstone. 