### PR TITLE
Updated SD_MMC init to match changes upstream

### DIFF
--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -43,22 +43,21 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit)
     }
     //mount
     sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
-    sdmmc_host_t host = {
-        .flags = SDMMC_HOST_FLAG_4BIT,
-        .slot = SDMMC_HOST_SLOT_1,
-        .max_freq_khz = SDMMC_FREQ_DEFAULT,
-        .io_voltage = 3.3f,
-        .init = &sdmmc_host_init,
-        .set_bus_width = &sdmmc_host_set_bus_width,
-        .get_bus_width = &sdmmc_host_get_slot_width,
-        .set_bus_ddr_mode = &sdmmc_host_set_bus_ddr_mode,
-        .set_card_clk = &sdmmc_host_set_card_clk,
-        .do_transaction = &sdmmc_host_do_transaction,
-        .deinit = &sdmmc_host_deinit,
-        .io_int_enable = &sdmmc_host_io_int_enable,
-        .io_int_wait = &sdmmc_host_io_int_wait,
-        .command_timeout_ms = 0
-    };
+    sdmmc_host_t host;
+    host.flags = SDMMC_HOST_FLAG_4BIT;
+    host.slot = SDMMC_HOST_SLOT_1;
+    host.max_freq_khz = SDMMC_FREQ_DEFAULT;
+    host.io_voltage = 3.3f;
+    host.init = &sdmmc_host_init;
+    host.set_bus_width = &sdmmc_host_set_bus_width;
+    host.get_bus_width = &sdmmc_host_get_slot_width;
+    host.set_bus_ddr_mode = &sdmmc_host_set_bus_ddr_mode;
+    host.set_card_clk = &sdmmc_host_set_card_clk;
+    host.do_transaction = &sdmmc_host_do_transaction;
+    host.deinit_p = &sdspi_host_remove_device;
+    host.io_int_enable = &sdmmc_host_io_int_enable;
+    host.io_int_wait = &sdmmc_host_io_int_wait;
+    host.command_timeout_ms = 0;
     host.max_freq_khz = SDMMC_FREQ_HIGHSPEED;
 #ifdef BOARD_HAS_1BIT_SDMMC
     mode1bit = true;


### PR DESCRIPTION
sd_mmc_host_t was changed to add a union on one of the elements.  So, the c-style initialization needed to be changed to verbose style.