### PR TITLE
Enable progress bar on ArduinoOTA upload (platform.txt)

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -10,7 +10,7 @@ tools.esptool_py.cmd=esptool
 tools.esptool_py.cmd.linux=esptool.py
 tools.esptool_py.cmd.windows=esptool.exe
 
-tools.esptool_py.network_cmd=python "{runtime.platform.path}/tools/espota.py"
+tools.esptool_py.network_cmd=python "{runtime.platform.path}/tools/espota.py" -r
 tools.esptool_py.network_cmd.windows="{runtime.platform.path}/tools/espota.exe"
 
 tools.gen_esp32part.cmd=python "{runtime.platform.path}/tools/gen_esp32part.py"

--- a/platform.txt
+++ b/platform.txt
@@ -11,7 +11,7 @@ tools.esptool_py.cmd.linux=esptool.py
 tools.esptool_py.cmd.windows=esptool.exe
 
 tools.esptool_py.network_cmd=python "{runtime.platform.path}/tools/espota.py" -r
-tools.esptool_py.network_cmd.windows="{runtime.platform.path}/tools/espota.exe"
+tools.esptool_py.network_cmd.windows="{runtime.platform.path}/tools/espota.exe" -r
 
 tools.gen_esp32part.cmd=python "{runtime.platform.path}/tools/gen_esp32part.py"
 tools.gen_esp32part.cmd.windows="{runtime.platform.path}/tools/gen_esp32part.exe"

--- a/tools/espota.py
+++ b/tools/espota.py
@@ -41,7 +41,7 @@ import random
 FLASH = 0
 SPIFFS = 100
 AUTH = 200
-PROGRESS = True
+PROGRESS = False
 # update_progress() : Displays or updates a console progress bar
 ## Accepts a float between 0 and 1. Any int will be converted to a float.
 ## A value under 0 represents a 'halt'.
@@ -305,7 +305,7 @@ def parser(unparsed_args):
     dest = "progress",
     help = "Show progress output. Does not work for ArduinoIDE",
     action = "store_true",
-    default = True
+    default = False
   )
   group.add_option("-t", "--timeout",
     dest = "timeout",

--- a/tools/espota.py
+++ b/tools/espota.py
@@ -41,7 +41,7 @@ import random
 FLASH = 0
 SPIFFS = 100
 AUTH = 200
-PROGRESS = False
+PROGRESS = True
 # update_progress() : Displays or updates a console progress bar
 ## Accepts a float between 0 and 1. Any int will be converted to a float.
 ## A value under 0 represents a 'halt'.
@@ -305,7 +305,7 @@ def parser(unparsed_args):
     dest = "progress",
     help = "Show progress output. Does not work for ArduinoIDE",
     action = "store_true",
-    default = False
+    default = True
   )
   group.add_option("-t", "--timeout",
     dest = "timeout",


### PR DESCRIPTION
See #5656

## Summary
Enabling the progress bar on OTA upload.

## Impact
Instead of showing
`Uploading...........................................................................................`
and nothing when finished, a progress bar is shown:
`Uploading: [============================================================] 100% Done...`
