### PR TITLE
Update / HTTP-Update: Add callback for custom LED initialization and LED function

### DIFF
--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -78,23 +78,17 @@ public:
         _followRedirects = follow;
     }
 
-    void setLedPin(int ledPin = -1, uint8_t ledOn = HIGH)
-    {
-        _ledPin = ledPin;
-        _ledOn = ledOn;
-    }
-
-    t_httpUpdate_return update(WiFiClient& client, const String& url, const String& currentVersion = "");
+    t_httpUpdate_return update(WiFiClient& client, const String& url, const String& currentVersion = "", LED_Init_t on_LED_Init = NULL, LED_Write_t on_LED_Write = NULL);
 
     t_httpUpdate_return update(WiFiClient& client, const String& host, uint16_t port, const String& uri = "/",
-                               const String& currentVersion = "");
+                               const String& currentVersion = "", LED_Init_t on_LED_Init = NULL, LED_Write_t on_LED_Write = NULL);
 
-    t_httpUpdate_return updateSpiffs(WiFiClient& client, const String& url, const String& currentVersion = "");
+    t_httpUpdate_return updateSpiffs(WiFiClient& client, const String& url, const String& currentVersion = "", LED_Init_t on_LED_Init = NULL, LED_Write_t on_LED_Write = NULL);
 
     t_httpUpdate_return update(HTTPClient& httpClient,
-                               const String& currentVersion = "");
+                               const String& currentVersion = "", LED_Init_t on_LED_Init = NULL, LED_Write_t on_LED_Write = NULL);
 
-    t_httpUpdate_return updateSpiffs(HTTPClient &httpClient, const String &currentVersion = "");
+    t_httpUpdate_return updateSpiffs(HTTPClient &httpClient, const String &currentVersion = "", LED_Init_t on_LED_Init = NULL, LED_Write_t on_LED_Write = NULL);
 
     // Notification callbacks
     void onStart(HTTPUpdateStartCB cbOnStart)          { _cbStart = cbOnStart; }
@@ -106,8 +100,8 @@ public:
     String getLastErrorString(void);
 
 protected:
-    t_httpUpdate_return handleUpdate(HTTPClient& http, const String& currentVersion, bool spiffs = false);
-    bool runUpdate(Stream& in, uint32_t size, String md5, int command = U_FLASH);
+    t_httpUpdate_return handleUpdate(HTTPClient& http, const String& currentVersion, bool spiffs = false, LED_Init_t on_LED_Init = NULL, LED_Write_t on_LED_Write = NULL);
+    bool runUpdate(Stream& in, uint32_t size, String md5, int command = U_FLASH, LED_Init_t on_LED_Init = NULL, LED_Write_t on_LED_Write = NULL);
 
     // Set the error and potentially use a CB to notify the application
     void _setLastError(int err) {
@@ -127,9 +121,6 @@ private:
     HTTPUpdateEndCB      _cbEnd;
     HTTPUpdateErrorCB    _cbError;
     HTTPUpdateProgressCB _cbProgress;
-
-    int _ledPin;
-    uint8_t _ledOn;
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_HTTPUPDATE)


### PR DESCRIPTION
----------------------------------------------------------------------------------------------------------------------------------------------------
This entire section can be deleted if all items are checked.

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist

1. [x] Please provide specific title of the PR describing the change, including the component name (eg."Update of Documentation link on Readme.md")
2. [ ] Please provide related links (eg. Issue, other Project, submodule PR..)
----------------------------------------------------------------------------------------------------------------------------------------------------

## Summary
This pull request contains a small modification for the Update and HTTP Update class to add a function as a parameter to toggle a LED during the update. This is i. e. useful when your device doesn´t use an LED that is directly connected with the ESP, for example, an LED that is connected by a port expander.

As an example:
The LED is connected with a port expander in my design

```
void LED_Init(void)
{
    uint8_t Data;

    Wire.begin(SDA, SCL);

    // Configure the pin for the green LED as output
    Wire.beginTransmission(ADDRESS);

    // Configuration register for port 1
    Wire.write(0x07);

    // '1' represents an input
    // '0' represents an output
    Data = 0xFF;
    Data &= ~(0x01 << LED_GREEN);
    Wire.write(Data);
    Wire.endTransmission();
}

// `true` means the HTTP Update will turn on the LED. `false` means the LED should be turned off
// The LED is connected active-low with the port expander. So the signal must be inverted.
void LED_Write(bool Value)
{
    Wire.beginTransmission(ADDRESS);
    Wire.write(PORT_EXPANDER_ADDR_OUTPUT_1);
    Wire.write(!Value << LED_GREEN);
    Wire.endTransmission();
}

HTTPUpdateResult Return = httpUpdate.update(client, ota, "2.0.0", LED_Init, LED_Write);
```

```
void LED_Init(void)
{
   pinMode(LED_GREEN, OUTPUT);
}

void LED_Write(bool Value)
{
    digitalWrite(LED_GREEN, Value);
}

HTTPUpdateResult Return = httpUpdate.update(client, ota, "2.0.0", LED_Init, LED_Write);
```

## Impact
Fix LED assignment is replaced by two function pointers. The default value for these pointers is `NULL`. An issue only occurs when the "old" style is used. But the necessary modifications are very small
