### PR TITLE
Refactoring TwoWire::requestFrom() headers in Wire.cpp

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -464,7 +464,7 @@ uint8_t TwoWire::requestFrom(uint16_t address, uint8_t quantity, uint8_t sendSto
 /* Added to match the Arduino function definition: https://github.com/arduino/ArduinoCore-API/blob/173e8eadced2ad32eeb93bcbd5c49f8d6a055ea6/api/HardwareI2C.h#L39
  * See: https://github.com/arduino-libraries/ArduinoECCX08/issues/25
 */
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len, bool stopBit)
+uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, bool stopBit)
 {
     return requestFrom((uint16_t)address, (size_t)len, stopBit);
 }

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -445,19 +445,19 @@ void TwoWire::flush(void)
     //i2cFlush(num); // cleanup
 }
 
-size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop)
+size_t TwoWire::requestFrom(uint8_t address, size_t len, bool sendStop)
 {
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop));
 }
   
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len, uint8_t sendStop)
 {
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop));
 }
 
-uint8_t TwoWire::requestFrom(uint16_t address, uint8_t quantity, uint8_t sendStop)
+uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, uint8_t sendStop)
 {
-    return requestFrom(address, static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+    return requestFrom(address, static_cast<size_t>(len), static_cast<bool>(sendStop));
 }
 
 /* Added to match the Arduino function definition: https://github.com/arduino/ArduinoCore-API/blob/173e8eadced2ad32eeb93bcbd5c49f8d6a055ea6/api/HardwareI2C.h#L39
@@ -468,24 +468,24 @@ uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, bool stopBit)
     return requestFrom((uint16_t)address, (size_t)len, stopBit);
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len)
 {
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), true);
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), true);
 }
 
-uint8_t TwoWire::requestFrom(uint16_t address, uint8_t quantity)
+uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len)
 {
-    return requestFrom(address, static_cast<size_t>(quantity), true);
+    return requestFrom(address, static_cast<size_t>(len), true);
 }
 
-uint8_t TwoWire::requestFrom(int address, int quantity)
+uint8_t TwoWire::requestFrom(int address, int len)
 {
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), true);
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), true);
 }
 
-uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)
+uint8_t TwoWire::requestFrom(int address, int len, int sendStop)
 {
-    return static_cast<uint8_t>(requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop)));
+    return static_cast<uint8_t>(requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop)));
 }
 
 void TwoWire::beginTransmission(int address)

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -354,7 +354,7 @@ uint8_t TwoWire::endTransmission(bool sendStop)
     return 4;
 }
 
-uint8_t TwoWire::requestFrom(uint16_t address, uint8_t size, bool sendStop)
+size_t TwoWire::requestFrom(uint16_t address, size_t size, bool sendStop)
 {
     if(is_slave){
         log_e("Bus is in Slave Mode");
@@ -373,7 +373,8 @@ uint8_t TwoWire::requestFrom(uint16_t address, uint8_t size, bool sendStop)
         nonStop = false;
         rxIndex = 0;
         rxLength = 0;
-        err = i2cWriteReadNonStop(num, address, txBuffer, txLength, rxBuffer, size, _timeOutMillis, &rxLength);
+        err = i2cWriteReadNonStop(num, address, txBuffer, txLength, rxBuffer, size, _timeOutMillis, &
+);
     } else {
 #if !CONFIG_DISABLE_HAL_LOCKS
         //acquire lock
@@ -447,40 +448,40 @@ void TwoWire::flush(void)
 
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
 {
-    return requestFrom(static_cast<uint16_t>(address), static_cast<uint8_t>(quantity), static_cast<bool>(sendStop));
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));
 }
 
 uint8_t TwoWire::requestFrom(uint16_t address, uint8_t quantity, uint8_t sendStop)
 {
-    return requestFrom(address, static_cast<uint8_t>(quantity), static_cast<bool>(sendStop));
+    return requestFrom(address, static_cast<size_t>(quantity), static_cast<bool>(sendStop));
 }
 
 /* Added to match the Arduino function definition: https://github.com/arduino/ArduinoCore-API/blob/173e8eadced2ad32eeb93bcbd5c49f8d6a055ea6/api/HardwareI2C.h#L39
  * See: https://github.com/arduino-libraries/ArduinoECCX08/issues/25
 */
-size_t TwoWire::requestFrom(uint8_t address, size_t len, bool stopBit)
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len, bool stopBit)
 {
-    return requestFrom((uint16_t)address, (uint8_t)len, stopBit);
+    return requestFrom((uint16_t)address, (size_t)len, stopBit);
 }
 
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
 {
-    return requestFrom(static_cast<uint16_t>(address), static_cast<uint8_t>(quantity), true);
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), true);
 }
 
 uint8_t TwoWire::requestFrom(uint16_t address, uint8_t quantity)
 {
-    return requestFrom(address, static_cast<uint8_t>(quantity), true);
+    return requestFrom(address, static_cast<size_t>(quantity), true);
 }
 
 uint8_t TwoWire::requestFrom(int address, int quantity)
 {
-    return requestFrom(static_cast<uint16_t>(address), static_cast<uint8_t>(quantity), true);
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), true);
 }
 
 uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)
 {
-    return static_cast<uint8_t>(requestFrom(static_cast<uint16_t>(address), static_cast<uint8_t>(quantity), static_cast<bool>(sendStop)));
+    return static_cast<uint8_t>(requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop)));
 }
 
 void TwoWire::beginTransmission(int address)

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -446,6 +446,11 @@ void TwoWire::flush(void)
     //i2cFlush(num); // cleanup
 }
 
