### PR TITLE
Notify the batteryLevel change

### DIFF
--- a/libraries/BLE/src/BLEHIDDevice.cpp
+++ b/libraries/BLE/src/BLEHIDDevice.cpp
@@ -194,6 +194,7 @@ BLECharacteristic* BLEHIDDevice::protocolMode() {
 
 void BLEHIDDevice::setBatteryLevel(uint8_t level) {
 	m_batteryLevelCharacteristic->setValue(&level, 1);
+	m_batteryLevelCharacteristic->notify();	
 }
 /*
  * @brief Returns battery level characteristic


### PR DESCRIPTION
In order for the host device to be able to update the battery level, a notification is needed.
This way, Windows wil automatically update the battery level of connected devices