### PR TITLE
Add Lolin32 Lite and TTGO T7 boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -700,6 +700,238 @@ ttgo-t1.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 
+ttgo-t7-v13-mini32.name=TTGO T7 V1.3 Mini32
+
+ttgo-t7-v13-mini32.upload.tool=esptool_py
+ttgo-t7-v13-mini32.upload.maximum_size=1310720
+ttgo-t7-v13-mini32.upload.maximum_data_size=327680
+ttgo-t7-v13-mini32.upload.wait_for_upload_port=true
+
+ttgo-t7-v13-mini32.serial.disableDTR=true
+ttgo-t7-v13-mini32.serial.disableRTS=true
+
+ttgo-t7-v13-mini32.build.mcu=esp32
+ttgo-t7-v13-mini32.build.core=esp32
+ttgo-t7-v13-mini32.build.variant=ttgo-t7-v13-mini32
+ttgo-t7-v13-mini32.build.board=TTGO_T7_V13_Mini32
+
+ttgo-t7-v13-mini32.build.f_cpu=240000000L
+ttgo-t7-v13-mini32.build.flash_size=4MB
+ttgo-t7-v13-mini32.build.flash_freq=40m
+ttgo-t7-v13-mini32.build.flash_mode=dio
+ttgo-t7-v13-mini32.build.boot=dio
+ttgo-t7-v13-mini32.build.partitions=default
+ttgo-t7-v13-mini32.build.defines=
+
+ttgo-t7-v13-mini32.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.default.build.partitions=default
+ttgo-t7-v13-mini32.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+ttgo-t7-v13-mini32.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.minimal.build.partitions=minimal
+ttgo-t7-v13-mini32.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+ttgo-t7-v13-mini32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+ttgo-t7-v13-mini32.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+ttgo-t7-v13-mini32.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.huge_app.build.partitions=huge_app
+ttgo-t7-v13-mini32.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+ttgo-t7-v13-mini32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+ttgo-t7-v13-mini32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+ttgo-t7-v13-mini32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+ttgo-t7-v13-mini32.menu.CPUFreq.240=240MHz (WiFi/BT)
+ttgo-t7-v13-mini32.menu.CPUFreq.240.build.f_cpu=240000000L
+ttgo-t7-v13-mini32.menu.CPUFreq.160=160MHz (WiFi/BT)
+ttgo-t7-v13-mini32.menu.CPUFreq.160.build.f_cpu=160000000L
+ttgo-t7-v13-mini32.menu.CPUFreq.80=80MHz (WiFi/BT)
+ttgo-t7-v13-mini32.menu.CPUFreq.80.build.f_cpu=80000000L
+ttgo-t7-v13-mini32.menu.CPUFreq.40=40MHz (40MHz XTAL)
+ttgo-t7-v13-mini32.menu.CPUFreq.40.build.f_cpu=40000000L
+ttgo-t7-v13-mini32.menu.CPUFreq.26=26MHz (26MHz XTAL)
+ttgo-t7-v13-mini32.menu.CPUFreq.26.build.f_cpu=26000000L
+ttgo-t7-v13-mini32.menu.CPUFreq.20=20MHz (40MHz XTAL)
+ttgo-t7-v13-mini32.menu.CPUFreq.20.build.f_cpu=20000000L
+ttgo-t7-v13-mini32.menu.CPUFreq.13=13MHz (26MHz XTAL)
+ttgo-t7-v13-mini32.menu.CPUFreq.13.build.f_cpu=13000000L
+ttgo-t7-v13-mini32.menu.CPUFreq.10=10MHz (40MHz XTAL)
+ttgo-t7-v13-mini32.menu.CPUFreq.10.build.f_cpu=10000000L
+
+ttgo-t7-v13-mini32.menu.FlashMode.qio=QIO
+ttgo-t7-v13-mini32.menu.FlashMode.qio.build.flash_mode=dio
+ttgo-t7-v13-mini32.menu.FlashMode.qio.build.boot=qio
+ttgo-t7-v13-mini32.menu.FlashMode.dio=DIO
+ttgo-t7-v13-mini32.menu.FlashMode.dio.build.flash_mode=dio
+ttgo-t7-v13-mini32.menu.FlashMode.dio.build.boot=dio
+ttgo-t7-v13-mini32.menu.FlashMode.qout=QOUT
+ttgo-t7-v13-mini32.menu.FlashMode.qout.build.flash_mode=dout
+ttgo-t7-v13-mini32.menu.FlashMode.qout.build.boot=qout
+ttgo-t7-v13-mini32.menu.FlashMode.dout=DOUT
+ttgo-t7-v13-mini32.menu.FlashMode.dout.build.flash_mode=dout
+ttgo-t7-v13-mini32.menu.FlashMode.dout.build.boot=dout
+
+ttgo-t7-v13-mini32.menu.FlashFreq.80=80MHz
+ttgo-t7-v13-mini32.menu.FlashFreq.80.build.flash_freq=80m
+ttgo-t7-v13-mini32.menu.FlashFreq.40=40MHz
+ttgo-t7-v13-mini32.menu.FlashFreq.40.build.flash_freq=40m
+
+ttgo-t7-v13-mini32.menu.FlashSize.4M=4MB (32Mb)
+ttgo-t7-v13-mini32.menu.FlashSize.4M.build.flash_size=4MB
+
+ttgo-t7-v13-mini32.menu.UploadSpeed.921600=921600
+ttgo-t7-v13-mini32.menu.UploadSpeed.921600.upload.speed=921600
+ttgo-t7-v13-mini32.menu.UploadSpeed.115200=115200
+ttgo-t7-v13-mini32.menu.UploadSpeed.115200.upload.speed=115200
+ttgo-t7-v13-mini32.menu.UploadSpeed.256000.windows=256000
+ttgo-t7-v13-mini32.menu.UploadSpeed.256000.upload.speed=256000
+ttgo-t7-v13-mini32.menu.UploadSpeed.230400.windows.upload.speed=256000
+ttgo-t7-v13-mini32.menu.UploadSpeed.230400=230400
+ttgo-t7-v13-mini32.menu.UploadSpeed.230400.upload.speed=230400
+ttgo-t7-v13-mini32.menu.UploadSpeed.460800.linux=460800
+ttgo-t7-v13-mini32.menu.UploadSpeed.460800.macosx=460800
+ttgo-t7-v13-mini32.menu.UploadSpeed.460800.upload.speed=460800
+ttgo-t7-v13-mini32.menu.UploadSpeed.512000.windows=512000
+ttgo-t7-v13-mini32.menu.UploadSpeed.512000.upload.speed=512000
+
+ttgo-t7-v13-mini32.menu.DebugLevel.none=None
+ttgo-t7-v13-mini32.menu.DebugLevel.none.build.code_debug=0
+ttgo-t7-v13-mini32.menu.DebugLevel.error=Error
+ttgo-t7-v13-mini32.menu.DebugLevel.error.build.code_debug=1
+ttgo-t7-v13-mini32.menu.DebugLevel.warn=Warn
+ttgo-t7-v13-mini32.menu.DebugLevel.warn.build.code_debug=2
+ttgo-t7-v13-mini32.menu.DebugLevel.info=Info
+ttgo-t7-v13-mini32.menu.DebugLevel.info.build.code_debug=3
+ttgo-t7-v13-mini32.menu.DebugLevel.debug=Debug
+ttgo-t7-v13-mini32.menu.DebugLevel.debug.build.code_debug=4
+ttgo-t7-v13-mini32.menu.DebugLevel.verbose=Verbose
+ttgo-t7-v13-mini32.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
+ttgo-t7-v14-mini32.name=TTGO T7 V1.4 Mini32
+
+ttgo-t7-v14-mini32.upload.tool=esptool_py
+ttgo-t7-v14-mini32.upload.maximum_size=1310720
+ttgo-t7-v14-mini32.upload.maximum_data_size=327680
+ttgo-t7-v14-mini32.upload.wait_for_upload_port=true
+
+ttgo-t7-v14-mini32.serial.disableDTR=true
+ttgo-t7-v14-mini32.serial.disableRTS=true
+
+ttgo-t7-v14-mini32.build.mcu=esp32
+ttgo-t7-v14-mini32.build.core=esp32
+ttgo-t7-v14-mini32.build.variant=ttgo-t7-v14-mini32
+ttgo-t7-v14-mini32.build.board=TTGO_T7_V14_Mini32
+
+ttgo-t7-v14-mini32.build.f_cpu=240000000L
+ttgo-t7-v14-mini32.build.flash_size=4MB
+ttgo-t7-v14-mini32.build.flash_freq=40m
+ttgo-t7-v14-mini32.build.flash_mode=dio
+ttgo-t7-v14-mini32.build.boot=dio
+ttgo-t7-v14-mini32.build.partitions=default
+ttgo-t7-v14-mini32.build.defines=
+
+ttgo-t7-v14-mini32.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.default.build.partitions=default
+ttgo-t7-v14-mini32.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+ttgo-t7-v14-mini32.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.minimal.build.partitions=minimal
+ttgo-t7-v14-mini32.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+ttgo-t7-v14-mini32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+ttgo-t7-v14-mini32.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+ttgo-t7-v14-mini32.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.huge_app.build.partitions=huge_app
+ttgo-t7-v14-mini32.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+ttgo-t7-v14-mini32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+ttgo-t7-v14-mini32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+ttgo-t7-v14-mini32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+ttgo-t7-v14-mini32.menu.CPUFreq.240=240MHz (WiFi/BT)
+ttgo-t7-v14-mini32.menu.CPUFreq.240.build.f_cpu=240000000L
+ttgo-t7-v14-mini32.menu.CPUFreq.160=160MHz (WiFi/BT)
+ttgo-t7-v14-mini32.menu.CPUFreq.160.build.f_cpu=160000000L
+ttgo-t7-v14-mini32.menu.CPUFreq.80=80MHz (WiFi/BT)
+ttgo-t7-v14-mini32.menu.CPUFreq.80.build.f_cpu=80000000L
+ttgo-t7-v14-mini32.menu.CPUFreq.40=40MHz (40MHz XTAL)
+ttgo-t7-v14-mini32.menu.CPUFreq.40.build.f_cpu=40000000L
+ttgo-t7-v14-mini32.menu.CPUFreq.26=26MHz (26MHz XTAL)
+ttgo-t7-v14-mini32.menu.CPUFreq.26.build.f_cpu=26000000L
+ttgo-t7-v14-mini32.menu.CPUFreq.20=20MHz (40MHz XTAL)
+ttgo-t7-v14-mini32.menu.CPUFreq.20.build.f_cpu=20000000L
+ttgo-t7-v14-mini32.menu.CPUFreq.13=13MHz (26MHz XTAL)
+ttgo-t7-v14-mini32.menu.CPUFreq.13.build.f_cpu=13000000L
+ttgo-t7-v14-mini32.menu.CPUFreq.10=10MHz (40MHz XTAL)
+ttgo-t7-v14-mini32.menu.CPUFreq.10.build.f_cpu=10000000L
+
+ttgo-t7-v14-mini32.menu.FlashMode.qio=QIO
+ttgo-t7-v14-mini32.menu.FlashMode.qio.build.flash_mode=dio
+ttgo-t7-v14-mini32.menu.FlashMode.qio.build.boot=qio
+ttgo-t7-v14-mini32.menu.FlashMode.dio=DIO
+ttgo-t7-v14-mini32.menu.FlashMode.dio.build.flash_mode=dio
+ttgo-t7-v14-mini32.menu.FlashMode.dio.build.boot=dio
+ttgo-t7-v14-mini32.menu.FlashMode.qout=QOUT
+ttgo-t7-v14-mini32.menu.FlashMode.qout.build.flash_mode=dout
+ttgo-t7-v14-mini32.menu.FlashMode.qout.build.boot=qout
+ttgo-t7-v14-mini32.menu.FlashMode.dout=DOUT
+ttgo-t7-v14-mini32.menu.FlashMode.dout.build.flash_mode=dout
+ttgo-t7-v14-mini32.menu.FlashMode.dout.build.boot=dout
+
+ttgo-t7-v14-mini32.menu.FlashFreq.80=80MHz
+ttgo-t7-v14-mini32.menu.FlashFreq.80.build.flash_freq=80m
+ttgo-t7-v14-mini32.menu.FlashFreq.40=40MHz
+ttgo-t7-v14-mini32.menu.FlashFreq.40.build.flash_freq=40m
+
+ttgo-t7-v14-mini32.menu.FlashSize.4M=4MB (32Mb)
+ttgo-t7-v14-mini32.menu.FlashSize.4M.build.flash_size=4MB
+
+ttgo-t7-v14-mini32.menu.UploadSpeed.921600=921600
+ttgo-t7-v14-mini32.menu.UploadSpeed.921600.upload.speed=921600
+ttgo-t7-v14-mini32.menu.UploadSpeed.115200=115200
+ttgo-t7-v14-mini32.menu.UploadSpeed.115200.upload.speed=115200
+ttgo-t7-v14-mini32.menu.UploadSpeed.256000.windows=256000
+ttgo-t7-v14-mini32.menu.UploadSpeed.256000.upload.speed=256000
+ttgo-t7-v14-mini32.menu.UploadSpeed.230400.windows.upload.speed=256000
+ttgo-t7-v14-mini32.menu.UploadSpeed.230400=230400
+ttgo-t7-v14-mini32.menu.UploadSpeed.230400.upload.speed=230400
+ttgo-t7-v14-mini32.menu.UploadSpeed.460800.linux=460800
+ttgo-t7-v14-mini32.menu.UploadSpeed.460800.macosx=460800
+ttgo-t7-v14-mini32.menu.UploadSpeed.460800.upload.speed=460800
+ttgo-t7-v14-mini32.menu.UploadSpeed.512000.windows=512000
+ttgo-t7-v14-mini32.menu.UploadSpeed.512000.upload.speed=512000
+
+ttgo-t7-v14-mini32.menu.DebugLevel.none=None
+ttgo-t7-v14-mini32.menu.DebugLevel.none.build.code_debug=0
+ttgo-t7-v14-mini32.menu.DebugLevel.error=Error
+ttgo-t7-v14-mini32.menu.DebugLevel.error.build.code_debug=1
+ttgo-t7-v14-mini32.menu.DebugLevel.warn=Warn
+ttgo-t7-v14-mini32.menu.DebugLevel.warn.build.code_debug=2
+ttgo-t7-v14-mini32.menu.DebugLevel.info=Info
+ttgo-t7-v14-mini32.menu.DebugLevel.info.build.code_debug=3
+ttgo-t7-v14-mini32.menu.DebugLevel.debug=Debug
+ttgo-t7-v14-mini32.menu.DebugLevel.debug.build.code_debug=4
+ttgo-t7-v14-mini32.menu.DebugLevel.verbose=Verbose
+ttgo-t7-v14-mini32.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 cw02.name=XinaBox CW02
 
 cw02.upload.tool=esptool_py
