### PR TITLE
Remove an unused variable 'channel'

### DIFF
--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -241,7 +241,6 @@ bool rmtLoop(rmt_obj_t* rmt, rmt_data_t* data, size_t size)
         return false;
     }
 
-    int channel = rmt->channel;
     int allocated_size = MAX_DATA_PER_CHANNEL * rmt->buffers;
 
     if (size > allocated_size) {


### PR DESCRIPTION
I fixed the following compilation warning.
 
```
C:\Users\estshorter\.platformio\packages\framework-arduinoespressif32\cores\esp32\esp32-hal-rmt.c: In function 'rmtLoop':
C:\Users\estshorter\.platformio\packages\framework-arduinoespressif32\cores\esp32\esp32-hal-rmt.c:244:9: warning: unused variable 'channel' [-Wunused-variable]
     int channel = rmt->channel;
         ^
```

Note: This is already fixed in the `idf-release/v4.0` and `idf-release/v4.2` branches.
https://github.com/espressif/arduino-esp32/blob/d011dd7ef5d26e7ba2c2c093f422c534bacf4661/cores/esp32/esp32-hal-rmt.c#L237-L249