### PR TITLE
HTTPClient: Support for Transfer-Encoding headers that specify "identify"

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1264,6 +1264,8 @@ int HTTPClient::handleHeaderResponse()
                     log_d("Transfer-Encoding: %s", transferEncoding.c_str());
                     if(transferEncoding.equalsIgnoreCase("chunked")) {
                         _transferEncoding = HTTPC_TE_CHUNKED;
+                    } else if(transferEncoding.equalsIgnoreCase("identity")) {
+                        _transferEncoding = HTTPC_TE_IDENTITY;
                     } else {
                         return HTTPC_ERROR_ENCODING;
                     }


### PR DESCRIPTION
In [HTTPClient](https://github.com/espressif/arduino-esp32/tree/master/libraries/HTTPClient), if the `Transfer-Encoding` header is set to `identity`, an error (Transfer-Encoding not supported) will occur.

HTTPClient will consider the request as `identity` if the `Transfer-Encoding` header is not set. But it is also defined a response with `identity` explicitly set in the `Transfer-Encoding` header (ref:[MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding)).

This pull request will allow the request to be processed normally even when `identity` is explicitly set. Please consider this fix.
