### PR TITLE
Adds support to change LoopTask Stack size

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -179,6 +179,11 @@ uint16_t makeWord(uint8_t h, uint8_t l);
 
 #define word(...) makeWord(__VA_ARGS__)
 
+#define ESP_LOOP_TASK_STACK_SIZE(sz) \
+    size_t getArduinoLoopTaskStackSize(void) { \
+        return sz; \
+    }
+    
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -180,7 +180,7 @@ uint16_t makeWord(uint8_t h, uint8_t l);
 #define word(...) makeWord(__VA_ARGS__)
 
 size_t getArduinoLoopTaskStackSize(void);
-#define SET_LOOPTASK_STACK_SIZE(sz) size_t getArduinoLoopTaskStackSize() { return sz;}
+#define SET_LOOP_TASK_STACK_SIZE(sz) size_t getArduinoLoopTaskStackSize() { return sz;}
     
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -179,10 +179,8 @@ uint16_t makeWord(uint8_t h, uint8_t l);
 
 #define word(...) makeWord(__VA_ARGS__)
 
-#define ESP_LOOP_TASK_STACK_SIZE(sz) \
-    size_t getArduinoLoopTaskStackSize(void) { \
-        return sz; \
-    }
+size_t getArduinoLoopTaskStackSize(void);
+#define SET_LOOPTASK_STACK_SIZE(sz) size_t getArduinoLoopTaskStackSize() { return sz;}
     
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -33,6 +33,10 @@ void yieldIfNecessary(void){
 
 bool loopTaskWDTEnabled;
 
+__attribute__((weak)) size_t getArduinoLoopTaskStackSize(void) {
+    return ARDUINO_LOOP_STACK_SIZE;
+}
+
 void loopTask(void *pvParameters)
 {
     setup();
@@ -64,7 +68,7 @@ extern "C" void app_main()
 #endif
     loopTaskWDTEnabled = false;
     initArduino();
-    xTaskCreateUniversal(loopTask, "loopTask", ARDUINO_LOOP_STACK_SIZE, NULL, 1, &loopTaskHandle, ARDUINO_RUNNING_CORE);
+    xTaskCreateUniversal(loopTask, "loopTask", getArduinoLoopTaskStackSize(), NULL, 1, &loopTaskHandle, ARDUINO_RUNNING_CORE);
 }
 
 #endif

--- a/libraries/ESP32/examples/ArduinoStackSize/ArduinoStackSize.ino
+++ b/libraries/ESP32/examples/ArduinoStackSize/ArduinoStackSize.ino
@@ -6,19 +6,19 @@
     This should be plenty for most general sketches.
 
     There is a way to change the stack size of this task by using
-    SET_LOOPTASK_STACK_SIZE(size);
+    SET_LOOP_TASK_STACK_SIZE(size);
     It will bypass the default stack size of 8KB and allow the user to define a new size.
 
     It is recommend this value to be higher than 8KB, for instance 16KB.
     This increasing may be necessary for the sketches that use deep recursion for instance.
 
-    In this example, you can verify it by changing or just commenting out SET_LOOPTASK_STACK_SIZE();
+    In this example, you can verify it by changing or just commenting out SET_LOOP_TASK_STACK_SIZE();
 */
 
 #define ARDUINO_TASK_STACK_SIZE     (16*1024)       // 16KB
 
 // This sets Arduino Stack Size - comment this line to use default 8K stack size
-SET_LOOPTASK_STACK_SIZE(ARDUINO_TASK_STACK_SIZE);
+SET_LOOP_TASK_STACK_SIZE(ARDUINO_TASK_STACK_SIZE);
 
 void setup() {
   Serial.begin(115200);

--- a/libraries/ESP32/examples/ArduinoStackSize/ArduinoStackSize.ino
+++ b/libraries/ESP32/examples/ArduinoStackSize/ArduinoStackSize.ino
@@ -15,10 +15,9 @@
     In this example, you can verify it by changing or just commenting out SET_LOOP_TASK_STACK_SIZE();
 */
 
-#define ARDUINO_TASK_STACK_SIZE     (16*1024)       // 16KB
 
 // This sets Arduino Stack Size - comment this line to use default 8K stack size
-SET_LOOP_TASK_STACK_SIZE(ARDUINO_TASK_STACK_SIZE);
+SET_LOOP_TASK_STACK_SIZE(16*1024); // 16KB
 
 void setup() {
   Serial.begin(115200);

--- a/libraries/ESP32/examples/ArduinoStackSize/ArduinoStackSize.ino
+++ b/libraries/ESP32/examples/ArduinoStackSize/ArduinoStackSize.ino
@@ -1,0 +1,37 @@
+/*
+    ESP32 Arduino creates a task to run setup() and then to execute loop() continuously
+    This task can be found at https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/main.cpp
+
+    By default "loopTask" will be created with a stack size of 8KB.
+    This should be plenty for most general sketches.
+
+    There is a way to change the stack size of this task by using
+    SET_LOOPTASK_STACK_SIZE(size);
+    It will bypass the default stack size of 8KB and allow the user to define a new size.
+
+    It is recommend this value to be higher than 8KB, for instance 16KB.
+    This increasing may be necessary for the sketches that use deep recursion for instance.
+
+    In this example, you can verify it by changing or just commenting out SET_LOOPTASK_STACK_SIZE();
+*/
+
+#define ARDUINO_TASK_STACK_SIZE     (16*1024)       // 16KB
+
+// This sets Arduino Stack Size - comment this line to use default 8K stack size
+SET_LOOPTASK_STACK_SIZE(ARDUINO_TASK_STACK_SIZE);
+
+void setup() {
+  Serial.begin(115200);
+
+  Serial.printf("Arduino Stack was set to %d bytes", getArduinoLoopTaskStackSize());
+
+  // Print unused stack for the task that is running setup()
+  Serial.printf("\nSetup() - Free Stack Space: %d", uxTaskGetStackHighWaterMark(NULL));
+}
+
+void loop() {
+  delay(1000);
+
+  // Print unused stack for the task that is running loop() - the same as for setup()
+  Serial.printf("\nLoop() - Free Stack Space: %d", uxTaskGetStackHighWaterMark(NULL));
+}


### PR DESCRIPTION
## Summary
Arduino ```setup()``` and ```loop()``` run under a Task with a fixed Stack size of 8KB.
Users may want to change this size.

This PR adds this possibility by just adding a line of code, as for example:
``` dart
ESP_LOOP_TASK_STACK_SIZE(16384);

void setup() { 
}

void loop() { 
}
```
## Impact
None. It adds a new functionality to ESP32 Arduino.
If ```ESP_LOOP_TASK_STACK_SIZE(newSize);``` is not declared/used, it will compile the sketch with the default stack size of 8KB.

## Related links
fix #6010 

https://github.com/espressif/arduino-esp32/issues/6010#issuecomment-992701658
Thanks @igrr for the suggestion!