### PR TITLE
GPIO refactoring

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -13,50 +13,14 @@
 // limitations under the License.
 
 #include "esp32-hal-gpio.h"
-#include "pins_arduino.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include "esp_attr.h"
-#include "soc/gpio_reg.h"
-#include "soc/io_mux_reg.h"
-#include "soc/gpio_struct.h"
-#include "driver/gpio.h"
-#include "esp_system.h"
-
-#ifdef ESP_IDF_VERSION_MAJOR // IDF 4+
-#if CONFIG_IDF_TARGET_ESP32 // ESP32/PICO-D4
-#include "esp32/rom/ets_sys.h"
-#include "esp32/rom/gpio.h"
-#include "esp_intr_alloc.h"
-#include "soc/rtc_io_reg.h"
-#define GPIO_FUNC 2
-#elif CONFIG_IDF_TARGET_ESP32S2
-#include "esp32s2/rom/ets_sys.h"
-#include "esp32s2/rom/gpio.h"
-#include "esp_intr_alloc.h"
-#include "soc/periph_defs.h"
-#include "soc/rtc_io_reg.h"
-#define GPIO_FUNC 1
-#elif CONFIG_IDF_TARGET_ESP32C3
-#include "esp32c3/rom/ets_sys.h"
-#include "esp32c3/rom/gpio.h"
-#include "esp_intr_alloc.h"
-#include "soc/periph_defs.h"
-#define USE_ESP_IDF_GPIO 1
-#else
-#define USE_ESP_IDF_GPIO 1
-#endif
-#else // ESP32 Before IDF 4.0
-#include "rom/ets_sys.h"
-#include "rom/gpio.h"
-#include "esp_intr.h"
-#endif
-
+#include "hal/gpio_hal.h"
 #include "soc/soc_caps.h"
+
 // It fixes lack of pin definition for S3 and for any future SoC
 // this function works for ESP32, ESP32-S2 and ESP32-S3 - including the C3, it will return -1 for any pin
 #if SOC_TOUCH_SENSOR_NUM >  0
 #include "soc/touch_sensor_periph.h"
+
 int8_t digitalPinToTouchChannel(uint8_t pin) 
 {
     int8_t ret = -1;
@@ -78,128 +42,40 @@ int8_t digitalPinToTouchChannel(uint8_t pin)
 }
 #endif
 
-#if CONFIG_IDF_TARGET_ESP32
-const int8_t esp32_adc2gpio[20] = {36, 37, 38, 39, 32, 33, 34, 35, -1, -1, 4, 0, 2, 15, 13, 12, 14, 27, 25, 26};
-#elif CONFIG_IDF_TARGET_ESP32S2
-const int8_t esp32_adc2gpio[20] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
-#endif
+#ifdef SOC_ADC_SUPPORTED
+#include "soc/adc_periph.h"
 
