### PR TITLE
Change define "ttgo-t-watch.build.board=T-Watch" to "ttgo-t-watch.build.board=T_Watch" prevent "warning: ISO C99 requires whitespace after the macro name"

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -4100,7 +4100,7 @@ ttgo-t-watch.serial.disableRTS=true
 ttgo-t-watch.build.mcu=esp32
 ttgo-t-watch.build.core=esp32
 ttgo-t-watch.build.variant=twatch
-ttgo-t-watch.build.board=T-Watch
+ttgo-t-watch.build.board=T_Watch
 
 ttgo-t-watch.build.f_cpu=240000000L
 ttgo-t-watch.build.flash_size=16MB


### PR DESCRIPTION
The "-" in the board name causes a compiler warning when this is expanded to -DARDUINO_BOARD="T-Watch".
This pull request fixes those warnings by replacing the "-" with "_" and aligns with other board definitions.