### PR TITLE
Adjustable Serial Event Task Stack Size And Priority

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -31,6 +31,7 @@ choice ARDUINO_RUNNING_CORE
         bool "CORE 1"
     config ARDUINO_RUN_NO_AFFINITY
         bool "BOTH"
+        depends on !CONFIG_FREERTOS_UNICORE
 
 endchoice
 
@@ -58,6 +59,7 @@ choice ARDUINO_EVENT_RUNNING_CORE
         bool "CORE 1"
     config ARDUINO_EVENT_RUN_NO_AFFINITY
         bool "BOTH"
+        depends on !CONFIG_FREERTOS_UNICORE
 
 endchoice
 
@@ -66,21 +68,6 @@ config ARDUINO_EVENT_RUNNING_CORE
     default 0 if ARDUINO_EVENT_RUN_CORE0
     default 1 if ARDUINO_EVENT_RUN_CORE1
     default -1 if ARDUINO_EVENT_RUN_NO_AFFINITY
-
-choice ARDUINO_UDP_RUNNING_CORE
-    bool "Core on which Arduino's UDP is running"
-    default ARDUINO_UDP_RUN_CORE1
-    help
-        Select on which core Arduino's UDP run
-
-    config ARDUINO_UDP_RUN_CORE0
-        bool "CORE 0"
-    config ARDUINO_UDP_RUN_CORE1
-        bool "CORE 1"
-    config ARDUINO_UDP_RUN_NO_AFFINITY
-        bool "BOTH"
-
-endchoice
 
 choice ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
     bool "Core on which Arduino's Serial Event task is running"
@@ -94,6 +81,7 @@ choice ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
         bool "CORE 1"
     config ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY
         bool "BOTH"
+        depends on !CONFIG_FREERTOS_UNICORE
 
 endchoice
 
@@ -120,6 +108,22 @@ config ARDUINO_UDP_TASK_PRIORITY
     default 3
     help
         Select at what priority you want the UDP task to run.
+
+choice ARDUINO_UDP_RUNNING_CORE
+    bool "Core on which Arduino's UDP is running"
+    default ARDUINO_UDP_RUN_CORE1
+    help
+        Select on which core Arduino's UDP run
+
+    config ARDUINO_UDP_RUN_CORE0
+        bool "CORE 0"
+    config ARDUINO_UDP_RUN_CORE1
+        bool "CORE 1"
+    config ARDUINO_UDP_RUN_NO_AFFINITY
+        bool "BOTH"
+        depends on !CONFIG_FREERTOS_UNICORE
+
+endchoice
 
 config ARDUINO_UDP_RUNNING_CORE
     int

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -21,7 +21,8 @@ config AUTOSTART_ARDUINO
 
 choice ARDUINO_RUNNING_CORE
     bool "Core on which Arduino's setup() and loop() are running"
-    default ARDUINO_RUN_CORE1
+    default ARDUINO_RUN_CORE0 if FREERTOS_UNICORE
+    default ARDUINO_RUN_CORE1 if !FREERTOS_UNICORE
     help
         Select on which core Arduino's setup() and loop() functions run
 
@@ -29,6 +30,7 @@ choice ARDUINO_RUNNING_CORE
         bool "CORE 0"
     config ARDUINO_RUN_CORE1
         bool "CORE 1"
+        depends on !FREERTOS_UNICORE
     config ARDUINO_RUN_NO_AFFINITY
         bool "BOTH"
         depends on !FREERTOS_UNICORE
@@ -49,7 +51,8 @@ config ARDUINO_LOOP_STACK_SIZE
 
 choice ARDUINO_EVENT_RUNNING_CORE
     bool "Core on which Arduino's event handler is running"
-    default ARDUINO_EVENT_RUN_CORE1
+    default ARDUINO_EVENT_RUN_CORE0 if FREERTOS_UNICORE
+    default ARDUINO_EVENT_RUN_CORE1 if !FREERTOS_UNICORE
     help
         Select on which core Arduino's WiFi.onEvent() run
 
