### PR TITLE
LittleFS PIatformIO example: removed external lib dependency since it's the purpose of this library addition

### DIFF
--- a/libraries/LittleFS/examples/LITTLEFS_PlatformIO/platformio.ini
+++ b/libraries/LittleFS/examples/LITTLEFS_PlatformIO/platformio.ini
@@ -25,8 +25,6 @@ build_flags =
 	-D=${PIOENV} 
 	;-D CONFIG_LITTLEFS_FOR_IDF_3_2
 
-lib_deps = https://github.com/lorol/LITTLEFS.git
-
 board = esp32dev
 ;board_build.partitions = partitions_custom.csv
 monitor_filters = esp32_exception_decoder


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist
1. [ x] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [x ] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [ x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
platformio.ini had extra library dependency coming from https://github.com/lorol/LITTLEFS before it was imported as a core lib here

## Impact
no real impact as far as know

## Related links

