### PR TITLE
Forces UART Flush() to wait until all bits are sent

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -140,6 +140,9 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
         ESP_ERROR_CHECK(uart_set_line_inverse(uart_nr, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV));    
     }
 
+    // Set RS485 half duplex mode on UART.  This shall force flush to wait up to sending all bits out
+    ESP_ERROR_CHECK(uart_set_mode(uart_nr, UART_MODE_RS485_HALF_DUPLEX));
+
     UART_MUTEX_UNLOCK();
 
     uartFlush(uart);


### PR DESCRIPTION
## Summary
HardwareSerial flush() was returning before all data was sent out through serial port.
This is a problem to some RS485 libraries that depend on it to signaling.

This PR solves the issue by forcing it to block flush() until all data is sent.

## Impact
None, just fixes an issue.

## Related links
fix #5877 