### PR TITLE
Fix HTTPClient::getString() freeze on empty responses

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -844,12 +844,15 @@ String HTTPClient::getString(void)
 {
     StreamString sstring;
 
-    if(_size) {
+    if(_size > 0) {
         // try to reserve needed memmory
         if(!sstring.reserve((_size + 1))) {
             log_d("not enough memory to reserve a string! need: %d", (_size + 1));
             return "";
         }
+    }
+    else {
+        return "";
     }
 
     writeToStream(&sstring);


### PR DESCRIPTION
Currently when getString() is called when content-length is not set (for example for 204 no-content http code) program execution freezes.
I found similar problems mentioned in https://github.com/espressif/arduino-esp32/issues/2667 and https://github.com/espressif/arduino-esp32/issues/3586  but no fix to date.