### PR TITLE
ESP32S2 Fix analogRead of adc2 channels

### DIFF
--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -46,7 +46,11 @@ static uint8_t __analogVRefPin = 0;
 #endif
 
 static uint8_t __analogAttenuation = 3;//11db
+#if CONFIG_IDF_TARGET_ESP32S2
+static uint8_t __analogWidth = 4;//13 bits
+#else
 static uint8_t __analogWidth = 3;//12 bits
+#endif
 static uint8_t __analogClockDiv = 1;
 static adc_attenuation_t __pin_attenuation[SOC_GPIO_PIN_COUNT];
 


### PR DESCRIPTION
See also #5658 " [ESP32-S2] analogRead(A10) WIDTH ERR #5658" and #5671 "ESP32-S2 analogRead function not returning correct value"
