### PR TITLE
Add Github action for uploading arduino-esp32 component. 

### DIFF
--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -1,0 +1,19 @@
+name: Push components to https://components.espressif.com
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: Upload components to the component registry
+        uses: espressif/github-actions/upload_components@master
+        with:
+          name: arduino-esp32
+          namespace: espressif
+          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,20 @@
+description: "Arduino core for ESP32, ESP32-S and ESP32-C series of SoCs"
+url: "https://github.com/espressif/arduino-esp32"
+targets:
+  - esp32
+  - esp32s2
+  - esp32c3
+tags:
+  - arduino
+files:
+  include:
+    - "cores/**/*"
+    - "variants/esp32/**/*"
+    - "variants/esp32s2/**/*"
+    - "variants/esp32s3/**/*"
+    - "variants/esp32c3/**/*"
+    - "libraries/**/*"
+    - "CMakeLists.txt"
+    - "Kconfig.projbuild"
+  exclude:
+    - "**/*"


### PR DESCRIPTION
## Summary
Add upload-idf-componen.yml file for Github Workflow. After each push on the master branch, the component will be uploaded to the component registry

## Impact
After that PR users can use the Arduino-ESP32 component from the component registry.
