### PR TITLE
SDMMC frequency selection based on board type

### DIFF
--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -36,7 +36,7 @@ SDMMCFS::SDMMCFS(FSImplPtr impl)
     : FS(impl), _card(NULL)
 {}
 
-bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount_failed)
+bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount_failed, int sdmmc_frequency)
 {
     if(_card) {
         return true;
@@ -46,7 +46,7 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount
     sdmmc_host_t host;
     host.flags = SDMMC_HOST_FLAG_4BIT;
     host.slot = SDMMC_HOST_SLOT_1;
-    host.max_freq_khz = SDMMC_FREQ_DEFAULT;
+    host.max_freq_khz = sdmmc_frequency;
     host.io_voltage = 3.3f;
     host.init = &sdmmc_host_init;
     host.set_bus_width = &sdmmc_host_set_bus_width;
@@ -58,7 +58,6 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount
     host.io_int_enable = &sdmmc_host_io_int_enable;
     host.io_int_wait = &sdmmc_host_io_int_wait;
     host.command_timeout_ms = 0;
-    host.max_freq_khz = SDMMC_FREQ_HIGHSPEED;
 #ifdef BOARD_HAS_1BIT_SDMMC
     mode1bit = true;
 #endif

--- a/libraries/SD_MMC/src/SD_MMC.h
+++ b/libraries/SD_MMC/src/SD_MMC.h
@@ -21,6 +21,13 @@
 #include "driver/sdmmc_types.h"
 #include "sd_defines.h"
 
+// If reading/writing to the SD card is unstable, 
+// you can define BOARD_MAX_SDMMC_FREQ with lower value (Ex. SDMMC_FREQ_DEFAULT) 
+// in pins_arduino.h for your board variant.
+#ifndef BOARD_MAX_SDMMC_FREQ
+#define BOARD_MAX_SDMMC_FREQ SDMMC_FREQ_HIGHSPEED
+#endif
+
 namespace fs
 {
 
@@ -31,11 +38,7 @@ protected:
 
 public:
     SDMMCFS(FSImplPtr impl);
-#ifdef ETH_CAN_INTERFERE_WITH_SDMMC
-    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false, int sdmmc_frequency=SDMMC_FREQ_DEFAULT);
-#else
-    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false, int sdmmc_frequency=SDMMC_FREQ_HIGHSPEED);
-#endif
+    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false, int sdmmc_frequency=BOARD_MAX_SDMMC_FREQ);
     void end();
     sdcard_type_t cardType();
     uint64_t cardSize();

--- a/libraries/SD_MMC/src/SD_MMC.h
+++ b/libraries/SD_MMC/src/SD_MMC.h
@@ -31,7 +31,11 @@ protected:
 
 public:
     SDMMCFS(FSImplPtr impl);
-    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false);
+#ifdef ETH_CAN_INTERFERE_WITH_SDMMC
+    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false, int sdmmc_frequency=SDMMC_FREQ_DEFAULT);
+#else
+    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false, int sdmmc_frequency=SDMMC_FREQ_HIGHSPEED);
+#endif
     void end();
     sdcard_type_t cardType();
     uint64_t cardSize();

--- a/variants/esp32-evb/pins_arduino.h
+++ b/variants/esp32-evb/pins_arduino.h
@@ -29,5 +29,6 @@ static const uint8_t MISO  = 15;
 static const uint8_t SCK   = 14;
 
 #define BOARD_HAS_1BIT_SDMMC
+#define ETH_CAN_INTERFERE_WITH_SDMMC
 
 #endif /* Pins_Arduino_h */

--- a/variants/esp32-evb/pins_arduino.h
+++ b/variants/esp32-evb/pins_arduino.h
@@ -29,6 +29,6 @@ static const uint8_t MISO  = 15;
 static const uint8_t SCK   = 14;
 
 #define BOARD_HAS_1BIT_SDMMC
-#define ETH_CAN_INTERFERE_WITH_SDMMC
+#define BOARD_MAX_SDMMC_FREQ SDMMC_FREQ_DEFAULT
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
On Olimex ESP32 EVB I/O operations with SD card can cause error when LAN is used in same time.
Problem is disappearing if SD MMC frequency lower down from SDMMC_FREQ_HIGHSPEED to SDMMC_FREQ_DEFAULT.

No problem if WiFi used instead LAN.

For issue https://github.com/espressif/arduino-esp32/issues/5682