@@ -57,6 +60,7 @@ choice ARDUINO_EVENT_RUNNING_CORE
         bool "CORE 0"
     config ARDUINO_EVENT_RUN_CORE1
         bool "CORE 1"
+        depends on !FREERTOS_UNICORE
     config ARDUINO_EVENT_RUN_NO_AFFINITY
         bool "BOTH"
         depends on !FREERTOS_UNICORE
@@ -71,7 +75,8 @@ config ARDUINO_EVENT_RUNNING_CORE
 
 choice ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
     bool "Core on which Arduino's Serial Event task is running"
-    default ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY
+    default ARDUINO_SERIAL_EVENT_RUN_CORE0 if FREERTOS_UNICORE
+    default ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY if !FREERTOS_UNICORE
     help
         Select on which core Arduino's Serial Event task run
 
@@ -79,6 +84,7 @@ choice ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
         bool "CORE 0"
     config ARDUINO_SERIAL_EVENT_RUN_CORE1
         bool "CORE 1"
+        depends on !FREERTOS_UNICORE
     config ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY
         bool "BOTH"
         depends on !FREERTOS_UNICORE
@@ -103,15 +109,9 @@ config ARDUINO_SERIAL_EVENT_TASK_PRIORITY
     help
         Select at what priority you want the Serial Event task to run.
 
-config ARDUINO_UDP_TASK_PRIORITY
-    int "Priority of the UDP task"
-    default 3
-    help
-        Select at what priority you want the UDP task to run.
-
 choice ARDUINO_UDP_RUNNING_CORE
     bool "Core on which Arduino's UDP is running"
-    default ARDUINO_UDP_RUN_CORE1
+    default ARDUINO_UDP_RUN_CORE0
     help
         Select on which core Arduino's UDP run
 
@@ -119,6 +119,7 @@ choice ARDUINO_UDP_RUNNING_CORE
         bool "CORE 0"
     config ARDUINO_UDP_RUN_CORE1
         bool "CORE 1"
+        depends on !FREERTOS_UNICORE
     config ARDUINO_UDP_RUN_NO_AFFINITY
         bool "BOTH"
         depends on !FREERTOS_UNICORE
@@ -130,6 +131,12 @@ config ARDUINO_UDP_RUNNING_CORE
     default 0 if ARDUINO_UDP_RUN_CORE0
     default 1 if ARDUINO_UDP_RUN_CORE1
     default -1 if ARDUINO_UDP_RUN_NO_AFFINITY
+
+config ARDUINO_UDP_TASK_PRIORITY
+    int "Priority of the UDP task"
+    default 3
+    help
+        Select at what priority you want the UDP task to run.
 
 config ARDUINO_ISR_IRAM
     bool "Run interrupts in IRAM"

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -82,6 +82,27 @@ choice ARDUINO_UDP_RUNNING_CORE
 
 endchoice
 
+choice ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
+    bool "Core on which Arduino's Serial Event task is running"
+    default ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY
+    help
+        Select on which core Arduino's Serial Event task run
+
+    config ARDUINO_SERIAL_EVENT_RUN_CORE0
+        bool "CORE 0"
+    config ARDUINO_SERIAL_EVENT_RUN_CORE1
+        bool "CORE 1"
+    config ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY
+        bool "BOTH"
+
+endchoice
+
+config ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
+    int
+    default 0 if ARDUINO_SERIAL_EVENT_RUN_CORE0
+    default 1 if ARDUINO_SERIAL_EVENT_RUN_CORE1
+    default -1 if ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY
+
 config ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE
     int "Serial Event task stack size"
     default 2048

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -31,7 +31,7 @@ choice ARDUINO_RUNNING_CORE
         bool "CORE 1"
     config ARDUINO_RUN_NO_AFFINITY
         bool "BOTH"
-        depends on !CONFIG_FREERTOS_UNICORE
+        depends on !FREERTOS_UNICORE
 
 endchoice
 
@@ -59,7 +59,7 @@ choice ARDUINO_EVENT_RUNNING_CORE
         bool "CORE 1"
     config ARDUINO_EVENT_RUN_NO_AFFINITY
         bool "BOTH"
