### PR TITLE
add missing S3

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -3,6 +3,7 @@ url: "https://github.com/espressif/arduino-esp32"
 targets:
   - esp32
   - esp32s2
+  - esp32s3
   - esp32c3
 tags:
   - arduino


### PR DESCRIPTION

Arduino Lib builder fails on branch esp32-s3-support since the s3 entry is missing

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
