### PR TITLE
Added BLEAddress operator overload methods

### DIFF
--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -62,6 +62,13 @@ bool BLEAddress::equals(BLEAddress otherAddress) {
 	return memcmp(otherAddress.getNative(), m_address, 6) == 0;
 } // equals
 
+bool BLEAddress::operator==(BLEAddress otherAddress) {
+  return equals(otherAddress);
+}
+
+bool BLEAddress::operator!=(BLEAddress otherAddress) {
+  return !equals(otherAddress);
+}
 
 /**
  * @brief Return the native representation of the address.

--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -62,34 +62,34 @@ bool BLEAddress::equals(BLEAddress otherAddress) {
 	return memcmp(otherAddress.getNative(), m_address, ESP_BD_ADDR_LEN) == 0;
 } // equals
 
-bool BLEAddress::operator==(BLEAddress otherAddress) {
-  return equals(otherAddress);
+bool BLEAddress::operator==(const BLEAddress& otherAddress) const {
+	return memcmp(otherAddress.m_address, m_address, ESP_BD_ADDR_LEN) == 0;
 }
 
-bool BLEAddress::operator!=(BLEAddress otherAddress) {
-  return ! this == otherAddress;
+bool BLEAddress::operator!=(const BLEAddress& otherAddress) const {
+  return !(*this == otherAddress);
 }
 
-bool BLEAddress::operator<(BLEAddress otherAddress) {
-  return memcmp(otherAddress.getNative(), m_address, ESP_BD_ADDR_LEN) < 0;
+bool BLEAddress::operator<(const BLEAddress& otherAddress) const {
+  return memcmp(otherAddress.m_address, m_address, ESP_BD_ADDR_LEN) < 0;
 }
 
-bool BLEAddress::operator<=(BLEAddress otherAddress) {
-  return !this > otherAddress;
+bool BLEAddress::operator<=(const BLEAddress& otherAddress) const {
+  return !(*this > otherAddress);
 }
 
-bool BLEAddress::operator>=(BLEAddress otherAddress) {
-  return !this < otherAddress;
+bool BLEAddress::operator>=(const BLEAddress& otherAddress) const {
+  return !(*this < otherAddress);
 }
 
-bool BLEAddress::operator>(BLEAddress otherAddress) {
-  return memcmp(otherAddress.getNative(), m_address, ESP_BD_ADDR_LEN) > 0;
+bool BLEAddress::operator>(const BLEAddress& otherAddress) const {
+  return memcmp(otherAddress.m_address, m_address, ESP_BD_ADDR_LEN) > 0;
 }
 
 /**
  * @brief Return the native representation of the address.
  * @return The native representation of the address.
- */
+ */   
 esp_bd_addr_t *BLEAddress::getNative() {
 	return &m_address;
 } // getNative

--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -59,7 +59,7 @@ BLEAddress::BLEAddress(std::string stringAddress) {
  * @return True if the addresses are equal.
  */
 bool BLEAddress::equals(BLEAddress otherAddress) {
-	return memcmp(otherAddress.getNative(), m_address, 6) == 0;
+	return memcmp(otherAddress.getNative(), m_address, ESP_BD_ADDR_LEN) == 0;
 } // equals
 
 bool BLEAddress::operator==(BLEAddress otherAddress) {

--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -67,7 +67,23 @@ bool BLEAddress::operator==(BLEAddress otherAddress) {
 }
 
 bool BLEAddress::operator!=(BLEAddress otherAddress) {
-  return !equals(otherAddress);
+  return ! this == otherAddress;
+}
+
+bool BLEAddress::operator<(BLEAddress otherAddress) {
+  return memcmp(otherAddress.getNative(), m_address, ESP_BD_ADDR_LEN) < 0;
+}
+
+bool BLEAddress::operator<=(BLEAddress otherAddress) {
+  return !this > otherAddress;
+}
+
+bool BLEAddress::operator>=(BLEAddress otherAddress) {
+  return !this < otherAddress;
+}
+
+bool BLEAddress::operator>(BLEAddress otherAddress) {
+  return memcmp(otherAddress.getNative(), m_address, ESP_BD_ADDR_LEN) > 0;
 }
 
 /**

--- a/libraries/BLE/src/BLEAddress.h
+++ b/libraries/BLE/src/BLEAddress.h
@@ -23,12 +23,12 @@ public:
 	BLEAddress(esp_bd_addr_t address);
 	BLEAddress(std::string stringAddress);
 	bool           equals(BLEAddress otherAddress);
-  bool           operator==(BLEAddress otherAddress);
-  bool           operator!=(BLEAddress otherAddress);
-  bool           operator<(BLEAddress otherAddress);
-  bool           operator<=(BLEAddress otherAddress);
-  bool           operator>(BLEAddress otherAddress);
-  bool           operator>=(BLEAddress otherAddress);
+  bool           operator==(const BLEAddress& otherAddress) const;
+  bool           operator!=(const BLEAddress& otherAddress) const;
+  bool           operator<(const BLEAddress& otherAddress) const;
+  bool           operator<=(const BLEAddress& otherAddress) const;
+  bool           operator>(const BLEAddress& otherAddress) const;
+  bool           operator>=(const BLEAddress& otherAddress) const;
 	esp_bd_addr_t* getNative();
 	std::string    toString();
 

--- a/libraries/BLE/src/BLEAddress.h
+++ b/libraries/BLE/src/BLEAddress.h
@@ -25,6 +25,10 @@ public:
 	bool           equals(BLEAddress otherAddress);
   bool           operator==(BLEAddress otherAddress);
   bool           operator!=(BLEAddress otherAddress);
+  bool           operator<(BLEAddress otherAddress);
+  bool           operator<=(BLEAddress otherAddress);
+  bool           operator>(BLEAddress otherAddress);
+  bool           operator>=(BLEAddress otherAddress);
 	esp_bd_addr_t* getNative();
 	std::string    toString();
 

--- a/libraries/BLE/src/BLEAddress.h
+++ b/libraries/BLE/src/BLEAddress.h
@@ -23,6 +23,8 @@ public:
 	BLEAddress(esp_bd_addr_t address);
 	BLEAddress(std::string stringAddress);
 	bool           equals(BLEAddress otherAddress);
+  bool           operator==(BLEAddress otherAddress);
+  bool           operator!=(BLEAddress otherAddress);
 	esp_bd_addr_t* getNative();
 	std::string    toString();
 


### PR DESCRIPTION
Allows BLEAddress to be used as key in std::map etc