### PR TITLE
Add string constructor and concat routines taking explicit length args

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -35,6 +35,12 @@ String::String(const char *cstr) {
         copy(cstr, strlen(cstr));
 }
 
+String::String(const char *cstr, unsigned int length) {
+    init();
+    if (cstr)
+        copy(cstr, length);
+}
+
 String::String(const String &value) {
     init();
     *this = value;

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -711,10 +711,7 @@ String String::substring(unsigned int left, unsigned int right) const {
         return out;
     if(right > len())
         right = len();
-    char temp = buffer()[right];  // save the replaced character
-    wbuffer()[right] = '\0';
-    out = wbuffer() + left;  // pointer arithmetic
-    wbuffer()[right] = temp;  //restore character
+    out.copy(buffer() + left, right - left);
     return out;
 }
 

--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -55,6 +55,7 @@ class String {
         // fails, the string will be marked as invalid (i.e. "if (s)" will
         // be false).
         String(const char *cstr = "");
+        String(const char *cstr, unsigned int length);
         String(const String &str);
         String(const __FlashStringHelper *str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__

--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -110,6 +110,7 @@ class String {
         unsigned char concat(const String &str);
         unsigned char concat(const char *cstr);
         unsigned char concat(const char *cstr, unsigned int length);
+        unsigned char concat(const uint8_t *cstr, unsigned int length) {return concat((const char*)cstr, length);}
         unsigned char concat(char c);
         unsigned char concat(unsigned char c);
         unsigned char concat(int num);

--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -108,6 +108,7 @@ class String {
         // concatenation is considered unsuccessful.
         unsigned char concat(const String &str);
         unsigned char concat(const char *cstr);
+        unsigned char concat(const char *cstr, unsigned int length);
         unsigned char concat(char c);
         unsigned char concat(unsigned char c);
         unsigned char concat(int num);
@@ -326,7 +327,6 @@ class String {
         void init(void);
         void invalidate(void);
         unsigned char changeBuffer(unsigned int maxStrLen);
-        unsigned char concat(const char *cstr, unsigned int length);
 
         // copy and move
         String & copy(const char *cstr, unsigned int length);

--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -56,6 +56,9 @@ class String {
         // be false).
         String(const char *cstr = "");
         String(const char *cstr, unsigned int length);
+#ifdef __GXX_EXPERIMENTAL_CXX0X__
+        String(const uint8_t *cstr, unsigned int length) : String((const char*)cstr, length) {}
+#endif
         String(const String &str);
         String(const __FlashStringHelper *str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__


### PR DESCRIPTION
## Summary
Applies the upstream changes here: https://github.com/arduino/ArduinoCore-API/compare/3b88acac8%5E...0d83f1afc3367037dbde5323c2abd0ae1bd2c583

## Impact
Adds new String convenience methods that are now available in the mainline Arduino implementation, simplifying interoperability with C code that uses pointer+length strings rather than 0-termination. Also includes a change to avoid mutating the source string when taking a substring.