### PR TITLE
Added comment for user clarity in SDWebserver example

### DIFF
--- a/libraries/WebServer/examples/SDWebServer/SDWebServer.ino
+++ b/libraries/WebServer/examples/SDWebServer/SDWebServer.ino
@@ -25,6 +25,8 @@
   index.htm is the default index (works on subfolders as well)
 
   upload the contents of SdRoot to the root of the SDcard and access the editor by going to http://esp8266sd.local/edit
+  To retrieve the contents of SDcard, visit http://esp32sd.local/list?dir=/
+      dir is the argument that needs to be passed to the function PrintDirectory via HTTP Get request.
 
 */
 #include <WiFi.h>


### PR DESCRIPTION
## Summary
Struggled myself trying to access content on SD card with SDWebserver.ino example, finally figured that I need to pass argument via HTTP Get request. Added that in the comment section of the example to increase user clarity.

## Impact
Improved comment and usage clarity of an example.
