### PR TITLE
Adds HardwareSerial::onReceiveTimeout() 

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -233,10 +233,12 @@ void HardwareSerial::_uartEventTask(void *args)
                     case UART_FIFO_OVF:
                         log_w("UART%d FIFO Overflow. Consider adding Hardware Flow Control to your Application.", uart->_uart_nr);
                         if(uart->_onReceiveErrorCB) uart->_onReceiveErrorCB(UART_FIFO_OVF_ERROR);
+                        xQueueReset(uartEventQueue);
                         break;
                     case UART_BUFFER_FULL:
                         log_w("UART%d Buffer Full. Consider encreasing your buffer size of your Application.", uart->_uart_nr);
                         if(uart->_onReceiveErrorCB) uart->_onReceiveErrorCB(UART_BUFFER_FULL_ERROR);
+                        xQueueReset(uartEventQueue);
                         break;
                     case UART_BREAK:
                         log_w("UART%d RX break.", uart->_uart_nr);

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -129,7 +129,7 @@ _uart_nr(uart_nr),
 _uart(NULL), 
 _rxBufferSize(256), 
 _onReceiveCB(NULL),
-_onReceiveTimeout(1),
+_onReceiveTimeout(5),
 _onReceiveErrorCB(NULL),
 _eventTask(NULL)
 #if !CONFIG_DISABLE_HAL_LOCKS

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -73,9 +73,21 @@ public:
     HardwareSerial(int uart_nr);
     ~HardwareSerial();
 
-    // onReceive will setup a callback for whenever UART data is received
+    // onReceive will setup a callback for whenever UART data is received and a later timeout occurs (no receiving data after specified time):
+    // param function        is the callback to be called after reception timeout
+    
     // it will work as UART Rx interrupt -- Using C++ 11 std::fuction 
     void onReceive(OnReceiveCb function);
+
+    // onReceiveTimeout sets the timeout after which onReceive callback will be called (after receiving data, it waits for this time of UART rx inactivity to call the callback fnc)
+    // param symbols_timeout defines a timeout threshold in uart symbol periods. 
+    //                       Minimum is 1 symbol timeout. Maximum is calculacted automatically by IDF. If set above the maximum, it is ignored and an error is printed on Serial0 (check console).
+    //                       Examples: Maximum for 11 bits symbol is 92 (SERIAL_8N2, SERIAL_8E1, SERIAL_8O1, etc), Maximum for 11 bits symbol is 101 (SERIAL_8N1).
+    //                       For example symbols_timeout=1 defines a timeout equal to transmission time of one symbol (~11 bit) on current baudrate. 
+    //                       For a baudrate of 9600, SERIAL_8N1 (10 bit symbol) and symbols_timeout = 3, the timeout would be 3 / (9600 / 10) = 3.125 ms
+    void onReceiveTimeout(uint8_t symbols_timeout);
+
+    // onReceive will be called on error events (see hardwareSerial_error_t)
     void onReceiveError(OnReceiveErrorCb function);
  
     void begin(unsigned long baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1, bool invert=false, unsigned long timeout_ms = 20000UL, uint8_t rxfifo_full_thrhd = 112);
@@ -138,6 +150,7 @@ protected:
     uart_t* _uart;
     size_t _rxBufferSize;
     OnReceiveCb _onReceiveCB;
+    uint8_t _onReceiveTimeout;
     OnReceiveErrorCb _onReceiveErrorCB;
     TaskHandle_t _eventTask;
 


### PR DESCRIPTION
-----------
## Summary
Adds onReceiveTimeout() to HardwareSerial. Default value of the timeout is 5 symbols. This method allows the user to change the timeout on which the onReceive callback is called. 
Before this change, the callback was called on 120 bytes always and then on timeout (when receiving more than 120 bytes). Now the callback gets called ONLY on timeout. 

## Impact
No impact. Everything should work as always.

## Related links
No issue related. I did this modifications myself because on my modbus library I was seeing that on long messages (more than 120 bytes), the callbacks was getting called twice. Now it only calls for timeouts (of no receiving data).
