### PR TITLE
feat: Server Side Events (SSE)

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -314,6 +314,11 @@ void WebServer::handleClient() {
           _contentLength = CONTENT_LENGTH_NOT_SET;
           _handleRequest();
 
+          if (_currentClient.isSSE()) {
+            _currentStatus = HC_WAIT_CLOSE;
+            _statusChange = millis();
+            keepCurrentClient = true;
+          }
 // Fix for issue with Chrome based browsers: https://github.com/espressif/arduino-esp32/issues/3652
 //           if (_currentClient.connected()) {
 //             _currentStatus = HC_WAIT_CLOSE;
@@ -329,6 +334,10 @@ void WebServer::handleClient() {
       }
       break;
     case HC_WAIT_CLOSE:
+      if (_currentClient.isSSE()) {
+        // Never close connection
+        _statusChange = millis();
+      }
       // Wait for client to close the connection
       if (millis() - _statusChange <= HTTP_MAX_CLOSE_WAIT) {
         keepCurrentClient = true;

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -174,7 +174,7 @@ public:
     }
 };
 
-WiFiClient::WiFiClient():_connected(false),next(NULL)
+WiFiClient::WiFiClient():_connected(false),_sse(false),next(NULL)
 {
 }
 
@@ -321,7 +321,7 @@ int WiFiClient::setOption(int option, int *value)
 
 int WiFiClient::getOption(int option, int *value)
 {
-	socklen_t size = sizeof(int);
+    socklen_t size = sizeof(int);
     int res = getsockopt(fd(), IPPROTO_TCP, option, (char *)value, &size);
     if(res < 0) {
         log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
@@ -606,5 +606,15 @@ int WiFiClient::fd() const
     } else {
         return clientSocketHandle->fd();
     }
+}
+
+void WiFiClient::setSSE(bool sse)
+{
+    _sse = sse;
+}
+
+bool WiFiClient::isSSE()
+{
+    return _sse;
 }
 

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -42,6 +42,7 @@ protected:
     std::shared_ptr<WiFiClientSocketHandle> clientSocketHandle;
     std::shared_ptr<WiFiClientRxBuffer> _rxBuffer;
     bool _connected;
+    bool _sse;
 
 public:
     WiFiClient *next;
@@ -63,6 +64,8 @@ public:
     void flush();
     void stop();
     uint8_t connected();
+    void setSSE(bool sse);
+    bool isSSE();
 
     operator bool()
     {


### PR DESCRIPTION
Tested in Chrome

This way we can leave connection opened and send SSE events like this:

```c++
class HttpServer : public WebServer {
   public:
    HttpServer(int port = 80) : WebServer(port) {
    }

    void begin() {
        if (!this->isStarted) {
            this->isStarted = true;
            this->enableCORS();
            on("/logs", std::bind(&HttpServer::handleLogs, this));
            on("/logs-stream", std::bind(&HttpServer::handleLogsStream, this));

            WebServer::begin();  // Web server start
        }
    }

    void close() {
        if (this->isStarted) {
            this->isStarted = false;
            WebServer::stop();
        }
    }

    void handleLogMessage(const char *message) {
        if (this->logClient && this->logClient->connected()) {
            this->logClient->println("event:message");
            this->logClient->println("data:" + String(message));
            this->logClient->println();
            this->logClient->flush();
        } else if (this->logClient) {
            // give the web browser time to receive the data
            delay(1);
            // close the connection:
            this->logClient->stop();
            this->logClient = NULL;
        }
    }

   private:
    bool isStarted = false;
    WiFiClient *logClient = NULL;

    void handleLogs() {
        this->prepareResponse(200, "text/html");
        sendContent(
            "<!DOCTYPE html>"
            "<html><head>"
            "<meta name='viewport' content='width=device-width, initial-scale=1.0'>"
            "<style>.E .tag{color:red}.W .tag{color:orange}.I .tag{color:lightblue}.D .tag{color:yellow}.V .tag{color:gray}</style>"
            "</head><body>"
            "<h1>Messages sent via SSE</h1>"
            "<div id='logs' style='width:100%;height:100%;background-color:black;color:white;'></div>"
            "<script>var logDiv = document.getElementById('logs');"
            "var source = new EventSource('logs-stream');"
            "source.onmessage = function (event) {"
            "  var data = JSON.parse(event.data);"
            "  logDiv.innerHTML += '<span class=\"' + data.level + '\">"
            "<span class=\"tag\">[' + data.tag + ']</span> <span class=\"message\">' + data.message + '</span></span><br/>';"
            "};"
            "</script>"
            "</body></html>");
        this->finishResponse();
    }

    void handleLogsStream() {
        // TODO: only one client supported
        this->logClient = &_currentClient;

        if (this->logClient) {
            this->logClient->println("HTTP/1.1 200 OK");
            this->logClient->println("Content-Type: text/event-stream;charset=UTF-8");
            this->logClient->println("Connection: close");
            this->logClient->println("Access-Control-Allow-Origin: *");
            this->logClient->println("Cache-Control: no-cache");
            this->logClient->println();
            this->logClient->flush();
        }

        this->logClient->setSSE(true);
    }

    void prepareResponse(int code, const char *content_type = (const char *)__null, const String &content = ((String)(""))) {
        sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
        sendHeader("X-Frame-Options", "");
        sendHeader("Pragma", "no-cache");
        sendHeader("Expires", "-1");
        setContentLength(CONTENT_LENGTH_UNKNOWN);
        send(code, content_type, "");
        if (content.length() > 0) {
            sendContent(content);
        }
    }

    void finishResponse() {
        sendContent("");
        client().flush();
        client().stop();
    }
}

```

*main.ino*
```c++
HttpServer *server;

void setup() {
    server = new HttpServer(80);
    server->begin();
}

void loop() {
    server->handleLogMessage("{\"message\":\"Some message ;)\"}");
    delay(2000);
}
```