### PR TITLE
Make flash type setting possible for S3 from Platformio

### DIFF
--- a/tools/platformio-build-esp32s3.py
+++ b/tools/platformio-build-esp32s3.py
@@ -295,7 +295,7 @@ env.Append(
     LIBPATH=[
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", "lib"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", "ld"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", "qspi_qspi")
+        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", env.BoardConfig().get("build.arduino.memory_type", "qspi_qspi"))
     ],
 
     LIBS=[


### PR DESCRIPTION
since at the moment there is no possibility to select PSRAM type from Platformio.
See https://github.com/Jason2866/platform-espressif32/issues/12#issuecomment-1059458685

@me-no-dev 

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
