### PR TITLE
PlatformIO minor updates

### DIFF
--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export PLATFORMIO_ESP32_PATH="$HOME/.platformio/packages/framework-arduinoespressif32"
-PLATFORMIO_ESP32_URL="https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master"
+PLATFORMIO_ESP32_URL="https://github.com/platformio/platform-espressif32.git"
 
 TOOLCHAIN_VERSION="8.4.0+2021r2-patch3"
 ESPTOOLPY_VERSION="~1.30100.0"

--- a/tools/platformio-build-esp32.py
+++ b/tools/platformio-build-esp32.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join, basename
+from os.path import abspath, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -331,6 +331,12 @@ env.Append(
         ("0x8000", join(env.subst("$BUILD_DIR"), "partitions.bin")),
         ("0xe000", join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin"))
     ]
+    + [
+        (offset, join(FRAMEWORK_DIR, img))
+        for offset, img in env.BoardConfig().get(
+            "upload.arduino.flash_extra_images", []
+        )
+    ],
 )
 
 #

--- a/tools/platformio-build-esp32c3.py
+++ b/tools/platformio-build-esp32c3.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join, basename
+from os.path import abspath, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -324,6 +324,12 @@ env.Append(
         ("0x8000", join(env.subst("$BUILD_DIR"), "partitions.bin")),
         ("0xe000", join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin"))
     ]
+    + [
+        (offset, join(FRAMEWORK_DIR, img))
+        for offset, img in env.BoardConfig().get(
+            "upload.arduino.flash_extra_images", []
+        )
+    ],
 )
 
 #

--- a/tools/platformio-build-esp32s2.py
+++ b/tools/platformio-build-esp32s2.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join, basename
+from os.path import abspath, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -326,6 +326,12 @@ env.Append(
         ("0x8000", join(env.subst("$BUILD_DIR"), "partitions.bin")),
         ("0xe000", join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin"))
     ]
+    + [
+        (offset, join(FRAMEWORK_DIR, img))
+        for offset, img in env.BoardConfig().get(
+            "upload.arduino.flash_extra_images", []
+        )
+    ],
 )
 
 #

--- a/tools/platformio-build-esp32s3.py
+++ b/tools/platformio-build-esp32s3.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join, basename
+from os.path import abspath, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -343,6 +343,12 @@ env.Append(
         ("0x8000", join(env.subst("$BUILD_DIR"), "partitions.bin")),
         ("0xe000", join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin"))
     ]
+    + [
+        (offset, join(FRAMEWORK_DIR, img))
+        for offset, img in env.BoardConfig().get(
+            "upload.arduino.flash_extra_images", []
+        )
+    ],
 )
 
 #


### PR DESCRIPTION
This PR adds support for uploading additional flash images (e.g. Adafruit Tiny UF2 bootloader) specified in board manifests. 

Additionally, the PR switches the PlatformIO CI script to the upstream version of  the ESP32 dev-platform (basically reverts changes introduced in #5387 as they are no longer required).