### PR TITLE
Update MDNSResponder::addService to return a boolean

### DIFF
--- a/libraries/ESPmDNS/src/ESPmDNS.cpp
+++ b/libraries/ESPmDNS/src/ESPmDNS.cpp
@@ -130,7 +130,7 @@ void MDNSResponder::disableWorkstation(){
     }
 }
 
-void MDNSResponder::addService(char *name, char *proto, uint16_t port){
+bool MDNSResponder::addService(char *name, char *proto, uint16_t port){
     char _name[strlen(name)+2];
     char _proto[strlen(proto)+2];
 	if (name[0] == '_') {
@@ -146,7 +146,9 @@ void MDNSResponder::addService(char *name, char *proto, uint16_t port){
 
     if(mdns_service_add(NULL, _name, _proto, port, NULL, 0)) {
         log_e("Failed adding service %s.%s.\n", name, proto);
+	return false;
     }
+    return true;
 }
 
 bool MDNSResponder::addServiceTxt(char *name, char *proto, char *key, char *value){

--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -65,11 +65,11 @@ public:
     setInstanceName(String(name));
   }
 
-  void addService(char *service, char *proto, uint16_t port);
-  void addService(const char *service, const char *proto, uint16_t port){
+  bool addService(char *service, char *proto, uint16_t port);
+  bool addService(const char *service, const char *proto, uint16_t port){
     addService((char *)service, (char *)proto, port);
   }
-  void addService(String service, String proto, uint16_t port){
+  bool addService(String service, String proto, uint16_t port){
     addService(service.c_str(), proto.c_str(), port);
   }
   

--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -67,10 +67,10 @@ public:
 
   bool addService(char *service, char *proto, uint16_t port);
   bool addService(const char *service, const char *proto, uint16_t port){
-    addService((char *)service, (char *)proto, port);
+    return addService((char *)service, (char *)proto, port);
   }
   bool addService(String service, String proto, uint16_t port){
-    addService(service.c_str(), proto.c_str(), port);
+    return addService(service.c_str(), proto.c_str(), port);
   }
   
   bool addServiceTxt(char *name, char *proto, char * key, char * value);


### PR DESCRIPTION
I was playing with the mDNS service and noticed the method `MDNSResponder::addService` could return a Boolean with the way it is implemented just like other functions in this library.

This would be handy to know at a higher level weather or not the service was added correctly to the mDNS server of the ESP32.