### PR TITLE
Fix issue #5506 "WebServer serveStatic () can cause LoadProhibited ex…

### DIFF
--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -69,7 +69,7 @@ public:
     , _cache_header(cache_header)
     {
         _isFile = fs.exists(path);
-        log_v("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header);
+        log_v("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header ? cache_header : ""); // issue 5506 - cache_header can be nullptr
         _baseUriLength = _uri.length();
     }
 


### PR DESCRIPTION
…ception in _svfprintf_r"

"Using a Core Debug Level of Verbose and the WebServer serveStatic() function with the default value of nullptr for its cache_header argument, results in a LoadProhibited exception in _svfprintf_r().
This is because serveStatic() calls log_v() with cache_header corresponding to a "%s" in its format but without checking that cache_header is not nullptr, and then logv() (indirectly) calls _svfprintf_r().
On the other hand, with a Core Debug Level other than Verbose, this does not occur."

Changed serveStatic() to check the value of cache_header and if it is nullptr, instead pass an empty string to log_v().

----------------------------------------------------------------------------------------------------------------------------------------------------
This entire section can be deleted if all items are checked.

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist

1. [x] Please provide specific title of the PR describing the change, including the component name (eg."Update of Documentation link on Readme.md")
2. [x] Please provide related links (eg. Issue, other Project, submodule PR..)
----------------------------------------------------------------------------------------------------------------------------------------------------

## Summary
Fix issue #5506 "WebServer serveStatic () can cause LoadProhibited exception in _svfprintf_r"

## Impact
This change adds null-ness checking to the cache_header argument in WebServer::serveStatic() before passing it to log_v(). If it is null, it passes an empty string ("") instead of nullptr. The only intended/expected impact is to prevent a LoadProhibited exception in _svfprintf_r when serveStatic() is called with a nullptr value for its argument cache_header, which for example, occurs when the default value for cache_header is used.
