### PR TITLE
Update BLEScan.cpp

### DIFF
--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -126,7 +126,8 @@ void BLEScan::handleGAPEvent(
 
 					if (m_pAdvertisedDeviceCallbacks) { // if has callback, no need to record to vector
 						m_pAdvertisedDeviceCallbacks->onResult(*advertisedDevice);
-					} else if (!m_wantDuplicates && !found) {   // if no callback and not want duplicate, and not already in vector, record it
+					} 
+					if (!m_wantDuplicates && !found) {   // if no callback and not want duplicate, and not already in vector, record it
 						m_scanResults.m_vectorAdvertisedDevices.insert(std::pair<std::string, BLEAdvertisedDevice*>(advertisedAddress.toString(), advertisedDevice));
 						shouldDelete = false;
 					}


### PR DESCRIPTION
Proposed fix to #4627 as a remediation to PR #3995
#3995 introduced that a device detected on BLE would not be entered in vector if a callback has been defined. 
By doing so, it was not possible anymore to have a counter in a call back (AND device in vector) to limit the number of detected device in a single scan, which could crash ESP32 as a result.