### PR TITLE
cbuf: allow inheritance

### DIFF
--- a/cores/esp32/cbuf.h
+++ b/cores/esp32/cbuf.h
@@ -62,7 +62,7 @@ public:
 
     cbuf *next;
 
-private:
+protected:
     inline char* wrap_if_bufend(char* ptr) const
     {
         return (ptr == _bufend) ? _buf : ptr;


### PR DESCRIPTION
Changes "private" vars to "protected" so that descendants are allowed to access them.
