### PR TITLE
Olimex boards ESP32-EVB/Gateway ethernet fix

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -5550,11 +5550,11 @@ esp32-gateway.build.core=esp32
 esp32-gateway.build.variant=esp32-gateway
 esp32-gateway.build.board=ESP32_GATEWAY
 esp32-gateway.menu.Revision.RevC=Revision C or older
-esp32-gateway.menu.Revision.RevC.build.board=ESP32_GATEWAY_C
+esp32-gateway.menu.Revision.RevC.build.board=ESP32_GATEWAY='C'
 esp32-gateway.menu.Revision.RevE=Revision E
-esp32-gateway.menu.Revision.RevE.build.board=ESP32_GATEWAY_E
-esp32-gateway.menu.Revision.RevF=Revision F
-esp32-gateway.menu.Revision.RevF.build.board=ESP32_GATEWAY_F
+esp32-gateway.menu.Revision.RevE.build.board=ESP32_GATEWAY='E'
+esp32-gateway.menu.Revision.RevF=Revision F or newer
+esp32-gateway.menu.Revision.RevF.build.board=ESP32_GATEWAY='F'
 
 esp32-gateway.build.f_cpu=240000000L
 esp32-gateway.build.flash_mode=dio

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -228,6 +228,9 @@ ETHClass::~ETHClass()
 
 bool ETHClass::begin(uint8_t phy_addr, int power, int mdc, int mdio, eth_phy_type_t type, eth_clock_mode_t clock_mode)
 {
+#if defined ARDUINO_ESP32_EVB
+    delay (350); // Olimex board ESP32-EVB requires short delay before the phy initialization after reset
+#endif
 #if ESP_IDF_VERSION_MAJOR > 3
     eth_clock_mode = clock_mode;
     tcpipInit();


### PR DESCRIPTION
-----------
## Summary
Added short delay (350 ms) for ESP32-EVB at the start of the ethernet begin function (in ETH.cpp) to solve the issue with the inability to initialize the phy immediately after reset. 


Added values of the revision macros (in boards.txt) for ESP32-Gateway to match the #if conditions in the variant file and applying the changes for the respective revision.


## Impact
I have described the delay for ESP32-EVB subject in more details here: https://github.com/espressif/arduino-esp32/issues/6142


The values for ESP32-Gateway macros are needed so the changes can be applied not only for a specific revision but for the revisions after which is achieved by comparing the revision value to a constant inside the "pins_arduino.h" file inside the variants folder. For example:
```
#if	ARDUINO_ESP32_GATEWAY >= 'D'
#define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
#define ETH_PHY_POWER 5
#endif
```
The hardware changes were not only for revision D, but also for E, F etc. And without the values those comparisons were meaningless and the code inside was ignored. As a result the default ethernet example wasn't working. With these changes implemented the ethernet clock and power pins are defined and it works properly now.