### PR TITLE
Fixes UART MODBUS and Loopback issue

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -153,9 +153,6 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
         ESP_ERROR_CHECK(uart_set_line_inverse(uart_nr, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV));    
     }
 
-    // Set RS485 half duplex mode on UART.  This shall force flush to wait up to sending all bits out
-    ESP_ERROR_CHECK(uart_set_mode(uart_nr, UART_MODE_RS485_HALF_DUPLEX));
-
     UART_MUTEX_UNLOCK();
 
     uartFlush(uart);
@@ -306,7 +303,7 @@ void uartFlushTxOnly(uart_t* uart, bool txOnly)
     }
     
     UART_MUTEX_LOCK();
-    ESP_ERROR_CHECK(uart_wait_tx_done(uart->num, portMAX_DELAY));
+    while(!uart_ll_is_tx_idle(UART_LL_GET_HW(uart->num)));
 
     if ( !txOnly ) {
         ESP_ERROR_CHECK(uart_flush_input(uart->num));


### PR DESCRIPTION
## Summary
This PR fixes an issue created by #6026 not allowing UART loopback to work correctly.
It fixes both at the same time:
- makes flush() to wait up to the end of UART transmission before returning, fixing issue related to MODBUS #5877 
- solves the UART loopback issue in https://github.com/espressif/arduino-esp32/pull/5549#issuecomment-1009642889 and #6126

## Impact
None.

## Related links
Fixes #6126 
https://github.com/espressif/arduino-esp32/pull/5549#issuecomment-1009642889
#5877 
#4603

