### PR TITLE
Added example for connecting ESP32 to Mosquitto (mqtt) broker through TLS encrypted channel.

### DIFF
--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
@@ -7,10 +7,10 @@
   OpenSSL - https://www.openssl.org/
   Mosquitto broker - https://mosquitto.org/
   
-  1. step - Generating the certificates
+  1. step - Generate the certificates
   For generating self-signed certificates please run the following commands:
       
-  openssl req -new -x509 -days 365 -extensions v3_ca -keyout ca.key -out ca.crt -subj '/CN=TrustedCA.net'  #If you generating self-signed certificates the CN can be anything
+  openssl req -new -x509 -days 365 -extensions v3_ca -keyout ca.key -out ca.crt -subj '/CN=TrustedCA.net'  #If you generate self-signed certificates the CN can be anything
 
   openssl genrsa -out mosquitto.key 2048
   openssl req -out mosquitto.csr -key mosquitto.key -new -subj '/CN=Mosquitto_borker_adress'    #Its necessary to set the CN to the adress of which the client calls your Mosquitto server (eg. yourserver.com)!!!

--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
@@ -25,10 +25,10 @@
   corresponding const char CA_cert[], const char ESP_CA_cert[] and const char ESP_RSA_key[] with escape characters.
 
   (1-2.) Alternatively you can use the libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/certificates/certificate_generator.sh script 
-  for generating and formatting the certificates. Befor you run it, please modify the CN value for your adress.
+  for generating and formatting the certificates. Befor you run it, please modify the CN value for your adress, or modify any other settings based on yout requierments.
 
-  3. step - Install and setup you Mosquitto broker
-  Follow the instructions from https://mosquitto.org/ and check the manual for the coniguration.
+  3. step - Install and setup your   Mosquitto broker
+  Follow the instructions from https://mosquitto.org/ and check the manual for the configuration.
   For the Mosquito broker you need ca.crt, mosquitto.key and mosquitto.crt files generated in previous step.
   Recommended to put they in /etc/mosquitto/ca_certificates/ and /etc/mosquitto/certs/
   You need to config Mosquitto broker to use these files (usually /etc/mosquitto/conf.d/default.conf):
@@ -73,12 +73,13 @@ const char* ESP_RSA_key= \
 "-----END RSA PRIVATE KEY-----";
 
 
-const char* ssid     = "wifi";        // your network SSID (name of wifi network)
-const char* password = "wifi_pass";   // your network password
+const char* ssid        = "wifi";        // your network SSID (name of wifi network)
+const char* password    = "wifi_pass";   // your network password
 
-const char* server = "Mosquitto_borker_adress";
-const char* mqtt_user = "user";           //If it is configured, see Mosquitto config
-const char* mqtt_pass = "user_password";  //If it is configured, see Mosquitto config
+const char* mqtt_server = "Mosquitto_borker_adress";  //Adress for your Mosquitto broker server, it must be the same adress that you set in Mosquitto.csr CN field
+int port                = 8883;             //Port to your Mosquitto broker server. Dont forget to forward it in your router for remote access
+const char* mqtt_user   = "user";           //Depends on Mosquitto configuration, if it is not set, you do not need it
+const char* mqtt_pass   = "user_password";  //Depends on Mosquitto configuration, if it is not set, you do not need it
 
 WiFiClientSecure client;
 PubSubClient mqtt_client(client); 
@@ -101,15 +102,15 @@ void setup() {
   Serial.print("Connected to ");
   Serial.println(ssid);
 
-  client.setCACert(CA_cert);
-  client.setCertificate(ESP_CA_cert); // for client verification if the require_certificate is set to true  in the mosquitto broker config
-  client.setPrivateKey(ESP_RSA_key);  // for client verification if the require_certificate is set to true  in the mosquitto broker config
-  mqtt_client.setServer(server, 8883);
+  //Set up the certificates and keys
+  client.setCACert(CA_cert);          //Root CA certificate
+  client.setCertificate(ESP_CA_cert); //for client verification if the require_certificate is set to true in the mosquitto broker config
+  client.setPrivateKey(ESP_RSA_key);  //for client verification if the require_certificate is set to true in the mosquitto broker config
   
+  mqtt_client.setServer(mqtt_server, port);
 }
 
