### PR TITLE
log statement missing parameter #5778

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -133,7 +133,7 @@ bool EEPROMClass::begin(size_t size) {
 
   _data = (uint8_t*) malloc(size);
   if(!_data) {
-    log_e("Not enough memory for %d bytes in EEPROM");
+    log_e("Not enough memory for %d bytes in EEPROM", size);
     return false;
   }
   _size = size;


### PR DESCRIPTION
## Summary
Fixes #5778 
Very simple bug - missing parameter in log_e()

## Impact
None - bug fix.