### PR TITLE
HTTPClient: Support concatenation of headers

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1263,12 +1263,19 @@ int HTTPClient::handleHeaderResponse()
                     _location = headerValue;
                 }
 
-                for(size_t i = 0; i < _headerKeysCount; i++) {
-                    if(_currentHeaders[i].key.equalsIgnoreCase(headerName)) {
-                        _currentHeaders[i].value = headerValue;
-                        break;
+                for (size_t i = 0; i < _headerKeysCount; i++) {
+                    if (_currentHeaders[i].key.equalsIgnoreCase(headerName)) {
+                        if (!_currentHeaders[i].value.isEmpty()) {
+                            // Existing value, append this one with a comma
+                            _currentHeaders[i].value += ',';
+                            _currentHeaders[i].value += headerValue;
+                        } else {
+                            _currentHeaders[i].value = headerValue;
+                        }
+                        break; // We found a match, stop looking
                     }
                 }
+
             }
 
             if(headerLine == "") {


### PR DESCRIPTION
## Summary
Adds support for multiple response headers with identical keys; the main goal is to support setting several cookies requested by a server, which result in several "set-cookie" response headers.

## Impact
If several headers with the same key are received in a response, they are concatenated using commas.

## Related links
* Alignment with ESP8266 implementation (see https://github.com/esp8266/Arduino/commit/1de0c341b55ba8c0993fd3d2e0c5696935578751#diff-977435a9cc4619fa0b8b995085f6ae683485cf563722756bab57108b362da316)
* Fixes https://github.com/espressif/arduino-esp32/issues/4069
