### PR TITLE
Fix duplicated pin constant

### DIFF
--- a/variants/m5stack_atom/pins_arduino.h
+++ b/variants/m5stack_atom/pins_arduino.h
@@ -20,7 +20,7 @@ static const uint8_t SCL = 32;
 
 static const uint8_t G12 = 12;
 static const uint8_t G19 = 19;
-static const uint8_t G22 = 21;
+static const uint8_t G21 = 21;
 static const uint8_t G22 = 22;
 static const uint8_t G23 = 23;
 static const uint8_t G25 = 25;


### PR DESCRIPTION
G22 was defined twice, changing the first one to G21