### PR TITLE
MDNSResponder: Add method to get TXT key values.

### DIFF
--- a/libraries/ESPmDNS/src/ESPmDNS.cpp
+++ b/libraries/ESPmDNS/src/ESPmDNS.cpp
@@ -245,6 +245,16 @@ mdns_result_t * MDNSResponder::_getResult(int idx){
     return result;
 }
 
+mdns_txt_item_t * MDNSResponder::_getResultTxt(int idx, int txtIdx){
+    mdns_result_t * result = _getResult(idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return NULL;
+    }
+    if (txtIdx >= result->txt_count) return NULL;
+    return &result->txt[txtIdx];
+}
+
 String MDNSResponder::hostname(int idx) {
     mdns_result_t * result = _getResult(idx);
     if(!result){
@@ -333,13 +343,17 @@ String MDNSResponder::txt(int idx, const char * key) {
 }
 
 String MDNSResponder::txt(int idx, int txtIdx) {
-    mdns_result_t * result = _getResult(idx);
-    if(!result){
-        log_e("Result %d not found", idx);
-        return "";
-    }
-    if (txtIdx >= result->txt_count) return "";
-    return result->txt[txtIdx].value;
+    mdns_txt_item_t * resultTxt = _getResultTxt(idx, txtIdx);
+    return !resultTxt
+        ? ""
+        : resultTxt->value;
+}
+
+String MDNSResponder::txtKey(int idx, int txtIdx) {
+    mdns_txt_item_t * resultTxt = _getResultTxt(idx, txtIdx);
+    return !resultTxt
+        ? ""
+        : resultTxt->key;
 }
 
 MDNSResponder MDNS;

--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -111,11 +111,13 @@ public:
   bool hasTxt(int idx, const char * key);
   String txt(int idx, const char * key);
   String txt(int idx, int txtIdx);
+  String txtKey(int idx, int txtIdx);
   
 private:
   String _hostname;
   mdns_result_t * results;
   mdns_result_t * _getResult(int idx);
+  mdns_txt_item_t * _getResultTxt(int idx, int txtIdx);
 };
 
 extern MDNSResponder MDNS;


### PR DESCRIPTION
Add method `MDNSResponder::txtKey(int idx, int txtIdx)` aka `MDNS.txtKey(int idx, int txtIdx)` to be able to get mDNS TXT record name (key) and explore TXT records. Closes #5132 