### PR TITLE
New Class MacAddress similar to IPAddress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ set(CORE_SRCS
   cores/esp32/libb64/cdecode.c
   cores/esp32/libb64/cencode.c
   cores/esp32/main.cpp
+  cores/esp32/MacAddress.cpp
+  cores/esp32/MacAddress8.cpp
   cores/esp32/MD5Builder.cpp
   cores/esp32/Print.cpp
   cores/esp32/stdlib_noniso.c

--- a/cores/esp32/MacAddress.cpp
+++ b/cores/esp32/MacAddress.cpp
@@ -129,7 +129,7 @@ size_t MacAddress::printTo(Print& p) const
         if(i){
             n += p.print(':');
         }
-        n += p.printf("%02x", _mac.bytes[i]);
+        n += p.printf("%02X", _mac.bytes[i]);
     }
     return n;
 }

--- a/cores/esp32/MacAddress.cpp
+++ b/cores/esp32/MacAddress.cpp
@@ -1,5 +1,6 @@
 #include <MacAddress.h>
 #include <stdio.h>
+#include <Print.h>
 
 //Default constructor, blank mac address.
 MacAddress::MacAddress() {

--- a/cores/esp32/MacAddress.cpp
+++ b/cores/esp32/MacAddress.cpp
@@ -14,7 +14,7 @@ MacAddress::MacAddress(const uint8_t *macbytearray) {
     memcpy(_mac.bytes, macbytearray, sizeof(_mac.bytes));
 }
 
-MacAddress::MacAddress((uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6) {
+MacAddress::MacAddress(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6) {
     _mac.bytes[0] = b1;
     _mac.bytes[1] = b2;
     _mac.bytes[2] = b3;

--- a/cores/esp32/MacAddress.cpp
+++ b/cores/esp32/MacAddress.cpp
@@ -1,0 +1,95 @@
+#include <MacAddress.h>
+#include <stdio.h>
+
+//Default constructor, blank mac address.
+MacAddress::MacAddress() {
+    _mac.val = 0;
+}
+
+MacAddress::MacAddress(uint64_t mac) {
+    _mac.val = mac;
+}
+
+MacAddress::MacAddress(const uint8_t *macbytearray) {
+    memcpy(_mac.bytes, macbytearray, sizeof(_mac.bytes));
+}
+
+//Parse user entered string into MAC address
+bool MacAddress::fromCStr(const char *buf) {
+  char cs[18];
+  char *token;
+  char *next; //Unused but required
+  int i;
+
+  strncpy(cs, buf, sizeof(cs)); //strtok modifies the buffer: copy to working buffer.
+
+  for(i=0; i<sizeof(_mac.bytes); i++) {
+    token = strtok((i==0) ? cs : NULL, ":");    //Find first or next token
+    if(!token) {                                //No more tokens found
+        return false;
+    }
+    _mac.bytes[i] = strtol(token, &next, 16);
+  }
+  return true;
+}
+
+//Parse user entered string into MAC address
+bool MacAddress::fromString(const String &macstr) {
+    return fromCStr(macstr.c_str());
+}
+
+//Copy MAC into 6 byte array
+void MacAddress::toBytes(uint8_t *buf) {
+    memcpy(buf, _mac.bytes, sizeof(_mac.bytes));
+}
+
+//Print MAC address into a C string.
+//MAC: Buffer must be at least 18 chars
+int MacAddress::toCStr(char *buf) {
+    return sprintf(buf, "%02X:%02X:%02X:%02X:%02X:%02X",
+        _mac.bytes[0], _mac.bytes[1], _mac.bytes[2],
+        _mac.bytes[3], _mac.bytes[4], _mac.bytes[5]);
+}
+
+String MacAddress::toString() const {
+    char buf[18];
+    sprintf(buf, "%02X:%02X:%02X:%02X:%02X:%02X",
+        _mac.bytes[0], _mac.bytes[1], _mac.bytes[2],
+        _mac.bytes[3], _mac.bytes[4], _mac.bytes[5]);
+    return String(buf);
+}
+
+uint64_t MacAddress::Value() {
+    return _mac.val;
+}
+
+//Implicit conversion object to number [same as .Value()]
+MacAddress::operator uint64_t() const
+{
+    return _mac.val;
+}
+
+//Overloaded copy operators to allow initialisation of MacAddress objects from other types
+MacAddress& MacAddress::operator=(const uint8_t *mac)
+{
+    memcpy(_mac.bytes, mac, sizeof(_mac.bytes));
+    return *this;
+}
+
+MacAddress& MacAddress::operator=(uint64_t macval)
+{
+    _mac.val = macval;
+    return *this;
+}
+
+//Compare class to byte array
+bool MacAddress::operator==(const uint8_t *mac) const
+{
+    return !memcmp(_mac.bytes, mac, sizeof(_mac.bytes));
+}
+
+//Allow comparing value of two classes
+bool MacAddress::operator==(const MacAddress& mac2) const
+{
+    return _mac.val == mac2._mac.val;
+}

--- a/cores/esp32/MacAddress.cpp
+++ b/cores/esp32/MacAddress.cpp
@@ -14,6 +14,15 @@ MacAddress::MacAddress(const uint8_t *macbytearray) {
     memcpy(_mac.bytes, macbytearray, sizeof(_mac.bytes));
 }
 
+MacAddress::MacAddress((uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6) {
+    _mac.bytes[0] = b1;
+    _mac.bytes[1] = b2;
+    _mac.bytes[2] = b3;
+    _mac.bytes[3] = b4;
+    _mac.bytes[4] = b5;
+    _mac.bytes[5] = b6;
+}
+
 //Parse user entered string into MAC address
 bool MacAddress::fromCStr(const char *buf) {
   char cs[18];
@@ -63,12 +72,6 @@ uint64_t MacAddress::Value() {
     return _mac.val;
 }
 
-//Implicit conversion object to number [same as .Value()]
-MacAddress::operator uint64_t() const
-{
-    return _mac.val;
-}
-
 //Overloaded copy operators to allow initialisation of MacAddress objects from other types
 MacAddress& MacAddress::operator=(const uint8_t *mac)
 {
@@ -93,3 +96,16 @@ bool MacAddress::operator==(const MacAddress& mac2) const
 {
     return _mac.val == mac2._mac.val;
 }
+                       
+size_t MacAddress::printTo(Print& p) const
+{
+    size_t n = 0;
+    for(int i = 0; i < 6; i++) {
+        if(i){
+            n += p.print(':');
+        }
+        n += p.printf("%02x", _mac.bytes[i]);
+    }
+    return n;
+}
+                       

--- a/cores/esp32/MacAddress.cpp
+++ b/cores/esp32/MacAddress.cpp
@@ -73,31 +73,55 @@ uint64_t MacAddress::Value() {
     return _mac.val;
 }
 
-//Overloaded copy operators to allow initialisation of MacAddress objects from other types
-MacAddress& MacAddress::operator=(const uint8_t *mac)
-{
-    memcpy(_mac.bytes, mac, sizeof(_mac.bytes));
+//Allow getting individual octets of the address. e.g. uint8_t b0 = ma[0];
+uint8_t MacAddress::operator[](int index) const {
+    index = EnforceIndexBounds(index);
+    return _mac.bytes[index];
+}
+
+//Allow setting individual octets of the address. e.g. ma[2] = 255;
+uint8_t& MacAddress::operator[](int index) {
+    index = EnforceIndexBounds(index);
+    return _mac.bytes[index];
+}
+
+//Overloaded copy operator: init MacAddress object from byte array
+MacAddress& MacAddress::operator=(const uint8_t *macbytearray) {
+    memcpy(_mac.bytes, macbytearray, sizeof(_mac.bytes));
     return *this;
 }
 
-MacAddress& MacAddress::operator=(uint64_t macval)
-{
+//Overloaded copy operator: init MacAddress object from uint64_t
+MacAddress& MacAddress::operator=(uint64_t macval) {
     _mac.val = macval;
     return *this;
 }
 
 //Compare class to byte array
-bool MacAddress::operator==(const uint8_t *mac) const
-{
-    return !memcmp(_mac.bytes, mac, sizeof(_mac.bytes));
+bool MacAddress::operator==(const uint8_t *macbytearray) const {
+    return !memcmp(_mac.bytes, macbytearray, sizeof(_mac.bytes));
 }
 
 //Allow comparing value of two classes
-bool MacAddress::operator==(const MacAddress& mac2) const
-{
+bool MacAddress::operator==(const MacAddress& mac2) const {
     return _mac.val == mac2._mac.val;
 }
-                       
+
+//Type converter object to uint64_t [same as .Value()]
+MacAddress::operator uint64_t() const {
+    return _mac.val;
+}
+
+//Type converter object to read only pointer to mac bytes. e.g. const uint8_t *ip_8 = ma;
+MacAddress::operator const uint8_t*() const {
+    return _mac.bytes;
+}
+
+//Type converter object to read only pointer to mac value. e.g. const uint32_t *ip_64 = ma;
+MacAddress::operator const uint64_t*() const {
+    return &_mac.val;
+}
+
 size_t MacAddress::printTo(Print& p) const
 {
     size_t n = 0;
@@ -109,4 +133,14 @@ size_t MacAddress::printTo(Print& p) const
     }
     return n;
 }
-                       
+
+//Bounds checking
+int MacAddress::EnforceIndexBounds(int i) const {
+    if(i < 0) {
+        return 0;
+    }
+    if(i >= sizeof(_mac.bytes)) {
+        return sizeof(_mac.bytes)-1;
+    }
+    return i;
+}

--- a/cores/esp32/MacAddress.h
+++ b/cores/esp32/MacAddress.h
@@ -37,7 +37,7 @@ public:
     MacAddress();
     MacAddress(uint64_t mac);
     MacAddress(const uint8_t *macbytearray);
-    MAcAddress(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6);
+    MacAddress(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6);
     virtual ~MacAddress() {}
     bool fromCStr(const char *buf);
     bool fromString(const String &macstr);

--- a/cores/esp32/MacAddress.h
+++ b/cores/esp32/MacAddress.h
@@ -46,33 +46,15 @@ public:
     String toString() const;
     uint64_t Value();
 
-    // Overloaded index operator to allow getting and setting individual octets of the address
-    uint8_t operator[](int index) const
-    {
-        return _mac.bytes[index];
-    }
-    uint8_t& operator[](int index)
-    {
-        return _mac.bytes[index];
-    }
-
-    MacAddress& operator=(const uint8_t *mac);
+    uint8_t operator[](int index) const;
+    uint8_t& operator[](int index);
+    MacAddress& operator=(const uint8_t *macbytearray);
     MacAddress& operator=(uint64_t macval);
-    bool operator==(const uint8_t *mac) const;
+    bool operator==(const uint8_t *macbytearray) const;
     bool operator==(const MacAddress& mac2) const;
-    
-    operator uint64_t() const
-    {
-        return _mac.val;
-    }
-    operator const uint8_t*() const
-    {
-        return _mac.bytes;
-    }
-    operator const uint64_t*() const
-    {
-        return &_mac.val;
-    }
+    operator uint64_t() const;
+    operator const uint8_t*() const;
+    operator const uint64_t*() const;
 
     virtual size_t printTo(Print& p) const;
 
@@ -83,6 +65,9 @@ public:
     friend class Server;
     friend class DhcpClass;
     friend class DNSClient;
+
+private:
+    int EnforceIndexBounds(int i) const;
 };
 
 #endif

--- a/cores/esp32/MacAddress.h
+++ b/cores/esp32/MacAddress.h
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------------
+// MacAddress.h - class to make it easier to handle BSSID and MAC addresses.
+// 
+// Copyright 2022 David McCurley
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+//     
+// Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//   limitations under the License.
+//-----------------------------------------------------------------------------
+
+#ifndef MacAddress_h
+#define MacAddress_h
+
+#include <WString.h>
+
+// A class to make it easier to handle and pass around 6-byte BSSID and MAC addresses.
+class MacAddress {
+private:
+    union {
+        struct {
+            uint8_t align[2];
+            uint8_t bytes[6];
+        };
+        uint64_t val;
+    } _mac;
+
+public:
+    MacAddress();
+    MacAddress(uint64_t mac);
+    MacAddress(const uint8_t *macbytearray);
+    virtual ~MacAddress() {}
+    bool fromCStr(const char *buf);
+    bool fromString(const String &macstr);
+    void toBytes(uint8_t *buf);
+    int  toCStr(char *buf);
+    String toString() const;
+    uint64_t Value();
+
+    operator uint64_t() const;
+    MacAddress& operator=(const uint8_t *mac);
+    MacAddress& operator=(uint64_t macval);
+    bool operator==(const uint8_t *mac) const;
+    bool operator==(const MacAddress& mac2) const;
+};
+
+#endif

--- a/cores/esp32/MacAddress.h
+++ b/cores/esp32/MacAddress.h
@@ -18,7 +18,9 @@
 #ifndef MacAddress_h
 #define MacAddress_h
 
+#include <stdint.h>
 #include <WString.h>
+#include <Printable.h>
 
 // A class to make it easier to handle and pass around 6-byte BSSID and MAC addresses.
 class MacAddress : public Printable {

--- a/cores/esp32/MacAddress.h
+++ b/cores/esp32/MacAddress.h
@@ -21,7 +21,7 @@
 #include <WString.h>
 
 // A class to make it easier to handle and pass around 6-byte BSSID and MAC addresses.
-class MacAddress {
+class MacAddress : public Printable {
 private:
     union {
         struct {
@@ -35,6 +35,7 @@ public:
     MacAddress();
     MacAddress(uint64_t mac);
     MacAddress(const uint8_t *macbytearray);
+    MAcAddress(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6);
     virtual ~MacAddress() {}
     bool fromCStr(const char *buf);
     bool fromString(const String &macstr);
@@ -43,11 +44,43 @@ public:
     String toString() const;
     uint64_t Value();
 
-    operator uint64_t() const;
+    // Overloaded index operator to allow getting and setting individual octets of the address
+    uint8_t operator[](int index) const
+    {
+        return _mac.bytes[index];
+    }
+    uint8_t& operator[](int index)
+    {
+        return _mac.bytes[index];
+    }
+
     MacAddress& operator=(const uint8_t *mac);
     MacAddress& operator=(uint64_t macval);
     bool operator==(const uint8_t *mac) const;
     bool operator==(const MacAddress& mac2) const;
+    
+    operator uint64_t() const
+    {
+        return _mac.val;
+    }
+    operator const uint8_t*() const
+    {
+        return _mac.bytes;
+    }
+    operator const uint64_t*() const
+    {
+        return &_mac.val;
+    }
+
+    virtual size_t printTo(Print& p) const;
+
+    // future use in Arduino Networking 
+    friend class EthernetClass;
+    friend class UDP;
+    friend class Client;
+    friend class Server;
+    friend class DhcpClass;
+    friend class DNSClient;
 };
 
 #endif

--- a/cores/esp32/MacAddress8.cpp
+++ b/cores/esp32/MacAddress8.cpp
@@ -1,0 +1,95 @@
+#include <MacAddress8.h>
+#include <stdio.h>
+
+//Default constructor, blank mac address.
+MacAddress8::MacAddress8() {
+    _mac.val = 0;
+}
+
+MacAddress8::MacAddress8(uint64_t mac) {
+    _mac.val = mac;
+}
+
+MacAddress8::MacAddress8(const uint8_t *macbytearray) {
+    memcpy(_mac.bytes, macbytearray, sizeof(_mac.bytes));
+}
+
+//Parse user entered string into MAC address
+bool MacAddress8::fromCStr(const char *buf) {
+  char cs[24];
+  char *token;
+  char *next; //Unused but required
+  int i;
+
+  strncpy(cs, buf, sizeof(cs)); //strtok modifies the buffer: copy to working buffer.
+
+  for(i=0; i<sizeof(_mac.bytes); i++) {
+    token = strtok((i==0) ? cs : NULL, ":");    //Find first or next token
+    if(!token) {                                //No more tokens found
+        return false;
+    }
+    _mac.bytes[i] = strtol(token, &next, 16);
+  }
+  return true;
+}
+
+//Parse user entered string into MAC address
+bool MacAddress8::fromString(const String &macstr) {
+    return fromCStr(macstr.c_str());
+}
+
+//Copy MAC into 8 byte array
+void MacAddress8::toBytes(uint8_t *buf) {
+    memcpy(buf, _mac.bytes, sizeof(_mac.bytes));
+}
+
+//Print MAC address into a C string.
+//EUI-64: Buffer must be at least 24 chars
+int MacAddress8::toCStr(char *buf) {
+    return sprintf(buf, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X",
+        _mac.bytes[0], _mac.bytes[1], _mac.bytes[2], _mac.bytes[3],
+        _mac.bytes[4], _mac.bytes[5], _mac.bytes[6], _mac.bytes[7]);
+}
+
+String MacAddress8::toString() const {
+    char buf[24];
+    sprintf(buf, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X",
+        _mac.bytes[0], _mac.bytes[1], _mac.bytes[2], _mac.bytes[3],
+        _mac.bytes[4], _mac.bytes[5], _mac.bytes[6], _mac.bytes[7]);
+    return String(buf);
+}
+
+uint64_t MacAddress8::Value() {
+    return _mac.val;
+}
+
+//Implicit conversion object to number [same as .Value()]
+MacAddress8::operator uint64_t() const
+{
+    return _mac.val;
+}
+
+//Overloaded copy operators to allow initialisation of MacAddress objects from other types
+MacAddress8& MacAddress8::operator=(const uint8_t *mac)
+{
+    memcpy(_mac.bytes, mac, sizeof(_mac.bytes));
+    return *this;
+}
+
+MacAddress8& MacAddress8::operator=(uint64_t macval)
+{
+    _mac.val = macval;
+    return *this;
+}
+
+//Compare class to byte array
+bool MacAddress8::operator==(const uint8_t *mac) const
+{
+    return !memcmp(_mac.bytes, mac, sizeof(_mac.bytes));
+}
+
+//Allow comparing value of two classes
+bool MacAddress8::operator==(const MacAddress8& mac2) const
+{
+    return _mac.val == mac2._mac.val;
+}

--- a/cores/esp32/MacAddress8.cpp
+++ b/cores/esp32/MacAddress8.cpp
@@ -1,5 +1,6 @@
 #include <MacAddress8.h>
 #include <stdio.h>
+#include <Print.h>
 
 //Default constructor, blank mac address.
 MacAddress8::MacAddress8() {
@@ -92,4 +93,16 @@ bool MacAddress8::operator==(const uint8_t *mac) const
 bool MacAddress8::operator==(const MacAddress8& mac2) const
 {
     return _mac.val == mac2._mac.val;
+}
+
+size_t MacAddress8::printTo(Print& p) const
+{
+    size_t n = 0;
+    for(int i = 0; i < 8; i++) {
+        if(i){
+            n += p.print(':');
+        }
+        n += p.printf("%02x", _mac.bytes[i]);
+    }
+    return n;
 }

--- a/cores/esp32/MacAddress8.cpp
+++ b/cores/esp32/MacAddress8.cpp
@@ -130,7 +130,7 @@ size_t MacAddress8::printTo(Print& p) const
         if(i){
             n += p.print(':');
         }
-        n += p.printf("%02x", _mac.bytes[i]);
+        n += p.printf("%02X", _mac.bytes[i]);
     }
     return n;
 }

--- a/cores/esp32/MacAddress8.cpp
+++ b/cores/esp32/MacAddress8.cpp
@@ -15,6 +15,17 @@ MacAddress8::MacAddress8(const uint8_t *macbytearray) {
     memcpy(_mac.bytes, macbytearray, sizeof(_mac.bytes));
 }
 
+MacAddress8::MacAddress8(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6, uint8_t b7, uint8_t b8) {
+    _mac.bytes[0] = b1;
+    _mac.bytes[1] = b2;
+    _mac.bytes[2] = b3;
+    _mac.bytes[3] = b4;
+    _mac.bytes[4] = b5;
+    _mac.bytes[5] = b6;
+    _mac.bytes[6] = b7;
+    _mac.bytes[7] = b8;
+}
+
 //Parse user entered string into MAC address
 bool MacAddress8::fromCStr(const char *buf) {
   char cs[24];
@@ -64,35 +75,52 @@ uint64_t MacAddress8::Value() {
     return _mac.val;
 }
 
-//Implicit conversion object to number [same as .Value()]
-MacAddress8::operator uint64_t() const
-{
-    return _mac.val;
+uint8_t MacAddress8::operator[](int index) const {
+    index = EnforceIndexBounds(index);
+    return _mac.bytes[index];
 }
 
-//Overloaded copy operators to allow initialisation of MacAddress objects from other types
-MacAddress8& MacAddress8::operator=(const uint8_t *mac)
-{
-    memcpy(_mac.bytes, mac, sizeof(_mac.bytes));
+//Allow setting individual octets of the address. e.g. ma[2] = 255;
+uint8_t& MacAddress8::operator[](int index) {
+    index = EnforceIndexBounds(index);
+    return _mac.bytes[index];
+}
+
+//Overloaded copy operator: init MacAddress object from byte array
+MacAddress8& MacAddress8::operator=(const uint8_t *macbytearray) {
+    memcpy(_mac.bytes, macbytearray, sizeof(_mac.bytes));
     return *this;
 }
 
-MacAddress8& MacAddress8::operator=(uint64_t macval)
-{
+//Overloaded copy operator: init MacAddress object from uint64_t
+MacAddress8& MacAddress8::operator=(uint64_t macval) {
     _mac.val = macval;
     return *this;
 }
 
 //Compare class to byte array
-bool MacAddress8::operator==(const uint8_t *mac) const
-{
-    return !memcmp(_mac.bytes, mac, sizeof(_mac.bytes));
+bool MacAddress8::operator==(const uint8_t *macbytearray) const {
+    return !memcmp(_mac.bytes, macbytearray, sizeof(_mac.bytes));
 }
 
 //Allow comparing value of two classes
-bool MacAddress8::operator==(const MacAddress8& mac2) const
-{
+bool MacAddress8::operator==(const MacAddress8& mac2) const {
     return _mac.val == mac2._mac.val;
+}
+
+//Type converter object to uint64_t [same as .Value()]
+MacAddress8::operator uint64_t() const {
+    return _mac.val;
+}
+
+//Type converter object to read only pointer to mac bytes. e.g. const uint8_t *ip_8 = ma;
+MacAddress8::operator const uint8_t*() const {
+    return _mac.bytes;
+}
+
+//Type converter object to read only pointer to mac value. e.g. const uint32_t *ip_64 = ma;
+MacAddress8::operator const uint64_t*() const {
+    return &_mac.val;
 }
 
 size_t MacAddress8::printTo(Print& p) const
@@ -105,4 +133,15 @@ size_t MacAddress8::printTo(Print& p) const
         n += p.printf("%02x", _mac.bytes[i]);
     }
     return n;
+}
+
+//Bounds checking
+int MacAddress8::EnforceIndexBounds(int i) const {
+    if(i < 0) {
+        return 0;
+    }
+    if(i >= sizeof(_mac.bytes)) {
+        return sizeof(_mac.bytes)-1;
+    }
+    return i;
 }

--- a/cores/esp32/MacAddress8.h
+++ b/cores/esp32/MacAddress8.h
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// MacAddress8.h - class to make it easier to handle BSSID and MAC addresses.
+// MacAddress8.h - class to make it easier to handle 8-byte EUI-64 addresses.
 // 
 // Copyright 2022 David McCurley
 // Licensed under the Apache License, Version 2.0 (the "License").

--- a/cores/esp32/MacAddress8.h
+++ b/cores/esp32/MacAddress8.h
@@ -34,39 +34,24 @@ public:
     MacAddress8();
     MacAddress8(uint64_t mac);
     MacAddress8(const uint8_t *macbytearray);
+    MacAddress8(uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4, uint8_t b5, uint8_t b6, uint8_t b7, uint8_t b8);
     virtual ~MacAddress8() {}
     bool fromCStr(const char *buf);
     bool fromString(const String &macstr);
     void toBytes(uint8_t *buf);
-    int toCStr(char *buf);
+    int  toCStr(char *buf);
     String toString() const;
     uint64_t Value();
 
-    operator uint64_t() const;
-    MacAddress8& operator=(const uint8_t *mac);
+    uint8_t operator[](int index) const;
+    uint8_t& operator[](int index);
+    MacAddress8& operator=(const uint8_t *macbytearray);
     MacAddress8& operator=(uint64_t macval);
-    bool operator==(const uint8_t *mac) const;
+    bool operator==(const uint8_t *macbytearray) const;
     bool operator==(const MacAddress8& mac2) const;
-
-    // Overloaded index operator to allow getting and setting individual octets of the address
-    uint8_t operator[](int index) const
-    {
-        return _mac.bytes[index];
-    }
-    uint8_t& operator[](int index)
-    {
-        return _mac.bytes[index];
-    }
-
-    operator const uint8_t*() const
-    {
-        return _mac.bytes;
-    }
-    operator const uint64_t*() const
-    {
-        return &_mac.val;
-    }
-
+    operator uint64_t() const;
+    operator const uint8_t*() const;
+    operator const uint64_t*() const;
     virtual size_t printTo(Print& p) const;
 
     // future use in Arduino Networking 
@@ -75,7 +60,10 @@ public:
     friend class Client;
     friend class Server;
     friend class DhcpClass;
-    friend class DNSClient;    
+    friend class DNSClient;
+
+private:
+    int EnforceIndexBounds(int i) const;
 };
 
 #endif

--- a/cores/esp32/MacAddress8.h
+++ b/cores/esp32/MacAddress8.h
@@ -52,6 +52,7 @@ public:
     operator uint64_t() const;
     operator const uint8_t*() const;
     operator const uint64_t*() const;
+
     virtual size_t printTo(Print& p) const;
 
     // future use in Arduino Networking 

--- a/cores/esp32/MacAddress8.h
+++ b/cores/esp32/MacAddress8.h
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------------------------
+// MacAddress8.h - class to make it easier to handle BSSID and MAC addresses.
+// 
+// Copyright 2022 David McCurley
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+//     
+// Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+//   limitations under the License.
+//-----------------------------------------------------------------------------
+
+#ifndef MacAddress8_h
+#define MacAddress8_h
+
+#include <WString.h>
+
+// A class to make it easier to handle and pass around 8-byte EUI-64(used for IEEE 802.15.4) addresses. See <esp_mac.h>.
+class MacAddress8 {
+private:
+    union {
+        uint8_t bytes[8];
+        uint64_t val;
+    } _mac;
+
+public:
+    MacAddress8();
+    MacAddress8(uint64_t mac);
+    MacAddress8(const uint8_t *macbytearray);
+    virtual ~MacAddress8() {}
+    bool fromCStr(const char *buf);
+    bool fromString(const String &macstr);
+    void toBytes(uint8_t *buf);
+    int toCStr(char *buf);
+    String toString() const;
+    uint64_t Value();
+
+    operator uint64_t() const;
+    MacAddress8& operator=(const uint8_t *mac);
+    MacAddress8& operator=(uint64_t macval);
+    bool operator==(const uint8_t *mac) const;
+    bool operator==(const MacAddress8& mac2) const;
+};
+
+#endif

--- a/cores/esp32/MacAddress8.h
+++ b/cores/esp32/MacAddress8.h
@@ -18,10 +18,12 @@
 #ifndef MacAddress8_h
 #define MacAddress8_h
 
+#include <stdint.h>
 #include <WString.h>
+#include <Printable.h>
 
 // A class to make it easier to handle and pass around 8-byte EUI-64(used for IEEE 802.15.4) addresses. See <esp_mac.h>.
-class MacAddress8 {
+class MacAddress8 : public Printable {
 private:
     union {
         uint8_t bytes[8];
@@ -45,6 +47,35 @@ public:
     MacAddress8& operator=(uint64_t macval);
     bool operator==(const uint8_t *mac) const;
     bool operator==(const MacAddress8& mac2) const;
+
+    // Overloaded index operator to allow getting and setting individual octets of the address
+    uint8_t operator[](int index) const
+    {
+        return _mac.bytes[index];
+    }
+    uint8_t& operator[](int index)
+    {
+        return _mac.bytes[index];
+    }
+
+    operator const uint8_t*() const
+    {
+        return _mac.bytes;
+    }
+    operator const uint64_t*() const
+    {
+        return &_mac.val;
+    }
+
+    virtual size_t printTo(Print& p) const;
+
+    // future use in Arduino Networking 
+    friend class EthernetClass;
+    friend class UDP;
+    friend class Client;
+    friend class Server;
+    friend class DhcpClass;
+    friend class DNSClient;    
 };
 
 #endif


### PR DESCRIPTION
## Description of Change
This adds new classes MacAddress and MacAddress8.  MacAddress allows for better handling of MAC and BSSID addresses.  MacAddress8 is for 8-byte EUI-64 as noted in esp_mac.h.

## Test scenarios
Tested on Arduino Feather ESP32.
```
[env]
monitor_speed = 115200
build_flags = 

[env:fthr-esp32ard]
platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
framework = arduino
board = featheresp32
```

## RC1
No new changes. Bugfixes accepted.

## TESTING
See test project here: https://github.com/mrengineer7777/MA_Test.

## Related links
Closes #6658.
