### PR TITLE
Fix #5293 by adding missing dependency to nghttp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ set(includedirs
 
 set(srcs ${CORE_SRCS} ${LIBRARY_SRCS} ${BLE_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash mbedtls mdns esp_adc_cal wifi_provisioning)
+set(requires spi_flash mbedtls mdns esp_adc_cal wifi_provisioning nghttp)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support openssl bt main)
 
 if(IDF_TARGET MATCHES "esp32s2|esp32s3" AND CONFIG_TINYUSB_ENABLED)


### PR DESCRIPTION
Fix for the issue  #5293 `/components/arduino/libraries/WebServer/src/HTTP_Method.h:4:10: fatal error: http_parser.h: No such file or directory
 #include "http_parser.h"`