### PR TITLE
BLEAddress: Correct less- and greater-than operators

### DIFF
--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -71,7 +71,7 @@ bool BLEAddress::operator!=(const BLEAddress& otherAddress) const {
 }
 
 bool BLEAddress::operator<(const BLEAddress& otherAddress) const {
-  return memcmp(otherAddress.m_address, m_address, ESP_BD_ADDR_LEN) < 0;
+  return memcmp(m_address, otherAddress.m_address, ESP_BD_ADDR_LEN) < 0;
 }
 
 bool BLEAddress::operator<=(const BLEAddress& otherAddress) const {
@@ -83,7 +83,7 @@ bool BLEAddress::operator>=(const BLEAddress& otherAddress) const {
 }
 
 bool BLEAddress::operator>(const BLEAddress& otherAddress) const {
-  return memcmp(otherAddress.m_address, m_address, ESP_BD_ADDR_LEN) > 0;
+  return memcmp(m_address, otherAddress.m_address, ESP_BD_ADDR_LEN) > 0;
 }
 
 /**


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist

## Summary
Reversed the arguments to memcmp so that eg 'a4:...' > 'a3:...' is true

## Impact
Lets Manufacturer ranges in bluetooth address space be filtered correctly

## Related links
