### PR TITLE
Update getLocalTime to a more reasonable range

### DIFF
--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -84,7 +84,7 @@ bool getLocalTime(struct tm * info, uint32_t ms)
     while((millis()-start) <= ms) {
         time(&now);
         localtime_r(&now, info);
-        if(info->tm_year > (2016 - 1900)){
+        if(info->tm_year > (2030 - 1900)){
             return true;
         }
         delay(10);


### PR DESCRIPTION
It seems like getLocalTime is expecting a valid date to be in the year range 1900..2016
The problem is the retry logic, which defaults to 5000 msec.
So in the meanwhile at least the right range should be fixed.