### PR TITLE
Added RainMaker support on Arduino IDE for ESP32-C3/S2/S3

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -184,6 +184,9 @@ esp32s3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
 esp32s3.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
 esp32s3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
 esp32s3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32s3.menu.PartitionScheme.rainmaker=RainMaker
+esp32s3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32s3.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
 
 esp32s3.menu.CPUFreq.240=240MHz (WiFi)
 esp32s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -304,6 +307,9 @@ esp32c3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
 esp32c3.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
 esp32c3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
 esp32c3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32c3.menu.PartitionScheme.rainmaker=RainMaker
+esp32c3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32c3.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
 
 esp32c3.menu.CPUFreq.160=160MHz (WiFi)
 esp32c3.menu.CPUFreq.160.build.f_cpu=160000000L
@@ -475,6 +481,9 @@ esp32s2.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
 esp32s2.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
 esp32s2.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
 esp32s2.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32s2.menu.PartitionScheme.rainmaker=RainMaker
+esp32s2.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32s2.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
 
 esp32s2.menu.CPUFreq.240=240MHz (WiFi)
 esp32s2.menu.CPUFreq.240.build.f_cpu=240000000L

--- a/libraries/RainMaker/examples/README.md
+++ b/libraries/RainMaker/examples/README.md
@@ -1,10 +1,13 @@
 # ESP RainMaker Examples
 
 While building any examples for ESP RainMaker, take care of the following:
+
 1. Change partition scheme in Arduino IDE to RainMaker (Tools -> Partition Scheme -> RainMaker).
 2. Once ESP RainMaker gets started, compulsorily call `WiFi.beginProvision()` which is responsible for user-node mapping.
-3. Use appropriate provisioning scheme as per the board.
+3. Use the appropriate provisioning scheme as per the board.
     - ESP32 Board: BLE Provisioning
-    - ESP32S2 Board: SoftAP Provisioning
-4. Set debug level to Info (Tools -> Core Debug Level -> Info). This is recommended, but not mandatory.
+    - ESP32-C3 Board: BLE Provisioning
+    - ESP32-S3 Board: BLE Provisioning
+    - ESP32-S2 Board: SoftAP Provisioning
+4. Set debug level to Info (Tools -> Core Debug Level -> Info). This is recommended debug level but not mandatory to run RainMaker.
 

--- a/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
+++ b/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
@@ -9,10 +9,15 @@ const char *service_name = "PROV_1234";
 const char *pop = "abcd1234";
 
 //GPIO for push button
-static int gpio_0 = 0;
+#if CONFIG_IDF_TARGET_ESP32C3
+static int gpio_0 = 9;
+static int gpio_dimmer = 7;
+#else
 //GPIO for virtual device
+static int gpio_0 = 0;
 static int gpio_dimmer = 16;
-/* Variable for reading pin status*/
+#endif
+
 bool dimmer_state = true;
 
 // The framework provides some standard device types like switch, lightbulb, fan, temperature sensor.
@@ -23,12 +28,12 @@ void sysProvEvent(arduino_event_t *sys_event)
 {
     switch (sys_event->event_id) {      
         case ARDUINO_EVENT_PROV_START:
-#if CONFIG_IDF_TARGET_ESP32
-        Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
-        printQR(service_name, pop, "ble");
-#else
+#if CONFIG_IDF_TARGET_ESP32S2
         Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
         printQR(service_name, pop, "softap");
+#else
+        Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
+        printQR(service_name, pop, "ble");
 #endif        
         break;
     }
@@ -89,10 +94,10 @@ void setup()
     RMaker.start();
 
     WiFi.onEvent(sysProvEvent);
-#if CONFIG_IDF_TARGET_ESP32
-    WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
-#else
+#if CONFIG_IDF_TARGET_ESP32S2
     WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name);
+#else
+    WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
 #endif
 }
 

--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -10,12 +10,15 @@ const char *pop = "abcd1234";
 //GPIO for push button
 #if CONFIG_IDF_TARGET_ESP32C3
 static int gpio_0 = 9;
-static int gpio_dimmer = 7;
+static int gpio_switch = 7;
 #else
 //GPIO for virtual device
 static int gpio_0 = 0;
-static int gpio_dimmer = 16;
+static int gpio_switch = 16;
 #endif
+
+/* Variable for reading pin status*/
+bool switch_state = true;
 
 //The framework provides some standard device types like switch, lightbulb, fan, temperaturesensor.
 static Switch my_switch("Switch", &gpio_switch);

--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -8,11 +8,14 @@ const char *service_name = "PROV_1234";
 const char *pop = "abcd1234";
 
 //GPIO for push button
-static int gpio_0 = 0;
+#if CONFIG_IDF_TARGET_ESP32C3
+static int gpio_0 = 9;
+static int gpio_dimmer = 7;
+#else
 //GPIO for virtual device
-static int gpio_switch = 16;
-/* Variable for reading pin status*/
-bool switch_state = true;
+static int gpio_0 = 0;
+static int gpio_dimmer = 16;
+#endif
 
 //The framework provides some standard device types like switch, lightbulb, fan, temperaturesensor.
 static Switch my_switch("Switch", &gpio_switch);
@@ -21,13 +24,13 @@ void sysProvEvent(arduino_event_t *sys_event)
 {
     switch (sys_event->event_id) {      
         case ARDUINO_EVENT_PROV_START:
-#if CONFIG_IDF_TARGET_ESP32
-        Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
-        printQR(service_name, pop, "ble");
-#else
+#if CONFIG_IDF_TARGET_ESP32S2
         Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
         printQR(service_name, pop, "softap");
-#endif        
+#else
+        Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
+        printQR(service_name, pop, "ble");
+#endif         
         break;
     }
 }
@@ -74,10 +77,10 @@ void setup()
     RMaker.start();
 
     WiFi.onEvent(sysProvEvent);
-#if CONFIG_IDF_TARGET_ESP32
-    WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
-#else
+#if CONFIG_IDF_TARGET_ESP32S2
     WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name);
+#else
+    WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
 #endif
 }
 


### PR DESCRIPTION
## Summary

This PR adds the needed configuration on `boards.txt` and examples files for the **ESP32-C3/S2/S3** support on RainMaker.

## Impact

The ESP32-C3/S2/S3 does not work with RainMaker.

## Related links

Closes https://github.com/espressif/arduino-esp32/issues/6573
Note related to the issue https://github.com/espressif/arduino-esp32/issues/6435
