### PR TITLE
Support additional authorization schemes

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1188,6 +1188,7 @@ bool HTTPClient::sendHeader(const char * type)
     }
 
     if(_base64Authorization.length()) {
+        _base64Authorization.replace("\n", "");
         header += F("Authorization: ");
         header += _authorizationType; 
         header += " ";

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -464,6 +464,17 @@ void HTTPClient::setAuthorization(const char * auth)
 }
 
 /**
+ * set the Authorization type for the http request
+ * @param authType const char *
+ */
+void HTTPClient::setAuthorizationType(const char * authType)
+{
+    if(authType) {
+        _authorizationType = authType;
+    }
+}
+
+/**
  * set the timeout (ms) for establishing a connection to the server
  * @param connectTimeout int32_t
  */
@@ -1177,8 +1188,9 @@ bool HTTPClient::sendHeader(const char * type)
     }
 
     if(_base64Authorization.length()) {
-        _base64Authorization.replace("\n", "");
-        header += F("Authorization: Basic ");
+        header += F("Authorization: ");
+        header += _authorizationType; 
+        header += " ";
         header += _base64Authorization;
         header += "\r\n";
     }

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -171,6 +171,7 @@ public:
     void setUserAgent(const String& userAgent);
     void setAuthorization(const char * user, const char * password);
     void setAuthorization(const char * auth);
+    void setAuthorizationType(const char * authType);
     void setConnectTimeout(int32_t connectTimeout);
     void setTimeout(uint16_t timeout);
 
@@ -251,6 +252,7 @@ protected:
     String _headers;
     String _userAgent = "ESP32HTTPClient";
     String _base64Authorization;
+    String _authorizationType = "Basic";
 
     /// Response handling
     RequestArgument* _currentHeaders = nullptr;


### PR DESCRIPTION
## Summary
The client always appends "Basic" to the authorization header, however there are other auth schemes that can be used: https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication
For example "Bearer" when using OAuth.
This PR adds a `setAuthorizationType` method to the HTTPClient which allows this scheme to be configured by the caller. Authorization type is set to "Basic" by default so this will have no impact on existing usecases.

## Impact
This PR will allow callers to specify the authorization type when making requests, and will not impact any existing usecases as the default is "Basic".
