### PR TITLE
Fix ESP32-Solo WDT on HTTP OTA update

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -42,7 +42,7 @@ extern "C" {
 #elif CONFIG_IDF_TARGET_ESP32C3
 #include "esp32c3/rom/spi_flash.h"
 #define ESP_FLASH_IMAGE_BASE 0x0000     // Esp32c3 is located at 0x0000
-#else 
+#else
 #error Target CONFIG_IDF_TARGET is not supported
 #endif
 #else // ESP32 Before IDF 4.0
@@ -187,7 +187,7 @@ static uint32_t sketchSize(sketchSize_t response) {
         return data.image_len;
     }
 }
-    
+
 uint32_t EspClass::getSketchSize () {
     return sketchSize(SKETCH_SIZE_TOTAL);
 }
@@ -226,6 +226,8 @@ String EspClass::getSketchMD5()
         md5.add(buf.get(), readBytes);
         lengthLeft -= readBytes;
         offset += readBytes;
+
+        delay(1);  // Fix solo WDT
     }
     md5.calculate();
     result = md5.toString();
@@ -376,17 +378,17 @@ bool EspClass::flashRead(uint32_t offset, uint32_t *data, size_t size)
     return spi_flash_read(offset, (uint32_t*) data, size) == ESP_OK;
 }
 
-bool EspClass::partitionEraseRange(const esp_partition_t *partition, uint32_t offset, size_t size) 
+bool EspClass::partitionEraseRange(const esp_partition_t *partition, uint32_t offset, size_t size)
 {
     return esp_partition_erase_range(partition, offset, size) == ESP_OK;
 }
 
-bool EspClass::partitionWrite(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size) 
+bool EspClass::partitionWrite(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size)
 {
     return esp_partition_write(partition, offset, data, size) == ESP_OK;
 }
 
-bool EspClass::partitionRead(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size) 
+bool EspClass::partitionRead(const esp_partition_t *partition, uint32_t offset, uint32_t *data, size_t size)
 {
     return esp_partition_read(partition, offset, data, size) == ESP_OK;
 }

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -199,9 +199,6 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient& http, const String& curren
     if(sketchMD5.length() != 0) {
         http.addHeader("x-ESP32-sketch-md5", sketchMD5);
     }
-
-    delay(1);  // Fix solo WDT
-
     // Add also a SHA256
     String sketchSHA256 = getSketchSHA256();
     if(sketchSHA256.length() != 0) {

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -199,6 +199,9 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient& http, const String& curren
     if(sketchMD5.length() != 0) {
         http.addHeader("x-ESP32-sketch-md5", sketchMD5);
     }
+
+    delay(1);  // Fix solo WDT
+
     // Add also a SHA256
     String sketchSHA256 = getSketchSHA256();
     if(sketchSHA256.length() != 0) {

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -352,7 +352,7 @@ size_t UpdateClass::writeStream(Stream &data) {
             bytesToRead = remaining();
         }
 
-        /* 
+        /*
         Init read&timeout counters and try to read, if read failed, increase counter,
         wait 100ms and try to read again. If counter > 300 (30 sec), give up/abort
         */
@@ -377,6 +377,8 @@ size_t UpdateClass::writeStream(Stream &data) {
         if((_bufferLen == remaining() || _bufferLen == SPI_FLASH_SEC_SIZE) && !_writeBuffer())
             return written;
         written += toRead;
+
+        delay(1);  // Fix solo WDT
     }
     return written;
 }


### PR DESCRIPTION
ESP32-Solo without these changes will report below on executing HTTP OTA update:

``` 
E (72016) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
E (72016) task_wdt:  - IDLE0 (CPU 0)
E (72016) task_wdt: Tasks currently running:
E (72016) task_wdt: CPU 0: loopTask
E (72016) task_wdt: Aborting.
abort() was called at PC 0x401641e8 on core 0
```

With these changes HTTP OTA update finish siccesfully.

(Tested with Tasmota on ESP32-Solo-1) 