### PR TITLE
Arduino component build process fixed

### DIFF
--- a/cores/esp32/IPAddress.h
+++ b/cores/esp32/IPAddress.h
@@ -91,6 +91,6 @@ public:
     friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0, 0, 0, 0);
+// const IPAddress INADDR_NONE(0, 0, 0, 0);
 
 #endif

--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -288,7 +288,7 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
             break;
 #endif
 
-#if ESP_IDF_VERSION_MAJOR > 4 && ESP_IDF_VERSION_MINOR > 3 
+#if ((ESP_IDF_VERSION_MAJOR >= 4) && (ESP_IDF_VERSION_MINOR > 3))
         case ETH_PHY_KSZ8081:
             eth_phy = esp_eth_phy_new_ksz8081(&phy_config);
             break;

--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -287,8 +287,12 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
             eth_phy = esp_eth_phy_new_dm9051(&phy_config);
             break;
 #endif
+
+#if ESP_IDF_VERSION_MAJOR > 4 && ESP_IDF_VERSION_MINOR > 3 
         case ETH_PHY_KSZ8081:
             eth_phy = esp_eth_phy_new_ksz8081(&phy_config);
+            break;
+#endif
         default:
             break;
     }


### PR DESCRIPTION
## Summary
* esp_eth_phy_new_ksz8081 call issue fixed, which was leading to build process error with error "error: 'esp_eth_phy_new_ksz8081' was not declared in this scope"
* INADDR_NONE const variable name conflict resolved in IPAdrdress.h module 

## Impact
This PR will allow other users to easily compile their ESP-IDF projects with arduino as a component
