### PR TITLE
revert remove of defines

### DIFF
--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -49,6 +49,13 @@ extern "C" {
 #define INPUT_PULLDOWN    0x09
 #define OPEN_DRAIN        0x10
 #define OUTPUT_OPEN_DRAIN 0x12
+#define SPECIAL           0xF0
+#define FUNCTION_1        0x00
+#define FUNCTION_2        0x20
+#define FUNCTION_3        0x40
+#define FUNCTION_4        0x60
+#define FUNCTION_5        0x80
+#define FUNCTION_6        0xA0
 #define ANALOG            0xC0
 
 //Interrupt Modes


### PR DESCRIPTION
since it is a uneeded breaking change. For example this library do not compile without https://github.com/earlephilhower/ESP8266Audio

Partially revert of #6527 @me-no-dev 

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
