### PR TITLE
Set scan_duplicate in BLE scan params

### DIFF
--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -25,6 +25,7 @@ BLEScan::BLEScan() {
 	m_scan_params.scan_type          = BLE_SCAN_TYPE_PASSIVE; // Default is a passive scan.
 	m_scan_params.own_addr_type      = BLE_ADDR_TYPE_PUBLIC;
 	m_scan_params.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
+  m_scan_params.scan_duplicate     = BLE_SCAN_DUPLICATE_DISABLE;
 	m_pAdvertisedDeviceCallbacks     = nullptr;
 	m_stopped                        = true;
 	m_wantDuplicates                 = false;

--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -25,7 +25,7 @@ BLEScan::BLEScan() {
 	m_scan_params.scan_type          = BLE_SCAN_TYPE_PASSIVE; // Default is a passive scan.
 	m_scan_params.own_addr_type      = BLE_ADDR_TYPE_PUBLIC;
 	m_scan_params.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
-  m_scan_params.scan_duplicate     = BLE_SCAN_DUPLICATE_DISABLE;
+	m_scan_params.scan_duplicate     = BLE_SCAN_DUPLICATE_DISABLE;
 	m_pAdvertisedDeviceCallbacks     = nullptr;
 	m_stopped                        = true;
 	m_wantDuplicates                 = false;


### PR DESCRIPTION

This value is uninitialised and as such can be a random (and invalid) value. It's needs to be set per the espressif documentation here:

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/bluetooth/esp_gap_ble.html#_CPPv4N21esp_ble_scan_params_t14scan_duplicateE

This PR sets it to DUPLICATE_DISABLE. Chosen as this is needed to ensure all scan data is populated in the scan callback, per this comment in the IDF:

https://github.com/espressif/esp-idf/blob/master/components/bt/host/bluedroid/stack/btm/btm_ble_gap.c#L3591

"//if scan duplicate is enabled, the adv packet without scan response is allowed to report to higher layer"

We **don't** want it to report to the higher layer (ie BLEScan.cpp) **unless** it has the active scan response.

Seems to resolve #3770 #3677 and possibly others.
