### PR TITLE
Remove `_user_defined_size` from `EEPROMClass` and `EEPROM::length()` just returns `_size`

### DIFF
--- a/libraries/EEPROM/examples/eeprom_class/eeprom_class.ino
+++ b/libraries/EEPROM/examples/eeprom_class/eeprom_class.ino
@@ -11,27 +11,27 @@
 #include "EEPROM.h"
 
 // Instantiate eeprom objects with parameter/argument names and sizes
-EEPROMClass  NAMES("eeprom0", 0x500);
-EEPROMClass  HEIGHT("eeprom1", 0x200);
-EEPROMClass  AGE("eeprom2", 0x100);
+EEPROMClass  NAMES("eeprom0");
+EEPROMClass  HEIGHT("eeprom1");
+EEPROMClass  AGE("eeprom2");
 
 void setup() {
   Serial.begin(115200);
   delay(1000);
   Serial.println("Testing EEPROMClass\n");
-  if (!NAMES.begin(NAMES.length())) {
+  if (!NAMES.begin(0x500)) {
     Serial.println("Failed to initialise NAMES");
     Serial.println("Restarting...");
     delay(1000);
     ESP.restart();
   }
-  if (!HEIGHT.begin(HEIGHT.length())) {
+  if (!HEIGHT.begin(0x200)) {
     Serial.println("Failed to initialise HEIGHT");
     Serial.println("Restarting...");
     delay(1000);
     ESP.restart();
   }
-  if (!AGE.begin(AGE.length())) {
+  if (!AGE.begin(0x100)) {
     Serial.println("Failed to initialise AGE");
     Serial.println("Restarting...");
     delay(1000);

--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -34,7 +34,6 @@ EEPROMClass::EEPROMClass(void)
   , _size(0)
   , _dirty(false)
   , _name("eeprom")
-  , _user_defined_size(0)
 {
 }
 
@@ -45,17 +44,15 @@ EEPROMClass::EEPROMClass(uint32_t sector)
   , _size(0)
   , _dirty(false)
   , _name("eeprom")
-  , _user_defined_size(0)
 {
 }
 
-EEPROMClass::EEPROMClass(const char* name, uint32_t user_defined_size)
+EEPROMClass::EEPROMClass(const char* name)
   : _handle(0)
   , _data(0)
   , _size(0)
   , _dirty(false)
   , _name(name)
-  , _user_defined_size(user_defined_size)
 {
 }
 
@@ -215,7 +212,7 @@ uint8_t * EEPROMClass::getDataPtr() {
 */
 uint16_t EEPROMClass::length ()
 {
-  return _user_defined_size;
+  return _size;
 }
 
 /* 

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -35,7 +35,7 @@ typedef uint32_t nvs_handle;
 class EEPROMClass {
   public:
     EEPROMClass(uint32_t sector);
-    EEPROMClass(const char* name, uint32_t user_defined_size);
+    EEPROMClass(const char* name);
     EEPROMClass(void);
     ~EEPROMClass(void);
 
@@ -112,7 +112,6 @@ class EEPROMClass {
     size_t _size;
     bool _dirty;
     const char* _name;
-    uint32_t _user_defined_size;
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_EEPROM)


### PR DESCRIPTION
## Summary

Related to the issue #5773 and #2280.

- `_user_defined_size` is removed from `EEPROMClass` because it is redundant in the current code
- `EEPROMClass::length()` returns `_size` that is the true available size of EEPROM

## Impact

- `_user_defined_size` is removed from `EEPROMClass`
- `EEPROMClass::length()` returns `_size` that is the true available size of EEPROM