### PR TITLE
Change sntp default update interval to 6 hours.

### DIFF
--- a/tools/sdk/esp32/include/lwip/lwip/src/include/lwip/apps/sntp_opts.h
+++ b/tools/sdk/esp32/include/lwip/lwip/src/include/lwip/apps/sntp_opts.h
@@ -165,10 +165,10 @@
 #endif
 
 /** SNTP update delay - in milliseconds
- * Default is 1 hour. Must not be beolw 60 seconds by specification (i.e. 60000)
+ * Default is 6 hours. Must not be below 60 seconds by specification (i.e. 60000)
  */
 #if !defined SNTP_UPDATE_DELAY || defined __DOXYGEN__
-#define SNTP_UPDATE_DELAY           3600000
+#define SNTP_UPDATE_DELAY           3600000 * 6
 #endif
 
 /** SNTP macro to get system time, used with SNTP_CHECK_RESPONSE >= 2


### PR DESCRIPTION
## Summary
Change sntp default update interval from 1 to 6 hours.

## Impact
This PR aims at reducing the amount of requests sent to the (free as-in-beer and community run) ntp time servers.
The amount of requests for the ntp project should be a a lot less (per esp32) than with the current settings. 

## Rationale
Just from my home network with 5 esp32 controllers there are more than 100 ntp requests per day with the 1 hour update interval. 
The [ntp project](http://www.ntp.org/) is a community run service and open source projects should strive to minimize their impact on this service.
