### PR TITLE
Fix I2C clock stretching issue with ESP32

### DIFF
--- a/cores/esp32/esp32-hal-i2c-slave.c
+++ b/cores/esp32/esp32-hal-i2c-slave.c
@@ -302,7 +302,7 @@ esp_err_t i2cSlaveInit(uint8_t num, int sda, int scl, uint16_t slaveID, uint32_t
     i2c_ll_slave_init(i2c->dev);
     i2c_ll_set_fifo_mode(i2c->dev, true);
     i2c_ll_set_slave_addr(i2c->dev, slaveID, false);
-    i2c_ll_set_tout(i2c->dev, 32000);
+    i2c_ll_set_tout(i2c->dev, I2C_LL_MAX_TIMEOUT);
     i2c_slave_set_frequency(i2c, frequency);
 
     if (!i2c_slave_check_line_state(sda, scl)) {

--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -24,6 +24,7 @@
 #include "soc/soc_caps.h"
 #include "soc/i2c_periph.h"
 #include "hal/i2c_hal.h"
+#include "hal/i2c_ll.h"
 #include "driver/i2c.h"
 
 typedef volatile struct {
@@ -91,6 +92,8 @@ esp_err_t i2cInit(uint8_t i2c_num, int8_t sda, int8_t scl, uint32_t frequency){
         } else {
             bus[i2c_num].initialized = true;
             bus[i2c_num].frequency = frequency;
+            //Clock Stretching Timeout: 20b:esp32, 5b:esp32-c3, 24b:esp32-s2
+            i2c_set_timeout((i2c_port_t)i2c_num, I2C_LL_MAX_TIMEOUT);
         }
     }
 #if !CONFIG_DISABLE_HAL_LOCKS


### PR DESCRIPTION
It was found that when I2C device is holding the clock LOW, ESP32 master is failing to wait for the clock to be released.

Fixes: https://github.com/espressif/arduino-esp32/issues/5875
Fixes: https://github.com/sparkfun/SparkFun_u-blox_GNSS_Arduino_Library/issues/77