### PR TITLE
Solving "wifi:channel=0 is invalid" when using FTM example code by adjusting default channel in WiFiGeneric.h

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -172,7 +172,7 @@ class WiFiGenericClass
     bool setTxPower(wifi_power_t power);
     wifi_power_t getTxPower();
 
-    bool initiateFTM(uint8_t frm_count=16, uint16_t burst_period=2, uint8_t channel=0, const uint8_t * mac=NULL);
+    bool initiateFTM(uint8_t frm_count=16, uint16_t burst_period=2, uint8_t channel=1, const uint8_t * mac=NULL);
 
     static const char * getHostname();
     static bool setHostname(const char * hostname);


### PR DESCRIPTION
When using the [FTM examples])https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFi/examples/FTM/) I got an error in the Serial Monitor for FTM_Initiator.ino:

*"wifi:channel=0 is invalid"*

I solved it for myself by simply passing the channel argument to be 1 in *WiFi.initiateFTM*. However, a better fix would be to directly change the default channel [here](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFiGeneric.h).


## Summary
channel=0 seems to be invalid for initiateFTM, i.e. we get the error message "wifi:channel=0 is invalid". The proposed fix changes the default channel in initiateFTM from 0 to 1.

## Impact
The example codes for FTM will work out of the box ;)
