### PR TITLE
FIX max SSID length is 32

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -50,7 +50,7 @@ bool WiFiMulti::addAP(const char* ssid, const char *passphrase)
 {
     WifiAPlist_t newAP;
 
-    if(!ssid || *ssid == 0x00 || strlen(ssid) > 31) {
+    if(!ssid || *ssid == 0x00 || strlen(ssid) > 32) {
         // fail SSID too long or missing!
         log_e("[WIFI][APlistAdd] no ssid or ssid too long");
         return false;


### PR DESCRIPTION
Same bug was in the WiFiSTA.cpp.
Maybe a definition file could contian these standard related boundaries.