### PR TITLE
fix off-by-one error in cores/esp32/libb64/cdecode.c

### DIFF
--- a/cores/esp32/libb64/cdecode.c
+++ b/cores/esp32/libb64/cdecode.c
@@ -12,7 +12,7 @@ static int base64_decode_value_signed(int8_t value_in){
   static const int8_t decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
   static const int8_t decoding_size = sizeof(decoding);
   value_in -= 43;
-  if (value_in < 0 || value_in > decoding_size) return -1;
+  if (value_in < 0 || value_in >= decoding_size) return -1;
   return decoding[(int)value_in];
 }
 


### PR DESCRIPTION
This commit fixes a logic error / off-by-one error in [cores/esp32/libb64/cdecode.c at lines 15+16](https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/libb64/cdecode.c#L15).
An if-condition bounds the value of 'value_in' which is used for array-indexing.

The array is 80 elements long, and the if-condition checks if value_in < 0 || value_in > decoding_size (80).

However accessing an array at index sizeof(array) is invalid - the condition should have been 'value_in < 0 || value_in >= decoding_size' instead.

```C
   11	static int base64_decode_value_signed(int8_t value_in){
   12	  static const int8_t decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
   13	  static const int8_t decoding_size = sizeof(decoding);
   14	  value_in -= 43;
   15	  if (value_in < 0 || value_in > decoding_size) return -1; // <-- condition should be 'value_in >= decoding_size'
   16	  return decoding[(int)value_in];
   17	}
```
