### PR TITLE
Add SparkFun ESP32 MicroMod microcontroller

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2309,6 +2309,144 @@ sparkfun_esp32s2_thing_plus.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 
+esp32micromod.name=SparkFun ESP32 MicroMod
+
+esp32micromod.upload.tool=esptool_py
+esp32micromod.upload.maximum_size=1310720
+esp32micromod.upload.maximum_data_size=327680
+esp32micromod.upload.wait_for_upload_port=true
+
+esp32micromod.serial.disableDTR=true
+esp32micromod.serial.disableRTS=true
+
+esp32micromod.build.mcu=esp32
+esp32micromod.build.core=esp32
+esp32micromod.build.variant=esp32micromod
+esp32micromod.build.board=ESP32_MICROMOD
+
+esp32micromod.build.f_cpu=240000000L
+esp32micromod.build.flash_size=4MB
+esp32micromod.build.flash_freq=40m
+esp32micromod.build.flash_mode=dio
+esp32micromod.build.boot=dio
+esp32micromod.build.partitions=default
+esp32micromod.build.defines=
+
+esp32micromod.menu.PSRAM.disabled=Disabled
+esp32micromod.menu.PSRAM.disabled.build.defines=
+esp32micromod.menu.PSRAM.enabled=Enabled
+esp32micromod.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+
+esp32micromod.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+esp32micromod.menu.PartitionScheme.default.build.partitions=default
+esp32micromod.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+esp32micromod.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+esp32micromod.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+esp32micromod.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32micromod.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32micromod.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+esp32micromod.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32micromod.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+esp32micromod.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32micromod.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32micromod.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+esp32micromod.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+esp32micromod.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+esp32micromod.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+esp32micromod.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+esp32micromod.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+esp32micromod.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+esp32micromod.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+esp32micromod.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+esp32micromod.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+esp32micromod.menu.PartitionScheme.huge_app.build.partitions=huge_app
+esp32micromod.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+esp32micromod.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+esp32micromod.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32micromod.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32micromod.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FAT)
+esp32micromod.menu.PartitionScheme.fatflash.build.partitions=ffat
+esp32micromod.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+esp32micromod.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
+esp32micromod.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+esp32micromod.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+esp32micromod.menu.CPUFreq.240=240MHz (WiFi/BT)
+esp32micromod.menu.CPUFreq.240.build.f_cpu=240000000L
+esp32micromod.menu.CPUFreq.160=160MHz (WiFi/BT)
+esp32micromod.menu.CPUFreq.160.build.f_cpu=160000000L
+esp32micromod.menu.CPUFreq.80=80MHz (WiFi/BT)
+esp32micromod.menu.CPUFreq.80.build.f_cpu=80000000L
+esp32micromod.menu.CPUFreq.40=40MHz (40MHz XTAL)
+esp32micromod.menu.CPUFreq.40.build.f_cpu=40000000L
+esp32micromod.menu.CPUFreq.26=26MHz (26MHz XTAL)
+esp32micromod.menu.CPUFreq.26.build.f_cpu=26000000L
+esp32micromod.menu.CPUFreq.20=20MHz (40MHz XTAL)
+esp32micromod.menu.CPUFreq.20.build.f_cpu=20000000L
+esp32micromod.menu.CPUFreq.13=13MHz (26MHz XTAL)
+esp32micromod.menu.CPUFreq.13.build.f_cpu=13000000L
+esp32micromod.menu.CPUFreq.10=10MHz (40MHz XTAL)
+esp32micromod.menu.CPUFreq.10.build.f_cpu=10000000L
+
+esp32micromod.menu.FlashMode.qio=QIO
+esp32micromod.menu.FlashMode.qio.build.flash_mode=dio
+esp32micromod.menu.FlashMode.qio.build.boot=qio
+esp32micromod.menu.FlashMode.dio=DIO
+esp32micromod.menu.FlashMode.dio.build.flash_mode=dio
+esp32micromod.menu.FlashMode.dio.build.boot=dio
+esp32micromod.menu.FlashMode.qout=QOUT
+esp32micromod.menu.FlashMode.qout.build.flash_mode=dout
+esp32micromod.menu.FlashMode.qout.build.boot=qout
+esp32micromod.menu.FlashMode.dout=DOUT
+esp32micromod.menu.FlashMode.dout.build.flash_mode=dout
+esp32micromod.menu.FlashMode.dout.build.boot=dout
+
+esp32micromod.menu.FlashFreq.80=80MHz
+esp32micromod.menu.FlashFreq.80.build.flash_freq=80m
+esp32micromod.menu.FlashFreq.40=40MHz
+esp32micromod.menu.FlashFreq.40.build.flash_freq=40m
+
+esp32micromod.menu.FlashSize.4M=4MB (32Mb)
+esp32micromod.menu.FlashSize.4M.build.flash_size=4MB
+esp32micromod.menu.FlashSize.8M=8MB (64Mb)
+esp32micromod.menu.FlashSize.8M.build.flash_size=8MB
+esp32micromod.menu.FlashSize.8M.build.partitions=default_8MB
+esp32micromod.menu.FlashSize.2M=2MB (16Mb)
+esp32micromod.menu.FlashSize.2M.build.flash_size=2MB
+esp32micromod.menu.FlashSize.2M.build.partitions=minimal
+esp32micromod.menu.FlashSize.16M=16MB (128Mb)
+esp32micromod.menu.FlashSize.16M.build.flash_size=16MB
+
+esp32micromod.menu.UploadSpeed.921600=921600
+esp32micromod.menu.UploadSpeed.921600.upload.speed=921600
+esp32micromod.menu.UploadSpeed.115200=115200
+esp32micromod.menu.UploadSpeed.115200.upload.speed=115200
+esp32micromod.menu.UploadSpeed.256000.windows=256000
+esp32micromod.menu.UploadSpeed.256000.upload.speed=256000
+esp32micromod.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32micromod.menu.UploadSpeed.230400=230400
+esp32micromod.menu.UploadSpeed.230400.upload.speed=230400
+esp32micromod.menu.UploadSpeed.460800.linux=460800
+esp32micromod.menu.UploadSpeed.460800.macosx=460800
+esp32micromod.menu.UploadSpeed.460800.upload.speed=460800
+esp32micromod.menu.UploadSpeed.512000.windows=512000
+esp32micromod.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32micromod.menu.DebugLevel.none=None
+esp32micromod.menu.DebugLevel.none.build.code_debug=0
+esp32micromod.menu.DebugLevel.error=Error
+esp32micromod.menu.DebugLevel.error.build.code_debug=1
+esp32micromod.menu.DebugLevel.warn=Warn
+esp32micromod.menu.DebugLevel.warn.build.code_debug=2
+esp32micromod.menu.DebugLevel.info=Info
+esp32micromod.menu.DebugLevel.info.build.code_debug=3
+esp32micromod.menu.DebugLevel.debug=Debug
+esp32micromod.menu.DebugLevel.debug.build.code_debug=4
+esp32micromod.menu.DebugLevel.verbose=Verbose
+esp32micromod.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 sparkfun_lora_gateway_1-channel.name=SparkFun LoRa Gateway 1-Channel
 
 sparkfun_lora_gateway_1-channel.upload.tool=esptool_py

