### PR TITLE
SD Card status check fix

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -609,6 +609,11 @@ unknown_card:
 
 DSTATUS ff_sd_status(uint8_t pdrv)
 {
+    if(sdCommand(pdrv, SEND_STATUS, 0, NULL) == 0xFF)
+    {
+        log_e("Check status failed");
+        return STA_NOINIT;
+    }
     return s_cards[pdrv]->status;
 }
 


### PR DESCRIPTION
## Summary
Edited sd_diskio to work the same as SD_MMC. The ff_sd_status function send command to card to check its status.
If card is disconnected, command will fail.

Fix for #3603

## Impact
Might have very low impact on speed.
