### PR TITLE
Add div by zero check back into WMath::map

### DIFF
--- a/cores/esp32/WMath.cpp
+++ b/cores/esp32/WMath.cpp
@@ -70,6 +70,7 @@ long map(long x, long in_min, long in_max, long out_min, long out_max) {
     const long divisor = in_max - in_min;
     const long delta = x - in_min;
     if(divisor == 0){
+        log_e("Invalid map input range, min == max");
         return -1; //AVR returns -1, SAM returns 0
     }
     return (delta * dividend + (divisor / 2)) / divisor + out_min;

--- a/cores/esp32/WMath.cpp
+++ b/cores/esp32/WMath.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include <stdlib.h>
 #include "esp_system.h"
 }
+#include "esp32-hal-log.h"
 
 void randomSeed(unsigned long seed)
 {

--- a/cores/esp32/WMath.cpp
+++ b/cores/esp32/WMath.cpp
@@ -69,7 +69,9 @@ long map(long x, long in_min, long in_max, long out_min, long out_max) {
     const long dividend = out_max - out_min;
     const long divisor = in_max - in_min;
     const long delta = x - in_min;
-
+    if(divisor == 0){
+        return -1; //AVR returns -1, SAM returns 0
+    }
     return (delta * dividend + (divisor / 2)) / divisor + out_min;
 }
 


### PR DESCRIPTION
The check for divisor==0 was removed in last commit.  This is still necessary.