### PR TITLE
Allows you to specify which channels are used to advertise.

### DIFF
--- a/libraries/BLE/src/BLEAdvertising.cpp
+++ b/libraries/BLE/src/BLEAdvertising.cpp
@@ -91,6 +91,10 @@ void BLEAdvertising::setAdvertisementType(esp_ble_adv_type_t adv_type){
 	m_advParams.adv_type = adv_type;
 } // setAdvertisementType
 
+void BLEAdvertising::setAdvertisementChannelMap(esp_ble_adv_channel_t channel_map) {
+	m_advParams.channel_map = channel_map;
+} // setAdvertisementChannelMap
+
 void BLEAdvertising::setMinInterval(uint16_t mininterval) {
 	m_advParams.adv_int_min = mininterval;
 } // setMinInterval

--- a/libraries/BLE/src/BLEAdvertising.h
+++ b/libraries/BLE/src/BLEAdvertising.h
@@ -53,6 +53,7 @@ public:
 	void stop();
 	void setAppearance(uint16_t appearance);
 	void setAdvertisementType(esp_ble_adv_type_t adv_type);
+	void setAdvertisementChannelMap(esp_ble_adv_channel_t channel_map);
 	void setMaxInterval(uint16_t maxinterval);
 	void setMinInterval(uint16_t mininterval);
 	void setAdvertisementData(BLEAdvertisementData& advertisementData);


### PR DESCRIPTION
In some use cases getting rssi signal from one channel is more stable (less variance) than rssi from the three advertising channels. 

This change allows you to specify which channels are used to advertise.

