### PR TITLE
Upload component to the registry on any tag

### DIFF
--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -2,7 +2,7 @@ name: Push components to https://components.espressif.com
 on:
   push:
     tags:
-      - v*
+      - *
 jobs:
   upload_components:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description of Change

`upload-idf-component.yml` action was only running for tags like `v*`, while in this project tags like `2.0.3` are used. With this change, the workflow will run for all tags.
