### PR TITLE
fix port{Input,Output,Mode}Register macros for chips with <=32 pins

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -99,13 +99,23 @@
 #define bit(b) (1UL << (b))
 #define _BV(b) (1UL << (b))
 
-#define digitalPinToPort(pin)       (((pin)>31)?1:0)
-#define digitalPinToBitMask(pin)    (1UL << (((pin)>31)?((pin)-32):(pin)))
 #define digitalPinToTimer(pin)      (0)
 #define analogInPinToBit(P)         (P)
+#if SOC_GPIO_PIN_COUNT <= 32
+#define digitalPinToPort(pin)       (0)
+#define digitalPinToBitMask(pin)    (1UL << (pin))
+#define portOutputRegister(port)    ((volatile uint32_t*)GPIO_OUT_REG)
+#define portInputRegister(port)     ((volatile uint32_t*)GPIO_IN_REG)
+#define portModeRegister(port)      ((volatile uint32_t*)GPIO_ENABLE_REG)
+#elif SOC_GPIO_PIN_COUNT <= 64
+#define digitalPinToPort(pin)       (((pin)>31)?1:0)
+#define digitalPinToBitMask(pin)    (1UL << (((pin)>31)?((pin)-32):(pin)))
 #define portOutputRegister(port)    ((volatile uint32_t*)((port)?GPIO_OUT1_REG:GPIO_OUT_REG))
 #define portInputRegister(port)     ((volatile uint32_t*)((port)?GPIO_IN1_REG:GPIO_IN_REG))
 #define portModeRegister(port)      ((volatile uint32_t*)((port)?GPIO_ENABLE1_REG:GPIO_ENABLE_REG))
+#else
+#error SOC_GPIO_PIN_COUNT > 64 not implemented
+#endif
 
 #define NOT_A_PIN -1
 #define NOT_A_PORT -1


### PR DESCRIPTION
Added definitions of direct GPIO access macros for SOC_GPIO_PIN_COUNT <= 32.

Closes https://github.com/espressif/arduino-esp32/issues/5378