### PR TITLE
Set SD state to idle before unregister (reduces power)

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -648,6 +648,7 @@ uint8_t sdcard_uninit(uint8_t pdrv)
     if (pdrv >= FF_VOLUMES || card == NULL) {
         return 1;
     }
+    sdTransaction(pdrv, GO_IDLE_STATE, 0, NULL);
     ff_diskio_register(pdrv, NULL);
     s_cards[pdrv] = NULL;
     esp_err_t err = ESP_OK;


### PR DESCRIPTION
SD is left in an active state if you simply detach the device.  Set into idle first, this reduces power consumption by ~12mA.  See #2958 