### PR TITLE
BUGFIX: FS read + speed improvements for SD

### DIFF
--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -130,6 +130,15 @@ size_t File::size() const
     return _p->size();
 }
 
+bool File::setBufferSize(size_t size)
+{
+    if (!*this) {
+        return 0;
+    }
+
+    return _p->setBufferSize(size);
+}
+
 void File::close()
 {
     if (_p) {

--- a/libraries/FS/src/FS.h
+++ b/libraries/FS/src/FS.h
@@ -70,6 +70,7 @@ public:
     }
     size_t position() const;
     size_t size() const;
+    bool setBufferSize(size_t size);
     void close();
     operator bool() const;
     time_t getLastWrite();

--- a/libraries/FS/src/FSImpl.h
+++ b/libraries/FS/src/FSImpl.h
@@ -36,6 +36,7 @@ public:
     virtual bool seek(uint32_t pos, SeekMode mode) = 0;
     virtual size_t position() const = 0;
     virtual size_t size() const = 0;
+    virtual bool setBufferSize(size_t size) = 0;
     virtual void close() = 0;
     virtual time_t getLastWrite() = 0;
     virtual const char* path() const = 0;

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 #include "vfs_api.h"
-#include <stdio_ext.h>
 
 using namespace fs;
-
-#define READ_SIZE_SWITCH 128    //swithc to read func when read size > 128bytes
 
 FileImplPtr VFSImpl::open(const char* fpath, const char* mode, const bool create)
 {
@@ -377,28 +374,7 @@ size_t VFSFileImpl::read(uint8_t* buf, size_t size)
         return 0;
     }
 
-    //ERASE BYTEBUFFER and use read when size > READ_SIZE_SWITCH always
-    if(size > READ_SIZE_SWITCH)
-    {
-        //check some data in buffer exists –> clear buffer and move pointer to deleted data
-        size_t bytesinbuf = __fpending(_f);
-        if (bytesinbuf && (bytesinbuf != 128))  //buffer lenght is 128 bytes
-        {
-            fpurge(_f);
-            lseek(fileno(_f),(-128+bytesinbuf),SEEK_CUR);
-        }
-
-        int res = ::read(fileno(_f), buf, size);
-        if (res < 0) {
-            // an error occurred
-            return 0;
-        }
-        return res;
-    }
-    else
-    {
-        return fread(buf, 1, size, _f);
-    }
+    return fread(buf, 1, size, _f);
 }
 
 void VFSFileImpl::flush()

--- a/libraries/FS/src/vfs_api.h
+++ b/libraries/FS/src/vfs_api.h
@@ -65,10 +65,11 @@ public:
     bool        seek(uint32_t pos, SeekMode mode) override;
     size_t      position() const override;
     size_t      size() const override;
+    bool        setBufferSize(size_t size);
     void        close() override;
     const char* path() const override;
     const char* name() const override;
-    time_t getLastWrite()  override;
+    time_t      getLastWrite()  override;
     boolean     isDirectory(void) override;
     FileImplPtr openNextFile(const char* mode) override;
     void        rewindDirectory(void) override;


### PR DESCRIPTION
## Summary
1. Reverted changes #6456 that are breaking the FS reads.
2. Files internal buffer is now set to 4Kb by default where the recommended size cannot be read from _stat.

## Impact
Fix FS issues in 2.0.3-RC1 release.
Improve SD reading speed (approx 40-50%)

## Related links
Closes #6507 
Closes #6502 
Closes #6516 
