### PR TITLE
ESPLwIPClient::setTimeout conflict fix with Stream::setTimeout

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -495,7 +495,7 @@ void HTTPClient::setTimeout(uint16_t timeout)
 {
     _tcpTimeout = timeout;
     if(connected()) {
-        _client->setTimeout(timeout + 500); /* / 1000 removed, WifiClient setTimeout changed to ms */
+        _client->setTimeout(timeout);
     }
 }
 
@@ -1165,7 +1165,7 @@ bool HTTPClient::connect(void)
     }
 
     // set Timeout for WiFiClient and for Stream::readBytesUntil() and Stream::readStringUntil()
-    _client->setTimeout(_tcpTimeout + 500); /* / 1000 removed, WifiClient setTimeout changed to ms */	
+    _client->setTimeout(_tcpTimeout);	
 
     log_d(" connected to %s:%u", _host.c_str(), _port);
 

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -495,7 +495,7 @@ void HTTPClient::setTimeout(uint16_t timeout)
 {
     _tcpTimeout = timeout;
     if(connected()) {
-        _client->setTimeout((timeout + 500) / 1000);
+        _client->setTimeout(timeout + 500); /* / 1000 removed, WifiClient setTimeout changed to ms */
     }
 }
 
@@ -1165,7 +1165,7 @@ bool HTTPClient::connect(void)
     }
 
     // set Timeout for WiFiClient and for Stream::readBytesUntil() and Stream::readStringUntil()
-    _client->setTimeout((_tcpTimeout + 500) / 1000);	
+    _client->setTimeout(_tcpTimeout + 500); /* / 1000 removed, WifiClient setTimeout changed to ms */	
 
     log_d(" connected to %s:%u", _host.c_str(), _port);
 

