### PR TITLE
Added callbacks to BLERemoteCharacteristic

### DIFF
--- a/libraries/BLE/src/BLERemoteCharacteristic.h
+++ b/libraries/BLE/src/BLERemoteCharacteristic.h
@@ -11,6 +11,7 @@
 #if defined(CONFIG_BT_ENABLED)
 
 #include <string>
+#include <functional>
 
 #include <esp_gattc_api.h>
 
@@ -21,8 +22,7 @@
 
 class BLERemoteService;
 class BLERemoteDescriptor;
-typedef void (*notify_callback)(BLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
-
+typedef std::function<void(BLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify)> notify_callback;
 /**
  * @brief A model of a remote %BLE characteristic.
  */


### PR DESCRIPTION
Hello,

currently it is not possible to subscribe for the remote characteristic's notification with additional context. This way it's really hard to distinguish the source of callback in case if you are connected to multiple devices that shares the same callback function. Thanks to this pull request one can implement the BLERemoteCharacteristicCallbacks interface and then they can easily determine the device connected to particular notification. It is very useful for my case.

Let me know what do you think about it