### PR TITLE
Allows user to bypass PSRAM test and boot faster with WROVER

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -166,6 +166,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 #include "Udp.h"
 #include "HardwareSerial.h"
 #include "Esp.h"
+#include "esp32/spiram.h"
 
 using std::abs;
 using std::isinf;
@@ -181,7 +182,10 @@ uint16_t makeWord(uint8_t h, uint8_t l);
 
 size_t getArduinoLoopTaskStackSize(void);
 #define SET_LOOP_TASK_STACK_SIZE(sz) size_t getArduinoLoopTaskStackSize() { return sz;}
-    
+
+// allows user to bypass esp_spiram_test()
+#define BYPASS_SPIRAM_TEST(bypass) bool testSPIRAM(void) { if (bypass) return true; else return esp_spiram_test(); }
+
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
 

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -56,6 +56,12 @@
 #ifdef CONFIG_IDF_TARGET_ESP32
 uint8_t temprature_sens_read();
 
+//allows user to bypass SPI RAM test routine
+__attribute__((weak)) bool testSPIRAM(void) 
+{ 
+     return esp_spiram_test(); 
+}
+
 float temperatureRead()
 {
     return (temprature_sens_read() - 32) / 1.8;

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -56,12 +56,6 @@
 #ifdef CONFIG_IDF_TARGET_ESP32
 uint8_t temprature_sens_read();
 
-//allows user to bypass SPI RAM test routine
-__attribute__((weak)) bool testSPIRAM(void) 
-{ 
-     return esp_spiram_test(); 
-}
-
 float temperatureRead()
 {
     return (temprature_sens_read() - 32) / 1.8;

--- a/cores/esp32/esp32-hal-psram.c
+++ b/cores/esp32/esp32-hal-psram.c
@@ -35,6 +35,13 @@
 static volatile bool spiramDetected = false;
 static volatile bool spiramFailed = false;
 
+//allows user to bypass SPI RAM test routine
+__attribute__((weak)) bool testSPIRAM(void) 
+{ 
+     return esp_spiram_test(); 
+}
+
+
 bool psramInit(){
     if (spiramDetected) {
         return true;

--- a/cores/esp32/esp32-hal-psram.c
+++ b/cores/esp32/esp32-hal-psram.c
@@ -66,7 +66,8 @@ bool psramInit(){
         return false;
     }
     esp_spiram_init_cache();
-    if (!esp_spiram_test()) {
+    //testSPIRAM() allows user to bypass SPI RAM test routine
+    if (!testSPIRAM()) {
         spiramFailed = true;
         log_e("PSRAM test failed!");
         return false;

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -95,6 +95,9 @@ void analogWrite(uint8_t pin, int value);
 //returns chip temperature in Celsius
 float temperatureRead();
 
+//allows user to bypass SPI RAM test routine
+bool testSPIRAM(void);
+
 #if CONFIG_AUTOSTART_ARDUINO
 //enable/disable WDT for Arduino's setup and loop functions
 void enableLoopWDT();


### PR DESCRIPTION
## Summary
Users have requested a way to make the WROVER module to boot faster.
It takes about 1 second to boot in a 4MB PSRAM configuration because of SPI RAM Test routine.

This PR adds a function to ESP32 Arduino that allows the user to programmatically tell Arduino not to spend time on PSRAM test. The default behavior is to test it.

The API is ```BYPASS_SPIRAM_TEST(bool)```

Example:

``` dart
BYPASS_SPIRAM_TEST(true);  // not declaring it or using BYPASS_SPIRAM_TEST(false) will run SPI RAM Test

void setup() {
  Serial.begin(115200);
  Serial.println("\n --- SPIRAM test bypass!");
  Serial.println("Check how long does it take to boot in a WROVER module.");
}

void loop() {
  static uint8_t count = 0;
  Serial.print("-");
  delay(500);
  if (++count == 32) {
    count = 0;
    Serial.println();
  }
}
````

## Impact
The user decides if SPI RAM shall be tested before starting or not. This is not forced anymore by software.
Documentation is necessary (@pedrominatel)

## Related links
Fixes #5737
