### PR TITLE
Update RequestHandlersImpl.h to enable serveStatic on folders with LittleFS. 

### DIFF
--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -68,7 +68,8 @@ public:
     , _path(path)
     , _cache_header(cache_header)
     {
-        _isFile = fs.exists(path);
+        File f = fs.open(path);
+        _isFile = (f && (! f.isDirectory()));
         log_v("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header ? cache_header : ""); // issue 5506 - cache_header can be nullptr
         _baseUriLength = _uri.length();
     }


### PR DESCRIPTION
## Summary
Using `serveStatic(...)` is broken when using folder names (not files) and LittleFS fil system.
This checks correctly for folders.

With LittleFS the `fs.exists(path)` returns true also on folders. A `isDirectory()` call is required to set _isFile to false on directories.
This enables serving all files from a folder like : `server.serveStatic("/", LittleFS, "/");`

## Impact
serveStatic is partially broken 

