### PR TITLE
[2.0.0] Removing unnecessary reference to WIFI_PROV_SCHEME_BLE #4828

### DIFF
--- a/libraries/WiFiProv/src/WiFiProv.cpp
+++ b/libraries/WiFiProv/src/WiFiProv.cpp
@@ -55,15 +55,7 @@ static void get_device_service_name(prov_scheme_t prov_scheme, char *service_nam
     	log_e("esp_wifi_get_mac failed!");
     	return;
     }
-#if CONFIG_IDF_TARGET_ESP32
-    if(prov_scheme == WIFI_PROV_SCHEME_BLE) {
-        snprintf(service_name, max, "%s%02X%02X%02X",SERV_NAME_PREFIX_PROV, eth_mac[3], eth_mac[4], eth_mac[5]);
-    } else {
-#endif
-         snprintf(service_name, max, "%s%02X%02X%02X",SERV_NAME_PREFIX_PROV, eth_mac[3], eth_mac[4], eth_mac[5]);
-#if CONFIG_IDF_TARGET_ESP32
-    }
-#endif
+    snprintf(service_name, max, "%s%02X%02X%02X",SERV_NAME_PREFIX_PROV, eth_mac[3], eth_mac[4], eth_mac[5]);
 }
 
 static esp_err_t custom_prov_data_handler(uint32_t session_id, const uint8_t *inbuf, ssize_t inlen, uint8_t **outbuf, ssize_t *outlen, void *priv_data){


### PR DESCRIPTION
Fixes compilation error when CONFIG_BLUEDROID_ENABLED is not defined.
Fixes https://github.com/espressif/arduino-esp32/issues/4828