### PR TITLE
Consistently change device index to singed integer in BluetoothSerial lib

### DIFF
--- a/libraries/BluetoothSerial/src/BTScan.h
+++ b/libraries/BluetoothSerial/src/BTScan.h
@@ -24,14 +24,14 @@ public:
 
     virtual void        		dump(Print *print = nullptr);
     virtual int         		getCount();
-    virtual BTAdvertisedDevice* getDevice(uint32_t i);
+    virtual BTAdvertisedDevice* getDevice(int i);
 };
 
 class BTScanResultsSet : public BTScanResults {
 public:
     void                	dump(Print *print = nullptr);
     int                 	getCount();
-    BTAdvertisedDevice*		getDevice(uint32_t i);
+    BTAdvertisedDevice*		getDevice(int i);
 
 	bool add(BTAdvertisedDeviceSet advertisedDevice, bool unique = true);
 	void clear();

--- a/libraries/BluetoothSerial/src/BTScanResultsSet.cpp
+++ b/libraries/BluetoothSerial/src/BTScanResultsSet.cpp
@@ -63,11 +63,11 @@ int BTScanResultsSet::getCount() {
  * @param [in] i The index of the device.
  * @return The device at the specified index.
  */
-BTAdvertisedDevice* BTScanResultsSet::getDevice(uint32_t i) {
+BTAdvertisedDevice* BTScanResultsSet::getDevice(int i) {
 	if (i < 0)
 		return nullptr;
 
-	uint32_t x = 0;
+	int x = 0;
 	BTAdvertisedDeviceSet* pDev = &m_vectorAdvertisedDevices.begin()->second;
 	for (auto it = m_vectorAdvertisedDevices.begin(); it != m_vectorAdvertisedDevices.end(); it++) {
 		pDev = &it->second;


### PR DESCRIPTION
## Summary
Change device index consistently for getCount() parameter list to signed integer type.

## Impact
Get rid of compiler warning as below and get parameter check work that won't work with unsigned type:

BTScanResultsSet.cpp:67:8: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
  if (i < 0)
      ~~^~~
[ 83%] Linking C static library libarduino-esp32.a

## Related links
This is related to discussion under:
https://github.com/espressif/arduino-esp32/pull/6091