### PR TITLE
Add missing "-mlongcalls" flag to PlatformIO build script

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -35,7 +35,7 @@ FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
 assert isdir(FRAMEWORK_DIR)
 
 env.Append(
-    ASFLAGS=["-x", "assembler-with-cpp"],
+    ASFLAGS=["-x", "assembler-with-cpp", "-mlongcalls"],
 
     CFLAGS=[
         "-std=gnu99",


### PR DESCRIPTION
Fixes possible issues with assembly files in external libraries