### PR TITLE
Make esp32-hal-tinyusb.h conditional on tinyusb

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.h
+++ b/cores/esp32/esp32-hal-tinyusb.h
@@ -16,6 +16,7 @@
 #include "esp32-hal.h"
 
 #if CONFIG_IDF_TARGET_ESP32S2
+#if CONFIG_USB_ENABLED
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,4 +86,5 @@ uint8_t tinyusb_get_free_out_endpoint(void);
 }
 #endif
 
+#endif /* CONFIG_USB_ENABLED */
 #endif /* CONFIG_IDF_TARGET_ESP32S2 */


### PR DESCRIPTION
Without this, the build fails unless tinyusb happens to be enabled.