### PR TITLE
Don't clear custom HTTP headers on redirect in HTTPClient

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -200,6 +200,7 @@ bool HTTPClient::begin(String url, const char* CAcert)
         end();
     }
 
+    clear();
     _port = 443;
     if (!beginInternal(url, "https")) {
         return false;
@@ -226,6 +227,7 @@ bool HTTPClient::begin(String url)
         end();
     }
 
+    clear();
     _port = 80;
     if (!beginInternal(url, "http")) {
         return begin(url, (const char*)NULL);
@@ -243,7 +245,6 @@ bool HTTPClient::begin(String url)
 bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
 {
     log_v("url: %s", url.c_str());
-    clear();
 
     // check for : (http: or https:
     int index = url.indexOf(':');
@@ -1212,8 +1213,8 @@ int HTTPClient::handleHeaderResponse()
         return HTTPC_ERROR_NOT_CONNECTED;
     }
 
-    clear();
-
+    _returnCode = 0;
+    _size = -1;
     _canReuse = _reuse;
 
     String transferEncoding;


### PR DESCRIPTION
## Summary
Current implementation clears _headers when request was sent. If the user added custom request headers, they will be lost and the redirected request will not contain them. This commit changes the scope of cleanup (moved from beginInternal() to begin(), changed the amount of data cleared in handleHeaderResponse()), so that the headers survive redirects but don't survive connection reuse.

## Impact
Possible impact on connection reuse. Tested manually to behave properly.
