### PR TITLE
Fixes softAPConfig() return

### DIFF
--- a/libraries/WiFi/src/WiFiAP.cpp
+++ b/libraries/WiFi/src/WiFiAP.cpp
@@ -205,7 +205,23 @@ bool WiFiAPClass::softAPConfig(IPAddress local_ip, IPAddress gateway, IPAddress 
     }
 
     err = set_esp_interface_ip(ESP_IF_WIFI_AP, local_ip, gateway, subnet);
-    return err == ESP_OK;
+
+    // testing effectiveness of the operation beyond internal DHCP Client process
+	esp_netif_ip_info_t ip;
+    if(esp_netif_get_ip_info(get_esp_interface_netif(ESP_IF_WIFI_AP), &ip) != ESP_OK){
+    	log_e("Netif Get IP Failed!");
+    	return false;
+    }
+    bool ip_ok = IPAddress(ip.ip.addr) == local_ip;
+    bool gw_ok = IPAddress(ip.gw.addr) == gateway;
+    bool mk_ok = IPAddress(ip.netmask.addr) == subnet;
+
+    if (ip_ok && gw_ok && mk_ok) {
+        return true;
+    } else {
+        log_e("Failed setting: %s %s %s", ip_ok ? "" : "Static IP", gw_ok ? "" : "- Gateway", mk_ok ? "" : "- Netmask"); 
+        return false;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
This PR fixes the return of Static IP setup using ```softAPConfig()``` function.
```softAPConfig()``` returns always ```false``` even when the operation is successful.
This occurs because of a failure return code while trying to stop DHCP Client Service.

## Impact
None, just fixes the function.

## Related links
Fixes #6270 