-const DRAM_ATTR esp32_gpioMux_t esp32_gpioMux[SOC_GPIO_PIN_COUNT]={
-#if CONFIG_IDF_TARGET_ESP32
-    {0x44, 11, 11, 1},
-    {0x88, -1, -1, -1},
-    {0x40, 12, 12, 2},
-    {0x84, -1, -1, -1},
-    {0x48, 10, 10, 0},
-    {0x6c, -1, -1, -1},
-    {0x60, -1, -1, -1},
-    {0x64, -1, -1, -1},
-    {0x68, -1, -1, -1},
-    {0x54, -1, -1, -1},
-    {0x58, -1, -1, -1},
-    {0x5c, -1, -1, -1},
-    {0x34, 15, 15, 5},
-    {0x38, 14, 14, 4},
-    {0x30, 16, 16, 6},
-    {0x3c, 13, 13, 3},
-    {0x4c, -1, -1, -1},
-    {0x50, -1, -1, -1},
-    {0x70, -1, -1, -1},
-    {0x74, -1, -1, -1},
-    {0x78, -1, -1, -1},
-    {0x7c, -1, -1, -1},
-    {0x80, -1, -1, -1},
-    {0x8c, -1, -1, -1},
-    {0, -1, -1, -1},
-    {0x24, 6, 18, -1}, //DAC1
-    {0x28, 7, 19, -1}, //DAC2
-    {0x2c, 17, 17, 7},
-    {0, -1, -1, -1},
-    {0, -1, -1, -1},
-    {0, -1, -1, -1},
-    {0, -1, -1, -1},
-    {0x1c, 9, 4, 8},
-    {0x20, 8, 5, 9},
-    {0x14, 4, 6, -1},
-    {0x18, 5, 7, -1},
-    {0x04, 0, 0, -1},
-    {0x08, 1, 1, -1},
-    {0x0c, 2, 2, -1},
-    {0x10, 3, 3, -1}
-#elif CONFIG_IDF_TARGET_ESP32S2
-    {0x04,  0, -1, -1},
-    {0x08,  1,  0,  1},
-    {0x0c,  2,  1,  2},
-    {0x10,  3,  2,  3},
-    {0x14,  4,  3,  4},
-    {0x18,  5,  4,  5},
-    {0x1c,  6,  5,  6},
-    {0x20,  7,  6,  7},
-    {0x24,  8,  7,  8},
-    {0x28,  9,  8,  9},//FSPI_HD
-    {0x2c, 10,  9, 10},//FSPI_CS0 / FSPI_D4
-    {0x30, 11, 10, 11},//FSPI_D / FSPI_D5
-    {0x34, 12, 11, 12},//FSPI_CLK / FSPI_D6
-    {0x38, 13, 12, 13},//FSPI_Q / FSPI_D7
-    {0x3c, 14, 13, 14},//FSPI_WP / FSPI_DQS
-    {0x40, 15, 14, -1},//32K+ / RTS0
-    {0x44, 16, 15, -1},//32K- / CTS0
-    {0x48, 17, 16, -1},//DAC1 / TXD1
-    {0x4c, 18, 17, -1},//DAC2 / RXD1
-    {0x50, 19, 18, -1},//USB D- / RTS1
-    {0x54, 20, 19, -1},//USB D+ / CTS1
-    {0x58, 21, -1, -1},//SDA?
-    {   0, -1, -1, -1},//UNAVAILABLE
-    {   0, -1, -1, -1},//UNAVAILABLE
-    {   0, -1, -1, -1},//UNAVAILABLE
-    {   0, -1, -1, -1},//UNAVAILABLE
-    {0x6c, -1, -1, -1},//RESERVED SPI_CS1
-    {0x70, -1, -1, -1},//RESERVED SPI_HD
-    {0x74, -1, -1, -1},//RESERVED SPI_WP
-    {0x78, -1, -1, -1},//RESERVED SPI_CS0
-    {0x7c, -1, -1, -1},//RESERVED SPI_CLK
-    {0x80, -1, -1, -1},//RESERVED SPI_Q
-    {0x84, -1, -1, -1},//RESERVED SPI_D
-    {0x88, -1, -1, -1},//FSPI_HD
-    {0x8c, -1, -1, -1},//FSPI_CS0
-    {0x90, -1, -1, -1},//FSPI_D
-    {0x94, -1, -1, -1},//FSPI_CLK
-    {0x98, -1, -1, -1},//FSPI_Q
-    {0x9c, -1, -1, -1},//FSPI_WP
-    {0xa0, -1, -1, -1},//MTCK
-    {0xa4, -1, -1, -1},//MTDO
-    {0xa8, -1, -1, -1},//MTDI
-    {0xac, -1, -1, -1},//MTMS
-    {0xb0, -1, -1, -1},//TXD0
-    {0xb4, -1, -1, -1},//RXD0
-    {0xb8, -1, -1, -1},//SCL?
-    {0xbc, -1, -1, -1},//INPUT ONLY
-    {0, -1, -1, -1}
-#elif CONFIG_IDF_TARGET_ESP32C3
-    {0x04, -1, 0, -1}, // ADC1_CH0
-    {0x08, -1, 1, -1}, // ADC1_CH1
-    {0x0c, -1, 2, -1}, // ADC1_CH2 | FSPIQ
-    {0x10, -1, 3, -1}, // ADC1_CH3
-    {0x14, -1, 4, -1}, // MTMS | ADC1_CH4 | FSPIHD
-    {0x18, -1, 5, -1}, // MTDI | ADC2_CH0 | FSPIWP
-    {0x1c, -1, -1, -1}, // MTCK | FSPICLK
-    {0x20, -1, -1, -1}, // MTDO | FSPID
-    {0x24, -1, -1, -1}, //
-    {0x28, -1, -1, -1}, //
-    {0x2c, -1, -1, -1}, // FSPICSO
-    {0x30, -1, -1, -1}, //
-    {0x34, -1, -1, -1}, // SPIHD
-    {0x38, -1, -1, -1}, // SPIWP
-    {0x3c, -1, -1, -1}, // SPICSO
-    {0x40, -1, -1, -1}, // SPICLK
-    {0x44, -1, -1, -1}, // SPID
-    {0x48, -1, -1, -1}, // SPIQ
-    {0x4c, -1, -1, -1}, // USB-
-    {0x50, -1, -1, -1}, // USB+
-    {0x54, -1, -1, -1}, // U0RXD
-    {0x58, -1, -1, -1}, // U0TXD
+int8_t digitalPinToAnalogChannel(uint8_t pin) 
+{
+    uint8_t channel;
+    int8_t ret = -1;
+    if (pin < SOC_GPIO_PIN_COUNT) {
+        for (uint8_t i = 0; i < SOC_ADC_PERIPH_NUM; i++) {
+            for (uint8_t j = 0; j < SOC_ADC_MAX_CHANNEL_NUM; j++) {
+                if (adc_channel_io_map[i][j] == pin) {
+                ret = channel;
+                break;
+                }
+                channel++;
+            }
+        }
+    }
+    return ret;
+}
+
+int8_t analogChannelToDigitalPin(uint8_t channel) 
+{
+    uint8_t adc_unit = (channel / SOC_ADC_MAX_CHANNEL_NUM);
+    uint8_t adc_chan = (channel % SOC_ADC_MAX_CHANNEL_NUM);
+    return adc_channel_io_map[adc_unit][adc_chan];
+}
+#else
+// No Analog channels availible
+int8_t analogChannelToDigitalPin(uint8_t channel) 
+{
+    return -1;
+}
 #endif
-};
 
 typedef void (*voidFuncPtr)(void);
 typedef void (*voidFuncPtrArg)(void*);
