### PR TITLE
Added Unexpected Maker Reflow Master Pro (UM RMP) board + Fixed TinyS2 pins

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2119,7 +2119,131 @@ tinys2.menu.DebugLevel.verbose=Verbose
 tinys2.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
+rmp.name=UM RMP
+rmp.vid.0=0x303a
+rmp.pid.0=0x80F6
 
+rmp.upload.tool=esptool_py
+rmp.upload.maximum_size=1310720
+rmp.upload.maximum_data_size=327680
+rmp.upload.flags=
+rmp.upload.extra_flags=
+rmp.upload.use_1200bps_touch=true
+rmp.upload.wait_for_upload_port=true
+
+rmp.serial.disableDTR=false
+rmp.serial.disableRTS=false
+
+rmp.build.tarch=xtensa
+rmp.build.bootloader_addr=0x1000
+rmp.build.target=esp32s2
+rmp.build.mcu=esp32s2
+rmp.build.core=esp32
+rmp.build.variant=um_rmp
+rmp.build.board=RMP
+
+rmp.build.cdc_on_boot=1
+rmp.build.msc_on_boot=0
+rmp.build.dfu_on_boot=0
+rmp.build.f_cpu=240000000L
+rmp.build.flash_size=4MB
+rmp.build.flash_freq=80m
+rmp.build.flash_mode=dio
+rmp.build.boot=qio
+rmp.build.partitions=default
+rmp.build.defines=
+
+rmp.menu.CDCOnBoot.cdc=Enabled
+rmp.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+rmp.menu.CDCOnBoot.default=Disabled
+rmp.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+rmp.menu.MSCOnBoot.default=Disabled
+rmp.menu.MSCOnBoot.default.build.msc_on_boot=0
+rmp.menu.MSCOnBoot.msc=Enabled
+rmp.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+rmp.menu.DFUOnBoot.default=Disabled
+rmp.menu.DFUOnBoot.default.build.dfu_on_boot=0
+rmp.menu.DFUOnBoot.dfu=Enabled
+rmp.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+rmp.menu.PSRAM.enabled=Enabled
+rmp.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+rmp.menu.PSRAM.disabled=Disabled
+rmp.menu.PSRAM.disabled.build.defines=
+
+rmp.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+rmp.menu.PartitionScheme.default.build.partitions=default
+rmp.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+rmp.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+rmp.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+rmp.menu.PartitionScheme.minimal.build.partitions=minimal
+rmp.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+rmp.menu.PartitionScheme.no_ota.build.partitions=no_ota
+rmp.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+rmp.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+rmp.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+rmp.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+rmp.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+rmp.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+rmp.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+rmp.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+rmp.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+rmp.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+rmp.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+rmp.menu.PartitionScheme.huge_app.build.partitions=huge_app
+rmp.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+rmp.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+rmp.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+rmp.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+rmp.menu.CPUFreq.240=240MHz (WiFi)
+rmp.menu.CPUFreq.240.build.f_cpu=240000000L
+rmp.menu.CPUFreq.160=160MHz (WiFi)
+rmp.menu.CPUFreq.160.build.f_cpu=160000000L
+rmp.menu.CPUFreq.80=80MHz (WiFi)
+rmp.menu.CPUFreq.80.build.f_cpu=80000000L
+rmp.menu.CPUFreq.40=40MHz
+rmp.menu.CPUFreq.40.build.f_cpu=40000000L
+rmp.menu.CPUFreq.20=20MHz
+rmp.menu.CPUFreq.20.build.f_cpu=20000000L
+rmp.menu.CPUFreq.10=10MHz
+rmp.menu.CPUFreq.10.build.f_cpu=10000000L
+
+rmp.menu.FlashSize.4M=4MB (32Mb)
+rmp.menu.FlashSize.4M.build.flash_size=4MB
+rmp.menu.FlashSize.2M=2MB (16Mb)
+rmp.menu.FlashSize.2M.build.flash_size=2MB
+rmp.menu.FlashSize.2M.build.partitions=minimal
+
+rmp.menu.UploadSpeed.921600=921600
+rmp.menu.UploadSpeed.921600.upload.speed=921600
+rmp.menu.UploadSpeed.115200=115200
+rmp.menu.UploadSpeed.115200.upload.speed=115200
+rmp.menu.UploadSpeed.256000.windows=256000
+rmp.menu.UploadSpeed.256000.upload.speed=256000
+rmp.menu.UploadSpeed.230400.windows.upload.speed=256000
+rmp.menu.UploadSpeed.230400=230400
+rmp.menu.UploadSpeed.230400.upload.speed=230400
+rmp.menu.UploadSpeed.460800.linux=460800
+rmp.menu.UploadSpeed.460800.macosx=460800
+rmp.menu.UploadSpeed.460800.upload.speed=460800
+
+rmp.menu.DebugLevel.none=None
+rmp.menu.DebugLevel.none.build.code_debug=0
+rmp.menu.DebugLevel.error=Error
+rmp.menu.DebugLevel.error.build.code_debug=1
+rmp.menu.DebugLevel.warn=Warn
+rmp.menu.DebugLevel.warn.build.code_debug=2
+rmp.menu.DebugLevel.info=Info
+rmp.menu.DebugLevel.info.build.code_debug=3
+rmp.menu.DebugLevel.debug=Debug
+rmp.menu.DebugLevel.debug.build.code_debug=4
+rmp.menu.DebugLevel.verbose=Verbose
+rmp.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
 tinys3.name=UM TinyS3
 tinys3.vid.0=0x303a
 tinys3.pid.0=0x80D0

--- a/variants/um_rmp/pins_arduino.h
+++ b/variants/um_rmp/pins_arduino.h
@@ -6,14 +6,14 @@
 #define USB_VID 0x303A
 #define USB_PID 0x8001
 #define USB_MANUFACTURER "Unexpected Maker"
-#define USB_PRODUCT "TinyS2"
+#define USB_PRODUCT "RM Pro"
 #define USB_SERIAL ""
 
 #define EXTERNAL_NUM_INTERRUPTS 46
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       20
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 


### PR DESCRIPTION
## Description of Change
Added Unexpected Maker Reflow Master Pro (UM RMP) board (ESP32-S2FN4R2)
Fixed wrong SCK and MISO pins assigned for TinyS2 in pins_arduino.h

## Tests scenarios
Changes tested locally on respective hardware

## Related links
N/A