### PR TITLE
SD_MMC max_freq_khz is set to HIGHSPEED by default

### DIFF
--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -46,7 +46,7 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount
     sdmmc_host_t host;
     host.flags = SDMMC_HOST_FLAG_4BIT;
     host.slot = SDMMC_HOST_SLOT_1;
-    host.max_freq_khz = SDMMC_FREQ_DEFAULT;
+    host.max_freq_khz = SDMMC_FREQ_HIGHSPEED;
     host.io_voltage = 3.3f;
     host.init = &sdmmc_host_init;
     host.set_bus_width = &sdmmc_host_set_bus_width;
@@ -58,7 +58,6 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount
     host.io_int_enable = &sdmmc_host_io_int_enable;
     host.io_int_wait = &sdmmc_host_io_int_wait;
     host.command_timeout_ms = 0;
-    host.max_freq_khz = SDMMC_FREQ_HIGHSPEED;
 #ifdef BOARD_HAS_1BIT_SDMMC
     mode1bit = true;
 #endif


### PR DESCRIPTION
## Summary
I noticed that `max_freq_khz` was set twice to different values; I picked the last one. I made a fix because previously `SDMMC_FREQ_DEFAULT` was used in the host initialization, and some users elsewhere suggest lowering `SDMMC_FREQ_DEFAULT` from 20_000 to 5_000. Now it's clearly seen that changing `SDMMC_FREQ_DEFAULT` won't affect the initialization of an SD card with the SD_MMC driver.

## Impact
It has no impact other than improving code clarity.

------

BTW, I don't understand why `host` initialization has been changed from
```c
    sdmmc_host_t host = {
        .flags = SDMMC_HOST_FLAG_4BIT,
        .slot = SDMMC_HOST_SLOT_1,
        .max_freq_khz = SDMMC_FREQ_DEFAULT,
        .io_voltage = 3.3f,
        .init = &sdmmc_host_init,
        .set_bus_width = &sdmmc_host_set_bus_width,
        .get_bus_width = &sdmmc_host_get_slot_width,
        .set_bus_ddr_mode = &sdmmc_host_set_bus_ddr_mode,
        .set_card_clk = &sdmmc_host_set_card_clk,
        .do_transaction = &sdmmc_host_do_transaction,
        .deinit = &sdmmc_host_deinit,
        .io_int_enable = &sdmmc_host_io_int_enable,
        .io_int_wait = &sdmmc_host_io_int_wait,
        .command_timeout_ms = 0
    };
```
to
```c
    sdmmc_host_t host;
    host.flags = SDMMC_HOST_FLAG_4BIT;
    host.slot = SDMMC_HOST_SLOT_1;
    host.max_freq_khz = SDMMC_FREQ_DEFAULT;
    host.io_voltage = 3.3f;
    host.init = &sdmmc_host_init;
    host.set_bus_width = &sdmmc_host_set_bus_width;
    host.get_bus_width = &sdmmc_host_get_slot_width;
    host.set_bus_ddr_mode = &sdmmc_host_set_bus_ddr_mode;
    host.set_card_clk = &sdmmc_host_set_card_clk;
    host.do_transaction = &sdmmc_host_do_transaction;
    host.deinit_p = &sdspi_host_remove_device;
    host.io_int_enable = &sdmmc_host_io_int_enable;
    host.io_int_wait = &sdmmc_host_io_int_wait;
    host.command_timeout_ms = 0;
```
The first one is more informative, clear, and concise.