### PR TITLE
Add IP101 support

### DIFF
--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -22,6 +22,7 @@
 #include "eth_phy/phy.h"
 #include "eth_phy/phy_tlk110.h"
 #include "eth_phy/phy_lan8720.h"
+#include "eth_phy/phy_ip101.h"
 #include "lwip/err.h"
 #include "lwip/dns.h"
 
@@ -78,6 +79,9 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
     } else if(type == ETH_PHY_TLK110){
         eth_config_t config = phy_tlk110_default_ethernet_config;
         memcpy(&eth_config, &config, sizeof(eth_config_t));
+    } else if(type == ETH_PHY_IP101) {
+      eth_config_t config = phy_ip101_default_ethernet_config;
+      memcpy(&eth_config, &config, sizeof(eth_config_t));
     } else {
         log_e("Bad ETH_PHY type: %u", (uint8_t)type);
         return false;

--- a/libraries/WiFi/src/ETH.h
+++ b/libraries/WiFi/src/ETH.h
@@ -48,7 +48,7 @@
 #define ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
 #endif
 
-typedef enum { ETH_PHY_LAN8720, ETH_PHY_TLK110, ETH_PHY_MAX } eth_phy_type_t;
+typedef enum { ETH_PHY_LAN8720, ETH_PHY_TLK110, ETH_PHY_IP101, ETH_PHY_MAX } eth_phy_type_t;
 
 class ETHClass {
     private:


### PR DESCRIPTION
Add support for the IP101 chip to be able to use the Espressif Ethernet Kit. Based on this issue: https://github.com/espressif/arduino-esp32/issues/3554