### PR TITLE
update ESP_ARDUINO_VERSION macro to 2.0.2

### DIFF
--- a/cores/esp32/esp_arduino_version.h
+++ b/cores/esp32/esp_arduino_version.h
@@ -23,7 +23,7 @@ extern "C" {
 /** Minor version number (x.X.x) */
 #define ESP_ARDUINO_VERSION_MINOR   0
 /** Patch version number (x.x.X) */
-#define ESP_ARDUINO_VERSION_PATCH   0
+#define ESP_ARDUINO_VERSION_PATCH   2
 
 /**
  * Macro to convert ARDUINO version number into an integer


### PR DESCRIPTION
## Summary
Latest release is 2.0.2, this PR update esp_arduino_version.h **ESP_ARDUINO_VERSION** to correctly reflect that.

## Impact
Correct the macro version to match latest release