### PR TITLE
Mention size limitation in default configuration

### DIFF
--- a/docs/arduino-ide/boards_manager.md
+++ b/docs/arduino-ide/boards_manager.md
@@ -10,3 +10,5 @@ Starting with 1.6.4, Arduino allows installation of third-party platform package
 - Start Arduino and open Preferences window.
 - Enter one of the release links above into *Additional Board Manager URLs* field. You can add multiple URLs, separating them with commas.
 - Open Boards Manager from Tools > Board menu and install *esp32* platform (and don't forget to select your ESP32 board from Tools > Board menu after installation).
+
+**Note:** The default configuration does not work for using both BLE and WiFi in the same sketch. If you need both or even more modules at the same time other Partition Schemes _(Tools -> Partition Scheme)_ may work (for example "Minimal SPIFFS (1.9MB APP with OTA/190K SPIFFS)")


### PR DESCRIPTION
Given that BLE and WiFi are kind of a selling point of ESP32 to begin with it's worth mentioning they can't be used together without some tweaks to default configuration.

---

The alternate partitioning scheme I picked is one I think is the _least_ drastically different from the default. I have no experience to evaluate the alternatives other than things like dropping OTA completely, or switching to FATFS just feel completely unwarranted when all one needs is some more bytes. (I can guess the implications of no-OTA but I've absolutely no idea about FATFS.)

IMO the default configuration should "just work" out of the box to minimize any friction with newcomers while making as much of the chip accessible as possible, but I've no idea of all the things default configuration needs to cater to.

Ref: https://github.com/espressif/arduino-esp32/issues/4668