### PR TITLE
Fix for inconsistent behavior in serveStatic() of WebServer on ESP32 and LittleFS (issue #6172)

### DIFF
--- a/libraries/FFat/src/FFat.cpp
+++ b/libraries/FFat/src/FFat.cpp
@@ -177,5 +177,16 @@ bool F_Fat::exists(const String& path)
     return exists(path.c_str());
 }
 
+bool F_Fat::isDirectory(const char* path) // fix for #6172
+{
+    File f = open(path, "r",false);
+    return (f == true) && f.isDirectory();
+}
+
+bool F_Fat::isDirectory(const String& path) // fix for #6172
+{
+    return isDirectory(path.c_str());
+}
+
 
 F_Fat FFat = F_Fat(FSImplPtr(new VFSImpl()));

--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -213,6 +213,19 @@ bool FS::exists(const String& path)
     return exists(path.c_str());
 }
 
+bool FS::isDirectory(const char* path) // fix for #6172
+{
+    if (!_impl) {
+        return false;
+    }
+    return _impl->isDirectory(path);
+}
+
+bool FS::isDirectory(const String& path) // fix for #6172
+{
+    return isDirectory(path.c_str());
+}
+
 bool FS::remove(const char* path)
 {
     if (!_impl) {

--- a/libraries/FS/src/FS.h
+++ b/libraries/FS/src/FS.h
@@ -95,6 +95,9 @@ public:
     bool exists(const char* path);
     bool exists(const String& path);
 
+    bool isDirectory(const char* path);     // fix for #6172
+    bool isDirectory(const String& path);
+
     bool remove(const char* path);
     bool remove(const String& path);
 

--- a/libraries/FS/src/FSImpl.h
+++ b/libraries/FS/src/FSImpl.h
@@ -40,7 +40,7 @@ public:
     virtual time_t getLastWrite() = 0;
     virtual const char* path() const = 0;
     virtual const char* name() const = 0;
-    virtual boolean isDirectory(void) = 0;
+    virtual boolean isDirectory(void) = 0; // fix for #6172
     virtual FileImplPtr openNextFile(const char* mode) = 0;
     virtual void rewindDirectory(void) = 0;
     virtual operator bool() = 0;
@@ -55,6 +55,7 @@ public:
     virtual ~FSImpl() { }
     virtual FileImplPtr open(const char* path, const char* mode, const bool create) = 0;
     virtual bool exists(const char* path) = 0;
+    virtual bool isDirectory(const char* path) = 0; // fix for #6172
     virtual bool rename(const char* pathFrom, const char* pathTo) = 0;
     virtual bool remove(const char* path) = 0;
     virtual bool mkdir(const char *path) = 0;

--- a/libraries/FS/src/vfs_api.h
+++ b/libraries/FS/src/vfs_api.h
@@ -37,6 +37,7 @@ protected:
 public:
     FileImplPtr open(const char* path, const char* mode, const bool create) override;
     bool        exists(const char* path) override;
+    bool        isDirectory(const char* path) override;
     bool        rename(const char* pathFrom, const char* pathTo) override;
     bool        remove(const char* path) override;
     bool        mkdir(const char *path) override;

--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -37,6 +37,7 @@ public:
     LittleFSImpl();
     virtual ~LittleFSImpl() { }
     virtual bool exists(const char* path);
+    virtual bool isDirectory(const char* path); // fix for #6172
 };
 
 LittleFSImpl::LittleFSImpl()
@@ -47,6 +48,12 @@ bool LittleFSImpl::exists(const char* path)
 {
     File f = open(path, "r",false);
     return (f == true);
+}
+
+bool LittleFSImpl::isDirectory(const char* path)
+{
+    File f = open(path, "r",false);
+    return (f == true) && f.isDirectory(); // fix for #6172
 }
 
 LittleFSFS::LittleFSFS() : FS(FSImplPtr(new LittleFSImpl())), partitionLabel_(NULL)

--- a/libraries/SPIFFS/src/SPIFFS.cpp
+++ b/libraries/SPIFFS/src/SPIFFS.cpp
@@ -31,6 +31,7 @@ public:
     SPIFFSImpl();
     virtual ~SPIFFSImpl() { }
     virtual bool exists(const char* path);
+    virtual bool isDirectory(const char* path); // fix for #6172
 };
 
 SPIFFSImpl::SPIFFSImpl()
@@ -41,6 +42,12 @@ bool SPIFFSImpl::exists(const char* path)
 {
     File f = open(path, "r",false);
     return (f == true) && !f.isDirectory();
+}
+
+bool SPIFFSImpl::isDirectory(const char* path) // fix for #6172
+{
+    File f = open(path, "r",false);
+    return (f == true) && f.isDirectory();
 }
 
 SPIFFSFS::SPIFFSFS() : FS(FSImplPtr(new SPIFFSImpl())), partitionLabel_(NULL)

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -68,7 +68,7 @@ public:
     , _path(path)
     , _cache_header(cache_header)
     {
-        _isFile = fs.exists(path);
+        _isFile = fs.exists(path) && !fs.isDirectory(); // fix for #6172
         log_v("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header ? cache_header : ""); // issue 5506 - cache_header can be nullptr
         _baseUriLength = _uri.length();
     }


### PR DESCRIPTION
## Summary
This PR fixes the issue reported in issue #6172 the clean way by adding _isDirectory()_ to the _FileImpl_ interface, implementing the method in all file system related modules and setting the __isFile_ flag correctly in constructor of _StaticRequestHandler_.

## Impact
The _StaticRequestHandler_ instance now works as expected (same as on ESP8266) when passing a folder in the arguments of _serveStatic()_. This eliminates the need of listing each file separately and thus, makes the code less messy and better readable.
For example, code to add a web page based on Bootstrap to ESP32 on LittleFS before:
```    webServer.serveStatic("/assets/bootstrap/css/bootstrap.min.css", LittleFS, "/assets/bootstrap/css/bootstrap.min.css");
    webServer.serveStatic("/assets/css/styles.min.css", LittleFS, "/assets/css/styles.min.css");
    webServer.serveStatic("/assets/img/Logo.png", LittleFS, "/assets/img/Logo.png");
    webServer.serveStatic("/assets/img/fav16.png", LittleFS, "/assets/img/fav16.png");
    webServer.serveStatic("/assets/img/fav32.png", LittleFS, "/assets/img/fav32.png");
    webServer.serveStatic("/assets/img/fav180.png", LittleFS, "/assets/img/fav180.png");
    webServer.serveStatic("/assets/img/fav196.png", LittleFS, "/assets/img/fav196.png");
    webServer.serveStatic("/assets/img/fav512.png", LittleFS, "/assets/img/fav512.png");
    webServer.serveStatic("/assets/js/script.min.js", LittleFS, "/assets/js/script.min.js");
```
Code after:
```
    webServer.serveStatic("/", LittleFS, "/");
```

## Related links
See issue #6172 