@@ -214,8 +90,8 @@ static InterruptHandle_t __pinInterruptHandlers[SOC_GPIO_PIN_COUNT] = {0,};
 
 extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 {
-#if USE_ESP_IDF_GPIO
 	if (!GPIO_IS_VALID_GPIO(pin)) {
+        log_e("Invalid pin selected");
 		return;
 	}
 	gpio_config_t conf = {
@@ -237,157 +113,23 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 			conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
 		}
 	}
-	gpio_config(&conf);
-
-	if(mode == SPECIAL){
-#if CONFIG_IDF_TARGET_ESP32
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin], (uint32_t)(((pin)==RX||(pin)==TX)?0:1));
-#elif CONFIG_IDF_TARGET_ESP32S2
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin], (uint32_t)(((pin)==RX||(pin)==TX)?0:2));
-#endif
-	} else if(mode == ANALOG){
-#if !CONFIG_IDF_TARGET_ESP32C3
-		//adc_gpio_init(ADC_UNIT_1, ADC_CHANNEL_0);
-#endif
-	} else if(mode >= 0x20 && mode < ANALOG) {//function
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin], mode >> 5);
-	}
-#else
-    if(!digitalPinIsValid(pin)) {
+	if(gpio_config(&conf) != ESP_OK)
+    {
+        log_e("GPIO config failed");
         return;
     }
-
-    int8_t rtc_io = esp32_gpioMux[pin].rtc;
-    uint32_t rtc_reg = (rtc_io != -1)?rtc_io_desc[rtc_io].reg:0;
-    if(mode == ANALOG) {
-        if(!rtc_reg) {
-            return;//not rtc pin
-        }
-#if CONFIG_IDF_TARGET_ESP32S2
-        SENS.sar_io_mux_conf.iomux_clk_gate_en = 1;
-#endif
-        SET_PERI_REG_MASK(rtc_io_desc[rtc_io].reg, (rtc_io_desc[rtc_io].mux));
-        SET_PERI_REG_BITS(rtc_io_desc[rtc_io].reg, RTC_IO_TOUCH_PAD1_FUN_SEL_V, 0, rtc_io_desc[rtc_io].func);
-
-        RTCIO.pin[rtc_io].pad_driver = 0;//OD = 1
-        RTCIO.enable_w1tc.w1tc = (1U << rtc_io);
-        CLEAR_PERI_REG_MASK(rtc_io_desc[rtc_io].reg, rtc_io_desc[rtc_io].ie);
-
-        if (rtc_io_desc[rtc_io].pullup) {
-            CLEAR_PERI_REG_MASK(rtc_io_desc[rtc_io].reg, rtc_io_desc[rtc_io].pullup);
-        }
-        if (rtc_io_desc[rtc_io].pulldown) {
-            CLEAR_PERI_REG_MASK(rtc_io_desc[rtc_io].reg, rtc_io_desc[rtc_io].pulldown);
-        }
-        ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = ((uint32_t)GPIO_FUNC << MCU_SEL_S) | ((uint32_t)2 << FUN_DRV_S) | FUN_IE;
-        return;
-    }
-
-    //RTC pins PULL settings
-    if(rtc_reg) {
-        ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].mux);
-        if(mode & PULLUP) {
-            ESP_REG(rtc_reg) = (ESP_REG(rtc_reg) | rtc_io_desc[rtc_io].pullup) & ~(rtc_io_desc[rtc_io].pulldown);
-        } else if(mode & PULLDOWN) {
-            ESP_REG(rtc_reg) = (ESP_REG(rtc_reg) | rtc_io_desc[rtc_io].pulldown) & ~(rtc_io_desc[rtc_io].pullup);
-        } else {
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].pullup | rtc_io_desc[rtc_io].pulldown);
-        }
-    }
-
-    uint32_t pinFunction = 0, pinControl = 0;
-
-    if(mode & INPUT) {
-        if(pin < 32) {
-            GPIO.enable_w1tc = ((uint32_t)1 << pin);
-        } else {
-            GPIO.enable1_w1tc.val = ((uint32_t)1 << (pin - 32));
-        }
-    } else if(mode & OUTPUT) {
-        if(pin >= NUM_OUPUT_PINS){
-            return;
-        } else if(pin < 32) {
-            GPIO.enable_w1ts = ((uint32_t)1 << pin);
-        } else {
-            GPIO.enable1_w1ts.val = ((uint32_t)1 << (pin - 32));
-        }
-    }
-
-    if(mode & PULLUP) {
-        pinFunction |= FUN_PU;
-    } else if(mode & PULLDOWN) {
-        pinFunction |= FUN_PD;
-    }
-
-    pinFunction |= ((uint32_t)2 << FUN_DRV_S);//what are the drivers?
-    pinFunction |= FUN_IE;//input enable but required for output as well?
-
-    if(mode & (INPUT | OUTPUT)) {
-        pinFunction |= ((uint32_t)PIN_FUNC_GPIO << MCU_SEL_S);
-    } else if(mode == SPECIAL) {
-#if CONFIG_IDF_TARGET_ESP32
-        pinFunction |= ((uint32_t)(((pin)==RX||(pin)==TX)?0:1) << MCU_SEL_S);
-#elif CONFIG_IDF_TARGET_ESP32S2
-        pinFunction |= ((uint32_t)(((pin)==RX||(pin)==TX)?0:2) << MCU_SEL_S);
-#endif
-    } else {
-        pinFunction |= ((uint32_t)(mode >> 5) << MCU_SEL_S);
-    }
-
-    ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = pinFunction;
-
-    if(mode & OPEN_DRAIN) {
-        pinControl = (1 << GPIO_PIN0_PAD_DRIVER_S);
-    }
-
-    GPIO.pin[pin].val = pinControl;
-#endif
 }
 
 extern void ARDUINO_ISR_ATTR __digitalWrite(uint8_t pin, uint8_t val)
 {
-#if USE_ESP_IDF_GPIO
 	gpio_set_level((gpio_num_t)pin, val);
-#elif CONFIG_IDF_TARGET_ESP32C3
-    if (val) {
-    	GPIO.out_w1ts.out_w1ts = (1 << pin);
-    } else {
-    	GPIO.out_w1tc.out_w1tc = (1 << pin);
-    }
-#else
-    if(val) {
-        if(pin < 32) {
-            GPIO.out_w1ts = ((uint32_t)1 << pin);
-        } else if(pin < NUM_OUPUT_PINS) {
-            GPIO.out1_w1ts.val = ((uint32_t)1 << (pin - 32));
-        }
-    } else {
-        if(pin < 32) {
-            GPIO.out_w1tc = ((uint32_t)1 << pin);
-        } else if(pin < NUM_OUPUT_PINS) {
-            GPIO.out1_w1tc.val = ((uint32_t)1 << (pin - 32));
-        }
-    }
-#endif
 }
 
 extern int ARDUINO_ISR_ATTR __digitalRead(uint8_t pin)
 {
-#if USE_ESP_IDF_GPIO
 	return gpio_get_level((gpio_num_t)pin);
-#elif CONFIG_IDF_TARGET_ESP32C3
-	return (GPIO.in.data >> pin) & 0x1;
-#else
-    if(pin < 32) {
-        return (GPIO.in >> pin) & 0x1;
-    } else if(pin < GPIO_PIN_COUNT) {
-        return (GPIO.in1.val >> (pin - 32)) & 0x1;
-    }
-    return 0;
-#endif
 }
 
