### PR TITLE
[Docs] Add link to supported soc list on README and ESP32-S3 datasheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You can use [Arduino-ESP32 Online Documentation](https://docs.espressif.com/proj
 * [FAQ](https://docs.espressif.com/projects/arduino-esp32/en/latest/faq.html)
 * [Troubleshooting](https://docs.espressif.com/projects/arduino-esp32/en/latest/troubleshooting.html)
 
+### Supported Chips
+
+Visit the [supported chips](https://docs.espressif.com/projects/arduino-esp32/en/latest/getting_started.html#supported-soc-s) documentation to see the list of current supported ESP32 SoCs.
+
 ### Decoding exceptions
 
 You can use [EspExceptionDecoder](https://github.com/me-no-dev/EspExceptionDecoder) to get meaningful call trace.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -37,7 +37,7 @@ SoC      Stable Development Datasheet
 ESP32    Yes    Yes         `ESP32 Datasheet`_
 ESP32-S2 Yes    Yes         `ESP32-S2 Datasheet`_
 ESP32-C3 Yes    Yes         `ESP32-C3 Datasheet`_
-ESP32-S3 No     No          Not Available Yet
+ESP32-S3 No     No          `ESP32-S3 Datasheet`_
 ======== ====== =========== ===================================
 
 See `Boards <boards/boards.html>`_ for more details about ESP32 development boards.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -122,6 +122,7 @@ Resources
 .. _ESP32 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
 .. _ESP32-S2 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
 .. _ESP32-C3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _ESP32-S3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf
 .. _Arduino.cc: https://www.arduino.cc/en/Main/Software
 .. _Arduino Reference: https://www.arduino.cc/reference/en/
 .. _ESP32 Forum: https://esp32.com


### PR DESCRIPTION
## Summary

Added the link to the supported SoCs on README file.
Added the link to the ESP32-S3 datasheet to the Getting Started page.

Closes: https://github.com/espressif/arduino-esp32/issues/5890

## Impact

None.