### PR TITLE
Added method to change the ledc PWM frequency programmatically

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -279,7 +279,7 @@ void ledcDetachPin(uint8_t pin)
     pinMatrixOutDetach(pin, false, false);
 }
 
-void ledcChangeFrequence(uint8_t chan, double freq, uint8_t bit_num)
+void ledcChangeFrequency(uint8_t chan, double freq, uint8_t bit_num)
 {
     if (chan > 15) {
         return 0;

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -279,10 +279,11 @@ void ledcDetachPin(uint8_t pin)
     pinMatrixOutDetach(pin, false, false);
 }
 
-void ledcChangeFrequency(uint8_t chan, double freq, uint8_t bit_num)
+double ledcChangeFrequency(uint8_t chan, double freq, uint8_t bit_num)
 {
     if (chan > 15) {
         return 0;
     }
-    _ledcSetupTimerFreq(chan, freq, bit_num);
+    double res_freq = _ledcSetupTimerFreq(chan, freq, bit_num);
+    return res_freq;
 }

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -278,3 +278,11 @@ void ledcDetachPin(uint8_t pin)
 {
     pinMatrixOutDetach(pin, false, false);
 }
+
+void ledcChangeFrequence(uint8_t chan, double freq, uint8_t bit_num)
+{
+    if (chan > 15) {
+        return 0;
+    }
+    _ledcSetupTimerFreq(chan, freq, bit_num);
+}

--- a/cores/esp32/esp32-hal-ledc.h
+++ b/cores/esp32/esp32-hal-ledc.h
@@ -35,7 +35,7 @@ uint32_t    ledcRead(uint8_t channel);
 double      ledcReadFreq(uint8_t channel);
 void        ledcAttachPin(uint8_t pin, uint8_t channel);
 void        ledcDetachPin(uint8_t pin);
-void        ledcChangeFrequency(uint8_t channel, double freq, uint8_t resolution_bits);
+double      ledcChangeFrequency(uint8_t channel, double freq, uint8_t resolution_bits);
 
 
 #ifdef __cplusplus

--- a/cores/esp32/esp32-hal-ledc.h
+++ b/cores/esp32/esp32-hal-ledc.h
@@ -35,6 +35,7 @@ uint32_t    ledcRead(uint8_t channel);
 double      ledcReadFreq(uint8_t channel);
 void        ledcAttachPin(uint8_t pin, uint8_t channel);
 void        ledcDetachPin(uint8_t pin);
+void        ledcChangeFrequence(uint8_t channel, double freq, uint8_t resolution_bits);
 
 
 #ifdef __cplusplus

--- a/cores/esp32/esp32-hal-ledc.h
+++ b/cores/esp32/esp32-hal-ledc.h
@@ -35,7 +35,7 @@ uint32_t    ledcRead(uint8_t channel);
 double      ledcReadFreq(uint8_t channel);
 void        ledcAttachPin(uint8_t pin, uint8_t channel);
 void        ledcDetachPin(uint8_t pin);
-void        ledcChangeFrequence(uint8_t channel, double freq, uint8_t resolution_bits);
+void        ledcChangeFrequency(uint8_t channel, double freq, uint8_t resolution_bits);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Currently there is no real option to change the pwm frequency programmatically. The only "hack" solution is to use the `ledcWriteTone(uint8_t chan, double freq)` method.

But there is problem with this hack. Inside this method the bit resolution value is hard coded to 10. Which means if you had a different bit resolution inside your setup it would be overrided here.

So I added a simple method to change the pwm frequency programmatically. This method takes three parameters:
`uint8_t chan, double freq, uint8_t bit_num`