### PR TITLE
include pin_arduino.h for variant USB defines

### DIFF
--- a/cores/esp32/USB.cpp
+++ b/cores/esp32/USB.cpp
@@ -15,6 +15,7 @@
 
 #if CONFIG_TINYUSB_ENABLED
 
+#include "pins_arduino.h"
 #include "esp32-hal.h"
 #include "esp32-hal-tinyusb.h"
 #include "common/tusb_common.h"


### PR DESCRIPTION
## Summary

add `pin_arduino.h` include in core's USB.cpp. This allows macro defined by variant e.g USB_VID, USB_PID to be used correct per board.

## Impact

Correct the USB defines such as VID/PID, manufacturer in usb descriptor. Following is `lsusb` output with Adafruit Metro ESP32-S2 board before and after the PR

Before

```
Bus 003 Device 094: ID 303a:0002 Espressif Systems METRO_ESP32S2
```

After

```
Bus 003 Device 096: ID 239a:80df Adafruit Metro ESP32-S2
```

@ladyada 