### PR TITLE
Touch change to init only selected GPIO.

### DIFF
--- a/cores/esp32/esp32-hal-touch.c
+++ b/cores/esp32/esp32-hal-touch.c
@@ -174,7 +174,6 @@ static void __touchChannelInit(int pad)
     // Initial no Threshold and setup - TOUCH0 is internal denoise channel
         __touchInterruptHandlers[pad].fn =  NULL;
         touch_pad_config(pad);                       // returns ESP_OK
-    }
 #endif
 
     channels_initialized[pad] = true;


### PR DESCRIPTION
## Description of Change
After touch has been refactored to use ESP-IDF API, its initialising all channels for touch loosing previously setup pins for different purposes. 

The change is that the `touchRead()` and `touchAttachInterrupt()` will initialise touch sensor, but will configure only the pad selected. Other pins will remain as was.

## Tests scenarios
Sketch from issue #6443 tested on ESP32 and S2+S3 with different pins.

## Related links
Closes #6443 
