### PR TITLE
Fix analogWidth for ESP32S2 in esp32-hal-adc.c

### DIFF
--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -46,7 +46,11 @@ static uint8_t __analogVRefPin = 0;
 #endif
 
 static uint8_t __analogAttenuation = 3;//11db
+#if CONFIG_IDF_TARGET_ESP32
 static uint8_t __analogWidth = 3;//12 bits
+#elif CONFIG_IDF_TARGET_ESP32S2
+static uint8_t __analogWidth = 4;   // 13 bits
+#endif
 static uint8_t __analogClockDiv = 1;
 static adc_attenuation_t __pin_attenuation[SOC_GPIO_PIN_COUNT];
 

--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -37,7 +37,7 @@ static uint8_t __analogVRefPin = 0;
 #include "soc/rtc_io_reg.h"
 #elif CONFIG_IDF_TARGET_ESP32C3
 #include "esp32c3/rom/ets_sys.h"
-#else 
+#else
 #error Target CONFIG_IDF_TARGET is not supported
 #endif
 #else // ESP32 Before IDF 4.0
@@ -46,10 +46,10 @@ static uint8_t __analogVRefPin = 0;
 #endif
 
 static uint8_t __analogAttenuation = 3;//11db
-#if CONFIG_IDF_TARGET_ESP32
-static uint8_t __analogWidth = 3;//12 bits
-#elif CONFIG_IDF_TARGET_ESP32S2
-static uint8_t __analogWidth = 4;   // 13 bits
+#if CONFIG_IDF_TARGET_ESP32S2
+static uint8_t __analogWidth = 4; // 13 bits
+#else
+static uint8_t __analogWidth = 3; // 12 bits
 #endif
 static uint8_t __analogClockDiv = 1;
 static adc_attenuation_t __pin_attenuation[SOC_GPIO_PIN_COUNT];


### PR DESCRIPTION
## Summary
Potential fix for #5691 and #5658.

## Impact
Sets a different default value for `analogWidth` in `esp32-hal-adc.c` for ESP32S2 based boards. This fixes issue with performing `analogRead` on that platform.

Test sketch run on an [Adafruit FunHouse](https://www.adafruit.com/product/4985) which has an analog light sensor attached to `A3`:
```cpp
void setup() {
  Serial.begin(9600);
}

void loop() {
  Serial.println(analogRead(A3));
  delay(100);
}
``` 

![Screenshot from 2021-09-27 08-35-21](https://user-images.githubusercontent.com/8755041/134940787-7f68039a-0fbd-4003-b805-dfe4bfc182b6.png)