--- a/variants/esp32micromod/pins_arduino.h
+++ b/variants/esp32micromod/pins_arduino.h
@@ -1,0 +1,74 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+#define TX1  17
+#define RX1  16
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+static const uint8_t I2C_INT = 4;
+
+static const uint8_t SDA1 = 26;
+static const uint8_t SCL1 = 25;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 34;
+static const uint8_t A1 = 35;
+static const uint8_t BATT_VIN = 39;
+
+static const uint8_t PWM0 = 13;
+static const uint8_t PWM1 = 12;
+
+static const uint8_t D0 = 14;
+static const uint8_t D1 = 27;
+
+static const uint8_t G0 = 15;
+static const uint8_t G1 = 25;
+static const uint8_t G2 = 26;
+static const uint8_t G3 = 17;
+static const uint8_t G4 = 16;
+static const uint8_t G5 = 32;
+static const uint8_t G6 = 33;
+
+
+
+static const uint8_t AUD_OUT = 17;
+static const uint8_t AUD_IN = 16;
+static const uint8_t AUD_LRCLK = 25;
+static const uint8_t AUD_BCLK = 26;
+
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+static const uint8_t LED_BUILTIN = 2;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Summary
Adds support for the [SparkFun ESP32 MicroMod microcontroller board](https://www.sparkfun.com/products/16781). Adds the relevant section to `boards.txt` and adds an `esp32micromod` folder with the proper `pins_arduino.h` to the `variants` folder.

Feedback is requested! I'm not sure if there's anything else required to add support for this microcontroller; let me know what needs doing and I'll figure out how to do it!

## Impact
Allows users to compile code properly for the ESP32 MicroMod without having to use a similar board and manually entering pin numbers.

## Links
- [SparkFun Product Page](https://www.sparkfun.com/products/16781)
- [SparkFun Software Setup Guide](https://learn.sparkfun.com/tutorials/micromod-esp32-processor-board-hookup-guide/software-setup-and-programming)
- [SparkFun Board Manager JSON](https://raw.githubusercontent.com/sparkfun/Arduino_Boards/main/IDE_Board_Manager/package_sparkfun_index.json
)
- (From the JSON link above) [SparkFun Board Support Tarball](https://github.com/sparkfun/Arduino_Boards/raw/main/IDE_Board_Manager/sparkfun-esp32-1.0.1.tar.bz2) -- where the information for `boards.txt` and `variants/esp32micromod/pins_arduino.h` comes from
- [Issue on PlatformIO requesting support](https://github.com/platformio/platform-espressif32/issues/521) where I commented with how to get it working manually by modifying files locally
- [PR adding support for the ESP32 MicroMod to PlatformIO](https://github.com/platformio/platform-espressif32/pull/605) -- also from me, basically translating the relevant part of `boards.txt` into the JSON file PlatformIO needs to have the board settings