### PR TITLE
Properly handle ARDUINO_PARTITION define in PlatformIO

### DIFF
--- a/tools/platformio-build-esp32.py
+++ b/tools/platformio-build-esp32.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join
+from os.path import abspath, basename, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -319,7 +319,8 @@ env.Append(
         ("ARDUINO", 10812),
         ("ARDUINO_VARIANT", '\\"%s\\"' % env.BoardConfig().get("build.variant").replace('"', "")),
         ("ARDUINO_BOARD", '\\"%s\\"' % env.BoardConfig().get("name").replace('"', "")),
-        "ARDUINO_PARTITION_%s" % env.BoardConfig().get("build.partitions", "default.csv").replace(".csv", "")
+        "ARDUINO_PARTITION_%s" % basename(env.BoardConfig().get(
+            "build.partitions", "default.csv")).replace(".csv", "").replace("-", "_")
     ],
 
     LIBSOURCE_DIRS=[

--- a/tools/platformio-build-esp32c3.py
+++ b/tools/platformio-build-esp32c3.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join
+from os.path import abspath, basename, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -312,7 +312,8 @@ env.Append(
         ("ARDUINO", 10812),
         ("ARDUINO_VARIANT", '\\"%s\\"' % env.BoardConfig().get("build.variant").replace('"', "")),
         ("ARDUINO_BOARD", '\\"%s\\"' % env.BoardConfig().get("name").replace('"', "")),
-        "ARDUINO_PARTITION_%s" % env.BoardConfig().get("build.partitions", "default.csv").replace(".csv", "")
+        "ARDUINO_PARTITION_%s" % basename(env.BoardConfig().get(
+            "build.partitions", "default.csv")).replace(".csv", "").replace("-", "_")
     ],
 
     LIBSOURCE_DIRS=[

--- a/tools/platformio-build-esp32s2.py
+++ b/tools/platformio-build-esp32s2.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join
+from os.path import abspath, basename, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -314,7 +314,8 @@ env.Append(
         ("ARDUINO", 10812),
         ("ARDUINO_VARIANT", '\\"%s\\"' % env.BoardConfig().get("build.variant").replace('"', "")),
         ("ARDUINO_BOARD", '\\"%s\\"' % env.BoardConfig().get("name").replace('"', "")),
-        "ARDUINO_PARTITION_%s" % env.BoardConfig().get("build.partitions", "default.csv").replace(".csv", "")
+        "ARDUINO_PARTITION_%s" % basename(env.BoardConfig().get(
+            "build.partitions", "default.csv")).replace(".csv", "").replace("-", "_")
     ],
 
     LIBSOURCE_DIRS=[

--- a/tools/platformio-build-esp32s3.py
+++ b/tools/platformio-build-esp32s3.py
@@ -24,7 +24,7 @@ http://arduino.cc/en/Reference/HomePage
 
 # Extends: https://github.com/platformio/platform-espressif32/blob/develop/builder/main.py
 
-from os.path import abspath, isdir, isfile, join
+from os.path import abspath, basename, isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -331,7 +331,8 @@ env.Append(
         ("ARDUINO", 10812),
         ("ARDUINO_VARIANT", '\\"%s\\"' % env.BoardConfig().get("build.variant").replace('"', "")),
         ("ARDUINO_BOARD", '\\"%s\\"' % env.BoardConfig().get("name").replace('"', "")),
-        "ARDUINO_PARTITION_%s" % env.BoardConfig().get("build.partitions", "default.csv").replace(".csv", "")
+        "ARDUINO_PARTITION_%s" % basename(env.BoardConfig().get(
+            "build.partitions", "default.csv")).replace(".csv", "").replace("-", "_")
     ],
 
     LIBSOURCE_DIRS=[


### PR DESCRIPTION
This fixes possible issues when developers specify arbitrary partition files using relative or absolute paths.

Additionally, hyphens in filenames are replaced with underscores to avoid compilation warnings like `ISO C++11 requires whitespace after the macro name`

Resolves platformio/platform-espressif32#787

