### PR TITLE
Implement SigmaDelta based on ESP-IDF API

### DIFF
--- a/cores/esp32/esp32-hal-sigmadelta.c
+++ b/cores/esp32/esp32-hal-sigmadelta.c
@@ -12,38 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
+
 #include "esp32-hal.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "freertos/semphr.h"
-#include "esp32-hal-matrix.h"
-#include "soc/gpio_sd_reg.h"
-#include "soc/gpio_sd_struct.h"
+#include "soc/soc_caps.h"
+#include "driver/sigmadelta.h"
 
-#include "esp_system.h"
-#ifdef ESP_IDF_VERSION_MAJOR // IDF 4+
-#if CONFIG_IDF_TARGET_ESP32 // ESP32/PICO-D4
-#include "esp32/rom/ets_sys.h"
-#elif CONFIG_IDF_TARGET_ESP32S2
-#include "esp32s2/rom/ets_sys.h"
-#elif CONFIG_IDF_TARGET_ESP32C3
-#include "esp32c3/rom/ets_sys.h"
-#else 
-#error Target CONFIG_IDF_TARGET is not supported
-#endif
-#else // ESP32 Before IDF 4.0
-#include "rom/ets_sys.h"
-#endif
-
-
-#if CONFIG_DISABLE_HAL_LOCKS
-#define SD_MUTEX_LOCK()
-#define SD_MUTEX_UNLOCK()
-#else
-#define SD_MUTEX_LOCK()    do {} while (xSemaphoreTake(_sd_sys_lock, portMAX_DELAY) != pdPASS)
-#define SD_MUTEX_UNLOCK()  xSemaphoreGive(_sd_sys_lock)
-xSemaphoreHandle _sd_sys_lock;
-#endif
+static uint8_t duty_set[SOC_SIGMADELTA_CHANNEL_NUM] = {0};
+static uint32_t prescaler_set[SOC_SIGMADELTA_CHANNEL_NUM] = {0};
 
 static void _on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb){
     if(old_apb == new_apb){
@@ -51,79 +27,60 @@ static void _on_apb_change(void * arg, apb_change_ev_t ev_type, uint32_t old_apb
     }
     uint32_t iarg = (uint32_t)arg;
     uint8_t channel = iarg;
-    if(ev_type == APB_BEFORE_CHANGE){
-        SIGMADELTA.cg.clk_en = 0;
-    } else {
+    if(ev_type == APB_AFTER_CHANGE){
         old_apb /= 1000000;
         new_apb /= 1000000;
-        SD_MUTEX_LOCK();
-        uint32_t old_prescale = SIGMADELTA.channel[channel].prescale + 1;
-        SIGMADELTA.channel[channel].prescale = ((new_apb * old_prescale) / old_apb) - 1;
-        SIGMADELTA.cg.clk_en = 0;
-        SIGMADELTA.cg.clk_en = 1;
-        SD_MUTEX_UNLOCK();
+        uint32_t old_prescale = prescaler_set[channel] + 1;
+        uint32_t new_prescale = ((new_apb * old_prescale) / old_apb) - 1;
+        sigmadelta_set_prescale(channel,new_prescale);
+        prescaler_set[channel] = new_prescale;
     }
 }
 
-uint32_t sigmaDeltaSetup(uint8_t channel, uint32_t freq) //chan 0-7 freq 1220-312500
+uint32_t sigmaDeltaSetup(uint8_t pin, uint8_t channel, uint32_t freq) //chan 0-x according to SOC, freq 1220-312500
 {
-    if(channel > 7) {
+    if(channel >= SOC_SIGMADELTA_CHANNEL_NUM){
         return 0;
     }
-#if !CONFIG_DISABLE_HAL_LOCKS
-    static bool tHasStarted = false;
-    if(!tHasStarted) {
-        tHasStarted = true;
-        _sd_sys_lock = xSemaphoreCreateMutex();
-    }
-#endif
+    
     uint32_t apb_freq = getApbFrequency();
     uint32_t prescale = (apb_freq/(freq*256)) - 1;
     if(prescale > 0xFF) {
         prescale = 0xFF;
     }
-    SD_MUTEX_LOCK();
-#ifndef CONFIG_IDF_TARGET_ESP32
-    SIGMADELTA.misc.function_clk_en = 1;
-#endif
-    SIGMADELTA.channel[channel].prescale = prescale;
-    SIGMADELTA.cg.clk_en = 0;
-    SIGMADELTA.cg.clk_en = 1;
-    SD_MUTEX_UNLOCK();
+
+    sigmadelta_config_t sigmadelta_cfg = {
+        .channel = channel,
+        .sigmadelta_prescale = prescale,
+        .sigmadelta_duty = 0,
+        .sigmadelta_gpio = pin,
+    };
+    sigmadelta_config(&sigmadelta_cfg);
+
+    prescaler_set[channel] = prescale;
     uint32_t iarg = channel;
     addApbChangeCallback((void*)iarg, _on_apb_change);
+
     return apb_freq/((prescale + 1) * 256);
 }
 
-void sigmaDeltaWrite(uint8_t channel, uint8_t duty) //chan 0-7 duty 8 bit
+void sigmaDeltaWrite(uint8_t channel, uint8_t duty) //chan 0-x according to SOC duty 8 bit
 {
-    if(channel > 7) {
+    if(channel >= SOC_SIGMADELTA_CHANNEL_NUM){
         return;
     }
-    duty -= 128;
-    SD_MUTEX_LOCK();
-    SIGMADELTA.channel[channel].duty = duty;
-    SD_MUTEX_UNLOCK();
+    duty -= 128; 
+
+    sigmadelta_set_duty(channel,duty);
+    duty_set[channel] = duty;
 }
 
-uint8_t sigmaDeltaRead(uint8_t channel) //chan 0-7
+uint8_t sigmaDeltaRead(uint8_t channel) //chan 0-x according to SOC
 {
-    if(channel > 7) {
+    if(channel >= SOC_SIGMADELTA_CHANNEL_NUM){
         return 0;
     }
-    SD_MUTEX_LOCK();
-    uint8_t duty = SIGMADELTA.channel[channel].duty + 128;
-    SD_MUTEX_UNLOCK();
-    return duty;
-}
-
-void sigmaDeltaAttachPin(uint8_t pin, uint8_t channel) //channel 0-7
-{
-    if(channel > 7) {
-        return;
-    }
-    pinMode(pin, OUTPUT);
-    pinMatrixOutAttach(pin, GPIO_SD0_OUT_IDX + channel, false, false);
+    return duty_set[channel]+128;
 }
 
 void sigmaDeltaDetachPin(uint8_t pin)

--- a/cores/esp32/esp32-hal-sigmadelta.h
+++ b/cores/esp32/esp32-hal-sigmadelta.h
@@ -23,10 +23,9 @@ extern "C" {
 #include <stdbool.h>
 
 //channel 0-7 freq 1220-312500 duty 0-255
-uint32_t    sigmaDeltaSetup(uint8_t channel, uint32_t freq);
+uint32_t    sigmaDeltaSetup(uint8_t pin, uint8_t channel, uint32_t freq);
 void        sigmaDeltaWrite(uint8_t channel, uint8_t duty);
 uint8_t     sigmaDeltaRead(uint8_t channel);
-void        sigmaDeltaAttachPin(uint8_t pin, uint8_t channel);
 void        sigmaDeltaDetachPin(uint8_t pin);
 
 

--- a/libraries/ESP32/examples/AnalogOut/SigmaDelta/SigmaDelta.ino
+++ b/libraries/ESP32/examples/AnalogOut/SigmaDelta/SigmaDelta.ino
@@ -1,9 +1,7 @@
 void setup()
 {
-    //setup channel 0 with frequency 312500 Hz
-    sigmaDeltaSetup(0, 312500);
-    //attach pin 18 to channel 0
-    sigmaDeltaAttachPin(18,0);
+    //setup on pin 18, channel 0 with frequency 312500 Hz
+    sigmaDeltaSetup(18,0, 312500);
     //initialize channel 0 to off
     sigmaDeltaWrite(0, 0);
 }


### PR DESCRIPTION
## Summary
This PR is refactoring of SigmaDelta HAL in order to use IDF instead of current Register manipulation approach.

## Impact

**Change in API:**

* `uint32_t sigmaDeltaSetup(uint8_t channel, uint32_t freq);`
 changed to -->
`uint32_t sigmaDeltaSetup(uint8_t pin, uint8_t channel, uint32_t freq);`

* `void sigmaDeltaAttachPin(uint8_t pin);` removed, no longer needed. Pin is attached in `sigmaDeltaSetup()`

## Related links
