### PR TITLE
using ksz8081 only from ESP-IDF 4.4 onwards

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -282,7 +282,7 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
             break;
 #endif
         case ETH_PHY_KSZ8081:
-#if ESP_IDF_VERSION => ESP_IDF_VERSION_VAL(4,4,0)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4,4,0)
             eth_phy = esp_eth_phy_new_ksz8081(&phy_config);
 #else
             log_e("unsupported ethernet type 'ETH_PHY_KSZ8081'");

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -282,7 +282,7 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
             break;
 #endif
         case ETH_PHY_KSZ8081:
-#if ESP_IDF_VERSION_MAJOR >= 4 && ESP_IDF_VERSION_MINOR >= 4
+#if ESP_IDF_VERSION => ESP_IDF_VERSION_VAL(4,4,0)
             eth_phy = esp_eth_phy_new_ksz8081(&phy_config);
 #else
             log_e("unsupported ethernet type 'ETH_PHY_KSZ8081'");

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -282,7 +282,7 @@ bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_typ
             break;
 #endif
         case ETH_PHY_KSZ8081:
-#if ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(4,3,0)
+#if ESP_IDF_VERSION_MAJOR >= 4 && ESP_IDF_VERSION_MINOR >= 4
             eth_phy = esp_eth_phy_new_ksz8081(&phy_config);
 #else
             log_e("unsupported ethernet type 'ETH_PHY_KSZ8081'");


### PR DESCRIPTION
## Summary
The previous assertion only considerate the existence of ESP-IDF 4.3, but with the ESP-IDF 4.3.1 release this assertion would generate errors. Now only includes from ESP-IDF 4.4 onwards.

## Impact
Now don't generate esp_eth_phy_new_ksz8081 not included error
