### PR TITLE
Fixes boards.txt entries for the atmegazero_esp32s2, and also the pla…

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -9386,19 +9386,32 @@ atmegazero_esp32s2.build.core=esp32
 atmegazero_esp32s2.build.variant=atmegazero_esp32s2
 atmegazero_esp32s2.build.board=atmegazero_esp32s2
 
+atmegazero_esp32s2.build.cdc_on_boot=1
+atmegazero_esp32s2.build.msc_on_boot=0
+atmegazero_esp32s2.build.dfu_on_boot=0
 atmegazero_esp32s2.build.serial=0
 atmegazero_esp32s2.build.f_cpu=240000000L
-atmegazero_esp32s2.build.flash_size=4MB
-atmegazero_esp32s2.build.flash_freq=80m
+atmegazero_esp32s2.build.flash_size=16MB
+atmegazero_esp32s2.build.flash_freq=40m
 atmegazero_esp32s2.build.flash_mode=qio
 atmegazero_esp32s2.build.boot=qio
 atmegazero_esp32s2.build.partitions=default
 atmegazero_esp32s2.build.defines=
 
-atmegazero_esp32s2.menu.SerialMode.cdc=USB CDC
-atmegazero_esp32s2.menu.SerialMode.cdc.build.serial=1
-atmegazero_esp32s2.menu.SerialMode.default=UART0
-atmegazero_esp32s2.menu.SerialMode.default.build.serial=0
+atmegazero_esp32s2.menu.CDCOnBoot.cdc=Enabled
+atmegazero_esp32s2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+atmegazero_esp32s2.menu.CDCOnBoot.default=Disabled
+atmegazero_esp32s2.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+atmegazero_esp32s2.menu.MSCOnBoot.default=Disabled
+atmegazero_esp32s2.menu.MSCOnBoot.default.build.msc_on_boot=0
+atmegazero_esp32s2.menu.MSCOnBoot.msc=Enabled
+atmegazero_esp32s2.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+atmegazero_esp32s2.menu.DFUOnBoot.default=Disabled
+atmegazero_esp32s2.menu.DFUOnBoot.default.build.dfu_on_boot=0
+atmegazero_esp32s2.menu.DFUOnBoot.dfu=Enabled
+atmegazero_esp32s2.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
 atmegazero_esp32s2.menu.PSRAM.disabled=Disabled
 atmegazero_esp32s2.menu.PSRAM.disabled.build.defines=

--- a/platform.txt
+++ b/platform.txt
@@ -172,7 +172,7 @@ recipe.size.regex.data=^(?:\.dram0\.data|\.dram0\.bss|\.noinit)\s+([0-9]+).*
 tools.esptool_py.upload.protocol=esp32
 tools.esptool_py.upload.params.verbose=
 tools.esptool_py.upload.params.quiet=
-tools.esptool_py.upload.pattern_args=--chip {build.mcu} --port "{serial.port}" --baud {upload.speed} {upload.flags} --before default_reset --after hard_reset write_flash -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size detect 0xe000 "{runtime.platform.path}/tools/partitions/boot_app0.bin" {build.bootloader_addr} "{build.path}/{build.project_name}.bootloader.bin" 0x10000 "{build.path}/{build.project_name}.bin" 0x8000 "{build.path}/{build.project_name}.partitions.bin" {upload.extra_flags}
+tools.esptool_py.upload.pattern_args=--chip {build.mcu} --port "{serial.port}" --baud {upload.speed} {upload.flags} --before default_reset --after hard_reset write_flash -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} 0xe000 "{runtime.platform.path}/tools/partitions/boot_app0.bin" {build.bootloader_addr} "{build.path}/{build.project_name}.bootloader.bin" 0x10000 "{build.path}/{build.project_name}.bin" 0x8000 "{build.path}/{build.project_name}.partitions.bin" {upload.extra_flags}
 tools.esptool_py.upload.pattern="{path}/{cmd}" {upload.pattern_args}
 tools.esptool_py.upload.pattern.linux=python "{path}/{cmd}" {upload.pattern_args}
 tools.esptool_py.upload.network_pattern={network_cmd} -i "{serial.port}" -p "{network.port}" "--auth={network.password}" -f "{build.path}/{build.project_name}.bin"


### PR DESCRIPTION
## Summary
This PR fixes the compiling issue with the ATMegaZero ESP32-S2 board.  I had entered some values wrong in the boards.txt definition for this board but I fixed them in this PR.

I'm also having issues compiling because of the `-flash-size detect` flag which is not respecting the flash-size entered in the boards.txt file and instead is auto-detecting the size of memory on the board. This will fail on the ATMegaZero since this board comes with 32MB of Flash memory but at the moment we are only using 16MB due to esptool.py limitations.

## Impact
It will fix the atmegazero_esp32s2 board, which is affecting a lot of our users who want to use Arduino vs CircuitPython.
