### PR TITLE
workflows/publish.yml: Run the workflow on success and failure only.

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -7,18 +7,21 @@ function build_sketch(){ # build_sketch <ide_path> <user_path> <fqbn> <path-to-i
         return 1
     fi
 
-    ARDUINO_CACHE_DIR="$HOME/.arduino/cache.tmp"
-    if [ -z "$ARDUINO_BUILD_DIR" ]; then
-        build_dir="$(dirname $sketch)/build"
-    else
-        build_dir="$ARDUINO_BUILD_DIR"
-    fi
     local ide_path=$1
     local usr_path=$2
     local fqbn=$3
     local sketch=$4
     local xtra_opts=$5
     local win_opts=$6
+
+    ARDUINO_CACHE_DIR="$HOME/.arduino/cache.tmp"
+    if [ -z "$ARDUINO_BUILD_DIR" ]; then
+        build_dir="$(dirname $sketch)/build"
+    else
+        build_dir="$ARDUINO_BUILD_DIR"
+    fi
+
+    echo $sketch
 
     rm -rf "$build_dir"
     mkdir -p "$build_dir"

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -67,7 +67,12 @@ jobs:
   Test:
     needs: [gen_chunks, Build]
     name: ${{matrix.chip}}-Test#${{matrix.chunks}}
-    runs-on: ESP32
+    runs-on:
+      - ESP32
+      - ESP32-S2
+      - ESP32-S3
+      - ESP32-C3
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -92,11 +92,6 @@ jobs:
            name: ${{matrix.chip}}-${{matrix.chunks}}.artifacts
            path: tests/
 
-       - name: Check Artifacts
-         run: |
-           ls -R tests
-           cat tests/*/build/build.options.json
-
        - name: Install dependencies
          run: |
            pip install -U pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'skipped'
+      (github.event.workflow_run.conclusion == 'success' ||
+      (github.event.workflow_run.conclusion == 'failure')
     steps:
       - name: Download and Extract Artifacts
         env:


### PR DESCRIPTION
## Summary
- This prevents trying to run when the trigger was cancelled or skipped.
In these cases there will be no event file to upload and the workflow will fail.

- Update the runners' tags.  One of the available runners doesn't have an S2 board anymore.

## Impact
Publish workflow.

## Related links
https://github.com/Ouss4/arduino-esp32/actions/runs/2083991236
https://github.com/Ouss4/arduino-esp32/actions/runs/2087421730
