### PR TITLE
Update FTM_Initiator.ino: solving *"wifi:channel=0 is invalid"*

### DIFF
--- a/libraries/WiFi/examples/FTM/FTM_Initiator/FTM_Initiator.ino
+++ b/libraries/WiFi/examples/FTM/FTM_Initiator/FTM_Initiator.ino
@@ -48,7 +48,7 @@ void onFtmReport(arduino_event_t *event) {
 
 // Initiate FTM Session and wait for FTM Report
 bool getFtmReport(){
-  if(!WiFi.initiateFTM(FTM_FRAME_COUNT, FTM_BURST_PERIOD)){
+  if(!WiFi.initiateFTM(FTM_FRAME_COUNT, FTM_BURST_PERIOD,1)){
     Serial.println("FTM Error: Initiate Session Failed");
     return false;
   }


### PR DESCRIPTION
Using the vanilla code I got an error:

*"wifi:channel=0 is invalid"*

Looking up the arguments passed to *initiateFTM* [here](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFiGeneric.h) I found that the default channel is indeed 0, which apperently is not valid. I hence passed the channel argument to be 1, which solved the issue for me.

----------------------------------------------------------------------------------------------------------------------------------------------------
This entire section can be deleted if all items are checked.

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist

1. [ ] Please provide specific title of the PR describing the change, including the component name (eg."Update of Documentation link on Readme.md")
2. [ ] Please provide related links (eg. Issue, other Project, submodule PR..)
----------------------------------------------------------------------------------------------------------------------------------------------------

## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.
