### PR TITLE
Fix compile error of TinyUSB on ESP32-S3

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -20,7 +20,6 @@
 
 #include "hal/usb_hal.h"
 #include "hal/gpio_ll.h"
-#include "hal/usb_serial_jtag_ll.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -40,6 +39,7 @@
 #include "esp32s2/rom/usb/usb_dc.h"
 #include "esp32s2/rom/usb/chip_usb_dw_wrapper.h"
 #elif CONFIG_IDF_TARGET_ESP32S3
+#include "hal/usb_serial_jtag_ll.h"
 #include "esp32s3/rom/usb/usb_persist.h"
 #include "esp32s3/rom/usb/usb_dc.h"
 #include "esp32s3/rom/usb/chip_usb_dw_wrapper.h"


### PR DESCRIPTION
Fixes compile error of commit https://github.com/espressif/arduino-esp32/commit/2330e9992f46e265a34afafd1b14858d993e9621

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
