### PR TITLE
fixed http.end taking too long

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -386,9 +386,7 @@ void HTTPClient::disconnect(bool preserveClient)
     if(connected()) {
         if(_client->available() > 0) {
             log_d("still data in buffer (%d), clean up.\n", _client->available());
-            while(_client->available() > 0) {
-                _client->read();
-            }
+                _client->flush();
         }
 
         if(_reuse && _canReuse) {


### PR DESCRIPTION
http end takes 20-30 seconds if there is a large amount of data
replacing this read loop with flush fixes that problem
