### PR TITLE
Removed second NTP server from configTime. SNTP only uses one

### DIFF
--- a/libraries/HTTPClient/examples/BasicHttpsClient/BasicHttpsClient.ino
+++ b/libraries/HTTPClient/examples/BasicHttpsClient/BasicHttpsClient.ino
@@ -56,7 +56,7 @@ const char* rootCACertificate = \
 // Not sure if WiFiClientSecure checks the validity date of the certificate. 
 // Setting clock just to be sure...
 void setClock() {
-  configTime(0, 0, "pool.ntp.org", "time.nist.gov");
+  configTime(0, 0, "pool.ntp.org");
 
   Serial.print(F("Waiting for NTP time sync: "));
   time_t nowSecs = time(nullptr);


### PR DESCRIPTION
Having two servers in the list implies that sntp will use the second if first is not available.  SNTP will only use one as compiled - [source](https://github.com/espressif/esp-lwip/blob/2c9c531f0a7e0ee536db9de4f9dc54e453712087/src/include/lwip/apps/sntp_opts.h#L61).