### PR TITLE
bugfix: Conflicting declaration error when include<rom/secure_boot.h>  with ESP32S2 or ESP32C3

### DIFF
--- a/tools/sdk/esp32/include/esp_rom/include/esp32c3/rom/secure_boot.h
+++ b/tools/sdk/esp32/include/esp_rom/include/esp32c3/rom/secure_boot.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32/include/esp_rom/include/esp32h2/rom/secure_boot.h
+++ b/tools/sdk/esp32/include/esp_rom/include/esp32h2/rom/secure_boot.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32/include/esp_rom/include/esp32s2/rom/secure_boot.h
+++ b/tools/sdk/esp32/include/esp_rom/include/esp32s2/rom/secure_boot.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32/include/esp_rom/include/esp32s3/rom/secure_boot.h
+++ b/tools/sdk/esp32/include/esp_rom/include/esp32s3/rom/secure_boot.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32c3/include/esp_rom/include/esp32c3/rom/secure_boot.h
+++ b/tools/sdk/esp32c3/include/esp_rom/include/esp32c3/rom/secure_boot.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32c3/include/esp_rom/include/esp32h2/rom/secure_boot.h
+++ b/tools/sdk/esp32c3/include/esp_rom/include/esp32h2/rom/secure_boot.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32c3/include/esp_rom/include/esp32s2/rom/secure_boot.h
+++ b/tools/sdk/esp32c3/include/esp_rom/include/esp32s2/rom/secure_boot.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32c3/include/esp_rom/include/esp32s3/rom/secure_boot.h
+++ b/tools/sdk/esp32c3/include/esp_rom/include/esp32s3/rom/secure_boot.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32s2/include/esp_rom/include/esp32c3/rom/secure_boot.h
+++ b/tools/sdk/esp32s2/include/esp_rom/include/esp32c3/rom/secure_boot.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32s2/include/esp_rom/include/esp32h2/rom/secure_boot.h
+++ b/tools/sdk/esp32s2/include/esp_rom/include/esp32h2/rom/secure_boot.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32s2/include/esp_rom/include/esp32s2/rom/secure_boot.h
+++ b/tools/sdk/esp32s2/include/esp_rom/include/esp32s2/rom/secure_boot.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;

--- a/tools/sdk/esp32s2/include/esp_rom/include/esp32s3/rom/secure_boot.h
+++ b/tools/sdk/esp32s2/include/esp_rom/include/esp32s3/rom/secure_boot.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 struct ets_secure_boot_sig_block;
-struct ets_secure_boot_signature_t;
+struct ets_secure_boot_signature;
 
 typedef struct ets_secure_boot_sig_block ets_secure_boot_sig_block_t;
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;


### PR DESCRIPTION

## Summary
Conflicting declaration error occurs between lines 28 and 31 of file rom/secure_boot.h.
This error can be reproduced by writing # include <esp_efuse.h> and building ESP32S2 or ESP32C3 as the target.

```
#include <esp_efuse.h>
void setup(void) {}
void loop(void) {}
```
```
C:\Users\dummy\AppData\Local\Arduino15\packages\esp32\hardware\esp32\2.0.1/tools/sdk/esp32c3/include/esp_rom/include/esp32c3/rom/secure_boot.h:31:42: error: conflicting declaration 'typedef struct ets_secure_boot_signature ets_secure_boot_signature_t'
 typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Users\dummy\AppData\Local\Arduino15\packages\esp32\hardware\esp32\2.0.1/tools/sdk/esp32c3/include/esp_rom/include/esp32c3/rom/secure_boot.h:28:8: note: previous declaration as 'struct ets_secure_boot_signature_t'
 struct ets_secure_boot_signature_t;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```


## Impact
This problem is caused by the extra _t at the end of the name, as shown below.
```
struct foo_t;
typedef struct foo foo_t;
```

This pull request removes the trailing _t from " struct ets_secure_boot_signature_t; " on line 28.