-#if USE_ESP_IDF_GPIO
 static void ARDUINO_ISR_ATTR __onPinInterrupt(void * arg) {
 	InterruptHandle_t * isr = (InterruptHandle_t*)arg;
     if(isr->fn) {
@@ -398,49 +140,6 @@ static void ARDUINO_ISR_ATTR __onPinInterrupt(void * arg) {
         }
     }
 }
-#else
-static intr_handle_t gpio_intr_handle = NULL;
-
-static void ARDUINO_ISR_ATTR __onPinInterrupt()
-{
-    uint32_t gpio_intr_status_l=0;
-    uint32_t gpio_intr_status_h=0;
-
-    gpio_intr_status_l = GPIO.status;
-    gpio_intr_status_h = GPIO.status1.val;
-    GPIO.status_w1tc = gpio_intr_status_l;//Clear intr for gpio0-gpio31
-    GPIO.status1_w1tc.val = gpio_intr_status_h;//Clear intr for gpio32-39
-
-    uint8_t pin=0;
-    if(gpio_intr_status_l) {
-        do {
-            if(gpio_intr_status_l & ((uint32_t)1 << pin)) {
-                if(__pinInterruptHandlers[pin].fn) {
-                    if(__pinInterruptHandlers[pin].arg){
-                        ((voidFuncPtrArg)__pinInterruptHandlers[pin].fn)(__pinInterruptHandlers[pin].arg);
-                    } else {
-                        __pinInterruptHandlers[pin].fn();
-                    }
-                }
-            }
-        } while(++pin<32);
-    }
-    if(gpio_intr_status_h) {
-        pin=32;
-        do {
-            if(gpio_intr_status_h & ((uint32_t)1 << (pin - 32))) {
-                if(__pinInterruptHandlers[pin].fn) {
-                    if(__pinInterruptHandlers[pin].arg){
-                        ((voidFuncPtrArg)__pinInterruptHandlers[pin].fn)(__pinInterruptHandlers[pin].arg);
-                    } else {
-                        __pinInterruptHandlers[pin].fn();
-                    }
-                }
-            }
-        } while(++pin<GPIO_PIN_COUNT);
-    }
-}
-#endif
 
 extern void cleanupFunctional(void* arg);
 
