### PR TITLE
WIFI STA AutoReconnect fix for assocfail reason,  Proposed fix for #2501

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -852,7 +852,7 @@ esp_err_t WiFiGenericClass::_eventCallback(arduino_event_t *event)
         log_w("Reason: %u - %s", reason, reason2str(reason));
         if(reason == WIFI_REASON_NO_AP_FOUND) {
             WiFiSTAClass::_setStatus(WL_NO_SSID_AVAIL);
-        } else if(reason == WIFI_REASON_AUTH_FAIL || reason == WIFI_REASON_ASSOC_FAIL) {
+        } else if(reason == WIFI_REASON_AUTH_FAIL) {
             WiFiSTAClass::_setStatus(WL_CONNECT_FAILED);
         } else if(reason == WIFI_REASON_BEACON_TIMEOUT || reason == WIFI_REASON_HANDSHAKE_TIMEOUT) {
             WiFiSTAClass::_setStatus(WL_CONNECTION_LOST);
@@ -862,12 +862,17 @@ esp_err_t WiFiGenericClass::_eventCallback(arduino_event_t *event)
             WiFiSTAClass::_setStatus(WL_DISCONNECTED);
         }
         clearStatusBits(STA_CONNECTED_BIT | STA_HAS_IP_BIT | STA_HAS_IP6_BIT);
-        if(((reason == WIFI_REASON_AUTH_EXPIRE) ||
-            (reason >= WIFI_REASON_BEACON_TIMEOUT && reason != WIFI_REASON_AUTH_FAIL)) &&
-            WiFi.getAutoReconnect())
-        {
-            WiFi.disconnect();
-            WiFi.begin();
+        if(WiFi.getAutoReconnect()){
+            if((reason == WIFI_REASON_AUTH_EXPIRE) ||
+            (reason >= WIFI_REASON_BEACON_TIMEOUT && reason != WIFI_REASON_AUTH_FAIL))
+            {
+                log_d("WiFi AutoReconnect Running");
+                WiFi.disconnect();
+                WiFi.begin();
+            }
+        }
+        else if (reason == WIFI_REASON_ASSOC_FAIL){
+            WiFiSTAClass::_setStatus(WL_CONNECT_FAILED);
         }
     } else if(event->event_id == ARDUINO_EVENT_WIFI_STA_GOT_IP) {
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG


### PR DESCRIPTION
Reliability fix for autoReconnect when assoc_fail, autoReconnect did not work before for these failures.

## Summary
Changes behavior of WIFI_REASON_ASSOC_FAIL event when autoReconnect is set, removes WIFI_REASON_ASSOC_FAIL/WL_CONNECT_FAILED so retry waitforconnectresult loop stays active for the retry, was not working before.

## Impact
Same behavior if autoReconnect is not enabled, suppress WL_disconnect when it is. 
Possible event loop, similar to other events, I see no special checks for avoiding, whole event method need a rewrite, currently prone to bugs

## Related links
#2501 
