### PR TITLE
Weaken tinyusb callbacks

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -263,7 +263,7 @@ static tinyusb_endpoints_usage_t tinyusb_endpoints;
 /**
  * @brief Invoked when received GET CONFIGURATION DESCRIPTOR.
  */
-uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
+__attribute__ ((weak)) uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
 {
     //log_d("%u", index);
     return tinyusb_config_descriptor;
@@ -272,7 +272,7 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
 /**
  * @brief Invoked when received GET DEVICE DESCRIPTOR.
  */
-uint8_t const *tud_descriptor_device_cb(void)
+__attribute__ ((weak)) uint8_t const *tud_descriptor_device_cb(void)
 {
     //log_d("");
     return (uint8_t const *)&tinyusb_device_descriptor;
@@ -281,7 +281,7 @@ uint8_t const *tud_descriptor_device_cb(void)
 /**
  * @brief Invoked when received GET STRING DESCRIPTOR request.
  */
-uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+__attribute__ ((weak)) uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 {
     //log_d("%u (0x%x)", index, langid);
     static uint16_t _desc_str[127];


### PR DESCRIPTION
Weaken tinyusb callbacks to allow other libraries to coex with hal library.