@@ -449,13 +148,8 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
     static bool interrupt_initialized = false;
 
     if(!interrupt_initialized) {
-#if USE_ESP_IDF_GPIO
     	esp_err_t err = gpio_install_isr_service((int)ARDUINO_ISR_FLAG);
     	interrupt_initialized = (err == ESP_OK) || (err == ESP_ERR_INVALID_STATE);
-#else
-        interrupt_initialized = true;
-        esp_intr_alloc(ETS_GPIO_INTR_SOURCE, (int)ARDUINO_ISR_FLAG, __onPinInterrupt, NULL, &gpio_intr_handle);
-#endif
     }
     if(!interrupt_initialized) {
     	log_e("GPIO ISR Service Failed To Start");
@@ -471,27 +165,18 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
     __pinInterruptHandlers[pin].arg = arg;
     __pinInterruptHandlers[pin].functional = functional;
 
-#if USE_ESP_IDF_GPIO
     gpio_set_intr_type((gpio_num_t)pin, (gpio_int_type_t)(intr_type & 0x7));
     if(intr_type & 0x8){
     	gpio_wakeup_enable((gpio_num_t)pin, (gpio_int_type_t)(intr_type & 0x7));
     }
     gpio_isr_handler_add((gpio_num_t)pin, __onPinInterrupt, &__pinInterruptHandlers[pin]);
-    gpio_intr_enable((gpio_num_t)pin);
-#else
-    esp_intr_disable(gpio_intr_handle);
-#if CONFIG_IDF_TARGET_ESP32
-    if(esp_intr_get_cpu(gpio_intr_handle)) { //APP_CPU
-#endif
-        GPIO.pin[pin].int_ena = 1;
-#if CONFIG_IDF_TARGET_ESP32
-    } else { //PRO_CPU
-        GPIO.pin[pin].int_ena = 4;
-    }
-#endif
-    GPIO.pin[pin].int_type = intr_type;
-    esp_intr_enable(gpio_intr_handle);
-#endif
+
+
+    //FIX interrupts on peripherals outputs (eg. LEDC,...)
+    //Enable input in GPIO register
+    gpio_hal_context_t gpiohal;
+    gpiohal.dev = GPIO_LL_GET_HW(GPIO_PORT_0);
+    gpio_hal_input_enable(&gpiohal, pin);
 }
 
 extern void __attachInterruptArg(uint8_t pin, voidFuncPtrArg userFunc, void * arg, int intr_type)
@@ -505,13 +190,9 @@ extern void __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int intr_type) 
 
 extern void __detachInterrupt(uint8_t pin)
 {
-#if USE_ESP_IDF_GPIO
-	gpio_intr_disable((gpio_num_t)pin);
-	gpio_isr_handler_remove((gpio_num_t)pin);
+	gpio_isr_handler_remove((gpio_num_t)pin); //remove handle and disable isr for pin
 	gpio_wakeup_disable((gpio_num_t)pin);
-#else
-    esp_intr_disable(gpio_intr_handle);
-#endif
+
     if (__pinInterruptHandlers[pin].functional && __pinInterruptHandlers[pin].arg)
     {
     	cleanupFunctional(__pinInterruptHandlers[pin].arg);
@@ -520,13 +201,7 @@ extern void __detachInterrupt(uint8_t pin)
     __pinInterruptHandlers[pin].arg = NULL;
     __pinInterruptHandlers[pin].functional = false;
 
-#if USE_ESP_IDF_GPIO
     gpio_set_intr_type((gpio_num_t)pin, GPIO_INTR_DISABLE);
-#else
-    GPIO.pin[pin].int_ena = 0;
-    GPIO.pin[pin].int_type = 0;
-    esp_intr_enable(gpio_intr_handle);
-#endif
 }
 
 

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -47,24 +47,25 @@ int8_t digitalPinToTouchChannel(uint8_t pin)
 
 int8_t digitalPinToAnalogChannel(uint8_t pin) 
 {
-    uint8_t channel;
-    int8_t ret = -1;
+    uint8_t channel = 0;
     if (pin < SOC_GPIO_PIN_COUNT) {
         for (uint8_t i = 0; i < SOC_ADC_PERIPH_NUM; i++) {
             for (uint8_t j = 0; j < SOC_ADC_MAX_CHANNEL_NUM; j++) {
                 if (adc_channel_io_map[i][j] == pin) {
-                ret = channel;
-                break;
+                    return channel;
                 }
                 channel++;
             }
         }
     }
-    return ret;
+    return -1;
 }
 
 int8_t analogChannelToDigitalPin(uint8_t channel) 
 {
+    if (channel >= (SOC_ADC_PERIPH_NUM * SOC_ADC_MAX_CHANNEL_NUM)) {
+        return -1;
+    }
     uint8_t adc_unit = (channel / SOC_ADC_MAX_CHANNEL_NUM);
     uint8_t adc_chan = (channel % SOC_ADC_MAX_CHANNEL_NUM);
     return adc_channel_io_map[adc_unit][adc_chan];

--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -68,21 +68,11 @@ extern "C" {
 #define ONLOW_WE  0x0C
 #define ONHIGH_WE 0x0D
 
-typedef struct {
-    uint8_t reg;      /*!< GPIO register offset from DR_REG_IO_MUX_BASE */
-    int8_t rtc;       /*!< RTC GPIO number (-1 if not RTC GPIO pin) */
-    int8_t adc;       /*!< ADC Channel number (-1 if not ADC pin) */
-    int8_t touch;     /*!< Touch Channel number (-1 if not Touch pin) */
-} esp32_gpioMux_t;
+#define digitalPinIsValid(pin)          GPIO_IS_VALID_GPIO(pin)
+#define digitalPinCanOutput(pin)        GPIO_IS_VALID_OUTPUT_GPIO(pin)
 
-extern const esp32_gpioMux_t esp32_gpioMux[SOC_GPIO_PIN_COUNT];
-extern const int8_t esp32_adc2gpio[20];
-
-#define digitalPinIsValid(pin)          ((pin) < SOC_GPIO_PIN_COUNT && esp32_gpioMux[(pin)].reg)
-#define digitalPinCanOutput(pin)        ((pin) < NUM_OUPUT_PINS && esp32_gpioMux[(pin)].reg)
-#define digitalPinToRtcPin(pin)         (((pin) < SOC_GPIO_PIN_COUNT)?esp32_gpioMux[(pin)].rtc:-1)
-#define digitalPinToAnalogChannel(pin)  (((pin) < SOC_GPIO_PIN_COUNT)?esp32_gpioMux[(pin)].adc:-1)
-#define digitalPinToDacChannel(pin)     (((pin) == PIN_DAC1)?0:((pin) == PIN_DAC2)?1:-1)
+#define digitalPinToRtcPin(pin)         ((RTC_GPIO_IS_VALID_GPIO(pin))?rtc_io_number_get(pin):-1) 
+#define digitalPinToDacChannel(pin)     (((pin) == DAC_CHANNEL_1_GPIO_NUM)?0:((pin) == DAC_CHANNEL_2_GPIO_NUM)?1:-1)
 
 void pinMode(uint8_t pin, uint8_t mode);
 void digitalWrite(uint8_t pin, uint8_t val);
@@ -93,6 +83,8 @@ void attachInterruptArg(uint8_t pin, void (*)(void*), void * arg, int mode);
 void detachInterrupt(uint8_t pin);
 
 int8_t digitalPinToTouchChannel(uint8_t pin);
+int8_t digitalPinToAnalogChannel(uint8_t pin);
+int8_t analogChannelToDigitalPin(uint8_t channel);
 
 #ifdef __cplusplus
 }

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -168,12 +168,6 @@ void ledcAttachPin(uint8_t pin, uint8_t chan)
         .hpoint         = 0
     };
     ledc_channel_config(&ledc_channel);
-
-    //Making attachInterrupt to work. 
-    //WILL BE REMOVED AFTER REFACTORING GPIO to use ESP-IDF API
-    #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
-    pinMode(pin,OUTPUT);
-    #endif
 }
 
 void ledcDetachPin(uint8_t pin)

