### PR TITLE
Fix crash in WiFiClient when read() called after stop()

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -442,20 +442,25 @@ size_t WiFiClient::write(Stream &stream)
 int WiFiClient::read(uint8_t *buf, size_t size)
 {
     int res = -1;
-    res = _rxBuffer->read(buf, size);
-    if(_rxBuffer->failed()) {
-        log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
-        stop();
+    if (_rxBuffer) {
+        res = _rxBuffer->read(buf, size);
+        if(_rxBuffer->failed()) {
+            log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
+            stop();
+        }
     }
     return res;
 }
 
 int WiFiClient::peek()
 {
-    int res = _rxBuffer->peek();
-    if(_rxBuffer->failed()) {
-        log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
-        stop();
+    int res = -1;
+    if (_rxBuffer) {
+        res = _rxBuffer->peek();
+        if(_rxBuffer->failed()) {
+            log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
+            stop();
+        }
     }
     return res;
 }


### PR DESCRIPTION
Thi may happen if `read()` gets called repeatedly (such as in `HttpClient` to parse response headers) and the connection is closed unexpectedly or the remote peer may have unexpected behavior that causes the underlying socket to report an error. In that case `read()` itself calls `stop()`, which invalidates the receive buffer object. Then when `read()` is called again without checking, such as inside `readStringUntil()`, the `_rxBuffer` is null and ESP32 crashes.

See also #3659