-void loop() {
-  
+void loop() {  
   Serial.println("\nStarting connection to server...");
   //if you use password for Mosquitto broker
   //if (mqtt_client.connect("ESP32", mqtt_user , mqtt_pass)) {
@@ -117,7 +118,8 @@ void loop() {
   if (mqtt_client.connect("ESP32")) {                       
     Serial.print("Connected, mqtt_client state: ");
     Serial.println(mqtt_client.state());
-    mqtt_client.publish("LIvingRoom/TEMPERATURE", "25");
+    //Publsih a demo message to topic LivingRoom/TEMPERATURE with a value of 25
+    mqtt_client.publish("LivingRoom/TEMPERATURE", "25");
   }
   else {
     Serial.println("Connected failed!  mqtt_client state:");

--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
@@ -25,7 +25,7 @@
   corresponding const char CA_cert[], const char ESP_CA_cert[] and const char ESP_RSA_key[] with escape characters.
 
   (1-2.) Alternatively you can use the libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/certificates/certificate_generator.sh script 
-  for generating and formatting the certificates.
+  for generating and formatting the certificates. Befor you run it, please modify the CN value for your adress.
 
   3. step - Install and setup you Mosquitto broker
   Follow the instructions from https://mosquitto.org/ and check the manual for the coniguration.

--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
@@ -1,0 +1,126 @@
+/*
+  Secure connection example for ESP32 <----> Mosquitto broker (used for MQTT) communcation
+  with possible client authentication
+
+  Prerequisite:
+  PubSubClient library for Arduino - https://github.com/knolleary/pubsubclient/
+  OpenSSL - https://www.openssl.org/
+  Mosquitto broker - https://mosquitto.org/
+  
+  1. step - Generating the certificates
+  For generating self-signed certificates please run the following commands:
+      
+  openssl req -new -x509 -days 365 -extensions v3_ca -keyout ca.key -out ca.crt -subj '/CN=TrustedCA.net'  #If you generating self-signed certificates the CN can be anything
+
+  openssl genrsa -out mosquitto.key 2048
+  openssl req -out mosquitto.csr -key mosquitto.key -new -subj '/CN=Mosquitto_borker_adress'    #Its necessary to set the CN to the adress of which the client calls your Mosquitto server (eg. yourserver.com)!!!
+  openssl x509 -req -in mosquitto.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out mosquitto.crt -days 365 
+
+  #This is only needed if the mosquitto broker requires a client autentithication (require_certificate is set to true in mosquitto config)
+  openssl genrsa -out esp.key 2048
+  openssl req -out esp.csr -key esp.key -new -subj '/CN=localhost'
+  openssl x509 -req -in esp.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out esp.crt -days 365
+
+  2. step - Install and setup you Mosquitto broker
+  Follow the instructions from https://mosquitto.org/ and check the manual for the coniguration.
+  For the Mosquito broker you need ca.crt, mosquitto.key and mosquitto.crt files generated in previous step.
+  Recommended to put they in /etc/mosquitto/ca_certificates/ and /etc/mosquitto/certs/
+  You need to config Mosquitto broker to use these files (usually /etc/mosquitto/conf.d/default.conf):
+  
+  listener 8883
+  cafile path/to/ca.crt
+  keyfile path/to/mosquitto.key
+  certfile path/to/mosquitto.crt
+  require_certificate true or false #If you need client authentication set it to true
+  log_type all  #for logging in /var/log/mosquitto/
+
+  3. Open ca.crt, esp.crt and esp.key with text viewer and copy the values to this WiFiClientSecureClientAuthentication.ino source file into 
+  corresponding const char CA_cert[], const char ESP_CA_cert[] and const char ESP_RSA_key[] with escape characters.
+
+  (4.) Alternatively you can use the libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/certificates/certificate_generator.sh script 
+  for generating and formatting the certificates.
+  
+  2021 - Norbert Gal - Apache 2.0 License.
+*/
+
+#include <PubSubClient.h>
+#include "WiFiClientSecure.h"
+
+const char* CA_cert = \
+"-----BEGIN CERTIFICATE-----\n" \
+"################################################################\n" \
+"################################################################\n" \
+"################################################################\n" \
+"-----END CERTIFICATE-----";
+
+const char* ESP_CA_cert = \
+"-----BEGIN CERTIFICATE-----\n" \
+"################################################################\n" \
+"################################################################\n" \
+"################################################################\n" \
+"-----END CERTIFICATE-----";
+
+const char* ESP_RSA_key= \
+"-----BEGIN RSA PRIVATE KEY-----\n" \
+"################################################################\n" \
+"################################################################\n" \
+"################################################################\n" \
+"-----END RSA PRIVATE KEY-----";
+
+
+const char* ssid     = "wifi";     // your network SSID (name of wifi network)
+const char* password = "wifi_pass"; // your network password
+
+const char* server = "Mosquitto_borker_adress";
+const char* mqtt_user = "user"; //If it is configured, see Mosquitto config
+const char* mqtt_pass = "user_password";  //If it is configured, see Mosquitto config
+
+WiFiClientSecure client;
+PubSubClient mqtt_client(client); 
+
+void setup() {
+  Serial.begin(115200);
+  delay(100); 
+
+  Serial.print("Attempting to connect to SSID: ");
+  Serial.println(ssid);
+  WiFi.begin(ssid, password);
+
+  // attempt to connect to Wifi network:
+  while (WiFi.status() != WL_CONNECTED) {
+    Serial.print(".");
+    // wait 1 second for re-trying
+    delay(1000);
+  }
+
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+
+  client.setCACert(CA_cert);
+  client.setCertificate(ESP_CA_cert); // for client verification if the require_certificate is set to true  in the mosquitto broker config
+  client.setPrivateKey(ESP_RSA_key);  // for client verification if the require_certificate is set to true  in the mosquitto broker config
+  mqtt_client.setServer(server, 8883);
+  
+}
+
+void loop() {
+  
+  Serial.println("\nStarting connection to server...");
+  //if you use password for Mosquitto broker
+  if (mqtt_client.connect("ESP32", mqtt_user , mqtt_pass)) {
+  //if you dont use password for Mosquitto broker
+  //if (mqtt_client.connect("ESP32")) {                       
+    Serial.print("Connected, mqtt_client state: ");
+    Serial.println(mqtt_client.state());
+    mqtt_client.publish("LIvingRoom/TEMPERATURE", "25");
+  }
+  else {
+    Serial.println("Connected failed!  mqtt_client state:");
+    Serial.print(mqtt_client.state());
+    Serial.println("WiFiClientSecure client state:");
+    char lastError[100];
+    client.lastError(lastError,100);  //Get the last error for WiFiClientSecure
+    Serial.print(lastError);
+  }
+  delay(10000);
+}

--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/WiFiClientSecureClientAuthentication.ino
@@ -21,7 +21,13 @@
   openssl req -out esp.csr -key esp.key -new -subj '/CN=localhost'
   openssl x509 -req -in esp.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out esp.crt -days 365
 
-  2. step - Install and setup you Mosquitto broker
+  2. Open ca.crt, esp.crt and esp.key with text viewer and copy the values to this WiFiClientSecureClientAuthentication.ino source file into 
+  corresponding const char CA_cert[], const char ESP_CA_cert[] and const char ESP_RSA_key[] with escape characters.
+
+  (1-2.) Alternatively you can use the libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/certificates/certificate_generator.sh script 
+  for generating and formatting the certificates.
+
+  3. step - Install and setup you Mosquitto broker
   Follow the instructions from https://mosquitto.org/ and check the manual for the coniguration.
   For the Mosquito broker you need ca.crt, mosquitto.key and mosquitto.crt files generated in previous step.
   Recommended to put they in /etc/mosquitto/ca_certificates/ and /etc/mosquitto/certs/
@@ -34,11 +40,10 @@
   require_certificate true or false #If you need client authentication set it to true
   log_type all  #for logging in /var/log/mosquitto/
 
-  3. Open ca.crt, esp.crt and esp.key with text viewer and copy the values to this WiFiClientSecureClientAuthentication.ino source file into 
-  corresponding const char CA_cert[], const char ESP_CA_cert[] and const char ESP_RSA_key[] with escape characters.
-
-  (4.) Alternatively you can use the libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/certificates/certificate_generator.sh script 
-  for generating and formatting the certificates.
+  4.Restart the Mosquitto service or start the broker:
+  sudo service mosquitto restart
+  or
+  mosquitto -c /etc/mosquitto/conf.d/default.conf
   
   2021 - Norbert Gal - Apache 2.0 License.
 */
@@ -68,11 +73,11 @@ const char* ESP_RSA_key= \
 "-----END RSA PRIVATE KEY-----";
 
 
-const char* ssid     = "wifi";     // your network SSID (name of wifi network)
-const char* password = "wifi_pass"; // your network password
+const char* ssid     = "wifi";        // your network SSID (name of wifi network)
+const char* password = "wifi_pass";   // your network password
 
 const char* server = "Mosquitto_borker_adress";
-const char* mqtt_user = "user"; //If it is configured, see Mosquitto config
+const char* mqtt_user = "user";           //If it is configured, see Mosquitto config
 const char* mqtt_pass = "user_password";  //If it is configured, see Mosquitto config
 
 WiFiClientSecure client;
@@ -107,9 +112,9 @@ void loop() {
   
   Serial.println("\nStarting connection to server...");
   //if you use password for Mosquitto broker
-  if (mqtt_client.connect("ESP32", mqtt_user , mqtt_pass)) {
+  //if (mqtt_client.connect("ESP32", mqtt_user , mqtt_pass)) {
   //if you dont use password for Mosquitto broker
-  //if (mqtt_client.connect("ESP32")) {                       
+  if (mqtt_client.connect("ESP32")) {                       
     Serial.print("Connected, mqtt_client state: ");
     Serial.println(mqtt_client.state());
     mqtt_client.publish("LIvingRoom/TEMPERATURE", "25");

--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/certificates/certificate_generator.sh
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureClientAuthentication/certificates/certificate_generator.sh
@@ -1,0 +1,29 @@
+#################################################################################################################################################################################
+#Certificate generator for TLS encryption																	#
+#################################################################################################################################################################################
+openssl req -new -x509 -days 365 -extensions v3_ca -keyout ca.key -out ca.crt -passout pass:1234 -subj '/CN=TrustedCA.net'
+#If you generating self-signed certificates the CN can be anything
+
+openssl genrsa -out mosquitto.key 2048
+openssl req -out mosquitto.csr -key mosquitto.key -new -subj '/CN=locsol.dynamic-dns.net'
+openssl x509 -req -in mosquitto.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out mosquitto.crt -days 365 -passin file:PEMpassphrase.pass
+#Mostly the client verifies the adress of the mosquitto server, so its necessary to set the CN to the correct adress (eg. yourserver.com)!!!
+
+
+#################################################################################################################################################################################
+#These certificates are only needed if the mosquitto broker requires a certificate for client autentithication (require_certificate is set to true in mosquitto config).      	#
+#################################################################################################################################################################################
+openssl genrsa -out esp.key 2048
+openssl req -out esp.csr -key esp.key -new -subj '/CN=localhost'
+openssl x509 -req -in esp.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out esp.crt -days 365 -passin pass:1234
+#If the server (mosquitto) identifies the clients based on CN key, its necessary to set it to the correct value, else it can be blank.
+
+#################################################################################################################################################################################
+#For ESP32. Formatting for source code. The output is the esp_certificates.c                                                                                                    #
+#################################################################################################################################################################################
+echo -en "#include \"esp_certificates.h\"\n\nconst char CA_cert[] = \\\\\n" > esp_certificates.c;
+sed -z '0,/-/s//"-/;s/\n/\\n" \\\n"/g;s/\\n" \\\n"$/";\n\n/g' ca.crt >> esp_certificates.c     #replace first occurance of - with "-  ;  all newlnies with \n " \ \n", except last newline where just add ;"
+echo "const char ESP_CA_cert[] = \\" >> esp_certificates.c;
+sed -z '0,/-/s//"-/;s/\n/\\n" \\\n"/g;s/\\n" \\\n"$/";\n\n/g' esp.crt >> esp_certificates.c     #replace first occurance of - with "-  ;  all newlnies with \n " \ \n", except last newline where just add ;"
+echo "const char ESP_RSA_key[] = \\" >> esp_certificates.c;
+sed -z '0,/-/s//"-/;s/\n/\\n" \\\n"/g;s/\\n" \\\n"$/";/g' esp.key >> esp_certificates.c     #replace first occurance of - with "-  ;  all newlnies with \n " \ \n", except last newline where just add ;"


### PR DESCRIPTION
I spent long hours to make working TLS encrypted communication with ESP32 <----> Mosquitto broker (MQTT) also opened for that an issue where others too suffered from a similar problem: https://github.com/espressif/arduino-esp32/issues/5021

I decided to make a useful example, I hope it can be useful in the future, please include it. 

In WiFiClientSecureClientAuthentication.ino soure file also contains short manual.
certificate_generator.sh is an easy tool for generating certificates