### PR TITLE
Append '/' to an URL with empty path in HTTPClient::begin

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -262,8 +262,8 @@ bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
 
     index = url.indexOf('/');
     if (index == -1) {
-        log_e("the path of url must not be empty");
-        return false;
+        index = url.length();
+        url += '/';
     }
     String host = url.substring(0, index);
     url.remove(0, index); // remove host part

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -261,6 +261,10 @@ bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
     url.remove(0, (index + 3)); // remove http:// or https://
 
     index = url.indexOf('/');
+    if (index == -1) {
+        log_e("the path of url must not be empty");
+        return false;
+    }
     String host = url.substring(0, index);
     url.remove(0, index); // remove host part
 


### PR DESCRIPTION
## Summary

Append '/' to an URL with empty path in HTTPClient::begin. For example, `http.begin("http://example.com")` is the same as `http.begin("http://example.com/")`.

~Add an error check for empty path of HTTPClient::begin. For example, `http.begin("http://example.com")` returns false because the path of it is empty (`http.begin("http://example.com/")` returns true).~

RFC2616 and RFC2396 say this url is invalid. Furthermore, most servers return `400 Bad Request`.