### PR TITLE
Fix missing headers when compiling as IDF component with Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ set(COMPONENT_ADD_INCLUDEDIRS
 set(COMPONENT_PRIV_INCLUDEDIRS cores/esp32/libb64)
 
 set(COMPONENT_REQUIRES spi_flash mbedtls mdns ethernet esp_adc_cal wifi_provisioning)
-set(COMPONENT_PRIV_REQUIRES fatfs nvs_flash app_update spiffs bootloader_support openssl bt)
+set(COMPONENT_PRIV_REQUIRES fatfs nvs_flash app_update spiffs bootloader_support openssl bt esp_http_client esp_https_ota)
 
 register_component()
 


### PR DESCRIPTION
* HttpsOTAUpdate introduced new IDF component requirements.

These have been added to CMakeLists.txt to correct compilation errors when using Cmake.