### PR TITLE
[esp32-hal-log.h] add #ifdef for LOG_LOCAL_LEVEL

### DIFF
--- a/cores/esp32/esp32-hal-log.h
+++ b/cores/esp32/esp32-hal-log.h
@@ -38,7 +38,9 @@ extern "C"
 #else
 #define ARDUHAL_LOG_LEVEL CORE_DEBUG_LEVEL
 #ifdef USE_ESP_IDF_LOG
+#ifndef LOG_LOCAL_LEVEL
 #define LOG_LOCAL_LEVEL CORE_DEBUG_LEVEL
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
#ifdef added, to avoid compiler redefinition warnings for `LOG_LOCAL_LEVEL` if defined by application, and we `USE_ESP_IDF_LOG`

