### PR TITLE
NTP Examples: revert obsolete comment and updated Time example

### DIFF
--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -44,8 +44,6 @@ static void setTimeZone(long offset, int daylight)
 /*
  * configTime
  * Source: https://github.com/esp8266/Arduino/blob/master/cores/esp8266/time.c
- * Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
- *       see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
  * */
 void configTime(long gmtOffset_sec, int daylightOffset_sec, const char* server1, const char* server2, const char* server3)
 {
@@ -65,8 +63,6 @@ void configTime(long gmtOffset_sec, int daylightOffset_sec, const char* server1,
 /*
  * configTzTime
  * sntp setup using TZ environment variable
- * Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
- *       see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
  * */
 void configTzTime(const char* tz, const char* server1, const char* server2, const char* server3)
 {

--- a/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
+++ b/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
@@ -1,27 +1,65 @@
 #include <WiFi.h>
 #include "time.h"
+#include "sntp.h"
 
 const char* ssid       = "YOUR_SSID";
 const char* password   = "YOUR_PASS";
 
-const char* ntpServer = "pool.ntp.org";
+const char* ntpServer1 = "pool.ntp.org";
+const char* ntpServer2 = "time.nist.gov";
 const long  gmtOffset_sec = 3600;
 const int   daylightOffset_sec = 3600;
+
+const char* time_zone = "CET-1CEST,M3.5.0,M10.5.0/3";  // TimeZone rule for Europe/Rome including daylight adjustment rules (optional)
 
 void printLocalTime()
 {
   struct tm timeinfo;
   if(!getLocalTime(&timeinfo)){
-    Serial.println("Failed to obtain time");
+    Serial.println("No time available (yet)");
     return;
   }
   Serial.println(&timeinfo, "%A, %B %d %Y %H:%M:%S");
 }
 
+// Callback function (get's called when time adjusts via NTP)
+void timeavailable(struct timeval *t)
+{
+  Serial.println("Got time adjustment from NTP!");
+  printLocalTime();
+}
+
 void setup()
 {
   Serial.begin(115200);
-  
+
+  // set notification call-back function
+  sntp_set_time_sync_notification_cb( timeavailable );
+
+  /**
+   * NTP server address could be aquired via DHCP,
+   *
+   * NOTE: This call should be made BEFORE esp32 aquires IP address via DHCP,
+   * otherwise SNTP option 42 would be rejected by default.
+   * NOTE: configTime() function call if made AFTER DHCP-client run
+   * will OVERRIDE aquired NTP server address
+   */
+  sntp_servermode_dhcp(1);    // (optional)
+
+  /**
+   * This will set configured ntp servers and constant TimeZone/daylightOffset
+   * should be OK if your time zone does not need to adjust daylightOffset twice a year,
+   * in such a case time adjustment won't be handled automagicaly.
+   */
+  configTime(gmtOffset_sec, daylightOffset_sec, ntpServer1, ntpServer2);
+
+  /**
+   * A more convenient approach to handle TimeZones with daylightOffset 
+   * would be to specify a environmnet variable with TimeZone definition including daylight adjustmnet rules.
+   * A list of rules for your zone could be obtained from https://github.com/esp8266/Arduino/blob/master/cores/esp8266/TZ.h
+   */
+  //configTzTime(time_zone, ntpServer1, ntpServer2);
+
   //connect to WiFi
   Serial.printf("Connecting to %s ", ssid);
   WiFi.begin(ssid, password);
@@ -30,18 +68,11 @@ void setup()
       Serial.print(".");
   }
   Serial.println(" CONNECTED");
-  
-  //init and get the time
-  configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
-  printLocalTime();
 
-  //disconnect WiFi as it's no longer needed
-  WiFi.disconnect(true);
-  WiFi.mode(WIFI_OFF);
 }
 
 void loop()
 {
-  delay(1000);
-  printLocalTime();
+  delay(5000);
+  printLocalTime();     // it will take some time to sync time :)
 }

--- a/libraries/FFat/examples/FFat_time/FFat_time.ino
+++ b/libraries/FFat/examples/FFat_time/FFat_time.ino
@@ -148,10 +148,6 @@ void setup(){
     Serial.println("IP address: ");
     Serial.println(WiFi.localIP());
     Serial.println("Contacting Time Server");
-    /*
-        Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
-        see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
-     */
 	configTime(3600*timezone, daysavetime*3600, "time.nist.gov", "0.pool.ntp.org", "1.pool.ntp.org");
 	struct tm tmstruct ;
     delay(2000);

--- a/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
@@ -17,10 +17,6 @@ WiFiMulti WiFiMulti;
 
 // Set time via NTP, as required for x.509 validation
 void setClock() {
-  /*
-    Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
-    see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
-  */
   configTime(0, 0, "pool.ntp.org", "time.nist.gov");  // UTC
 
   Serial.print(F("Waiting for NTP time sync: "));

--- a/libraries/LittleFS/examples/LITTLEFS_time/LITTLEFS_time.ino
+++ b/libraries/LittleFS/examples/LITTLEFS_time/LITTLEFS_time.ino
@@ -160,10 +160,6 @@ void setup(){
     Serial.println("IP address: ");
     Serial.println(WiFi.localIP());
     Serial.println("Contacting Time Server");
-    /*
-        Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
-        see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
-     */
 	configTime(3600*timezone, daysavetime*3600, "time.nist.gov", "0.pool.ntp.org", "1.pool.ntp.org");
 	struct tm tmstruct ;
     delay(2000);

--- a/libraries/SD/examples/SD_time/SD_time.ino
+++ b/libraries/SD/examples/SD_time/SD_time.ino
@@ -164,10 +164,6 @@ void setup(){
     Serial.println("IP address: ");
     Serial.println(WiFi.localIP());
     Serial.println("Contacting Time Server");
-    /*
-        Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
-        see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
-     */
 	configTime(3600*timezone, daysavetime*3600, "time.nist.gov", "0.pool.ntp.org", "1.pool.ntp.org");
 	struct tm tmstruct ;
     delay(2000);

--- a/libraries/SD_MMC/examples/SDMMC_time/SDMMC_time.ino
+++ b/libraries/SD_MMC/examples/SDMMC_time/SDMMC_time.ino
@@ -164,10 +164,6 @@ void setup(){
     Serial.println("IP address: ");
     Serial.println(WiFi.localIP());
     Serial.println("Contacting Time Server");
-    /*
-        Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
-        see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
-     */
 	configTime(3600*timezone, daysavetime*3600, "time.nist.gov", "0.pool.ntp.org", "1.pool.ntp.org");
 	struct tm tmstruct ;
     delay(2000);

--- a/libraries/SPIFFS/examples/SPIFFS_time/SPIFFS_time.ino
+++ b/libraries/SPIFFS/examples/SPIFFS_time/SPIFFS_time.ino
@@ -148,10 +148,6 @@ void setup(){
     Serial.println("IP address: ");
     Serial.println(WiFi.localIP());
     Serial.println("Contacting Time Server");
-    /*
-        Note: Bundled Arduino lwip supports only ONE ntp server, 2nd and 3rd options are silently ignored
-        see CONFIG_LWIP_DHCP_MAX_NTP_SERVERS define in ./tools/sdk/esp32/sdkconfig
-     */
 	configTime(3600*timezone, daysavetime*3600, "time.nist.gov", "0.pool.ntp.org", "1.pool.ntp.org");
 	struct tm tmstruct ;
     delay(2000);


### PR DESCRIPTION
## Summary
SNTP: revert comments for examples including configTime() call setup.
It's been obsolete since 2.0.2 build includes this PR espressif/esp32-arduino-lib-builder#51

Updated SimpleTime example with a bit more details regarding SNTP over DHCP use case and TimeZone env setup.

## Impact
none

## Related links
Obsoletes #5343