+size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop)
+{
+    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+}
+  
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
 {
     return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -373,7 +373,7 @@ size_t TwoWire::requestFrom(uint16_t address, size_t size, bool sendStop)
         nonStop = false;
         rxIndex = 0;
         rxLength = 0;
-        err = i2cWriteReadNonStop(num, address, txBuffer, txLength, rxBuffer, size, _timeOutMillis, &
+        err = i2cWriteReadNonStop(num, address, txBuffer, txLength, rxBuffer, size, _timeOutMillis, &rxLength
 );
     } else {
 #if !CONFIG_DISABLE_HAL_LOCKS

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -373,8 +373,7 @@ size_t TwoWire::requestFrom(uint16_t address, size_t size, bool sendStop)
         nonStop = false;
         rxIndex = 0;
         rxLength = 0;
-        err = i2cWriteReadNonStop(num, address, txBuffer, txLength, rxBuffer, size, _timeOutMillis, &rxLength
-);
+        err = i2cWriteReadNonStop(num, address, txBuffer, txLength, rxBuffer, size, _timeOutMillis, &rxLength);
     } else {
 #if !CONFIG_DISABLE_HAL_LOCKS
         //acquire lock

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -93,6 +93,7 @@ public:
     uint8_t endTransmission(bool sendStop);
     uint8_t endTransmission(void);
 
+    size_t requestFrom(uint16_t address, size_t size, bool sendStop)
     uint8_t requestFrom(uint16_t address, uint8_t size, bool sendStop);
     uint8_t requestFrom(uint16_t address, uint8_t size, uint8_t sendStop);
     size_t requestFrom(uint8_t address, size_t len, bool stopBit);

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -93,7 +93,7 @@ public:
     uint8_t endTransmission(bool sendStop);
     uint8_t endTransmission(void);
 
-    size_t requestFrom(uint16_t address, size_t size, bool sendStop)
+    size_t requestFrom(uint16_t address, size_t size, bool sendStop);
     uint8_t requestFrom(uint16_t address, uint8_t size, bool sendStop);
     uint8_t requestFrom(uint16_t address, uint8_t size, uint8_t sendStop);
     size_t requestFrom(uint8_t address, size_t len, bool stopBit);


### PR DESCRIPTION
----------------------------------------------------------------------------------------------------------------------------------------------------
This entire section can be deleted if all items are checked.

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist

1. [x] Please provide specific title of the PR describing the change, including the component name (eg."Update of Documentation link on Readme.md")
2. [x] Please provide related links (eg. Issue, other Project, submodule PR..)
----------------------------------------------------------------------------------------------------------------------------------------------------

## Summary
Changing the header so the main TwoWire::requestFrom() definition uses a `size_t` instead of a `uint8_t`, removing the 255 bytes limit on I2C requests.

The esp8266 arduino library for Wire is already using size_t for the function implementation : https://github.com/esp8266/Arduino/blob/076a4edf1e8146ef7420018a0b5b3eadc9acf6af/libraries/Wire/Wire.cpp#L123

This fix is in order to allow us to read 284 bytes, which is necessary for [this project](https://github.com/flaviut/emporia-vue2-reversing/issues/1#issuecomment-980757602).

## Impact
This shouldn't have any impact on existing code using this function.
