### PR TITLE
Allow custom variants directory

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -194,16 +194,20 @@ if not env.BoardConfig().get("build.ldscript", ""):
 
 libs = []
 
+variants_dir = join(FRAMEWORK_DIR, "variants")
+
+if "build.variants_dir" in env.BoardConfig():
+    variants_dir = join("$PROJECT_DIR", env.BoardConfig().get("build.variants_dir"))
+
 if "build.variant" in env.BoardConfig():
     env.Append(
         CPPPATH=[
-            join(FRAMEWORK_DIR, "variants",
-                 env.BoardConfig().get("build.variant"))
+            join(variants_dir, env.BoardConfig().get("build.variant"))
         ]
     )
     libs.append(env.BuildLibrary(
         join("$BUILD_DIR", "FrameworkArduinoVariant"),
-        join(FRAMEWORK_DIR, "variants", env.BoardConfig().get("build.variant"))
+        join(variants_dir, env.BoardConfig().get("build.variant"))
     ))
 
 envsafe = env.Clone()


### PR DESCRIPTION
The goal is to allow custom configuration for `variants_dir` to define our own board variant directly in the project.

With this functionnality, we are now allowed to define in our projects a custom board **AND** a custom variant.
https://docs.platformio.org/en/latest/platforms/creating_board.html#custom-embedded-boards

Here is an example of how to define a custom board with custom variant:
```
my_project
├── boards
│   └── custom_esp32dev.json
└── variants
    └── custom-esp32dev
        └── pins_arduino.h
```

custom_esp32dev.json
```json
{
  "build": {
    "arduino":{
      "ldscript": "esp32_out.ld"
    },
    "core": "esp32",
    "extra_flags": "-DARDUINO_ESP32_DEV",
    "f_cpu": "240000000L",
    "f_flash": "40000000L",
    "flash_mode": "dio",
    "mcu": "esp32",
    "variants_dir": "variants",
    "variant": "custom-esp32dev"
  },
  "connectivity": [
    "wifi",
    "bluetooth",
    "ethernet",
    "can"
  ],
  "debug": {
    "openocd_board": "esp-wroom-32.cfg"
  },
  "frameworks": [
    "arduino",
    "espidf"
  ],
  "name": "My Custom Espressif ESP32 Dev Module",
  "upload": {
    "flash_size": "4MB",
    "maximum_ram_size": 327680,
    "maximum_size": 4194304,
    "require_upload_port": true,
    "speed": 460800
  },
  "url": "https://en.wikipedia.org/wiki/ESP32",
  "vendor": "Espressif"
}
```