### PR TITLE
Minor changes in WiFiClientEnterprise.ino

### DIFF
--- a/libraries/WiFi/examples/WiFiClientEnterprise/WiFiClientEnterprise.ino
+++ b/libraries/WiFi/examples/WiFiClientEnterprise/WiFiClientEnterprise.ino
@@ -1,86 +1,89 @@
 #include <WiFi.h> //Wifi library
 #include "esp_wpa2.h" //wpa2 library for connections to Enterprise networks
-#define EAP_IDENTITY "login" //if connecting from another corporation, use identity@organisation.domain in Eduroam 
+#define EAP_IDENTITY "login" //if connecting from another corporation, use identity@organisation.domain in eduroam or anonymous@organisation.domain
 #define EAP_USERNAME "login" //oftentimes just a repeat of the identity
-#define EAP_PASSWORD "password" //your Eduroam password
-const char* ssid = "eduroam"; // Eduroam SSID
-const char* host = "arduino.php5.sk"; //external server domain for HTTP connection after authentification
+#define EAP_PASSWORD "password" //your eduroam password
+const char* ssid = "eduroam"; // eduroam SSID
+const char* host = "arduino.clanweb.eu"; //external server domain for HTTP connection after authentification
+String url = F("/studna_s_prekladom/json_output.php");
 int counter = 0;
-
 // NOTE: For some systems, various certification keys are required to connect to the wifi system.
 //       Usually you are provided these by the IT department of your organization when certs are required
 //       and you can't connect with just an identity and password.
 //       Most eduroam setups we have seen do not require this level of authentication, but you should contact
 //       your IT department to verify.
 //       You should uncomment these and populate with the contents of the files if this is required for your scenario (See Example 2 and Example 3 below).
-//const char *ca_pem = "insert your CA cert from your .pem file here";
-//const char *client_cert = "insert your client cert from your .crt file here";
-//const char *client_key = "insert your client key from your .key file here";
+
+//const char *ca_pem PROGMEM = "insert your CA cert from your .pem file here";
+//const char *client_cert PROGMEM = "insert your client cert from your .crt file here";
+//const char *client_key PROGMEM = "insert your client key from your .key file here";
 
 void setup() {
   Serial.begin(115200);
   delay(10);
   Serial.println();
-  Serial.print("Connecting to network: ");
+  Serial.print(F("Connecting to network: "));
   Serial.println(ssid);
   WiFi.disconnect(true);  //disconnect form wifi to set new wifi connection
   WiFi.mode(WIFI_STA); //init wifi mode
-  
+
   // Example1 (most common): a cert-file-free eduroam with PEAP (or TTLS)
   WiFi.begin(ssid, WPA2_AUTH_PEAP, EAP_IDENTITY, EAP_USERNAME, EAP_PASSWORD);
 
   // Example 2: a cert-file WPA2 Enterprise with PEAP
   //WiFi.begin(ssid, WPA2_AUTH_PEAP, EAP_IDENTITY, EAP_USERNAME, EAP_PASSWORD, ca_pem, client_cert, client_key);
-  
+
   // Example 3: TLS with cert-files and no password
   //WiFi.begin(ssid, WPA2_AUTH_TLS, EAP_IDENTITY, NULL, NULL, ca_pem, client_cert, client_key);
-  
-  
+
+
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
-    Serial.print(".");
+    Serial.print(F("."));
     counter++;
-    if(counter>=60){ //after 30 seconds timeout - reset board
+    if (counter >= 60) { //after 30 seconds timeout - reset board
       ESP.restart();
     }
   }
-  Serial.println("");
-  Serial.println("WiFi connected");
-  Serial.println("IP address set: "); 
+  Serial.println(F(""));
+  Serial.println(F("WiFi connected"));
+  Serial.println(F("IP address set: "));
   Serial.println(WiFi.localIP()); //print LAN IP
 }
 void loop() {
-  if (WiFi.status() == WL_CONNECTED) { //if we are connected to Eduroam network
+  if (WiFi.status() == WL_CONNECTED) { //if we are connected to eduroam network
     counter = 0; //reset counter
-    Serial.println("Wifi is still connected with IP: "); 
+    Serial.println(F("Wifi is still connected with IP: "));
     Serial.println(WiFi.localIP());   //inform user about his IP address
-  }else if (WiFi.status() != WL_CONNECTED) { //if we lost connection, retry
-    WiFi.begin(ssid);      
+  } else if (WiFi.status() != WL_CONNECTED) { //if we lost connection, retry
+    WiFi.begin(ssid);
   }
   while (WiFi.status() != WL_CONNECTED) { //during lost connection, print dots
     delay(500);
-    Serial.print(".");
+    Serial.print(F("."));
     counter++;
-    if(counter>=60){ //30 seconds timeout - reset board
-    ESP.restart();
+    if (counter >= 60) { //30 seconds timeout - reset board
+      ESP.restart();
     }
   }
-  Serial.print("Connecting to website: ");
+  Serial.print(F("Connecting to website: "));
   Serial.println(host);
   WiFiClient client;
   if (client.connect(host, 80)) {
-    String url = "/rele/rele1.txt";
-    client.print(String("GET ") + url + " HTTP/1.1\r\n" + "Host: " + host + "\r\n" + "User-Agent: ESP32\r\n" + "Connection: close\r\n\r\n");
-
+    Serial.println(F("Connection successful"));
+    client.print(String("GET ") + url + " HTTP/1.0\r\n" + "Host: " + host + "\r\n" + "User-Agent: ESP32\r\n" + "Connection: close\r\n\r\n");
     while (client.connected()) {
-      String line = client.readStringUntil('\n');
+      String line = client.readStringUntil('\n'); //read HTTP header line-by-line
       if (line == "\r") {
         break;
       }
     }
-    String line = client.readStringUntil('\n');
-   Serial.println(line);
-  }else{
-      Serial.println("Connection unsucessful");
-    }  
+    Serial.println(F("JSON payload: "));
+    String line = client.readString(); //read JSON payload
+    Serial.println(line); //Print JSON payload
+  } else {
+    Serial.println(F("Connection unsucessful"));
+  }
+  client.stop();
+  delay(30000);
 }


### PR DESCRIPTION

## Summary
**This pull request contains changes in [WiFiClientEnterprise.ino](https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/examples/WiFiClientEnterprise/WiFiClientEnterprise.ino) file in main branch:**

- added PROGMEM for certs for storing them in flash memory of ESP32
- changed host (arduino.php5.sk) that is not working for more than year
- new host (arduino.clanweb.eu) will provide JSON output for client after successful connection
- added F macro to constant Strings
- changed Eduroam to eduroam in comments (eduroam network is still with small e character)

**Expected output after pull request:**
![eduroam - WiFiClientEnterprise on ESP32](https://i.imgur.com/C6YtYRt.png)


## Impact
**Purpose of this Pull Request is to:**
- Imporoved User Experience
- User can now connect to host after gets connectivity from eduroam network
