### PR TITLE
Fix: SD_MMC deinit

### DIFF
--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -75,7 +75,7 @@ FileImplPtr VFSImpl::open(const char* fpath, const char* mode, const bool create
 
         while (token != NULL)
         {
-            memccpy(folder,fpath + start_index, NULL, end_index-start_index);
+            memcpy(folder,fpath + start_index, end_index-start_index);
             folder[end_index-start_index] = '\0';
             
             if(!VFSImpl::mkdir(folder))

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -75,7 +75,7 @@ FileImplPtr VFSImpl::open(const char* fpath, const char* mode, const bool create
 
         while (token != NULL)
         {
-            memcpy(folder,fpath + start_index, end_index-start_index);
+            memccpy(folder,fpath + start_index, NULL, end_index-start_index);
             folder[end_index-start_index] = '\0';
             
             if(!VFSImpl::mkdir(folder))

--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -54,7 +54,7 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount
     host.set_bus_ddr_mode = &sdmmc_host_set_bus_ddr_mode;
     host.set_card_clk = &sdmmc_host_set_card_clk;
     host.do_transaction = &sdmmc_host_do_transaction;
-    host.deinit_p = &sdspi_host_remove_device;
+    host.deinit = &sdmmc_host_deinit;
     host.io_int_enable = &sdmmc_host_io_int_enable;
     host.io_int_wait = &sdmmc_host_io_int_wait;
     host.command_timeout_ms = 0;


### PR DESCRIPTION
## Summary
Fixed wrong deinit called in SD_MMC lib. The SD_MMC deinit was callid SPI deinit instead of MMC deinit.

Issue #5195 

## Impact
No impact.
