### PR TITLE
Update debian_ubuntu.md

### DIFF
--- a/docs/arduino-ide/debian_ubuntu.md
+++ b/docs/arduino-ide/debian_ubuntu.md
@@ -7,7 +7,7 @@ Installation instructions for Debian / Ubuntu OS
   ```bash
   sudo usermod -a -G dialout $USER && \
   sudo apt-get install git && \
-  wget https://bootstrap.pypa.io/get-pip.py && \
+  wget https://bootstrap.pypa.io/2.7/get-pip.py && \
   sudo python get-pip.py && \
   sudo pip install pyserial && \
   mkdir -p ~/Arduino/hardware/espressif && \

--- a/docs/arduino-ide/debian_ubuntu.md
+++ b/docs/arduino-ide/debian_ubuntu.md
@@ -7,9 +7,9 @@ Installation instructions for Debian / Ubuntu OS
   ```bash
   sudo usermod -a -G dialout $USER && \
   sudo apt-get install git && \
-  wget https://bootstrap.pypa.io/2.7/get-pip.py && \
-  sudo python get-pip.py && \
-  sudo pip install pyserial && \
+  wget https://bootstrap.pypa.io/get-pip.py && \
+  sudo python3 get-pip.py && \
+  sudo pip3 install pyserial && \
   mkdir -p ~/Arduino/hardware/espressif && \
   cd ~/Arduino/hardware/espressif && \
   git clone https://github.com/espressif/arduino-esp32.git esp32 && \


### PR DESCRIPTION
ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/2.7/get-pip.py instead.