--- a/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
+++ b/libraries/HTTPUpdate/examples/httpUpdateSecure/httpUpdateSecure.ino
@@ -96,7 +96,7 @@ void loop() {
     client.setCACert(rootCACertificate);
 
     // Reading data over SSL may be slow, use an adequate timeout
-    client.setTimeout(12000 / 1000); // timeout argument is defined in seconds for setTimeout
+    client.setTimeout(12000); // timeout argument is defined in miliseconds for setTimeout
 
     // The line below is optional. It can be used to blink the LED on the board during flashing
     // The LED will be on during download of one buffer of data from the network. The LED will

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -303,7 +303,7 @@ void WebServer::handleClient() {
         if (_parseRequest(_currentClient)) {
           // because HTTP_MAX_SEND_WAIT is expressed in milliseconds,
           // it must be divided by 1000
-          _currentClient.setTimeout(HTTP_MAX_SEND_WAIT / 1000);
+          _currentClient.setTimeout(HTTP_MAX_SEND_WAIT); /* / 1000 removed, WifiClient setTimeout changed to ms */
           _contentLength = CONTENT_LENGTH_NOT_SET;
           _handleRequest();
 

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -404,8 +404,8 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
         if(_lastWriteTimeout != _timeout){
             if(fd() >= 0){
                 struct timeval timeout_tv;
-                timeout_tv.tv_sec = _timeout/1000;
-                timeout_tv.tv_usec = 0;
+                timeout_tv.tv_sec = _timeout / 1000;
+                timeout_tv.tv_usec = (_timeout % 1000) * 1000;
                 if(setSocketOption(SO_SNDTIMEO, (char *)&timeout_tv, sizeof(struct timeval)) >= 0)
                 {
                     _lastWriteTimeout = _timeout;
@@ -475,8 +475,8 @@ int WiFiClient::read(uint8_t *buf, size_t size)
     if(_lastReadTimeout != _timeout){
         if(fd() >= 0){
             struct timeval timeout_tv;
-            timeout_tv.tv_sec = _timeout/1000;
-            timeout_tv.tv_usec = 0;
+            timeout_tv.tv_sec = _timeout / 1000;
+            timeout_tv.tv_usec = (_timeout % 1000) * 1000;
             if(setSocketOption(SO_RCVTIMEO, (char *)&timeout_tv, sizeof(struct timeval)) >= 0)
             {
                 _lastReadTimeout = _timeout;

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -211,6 +211,8 @@ void WiFiClient::stop()
     clientSocketHandle = NULL;
     _rxBuffer = NULL;
     _connected = false;
+    _lastReadTimeout = 0;
+    _lastWriteTimeout = 0;
 }
 
 int WiFiClient::connect(IPAddress ip, uint16_t port)
@@ -329,13 +331,6 @@ int WiFiClient::getSocketOption(int level, int option, const void* value, size_t
         log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
     }
     return res;
-}
-
-void WiFiClient::setTimeout(uint32_t seconds)
-{
-    _lastReadTimeout = _timeout;
-    _lastWriteTimeout = _timeout;
-    _timeout = seconds * 1000;
 }
 
 int WiFiClient::setOption(int option, int *value)

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -335,21 +335,7 @@ void WiFiClient::setTimeout(uint32_t seconds)
 {
     _lastReadTimeout = Client::getTimeout();
     _lastWriteTimeout = _lastReadTimeout;
-    Client::setTimeout(seconds * 1000); // This should be here?
     _timeout = seconds * 1000;
-    
-    // if(fd() >= 0) {
-    //     struct timeval tv;
-    //     tv.tv_sec = seconds;
-    //     tv.tv_usec = 0;
-    //     if(setSocketOption(SO_RCVTIMEO, (char *)&tv, sizeof(struct timeval)) < 0) {
-    //         return -1;
-    //     }
-    //     return setSocketOption(SO_SNDTIMEO, (char *)&tv, sizeof(struct timeval));
-    // }
-    // else {
-    //     return 0;
-    // }
 }
 
 int WiFiClient::setOption(int option, int *value)
@@ -422,10 +408,10 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
 
         if(_lastWriteTimeout != _timeout){
             if(fd() >= 0){
-                struct timeval tv;
-                tv.tv_sec = _timeout/1000;
-                tv.tv_usec = 0;
-                if(setSocketOption(SO_SNDTIMEO, (char *)&tv, sizeof(struct timeval)) >= 0)
+                struct timeval timeout_tv;
+                timeout_tv.tv_sec = _timeout/1000;
+                timeout_tv.tv_usec = 0;
+                if(setSocketOption(SO_SNDTIMEO, (char *)&timeout_tv, sizeof(struct timeval)) >= 0)
                 {
                     _lastWriteTimeout = _timeout;
                 }
@@ -493,10 +479,10 @@ int WiFiClient::read(uint8_t *buf, size_t size)
 {
     if(_lastReadTimeout != _timeout){
         if(fd() >= 0){
-            struct timeval tv;
-            tv.tv_sec = _timeout/1000;
-            tv.tv_usec = 0;
-            if(setSocketOption(SO_RCVTIMEO, (char *)&tv, sizeof(struct timeval)) >= 0)
+            struct timeval timeout_tv;
+            timeout_tv.tv_sec = _timeout/1000;
+            timeout_tv.tv_usec = 0;
+            if(setSocketOption(SO_RCVTIMEO, (char *)&timeout_tv, sizeof(struct timeval)) >= 0)
             {
                 _lastReadTimeout = _timeout;
             }

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -333,8 +333,8 @@ int WiFiClient::getSocketOption(int level, int option, const void* value, size_t
 
 void WiFiClient::setTimeout(uint32_t seconds)
 {
-    _lastReadTimeout = Client::getTimeout();
-    _lastWriteTimeout = _lastReadTimeout;
+    _lastReadTimeout = _timeout;
+    _lastWriteTimeout = _timeout;
     _timeout = seconds * 1000;
 }
 

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -33,7 +33,6 @@ class ESPLwIPClient : public Client
 public:
         virtual int connect(IPAddress ip, uint16_t port, int32_t timeout) = 0;
         virtual int connect(const char *host, uint16_t port, int32_t timeout) = 0;
-        virtual int setTimeout(uint32_t seconds) = 0;
 };
 
 class WiFiClient : public ESPLwIPClient
@@ -43,6 +42,8 @@ protected:
     std::shared_ptr<WiFiClientRxBuffer> _rxBuffer;
     bool _connected;
     int _timeout;
+    int _lastWriteTimeout;
+    int _lastReadTimeout;
 
 public:
     WiFiClient *next;
@@ -91,7 +92,7 @@ public:
     int getSocketOption(int level, int option, const void* value, size_t size);
     int setOption(int option, int *value);
     int getOption(int option, int *value);
-    int setTimeout(uint32_t seconds);
+    void setTimeout(uint32_t seconds);
     int setNoDelay(bool nodelay);
     bool getNoDelay();
 

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -92,7 +92,6 @@ public:
     int getSocketOption(int level, int option, const void* value, size_t size);
     int setOption(int option, int *value);
     int getOption(int option, int *value);
-    void setTimeout(uint32_t seconds);
     int setNoDelay(bool nodelay);
     bool getNoDelay();
 

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -419,6 +419,9 @@ int WiFiClientSecure::setTimeout(uint32_t seconds)
 }
 
 int WiFiClientSecure::fd() const
+{
+    return sslclient->socket;
+}
 
 int WiFiClientSecure::setSocketOption(int option, char* value, size_t len)
 {

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -205,8 +205,8 @@ size_t WiFiClientSecure::write(const uint8_t *buf, size_t size)
     }
     if(_lastWriteTimeout != _timeout){
         struct timeval timeout_tv;
-        timeout_tv.tv_sec = _timeout/1000;
-        timeout_tv.tv_usec = 0;
+        timeout_tv.tv_sec = _timeout / 1000;
+        timeout_tv.tv_usec = (_timeout % 1000) * 1000;
         if(setSocketOption(SO_SNDTIMEO, (char *)&timeout_tv, sizeof(struct timeval)) >= 0)
         {
             _lastWriteTimeout = _timeout;
@@ -226,8 +226,8 @@ int WiFiClientSecure::read(uint8_t *buf, size_t size)
     if(_lastReadTimeout != _timeout){
         if(fd() >= 0){
             struct timeval timeout_tv;
-            timeout_tv.tv_sec = _timeout/1000;
-            timeout_tv.tv_usec = 0;
+            timeout_tv.tv_sec = _timeout / 1000;
+            timeout_tv.tv_usec = (_timeout % 1000) * 1000;
             if(setSocketOption(SO_RCVTIMEO, (char *)&timeout_tv, sizeof(struct timeval)) >= 0)
             {
                 _lastReadTimeout = _timeout;

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -54,6 +54,8 @@ WiFiClientSecure::WiFiClientSecure(int sock)
 {
     _connected = false;
     _timeout = 30000; // Same default as ssl_client
+    _lastReadTimeout = 0;
+    _lastWriteTimeout = 0;
 
     sslclient = new sslclient_context;
     ssl_init(sslclient);
@@ -94,6 +96,8 @@ void WiFiClientSecure::stop()
         sslclient->socket = -1;
         _connected = false;
         _peek = -1;
+        _lastReadTimeout = 0;
+        _lastWriteTimeout = 0;
     }
     stop_ssl_socket(sslclient, _CA_cert, _cert, _private_key);
 }

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -422,9 +422,3 @@ int WiFiClientSecure::fd() const
 {
     return sslclient->socket;
 }
-
-int WiFiClientSecure::setSocketOption(int option, char* value, size_t len)
-{
-    return sslclient->socket;
-}
-

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.h
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.h
@@ -82,6 +82,7 @@ public:
     bool getFingerprintSHA256(uint8_t sha256_result[32]) { return get_peer_fingerprint(sslclient, sha256_result); };
     int setTimeout(uint32_t seconds);
     int fd() const;
+    int setSocketOption(int option, char* value, size_t len);
 
     operator bool()
     {

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.h
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.h
@@ -82,7 +82,6 @@ public:
     bool getFingerprintSHA256(uint8_t sha256_result[32]) { return get_peer_fingerprint(sslclient, sha256_result); };
     int setTimeout(uint32_t seconds);
     int fd() const;
-    int setSocketOption(int option, char* value, size_t len);
 
     operator bool()
     {


### PR DESCRIPTION
## Description of Change
Arduino Stream::settimeout() is not virtual so it cannot be virtual in ESPLwIPClient.
This change should fix this conflict.

## Tests scenarios

## Related links
Closes #5558 