### PR TITLE
Allows setting only one pin (rx or tx) in the first begin()

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -261,19 +261,25 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
     if (!uartIsDriverInstalled(_uart)) {
         switch (_uart_nr) {
             case UART_NUM_0:
-                rxPin = rxPin < 0 ? SOC_RX0 : rxPin;
-                txPin = txPin < 0 ? SOC_TX0 : txPin;
+                if (rxPin < 0 && txPin < 0) {
+                    rxPin = SOC_RX0;
+                    txPin = SOC_TX0;
+                }
             break;
 #if SOC_UART_NUM > 1                   // may save some flash bytes...
             case UART_NUM_1:
-                rxPin = rxPin < 0 ? RX1 : rxPin;
-                txPin = txPin < 0 ? TX1 : txPin;
+               if (rxPin < 0 && txPin < 0) {
+                    rxPin = RX1;
+                    txPin = TX1;
+                }
             break;
 #endif
 #if SOC_UART_NUM > 2                   // may save some flash bytes...
             case UART_NUM_2:
-                rxPin = rxPin < 0 ? RX2 : rxPin;
-                txPin = txPin < 0 ? TX2 : txPin;
+               if (rxPin < 0 && txPin < 0) {
+                    rxPin = RX2;
+                    txPin = TX2;
+                }
             break;
 #endif
             default:


### PR DESCRIPTION
## Summary
This PR allow users to start HardwareSerial setting just one pin (Rx or Tx) or both of them.
It allows these possible initial configurations:

```cpp
// In this case, Serial will configure rxPin and only be able to receive data
Serial1.begin(9600, SERIAL_8N1, rxPin);
```
```cpp
// In this case, Serial will configure txPin and only be able to send data
Serial1.begin(9600, SERIAL_8N1, -1, txPin);
```

```cpp
// In this case, Serial will configure rxPin and txPin with default pins for the chip (as in HardwareSerial.cpp)
Serial1.begin(9600, SERIAL_8N1);
```

```cpp
// In this case, Serial will configure rxPin and txPin as defined by the user
Serial1.begin(9600, SERIAL_8N1, rxPin, txPin);
```

## Impact
None

## Related links

This PR solves a discussion at https://github.com/espressif/arduino-esp32/discussions/6356
Fixes #6395 