### PR TITLE
Allow HTTPCLIENT_1_1_COMPATIBLE to be disabled

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -27,7 +27,9 @@
 #ifndef HTTPClient_H_
 #define HTTPClient_H_
 
+#ifndef HTTPCLIENT_1_1_COMPATIBLE
 #define HTTPCLIENT_1_1_COMPATIBLE
+#endif
 
 #include <memory>
 #include <Arduino.h>


### PR DESCRIPTION
Allow a user to disable the HTTPCLIENT_1_1_COMPATIBLE flag from the command line, or whichever means available.
