### PR TITLE
PlatformIO updates for CI

### DIFF
--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -1,19 +1,43 @@
 #!/bin/bash
 
 export PLATFORMIO_ESP32_PATH="$HOME/.platformio/packages/framework-arduinoespressif32"
-PLATFORMIO_ESP32_URL="https://github.com/platformio/platform-espressif32.git#feature/idf-master"
+PLATFORMIO_ESP32_URL="https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master"
+
+XTENSA32_TOOLCHAIN_VERSION="8.4.0+2021r1"
+XTENSA32S2_TOOLCHAIN_VERSION="8.4.0+2021r1"
+RISCV_TOOLCHAIN_VERSION="8.4.0+2021r1"
+ESPTOOLPY_VERSION="~1.30100.0"
+ESPRESSIF_ORGANIZATION_NAME="espressif"
 
 echo "Installing Python Wheel ..."
 pip install wheel > /dev/null 2>&1
 
 echo "Installing PlatformIO ..."
-pip install -U https://github.com/platformio/platformio/archive/develop.zip > /dev/null 2>&1
+pip install -U https://github.com/platformio/platformio/archive/master.zip > /dev/null 2>&1
 
 echo "Installing Platform ESP32 ..."
-python -m platformio platform install $PLATFORMIO_ESP32_URL > /dev/null 2>&1
+python -m platformio platform install $PLATFORMIO_ESP32_URL  > /dev/null 2>&1
 
-echo "Replacing the framework version ..."
-python -c "import json; import os; fp=open(os.path.expanduser('~/.platformio/platforms/espressif32/platform.json'), 'r+'); data=json.load(fp); data['packages']['framework-arduinoespressif32']['version'] = '*'; fp.seek(0); fp.truncate(); json.dump(data, fp); fp.close()"
+echo "Replacing the package versions ..."
+replace_script="import json; import os;"
+replace_script+="fp=open(os.path.expanduser('~/.platformio/platforms/espressif32/platform.json'), 'r+');"
+replace_script+="data=json.load(fp);"
+# Use framework sources from the repository
+replace_script+="data['packages']['framework-arduinoespressif32']['version'] = '*';"
+replace_script+="del data['packages']['framework-arduinoespressif32']['owner'];"
+# Use toolchain packages from the "espressif" organization
+replace_script+="data['packages']['toolchain-xtensa-esp32']['owner']='$ESPRESSIF_ORGANIZATION_NAME';"
+replace_script+="data['packages']['toolchain-xtensa-esp32s2']['owner']='$ESPRESSIF_ORGANIZATION_NAME';"
+replace_script+="data['packages']['toolchain-riscv32-esp']['owner']='$ESPRESSIF_ORGANIZATION_NAME';"
+# Update versions to use the upstream
+replace_script+="data['packages']['toolchain-xtensa-esp32']['version']='$XTENSA32_TOOLCHAIN_VERSION';"
+replace_script+="data['packages']['toolchain-xtensa-esp32s2']['version']='$XTENSA32S2_TOOLCHAIN_VERSION';"
+replace_script+="data['packages']['toolchain-riscv32-esp']['version']='$RISCV_TOOLCHAIN_VERSION';"
+# esptool.py may requires an upstream version (for now platformio is the owner)
+replace_script+="data['packages']['tool-esptoolpy']['version']='$ESPTOOLPY_VERSION';"
+# Save results
+replace_script+="fp.seek(0);fp.truncate();json.dump(data, fp, indent=2);fp.close()"
+python -c "$replace_script"
 
 if [ "$GITHUB_REPOSITORY" == "espressif/arduino-esp32" ];  then
 	echo "Linking Core..."

--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -33,7 +33,7 @@ replace_script+="data['packages']['toolchain-riscv32-esp']['owner']='$ESPRESSIF_
 replace_script+="data['packages']['toolchain-xtensa-esp32']['version']='$XTENSA32_TOOLCHAIN_VERSION';"
 replace_script+="data['packages']['toolchain-xtensa-esp32s2']['version']='$XTENSA32S2_TOOLCHAIN_VERSION';"
 replace_script+="data['packages']['toolchain-riscv32-esp']['version']='$RISCV_TOOLCHAIN_VERSION';"
-# esptool.py may requires an upstream version (for now platformio is the owner)
+# esptool.py may require an upstream version (for now platformio is the owner)
 replace_script+="data['packages']['tool-esptoolpy']['version']='$ESPTOOLPY_VERSION';"
 # Save results
 replace_script+="fp.seek(0);fp.truncate();json.dump(data, fp, indent=2);fp.close()"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - release/*
+    - platformio*
   pull_request:
 
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - master
     - release/*
-    - platformio*
   pull_request:
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,16 @@
 {
-    "name": "framework-arduinoespressif32",
-    "description": "Arduino Wiring-based Framework (ESP32 Core)",
-    "version": "0.0.0",
+  "name": "framework-arduinoespressif32",
+  "version": "0.0.0",
+  "description": "Arduino Wiring-based Framework for the Espressif ESP32, ESP32-S and ESP32-C series of SoCs",
+  "keywords": [
+    "framework",
+    "arduino",
+    "espressif",
+    "esp32"
+  ],
+  "license": "LGPL-2.1-or-later",
+  "repository": {
+    "type": "git",
     "url": "https://github.com/espressif/arduino-esp32"
+  }
 }


### PR DESCRIPTION
This PR is an initial attempt to switch the CI to the latest toolchains 8.4.0 for ESP32, ESP32S2, ESP32C3 from Espressif. Additionally, updated the CI to install PlatformIO from master branch for better robustness and freshened `package.json`.

cc @me-no-dev 