### PR TITLE
Fix for  ETH.cpp: 97:36: error: no matching function for call to 'WiF…

### DIFF
--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -94,7 +94,7 @@ void ETHClass::eth_event_handler(void *arg, esp_event_base_t event_base, int32_t
     default:
         break;
     }
-    WiFi._eventCallback(arg, &event);
+    WiFi._eventCallback(arg, &event,NULL);
 }
 
 


### PR DESCRIPTION
…iClass::_eventCallback(void*&, system_event_t*)