--- a/variants/ET-Board/pins_arduino.h
+++ b/variants/ET-Board/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       7
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/Microduino-esp32/pins_arduino.h
+++ b/variants/Microduino-esp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        22
 #define NUM_ANALOG_INPUTS       12
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/S_ODI_Ultra_v1/pins_arduino.h
+++ b/variants/S_ODI_Ultra_v1/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/adafruit_feather_esp32_v2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32_v2/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/adafruit_feather_esp32s2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/adafruit_funhouse_esp32s2/pins_arduino.h
+++ b/variants/adafruit_funhouse_esp32s2/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/adafruit_magtag29_esp32s2/pins_arduino.h
+++ b/variants/adafruit_magtag29_esp32s2/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/adafruit_metro_esp32s2/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s2/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/adafruit_qtpy_esp32/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/adafruit_qtpy_esp32c3/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32c3/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        22
 #define NUM_ANALOG_INPUTS       6
 
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
 #define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 

--- a/variants/adafruit_qtpy_esp32s2/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s2/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/alksesp32/pins_arduino.h
+++ b/variants/alksesp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/atmegazero_esp32s2/pins_arduino.h
+++ b/variants/atmegazero_esp32s2/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/bpi-bit/pins_arduino.h
+++ b/variants/bpi-bit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS 40
 #define NUM_ANALOG_INPUTS 16
 
-#define analogInputToDigitalPin(p) (((p) < 20) ? (esp32_adc2gpio[(p)]) : -1)
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
 #define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
 #define digitalPinHasPWM(p) (p < 34)
 

--- a/variants/ch_denky/pins_arduino.h
+++ b/variants/ch_denky/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/d-duino-32/pins_arduino.h
+++ b/variants/d-duino-32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/d32/d32_core.h
+++ b/variants/d32/d32_core.h
@@ -5,7 +5,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/deneyapkart/pins_arduino.h
+++ b/variants/deneyapkart/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/deneyapmini/pins_arduino.h
+++ b/variants/deneyapmini/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/doitESP32devkitV1/pins_arduino.h
+++ b/variants/doitESP32devkitV1/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/doitESPduino32/pins_arduino.h
+++ b/variants/doitESPduino32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/dpu_esp32/pins_arduino.h
+++ b/variants/dpu_esp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32-devkit-lipo/pins_arduino.h
+++ b/variants/esp32-devkit-lipo/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32-evb/pins_arduino.h
+++ b/variants/esp32-evb/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32-gateway/pins_arduino.h
+++ b/variants/esp32-gateway/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32-poe-iso/pins_arduino.h
+++ b/variants/esp32-poe-iso/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32-poe/pins_arduino.h
+++ b/variants/esp32-poe/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32-trueverit-iot-driver-mkii/pins_arduino.h
+++ b/variants/esp32-trueverit-iot-driver-mkii/pins_arduino.h
@@ -10,7 +10,7 @@ static const uint8_t LED_BUILTIN = 18;
 #define NUM_DIGITAL_PINS 40
 #define NUM_ANALOG_INPUTS 16
 
-#define analogInputToDigitalPin(p) (((p) < 20) ? (esp32_adc2gpio[(p)]) : -1)
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
 #define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
 #define digitalPinHasPWM(p) (p < 34)
 

