### PR TITLE
Prevent self hosted jobs to run on forks.

### DIFF
--- a/.github/workflows/test_selfhosted_runner.yml
+++ b/.github/workflows/test_selfhosted_runner.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Dummy test - self hosted GHR
     runs-on: self-hosted
+    if: github.repository == 'espressif/arduino-esp32'
     steps:
       - name: Check out repo
         uses: actions/checkout@v2


### PR DESCRIPTION

## Summary
Run jobs that require self hosted runners only on the main repository.
https://github.com/espressif/arduino-esp32/pull/5521#issuecomment-986145419
https://github.com/adafruit/arduino-esp32/pull/11

## Impact
Forks only.
