### PR TITLE
Fix - SD mount issue

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -506,10 +506,17 @@ DSTATUS ff_sd_initialize(uint8_t pdrv)
         card->spi->transfer(0XFF);
     }
 
-    if (sdTransaction(pdrv, GO_IDLE_STATE, 0, NULL) != 1) {
+    // Fix mount issue - sdWait fail ignored before command GO_IDLE_STATE
+    digitalWrite(card->ssPin, LOW);
+    if(!sdWait(pdrv, 500)){
+        log_w("sdWait fail ignored, card initialize continues");
+    }
+    if (sdCommand(pdrv, GO_IDLE_STATE, 0, NULL) != 1){
+        sdDeselectCard(pdrv);
         log_w("GO_IDLE_STATE failed");
         goto unknown_card;
     }
+    sdDeselectCard(pdrv);
 
     token = sdTransaction(pdrv, CRC_ON_OFF, 1, NULL);
     if (token == 0x5) {

--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -121,7 +121,7 @@ bool sdSelectCard(uint8_t pdrv)
 {
     ardu_sdcard_t * card = s_cards[pdrv];
     digitalWrite(card->ssPin, LOW);
-    bool s = sdWait(pdrv, 300);
+    bool s = sdWait(pdrv, 500);
     if (!s) {
         log_e("Select Failed");
         digitalWrite(card->ssPin, HIGH);


### PR DESCRIPTION
## Summary
On many issues with SD card mount, there is problem with sdWait() only before sending the 1st init cmd 0 = GO_IDLE_STATE. After this command sdWait() works as expected.

Edited GO_IDLE_STATE command:
-> sdWait() is ignored there, only warning message is logged.

Only in sdSelectCard timeout was 300 so added longer timeout as in other calls for sdWait.
According to issue #6107, making a timeout of 500 as in other calls should solve the issue.

Cannot reproduce issues with mounting SD cards.
Will appreciate someone to try this fix.

## Impact
Fixing SD card mounting problems.

## Related links
Closes #6143
Closes #6107 
Closes #5998