### PR TITLE
Sync PlatformIO build script with changes in partitions processing

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -224,7 +224,9 @@ env.Prepend(LIBS=libs)
 #
 
 fwpartitions_dir = join(FRAMEWORK_DIR, "tools", "partitions")
-partitions_csv = env.BoardConfig().get("build.partitions", "default.csv")
+partitions_csv = env.BoardConfig().get("build.arduino.partitions", "default.csv")
+if "build.partitions" in env.BoardConfig():
+    partitions_csv = env.BoardConfig().get("build.partitions")
 env.Replace(
     PARTITIONS_TABLE_CSV=abspath(
         join(fwpartitions_dir, partitions_csv) if isfile(


### PR DESCRIPTION
The default Arduino partitions are now moved to a separate section instead of global declaration. 
cc @ivankravets 