### PR TITLE
Set WiFiProv category to silence a warning in Arduino IDE

### DIFF
--- a/libraries/WiFiProv/library.properties
+++ b/libraries/WiFiProv/library.properties
@@ -4,6 +4,6 @@ author=Switi Mhaiske <sweetymhaiske@gmail.com>
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Enables provisioning.
 paragraph=With this library you can perform provisioning on esp32 via SoftAP or BLE.
-category=
+category=Communication
 url=
 architectures=esp32


### PR DESCRIPTION
Set the category to silence this warning in the Arduino IDE:
```
WARNING: Category '' in library WiFiProv is not valid. Setting to 'Uncategorized'
```