### PR TITLE
Adds UART RX IRQ Callback with onReceive()

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -159,6 +159,11 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
     }
 }
 
+void HardwareSerial::onReceive(void(*function)(void))
+{
+    uartOnReceive(_uart, function);
+}
+
 void HardwareSerial::updateBaudRate(unsigned long baud)
 {
 	uartSetBaudRate(_uart, baud);

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -57,6 +57,10 @@ class HardwareSerial: public Stream
 public:
     HardwareSerial(int uart_nr);
 
+    // onReceive will setup a callback for whenever UART data is received
+    // it will work as UART Rx interrupt 
+    void onReceive(void(*function)(void));
+
     void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms = 20000UL, uint8_t rxfifo_full_thrhd = 112);
     void end(bool turnOffDebug = true);
     void updateBaudRate(unsigned long baud);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -106,7 +106,9 @@ static void uart_event_task(void *args)
             switch(event.type) {
                 //Event of UART receving data
                 case UART_DATA:
+                    UART_MUTEX_LOCK();
                     if(uart->onReceive) uart->onReceive();
+                    UART_MUTEX_UNLOCK();
                     break;
                 //Event of HW FIFO overflow detected
                 case UART_FIFO_OVF:

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -54,6 +54,8 @@ typedef struct uart_struct_t uart_t;
 uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t queueLen, bool inverted, uint8_t rxfifo_full_thrhd);
 void uartEnd(uart_t* uart);
 
+void uartOnReceive(uart_t* uart, void(*function)(void));
+
 uint32_t uartAvailable(uart_t* uart);
 uint32_t uartAvailableForWrite(uart_t* uart);
 uint8_t uartRead(uart_t* uart);


### PR DESCRIPTION
## Summary
This PR adds a new feature to UART / Arduino Serial API.

Users have requested a feature related to UART ISR that allow a callback function to be executed as soon as data arrives to UART port. This PR adds ```Serial.onReceive()``` functionality to Arduino Hardware Serial.

Example:
``` dart
void UART_RX_IRQ() {
  uint16_t size = Serial.available();
  Serial.printf("Got %d bytes on Serial to read\n", size);
  while(Serial.available())  {
    Serial.write(Serial.read());
  }
  Serial.printf("\nSerial data processed!\n");
}

void setup() {
  Serial.begin(115200);
  Serial.onReceive(UART_RX_IRQ);
  Serial.println("Send data to UART0 in order to activate the RX callback");
}

void loop() {
  Serial.println("Sleeping for 10 seconds...");
  delay(10000);
}
```

Output of the example in the ESP32-C3 (```Hello World!``` sent to default Serial port using Arduino Serial Monitor):

``` dart
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd6100,len:0x420
load:0x403ce000,len:0x90c
load:0x403d0000,len:0x236c
SHA-256 comparison failed:
Calculated: ccb0d00bac7e84e1d90a12e4f75f4ab6c5f7e71bb209afd5819c4c9557a6db71
Expected: c9cf160580940ec7801c73b16423824e72ad12055c732e83ce66332240af42a7
Attempting to boot anyway...
entry 0x403ce000
Send data to UART0 in order to activate the RX callback
Sleeping for 10 seconds...
Sleeping for 10 seconds...
Got 13 bytes on Serial to read
Hello World!

Serial data processed!
Sleeping for 10 seconds...

````

## Impact
It includes a new feature to Arduino Hardware Serial.
It needs to be documented (@pedrominatel) 

## Related links

Initial PR requesting the feature
PR #4656
PR #3376 

Related Issues
Fixes #5678
Fixes #5620 
Fixes #5472
Fixes #6102
 