### PR TITLE
Fixing interrupts in LEDC

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -168,6 +168,8 @@ void ledcAttachPin(uint8_t pin, uint8_t chan)
         .hpoint         = 0
     };
     ledc_channel_config(&ledc_channel);
+
+    pinMode(pin,OUTPUT);
 }
 
 void ledcDetachPin(uint8_t pin)


### PR DESCRIPTION
## Summary
Added `pinMode(pin,OUTPUT);` to ledcAttach function to ensure that GPIO pin interrupts will work again.

## Impact
Fix for ledc output pin interrupt

## Related links
Closes #6140 
