### PR TITLE
Use WIFI_FAST_SCAN if a specific channel was used

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -176,15 +176,19 @@ wl_status_t WiFiSTAClass::begin(const char* ssid, const char *passphrase, int32_
     wifi_config_t conf;
     memset(&conf, 0, sizeof(wifi_config_t));
     _wifi_strncpy(reinterpret_cast<char*>(conf.sta.ssid), ssid, 32);
-    conf.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;       //force full scan to be able to choose the nearest / strongest AP
 
     if(passphrase) {
         _wifi_strncpy(reinterpret_cast<char*>(conf.sta.password), passphrase, 64);
     }
 
-    wifi_config_t current_conf;
-    wifi_sta_config(&conf, ssid, passphrase, bssid, channel);
+    if(channel == 0) {
+        // If no specific channel specified, then do an slower WIFI_ALL_CHANNEL_SCAN
+        wifi_sta_config(&conf, ssid, passphrase, bssid, channel, WIFI_ALL_CHANNEL_SCAN);
+    }
+    else
+        wifi_sta_config(&conf, ssid, passphrase, bssid, channel, WIFI_FAST_SCAN);
 
+    wifi_config_t current_conf;
     if(esp_wifi_get_config((wifi_interface_t)ESP_IF_WIFI_STA, &current_conf) != ESP_OK){
         log_e("get current config failed!");
         return WL_CONNECT_FAILED;


### PR DESCRIPTION
1.0.6 changed scanning method to always scan all available channels during connect. This results in results in connect taking about ~3 seconds instead of ~1. This patch changes the behavior to use WIFI_FAST_SCAN if client used a specific channel.

Fixes #1675
