### PR TITLE
Update WiFiProv.cpp: make globals static

### DIFF
--- a/libraries/WiFi/src/WiFiProv.cpp
+++ b/libraries/WiFi/src/WiFiProv.cpp
@@ -33,9 +33,10 @@
 #undef IPADDR_NONE
 #include "WiFi.h"
 
-wifi_prov_mgr_config_t config;
-scheme_t prov_scheme;
 extern esp_err_t postToSysQueue(system_prov_event_t *);
+
+static wifi_prov_mgr_config_t config;
+static scheme_t prov_scheme;
 static const uint8_t custom_service_uuid[16] = {  0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf,
                                                   0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02, };
 


### PR DESCRIPTION
Do not pollute the global namespace with generic names like 'config' by declaring global variables 'static'.