### PR TITLE
WiFiClientSecure fix flipped cert/key in comment

### DIFF
--- a/libraries/WiFiClientSecure/examples/WiFiClientSecure/WiFiClientSecure.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecure/WiFiClientSecure.ino
@@ -66,8 +66,8 @@ void setup() {
   Serial.println(ssid);
 
   client.setCACert(test_root_ca);
-  //client.setCertificate(test_client_key); // for client verification
-  //client.setPrivateKey(test_client_cert);	// for client verification
+  //client.setCertificate(test_client_cert); // for client verification
+  //client.setPrivateKey(test_client_key);	// for client verification
 
   Serial.println("\nStarting connection to server...");
   if (!client.connect(server, 443))

--- a/libraries/WiFiClientSecure/examples/WiFiClientSecureEnterprise/WiFiClientSecureEnterprise.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientSecureEnterprise/WiFiClientSecureEnterprise.ino
@@ -72,8 +72,8 @@ void setup() {
     }
   }
   client.setCACert(test_root_ca);
-  //client.setCertificate(test_client_key); // for client verification - certificate
-  //client.setPrivateKey(test_client_cert);  // for client verification - private key
+  //client.setCertificate(test_client_cert); // for client verification - certificate
+  //client.setPrivateKey(test_client_key);  // for client verification - private key
   Serial.println("");
   Serial.println("WiFi connected");
   Serial.println("IP address set: ");


### PR DESCRIPTION
The key and cert were flipped. It's just in the comments, but might avoid confusion.