### PR TITLE
publish.yml: Minor fix to the workflow syntax

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       (github.event.workflow_run.conclusion == 'success' ||
-      (github.event.workflow_run.conclusion == 'failure')
+       github.event.workflow_run.conclusion == 'failure')
     steps:
       - name: Download and Extract Artifacts
         env:


### PR DESCRIPTION

## Description of Change
Remove a leftover parenthesis that was making the workflow that was making the workflow invalid.

## Tests scenarios
Github Workflow.

## Related links
https://github.com/espressif/arduino-esp32/actions/runs/2213167501