### PR TITLE
Permit `notify` event subscription when BLE servers don't require registration

### DIFF
--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -453,7 +453,7 @@ std::string BLERemoteCharacteristic::readValue() {
  * unregistering a notification.
  * @return N/A.
  */
-void BLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, bool notifications) {
+void BLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, bool notifications, bool descriptorRequiresRegistration) {
 	log_v(">> registerForNotify(): %s", toString().c_str());
 
 	m_notifyCallback = notifyCallback;   // Save the notification callback.
@@ -474,7 +474,7 @@ void BLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, 
 		uint8_t val[] = {0x01, 0x00};
 		if(!notifications) val[0] = 0x02;
 		BLERemoteDescriptor* desc = getDescriptor(BLEUUID((uint16_t)0x2902));
-		if (desc != nullptr)
+		if (desc != nullptr && descriptorRequiresRegistration)
 			desc->writeValue(val, 2, true);
 	} // End Register
 	else {   // If we weren't passed a callback function, then this is an unregistration.
@@ -490,7 +490,7 @@ void BLERemoteCharacteristic::registerForNotify(notify_callback notifyCallback, 
 
 		uint8_t val[] = {0x00, 0x00};
 		BLERemoteDescriptor* desc = getDescriptor((uint16_t)0x2902);
-		if (desc != nullptr)
+		if (desc != nullptr && descriptorRequiresRegistration)
 			desc->writeValue(val, 2, true);
 	} // End Unregister
 

--- a/libraries/BLE/src/BLERemoteCharacteristic.h
+++ b/libraries/BLE/src/BLERemoteCharacteristic.h
@@ -46,7 +46,7 @@ public:
 	uint16_t    readUInt16();
 	uint32_t    readUInt32();
 	float       readFloat();
-	void        registerForNotify(notify_callback _callback, bool notifications = true);
+	void        registerForNotify(notify_callback _callback, bool notifications = true, bool descriptorRequiresRegistration = true);
 	void        writeValue(uint8_t* data, size_t length, bool response = false);
 	void        writeValue(std::string newValue, bool response = false);
 	void        writeValue(uint8_t newValue, bool response = false);


### PR DESCRIPTION
**Background**
I have an iTag that I'm wanting to use as a BLE button to control an application on my ESP32.

**Problem**
The iTag doesn't require explicit registration for a client to be able to listen to `notify` events. Currently, the `BLERemoteCharacteristic::registerForNotify` function tries to update the remote descriptor at `0x2902` and register/unregister the client as required.

As the iTag doesn't have this descriptor, it causes an unhandled exception error and crashes the application.

**Changes**
To support devices that don't require you to explicitly register to follow such events, I've added a simple `descriptorRequiresRegistration` flag to the `BLERemoteCharacteristic::registerForNotify` function. This defaults to true, for backward compatibility.

Thanks!