### PR TITLE
Fix header parsing

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1199,7 +1199,6 @@ int HTTPClient::handleHeaderResponse()
                     _canReuse = (headerLine[sizeof "HTTP/1." - 1] != '0');
                 }
     }
-    headerLine.substring(headerLine.indexOf(' '));
     _returnCode = headerLine.substring(headerLine.indexOf(' ')).toInt();
 	
     while(connected()) {


### PR DESCRIPTION
Valid responses can have other content than HTTP1.x as first line. A valid response is e.g. "ICY 200 OK".
This fix allows other responses. 

This makes it easy to use the client e.g. for streaming audio.

fixes https://github.com/espressif/arduino-esp32/issues/4454