### PR TITLE
Sd sectorsize/numSectors

### DIFF
--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -75,6 +75,22 @@ uint64_t SDFS::cardSize()
     return (uint64_t)sectors * sectorSize;
 }
 
+size_t SDFS::numSectors()
+{
+    if(_pdrv == 0xFF) {
+        return 0;
+    }
+    return sdcard_num_sectors(_pdrv);
+}
+
+size_t SDFS::sectorSize()
+{
+    if(_pdrv == 0xFF) {
+        return 0;
+    }
+    return sdcard_sector_size(_pdrv);
+}
+
 uint64_t SDFS::totalBytes()
 {
 	FATFS* fsinfo;

--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -32,6 +32,8 @@ public:
     void end();
     sdcard_type_t cardType();
     uint64_t cardSize();
+    size_t numSectors();
+    size_t sectorSize();
     uint64_t totalBytes();
     uint64_t usedBytes();
     bool readRAW(uint8_t* buffer, uint32_t sector);


### PR DESCRIPTION
This PR adds two methods to SD, the returned values may prove useful when using `MSC.begin()` with ESP32-S2