### PR TITLE
[2.0.0] Made selective compile of ArduinoOTA and LITTLEFS libraries add requires

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,13 @@ set(priv_includes cores/esp32/libb64)
 set(requires spi_flash mbedtls mdns esp_adc_cal)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support openssl bt tinyusb main)
 
+if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_ArduinoOTA)
+  list(APPEND priv_requires esp_https_ota)
+endif()
+if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_LITTLEFS)
+  list(APPEND priv_requires esp_littlefs)
+endif()
+
 idf_component_register(INCLUDE_DIRS ${includedirs} PRIV_INCLUDE_DIRS ${priv_includes} SRCS ${srcs} REQUIRES ${requires} PRIV_REQUIRES ${priv_requires})
 
 if(IDF_TARGET STREQUAL "esp32")


### PR DESCRIPTION
Made selective compile of ArduinoOTA and LITTLEFS libraries add necessary ESP-IDF components in priv_requires. If selective compilation is disabled the requirements will be added anyway.