### PR TITLE
Add KSZ8081 support.

### DIFF
--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -170,6 +170,8 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
             eth_phy = esp_eth_phy_new_dm9051(&phy_config);
             break;
 #endif
+        case ETH_PHY_KSZ8081:
+            eth_phy = esp_eth_phy_new_ksz8081(&phy_config);
         default:
             break;
     }

--- a/libraries/WiFi/src/ETH.h
+++ b/libraries/WiFi/src/ETH.h
@@ -51,7 +51,7 @@
 #endif
 #endif
 
-typedef enum { ETH_PHY_LAN8720, ETH_PHY_TLK110, ETH_PHY_RTL8201, ETH_PHY_DP83848, ETH_PHY_DM9051, ETH_PHY_MAX } eth_phy_type_t;
+typedef enum { ETH_PHY_LAN8720, ETH_PHY_TLK110, ETH_PHY_RTL8201, ETH_PHY_DP83848, ETH_PHY_DM9051, ETH_PHY_KSZ8081, ETH_PHY_MAX } eth_phy_type_t;
 
 class ETHClass {
     private:


### PR DESCRIPTION
This adds support for the KSZ8081 ethernet phy.
Only the IDF 4+ specific code is modified, as the phy support was only
added recently:
espressif/esp-idf@aecfbf96