### PR TITLE
Warns about SPP only available for ESP32

### DIFF
--- a/libraries/BluetoothSerial/examples/SerialToSerialBT/SerialToSerialBT.ino
+++ b/libraries/BluetoothSerial/examples/SerialToSerialBT/SerialToSerialBT.ino
@@ -10,6 +10,10 @@
 #error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
 #endif
 
+#if !defined(CONFIG_BT_SPP_ENABLED)
+#error Serial Bluetooth not available or not enabled. It is only available for the ESP32 chip.
+#endif
+
 BluetoothSerial SerialBT;
 
 void setup() {

--- a/libraries/BluetoothSerial/examples/SerialToSerialBTM/SerialToSerialBTM.ino
+++ b/libraries/BluetoothSerial/examples/SerialToSerialBTM/SerialToSerialBTM.ino
@@ -8,6 +8,10 @@
 
 #include "BluetoothSerial.h"
 
+#if !defined(CONFIG_BT_SPP_ENABLED)
+#error Serial Bluetooth not available or not enabled. It is only available for the ESP32 chip.
+#endif
+
 BluetoothSerial SerialBT;
 
 String MACadd = "AA:BB:CC:11:22:33";

--- a/libraries/BluetoothSerial/examples/SerialToSerialBT_SSP_pairing/SerialToSerialBT_SSP_pairing.ino
+++ b/libraries/BluetoothSerial/examples/SerialToSerialBT_SSP_pairing/SerialToSerialBT_SSP_pairing.ino
@@ -10,6 +10,10 @@
 #error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
 #endif
 
+#if !defined(CONFIG_BT_SPP_ENABLED)
+#error Serial Bluetooth not available or not enabled. It is only available for the ESP32 chip.
+#endif
+
 BluetoothSerial SerialBT;
 boolean confirmRequestPending = true;
 

--- a/libraries/BluetoothSerial/examples/bt_classic_device_discovery/bt_classic_device_discovery.ino
+++ b/libraries/BluetoothSerial/examples/bt_classic_device_discovery/bt_classic_device_discovery.ino
@@ -4,6 +4,10 @@
 #error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
 #endif
 
+#if !defined(CONFIG_BT_SPP_ENABLED)
+#error Serial Bluetooth not available or not enabled. It is only available for the ESP32 chip.
+#endif
+
 BluetoothSerial SerialBT;
 
 

--- a/libraries/BluetoothSerial/examples/bt_remove_paired_devices/bt_remove_paired_devices.ino
+++ b/libraries/BluetoothSerial/examples/bt_remove_paired_devices/bt_remove_paired_devices.ino
@@ -15,6 +15,10 @@
 #include"esp_gap_bt_api.h"
 #include "esp_err.h"
 
+#if !defined(CONFIG_BT_SPP_ENABLED)
+#error Serial Bluetooth not available or not enabled. It is only available for the ESP32 chip.
+#endif
+
 #define REMOVE_BONDED_DEVICES 0   // <- Set to 0 to view all bonded devices addresses, set to 1 to remove
 
 #define PAIR_MAX_DEVICES 20

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -12,7 +12,9 @@ arduino-esp32 includes libraries for Arduino compatibility along with some objec
   Bluetooth Low Energy v4.2 client/server framework
 
 ### BluetoothSerial
-  Serial to Bluetooth redirection server
+  Serial to Bluetooth redirection server\
+  Note: This library depends on Bluetooth Classic which is only available for ESP32\
+  (Bluetoothserial is **not available** for ESP32-S2, ESP32-C3, ESP32-S3).
 
 ### DNSServer
   A basic UDP DNS daemon (includes captive portal demo)


### PR DESCRIPTION
## Summary
This PR helps users that try to use BT SPP (BluetoothSerial), warning that it only works for the ESP32. 

## Impact
None

## Related links
Fix #6308 
Fix #6422 
