### PR TITLE
WebServer.handleClient delay

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -278,6 +278,7 @@ void WebServer::serveStatic(const char* uri, FS& fs, const char* path, const cha
 
 void WebServer::handleClient() {
   if (_currentStatus == HC_NONE) {
+    delay(1);
     WiFiClient client = _server.available();
     if (!client) {
       return;

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -45,6 +45,7 @@ WebServer::WebServer(IPAddress addr, int port)
 , _currentVersion(0)
 , _currentStatus(HC_NONE)
 , _statusChange(0)
+, _nullDelay(true)
 , _currentHandler(nullptr)
 , _firstHandler(nullptr)
 , _lastHandler(nullptr)
@@ -66,6 +67,7 @@ WebServer::WebServer(int port)
 , _currentVersion(0)
 , _currentStatus(HC_NONE)
 , _statusChange(0)
+, _nullDelay(true)
 , _currentHandler(nullptr)
 , _firstHandler(nullptr)
 , _lastHandler(nullptr)
@@ -278,9 +280,11 @@ void WebServer::serveStatic(const char* uri, FS& fs, const char* path, const cha
 
 void WebServer::handleClient() {
   if (_currentStatus == HC_NONE) {
-    delay(1);
     WiFiClient client = _server.available();
     if (!client) {
+      if (_nullDelay) {
+        delay(1);
+      }
       return;
     }
 
@@ -369,6 +373,10 @@ void WebServer::sendHeader(const String& name, const String& value, bool first) 
 
 void WebServer::setContentLength(const size_t contentLength) {
     _contentLength = contentLength;
+}
+
+void WebServer::enableDelay(boolean value) {
+  _nullDelay = value;
 }
 
 void WebServer::enableCORS(boolean value) {

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -123,6 +123,7 @@ public:
   void send_P(int code, PGM_P content_type, PGM_P content);
   void send_P(int code, PGM_P content_type, PGM_P content, size_t contentLength);
 
+  void enableDelay(boolean value);
   void enableCORS(boolean value = true);
   void enableCrossOrigin(boolean value = true);
 
@@ -176,6 +177,7 @@ protected:
   uint8_t     _currentVersion;
   HTTPClientStatus _currentStatus;
   unsigned long _statusChange;
+  boolean     _nullDelay;
 
   RequestHandler*  _currentHandler;
   RequestHandler*  _firstHandler;


### PR DESCRIPTION
If WebServer.handleClient is run in a tight loop, it will starve other processes.  So, if there is no connection, throw in a delay(1).  Fixes #4348