### PR TITLE
rmdir causes issues in SPIFFS. Fixes #4138, albeit not very cleanly

### DIFF
--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -184,13 +184,14 @@ bool VFSImpl::rmdir(const char *path)
         return false;
     }
 
+    if (strcmp(_mountpoint, "/spiffs") == 0) {
+        log_e("rmdir is unnecessary in SPIFFS");
+        return false;
+    }
+
     VFSFileImpl f(this, path, "r");
     if(!f || !f.isDirectory() || strcmp(_mountpoint, "/spiffs") == 0) {
-        if (strcmp(_mountpoint, "/spiffs") == 0) {
-           log_e("rmdir is unnecessary in SPIFFS");
-        } else {
-           log_e("%s does not exists or is a file", path);
-        }
+        log_e("%s does not exists or is a file", path);
         if(f) {
             f.close();
         }

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -190,7 +190,7 @@ bool VFSImpl::rmdir(const char *path)
     }
 
     VFSFileImpl f(this, path, "r");
-    if(!f || !f.isDirectory()) == 0) {
+    if(!f || !f.isDirectory()) {
         log_e("%s does not exists or is a file", path);
         if(f) {
             f.close();

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -191,10 +191,10 @@ bool VFSImpl::rmdir(const char *path)
 
     VFSFileImpl f(this, path, "r");
     if(!f || !f.isDirectory()) {
-        log_e("%s does not exists or is a file", path);
         if(f) {
             f.close();
         }
+        log_e("%s does not exists or is a file", path);
         return false;
     }
     f.close();

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -183,13 +183,16 @@ bool VFSImpl::rmdir(const char *path)
         log_e("File system is not mounted");
         return false;
     }
-
     VFSFileImpl f(this, path, "r");
-    if(!f || !f.isDirectory()) {
+    if(!f || !f.isDirectory() || _mountpoint == "/spiffs") {
+        if (_mountpoint == "/spiffs") {
+           log_e("rmdir is unnecessary in SPIFFS");
+        } else {
+           log_e("%s does not exists or is a file", path);
+        }
         if(f) {
             f.close();
         }
-        log_e("%s does not exists or is a file", path);
         return false;
     }
     f.close();
@@ -200,7 +203,7 @@ bool VFSImpl::rmdir(const char *path)
         return false;
     }
     sprintf(temp,"%s%s", _mountpoint, path);
-    auto rc = unlink(temp);
+    auto rc = rmdir(temp);
     free(temp);
     return rc == 0;
 }

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -184,8 +184,8 @@ bool VFSImpl::rmdir(const char *path)
         return false;
     }
     VFSFileImpl f(this, path, "r");
-    if(!f || !f.isDirectory() || _mountpoint == "/spiffs") {
-        if (_mountpoint == "/spiffs") {
+    if(!f || !f.isDirectory() || strcmp(_mountpoint, "/spiffs") == 0) {
+        if (strcmp(_mountpoint, "/spiffs") == 0) {
            log_e("rmdir is unnecessary in SPIFFS");
         } else {
            log_e("%s does not exists or is a file", path);

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -183,6 +183,7 @@ bool VFSImpl::rmdir(const char *path)
         log_e("File system is not mounted");
         return false;
     }
+
     VFSFileImpl f(this, path, "r");
     if(!f || !f.isDirectory() || strcmp(_mountpoint, "/spiffs") == 0) {
         if (strcmp(_mountpoint, "/spiffs") == 0) {

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -190,7 +190,7 @@ bool VFSImpl::rmdir(const char *path)
     }
 
     VFSFileImpl f(this, path, "r");
-    if(!f || !f.isDirectory() || strcmp(_mountpoint, "/spiffs") == 0) {
+    if(!f || !f.isDirectory()) == 0) {
         log_e("%s does not exists or is a file", path);
         if(f) {
             f.close();

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -204,7 +204,7 @@ bool VFSImpl::rmdir(const char *path)
         return false;
     }
     sprintf(temp,"%s%s", _mountpoint, path);
-    auto rc = rmdir(temp);
+    auto rc = ::rmdir(temp);
     free(temp);
     return rc == 0;
 }


### PR DESCRIPTION
SPIFFS causes crashes if you attempt to rmdir. Since there are no true directories in spiffs, this ought to be a noop. It looks like @me-no-dev worked around this by using unlink instead of rmdir, which works in fatfs and doesn't panic spiffs. This behavior is not universal. In order to get littlefs working, it would be good to get this back to conformity. Rather than digging deep into the upstream spiffs, I just check the mountpoint and noop if it is "/spiffs". So, if the user has changed the mountpoint, this will not work, but I think it's a pretty good tradeoff.