--- a/variants/esp32-trueverit-iot-driver/pins_arduino.h
+++ b/variants/esp32-trueverit-iot-driver/pins_arduino.h
@@ -10,7 +10,7 @@ static const uint8_t LED_BUILTIN = 18;
 #define NUM_DIGITAL_PINS 40
 #define NUM_ANALOG_INPUTS 16
 
-#define analogInputToDigitalPin(p) (((p) < 20) ? (esp32_adc2gpio[(p)]) : -1)
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
 #define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
 #define digitalPinHasPWM(p) (p < 34)
 

--- a/variants/esp32/pins_arduino.h
+++ b/variants/esp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp320/pins_arduino.h
+++ b/variants/esp320/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        12
 #define NUM_ANALOG_INPUTS       5
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32c3/pins_arduino.h
+++ b/variants/esp32c3/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        22
 #define NUM_ANALOG_INPUTS       6
 
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
 #define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 

--- a/variants/esp32micromod/pins_arduino.h
+++ b/variants/esp32micromod/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32s2/pins_arduino.h
+++ b/variants/esp32s2/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/esp32s2thing_plus/pins_arduino.h
+++ b/variants/esp32s2thing_plus/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/esp32s2usb/pins_arduino.h
+++ b/variants/esp32s2usb/pins_arduino.h
@@ -24,7 +24,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/esp32s3/pins_arduino.h
+++ b/variants/esp32s3/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/esp32thing/pins_arduino.h
+++ b/variants/esp32thing/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32thing_plus/pins_arduino.h
+++ b/variants/esp32thing_plus/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/esp32vn-iot-uno/pins_arduino.h
+++ b/variants/esp32vn-iot-uno/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/espea32/pins_arduino.h
+++ b/variants/espea32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/espectro32/pins_arduino.h
+++ b/variants/espectro32/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/espino32/pins_arduino.h
+++ b/variants/espino32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        38
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/feather_esp32/pins_arduino.h
+++ b/variants/feather_esp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/firebeetle32/pins_arduino.h
+++ b/variants/firebeetle32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/fm-devkit/pins_arduino.h
+++ b/variants/fm-devkit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/franzininho_wifi_esp32s2/pins_arduino.h
+++ b/variants/franzininho_wifi_esp32s2/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/franzininho_wifi_msc_esp32s2/pins_arduino.h
+++ b/variants/franzininho_wifi_msc_esp32s2/pins_arduino.h
@@ -21,7 +21,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/frog32/pins_arduino.h
+++ b/variants/frog32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/gpy/pins_arduino.h
+++ b/variants/gpy/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       18
 
-#define analogInputToDigitalPin(p)  (((p)<40)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<40)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/healthypi4/pins_arduino.h
+++ b/variants/healthypi4/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/heltec_wifi_kit_32/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/heltec_wifi_lora_32/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/heltec_wifi_lora_32_V2/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V2/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/heltec_wireless_stick/pins_arduino.h
+++ b/variants/heltec_wireless_stick/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/heltec_wireless_stick_lite/pins_arduino.h
+++ b/variants/heltec_wireless_stick_lite/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/honeylemon/pins_arduino.h
+++ b/variants/honeylemon/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        38
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/hornbill32dev/pins_arduino.h
+++ b/variants/hornbill32dev/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/hornbill32minima/pins_arduino.h
+++ b/variants/hornbill32minima/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/imbrios-logsens-v1p1/pins_arduino.h
+++ b/variants/imbrios-logsens-v1p1/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        9
 #define NUM_ANALOG_INPUTS       7
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/intorobot-fig/pins_arduino.h
+++ b/variants/intorobot-fig/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        7
 #define NUM_ANALOG_INPUTS       10
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/lionbit/pins_arduino.h
+++ b/variants/lionbit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS 40
 #define NUM_ANALOG_INPUTS 16
 
-#define analogInputToDigitalPin(p) (((p) < 20) ? (esp32_adc2gpio[(p)]) : -1)
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
 #define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
 #define digitalPinHasPWM(p) (p < 34)
 

--- a/variants/lolin32-lite/pins_arduino.h
+++ b/variants/lolin32-lite/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/lolin32/pins_arduino.h
+++ b/variants/lolin32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/lopy/pins_arduino.h
+++ b/variants/lopy/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       18
 
-#define analogInputToDigitalPin(p)  (((p)<40)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<40)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/lopy4/pins_arduino.h
+++ b/variants/lopy4/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       18
 
