### PR TITLE
Remove tools/sdk/include/nimble from include path

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -138,7 +138,6 @@ env.Append(
         join(FRAMEWORK_DIR, "tools", "sdk", "include", "mqtt"),
         join(FRAMEWORK_DIR, "tools", "sdk", "include", "newlib"),
         join(FRAMEWORK_DIR, "tools", "sdk", "include", "nghttp"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "include", "nimble"),
         join(FRAMEWORK_DIR, "tools", "sdk", "include", "nvs_flash"),
         join(FRAMEWORK_DIR, "tools", "sdk", "include", "openssl"),
         join(FRAMEWORK_DIR, "tools", "sdk", "include", "protobuf-c"),


### PR DESCRIPTION
For the PlatformIO build script. 

Per https://github.com/espressif/arduino-esp32/tree/master/tools/sdk/include this folder doesn't exist exist anymore, so users will see a warning in VSCode regarding this non-existent folder (see [here](https://community.platformio.org/t/fatal-error-pins-arduino-h-no-such-file-or-directory/19634/7?u=maxgerhardt) for example).

I don't know whether nimble has been removed or renamed, but this change just removes the reference to the folder in the platformio build script.

It looks like it's also gone from other branches (v4.0, v4.2), so.. it should also be merged there I guess.