### PR TITLE
doitESPduino32 - Add definitions for SPI pins names

### DIFF
--- a/variants/doitESPduino32/pins_Arduino.h
+++ b/variants/doitESPduino32/pins_Arduino.h
@@ -19,10 +19,15 @@ static const uint8_t SDA = 21;
 static const uint8_t SCL = 22;
 
 //SPI
-static const uint8_t IO5    = 5; //SS
-static const uint8_t IO23  = 23; //MOSI
-static const uint8_t IO19  = 19; //MISO
-static const uint8_t IO18   = 18; //SCK
+static const uint8_t IO5  = 5;  //SS
+static const uint8_t IO23 = 23; //MOSI
+static const uint8_t IO19 = 19; //MISO
+static const uint8_t IO18 = 18; //SCK
+
+static const uint8_t SS   = IO5;
+static const uint8_t MOSI = IO23;
+static const uint8_t MISO = IO19;
+static const uint8_t SCK  = IO18;
 
 //ANALOG
 static const uint8_t IO36 = 36;


### PR DESCRIPTION
The doitESPduino32/pins_Arduino.h lacks definitions for the common SPI pins names: SS, MOSI, MISO, SCK
This breaks compatibility with Arduino libs, including SPI.h/.cpp

This PR solves the issue while maintaining compatibility with previous pin naming (IO5/23/19/18), and ensures consistency with other boards variants.