### PR TITLE
Add precompiled

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -148,7 +148,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.fla
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" "-Wl,--Map={build.path}/{build.project_name}.map" "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} {build.extra_flags} -Wl,--start-group {object_files} "{archive_file_path}" {compiler.c.elf.libs} -Wl,--end-group -Wl,-EL -o "{build.path}/{build.project_name}.elf"
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" "-Wl,--Map={build.path}/{build.project_name}.map" "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} {build.extra_flags} {compiler.libraries.ldflags} -Wl,--start-group {object_files} "{archive_file_path}" {compiler.c.elf.libs} -Wl,--end-group -Wl,-EL -o "{build.path}/{build.project_name}.elf"
 
 ## Create partitions.bin
 recipe.objcopy.partitions.bin.pattern={tools.gen_esp32part.cmd} -q "{build.path}/partitions.csv" "{build.path}/{build.project_name}.partitions.bin"


### PR DESCRIPTION
Added an option for using precompiled libraries.

Empty if there is no precompilation.

```
compiler.libraries.ldflags=
```

Compiler Message when there is precompilation.

```
Compiling libraries...
Compiling library "aquestalk-esp32"
Library aquestalk-esp32 has been declared precompiled:
Using precompiled library in C:\Users\tanaka\Documents\Arduino\libraries\aquestalk-esp32\src\esp32
```

The precompiler cannot be used because it is not set up now.

----------------------------------------------------------------------------------------------------------------------------------------------------
This entire section can be deleted if all items are checked.

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist

1. [x] Please provide specific title of the PR describing the change, including the component name (eg."Update of Documentation link on Readme.md")
2. [x] Please provide related links (eg. Issue, other Project, submodule PR..)
----------------------------------------------------------------------------------------------------------------------------------------------------

## Summary
Added an option for using precompiled libraries.

## Impact
None. Empty if there is no precompilation.