### PR TITLE
Fix String.replace() broken by #6190

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -774,9 +774,10 @@ void String::replace(const String& find, const String& replace) {
         }
         if(size == len())
             return;
-        if(size > capacity() && !changeBuffer(size))
+        if(size > capacity() && !changeBuffer(size)) {
             log_w("String.Replace() Insufficient space to replace string");
             return;
+        }
         int index = len() - 1;
         while(index >= 0 && (index = lastIndexOf(find, index)) >= 0) {
             readFrom = wbuffer() + index + find.len();


### PR DESCRIPTION
## Summary
This PR fixes a bug introduced by #6190

There was no braces after `if` so the `return` statement is taken every time, not just in case of failure.

## Impact
String.replace is not doing an actual replacement most of the time.

## Related links
