### PR TITLE
Print.flush() - Arduino API conformance

### DIFF
--- a/cores/esp32/Print.h
+++ b/cores/esp32/Print.h
@@ -108,6 +108,9 @@ public:
     size_t println(const Printable&);
     size_t println(struct tm * timeinfo, const char * format = NULL);
     size_t println(void);
+    
+    virtual void flush() { /* Empty implementation for backward compatibility */ }
+    
 };
 
 #endif

--- a/cores/esp32/Stream.h
+++ b/cores/esp32/Stream.h
@@ -48,7 +48,6 @@ public:
     virtual int available() = 0;
     virtual int read() = 0;
     virtual int peek() = 0;
-    virtual void flush() = 0;
 
     Stream():_startMillis(0)
     {


### PR DESCRIPTION

In ARDUINO 1.0 (2011.11.30) Arduino changed Serial.flush() to "wait for outgoing data to be transmitted". In following years other classes derived from Stream (or Print) implemented flush() as "send the buffer out". In ARDUINO 1.8.4 (2017.08.23) they moved flush() from Stream to Print in the prominent Arduino AVR core. For backward compatibility of flush() in Print they changed the pure virtual function to empty implementation. The [ArduinoCore-API](https://github.com/arduino/ArduinoCore-API) recommended for new cores or major updates has flush() in Print too.

Most major cores already implemented this change. This PR moves flush() from Stream.h to Print.h in this core.