### PR TITLE
[HWCDC] Improve HW CDC Implementation

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -57,13 +57,6 @@ esp32c3.menu.CDCOnBoot.default.build.cdc_on_boot=0
 esp32c3.menu.CDCOnBoot.cdc=Enabled
 esp32c3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 
-esp32c3.menu.UploadMode.default=UART0
-esp32c3.menu.UploadMode.default.upload.use_1200bps_touch=false
-esp32c3.menu.UploadMode.default.upload.wait_for_upload_port=false
-esp32c3.menu.UploadMode.cdc=Internal USB
-esp32c3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-esp32c3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-
 esp32c3.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 esp32c3.menu.PartitionScheme.default.build.partitions=default
 esp32c3.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -187,6 +187,10 @@ void HWCDC::flush(void)
     }
     UBaseType_t uxItemsWaiting = 0;
     vRingbufferGetInfo(tx_ring_buf, NULL, NULL, NULL, NULL, &uxItemsWaiting);
+    if(uxItemsWaiting){
+        // Now trigger the ISR to read data from the ring buffer.
+        usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
+    }
     while(uxItemsWaiting){
         delay(5);
         vRingbufferGetInfo(tx_ring_buf, NULL, NULL, NULL, NULL, &uxItemsWaiting);

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -17,13 +17,37 @@
 #if CONFIG_IDF_TARGET_ESP32C3
 
 #include <inttypes.h>
+#include "esp_event.h"
 #include "Stream.h"
+
+ESP_EVENT_DECLARE_BASE(ARDUINO_HW_CDC_EVENTS);
+
+typedef enum {
+    ARDUINO_HW_CDC_ANY_EVENT = ESP_EVENT_ANY_ID,
+    ARDUINO_HW_CDC_CONNECTED_EVENT = 0,
+    ARDUINO_HW_CDC_BUS_RESET_EVENT,
+    ARDUINO_HW_CDC_RX_EVENT,
+    ARDUINO_HW_CDC_TX_EVENT,
+    ARDUINO_HW_CDC_MAX_EVENT,
+} arduino_hw_cdc_event_t;
+
+typedef union {
+    struct {
+            size_t len;
+    } rx;
+    struct {
+            size_t len;
+    } tx;
+} arduino_hw_cdc_event_data_t;
 
 class HWCDC: public Stream
 {
 public:
     HWCDC();
     ~HWCDC();
+
+    void onEvent(esp_event_handler_t callback);
+    void onEvent(arduino_hw_cdc_event_t event, esp_event_handler_t callback);
 
     size_t setRxBufferSize(size_t);
     size_t setTxBufferSize(size_t);

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -27,6 +27,7 @@ public:
 
     size_t setRxBufferSize(size_t);
     size_t setTxBufferSize(size_t);
+    void setTxTimeoutMs(uint32_t timeout);
     void begin(unsigned long baud=0);
     void end();
     

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -368,13 +368,9 @@ void uartSetDebug(uart_t* uart)
 {
     if(uart == NULL || uart->num >= SOC_UART_NUM) {
         s_uart_debug_nr = -1;
-        //ets_install_putc1(NULL);
-        //return;
-    } else
-    if(s_uart_debug_nr == uart->num) {
-        return;
-    } else
-    s_uart_debug_nr = uart->num;
+    } else {
+        s_uart_debug_nr = uart->num;
+    }
     uart_install_putc();
 }
 


### PR DESCRIPTION
This pull request contains a few fixes and improvements to the HWCDC implementation.
- Rework `HWCDC::write()` to accept unlimited data
- Add Semaphore to guard the TX Ring Buffer
- Add events support
- Remove unnecessary 1200bps touch for flashing over HWCDC
- Fix `HardwareSerial::setDebugOutput()` not resetting `putc` if the port is already selected, causing debug output to also show on HWCDC even when not selected.