### PR TITLE
Serial::end hang

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -114,6 +114,7 @@ void HardwareSerial::end()
     if(uartGetDebug() == _uart_nr) {
         uartSetDebug(0);
     }
+    delay(10);
     log_v("pins %d %d",_tx_pin, _rx_pin);
     uartEnd(_uart, _tx_pin, _rx_pin);
     _uart = 0;


### PR DESCRIPTION
workaround for #5043.  There is a timing issue with HardwareSerial::end.  I'm not sure what is hung, but it should be possible to see this in jtag, as it does cause a reboot if you let it.  The delay needs to be before you detach the device!?