@@ -1296,6 +1528,76 @@ lolin32.menu.UploadSpeed.460800.macosx=460800
 lolin32.menu.UploadSpeed.460800.upload.speed=460800
 lolin32.menu.UploadSpeed.512000.windows=512000
 lolin32.menu.UploadSpeed.512000.upload.speed=512000
+
+##############################################################
+
+lolin32-lite.name=WEMOS LOLIN32 Lite
+
+lolin32-lite.upload.tool=esptool_py
+lolin32-lite.upload.maximum_size=1310720
+lolin32-lite.upload.maximum_data_size=327680
+lolin32-lite.upload.wait_for_upload_port=true
+
+lolin32-lite.serial.disableDTR=true
+lolin32-lite.serial.disableRTS=true
+
+lolin32-lite.build.mcu=esp32
+lolin32-lite.build.core=esp32
+lolin32-lite.build.variant=lolin32-lite
+lolin32-lite.build.board=LOLIN32 Lite
+
+lolin32-lite.build.f_cpu=240000000L
+lolin32-lite.build.flash_mode=dio
+lolin32-lite.build.flash_size=4MB
+lolin32-lite.build.boot=dio
+lolin32-lite.build.partitions=default
+lolin32-lite.build.defines=
+
+lolin32-lite.menu.FlashFreq.80=80MHz
+lolin32-lite.menu.FlashFreq.80.build.flash_freq=80m
+lolin32-lite.menu.FlashFreq.40=40MHz
+lolin32-lite.menu.FlashFreq.40.build.flash_freq=40m
+
+lolin32-lite.menu.PartitionScheme.default=Default
+lolin32-lite.menu.PartitionScheme.default.build.partitions=default
+lolin32-lite.menu.PartitionScheme.no_ota=No OTA (Large APP)
+lolin32-lite.menu.PartitionScheme.no_ota.build.partitions=no_ota
+lolin32-lite.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+lolin32-lite.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+lolin32-lite.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+lolin32-lite.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+lolin32-lite.menu.CPUFreq.240=240MHz (WiFi/BT)
+lolin32-lite.menu.CPUFreq.240.build.f_cpu=240000000L
+lolin32-lite.menu.CPUFreq.160=160MHz (WiFi/BT)
+lolin32-lite.menu.CPUFreq.160.build.f_cpu=160000000L
+lolin32-lite.menu.CPUFreq.80=80MHz (WiFi/BT)
+lolin32-lite.menu.CPUFreq.80.build.f_cpu=80000000L
+lolin32-lite.menu.CPUFreq.40=40MHz (40MHz XTAL)
+lolin32-lite.menu.CPUFreq.40.build.f_cpu=40000000L
+lolin32-lite.menu.CPUFreq.26=26MHz (26MHz XTAL)
+lolin32-lite.menu.CPUFreq.26.build.f_cpu=26000000L
+lolin32-lite.menu.CPUFreq.20=20MHz (40MHz XTAL)
+lolin32-lite.menu.CPUFreq.20.build.f_cpu=20000000L
+lolin32-lite.menu.CPUFreq.13=13MHz (26MHz XTAL)
+lolin32-lite.menu.CPUFreq.13.build.f_cpu=13000000L
+lolin32-lite.menu.CPUFreq.10=10MHz (40MHz XTAL)
+lolin32-lite.menu.CPUFreq.10.build.f_cpu=10000000L
+
+lolin32-lite.menu.UploadSpeed.921600=921600
+lolin32-lite.menu.UploadSpeed.921600.upload.speed=921600
+lolin32-lite.menu.UploadSpeed.115200=115200
+lolin32-lite.menu.UploadSpeed.115200.upload.speed=115200
+lolin32-lite.menu.UploadSpeed.256000.windows=256000
+lolin32-lite.menu.UploadSpeed.256000.upload.speed=256000
+lolin32-lite.menu.UploadSpeed.230400.windows.upload.speed=256000
+lolin32-lite.menu.UploadSpeed.230400=230400
+lolin32-lite.menu.UploadSpeed.230400.upload.speed=230400
+lolin32-lite.menu.UploadSpeed.460800.linux=460800
+lolin32-lite.menu.UploadSpeed.460800.macosx=460800
+lolin32-lite.menu.UploadSpeed.460800.upload.speed=460800
+lolin32-lite.menu.UploadSpeed.512000.windows=512000
+lolin32-lite.menu.UploadSpeed.512000.upload.speed=512000
 
 ##############################################################
 

--- a/variants/lolin32-lite/pins_arduino.h
+++ b/variants/lolin32-lite/pins_arduino.h
@@ -1,0 +1,59 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t LED_BUILTIN = 22;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
+static const uint8_t SDA = 19;
+static const uint8_t SCL = 23;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */

--- a/variants/ttgo-t7-v13-mini32/pins_arduino.h
+++ b/variants/ttgo-t7-v13-mini32/pins_arduino.h
@@ -1,0 +1,59 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t LED_BUILTIN = 22;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */

--- a/variants/ttgo-t7-v14-mini32/pins_arduino.h
+++ b/variants/ttgo-t7-v14-mini32/pins_arduino.h
@@ -1,0 +1,59 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t LED_BUILTIN = 19;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Add the Wemos Lolin32 Lite (no longer being produced like the original Lolin32) and the TTGO T7 v1.3 and v1.4 boards (status unknown). All three are rather generic ESP32 boards the main difference being pin layouts and ESP32 module type.