### PR TITLE
[SSL] fix: restoring handshake timeout 

### DIFF
--- a/libraries/WiFiClientSecure/src/ssl_client.cpp
+++ b/libraries/WiFiClientSecure/src/ssl_client.cpp
@@ -335,8 +335,13 @@ void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, cons
     mbedtls_ssl_config_free(&ssl_client->ssl_conf);
     mbedtls_ctr_drbg_free(&ssl_client->drbg_ctx);
     mbedtls_entropy_free(&ssl_client->entropy_ctx);
+    
+    // save only interesting field
+    int timeout = ssl_client->handshake_timeout;
     // reset embedded pointers to zero
     memset(ssl_client, 0, sizeof(sslclient_context));
+    
+    ssl_client->handshake_timeout = timeout;
 }
 
 


### PR DESCRIPTION
## Summary
Restoring handshake_timeout after clearing the whole instance.

## Impact
Fix of regression.

## Related links
Closes #6165
