### PR TITLE
add board variant for WT32-ETH01 (wt32-eth01) from Wireless-Tag

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -6692,6 +6692,101 @@ wipy3.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
 
+wt32-eth01.name=WT32-ETH01 Ethernet Module
+
+wt32-eth01.upload.tool=esptool_py
+wt32-eth01.upload.maximum_size=8388608
+wt32-eth01.upload.maximum_data_size=327680
+wt32-eth01.upload.flags=
+wt32-eth01.upload.extra_flags=
+
+wt32-eth01.serial.disableDTR=true
+wt32-eth01.serial.disableRTS=true
+
+wt32-eth01.build.tarch=xtensa
+wt32-eth01.build.bootloader_addr=0x1000
+wt32-eth01.build.target=esp32
+wt32-eth01.build.mcu=esp32
+wt32-eth01.build.core=esp32
+wt32-eth01.build.variant=wt32-eth0
+wt32-eth01.build.board=WT32_ETH01
+
+wt32-eth01.build.f_cpu=240000000L
+wt32-eth01.build.flash_size=4MB
+wt32-eth01.build.flash_freq=40m
+wt32-eth01.build.flash_mode=dio
+wt32-eth01.build.boot=dio
+wt32-eth01.build.partitions=default
+wt32-eth01.build.defines=
+wt32-eth01.build.extra_libs=
+
+wt32-eth01.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+wt32-eth01.menu.PartitionScheme.default.build.partitions=default
+wt32-eth01.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+wt32-eth01.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+wt32-eth01.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+wt32-eth01.menu.PartitionScheme.minimal.build.partitions=minimal
+wt32-eth01.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+wt32-eth01.menu.PartitionScheme.no_ota.build.partitions=no_ota
+wt32-eth01.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+wt32-eth01.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+wt32-eth01.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+wt32-eth01.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+wt32-eth01.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+wt32-eth01.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+wt32-eth01.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+wt32-eth01.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+wt32-eth01.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+wt32-eth01.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+wt32-eth01.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+wt32-eth01.menu.PartitionScheme.huge_app.build.partitions=huge_app
+wt32-eth01.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+wt32-eth01.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+wt32-eth01.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+wt32-eth01.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+wt32-eth01.menu.FlashMode.qio=QIO
+wt32-eth01.menu.FlashMode.qio.build.flash_mode=dio
+wt32-eth01.menu.FlashMode.qio.build.boot=qio
+wt32-eth01.menu.FlashMode.dio=DIO
+wt32-eth01.menu.FlashMode.dio.build.flash_mode=dio
+wt32-eth01.menu.FlashMode.dio.build.boot=dio
+
+wt32-eth01.menu.FlashFreq.80=80MHz
+wt32-eth01.menu.FlashFreq.80.build.flash_freq=80m
+wt32-eth01.menu.FlashFreq.40=40MHz
+wt32-eth01.menu.FlashFreq.40.build.flash_freq=40m
+
+wt32-eth01.menu.UploadSpeed.921600=921600
+wt32-eth01.menu.UploadSpeed.921600.upload.speed=921600
+wt32-eth01.menu.UploadSpeed.115200=115200
+wt32-eth01.menu.UploadSpeed.115200.upload.speed=115200
+wt32-eth01.menu.UploadSpeed.256000.windows=256000
+wt32-eth01.menu.UploadSpeed.256000.upload.speed=256000
+wt32-eth01.menu.UploadSpeed.230400.windows.upload.speed=256000
+wt32-eth01.menu.UploadSpeed.230400=230400
+wt32-eth01.menu.UploadSpeed.230400.upload.speed=230400
+wt32-eth01.menu.UploadSpeed.460800.linux=460800
+wt32-eth01.menu.UploadSpeed.460800.macosx=460800
+wt32-eth01.menu.UploadSpeed.460800.upload.speed=460800
+wt32-eth01.menu.UploadSpeed.512000.windows=512000
+wt32-eth01.menu.UploadSpeed.512000.upload.speed=512000
+
+wt32-eth01.menu.DebugLevel.none=None
+wt32-eth01.menu.DebugLevel.none.build.code_debug=0
+wt32-eth01.menu.DebugLevel.error=Error
+wt32-eth01.menu.DebugLevel.error.build.code_debug=1
+wt32-eth01.menu.DebugLevel.warn=Warn
+wt32-eth01.menu.DebugLevel.warn.build.code_debug=2
+wt32-eth01.menu.DebugLevel.info=Info
+wt32-eth01.menu.DebugLevel.info.build.code_debug=3
+wt32-eth01.menu.DebugLevel.debug=Debug
+wt32-eth01.menu.DebugLevel.debug.build.code_debug=4
+wt32-eth01.menu.DebugLevel.verbose=Verbose
+wt32-eth01.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 bpi-bit.name=BPI-BIT
 
 bpi-bit.upload.tool=esptool_py

--- a/variants/wt32-eth01/pins_arduino.h
+++ b/variants/wt32-eth01/pins_arduino.h
@@ -1,0 +1,55 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+/**
+ * Variant: WT32-ETH01
+ * Vendor: Wireless-Tag
+ * Url: http://www.wireless-tag.com/portfolio/wt32-eth01/
+ */
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS 40
+#define NUM_ANALOG_INPUTS 16
+
+#define analogInputToDigitalPin(p) (((p) < 20) ? (esp32_adc2gpio[(p)]) : -1)
+#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < 34)
+
+// interface to Ethernet PHY (LAN8720A)
+#define ETH_PHY_ADDR 1
+#define ETH_PHY_POWER 16
+#define ETH_PHY_MDC 23
+#define ETH_PHY_MDIO 18
+#define ETH_PHY_TYPE ETH_PHY_LAN8720
+#define ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
+
+// general purpose IO pins
+static const uint8_t IO0 = 0;
+static const uint8_t IO1 = 1; // TXD0 / TX0 pin
+static const uint8_t IO2 = 2;
+static const uint8_t IO3 = 3; // RXD0 / RX0 pin
+static const uint8_t IO4 = 4;
+static const uint8_t IO5 = 5; // RXD2 / RXD pin
+static const uint8_t IO12 = 12;
+static const uint8_t IO14 = 14;
+static const uint8_t IO15 = 15;
+static const uint8_t IO17 = 17; // TXD2 / TXD pin
+static const uint8_t IO32 = 32; // CFG pin
+static const uint8_t IO33 = 33; // 485_EN pin
+
+// input-only pins
+static const uint8_t IO35 = 35;
+static const uint8_t IO36 = 36;
+static const uint8_t IO39 = 39;
+
+// UART interfaces
+static const uint8_t TXD0 = IO1, TX0 = IO1;
+static const uint8_t RXD0 = IO3, RX0 = IO3;
+static const uint8_t TXD2 = IO17, TXD = IO17;
+static const uint8_t RXD2 = IO5, RXD = IO5;
+static const uint8_t TX = TX0;
+static const uint8_t RX = TX0;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Summary
This pull request adds support for the Wireless-Tag WT32-ETH01 board based on the WT32-S1 module and a LAN8720A Ethernet PHY. Reference documentation available at http://www.wireless-tag.com/portfolio/wt32-eth01/

## Impact
- adds a new board definition
- adds a new pin definition for corresponding variant
- no further changes to existing code base
