### PR TITLE
Make BLERemoteCharacteristic::getRemoteService() public #3367

### DIFF
--- a/libraries/BLE/src/BLERemoteCharacteristic.h
+++ b/libraries/BLE/src/BLERemoteCharacteristic.h
@@ -39,6 +39,7 @@ public:
 	bool        canWriteNoResponse();
 	BLERemoteDescriptor* getDescriptor(BLEUUID uuid);
 	std::map<std::string, BLERemoteDescriptor*>* getDescriptors();
+	BLERemoteService* getRemoteService();
 	uint16_t    getHandle();
 	BLEUUID     getUUID();
 	std::string readValue();
@@ -63,7 +64,6 @@ private:
 	// Private member functions
 	void gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t* evtParam);
 
-	BLERemoteService* getRemoteService();
 	void              removeDescriptors();
 	void              retrieveDescriptors();
 


### PR DESCRIPTION
Provide access to characteristic's service, especially useful when receiving a notification registered via `BLERemoteCharacteristic::registerForNotify` as the callback only gets the characteristic as a parameter so you can't differentiate between multiple connected devices with multiple notification subscriptions.

More details in https://github.com/espressif/arduino-esp32/issues/3367 for use cases. 