### PR TITLE
publish.yml:  Limit the running scope of the publish Workflow. 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Unit Test Results
 on:
   workflow_run:
     workflows: [Run tests in hardware]
+    branches-ignore: [master]
 
     types:
       - completed
@@ -11,6 +12,9 @@ jobs:
   unit-test-results:
     name: Unit Test Results
     runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'skipped'
     steps:
       - name: Download and Extract Artifacts
         env:


### PR DESCRIPTION
## Summary

1. Don't run the publish test result workflow on the master branch.
2. Run only on Pull Requests to be able to publish the result as a PR comment.
3. Avoid running when the triggering workflow was skipped, this will
   cause a failure as no file will be uploaded.

Regarding running only on PRs and not on master branch or any other branch:  It's just that the results are kind of hidden.  One will need to check the output of the workflow the have a link to where the results are published.
Example for the schedule workflow: https://github.com/espressif/arduino-esp32/runs/5531527566

## Impact
CI

## Related links
https://github.com/espressif/arduino-esp32/actions
