### PR TITLE
add definition for power pin on i2c port

### DIFF
--- a/variants/adafruit_feather_esp32s2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2/pins_arduino.h
@@ -25,6 +25,7 @@
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on
+#define I2C_POWER           7     // I2C power pin
 
 static const uint8_t SDA = 3;
 static const uint8_t SCL = 4;


### PR DESCRIPTION
this just adds a simplification for folks who can't remember the pin for turning on the I2C power port