-#define analogInputToDigitalPin(p)  (((p)<40)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<40)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/m5stack_atom/pins_arduino.h
+++ b/variants/m5stack_atom/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/m5stack_core2/pins_arduino.h
+++ b/variants/m5stack_core2/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        20
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/m5stack_core_esp32/pins_arduino.h
+++ b/variants/m5stack_core_esp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        20
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/m5stack_coreink/pins_arduino.h
+++ b/variants/m5stack_coreink/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/m5stack_fire/pins_arduino.h
+++ b/variants/m5stack_fire/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        20
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/m5stack_timer_cam/pins_arduino.h
+++ b/variants/m5stack_timer_cam/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/m5stick_c/pins_arduino.h
+++ b/variants/m5stick_c/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/magicbit/pins_arduino.h
+++ b/variants/magicbit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/metro_esp-32/pins_arduino.h
+++ b/variants/metro_esp-32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/mgbot-iotik32a/pins_arduino.h
+++ b/variants/mgbot-iotik32a/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/mgbot-iotik32b/pins_arduino.h
+++ b/variants/mgbot-iotik32b/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/mhetesp32devkit/pins_arduino.h
+++ b/variants/mhetesp32devkit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/mhetesp32minikit/pins_arduino.h
+++ b/variants/mhetesp32minikit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/micro_s2/pins_arduino.h
+++ b/variants/micro_s2/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/mpython/pins_arduino.h
+++ b/variants/mpython/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/nano32/pins_arduino.h
+++ b/variants/nano32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        38
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/nina_w10/pins_arduino.h
+++ b/variants/nina_w10/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/node32s/pins_arduino.h
+++ b/variants/node32s/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/nodemcu-32s/pins_arduino.h
+++ b/variants/nodemcu-32s/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/odroid_esp32/pins_arduino.h
+++ b/variants/odroid_esp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/onehorse32dev/pins_arduino.h
+++ b/variants/onehorse32dev/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/openkb/pins_arduino.h
+++ b/variants/openkb/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        38
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/oroca_edubot/pins_arduino.h
+++ b/variants/oroca_edubot/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/pico32/pins_arduino.h
+++ b/variants/pico32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/piranha_esp-32/pins_arduino.h
+++ b/variants/piranha_esp-32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/pocket_32/pins_arduino.h
+++ b/variants/pocket_32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/quantum/pins_arduino.h
+++ b/variants/quantum/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/sonoff_dualr3/pins_arduino.h
+++ b/variants/sonoff_dualr3/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/sparkfun_lora_gateway_1-channel/pins_arduino.h
+++ b/variants/sparkfun_lora_gateway_1-channel/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/tbeam/pins_arduino.h
+++ b/variants/tbeam/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        20
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/ttgo-lora32-v1/pins_arduino.h
+++ b/variants/ttgo-lora32-v1/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/ttgo-lora32-v2/pins_arduino.h
+++ b/variants/ttgo-lora32-v2/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/ttgo-lora32-v21new/pins_arduino.h
+++ b/variants/ttgo-lora32-v21new/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/ttgo-t-oi-plus/pins_arduino.h
+++ b/variants/ttgo-t-oi-plus/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        12
 #define NUM_ANALOG_INPUTS       3
 
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
 #define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 

--- a/variants/ttgo-t1/pins_arduino.h
+++ b/variants/ttgo-t1/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/ttgo-t7-v13-mini32/pins_arduino.h
+++ b/variants/ttgo-t7-v13-mini32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/ttgo-t7-v14-mini32/pins_arduino.h
+++ b/variants/ttgo-t7-v14-mini32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/turta_iot_node/pins_arduino.h
+++ b/variants/turta_iot_node/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        21
 #define NUM_ANALOG_INPUTS       9
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/twatch/pins_arduino.h
+++ b/variants/twatch/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        20
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/uPesy_esp32_wroom_devkit/pins_arduino.h
+++ b/variants/uPesy_esp32_wroom_devkit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/uPesy_esp32_wrover_devkit/pins_arduino.h
+++ b/variants/uPesy_esp32_wrover_devkit/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/um_feathers2/pins_arduino.h
+++ b/variants/um_feathers2/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/um_feathers2neo/pins_arduino.h
+++ b/variants/um_feathers2neo/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS        22
 #define NUM_ANALOG_INPUTS       11
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/um_tinypico/pins_arduino.h
+++ b/variants/um_tinypico/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/um_tinys2/pins_arduino.h
+++ b/variants/um_tinys2/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 

--- a/variants/vintlabsdevkitv1/pins_arduino.h
+++ b/variants/vintlabsdevkitv1/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/watchy/pins_arduino.h
+++ b/variants/watchy/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/wesp32/pins_arduino.h
+++ b/variants/wesp32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/widora-air/pins_arduino.h
+++ b/variants/widora-air/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        7
 #define NUM_ANALOG_INPUTS       10
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/wifiduino32/pins_arduino.h
+++ b/variants/wifiduino32/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/wipy3/pins_arduino.h
+++ b/variants/wipy3/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       18
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 

--- a/variants/wt32-eth01/pins_arduino.h
+++ b/variants/wt32-eth01/pins_arduino.h
@@ -13,7 +13,7 @@
 #define NUM_DIGITAL_PINS 40
 #define NUM_ANALOG_INPUTS 16
 
-#define analogInputToDigitalPin(p) (((p) < 20) ? (esp32_adc2gpio[(p)]) : -1)
+#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
 #define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
 #define digitalPinHasPWM(p) (p < 34)
 

--- a/variants/xinabox/pins_arduino.h
+++ b/variants/xinabox/pins_arduino.h
@@ -7,7 +7,7 @@
 #define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 


### PR DESCRIPTION
## Summary
GPIO now using ESP-IDF API on all chips.
LEDC interrupt fix removed - no longer needed.
Edited pins_arduino.h in variants according to changes in gpio.

Known issue with GPIO interrupt on chip Esp32s3. Will be fixed in ESP-IDF.
For now GPIO interrupts work only on CORE 0.

## Impact
Close #6249
Close #6120

## Related links

