### PR TITLE
Optimized getErrorText() in Wire.cpp library

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -340,37 +340,30 @@ uint8_t TwoWire::lastError()
     return (uint8_t)last_error;
 }
 
-const char ERRORTEXT[] =
-    "OK\0"
-    "DEVICE\0"
-    "ACK\0"
-    "TIMEOUT\0"
-    "BUS\0"
-    "BUSY\0"
-    "MEMORY\0"
-    "CONTINUE\0"
-    "NO_BEGIN\0"
-    "\0";
+const char *const ERROR_TEXT[] = {
+    "OK",
+    "DEVICE",
+    "ACK",
+    "TIMEOUT",
+    "BUS",
+    "BUSY",
+    "MEMORY",
+    "CONTINUE",
+    "NO_BEGIN"
+};
 
-
-char * TwoWire::getErrorText(uint8_t err)
+const char *TwoWire::getErrorText(uint8_t error_number)
 {
-    uint8_t t = 0;
-    bool found = false;
-    char * message = (char*)&ERRORTEXT;
+    const char *message = NULL;
+    const uint8_t ERROR_TEXT_SIZE = sizeof(ERROR_TEXT) / sizeof(*ERROR_TEXT);
 
-    while(!found && message[0]) {
-        found = t == err;
-        if(!found) {
-            message = message + strlen(message) + 1;
-            t++;
-        }
-    }
-    if(!found) {
+    if (error_number >= ERROR_TEXT_SIZE)
+    {
         return NULL;
-    } else {
-        return message;
     }
+
+    message = ERROR_TEXT[error_number];
+    return message;
 }
 
 /*stickbreaker Dump i2c Interrupt buffer, i2c isr Debugging

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -83,7 +83,7 @@ public:
     uint16_t getTimeOut();
 
     uint8_t lastError();
-    char * getErrorText(uint8_t err);
+    const char * getErrorText(uint8_t err);
 
     //@stickBreaker for big blocks and ISR model
     i2c_err_t writeTransmission(uint16_t address, uint8_t* buff, uint16_t size, bool sendStop=true);


### PR DESCRIPTION
ERRORTEXT string was converted to an array of strings. Each substring is now an independent array element. That provides faster and more reliable execution w/o weird pointer arithmetic.

Original code in x86_64 assembly
<img width="534" alt="original" src="https://user-images.githubusercontent.com/8713394/135272340-2e30f218-624a-47e9-8822-df16fd8e7ca3.png">

Optimized code in x68_64 assembly
<img width="525" alt="optimized" src="https://user-images.githubusercontent.com/8713394/135272330-51786a33-019b-406c-93ac-34821f82c54a.png">
