### PR TITLE
Increase default timeout for WiFiClient from 3ms to 3s

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -23,10 +23,10 @@
 #include <lwip/netdb.h>
 #include <errno.h>
 
-#define WIFI_CLIENT_DEF_CONN_TIMEOUT  (3)
-#define WIFI_CLIENT_MAX_WRITE_RETRY   (10)
-#define WIFI_CLIENT_SELECT_TIMEOUT_US (1000000)
-#define WIFI_CLIENT_FLUSH_BUFFER_SIZE (1024)
+#define WIFI_CLIENT_DEF_CONN_TIMEOUT_MS  (3000)
+#define WIFI_CLIENT_MAX_WRITE_RETRY      (10)
+#define WIFI_CLIENT_SELECT_TIMEOUT_US    (1000000)
+#define WIFI_CLIENT_FLUSH_BUFFER_SIZE    (1024)
 
 #undef connect
 #undef write
@@ -208,9 +208,9 @@ void WiFiClient::stop()
 
 int WiFiClient::connect(IPAddress ip, uint16_t port)
 {
-    return connect(ip,port,WIFI_CLIENT_DEF_CONN_TIMEOUT);
-}
-int WiFiClient::connect(IPAddress ip, uint16_t port, int32_t timeout)
+    return connect(ip,port,WIFI_CLIENT_DEF_CONN_TIMEOUT_MS);
+   }
+   int WiFiClient::connect(IPAddress ip, uint16_t port, int32_t timeout   )
 {
     int sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0) {
@@ -279,9 +279,9 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, int32_t timeout)
 
 int WiFiClient::connect(const char *host, uint16_t port)
 {
-    return connect(host,port,WIFI_CLIENT_DEF_CONN_TIMEOUT);
-}
-int WiFiClient::connect(const char *host, uint16_t port, int32_t timeout)
+    return connect(host,port,WIFI_CLIENT_DEF_CONN_TIMEOUT_MS);
+   }
+   int WiFiClient::connect(const char *host, uint16_t port, int32_t timeout   )
 {
     IPAddress srv((uint32_t)0);
     if(!WiFiGenericClass::hostByName(host, srv)){


### PR DESCRIPTION
## Summary
https://github.com/espressif/arduino-esp32/pull/5487 introduced a default timeout for WiFiClient, however the default was specified in milliseconds instead of seconds, see https://github.com/espressif/arduino-esp32/commit/be84c8219c251210afd87cac71b8ef3527b601b3#commitcomment-54358731
This 3ms timeout breaks OTA when the processor is busy.

## Impact
Sets the default to a saner value, fixes OTA.
