### PR TITLE
Fix DNSServer crash

### DIFF
--- a/libraries/DNSServer/src/DNSServer.h
+++ b/libraries/DNSServer/src/DNSServer.h
@@ -67,7 +67,7 @@ struct DNSHeader
 struct DNSQuestion
 {
   uint8_t   QName[256] ; //need 1 Byte for zero termination!
-  uint8_t   QNameLength ; 
+  uint16_t  QNameLength ; 
   uint16_t  QType ; 
   uint16_t  QClass ; 
 } ; 


### PR DESCRIPTION
## Summary
Because of the changes in #6206 it is necessary to change the QNameLength datatype to uint16_t, to be able to address the QName max. size of 256.

## Impact
The problem appears int the following lines from the DNSServer.cpp if QNameLength is 255. The wrap around destroys the following memcpy.

https://github.com/espressif/arduino-esp32/blob/b254765ef81a2d80f498a8c22c7750152e3e68df/libraries/DNSServer/src/DNSServer.cpp#L88-L93
