### PR TITLE
Fix random CaptivePortal.ino crashes

### DIFF
--- a/libraries/DNSServer/src/DNSServer.h
+++ b/libraries/DNSServer/src/DNSServer.h
@@ -66,8 +66,8 @@ struct DNSHeader
 
 struct DNSQuestion
 {
-  uint8_t   QName[255] ;
-  int8_t    QNameLength ; 
+  uint8_t   QName[256] ; //need 1 Byte for zero termination!
+  uint8_t   QNameLength ; 
   uint16_t  QType ; 
   uint16_t  QClass ; 
 } ; 


### PR DESCRIPTION
## Summary
CaptivePortal.ino example did randomly crash for me ... so I start investigating ;-)

Decoding stack results
- 0x4016faea: WiFiUDP::write(unsigned char const*, unsigned int) at ...esp32\1.0.5\libraries\WiFi\src\WiFiUdp.cpp line 201
- 0x400d4a4a: DNSServer::replyWithIP() at ....\DNSServer\DNSServer.cpp line 187
- 0x400d4d01: DNSServer::processNextRequest() at ...\DNSServer\DNSServer.cpp line 117
- 0x400d3e81: loop() at  ....
- 0x400dd545: loopTask(void*) at  ...\esp32\1.0.5\cores\esp32\main.cpp line 37
- 0x4008a0de: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c line 143

I found with wireshark a possibility to trigger the crash on demand is:

nslookup 3.1o1osr0092ons87rp375p1pq8q066o8p56or1sqsps6rs17r4384q9748qr1r52.699p1r741q737393648s29917o45p16q50rn517rnsp73pp68p1q259s92693qp.s607408539s0p06p7559os0899866344r7qq7rpns960o9576q65.r5n94r5so9784pq1.i.03.s.sophosxl.net

The problem was that QNameLength is a signed byte and therefore its not possible to count up to 255. Additionally we need 256 bytes for the QName string to accommodate for the zero termination.

## Impact
Fixed random crashes in DNSServer 

