### PR TITLE
Fix boot freeze when trying to init PSRAM on Pico D4

### DIFF
--- a/cores/esp32/esp32-hal-psram.c
+++ b/cores/esp32/esp32-hal-psram.c
@@ -53,7 +53,7 @@ bool psramInit(){
 #if CONFIG_IDF_TARGET_ESP32
     uint32_t chip_ver = REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_VER_PKG);
     uint32_t pkg_ver = chip_ver & 0x7;
-    if (pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5 || pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2) {
+    if (pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5 || pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2 || pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4) {
         spiramFailed = true;
         log_w("PSRAM not supported!");
         return false;


### PR DESCRIPTION
## Summary
Fix a boot freeze when trying to initialize PSRAM on Pico D4.

When not setting `CONFIG_SPIRAM_BOOT_INIT`, the code in `psramInit()` probes for PSRAM, and when it does not detect any PSRAM, deconfigures GPIO16/17 except for `ESP32D2WDQ5` and `ESP32PICOD2`. The test is missing `ESP32PICOD4` for which GPIO16/17 are used for Flash and should not be deconfigured.

Tasmota uses a single firmware for multiple ESP32 variants, with or without PSRAM. So it's important that the absence of PSRAM on Pico D4 allows for normal boot.

## Impact
Allow normal boot on Pico D4 without PSRAM support
