### PR TITLE
Update of CameraWebServer example

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
@@ -62,6 +62,7 @@ void setup() {
     config.frame_size = FRAMESIZE_SVGA;
     config.jpeg_quality = 12;
     config.fb_count = 1;
+    config.fb_location = CAMERA_FB_IN_DRAM;
   }
 
 #if defined(CAMERA_MODEL_ESP_EYE)


### PR DESCRIPTION
## Summary
If board has no PSRAM, we need to set the framebuffer location to DRAM:
config.fb_location = CAMERA_FB_IN_DRAM;

## Impact
It is just a minor change in an example. The "M5 esp32cam" board without PSRAM can run the example with this modification. Before, the example crashed.
