### PR TITLE
add S3 board in package_esp32_index.template.json

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -29,6 +29,9 @@
               "name": "ESP32-S2 Dev Board"
             },
             {
+              "name": "ESP32-S3 Dev Board"
+            },
+            {
               "name": "ESP32-C3 Dev Board"
             }
           ],


### PR DESCRIPTION
since it is missing in `package/package_esp32_index.template.json`

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
