### PR TITLE
[backport-v1] Fix softap_config_equal compare auth_mode/cipher

### DIFF
--- a/libraries/WiFi/src/WiFiAP.cpp
+++ b/libraries/WiFi/src/WiFiAP.cpp
@@ -67,6 +67,9 @@ static bool softap_config_equal(const wifi_config_t& lhs, const wifi_config_t& r
     if(lhs.ap.channel != rhs.ap.channel) {
         return false;
     }
+    if(lhs.ap.authmode != rhs.ap.authmode) {
+        return false;
+    }
     if(lhs.ap.ssid_hidden != rhs.ap.ssid_hidden) {
         return false;
     }


### PR DESCRIPTION
backport from v2 to v1 of fix #5121
fixes #5038