### PR TITLE
Update httpUpdate.ino

### DIFF
--- a/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdate/httpUpdate.ino
@@ -36,22 +36,6 @@ void setup() {
 
 }
 
-void update_started() {
-  Serial.println("CALLBACK:  HTTP update process started");
-}
-
-void update_finished() {
-  Serial.println("CALLBACK:  HTTP update process finished");
-}
-
-void update_progress(int cur, int total) {
-  Serial.printf("CALLBACK:  HTTP update process at %d of %d bytes...\n", cur, total);
-}
-
-void update_error(int err) {
-  Serial.printf("CALLBACK:  HTTP update fatal error code %d\n", err);
-}
-
 void loop() {
   // wait for WiFi connection
   if ((WiFiMulti.run() == WL_CONNECTED)) {
@@ -65,11 +49,6 @@ void loop() {
     // on much longer than it will be off. Other pins than LED_BUILTIN may be used. The second
     // value is used to put the LED on. If the LED is on with HIGH, that value should be passed
     // httpUpdate.setLedPin(LED_BUILTIN, LOW);
-
-    httpUpdate.onStart(update_started);
-    httpUpdate.onEnd(update_finished);
-    httpUpdate.onProgress(update_progress);
-    httpUpdate.onError(update_error);
 
     t_httpUpdate_return ret = httpUpdate.update(client, "http://server/file.bin");
     // Or:


### PR DESCRIPTION
there are no keywords for httpUpdate.onStart(), onEnd(), onProgress() or onError() in httpUpdate.

This results in a exit status 1 in Arduino IDE
Example: 
'class HTTPUpdate' has no member named 'onStart'
