### PR TITLE
Remove useless parameter check for unit < 0 in BTScanResultsSet.cpp

### DIFF
--- a/libraries/BluetoothSerial/src/BTScanResultsSet.cpp
+++ b/libraries/BluetoothSerial/src/BTScanResultsSet.cpp
@@ -64,9 +64,6 @@ int BTScanResultsSet::getCount() {
  * @return The device at the specified index.
  */
 BTAdvertisedDevice* BTScanResultsSet::getDevice(uint32_t i) {
-	if (i < 0)
-		return nullptr;
-
 	uint32_t x = 0;
 	BTAdvertisedDeviceSet* pDev = &m_vectorAdvertisedDevices.begin()->second;
 	for (auto it = m_vectorAdvertisedDevices.begin(); it != m_vectorAdvertisedDevices.end(); it++) {


### PR DESCRIPTION
## Summary
Remove useless parameter check:

BTScanResultsSet.cpp:67:8: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
  if (i < 0)
      ~~^~~
[ 83%] Linking C static library libarduino-esp32.a

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
