### PR TITLE
Implemented tone and noTone; fixes #980

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(CORE_SRCS
   cores/esp32/stdlib_noniso.c
   cores/esp32/Stream.cpp
   cores/esp32/StreamString.cpp
+  cores/esp32/Tone.cpp
   cores/esp32/HWCDC.cpp
   cores/esp32/USB.cpp
   cores/esp32/USBCDC.cpp

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -195,6 +195,7 @@ extern "C" void configTime(long gmtOffset_sec, int daylightOffset_sec,
 extern "C" void configTzTime(const char* tz,
         const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 
+void setToneChannel(uint8_t channel = 0);
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);
 

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -195,6 +195,9 @@ extern "C" void configTime(long gmtOffset_sec, int daylightOffset_sec,
 extern "C" void configTzTime(const char* tz,
         const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 
+void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0, unsigned long duty = 50);
+void noTone(uint8_t _pin);
+
 // WMath prototypes
 long random(long);
 #endif /* __cplusplus */

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -195,7 +195,7 @@ extern "C" void configTime(long gmtOffset_sec, int daylightOffset_sec,
 extern "C" void configTzTime(const char* tz,
         const char* server1, const char* server2 = nullptr, const char* server3 = nullptr);
 
-void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0, unsigned long duty = 50);
+void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);
 
 // WMath prototypes

--- a/cores/esp32/Tone.cpp
+++ b/cores/esp32/Tone.cpp
@@ -1,8 +1,128 @@
 #include <Arduino.h>
 #include "esp32-hal-ledc.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "freertos/semphr.h"
+
+static TaskHandle_t _tone_task = NULL;
+static QueueHandle_t _tone_queue = NULL;
+static QueueHandle_t _tone_mutex = NULL;
+static uint8_t _channel = 0;
+
+typedef enum{
+  TONE_START,
+  TONE_END,
+  TONE_SET_CHANNEL
+} tone_cmd_t;
+
+typedef struct{
+  tone_cmd_t tone_cmd;
+  uint8_t pin;
+  unsigned int frequency;
+  unsigned long duration;
+  uint8_t channel;
+} tone_msg_t;
+
+static void tone_task(void*){
+  tone_msg_t tone_msg;
+  while(1){
+    xQueueReceive(_tone_queue, &tone_msg, portMAX_DELAY);
+    switch(tone_msg.tone_cmd){
+      case TONE_START:
+        log_d("Task received from queue TONE_START: _pin=%d, frequency=%u Hz, duration=%u ms", tone_msg.pin, tone_msg.frequency, tone_msg.duration);
+        if(xSemaphoreTake(_tone_mutex, portMAX_DELAY) != pdTRUE ){
+          log_e("Tone mutex take returned with error");
+          break;
+        }
+        log_d("Setup LED controll on channel %d", _channel);
+        ledcSetup(_channel, tone_msg.frequency, 11);
+        ledcAttachPin(tone_msg.pin, _channel);
+        ledcWrite(_channel, 1024);
+        if(xSemaphoreGive(_tone_mutex) != pdTRUE){
+          log_e("Tone mutex give returned with error");
+        }
+
+        if(tone_msg.duration){
+          vTaskDelay(pdMS_TO_TICKS(tone_msg.duration));
+          ledcDetachPin(tone_msg.pin);
+        }
+        break;
+
+      case TONE_END:
+        log_d("Task received from queue TONE_END: pin=%d", tone_msg.pin);
+        ledcDetachPin(tone_msg.pin);
+        break;
+
+      case TONE_SET_CHANNEL:
+        _channel = tone_msg.channel;
+        break;
+
+      default: ; // do nothing
+    } // switch
+  } // infinite loop
+}
+
+static int tone_init(){
+  if(_tone_mutex == NULL){
+    log_v("Creating tone mutex");
+    _tone_mutex = xSemaphoreCreateMutex();
+    if(_tone_mutex == NULL){
+      log_e("Could not create tone mutex");
+      return 0; // ERR
+    }
+    log_v("Tone mutex created");
+  }
+
+
+  if(_tone_queue == NULL){
+    log_v("Creating tone queue");
+    _tone_queue = xQueueCreate(128, sizeof(tone_msg_t));
+    if(_tone_queue == NULL){
+      log_e("Could not create tone queue");
+      return 0; // ERR
+    }
+    log_v("Tone queue created");
+  }
+
+  if(_tone_task == NULL){
+    log_v("Creating tone task");
+    xTaskCreate(
+      tone_task, // Function to implement the task
+      "toneTask", // Name of the task
+      3500,  // Stack size in words
+      NULL,  // Task input parameter
+      1,  // Priority of the task
+      &_tone_task  // Task handle.
+      );
+    if(_tone_task == NULL){
+      log_e("Could not create tone task");
+      return 0; // ERR
+    }
+    log_v("Tone task created");
+  }
+  return 1; // OK
+}
+
+void setToneChannel(uint8_t channel){
+  log_d("channel=%d", channel);
+  if(tone_init()){
+    tone_msg_t tone_msg = {
+      .tone_cmd = TONE_SET_CHANNEL,
+      .channel = channel
+    };
+    xQueueSend(_tone_queue, &tone_msg, portMAX_DELAY);
+  }
+}
 
 void noTone(uint8_t _pin){
-  ledcDetachPin(_pin);
+  log_d("noTone was called");
+  if(tone_init()){
+    tone_msg_t tone_msg = {
+      .tone_cmd = TONE_END,
+      .pin = _pin
+    };
+    xQueueSend(_tone_queue, &tone_msg, portMAX_DELAY);
+  }
 }
 
 // parameters:
@@ -11,12 +131,14 @@ void noTone(uint8_t _pin){
 // duration - time in ms - how long will the signal be outputted.
 //   If not provided, or 0 you must manually call noTone to end output
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration){
-  ledcSetup(0, frequency, 11);
-  ledcAttachPin(_pin, 0);
-
-  ledcWrite(0, 1024);
-  if(duration){
-    vTaskDelay(pdMS_TO_TICKS(duration));
-    noTone(_pin);
+  log_d("_pin=%d, frequency=%u Hz, duration=%u ms", _pin, frequency, duration);
+  if(tone_init()){
+    tone_msg_t tone_msg = {
+      .tone_cmd = TONE_START,
+      .pin = _pin,
+      .frequency = frequency,
+      .duration = duration
+    };
+    xQueueSend(_tone_queue, &tone_msg, portMAX_DELAY);
   }
 }

--- a/cores/esp32/Tone.cpp
+++ b/cores/esp32/Tone.cpp
@@ -10,12 +10,11 @@ void noTone(uint8_t _pin){
 // frequency - PWM frequency in Hz
 // duration - time in ms - how long will the signal be outputted.
 //   If not provided, or 0 you must manually call noTone to end output
-// duty - PWM duty in % (default 50%)
-void tone(uint8_t _pin, unsigned int frequency, unsigned long duration, unsigned long duty){
+void tone(uint8_t _pin, unsigned int frequency, unsigned long duration){
   ledcSetup(0, frequency, 11);
   ledcAttachPin(_pin, 0);
 
-  ledcWrite(0, duty * 20);
+  ledcWrite(0, 1024);
   if(duration){
     vTaskDelay(pdMS_TO_TICKS(duration));
     noTone(_pin);

--- a/cores/esp32/Tone.cpp
+++ b/cores/esp32/Tone.cpp
@@ -1,0 +1,23 @@
+#include <Arduino.h>
+#include "esp32-hal-ledc.h"
+
+void noTone(uint8_t _pin){
+  ledcDetachPin(_pin);
+}
+
+// parameters:
+// _pin - pin number which will output the signal
+// frequency - PWM frequency in Hz
+// duration - time in ms - how long will the signal be outputted.
+//   If not provided, or 0 you must manually call noTone to end output
+// duty - PWM duty in % (default 50%)
+void tone(uint8_t _pin, unsigned int frequency, unsigned long duration, unsigned long duty){
+  ledcSetup(0, frequency, 11);
+  ledcAttachPin(_pin, 0);
+
+  ledcWrite(0, duty * 20);
+  if(duration){
+    vTaskDelay(pdMS_TO_TICKS(duration));
+    noTone(_pin);
+  }
+}


### PR DESCRIPTION
Issue #980 requested tone to be implemented.
[tone in Arduino documentation](https://www.arduino.cc/reference/en/language/functions/advanced-io/tone/)
[noTone in Arduino documentation](https://www.arduino.cc/reference/en/language/functions/advanced-io/notone/)

## Summary
This PR provides new implementation of functions tone and noTone to be used with esp32.

## Impact
New functions are written with almost the same API as Arduino original functions. This implementation adds the option to change duty (default is 50% the same as in Arduino).

Closes #980