### PR TITLE
pinMatrixInDetach() has wrong parameter

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -179,7 +179,7 @@ static void uartDetachRx(uart_t* uart, uint8_t rxPin)
     if(uart == NULL) {
         return;
     }
-    pinMatrixInDetach(rxPin, false, false);
+    pinMatrixInDetach(UART_RDX_IDX(uart->num), false, false);
     uartDisableInterrupt(uart);
 }
 

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -179,7 +179,7 @@ static void uartDetachRx(uart_t* uart, uint8_t rxPin)
     if(uart == NULL) {
         return;
     }
-    pinMatrixInDetach(UART_RDX_IDX(uart->num), false, false);
+    pinMatrixInDetach(UART_RXD_IDX(uart->num), false, false);
     uartDisableInterrupt(uart);
 }
 


### PR DESCRIPTION
This solves issue #5112
Call to pinMatrixInDetach() was changed from version 1.0.6 in version 2.0.0 injecting a bug as seen in cores/esp32/esp32-hal-uart.c
https://github.com/espressif/arduino-esp32/commit/80418fadcfb91c75d5100a8fddeb9318a8ef7d42