### PR TITLE
Unnecessary operation removed from map() in WMath.cpp

### DIFF
--- a/cores/esp32/WMath.cpp
+++ b/cores/esp32/WMath.cpp
@@ -68,7 +68,7 @@ long random(long howsmall, long howbig)
 
 long map(long x, long in_min, long in_max, long out_min, long out_max) {
     const long run = in_max - in_min;
-    if(divisor == 0){
+    if(run == 0){
         log_e("map(): Invalid input range, min == max");
         return -1; // AVR returns -1, SAM returns 0
     }

--- a/cores/esp32/WMath.cpp
+++ b/cores/esp32/WMath.cpp
@@ -67,14 +67,14 @@ long random(long howsmall, long howbig)
 }
 
 long map(long x, long in_min, long in_max, long out_min, long out_max) {
-    const long dividend = out_max - out_min;
-    const long divisor = in_max - in_min;
-    const long delta = x - in_min;
+    const long run = in_max - in_min;
     if(divisor == 0){
-        log_e("Invalid map input range, min == max");
-        return -1; //AVR returns -1, SAM returns 0
+        log_e("map(): Invalid input range, min == max");
+        return -1; // AVR returns -1, SAM returns 0
     }
-    return (delta * dividend + (divisor / 2)) / divisor + out_min;
+    const long rise = out_max - out_min;
+    const long delta = x - in_min;
+    return (delta * rise) / run + out_min;
 }
 
 uint16_t makeWord(uint16_t w)


### PR DESCRIPTION
(A) extra operation not needed and incorrect:
      wrong by 0.5 but happens to be thrown out   
      if someone needs a float version and based their code  
      from this, they will get the wrong result (by 0.5 or 1)  
      (don't ask me how I know...)
```
     ( delta * dividend + (divisor / 2) ) / divisor

      delta * dividend   divisor
    = ---------------- + -----------
      divisor            2 * divisor

    = delta * dividend / divisor + 1/2
```
(B) check error and exit, before doing other computations

(C) changed to rise/run, easier for future maintainer
       since it's closer to equation of a line

(D) before: mult, shift, add, div, add
       now: mult, div, add

(E) error message easier to trace where thrown

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Removed unnecessary operations in map().

## Impact
Will make function run faster and correct if converted to float.

## Related links
Please provide links to related issue, PRs etc.
