### PR TITLE
Allow use of log_x() in if

### DIFF
--- a/cores/esp32/esp32-hal-log.h
+++ b/cores/esp32/esp32-hal-log.h
@@ -99,9 +99,9 @@ void log_print_buf(const uint8_t *b, size_t len);
 #define log_buf_v(b,l) do {ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_VERBOSE);}while(0)
 #endif
 #else
-#define log_v(format, ...)
-#define isr_log_v(format, ...)
-#define log_buf_v(b,l)
+#define log_v(format, ...)  do {} while(0)
+#define isr_log_v(format, ...)  do {} while(0)
+#define log_buf_v(b,l)  do {} while(0)
 #endif
 
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
@@ -115,9 +115,9 @@ void log_print_buf(const uint8_t *b, size_t len);
 #define log_buf_d(b,l) do {ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_DEBUG);}while(0)
 #endif
 #else
-#define log_d(format, ...)
-#define isr_log_d(format, ...)
-#define log_buf_d(b,l)
+#define log_d(format, ...)  do {} while(0)
+#define isr_log_d(format, ...) do {} while(0)
+#define log_buf_d(b,l) do {} while(0)
 #endif
 
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
@@ -131,9 +131,9 @@ void log_print_buf(const uint8_t *b, size_t len);
 #define log_buf_i(b,l) do {ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_INFO);}while(0)
 #endif
 #else
-#define log_i(format, ...)
-#define isr_log_i(format, ...)
-#define log_buf_i(b,l)
+#define log_i(format, ...) do {} while(0)
+#define isr_log_i(format, ...) do {} while(0)
+#define log_buf_i(b,l) do {} while(0)
 #endif
 
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_WARN
@@ -147,9 +147,9 @@ void log_print_buf(const uint8_t *b, size_t len);
 #define log_buf_w(b,l) do {ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_WARN);}while(0)
 #endif
 #else
-#define log_w(format, ...)
-#define isr_log_w(format, ...)
-#define log_buf_w(b,l)
+#define log_w(format, ...) do {} while(0)
+#define isr_log_w(format, ...) do {} while(0)
+#define log_buf_w(b,l) do {} while(0)
 #endif
 
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_ERROR
@@ -163,9 +163,9 @@ void log_print_buf(const uint8_t *b, size_t len);
 #define log_buf_e(b,l) do {ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_ERROR);}while(0)
 #endif
 #else
-#define log_e(format, ...)
-#define isr_log_e(format, ...)
-#define log_buf_e(b,l)
+#define log_e(format, ...) do {} while(0)
+#define isr_log_e(format, ...) do {} while(0)
+#define log_buf_e(b,l) do {} while(0)
 #endif
 
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_NONE
@@ -179,9 +179,9 @@ void log_print_buf(const uint8_t *b, size_t len);
 #define log_buf_n(b,l) do {ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_ERROR);}while(0)
 #endif
 #else
-#define log_n(format, ...)
-#define isr_log_n(format, ...)
-#define log_buf_n(b,l)
+#define log_n(format, ...) do {} while(0)
+#define isr_log_n(format, ...) do {} while(0)
+#define log_buf_n(b,l) do {} while(0)
 #endif
 
 #include "esp_log.h"


### PR DESCRIPTION
if (1) log_e("error") produces a warning ("missing braces") and probably wrong code if no log level is defined.
This fixes that.
