### PR TITLE
Change "python" to "python3"

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -10,10 +10,10 @@ tools.esptool_py.cmd=esptool
 tools.esptool_py.cmd.linux=esptool.py
 tools.esptool_py.cmd.windows=esptool.exe
 
-tools.esptool_py.network_cmd=python "{runtime.platform.path}/tools/espota.py" -r
+tools.esptool_py.network_cmd=python3 "{runtime.platform.path}/tools/espota.py" -r
 tools.esptool_py.network_cmd.windows="{runtime.platform.path}/tools/espota.exe" -r
 
-tools.gen_esp32part.cmd=python "{runtime.platform.path}/tools/gen_esp32part.py"
+tools.gen_esp32part.cmd=python3 "{runtime.platform.path}/tools/gen_esp32part.py"
 tools.gen_esp32part.cmd.windows="{runtime.platform.path}/tools/gen_esp32part.exe"
 
 compiler.path={runtime.tools.{build.tarch}-{build.target}-elf-gcc.path}/bin/


### PR DESCRIPTION
First aid for ESP32 builds not passing in Arduino IDE on macOS Monterey 12.3 that obsolete "python2.7".

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