-        depends on !CONFIG_FREERTOS_UNICORE
+        depends on !FREERTOS_UNICORE
 
 endchoice
 
@@ -81,7 +81,7 @@ choice ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
         bool "CORE 1"
     config ARDUINO_SERIAL_EVENT_RUN_NO_AFFINITY
         bool "BOTH"
-        depends on !CONFIG_FREERTOS_UNICORE
+        depends on !FREERTOS_UNICORE
 
 endchoice
 
@@ -121,7 +121,7 @@ choice ARDUINO_UDP_RUNNING_CORE
         bool "CORE 1"
     config ARDUINO_UDP_RUN_NO_AFFINITY
         bool "BOTH"
-        depends on !CONFIG_FREERTOS_UNICORE
+        depends on !FREERTOS_UNICORE
 
 endchoice
 

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -82,6 +82,18 @@ choice ARDUINO_UDP_RUNNING_CORE
 
 endchoice
 
+config ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE
+    int "Serial Event task stack size"
+    default 2048
+    help
+        Amount of stack available for the Serial Event task.
+
+config ARDUINO_SERIAL_EVENT_TASK_PRIORITY
+    int "Priority of the Serial Event task"
+    default 24
+    help
+        Select at what priority you want the Serial Event task to run.
+
 config ARDUINO_UDP_TASK_PRIORITY
     int "Priority of the UDP task"
     default 3

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -17,6 +17,10 @@
 #define ARDUINO_SERIAL_EVENT_TASK_PRIORITY (configMAX_PRIORITIES-1)
 #endif
 
+#ifndef ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
+#define ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE -1
+#endif
+
 #ifndef SOC_RX0
 #if CONFIG_IDF_TARGET_ESP32
 #define SOC_RX0 3
@@ -167,7 +171,7 @@ HardwareSerial::~HardwareSerial()
 void HardwareSerial::_createEventTask(void *args)
 {
     // Creating UART event Task
-    xTaskCreate(_uartEventTask, "uart_event_task", ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE, this, ARDUINO_SERIAL_EVENT_TASK_PRIORITY, &_eventTask);
+    xTaskCreateUniversal(_uartEventTask, "uart_event_task", ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE, this, ARDUINO_SERIAL_EVENT_TASK_PRIORITY, &_eventTask, ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE);
     if (_eventTask == NULL) {
         log_e(" -- UART%d Event Task not Created!", _uart_nr);
     }

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -9,6 +9,14 @@
 #include "driver/uart.h"
 #include "freertos/queue.h"
 
+#ifndef ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE
+#define ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE 2048
+#endif
+
+#ifndef ARDUINO_SERIAL_EVENT_TASK_PRIORITY
+#define ARDUINO_SERIAL_EVENT_TASK_PRIORITY (configMAX_PRIORITIES-1)
+#endif
+
 #ifndef SOC_RX0
 #if CONFIG_IDF_TARGET_ESP32
 #define SOC_RX0 3
@@ -159,7 +167,7 @@ HardwareSerial::~HardwareSerial()
 void HardwareSerial::_createEventTask(void *args)
 {
     // Creating UART event Task
-    xTaskCreate(_uartEventTask, "uart_event_task", 2048, this, configMAX_PRIORITIES - 1, &_eventTask);
+    xTaskCreate(_uartEventTask, "uart_event_task", ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE, this, ARDUINO_SERIAL_EVENT_TASK_PRIORITY, &_eventTask);
     if (_eventTask == NULL) {
         log_e(" -- UART%d Event Task not Created!", _uart_nr);
     }


### PR DESCRIPTION
This is just a proposal so we can change on compile time the stack size and priority of the Serial Event Task.

On my current software, the serial part does not fit the current 2048 bytes of stack that the Serial Event Task offers me. So I'm forced to implement a binary semaphore for synchronization (the serial event task just gives a semaphore). This is a waste of resources because now I have two tasks (one for the serial event task and one for my actual routine) and a semaphore. Even worse, it's slower.

Thanks!