### PR TITLE
Add missing custom menu item to boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -15,6 +15,7 @@ menu.LORAWAN_REGION=LoRaWan Region
 menu.LoRaWanDebugLevel=LoRaWan Debug Level
 menu.LoopCore=Arduino Runs On
 menu.EventsCore=Events Run On
+menu.SerialMode=Serial Mode
 
 ##############################################################
 ### DO NOT PUT BOARDS ABOVE THE OFFICIAL ESPRESSIF BOARDS! ###


### PR DESCRIPTION
# Summary
Recent version of arduino-cli (e.g. 1.9.x) currently have an issue parsing the boards.txt file. The can be seen by running something like `arduino-cli board list`, which results in the following error when using the 2.0.0 version of boards.txt:

```
Error initializing instance: loading platform release esp32:esp32@2.0.0: loading boards: skipping loading of boards esp32:esp32:deneyapmini, esp32:esp32:atmegazero_esp32s2: malformed custom board options
```

This is because the two boards mentioned use a custom menu item that has not yet been defined. This commit fixes that by adding the missing `menu.SerialMode`

# Impact

This change corrects an omission in `boards.txt` that results in a malformed custom menu definition. As a result, the board definitions for excluded items are parseable.