### PR TITLE
Fixes onReceive deadlock

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -106,9 +106,7 @@ static void uart_event_task(void *args)
             switch(event.type) {
                 //Event of UART receving data
                 case UART_DATA:
-                    UART_MUTEX_LOCK();
                     if(uart->onReceive) uart->onReceive();
-                    UART_MUTEX_UNLOCK();
                     break;
                 //Event of HW FIFO overflow detected
                 case UART_FIFO_OVF:


### PR DESCRIPTION
## Summary
Fixes a problem with deadlock when using HardwareSerial::onReceive()
OnReceive() can use other HardwareSerial APIs and it can not have its execution Locked with semophore.

## Impact
None

## Related links
None