### PR TITLE
Fix uploader tool for ESPduino32 in boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -8083,7 +8083,7 @@ esp32doit-devkit-v1.menu.DebugLevel.debug.build.code_debug=4
 
 esp32doit-espduino.name=DOIT ESPduino32
 
-esp32doit-espduino.upload.tool=esptool
+esp32doit-espduino.upload.tool=esptool_py
 esp32doit-espduino.upload.maximum_size=1310720
 esp32doit-espduino.upload.maximum_data_size=327680
 esp32doit-espduino.upload.wait_for_upload_port=true


### PR DESCRIPTION
## Description of Change
The uploader tool for that ESPduino32 board and its clones was erroneous in boards.txt.
This triggered a java nullpointer exception when trying to upload.

## Tests scenarios
Tested on an "AZ Delivery D1 R32" board which is a clone of the ESPduino32.
Tested by manually editing boards.txt in Arduino-esp32 core v2.0.3-RC1.
