### PR TITLE
Add missing slashes in HTTPUpdate examples

### DIFF
--- a/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
@@ -52,7 +52,7 @@ void loop() {
 
     t_httpUpdate_return ret = httpUpdate.update(client, "http://server/file.bin");
     // Or:
-    //t_httpUpdate_return ret = httpUpdate.update(client, "server", 80, "file.bin");
+    //t_httpUpdate_return ret = httpUpdate.update(client, "server", 80, "/file.bin");
 
     switch (ret) {
       case HTTP_UPDATE_FAILED:

--- a/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
@@ -108,7 +108,7 @@ void loop() {
 
     t_httpUpdate_return ret = httpUpdate.update(client, "https://server/file.bin");
     // Or:
-    //t_httpUpdate_return ret = httpUpdate.update(client, "server", 443, "file.bin");
+    //t_httpUpdate_return ret = httpUpdate.update(client, "server", 443, "/file.bin");
 
 
     switch (ret) {


### PR DESCRIPTION
I spent quite a while today figuring out how to get an OTA update over HTTPS on a custom port working. A part of my problem was not putting a slash before the .bin filename, since it wasn't there in the example. This produced invalid HTTP requests. Adding the slash would make it clear that it needs to be there.