### PR TITLE
Add ArduinoOTE = ArduinoOTA over Ethernet

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -2,7 +2,9 @@
 #define LWIP_OPEN_SRC
 #endif
 #include <functional>
+#ifndef ARDUINOOTE
 #include <WiFiUdp.h>
+#endif
 #include "ArduinoOTA.h"
 #include "ESPmDNS.h"
 #include "MD5Builder.h"
@@ -117,7 +119,11 @@ void ArduinoOTAClass::begin() {
     if (!_hostname.length()) {
         char tmp[20];
         uint8_t mac[6];
+#ifdef ARDUINOOTE
+        Ethernet.MACAddress(mac);
+#else
         WiFi.macAddress(mac);
+#endif
         sprintf(tmp, "esp32-%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
         _hostname = tmp;
     }
@@ -253,8 +259,11 @@ void ArduinoOTAClass::_runUpdate() {
     if (_progress_callback) {
         _progress_callback(0, _size);
     }
-
+#ifdef ARDUINOOTE
+    EthernetClient client;
+#else
     WiFiClient client;
+#endif
     if (!client.connect(_ota_ip, _ota_port)) {
         if (_error_callback) {
             _error_callback(OTA_CONNECT_ERROR);

--- a/libraries/ArduinoOTA/src/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.h
@@ -1,7 +1,11 @@
 #ifndef __ARDUINO_OTA_H
 #define __ARDUINO_OTA_H
 
+#ifdef ARDUINOOTE
+#include <Ethernet.h>
+#else
 #include <WiFi.h>
+#endif
 #include <functional>
 #include "Update.h"
 
@@ -81,7 +85,11 @@ class ArduinoOTAClass
     String _password;
     String _hostname;
     String _nonce;
+#ifdef ARDUINOOTE
+    EthernetUDP _udp_ota;
+#else
     WiFiUDP _udp_ota;
+#endif
     bool _initialized;
     bool _rebootOnSuccess;
     bool _mdnsEnabled;


### PR DESCRIPTION
I needed the ability to do OTA via Ethernet, so I modified ArduinoOTA.cpp and ArduinoOTA.h - just a few lines to be swapped in when the ``-DARDUINOOTE`` compiler flag is set. The default is still using WiFi.