### PR TITLE
Add conditional include to WiFiProv.h

### DIFF
--- a/libraries/WiFiProv/src/WiFiProv.h
+++ b/libraries/WiFiProv/src/WiFiProv.h
@@ -17,6 +17,9 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifndef WiFiProv_h
+#define WiFiProv_h
+
 #include "WiFi.h"
 #include "wifi_provisioning/manager.h"
 //Select the scheme using which you want to provision
@@ -48,3 +51,5 @@ class WiFiProvClass
 };
 
 extern WiFiProvClass WiFiProv;
+
+#endif


### PR DESCRIPTION
## Summary
Resolves issue #6171

## Impact
Allows compiling WiFiProv.h if included in multiple files.

## Related links
https://github.com/espressif/arduino-esp32/issues/6171
