### PR TITLE
Fix incorrect Flash Size in Esp32c3

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -35,15 +35,19 @@ extern "C" {
 #if CONFIG_IDF_TARGET_ESP32 // ESP32/PICO-D4
 #include "esp32/rom/spi_flash.h"
 #include "soc/efuse_reg.h"
+#define ESP_FLASH_IMAGE_BASE 0x1000     // Flash offset containing flash size and spi mode
 #elif CONFIG_IDF_TARGET_ESP32S2
 #include "esp32s2/rom/spi_flash.h"
+#define ESP_FLASH_IMAGE_BASE 0x1000
 #elif CONFIG_IDF_TARGET_ESP32C3
 #include "esp32c3/rom/spi_flash.h"
+#define ESP_FLASH_IMAGE_BASE 0x0000     // Esp32c3 is located at 0x0000
 #else 
 #error Target CONFIG_IDF_TARGET is not supported
 #endif
 #else // ESP32 Before IDF 4.0
 #include "rom/spi_flash.h"
+#define ESP_FLASH_IMAGE_BASE 0x1000
 #endif
 
 /**
@@ -289,7 +293,7 @@ const char * EspClass::getSdkVersion(void)
 uint32_t EspClass::getFlashChipSize(void)
 {
     esp_image_header_t fhdr;
-    if(flashRead(0x1000, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
+    if(flashRead(ESP_FLASH_IMAGE_BASE, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
         return 0;
     }
     return magicFlashChipSize(fhdr.spi_size);
@@ -298,7 +302,7 @@ uint32_t EspClass::getFlashChipSize(void)
 uint32_t EspClass::getFlashChipSpeed(void)
 {
     esp_image_header_t fhdr;
-    if(flashRead(0x1000, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
+    if(flashRead(ESP_FLASH_IMAGE_BASE, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
         return 0;
     }
     return magicFlashChipSpeed(fhdr.spi_speed);
@@ -307,7 +311,7 @@ uint32_t EspClass::getFlashChipSpeed(void)
 FlashMode_t EspClass::getFlashChipMode(void)
 {
     esp_image_header_t fhdr;
-    if(flashRead(0x1000, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
+    if(flashRead(ESP_FLASH_IMAGE_BASE, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
         return FM_UNKNOWN;
     }
     return magicFlashChipMode(fhdr.spi_mode);


### PR DESCRIPTION
original PR #5278 from @s-hadinger, which is not accepted because of failure of CLAassistant

`ESP.getFlashChipSize()` always returns `0` on Esp32c3 due to a change in the Flash layout. It looks like to Espressif documentation was not updated accordingly.

https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/storage/spi_flash.html#spi-flash-size

- Esp32 and Esp32s3 have the flash information update by esptool.py
and decribed here
- https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/spi_flash.html
Esp32c3 has no image information at 0x0000 and contrary to the docu
this information is at offset 0x0000