### PR TITLE
Make String::concat() faster for some types.

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -59,9 +59,7 @@ String::String(StringSumHelper &&rval) {
 
 String::String(char c) {
     init();
-    char buf[2];
-    buf[0] = c;
-    buf[1] = 0;
+    char buf[] = { c, '\0' };
     *this = buf;
 }
 
@@ -290,10 +288,11 @@ String & String::operator =(const char *cstr) {
     return *this;
 }
 
-String & String::operator = (const __FlashStringHelper *pstr)
-{
-    if (pstr) copy(pstr, strlen_P((PGM_P)pstr));
-    else invalidate();
+String & String::operator =(const __FlashStringHelper *pstr) {
+    if(pstr)
+        copy(pstr, strlen_P((PGM_P)pstr));
+    else
+        invalidate();
 
     return *this;
 }
@@ -347,22 +346,19 @@ unsigned char String::concat(const char *cstr) {
 }
 
 unsigned char String::concat(char c) {
-    char buf[2];
-    buf[0] = c;
-    buf[1] = 0;
+    char buf[] = { c, '\0' };
     return concat(buf, 1);
 }
 
 unsigned char String::concat(unsigned char num) {
     char buf[1 + 3 * sizeof(unsigned char)];
-    sprintf(buf, "%d", num);
-    return concat(buf, strlen(buf));
+    return concat(buf, sprintf(buf, "%d", num));
 }
 
 unsigned char String::concat(int num) {
     char buf[2 + 3 * sizeof(int)];
     sprintf(buf, "%d", num);
-    return concat(buf, strlen(buf));
+    return concat(buf, sprintf(buf, "%d", num));
 }
 
 unsigned char String::concat(unsigned int num) {
@@ -373,8 +369,7 @@ unsigned char String::concat(unsigned int num) {
 
 unsigned char String::concat(long num) {
     char buf[2 + 3 * sizeof(long)];
-    sprintf(buf, "%ld", num);
-    return concat(buf, strlen(buf));
+    return concat(buf, sprintf(buf, "%ld", num));
 }
 
 unsigned char String::concat(unsigned long num) {

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -357,7 +357,6 @@ unsigned char String::concat(unsigned char num) {
 
 unsigned char String::concat(int num) {
     char buf[2 + 3 * sizeof(int)];
-    sprintf(buf, "%d", num);
     return concat(buf, sprintf(buf, "%d", num));
 }
 


### PR DESCRIPTION
This patch removes the unneeded call to `strlen()` when concatenating some types to a `String`. Additionally it fixes some whitespace for consistency.