### PR TITLE
Fix build error when compiling with verbose logging

### DIFF
--- a/libraries/USB/src/USBVendor.cpp
+++ b/libraries/USB/src/USBVendor.cpp
@@ -40,8 +40,8 @@ uint16_t tusb_vendor_load_descriptor(uint8_t * dst, uint8_t * itf)
 }
 
 void tud_vendor_rx_cb(uint8_t itf){
-    log_v("%u", len);
     size_t len = tud_vendor_n_available(itf);
+    log_v("%u", len);
     if(len){
         uint8_t buffer[len];
         len = tud_vendor_n_read(itf, buffer, len);


### PR DESCRIPTION
## Summary
When compiling with verbose logging, the build would error with a message saying `len` is not defined in `tud_vendor_rx_cb()`. This pull request fixes the error.

## Impact
You can now build the project with verbose logging :) Other than this - no impact.