### PR TITLE
Add missing Wifi Provisioning dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ set(includedirs
 
 set(srcs ${CORE_SRCS} ${LIBRARY_SRCS} ${BLE_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash mbedtls mdns esp_adc_cal)
+set(requires spi_flash mbedtls mdns esp_adc_cal wifi_provisioning)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support openssl bt main)
 
 if(IDF_TARGET MATCHES "esp32s2|esp32s3" AND CONFIG_TINYUSB_ENABLED)


### PR DESCRIPTION
Adding back missing dependency for wifi provisioning.

This has been removed in https://github.com/espressif/arduino-esp32/commit/5502879a5b25e5fff84a7058f448be481c0a1f73#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a but does not describe why or whether this was an oversight.

It was also missing in 2020 and has been previously added in https://github.com/espressif/arduino-esp32/commit/934841e2360e3f3c87354fd5bf9d5789308bf9a8#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a.

Without this, compiling this library as part of an esp-idf component fails as the compiler cannot find `#include "wifi_provisioning/manager.h"` in WifiProv.h