### PR TITLE
Fixes Lib Builder compiling errors

### DIFF
--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -184,21 +184,21 @@ static void _rmtRxTask(void *args) {
     rmt_item32_t *data = NULL;
 
     if (!rmt) {
-        log_e(" -- Inavalid Argument \n");
+        log_e(" -- Inavalid Argument");
         goto err;
     }
 
     int channel = rmt->channel;
     rmt_get_ringbuf_handle(channel, &rb);
     if (!rb) {
-        log_e(" -- Failed to get RMT ringbuffer handle\n");
+        log_e(" -- Failed to get RMT ringbuffer handle");
         goto err;  
     }
     
     for(;;) {
         data = (rmt_item32_t *) xRingbufferReceive(rb, &rmt_len, portMAX_DELAY);
         if (data) {
-            log_d(" -- Got %d bytes on RX Ringbuffer - CH %d\n", rmt_len, rmt->channel);
+            log_d(" -- Got %d bytes on RX Ringbuffer - CH %d", rmt_len, rmt->channel);
             rmt->rx_completed = true;  // used in rmtReceiveCompleted()
             // callback
             if (rmt->cb) {
@@ -551,7 +551,7 @@ rmt_obj_t* rmtInit(int pin, bool tx_not_rx, rmt_reserve_memsize_t memsize)
     }
     if (i == MAX_CHANNELS || i+j > MAX_CHANNELS || j != buffers)  {
         xSemaphoreGive(g_rmt_block_lock);
-        log_e("rmInit Failed - not enough channels\n");
+        log_e("rmInit Failed - not enough channels");
         return NULL;
     }
     
@@ -587,7 +587,7 @@ rmt_obj_t* rmtInit(int pin, bool tx_not_rx, rmt_reserve_memsize_t memsize)
         esp_err_code = rmt_config(&config);
         if (esp_err_code == ESP_OK) 
             esp_err_code = rmt_driver_install(channel, 0, 0);
-        log_d(" -- %s RMT - CH %d - %d RAM Blocks - pin %d\n", tx_not_rx?"TX":"RX", channel, buffers, pin);
+        log_d(" -- %s RMT - CH %d - %d RAM Blocks - pin %d", tx_not_rx?"TX":"RX", channel, buffers, pin);
     } else {
         rmt_config_t config = RMT_DEFAULT_ARD_CONFIG_RX(pin, channel, buffers);
         esp_err_code = rmt_config(&config);
@@ -595,7 +595,7 @@ rmt_obj_t* rmtInit(int pin, bool tx_not_rx, rmt_reserve_memsize_t memsize)
             esp_err_code = rmt_driver_install(channel, 1024, 0);
         if (esp_err_code == ESP_OK) 
             esp_err_code = rmt_set_memory_owner(channel, RMT_MEM_OWNER_RX);
-        log_d(" -- %s RMT - CH %d - %d RAM Blocks - pin %d\n", tx_not_rx?"TX":"RX", channel, buffers, pin);
+        log_d(" -- %s RMT - CH %d - %d RAM Blocks - pin %d", tx_not_rx?"TX":"RX", channel, buffers, pin);
     } 
 
     RMT_MUTEX_UNLOCK(channel);

--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -515,9 +515,9 @@ float rmtSetTick(rmt_obj_t* rmt, float tick)
 rmt_obj_t* rmtInit(int pin, bool tx_not_rx, rmt_reserve_memsize_t memsize)
 {
     int buffers = memsize;
-    rmt_obj_t* rmt;
-    size_t i;
-    size_t j;
+    rmt_obj_t* rmt = NULL;
+    size_t i = 0;
+    size_t j = 0;
 
     // create common block mutex for protecting allocs from multiple threads
     if (!g_rmt_block_lock) {
@@ -536,7 +536,6 @@ rmt_obj_t* rmtInit(int pin, bool tx_not_rx, rmt_reserve_memsize_t memsize)
         ch_end = RMT_RX_CH_END;
     }
     for (i=ch_start; i<=ch_end; i++) {
-        j = 0;  // fixes compiling option -Werror=maybe-uninitialized
         for (j=0; j<buffers && i+j <= ch_end; j++) {
             // if the space is ocupied break and continue on other channel
             if (g_rmt_objects[i+j].allocated) {

--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -124,10 +124,6 @@ static rmt_obj_t g_rmt_objects[MAX_CHANNELS] = {
 /**
  * Internal variables for driver data
  */
-static  intr_handle_t intr_handle;
-
-static bool periph_enabled = false;
-
 static xSemaphoreHandle g_rmt_block_lock = NULL;
 
 /**
@@ -390,7 +386,6 @@ bool rmtReadData(rmt_obj_t* rmt, uint32_t* data, size_t size)
     if (!rmt) {
         return false;
     }
-    int channel = rmt->channel;
 
     rmtReadAsync(rmt, (rmt_data_t*) data, size, NULL, false, 0);
     return true;
@@ -492,7 +487,7 @@ bool rmtReadAsync(rmt_obj_t* rmt, rmt_data_t* data, size_t size, void* eventFlag
 
     // wait for data if requested so
     if (waitForData && eventFlag) {
-        uint32_t flags = xEventGroupWaitBits(eventFlag, RMT_FLAGS_ALL,
+        xEventGroupWaitBits(eventFlag, RMT_FLAGS_ALL,
                             pdTRUE /* clear on exit */, pdFALSE /* wait for all bits */, timeout);
     }
     return true;
@@ -541,6 +536,7 @@ rmt_obj_t* rmtInit(int pin, bool tx_not_rx, rmt_reserve_memsize_t memsize)
         ch_end = RMT_RX_CH_END;
     }
     for (i=ch_start; i<=ch_end; i++) {
+        j = 0;  // fixes compiling option -Werror=maybe-uninitialized
         for (j=0; j<buffers && i+j <= ch_end; j++) {
             // if the space is ocupied break and continue on other channel
             if (g_rmt_objects[i+j].allocated) {


### PR DESCRIPTION
## Summary
Fixes warnings and an error when compiling RMT with Arduino Lib Builder

## Impact
None

## Related links
https://github.com/espressif/arduino-esp32/pull/6024#issuecomment-999137002

## Related LOG:
```
2021-12-21T13:42:08.4507786Z FAILED: esp-idf/arduino/CMakeFiles/__idf_arduino.dir/cores/esp32/esp32-hal-rmt.c.obj 
2021-12-21T13:42:08.4596147Z /home/runner/.espressif/tools/riscv32-esp-elf/esp-2021r2-8.4.0/riscv32-esp-elf/bin/riscv32-esp-elf-gcc -DHAVE_CONFIG_H -DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\" -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/build/config -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/variants/esp32c3 -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32 -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/ArduinoOTA/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/AsyncUDP/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/BLE/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/BluetoothSerial/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/DNSServer/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/EEPROM/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/ESP32/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/ESPmDNS/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/FFat/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/FS/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/HTTPClient/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/HTTPUpdate/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/LittleFS/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/NetBIOS/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/Preferences/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/SD_MMC/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/SD/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/SimpleBLE/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/SPIFFS/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/SPI/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/Ticker/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/Update/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/USB/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/WebServer/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/WiFiClientSecure/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/WiFi/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/WiFiProv/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/libraries/Wire/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/libb64 -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/platform_include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/include/esp_additions/freertos -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port/riscv/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/include/esp_additions -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/include/soc -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/include/soc/esp32c3 -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/port/esp32c3/. -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/port/esp32c3/private_include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/log/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/include/apps -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/include/apps/sntp -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/port/esp32/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/port/esp32/include/arch -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/soc/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/soc/esp32c3/. -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/soc/esp32c3/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/hal/esp32c3/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/hal/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/hal/platform_port/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_rom/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_rom/include/esp32c3 -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_rom/esp32c3 -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_common/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/port/soc -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/port/include/riscv -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/port/public_compat -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/riscv/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/driver/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/driver/esp32c3/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_pm/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_ringbuf/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/efuse/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/efuse/esp32c3/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/vfs/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_wifi/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_event/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_netif/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_eth/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/tcpip_adapter/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_phy/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_phy/esp32c3/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_ipc/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/app_trace/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_timer/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spi_flash/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mbedtls/port/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mbedtls/mbedtls/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mbedtls/esp_crt_bundle/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mdns/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/console -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_adc_cal/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wifi_provisioning/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/protocomm/include/common -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/protocomm/include/security -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/protocomm/include/transports -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/bt/common/osi/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/bt/include/esp32c3/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/bt/common/api/include/api -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/bt/common/btc/profile/esp/blufi/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/bt/common/btc/profile/esp/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/bt/host/bluedroid/api/include/api -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nvs_flash/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nghttp/port/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/nghttp/nghttp2/lib/includes -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/fatfs/diskio -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/fatfs/vfs -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/fatfs/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wear_levelling/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/sdmmc/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/app_update/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/bootloader_support/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/spiffs/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/openssl/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hid/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_https_ota/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_http_client/include -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/esp_littlefs/src -I/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/esp_littlefs/include -march=rv32imc -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wextra -Wno-unused-parameter -Wno-sign-compare -ggdb -Wno-error=format= -nostartfiles -Wno-format -Os -freorder-blocks -fmacro-prefix-map=/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder=. -fmacro-prefix-map=/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf=IDF -fstrict-volatile-bitfields -Wno-error=unused-but-set-variable -fno-jump-tables -fno-tree-switch-conversion -std=gnu99 -Wno-old-style-declaration -D_GNU_SOURCE -DIDF_VER=\"v4.4-tasmota-144-g831152548\" -DESP_PLATFORM -DNDEBUG -D_POSIX_READER_WRITER_LOCKS -DARDUINO=10812 -DARDUINO_ESP32C3_DEV -DARDUINO_ARCH_ESP32 -DARDUINO_BOARD=\"ESP32C3_DEV\" -DARDUINO_VARIANT=\"esp32c3\" -DESP32 -MD -MT esp-idf/arduino/CMakeFiles/__idf_arduino.dir/cores/esp32/esp32-hal-rmt.c.obj -MF esp-idf/arduino/CMakeFiles/__idf_arduino.dir/cores/esp32/esp32-hal-rmt.c.obj.d -o esp-idf/arduino/CMakeFiles/__idf_arduino.dir/cores/esp32/esp32-hal-rmt.c.obj -c /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c
2021-12-21T13:42:08.4685167Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c: In function 'rmtReadData':
2021-12-21T13:42:08.4687087Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c:393:9: warning: unused variable 'channel' [-Wunused-variable]
2021-12-21T13:42:08.4688502Z      int channel = rmt->channel;
2021-12-21T13:42:08.4688849Z          ^~~~~~~
2021-12-21T13:42:08.4689954Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c: In function 'rmtReadAsync':
2021-12-21T13:42:08.4691756Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c:495:18: warning: unused variable 'flags' [-Wunused-variable]
2021-12-21T13:42:08.4692965Z          uint32_t flags = xEventGroupWaitBits(eventFlag, RMT_FLAGS_ALL,
2021-12-21T13:42:08.4693498Z                   ^~~~~
2021-12-21T13:42:08.4693794Z At top level:
2021-12-21T13:42:08.4695331Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c:129:13: warning: 'periph_enabled' defined but not used [-Wunused-variable]
2021-12-21T13:42:08.4696884Z  static bool periph_enabled = false;
2021-12-21T13:42:08.4697287Z              ^~~~~~~~~~~~~~
2021-12-21T13:42:08.4698755Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c:127:23: warning: 'intr_handle' defined but not used [-Wunused-variable]
2021-12-21T13:42:08.4700163Z  static  intr_handle_t intr_handle;
2021-12-21T13:42:08.4700573Z                        ^~~~~~~~~~~
2021-12-21T13:42:08.4701641Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c: In function 'rmtInit':
2021-12-21T13:42:08.4703473Z /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/components/arduino/cores/esp32/esp32-hal-rmt.c:556:31: error: 'j' may be used uninitialized in this function [-Werror=maybe-uninitialized]
2021-12-21T13:42:08.4705116Z      if (i == MAX_CHANNELS || i+j > MAX_CHANNELS || j != buffers)  {
2021-12-21T13:42:08.4705566Z                               ~^~
2021-12-21T13:42:08.4705963Z cc1: some warnings being treated as errors

```