### PR TITLE
Add support for arm64 linux toolchain for the board manager.

### DIFF
--- a/docs/arduino-ide/boards_manager.md
+++ b/docs/arduino-ide/boards_manager.md
@@ -4,7 +4,7 @@
 - Stable release link: `https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json`
 - Development release link: `https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json`
 
-Starting with 1.6.4, Arduino allows installation of third-party platform packages using Boards Manager. We have packages available for Windows, Mac OS, and Linux (32, 64 bit and ARM).
+Starting with 1.6.4, Arduino allows installation of third-party platform packages using Boards Manager. We have packages available for Windows, Mac OS, and Linux (x86, amd64, armhf and arm64).
 
 - Install the current upstream Arduino IDE at the 1.8 level or later. The current version is at the [Arduino website](http://www.arduino.cc/en/main/software).
 - Start Arduino and open Preferences window.

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -90,6 +90,13 @@
               "archiveFileName": "xtensa-esp32-elf-linux-armel-1.22.0-87-gb57bad3-5.2.0.tar.gz",
               "checksum": "SHA-256:9c68c87bb23b1256dc0a1859b515946763e5292dcab4a4159a52fae5618ce861",
               "size": "50655584"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "https://dl.espressif.com/dl/xtensa-esp32-elf-linux-armel-1.22.0-87-gb57bad3-5.2.0.tar.gz",
+              "archiveFileName": "xtensa-esp32-elf-linux-armel-1.22.0-87-gb57bad3-5.2.0.tar.gz",
+              "checksum": "SHA-256:9c68c87bb23b1256dc0a1859b515946763e5292dcab4a4159a52fae5618ce861",
+              "size": "50655584"
             }
           ]
         },
@@ -127,6 +134,13 @@
             },
             {
               "host": "arm-linux-gnueabihf",
+              "url": "https://dl.espressif.com/dl/esptool-2.6.1-linux.tar.gz",
+              "archiveFileName": "esptool-2.6.1-linux.tar.gz",
+              "checksum": "SHA-256:eaf82ff4070d9792f6a42ae1e485375de5a87bec59ef01dfb95de901519ec7fb",
+              "size": "44762"
+            },
+            {
+              "host": "aarch64-linux-gnu",
               "url": "https://dl.espressif.com/dl/esptool-2.6.1-linux.tar.gz",
               "archiveFileName": "esptool-2.6.1-linux.tar.gz",
               "checksum": "SHA-256:eaf82ff4070d9792f6a42ae1e485375de5a87bec59ef01dfb95de901519ec7fb",


### PR DESCRIPTION
Closes #4111.
gcc: I was not able to find an arm64 build on espressif's website so I choosed to put the armhf version, even if this should works this is only ok as temporary, arm64 runs better on arm64 than armhf :)
esptool: being interpreted python its ok
mkspiff: need igrr/mkspiffs#74 to be merged and artifacts added in [/package/package_esp32_index.template.json](https://github.com/espressif/arduino-esp32/blob/master/package/package_esp32_index.template.json).