### PR TITLE
Resolve hardware timer functions not in IRAM, crashes when called from ISR

### DIFF
--- a/cores/esp32/esp32-hal-timer.c
+++ b/cores/esp32/esp32-hal-timer.c
@@ -90,56 +90,56 @@ void IRAM_ATTR __timerISR(void * arg){
     }
 }
 
-uint64_t timerRead(hw_timer_t *timer){
+uint64_t IRAM_ATTR timerRead(hw_timer_t *timer){
     timer->dev->update = 1;
     uint64_t h = timer->dev->cnt_high;
     uint64_t l = timer->dev->cnt_low;
     return (h << 32) | l;
 }
 
-uint64_t timerAlarmRead(hw_timer_t *timer){
+uint64_t IRAM_ATTR timerAlarmRead(hw_timer_t *timer){
     uint64_t h = timer->dev->alarm_high;
     uint64_t l = timer->dev->alarm_low;
     return (h << 32) | l;
 }
 
-void timerWrite(hw_timer_t *timer, uint64_t val){
+void IRAM_ATTR timerWrite(hw_timer_t *timer, uint64_t val){
     timer->dev->load_high = (uint32_t) (val >> 32);
     timer->dev->load_low = (uint32_t) (val);
     timer->dev->reload = 1;
 }
 
-void timerAlarmWrite(hw_timer_t *timer, uint64_t alarm_value, bool autoreload){
+void IRAM_ATTR timerAlarmWrite(hw_timer_t *timer, uint64_t alarm_value, bool autoreload){
     timer->dev->alarm_high = (uint32_t) (alarm_value >> 32);
     timer->dev->alarm_low = (uint32_t) alarm_value;
     timer->dev->config.autoreload = autoreload;
 }
 
-void timerSetConfig(hw_timer_t *timer, uint32_t config){
+void IRAM_ATTR timerSetConfig(hw_timer_t *timer, uint32_t config){
     timer->dev->config.val = config;
 }
 
-uint32_t timerGetConfig(hw_timer_t *timer){
+uint32_t IRAM_ATTR timerGetConfig(hw_timer_t *timer){
     return timer->dev->config.val;
 }
 
-void timerSetCountUp(hw_timer_t *timer, bool countUp){
+void IRAM_ATTR timerSetCountUp(hw_timer_t *timer, bool countUp){
     timer->dev->config.increase = countUp;
 }
 
-bool timerGetCountUp(hw_timer_t *timer){
+bool IRAM_ATTR timerGetCountUp(hw_timer_t *timer){
     return timer->dev->config.increase;
 }
 
-void timerSetAutoReload(hw_timer_t *timer, bool autoreload){
+void IRAM_ATTR timerSetAutoReload(hw_timer_t *timer, bool autoreload){
     timer->dev->config.autoreload = autoreload;
 }
 
-bool timerGetAutoReload(hw_timer_t *timer){
+bool IRAM_ATTR timerGetAutoReload(hw_timer_t *timer){
     return timer->dev->config.autoreload;
 }
 
-void timerSetDivider(hw_timer_t *timer, uint16_t divider){//2 to 65536
+void IRAM_ATTR timerSetDivider(hw_timer_t *timer, uint16_t divider){//2 to 65536
     if(!divider){
         divider = 0xFFFF;
     } else if(divider == 1){
@@ -151,41 +151,41 @@ void timerSetDivider(hw_timer_t *timer, uint16_t divider){//2 to 65536
     timer->dev->config.enable = timer_en;
 }
 
-uint16_t timerGetDivider(hw_timer_t *timer){
+uint16_t IRAM_ATTR timerGetDivider(hw_timer_t *timer){
     return timer->dev->config.divider;
 }
 
-void timerStart(hw_timer_t *timer){
+void IRAM_ATTR timerStart(hw_timer_t *timer){
     timer->dev->config.enable = 1;
 }
 
-void timerStop(hw_timer_t *timer){
+void IRAM_ATTR timerStop(hw_timer_t *timer){
     timer->dev->config.enable = 0;
 }
 
-void timerRestart(hw_timer_t *timer){
+void IRAM_ATTR timerRestart(hw_timer_t *timer){
     timer->dev->config.enable = 0;
     timer->dev->reload = 1;
     timer->dev->config.enable = 1;
 }
 
-bool timerStarted(hw_timer_t *timer){
+bool IRAM_ATTR timerStarted(hw_timer_t *timer){
     return timer->dev->config.enable;
 }
 
-void timerAlarmEnable(hw_timer_t *timer){
+void IRAM_ATTR timerAlarmEnable(hw_timer_t *timer){
     timer->dev->config.alarm_en = 1;
 }
 
-void timerAlarmDisable(hw_timer_t *timer){
+void IRAM_ATTR timerAlarmDisable(hw_timer_t *timer){
     timer->dev->config.alarm_en = 0;
 }
 
-bool timerAlarmEnabled(hw_timer_t *timer){
+bool IRAM_ATTR timerAlarmEnabled(hw_timer_t *timer){
     return timer->dev->config.alarm_en;
 }
 
-static void _on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb){
+static void IRAM_ATTR _on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb){
     hw_timer_t * timer = (hw_timer_t *)arg;
     if(ev_type == APB_BEFORE_CHANGE){
         timer->dev->config.enable = 0;
@@ -197,7 +197,7 @@ static void _on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb
     }
 }
 
-hw_timer_t * timerBegin(uint8_t num, uint16_t divider, bool countUp){
+hw_timer_t * IRAM_ATTR timerBegin(uint8_t num, uint16_t divider, bool countUp){
     if(num > 3){
         return NULL;
     }
@@ -222,13 +222,13 @@ hw_timer_t * timerBegin(uint8_t num, uint16_t divider, bool countUp){
     return timer;
 }
 
-void timerEnd(hw_timer_t *timer){
+void IRAM_ATTR timerEnd(hw_timer_t *timer){
     timer->dev->config.enable = 0;
     timerAttachInterrupt(timer, NULL, false);
     removeApbChangeCallback(timer, _on_apb_change);
 }
 
-void timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge){
+void IRAM_ATTR timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge){
     static bool initialized = false;
     static intr_handle_t intr_handle = NULL;
     if(intr_handle){
@@ -279,29 +279,29 @@ void timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge){
     }
 }
 
-void timerDetachInterrupt(hw_timer_t *timer){
+void IRAM_ATTR timerDetachInterrupt(hw_timer_t *timer){
     timerAttachInterrupt(timer, NULL, false);
 }
 
-uint64_t timerReadMicros(hw_timer_t *timer){
+uint64_t IRAM_ATTR timerReadMicros(hw_timer_t *timer){
     uint64_t timer_val = timerRead(timer);
     uint16_t div = timerGetDivider(timer);
     return timer_val * div / (getApbFrequency() / 1000000);
 }
 
-double timerReadSeconds(hw_timer_t *timer){
+double IRAM_ATTR timerReadSeconds(hw_timer_t *timer){
     uint64_t timer_val = timerRead(timer);
     uint16_t div = timerGetDivider(timer);
     return (double)timer_val * div / getApbFrequency();
 }
 
-uint64_t timerAlarmReadMicros(hw_timer_t *timer){
+uint64_t IRAM_ATTR timerAlarmReadMicros(hw_timer_t *timer){
     uint64_t timer_val = timerAlarmRead(timer);
     uint16_t div = timerGetDivider(timer);
     return timer_val * div / (getApbFrequency() / 1000000);
 }
 
-double timerAlarmReadSeconds(hw_timer_t *timer){
+double IRAM_ATTR timerAlarmReadSeconds(hw_timer_t *timer){
     uint64_t timer_val = timerAlarmRead(timer);
     uint16_t div = timerGetDivider(timer);
     return (double)timer_val * div / getApbFrequency();


### PR DESCRIPTION
Hi folks,

As seen in https://github.com/crankyoldgit/IRremoteESP8266/issues/1350 and https://github.com/taligentx/dscKeybusInterface/issues/80, the Arduino/esp32 hardware timer functions are currently not in IRAM and cause crashes when called from an ISR:

```
Guru Meditation Error: Core  1 panic'ed (Cache disabled but cached memory region accessed)
Core 1 register dump:
PC      : 0x400d6838  PS      : 0x00060034  A0      : 0x80081aa8  A1      : 0x3ffbffa0  
A2      : 0x3ffc1be0  A3      : 0x20000000  A4      : 0x00000400  A5      : 0x00000000  
A6      : 0x3ffc7458  A7      : 0xffffffff  A8      : 0x800812ff  A9      : 0x00000001  
A10     : 0x3ffbdcb8  A11     : 0x00000000  A12     : 0x3ffba264  A13     : 0x0000abab  
A14     : 0x3ffc7058  A15     : 0x00000000  SAR     : 0x00000012  EXCCAUSE: 0x00000007  
EXCVADDR: 0x00000000  LBEG    : 0x00000000  LEND    : 0x00000000  LCOUNT  : 0x00000000  
Core 1 was running in ISR context:
EPC1    : 0x400833f9  EPC2    : 0x00000000  EPC3    : 0x00000000  EPC4    : 0x400d6838

ELF file SHA256: 0000000000000000

Backtrace: 0x400d6838:0x3ffbffa0 0x40081aa5:0x3ffbffc0 0x400848b5:0x3ffbffe0 0x400833f6:0x3ffba190 0x400858f3:0x3ffba1b0 0x40089d9e:0x3ffba1d0

Rebooting...

// Exception decoding: 

PC: 0x400d6838: timerStop at /Users/taligent/Library/Arduino15/packages/esp32/hardware/esp32/1.0.5-rc4/cores/esp32/esp32-hal-timer.c line 162
EXCVADDR: 0x00000000

Decoding stack results
0x400d6838: timerStop at /Users/taligent/Library/Arduino15/packages/esp32/hardware/esp32/1.0.5-rc4/cores/esp32/esp32-hal-timer.c line 162
0x40081aa5: __timerISR at /Users/taligent/Library/Arduino15/packages/esp32/hardware/esp32/1.0.5-rc4/cores/esp32/esp32-hal-timer.c line 88
0x400833f6: spi_flash_op_block_func at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/cache_utils.c line 82
0x400858f3: ipc_task at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/ipc.c line 62
0x40089d9e: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c line 143
```

I've run across this issue when using [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer) and [Blynk](https://github.com/blynkkk/blynk-library) with my library ([dscKeybusInterface](https://github.com/taligentx/dscKeybusInterface)).  The library uses a GPIO pin change interrupt to catch a clock signal, and that ISR triggers a timer interrupt to read data from a different GPIO after 250us.  This works fine with Arduino/AVR and esp8266, but calling `timerStart()` and `timerStop()` on Arduino/esp32 results in the above crash, and is resolved by placing these functions in IRAM.

For reference, Arduino/esp8266 places its hardware timer functions in IRAM: https://github.com/esp8266/Arduino/blob/master/cores/esp8266/core_esp8266_timer.cpp

The current workaround in the IRremoteESP8266 library bypasses the Arduino esp32 core functions and redefines `hw_timer_t` and `hw_timer_reg_t` so its ISR can configure the timers directly: https://github.com/crankyoldgit/IRremoteESP8266/pull/1351

It'd be great to be able to avoid these kinds of workarounds - thanks!
