### PR TITLE
Change pinMode OUTPUT to INPUT_OUTPUT

### DIFF
--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -42,7 +42,7 @@ extern "C" {
 
 //GPIO FUNCTIONS
 #define INPUT             0x01
-#define OUTPUT            0x02
+#define OUTPUT            0x03 //Changed from 0x02 to behave the same as Arduino pinMode(pin,OUTPUT) where yo ucan read the state of pin even when it is set as OUTPUT
 #define PULLUP            0x04
 #define INPUT_PULLUP      0x05
 #define PULLDOWN          0x08


### PR DESCRIPTION
## Summary
This change is to match the official Arduino API, where you can use digitalRead(pin) on OUTPUT pin to read its level.

## Impact
None.

## Related links
Closes #5552 
