### PR TITLE
Fixes Touch Sensor for ESP32-S3 and any future SoC

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -53,6 +53,7 @@
 #endif
 
 #include "soc/soc_caps.h"
+#include "soc/touch_sensor_periph.h"
 // It fixes lack of pin definition for S3 and for any future SoC
 // this function works for ESP32, ESP32-S2 and ESP32-S3 - including the C3, it will return -1 for any pin
 int8_t digitalPinToTouchChannel(uint8_t pin) {

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -53,10 +53,12 @@
 #endif
 
 #include "soc/soc_caps.h"
-#include "soc/touch_sensor_periph.h"
 // It fixes lack of pin definition for S3 and for any future SoC
 // this function works for ESP32, ESP32-S2 and ESP32-S3 - including the C3, it will return -1 for any pin
-int8_t digitalPinToTouchChannel(uint8_t pin) {
+#if SOC_TOUCH_SENSOR_NUM >  0
+#include "soc/touch_sensor_periph.h"
+int8_t digitalPinToTouchChannel(uint8_t pin) 
+{
     int8_t ret = -1;
     if (pin < SOC_GPIO_PIN_COUNT) {
         for (uint8_t i = 0; i < SOC_TOUCH_SENSOR_NUM; i++) {
@@ -68,6 +70,13 @@ int8_t digitalPinToTouchChannel(uint8_t pin) {
     }
     return ret;
 }
+#else
+// No Touch Sensor available
+int8_t digitalPinToTouchChannel(uint8_t pin) 
+{
+    return -1;
+}
+#endif
 
 #if CONFIG_IDF_TARGET_ESP32
 const int8_t esp32_adc2gpio[20] = {36, 37, 38, 39, 32, 33, 34, 35, -1, -1, 4, 0, 2, 15, 13, 12, 14, 27, 25, 26};

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -52,6 +52,22 @@
 #include "esp_intr.h"
 #endif
 
+#include "soc/soc_caps.h"
+// It fixes lack of pin definition for S3 and for any future SoC
+// this function works for ESP32, ESP32-S2 and ESP32-S3 - including the C3, it will return -1 for any pin
+int8_t digitalPinToTouchChannel(uint8_t pin) {
+    int8_t ret = -1;
+    if (pin < SOC_GPIO_PIN_COUNT) {
+        for (uint8_t i = 0; i < SOC_TOUCH_SENSOR_NUM; i++) {
+            if (touch_sensor_channel_io_map[i] == pin) {
+                ret = i;
+                break;
+            }
+        }
+    }
+    return ret;
+}
+
 #if CONFIG_IDF_TARGET_ESP32
 const int8_t esp32_adc2gpio[20] = {36, 37, 38, 39, 32, 33, 34, 35, -1, -1, 4, 0, 2, 15, 13, 12, 14, 27, 25, 26};
 #elif CONFIG_IDF_TARGET_ESP32S2

--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -82,7 +82,6 @@ extern const int8_t esp32_adc2gpio[20];
 #define digitalPinCanOutput(pin)        ((pin) < NUM_OUPUT_PINS && esp32_gpioMux[(pin)].reg)
 #define digitalPinToRtcPin(pin)         (((pin) < SOC_GPIO_PIN_COUNT)?esp32_gpioMux[(pin)].rtc:-1)
 #define digitalPinToAnalogChannel(pin)  (((pin) < SOC_GPIO_PIN_COUNT)?esp32_gpioMux[(pin)].adc:-1)
-#define digitalPinToTouchChannel(pin)   (((pin) < SOC_GPIO_PIN_COUNT)?esp32_gpioMux[(pin)].touch:-1)
 #define digitalPinToDacChannel(pin)     (((pin) == PIN_DAC1)?0:((pin) == PIN_DAC2)?1:-1)
 
 void pinMode(uint8_t pin, uint8_t mode);
@@ -92,6 +91,8 @@ int digitalRead(uint8_t pin);
 void attachInterrupt(uint8_t pin, void (*)(void), int mode);
 void attachInterruptArg(uint8_t pin, void (*)(void*), void * arg, int mode);
 void detachInterrupt(uint8_t pin);
+
+int8_t digitalPinToTouchChannel(uint8_t pin);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
Refactoring of ```int8_t digitalPinToTouchChannel(uint8_t pin)``` based on IDF 4.4.
This fixes this function that doesn't work for ESP32-S3 and any other future SoC.

## Impact
None

## Related links
PR #6194 