### PR TITLE
Added firebeetle32 D pin numbers

### DIFF
--- a/variants/firebeetle32/pins_arduino.h
+++ b/variants/firebeetle32/pins_arduino.h
@@ -27,6 +27,17 @@ static const uint8_t MOSI  = 23;
 static const uint8_t MISO  = 19;
 static const uint8_t SCK   = 18;
 
+static const uint8_t D0 = 3;
+static const uint8_t D1 = 1;
+static const uint8_t D2 = 25;
+static const uint8_t D3 = 26;
+static const uint8_t D4 = 27;
+static const uint8_t D5 = 9;
+static const uint8_t D6 = 10;
+static const uint8_t D7 = 13;
+static const uint8_t D8 = 5;
+static const uint8_t D9 = 2;
+
 static const uint8_t A0 = 36;
 static const uint8_t A3 = 39;
 static const uint8_t A4 = 32;


### PR DESCRIPTION
Source: https://wiki.dfrobot.com/FireBeetle_ESP32_IOT_Microcontroller(V3.0)__Supports_Wi-Fi_&_Bluetooth__SKU__DFR0478

![](https://github.com/Frances9/DFR0478/blob/master/DFR0478%E5%BC%95%E8%84%9A%E5%9B%BE01.png?raw=true)