### PR TITLE
[WiFiClient] Default connection timeout, when no timeout provided

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -279,7 +279,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, int32_t timeout)
 
 int WiFiClient::connect(const char *host, uint16_t port)
 {
-    return connect(host,port,-1);
+    return connect(host,port,WIFI_CLIENT_DEF_CONN_TIMEOUT);
 }
 int WiFiClient::connect(const char *host, uint16_t port, int32_t timeout)
 {

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -23,6 +23,7 @@
 #include <lwip/netdb.h>
 #include <errno.h>
 
+#define WIFI_CLIENT_DEF_CONN_TIMEOUT  (3)
 #define WIFI_CLIENT_MAX_WRITE_RETRY   (10)
 #define WIFI_CLIENT_SELECT_TIMEOUT_US (1000000)
 #define WIFI_CLIENT_FLUSH_BUFFER_SIZE (1024)
@@ -207,7 +208,7 @@ void WiFiClient::stop()
 
 int WiFiClient::connect(IPAddress ip, uint16_t port)
 {
-    return connect(ip,port,-1);
+    return connect(ip,port,WIFI_CLIENT_DEF_CONN_TIMEOUT);
 }
 int WiFiClient::connect(IPAddress ip, uint16_t port, int32_t timeout)
 {


### PR DESCRIPTION
## The problem
WiFiClient's connect method variant where no timeout is passed can block esp32 MCU and may then cause watchdog to kick in and reset the device. This behavior is different from that, what is in arduino-esp8266 core.

## Summary
Some cross-esp libraries (working both on esp32 and 8266), like PubSubClient simply call connect method on WiFiClient, to get connected to remote server. However, connect behavior varies betwen esp arduino 8266 and esp arduino 32 cores. This pull request tries introduce same behavior - to make connect method non-blocking on esp32, like it is with 8266 arduino core.

## Proposed solution
Introduce default fixed timeout that can be changed by #define - by default set to 3 seconds.

### Affected components: 
WiFiClient

### Affected methods:
```c++ 
int connect(IPAddress ip, uint16_t port);
int connect(const char *host, uint16_t port);
```

### Impact
May impact projects or libraries using connect method variant without specified timeout, where:
- remote is located far away or
- connection is heavily limited, or
- remote is slow, when it comes to accept the connection