### PR TITLE
[2.0.0] Add missing default TX and RX for T-watch

### DIFF
--- a/variants/twatch/pins_arduino.h
+++ b/variants/twatch/pins_arduino.h
@@ -21,6 +21,9 @@
 #define APX20X_INT          35
 #define BMA42X_INT1         39
 
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
 //Serial1 Already assigned to GPS LORA
 #define TX1                 33
 #define RX1                 34


### PR DESCRIPTION
That solves
```
C:\Users\user\.platformio\packages\framework-arduinoespressif32@src-7a495aa357652c59e127d3388578e1f1\cores\esp32\esp32-hal-gpio.c: In function '__pinMode':
C:\Users\user\.platformio\packages\framework-arduinoespressif32@src-7a495aa357652c59e127d3388578e1f1\cores\esp32\esp32-hal-gpio.c:238:44: error: 'RX' undeclared (first use in this function); did you mean 'RX1'?
         pinFunction |= ((uint32_t)(((pin)==RX||(pin)==TX)?0:1) << MCU_SEL_S);
                                            ^~
                                            RX1
```