### PR TITLE
The M5Core2 and M5Tough have 40 pins

### DIFF
--- a/variants/m5stack_core2/pins_arduino.h
+++ b/variants/m5stack_core2/pins_arduino.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
+#define NUM_DIGITAL_PINS        40
 #define NUM_ANALOG_INPUTS       16
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)


### PR DESCRIPTION
## Summary

The M5Core2 and the very similar M5Tough have 40 digital pins

See reference here: https://docs.m5stack.com/en/core/core2 as well as the constant declarations in the bottom part of the file.

## Impact
Without this, Code that needs the total number of pins (e.g. [firmata](https://github.com/firmata/ConfigurableFirmata)) doesn't show the higher pin numbers correctly.

