### PR TITLE
Back out duplicate definitions from #4220

### DIFF
--- a/variants/firebeetle32/pins_arduino.h
+++ b/variants/firebeetle32/pins_arduino.h
@@ -18,7 +18,6 @@ static const uint8_t LED_BUILTIN = 2;
 #define LED_BUILTIN LED_BUILTIN
 
 
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
@@ -56,20 +55,6 @@ static const uint8_t A11 = 14;
 static const uint8_t A12 = 27;
 static const uint8_t A13 = 25;
 static const uint8_t A14 = 26;
-
-
-
-static const uint8_t D0 = 3;
-static const uint8_t D1 = 1;
-static const uint8_t D2 = 25;
-static const uint8_t D3 = 26;
-static const uint8_t D4 = 27;
-static const uint8_t D5 = 9;
-static const uint8_t D6 = 10;
-static const uint8_t D7 = 13;
-static const uint8_t D8 = 5;
-static const uint8_t D9 = 2;
-static const uint8_t D10 = 0;
 
 static const uint8_t T0 = 4;
 static const uint8_t T1 = 0;


### PR DESCRIPTION
D[0-9] pins had duplicate definitions.  #4220 was invalid.