### PR TITLE
Added function to retrieve the amount of data received from an BLECharacteristic

### DIFF
--- a/libraries/BLE/src/BLECharacteristic.cpp
+++ b/libraries/BLE/src/BLECharacteristic.cpp
@@ -187,6 +187,13 @@ uint8_t* BLECharacteristic::getData() {
 	return m_value.getData();
 } // getData
 
+/**
+ * @brief Retrieve the current length of the data of the characteristic.
+ * @return Amount of databytes of the characteristic.
+ */
+uint8_t BLECharacteristic::getLength() {
+	return m_value.getLength();
+} // getLength
 
 /**
  * Handle a GATT server event.

--- a/libraries/BLE/src/BLECharacteristic.h
+++ b/libraries/BLE/src/BLECharacteristic.h
@@ -62,6 +62,7 @@ public:
 	BLEUUID        getUUID();
 	std::string    getValue();
 	uint8_t*       getData();
+	uint8_t BLECharacteristic::getLength();
 
 	void indicate();
 	void notify(bool is_notification = true);

--- a/libraries/BLE/src/BLECharacteristic.h
+++ b/libraries/BLE/src/BLECharacteristic.h
@@ -62,7 +62,7 @@ public:
 	BLEUUID        getUUID();
 	std::string    getValue();
 	uint8_t*       getData();
-	uint8_t BLECharacteristic::getLength();
+	uint8_t        getLength();
 
 	void indicate();
 	void notify(bool is_notification = true);


### PR DESCRIPTION
Is there a specific reason for it not to be included for the end user? The code should be self explanatory.