### PR TITLE
CameraWebServer duplicate line fix

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
@@ -17,7 +17,6 @@
 #include "img_converters.h"
 #include "fb_gfx.h"
 #include "driver/ledc.h"
-//#include "camera_index.h"
 #include "sdkconfig.h"
 #include "camera_index.h"
 


### PR DESCRIPTION
## Summary
Simple delete of one duplicate line in CameraWebServer example which can bring some confusion.

## Impact
N/A

## Related links
Related discussion https://github.com/espressif/arduino-esp32/discussions/6289