### PR TITLE
Add Ethernet to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ set(includedirs
   libraries/EEPROM/src
   libraries/ESP32/src
   libraries/ESPmDNS/src
+  libraries/Ethernet/src
   libraries/FFat/src
   libraries/FS/src
   libraries/HTTPClient/src


### PR DESCRIPTION
## Summary
It's a bug fix for `fatal error: ETH.h: No such file or directory` when building arduino as IDF component