### PR TITLE
[2.0.0] Remove temp buffer in lastError

### DIFF
--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -322,9 +322,7 @@ int WiFiClientSecure::lastError(char *buf, const size_t size)
     if (!_lastError) {
         return 0;
     }
-    char error_buf[100];
-    mbedtls_strerror(_lastError, error_buf, 100);
-    snprintf(buf, size, "%s", error_buf);
+    mbedtls_strerror(_lastError, buf, size);
     return _lastError;
 }
 


### PR DESCRIPTION
The temp buffer serves no purpose here. As a side-note mbedtls_strerror can be called with size == 0 safely. No need to check.