### PR TITLE
Added facility to invert the polarity of input UART bits.

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -179,3 +179,8 @@ HardwareSerial::operator bool() const
 {
     return true;
 }
+
+void HardwareSerial::setRxInvert(bool invert)
+{
+    uartSetRxInvert(_uart, invert);
+}

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -100,6 +100,8 @@ public:
 
     size_t setRxBufferSize(size_t);
     void setDebugOutput(bool);
+    
+    void setRxInvert(bool);
 
 protected:
     int _uart_nr;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -265,6 +265,17 @@ size_t uartResizeRxBuffer(uart_t * uart, size_t new_size) {
     return new_size;
 }
 
+void uartSetRxInvert(uart_t* uart, bool invert)
+{
+    if (uart == NULL)
+        return;
+    
+    if (invert)
+        uart->dev->conf0.rxd_inv = 1;
+    else
+        uart->dev->conf0.rxd_inv = 0;
+}
+
 uint32_t uartAvailable(uart_t* uart)
 {
     if(uart == NULL || uart->queue == NULL) {

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -70,6 +70,8 @@ uint32_t uartGetBaudRate(uart_t* uart);
 
 size_t uartResizeRxBuffer(uart_t* uart, size_t new_size);
 
+void uartSetRxInvert(uart_t* uart, bool invert);
+
 void uartSetDebug(uart_t* uart);
 int uartGetDebug();
 


### PR DESCRIPTION
This code exposes the ESP32's UART facility to invert input bits, which can resolve issues with bipolar receivers (e.g., RS-422) with user-error in hardware connections.  Adding this allows user code to detect reversed polarity inputs, and swap the bits in software to accommodate.