### PR TITLE
Fix ledc panic’ed when wrong setup of frequency and bit width

### DIFF
--- a/libraries/ESP32/examples/AnalogOut/LEDCSoftwareFade/LEDCSoftwareFade.ino
+++ b/libraries/ESP32/examples/AnalogOut/LEDCSoftwareFade/LEDCSoftwareFade.ino
@@ -13,8 +13,8 @@
 // use first channel of 16 channels (started from zero)
 #define LEDC_CHANNEL_0     0
 
-// use 13 bit precission for LEDC timer
-#define LEDC_TIMER_13_BIT  13
+// use 12 bit precission for LEDC timer
+#define LEDC_TIMER_12_BIT  12
 
 // use 5000 Hz as a LEDC base frequency
 #define LEDC_BASE_FREQ     5000
@@ -28,8 +28,8 @@ int fadeAmount = 5;    // how many points to fade the LED by
 // Arduino like analogWrite
 // value has to be between 0 and valueMax
 void ledcAnalogWrite(uint8_t channel, uint32_t value, uint32_t valueMax = 255) {
-  // calculate duty, 8191 from 2 ^ 13 - 1
-  uint32_t duty = (8191 / valueMax) * min(value, valueMax);
+  // calculate duty, 4095 from 2 ^ 12 - 1
+  uint32_t duty = (4095 / valueMax) * min(value, valueMax);
 
   // write duty to LEDC
   ledcWrite(channel, duty);
@@ -37,7 +37,7 @@ void ledcAnalogWrite(uint8_t channel, uint32_t value, uint32_t valueMax = 255) {
 
 void setup() {
   // Setup timer and attach timer to a led pin
-  ledcSetup(LEDC_CHANNEL_0, LEDC_BASE_FREQ, LEDC_TIMER_13_BIT);
+  ledcSetup(LEDC_CHANNEL_0, LEDC_BASE_FREQ, LEDC_TIMER_12_BIT);
   ledcAttachPin(LED_PIN, LEDC_CHANNEL_0);
 }
 


### PR DESCRIPTION
## Summary
Fixing ledc issue when result of IDFs functions was not checked before calling next function causing core panic’ed.
Changed ledcSoftwareFade example to work on all SOCs.

## Impact
Fix.

## Related links
