### PR TITLE
Add more controls over WiFi.begin and WiFi.scan

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -64,6 +64,11 @@ public:
 
     uint8_t waitForConnectResult(unsigned long timeoutLength = 60000);
 
+    // Next group functions must be called before WiFi.begin()
+    void setMinSecurity(wifi_auth_mode_t minSecurity);// Default is WIFI_AUTH_WPA2_PSK
+    void setScanMethod(wifi_scan_method_t scanMethod);// Default is WIFI_FAST_SCAN
+    void setSortMethod(wifi_sort_method_t sortMethod);// Default is WIFI_CONNECT_AP_BY_SIGNAL
+
     // STA network info
     IPAddress localIP();
 
@@ -96,6 +101,9 @@ public:
 protected:
     static bool _useStaticIp;
     static bool _autoReconnect;
+    static wifi_auth_mode_t _minSecurity;
+    static wifi_scan_method_t _scanMethod;
+    static wifi_sort_method_t _sortMethod;
 
 public: 
     bool beginSmartConfig(smartconfig_type_t type = SC_TYPE_ESPTOUCH, char* crypt_key = NULL);

--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -81,7 +81,7 @@ void* WiFiScanClass::_scanResult = 0;
  * @param show_hidden   show hidden networks
  * @return Number of discovered networks
  */
-int16_t WiFiScanClass::scanNetworks(bool async, bool show_hidden, bool passive, uint32_t max_ms_per_chan, uint8_t channel)
+int16_t WiFiScanClass::scanNetworks(bool async, bool show_hidden, bool passive, uint32_t max_ms_per_chan, uint8_t channel, const char * ssid, const uint8_t * bssid)
 {
     if(WiFiGenericClass::getStatusBits() & WIFI_SCANNING_BIT) {
         return WIFI_SCAN_RUNNING;
@@ -95,8 +95,8 @@ int16_t WiFiScanClass::scanNetworks(bool async, bool show_hidden, bool passive, 
     scanDelete();
 
     wifi_scan_config_t config;
-    config.ssid = 0;
-    config.bssid = 0;
+    config.ssid = (uint8_t*)ssid;
+    config.bssid = (uint8_t*)bssid;
     config.channel = channel;
     config.show_hidden = show_hidden;
     if(passive){

--- a/libraries/WiFi/src/WiFiScan.h
+++ b/libraries/WiFi/src/WiFiScan.h
@@ -31,7 +31,7 @@ class WiFiScanClass
 
 public:
 
-    int16_t scanNetworks(bool async = false, bool show_hidden = false, bool passive = false, uint32_t max_ms_per_chan = 300, uint8_t channel = 0);
+    int16_t scanNetworks(bool async = false, bool show_hidden = false, bool passive = false, uint32_t max_ms_per_chan = 300, uint8_t channel = 0, const char * ssid=nullptr, const uint8_t * bssid=nullptr);
 
     int16_t scanComplete();
     void scanDelete();

--- a/libraries/WiFi/src/WiFiType.h
+++ b/libraries/WiFi/src/WiFiType.h
@@ -23,6 +23,8 @@
 #ifndef ESP32WIFITYPE_H_
 #define ESP32WIFITYPE_H_
 
+#include "esp_wifi_types.h"
+
 #define WIFI_SCAN_RUNNING   (-1)
 #define WIFI_SCAN_FAILED    (-2)
 


### PR DESCRIPTION
Added options to WiFi STA for connect:
- setMinSecurity: default WIFI_AUTH_WPA2_PSK
- setScanMethod: default WIFI_FAST_SCAN
- setSortMethod: default WIFI_CONNECT_AP_BY_SIGNAL (required all channels scan method)

Added parameters for SSID and BSSID to WiFi.scanNetworks()

Fixes: https://github.com/espressif/arduino-esp32/issues/6485
Fixes: Any issue about WiFi connecting slower now than in 1.0.x