### PR TITLE
Return size_t instead of uint8_t from BLECharacteristic::getLength().…

### DIFF
--- a/libraries/BLE/src/BLECharacteristic.cpp
+++ b/libraries/BLE/src/BLECharacteristic.cpp
@@ -191,7 +191,7 @@ uint8_t* BLECharacteristic::getData() {
  * @brief Retrieve the current length of the data of the characteristic.
  * @return Amount of databytes of the characteristic.
  */
-uint8_t BLECharacteristic::getLength() {
+size_t BLECharacteristic::getLength() {
 	return m_value.getLength();
 } // getLength
 

--- a/libraries/BLE/src/BLECharacteristic.h
+++ b/libraries/BLE/src/BLECharacteristic.h
@@ -62,7 +62,7 @@ public:
 	BLEUUID        getUUID();
 	std::string    getValue();
 	uint8_t*       getData();
-	uint8_t        getLength();
+	size_t         getLength();
 
 	void indicate();
 	void notify(bool is_notification = true);


### PR DESCRIPTION
…  Allows large MTU to be used.
