### PR TITLE
BLEServer.cpp Fix: Crash on MTU change if m_pServerCallbacks not set.

### DIFF
--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -157,7 +157,9 @@ void BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t 
 
 		case ESP_GATTS_MTU_EVT:
 			updatePeerMTU(param->mtu.conn_id, param->mtu.mtu);
-			m_pServerCallbacks->onMtuChanged(this, param);
+			if (m_pServerCallbacks != nullptr) {
+				m_pServerCallbacks->onMtuChanged(this, param);
+			}
 			break;
 
 		// ESP_GATTS_CONNECT_EVT


### PR DESCRIPTION
## Summary

Fix this issue: https://github.com/espressif/arduino-esp32/issues/5573

To reproduce:
1. Run any sample code that starts a BLE server, and does not call `setCallbacks`.
2. Connect to the device using the "LightBlue" app on iOS.
3. Observe crash shown in the issue linked above.

## Impact
I'm not sure how often the MTU is updated, but the bug should cause a crash in any BLEServer instance, where `setCallbacks` was not called, if the MTU changes.

## Note

I haven't actually built and ran this locally, because I haven't had time to setup for local development. The change is tiny, and very simple, but it's probably always worth testing before merging.