### PR TITLE
HttpClient: Add cookie support (cookie jar)

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -39,6 +39,9 @@
 
 #include "HTTPClient.h"
 
+/// Cookie jar support
+#include <time.h>
+
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
 class TransportTraits
 {
@@ -603,6 +606,12 @@ int HTTPClient::sendRequest(const char * type, uint8_t * payload, size_t size)
             addHeader(F("Content-Length"), String(size));
         }
 
+        // add cookies to header, if present
+        String cookie_string;
+        if(generateCookieString(&cookie_string)) {
+            addHeader("Cookie", cookie_string);
+        }
+
         // send Header
         if(!sendHeader(type)) {
             return returnError(HTTPC_ERROR_SEND_HEADER_FAILED);
@@ -704,6 +713,12 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
 
     if(size > 0) {
         addHeader("Content-Length", String(size));
+    }
+
+    // add cookies to header, if present
+    String cookie_string;
+    if(generateCookieString(&cookie_string)) {
+        addHeader("Cookie", cookie_string);
     }
 
     // send Header
@@ -1222,6 +1237,7 @@ int HTTPClient::handleHeaderResponse()
     _transferEncoding = HTTPC_TE_IDENTITY;
     unsigned long lastDataTime = millis();
     bool firstLine = true;
+    String date;
 
     while(connected()) {
         size_t len = _client->available();
@@ -1234,7 +1250,7 @@ int HTTPClient::handleHeaderResponse()
             log_v("RX: '%s'", headerLine.c_str());
 
             if(firstLine) {
-		firstLine = false;
+		        firstLine = false;
                 if(_canReuse && headerLine.startsWith("HTTP/1.")) {
                     _canReuse = (headerLine[sizeof "HTTP/1." - 1] != '0');
                 }
@@ -1244,6 +1260,10 @@ int HTTPClient::handleHeaderResponse()
                 String headerName = headerLine.substring(0, headerLine.indexOf(':'));
                 String headerValue = headerLine.substring(headerLine.indexOf(':') + 1);
                 headerValue.trim();
+
+                if(headerName.equalsIgnoreCase("Date")) {
+                    date = headerValue;
+                }
 
                 if(headerName.equalsIgnoreCase("Content-Length")) {
                     _size = headerValue.toInt();
@@ -1261,6 +1281,10 @@ int HTTPClient::handleHeaderResponse()
 
                 if (headerName.equalsIgnoreCase("Location")) {
                     _location = headerValue;
+                }
+
+                if (headerName.equalsIgnoreCase("Set-Cookie")) {
+                    setCookie(date, headerValue);
                 }
 
                 for (size_t i = 0; i < _headerKeysCount; i++) {
@@ -1498,3 +1522,164 @@ const String &HTTPClient::getLocation(void)
 {
     return _location;
 }
+
+void HTTPClient::setCookieJar(CookieJar* cookieJar)
+{
+    _cookieJar = cookieJar;
+}
+
+void HTTPClient::resetCookieJar()
+{
+    _cookieJar = nullptr;
+}
+
+void HTTPClient::clearAllCookies()
+{
+    if (_cookieJar) _cookieJar->clear();
+}
+
+void HTTPClient::setCookie(String date, String headerValue)
+{
+    #define HTTP_TIME_PATTERN "%a, %d %b %Y %H:%M:%S"
+
+    Cookie cookie;
+    String value;
+    int pos1, pos2;
+
+    headerValue.toLowerCase();
+
+    struct tm tm;
+    strptime(date.c_str(), HTTP_TIME_PATTERN, &tm);
+    cookie.date = mktime(&tm);
+
+    pos1 = headerValue.indexOf('=');
+    pos2 = headerValue.indexOf(';');
+
+    if (pos1 >= 0 && pos2 > pos1){
+        cookie.name = headerValue.substring(0, pos1);
+        cookie.value = headerValue.substring(pos1 + 1, pos2);
+    } else {
+        return;     // invalid cookie header
+    }
+
+    // expires
+    if (headerValue.indexOf("expires=") >= 0){
+        pos1 = headerValue.indexOf("expires=") + strlen("expires=");
+        pos2 = headerValue.indexOf(';', pos1);
+
+        if (pos2 > pos1)
+            value = headerValue.substring(pos1, pos2);
+        else
+            value = headerValue.substring(pos1);
+    
+        strptime(value.c_str(), HTTP_TIME_PATTERN, &tm);
+        cookie.expires.date = mktime(&tm);
+        cookie.expires.valid = true;
+    }
+
+    // max-age
+    if (headerValue.indexOf("max-age=") >= 0){
+        pos1 = headerValue.indexOf("max-age=") + strlen("max-age=");
+        pos2 = headerValue.indexOf(';', pos1);
+
+        if (pos2 > pos1)
+            value = headerValue.substring(pos1, pos2);
+        else
+            value = headerValue.substring(pos1);
+    
+        cookie.max_age.duration = value.toInt();
+        cookie.max_age.valid = true;
+    }
+
+    // domain
+    if (headerValue.indexOf("domain=") >= 0){
+        pos1 = headerValue.indexOf("domain=") + strlen("domain=");
+        pos2 = headerValue.indexOf(';', pos1);
+
+        if (pos2 > pos1)
+            value = headerValue.substring(pos1, pos2);
+        else
+            value = headerValue.substring(pos1);
+
+        if (value.startsWith(".")) value.remove(0, 1);
+
+        if (_host.indexOf(value) >= 0) {
+            cookie.domain = value;
+        } else {
+            return;     // server tries to set a cookie on a different domain; ignore it
+        }
+    } else {
+        pos1 = _host.lastIndexOf('.', _host.lastIndexOf('.') - 1);
+        if (pos1 >= 0)
+            cookie.domain = _host.substring(pos1 + 1);
+        else
+            cookie.domain = _host;
+    }
+
+    // path
+    if (headerValue.indexOf("path=") >= 0){
+        pos1 = headerValue.indexOf("path=") + strlen("path=");
+        pos2 = headerValue.indexOf(';', pos1);
+
+        if (pos2 > pos1)
+            cookie.path = headerValue.substring(pos1, pos2);
+        else
+            cookie.path = headerValue.substring(pos1);
+    }
+
+    // HttpOnly
+    cookie.http_only = (headerValue.indexOf("httponly") >= 0);
+
+    // secure
+    cookie.secure = (headerValue.indexOf("secure") >= 0);
+
+    // overwrite or delete cookie in/from cookie jar
+    time_t now_local = time(NULL);
+    time_t now_gmt = mktime(gmtime(&now_local));
+    
+    bool found = false;
+
+	for (auto c = _cookieJar->begin(); c != _cookieJar->end(); ++c) {
+        if (c->domain == cookie.domain && c->name == cookie.name) {
+            // when evaluating, max-age takes precedence over expires if both are defined
+            if (cookie.max_age.valid && ((cookie.date + cookie.max_age.duration) < now_gmt || cookie.max_age.duration <= 0)
+            || (!cookie.max_age.valid && cookie.expires.valid && cookie.expires.date < now_gmt)) {
+                _cookieJar->erase(c);
+                c--;
+            } else {
+                *c = cookie;
+            }
+            found = true;
+        }
+    }
+
+    // add cookie to jar
+    if (!found && !(cookie.max_age.valid && cookie.max_age.duration <= 0)) 
+        _cookieJar->push_back(cookie);
+
+}
+
+bool HTTPClient::generateCookieString(String *cookieString)
+{
+    time_t now_local = time(NULL);
+    time_t now_gmt = mktime(gmtime(&now_local));
+
+    *cookieString = "";
+    bool found = false;
+
+ 	for (auto c = _cookieJar->begin(); c != _cookieJar->end(); ++c) {
+        if (c->max_age.valid && ((c->date + c->max_age.duration) < now_gmt) || (!c->max_age.valid && c->expires.valid && c->expires.date < now_gmt)) {
+            _cookieJar->erase(c);
+            c--;
+        } else if (_host.indexOf(c->domain) >= 0) {
+            if (*cookieString == "")
+                *cookieString = c->name + "=" + c->value;
+            else
+                *cookieString += " ;" + c->name + "=" + c->value;
+            found = true;
+        }
+    }
+    return found;
+}
+
+

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1671,7 +1671,7 @@ bool HTTPClient::generateCookieString(String *cookieString)
         if (c->max_age.valid && ((c->date + c->max_age.duration) < now_gmt) || (!c->max_age.valid && c->expires.valid && c->expires.date < now_gmt)) {
             _cookieJar->erase(c);
             c--;
-        } else if (_host.indexOf(c->domain) >= 0) {
+        } else if (_host.indexOf(c->domain) >= 0 && (!c->secure || _secure) ) {
             if (*cookieString == "")
                 *cookieString = c->name + "=" + c->value;
             else

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -160,6 +160,7 @@ bool HTTPClient::begin(WiFiClient &client, String url) {
     }
 
     _port = (protocol == "https" ? 443 : 80);
+    _secure = (protocol == "https");
     return beginInternal(url, protocol.c_str());
 }
 
@@ -190,6 +191,7 @@ bool HTTPClient::begin(WiFiClient &client, String host, uint16_t port, String ur
     _port = port;
     _uri = uri;
     _protocol = (https ? "https" : "http");
+    _secure = https;
     return true;
 }
 

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1263,12 +1263,19 @@ int HTTPClient::handleHeaderResponse()
                     _location = headerValue;
                 }
 
-                for(size_t i = 0; i < _headerKeysCount; i++) {
-                    if(_currentHeaders[i].key.equalsIgnoreCase(headerName)) {
-                        _currentHeaders[i].value = headerValue;
-                        break;
+                for (size_t i = 0; i < _headerKeysCount; i++) {
+                    if (_currentHeaders[i].key.equalsIgnoreCase(headerName)) {
+                        if (!_currentHeaders[i].value.isEmpty()) {
+                            // Existing value, append this one with a comma
+                            _currentHeaders[i].value += ',';
+                            _currentHeaders[i].value += headerValue;
+                        } else {
+                            _currentHeaders[i].value = headerValue;
+                        }
+                        break; // We found a match, stop looking
                     }
                 }
+
             }
 
             if(headerLine == "") {

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1291,13 +1291,14 @@ int HTTPClient::handleHeaderResponse()
 
                 for (size_t i = 0; i < _headerKeysCount; i++) {
                     if (_currentHeaders[i].key.equalsIgnoreCase(headerName)) {
-                        if (!_currentHeaders[i].value.isEmpty()) {
-                            // Existing value, append this one with a comma
-                            _currentHeaders[i].value += ',';
-                            _currentHeaders[i].value += headerValue;
-                        } else {
-                            _currentHeaders[i].value = headerValue;
-                        }
+                        // Uncomment the following lines if you need to add support for multiple headers with the same key:
+                        // if (!_currentHeaders[i].value.isEmpty()) {
+                        //     // Existing value, append this one with a comma
+                        //     _currentHeaders[i].value += ',';
+                        //     _currentHeaders[i].value += headerValue;
+                        // } else {
+                        _currentHeaders[i].value = headerValue;
+                        // }
                         break; // We found a match, stop looking
                     }
                 }

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -34,6 +34,9 @@
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
 
+/// Cookie jar support
+#include <vector>
+
 #define HTTPCLIENT_DEFAULT_TCP_TIMEOUT (5000)
 
 /// HTTP client errors
@@ -142,6 +145,28 @@ class TransportTraits;
 typedef std::unique_ptr<TransportTraits> TransportTraitsPtr;
 #endif
 
+// cookie jar support
+typedef struct  {
+    String host;       // host which tries to set the cookie
+    time_t date;       // timestamp of the response that set the cookie
+    String name;
+    String value;
+    String domain;
+    String path = "";
+    struct {
+        time_t date = 0;
+        bool valid = false;
+    } expires;
+    struct {
+        time_t duration = 0;
+        bool valid = false;
+    } max_age;
+    bool http_only = false;
+    bool secure = false;
+} Cookie;
+typedef std::vector<Cookie> CookieJar;
+
+
 class HTTPClient
 {
 public:
@@ -215,6 +240,11 @@ public:
 
     static String errorToString(int error);
 
+    /// Cookie jar support
+    void setCookieJar(CookieJar* cookieJar);
+    void resetCookieJar();
+    void clearAllCookies();
+
 protected:
     struct RequestArgument {
         String key;
@@ -230,6 +260,9 @@ protected:
     int handleHeaderResponse();
     int writeToStreamDataBlock(Stream * stream, int len);
 
+    /// Cookie jar support
+    void setCookie(String date, String headerValue);
+    bool generateCookieString(String *cookieString);
 
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
     TransportTraitsPtr _transportTraits;
@@ -265,6 +298,10 @@ protected:
     uint16_t _redirectLimit = 10;
     String _location;
     transferEncoding_t _transferEncoding = HTTPC_TE_IDENTITY;
+
+    /// Cookie jar support
+    CookieJar* _cookieJar = nullptr;
+
 };
 
 


### PR DESCRIPTION
This is a proposal to add cookie support in `HttpClient`. With this modification, the client is able to receive and store cookies and automatically send them in a subsequent request, if applicable as per `Domain` and `Path` attributes. Receiving multiple cookies in the same response (multiple `set-cookie` headers) is supported.

Cookie expiry (`Expires`and `Max-Age` attributes) is respected, but relies on RTC to be set properly. 

`Secure` is respected, `HttpOnly` is stored, but not used anywhere.

See [https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie](url) for a description of cookie attributes.

This proposal probably has room for additions, code style improvements whatsoever. I created this because I needed to handle cookies when dealing with AWS requests and thought others might have use for it. I tried my best to avoid memory leaks or other negative side effects. But I'm not a professional, and it would for sure be useful if others checked a bit upon possible weak spots.

Usage in addition to standard `HttpClient` handling):

Declare a cookie jar in the calling instance: 
`CookieJar cookie_jar;`

Before beginning the HTTP request, set 

```
    WiFiClientSecure *client = new WiFiClientSecure;

    if(client) {
        client->setCACert(cert);
        {
            // Add a scoping block for HTTPClient https to make sure it is destroyed before WiFiClientSecure *client is 
            HTTPClient https;

            https.setCookieJar(&cookie_jar);

            }
            if (https.begin(*client, url)) {
            ...

``` 
That's it.

The cookie jar is a vector of structs that holds all the cookies of the client and can be used for all requests.

The pull request includes concatenation of received headers, as already proposed in [https://github.com/espressif/arduino-esp32/pull/6183](url). The latter is not required for the cookie jar to work and has only been included since I had mistakenly been working on the master branch of my fork for the former. Sorry for this. 
