### PR TITLE
Fixes String(float) issue with Stack Smashing

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -114,14 +114,15 @@ String::String(unsigned long value, unsigned char base) {
 
 String::String(float value, unsigned char decimalPlaces) {
     init();
-    char buf[64];
-    *this = dtostrf(value, sizeof(buf) - 1, decimalPlaces, buf);
-}
+    char *buf = (char*)malloc(decimalPlaces + 42);
+    *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+    free(buf);}
 
 String::String(double value, unsigned char decimalPlaces) {
     init();
-    char buf[64];
-    *this = dtostrf(value,  sizeof(buf) - 1, decimalPlaces, buf);
+    char *buf = (char*)malloc(decimalPlaces + 312);
+    *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+    free(buf);
 }
 
 String::~String() {

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -112,13 +112,13 @@ String::String(unsigned long value, unsigned char base) {
     *this = buf;
 }
 
-String::String(float value, unsigned char decimalPlaces) {
+String::String(float value, unsigned int decimalPlaces) {
     init();
     char *buf = (char*)malloc(decimalPlaces + 42);
     *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
     free(buf);}
 
-String::String(double value, unsigned char decimalPlaces) {
+String::String(double value, unsigned int decimalPlaces) {
     init();
     char *buf = (char*)malloc(decimalPlaces + 312);
     *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -114,13 +114,13 @@ String::String(unsigned long value, unsigned char base) {
 
 String::String(float value, unsigned char decimalPlaces) {
     init();
-    char buf[33];
+    char buf[34];
     *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 
 String::String(double value, unsigned char decimalPlaces) {
     init();
-    char buf[33];
+    char buf[34];
     *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -115,14 +115,25 @@ String::String(unsigned long value, unsigned char base) {
 String::String(float value, unsigned int decimalPlaces) {
     init();
     char *buf = (char*)malloc(decimalPlaces + 42);
-    *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
-    free(buf);}
+    if (buf) {
+        *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+        free(buf);
+    } else {
+        *this = "nan";
+        log_e("No enought memory for the operation.");
+    }
+}
 
 String::String(double value, unsigned int decimalPlaces) {
     init();
     char *buf = (char*)malloc(decimalPlaces + 312);
-    *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
-    free(buf);
+    if (buf) {
+        *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+        free(buf);
+    } else {
+        *this = "nan";
+        log_e("No enought memory for the operation.");
+    }
 }
 
 String::~String() {

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -114,14 +114,14 @@ String::String(unsigned long value, unsigned char base) {
 
 String::String(float value, unsigned char decimalPlaces) {
     init();
-    char buf[34];
-    *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+    char buf[64];
+    *this = dtostrf(value, sizeof(buf) - 1, decimalPlaces, buf);
 }
 
 String::String(double value, unsigned char decimalPlaces) {
     init();
-    char buf[34];
-    *this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+    char buf[64];
+    *this = dtostrf(value,  sizeof(buf) - 1, decimalPlaces, buf);
 }
 
 String::~String() {

--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -71,8 +71,8 @@ class String {
         explicit String(unsigned int, unsigned char base = 10);
         explicit String(long, unsigned char base = 10);
         explicit String(unsigned long, unsigned char base = 10);
-        explicit String(float, unsigned char decimalPlaces = 2);
-        explicit String(double, unsigned char decimalPlaces = 2);
+        explicit String(float, unsigned int decimalPlaces = 2);
+        explicit String(double, unsigned int decimalPlaces = 2);
         ~String(void);
 
         // memory management

--- a/cores/esp32/stdlib_noniso.c
+++ b/cores/esp32/stdlib_noniso.c
@@ -92,25 +92,36 @@ char* ultoa(unsigned long value, char* result, int base) {
 // This version is intended to be user proof
 // It avoids Stack Smashing issue, even for s = String(-234223.4f, 32) or String(0.0f, 100) 
 char *dtostrf(double number, signed char width, unsigned char prec, char *s) {
-  char fmt[34];
-  // calculates how many characters the integer part of the float will take
-  sprintf(fmt, "%32.0f", number);
-  // finds the start of number ignoring the blanks
-  char *start = fmt;
-  while (*start == ' ') start++;
-  unsigned char numSize = strlen(start), maxSize = sizeof(fmt) - 1;
-  int maxPrec;
+    char fmt[20];  // just for the formating in sprintf()
+    uint8_t numSize = 0;
+    int maxPrec;
 
-  if (prec) numSize += 1; // for the '.'
+    if (isnan(number)) {
+        strcpy(s, "nan");
+        return s;
+    }
+    if (isinf(number)) {
+        strcpy(s, "inf");
+        return s;
+    }
 
-  // avoiding Stack smashing protect failure!
-  if (width > maxSize) width = maxSize;
-  maxPrec = maxSize - numSize;
-  prec = maxPrec > 0 ? maxPrec : 0;
-  
-  sprintf(fmt, "%%%d.%df", width, prec);
-  sprintf(s, fmt, number);
-  return s;
+    // calculates how many characters the integer part of the float will take
+    if (number < 0) {   // number is negative
+        numSize = 1;    // for the '-' simbol
+    }
+    double n = fabs(number);
+    do {
+        numSize++;
+        n = n / 10;
+    } while (n > 1);
+    if (prec) numSize += 1; // for the '.'
+    // avoiding Stack smashing protect failure!
+    maxPrec = width - numSize;
+    if (prec) prec = maxPrec > 0 ? maxPrec : 0;
+
+    sprintf(fmt, "%%%d.%df", numSize, prec);
+    sprintf(s, fmt, number);
+    return s;
 }
 #else
 // orginal code from Arduino ESP8266

--- a/cores/esp32/stdlib_noniso.c
+++ b/cores/esp32/stdlib_noniso.c
@@ -88,7 +88,7 @@ char* ultoa(unsigned long value, char* result, int base) {
     return result;
 }
 
-char * dtostrf(double number, signed char width, unsigned int prec, char *s) {
+char * dtostrf(double number, signed int width, unsigned int prec, char *s) {
     bool negative = false;
 
     if (isnan(number)) {

--- a/cores/esp32/stdlib_noniso.c
+++ b/cores/esp32/stdlib_noniso.c
@@ -88,7 +88,7 @@ char* ultoa(unsigned long value, char* result, int base) {
     return result;
 }
 
-char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
+char * dtostrf(double number, signed char width, unsigned int prec, char *s) {
     bool negative = false;
 
     if (isnan(number)) {
@@ -117,7 +117,7 @@ char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
     // Round correctly so that print(1.999, 2) prints as "2.00"
     // I optimized out most of the divisions
     double rounding = 2.0;
-    for (uint8_t i = 0; i < prec; ++i)
+    for (uint32_t i = 0; i < prec; ++i)
         rounding *= 10.0;
     rounding = 1.0 / rounding;
 

--- a/cores/esp32/stdlib_noniso.c
+++ b/cores/esp32/stdlib_noniso.c
@@ -88,43 +88,6 @@ char* ultoa(unsigned long value, char* result, int base) {
     return result;
 }
 
-#if 1
-// This version is intended to be user proof
-// It avoids Stack Smashing issue, even for s = String(-234223.4f, 32) or String(0.0f, 100) 
-char *dtostrf(double number, signed char width, unsigned char prec, char *s) {
-    char fmt[20];  // just for the formating in sprintf()
-    uint8_t numSize = 0;
-    int maxPrec;
-
-    if (isnan(number)) {
-        strcpy(s, "nan");
-        return s;
-    }
-    if (isinf(number)) {
-        strcpy(s, "inf");
-        return s;
-    }
-
-    // calculates how many characters the integer part of the float will take
-    if (number < 0) {   // number is negative
-        numSize = 1;    // for the '-' simbol
-    }
-    double n = fabs(number);
-    do {
-        numSize++;
-        n = n / 10;
-    } while (n > 1);
-    if (prec) numSize += 1; // for the '.'
-    // avoiding Stack smashing protect failure!
-    maxPrec = width - numSize;
-    if (prec) prec = maxPrec > 0 ? maxPrec : 0;
-
-    sprintf(fmt, "%%%d.%df", numSize, prec);
-    sprintf(s, fmt, number);
-    return s;
-}
-#else
-// orginal code from Arduino ESP8266
 char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
     bool negative = false;
 
@@ -197,4 +160,3 @@ char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
     *out = 0;
     return s;
 }
-#endif

--- a/cores/esp32/stdlib_noniso.c
+++ b/cores/esp32/stdlib_noniso.c
@@ -88,6 +88,32 @@ char* ultoa(unsigned long value, char* result, int base) {
     return result;
 }
 
+#if 1
+// This version is intended to be user proof
+// It avoids Stack Smashing issue, even for s = String(-234223.4f, 32) or String(0.0f, 100) 
+char *dtostrf(double number, signed char width, unsigned char prec, char *s) {
+  char fmt[34];
+  // calculates how many characters the integer part of the float will take
+  sprintf(fmt, "%32.0f", number);
+  // finds the start of number ignoring the blanks
+  char *start = fmt;
+  while (*start == ' ') start++;
+  unsigned char numSize = strlen(start), maxSize = sizeof(fmt) - 1;
+  int maxPrec;
+
+  if (prec) numSize += 1; // for the '.'
+
+  // avoiding Stack smashing protect failure!
+  if (width > maxSize) width = maxSize;
+  maxPrec = maxSize - numSize;
+  prec = maxPrec > 0 ? maxPrec : 0;
+  
+  sprintf(fmt, "%%%d.%df", width, prec);
+  sprintf(s, fmt, number);
+  return s;
+}
+#else
+// orginal code from Arduino ESP8266
 char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
     bool negative = false;
 
@@ -160,3 +186,4 @@ char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
     *out = 0;
     return s;
 }
+#endif

--- a/cores/esp32/stdlib_noniso.h
+++ b/cores/esp32/stdlib_noniso.h
@@ -39,7 +39,7 @@ char* utoa (unsigned int val, char *s, int radix);
 
 char* ultoa (unsigned long val, char *s, int radix);
 
-char* dtostrf (double val, signed char width, unsigned int prec, char *s);
+char* dtostrf (double val, signed int width, unsigned int prec, char *s);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cores/esp32/stdlib_noniso.h
+++ b/cores/esp32/stdlib_noniso.h
@@ -39,7 +39,7 @@ char* utoa (unsigned int val, char *s, int radix);
 
 char* ultoa (unsigned long val, char *s, int radix);
 
-char* dtostrf (double val, signed char width, unsigned char prec, char *s);
+char* dtostrf (double val, signed char width, unsigned int prec, char *s);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
## Summary
The PR fixes an issue related to Stack Smashing when trying to execute this sketch:

``` dart
void setup() {
  Serial.begin(115200);
  String s = String(1e32f, 0);
  Serial.println(s);
  Serial.println(String(-1.0f, 30));
  Serial.println(String(0.0f, 31));
}

void loop() {
  // put your main code here, to run repeatedly:
}
```

The wrong output is:
```
Stack smashing protect failure!

abort() was called at PC 0x400d74a0 on core 1

Backtrace:0x40082e19:0x3ffb26800x40087a21:0x3ffb26a0 0x4008c465:0x3ffb26c0 0x400d74a0:0x3ffb2740 0x400d1731:0x3ffb2760 0x400d0f73:0x3ffb27c0 0x400d17de:0x3ffb2820 
```

Expected correct output is:
```
100000003318135366470187364029698
-1.000000000000000000000000000000
0.0000000000000000000000000000000
```

## Impact
None.

## Related links
Fixes #5873