### PR TITLE
removes deprecated esp_eth_set_default_handlers()

### DIFF
--- a/libraries/WiFi/src/ETH.cpp
+++ b/libraries/WiFi/src/ETH.cpp
@@ -237,12 +237,6 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
     esp_netif_t *eth_netif = esp_netif_new(&cfg);
 
-    if(esp_eth_set_default_handlers(eth_netif) != ESP_OK){
-        log_e("esp_eth_set_default_handlers failed");
-        return false;
-    }
-    
-    
     esp_eth_mac_t *eth_mac = NULL;
 #if CONFIG_ETH_SPI_ETHERNET_DM9051
     if(type == ETH_PHY_DM9051){


### PR DESCRIPTION
## Summary
closes #5794 

esp_eth_clear_default_handlers() is deprecated in latest IDF 4.4

## Impact
None