### PR TITLE
Update PlatformIO build script to handle spaces in env names

### DIFF
--- a/tools/platformio-build-esp32.py
+++ b/tools/platformio-build-esp32.py
@@ -102,7 +102,7 @@ env.Append(
         "-u", "newlib_include_syscalls_impl",
         "-u", "newlib_include_pthread_impl",
         "-u", "__cxa_guard_dummy",
-        "-Wl,-Map=" + join("$BUILD_DIR", basename(env.subst("${PROJECT_DIR}.map")))
+        '-Wl,-Map="%s"' % join("$BUILD_DIR", basename(env.subst("${PROJECT_DIR}.map")))
     ],
 
     CPPPATH=[

--- a/tools/platformio-build-esp32s2.py
+++ b/tools/platformio-build-esp32s2.py
@@ -96,7 +96,7 @@ env.Append(
         "-u", "newlib_include_syscalls_impl",
         "-u", "newlib_include_pthread_impl",
         "-u", "__cxa_guard_dummy",
-        "-Wl,-Map=" + join("$BUILD_DIR", basename(env.subst("${PROJECT_DIR}.map")))
+        '-Wl,-Map="%s"' % join("$BUILD_DIR", basename(env.subst("${PROJECT_DIR}.map")))
     ],
 
     CPPPATH=[


### PR DESCRIPTION
This PR fixes a possible issue when a user specifies an environment with a whitespace character in its name, e.g.:
```ini
[env:esp wrover kit]
platform = espressif32
framework = arduino
board = esp-wrover-kit
```

https://github.com/platformio/platform-espressif32/pull/483 depends on this fix.

cc @me-no-dev 