### PR TITLE
log_printf may cause memory leak and unexpected behaviour

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -481,11 +481,12 @@ int log_printf(const char *format, ...)
     va_list copy;
     va_start(arg, format);
     va_copy(copy, arg);
-    len = vsnprintf(NULL, 0, format, arg);
+    len = vsnprintf(NULL, 0, format, copy);
     va_end(copy);
     if(len >= sizeof(loc_buf)){
         temp = (char*)malloc(len+1);
         if(temp == NULL) {
+            va_end(arg);
             return 0;
         }
     }


### PR DESCRIPTION
## Summary
Traversing a variable argument list twice may cause unexpected behaviour. Therefore the variable argument list 'arg' is copied to 'copy'. Unfortunately in line 484 'copy' is not used to retrieve the length, but 'arg'.
Additional if the retrieved length is greater or equal than the available buffer, the clean-up of the variable argument list 'arg' is missing.

## Impact
This may cause unexpected and compiler dependend behaviour, because 'arg' is used in line some lines below again.
The missing clean-up of the variable argument list may lead to a memory leak, but depends on the compiler.
