### PR TITLE
Remove pinMode in ledc for ESP32C3

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -169,7 +169,11 @@ void ledcAttachPin(uint8_t pin, uint8_t chan)
     };
     ledc_channel_config(&ledc_channel);
 
+    //Making attachInterrupt to work. 
+    //WILL BE REMOVED AFTER REFACTORING GPIO to use ESP-IDF API
+    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
     pinMode(pin,OUTPUT);
+    #endif
 }
 
 void ledcDetachPin(uint8_t pin)


### PR DESCRIPTION
## Summary
Fixing ledc is not working on ESP32C3, because of the pinMode.
Use pinMode only for ESP32 and ESP32S2 so attachInterrupt on ledc pin will be working.

After GPIO refactoring pinMode will be deleted.

## Impact
Fix ledc
#6160 

## Related links

