### PR TITLE
Changed pinMode() default interrupt type DISABLED to previously set

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -100,11 +100,11 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
     gpiohal.dev = GPIO_LL_GET_HW(GPIO_PORT_0);
 
     gpio_config_t conf = {
-        .pin_bit_mask = (1ULL<<pin),			        /*!< GPIO pin: set with bit mask, each bit maps to a GPIO */
-        .mode = GPIO_MODE_DISABLE,                      /*!< GPIO mode: set input/output mode                     */
-        .pull_up_en = GPIO_PULLUP_DISABLE,              /*!< GPIO pull-up                                         */
-        .pull_down_en = GPIO_PULLDOWN_DISABLE,          /*!< GPIO pull-down                                       */
-        .intr_type = gpiohal.dev->pin[pin].int_type     /*!< GPIO interrupt type - previously set                 */
+        .pin_bit_mask = (1ULL<<pin),                 /*!< GPIO pin: set with bit mask, each bit maps to a GPIO */
+        .mode = GPIO_MODE_DISABLE,                   /*!< GPIO mode: set input/output mode                     */
+        .pull_up_en = GPIO_PULLUP_DISABLE,           /*!< GPIO pull-up                                         */
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,       /*!< GPIO pull-down                                       */
+        .intr_type = gpiohal.dev->pin[pin].int_type  /*!< GPIO interrupt type - previously set                 */
     };
     if (mode < 0x20) {//io
         conf.mode = mode & (INPUT | OUTPUT);

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -95,12 +95,16 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
         log_e("Invalid pin selected");
 		return;
 	}
+
+    gpio_hal_context_t gpiohal;
+    gpiohal.dev = GPIO_LL_GET_HW(GPIO_PORT_0);
+
 	gpio_config_t conf = {
-		    .pin_bit_mask = (1ULL<<pin),			/*!< GPIO pin: set with bit mask, each bit maps to a GPIO */
-		    .mode = GPIO_MODE_DISABLE,              /*!< GPIO mode: set input/output mode                     */
-		    .pull_up_en = GPIO_PULLUP_DISABLE,      /*!< GPIO pull-up                                         */
-		    .pull_down_en = GPIO_PULLDOWN_DISABLE,  /*!< GPIO pull-down                                       */
-		    .intr_type = GPIO_INTR_DISABLE      	/*!< GPIO interrupt type                                  */
+		    .pin_bit_mask = (1ULL<<pin),			        /*!< GPIO pin: set with bit mask, each bit maps to a GPIO */
+		    .mode = GPIO_MODE_DISABLE,                      /*!< GPIO mode: set input/output mode                     */
+		    .pull_up_en = GPIO_PULLUP_DISABLE,              /*!< GPIO pull-up                                         */
+		    .pull_down_en = GPIO_PULLDOWN_DISABLE,          /*!< GPIO pull-down                                       */
+		    .intr_type = gpiohal.dev->pin[pin].int_type     /*!< GPIO interrupt type - previously set                 */
 	};
 	if (mode < 0x20) {//io
 		conf.mode = mode & (INPUT | OUTPUT);

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -91,34 +91,34 @@ static InterruptHandle_t __pinInterruptHandlers[SOC_GPIO_PIN_COUNT] = {0,};
 
 extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 {
-	if (!GPIO_IS_VALID_GPIO(pin)) {
+    if (!GPIO_IS_VALID_GPIO(pin)) {
         log_e("Invalid pin selected");
-		return;
-	}
-
+        return;
+    }
+    
     gpio_hal_context_t gpiohal;
     gpiohal.dev = GPIO_LL_GET_HW(GPIO_PORT_0);
 
-	gpio_config_t conf = {
-		    .pin_bit_mask = (1ULL<<pin),			        /*!< GPIO pin: set with bit mask, each bit maps to a GPIO */
-		    .mode = GPIO_MODE_DISABLE,                      /*!< GPIO mode: set input/output mode                     */
-		    .pull_up_en = GPIO_PULLUP_DISABLE,              /*!< GPIO pull-up                                         */
-		    .pull_down_en = GPIO_PULLDOWN_DISABLE,          /*!< GPIO pull-down                                       */
-		    .intr_type = gpiohal.dev->pin[pin].int_type     /*!< GPIO interrupt type - previously set                 */
-	};
-	if (mode < 0x20) {//io
-		conf.mode = mode & (INPUT | OUTPUT);
-		if (mode & OPEN_DRAIN) {
-			conf.mode |= GPIO_MODE_DEF_OD;
-		}
-		if (mode & PULLUP) {
-			conf.pull_up_en = GPIO_PULLUP_ENABLE;
-		}
-		if (mode & PULLDOWN) {
-			conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
-		}
-	}
-	if(gpio_config(&conf) != ESP_OK)
+    gpio_config_t conf = {
+        .pin_bit_mask = (1ULL<<pin),			        /*!< GPIO pin: set with bit mask, each bit maps to a GPIO */
+        .mode = GPIO_MODE_DISABLE,                      /*!< GPIO mode: set input/output mode                     */
+        .pull_up_en = GPIO_PULLUP_DISABLE,              /*!< GPIO pull-up                                         */
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,          /*!< GPIO pull-down                                       */
+        .intr_type = gpiohal.dev->pin[pin].int_type     /*!< GPIO interrupt type - previously set                 */
+    };
+    if (mode < 0x20) {//io
+        conf.mode = mode & (INPUT | OUTPUT);
+        if (mode & OPEN_DRAIN) {
+            conf.mode |= GPIO_MODE_DEF_OD;
+        }
+        if (mode & PULLUP) {
+            conf.pull_up_en = GPIO_PULLUP_ENABLE;
+        }
+        if (mode & PULLDOWN) {
+            conf.pull_down_en = GPIO_PULLDOWN_ENABLE;
+        }
+    }
+    if(gpio_config(&conf) != ESP_OK)
     {
         log_e("GPIO config failed");
         return;


### PR DESCRIPTION
## Description of Change
pins default configuration has `intr_type =  GPIO_INTR_DISABLE`
With this implementation, it will set the intr_type to previously set intr_type. It will no longer disable interrupt, when pinmode is called multiple times on same pin with interrupt enabled.

There is no option to get pin config from ESP-IDF API, that's why I made this implementation.

## Tests scenarios

```
//To trigger ISR, connect GPIO 19 to GND.

uint32_t interrupt_count = 0;

void IRAM_ATTR pin_interrupt(void *arg) {
  interrupt_count++;
  pinMode(19, INPUT);
  //attachInterruptArg(19, pin_interrupt, 0, CHANGE);
}

void setup() {
  pinMode(19, INPUT);
  attachInterruptArg(19, pin_interrupt, 0, CHANGE);
}

void loop() {
  ESP_LOGD("loop", "interrupt count %d", interrupt_count);
  delay(500);
}
```

## Related links
Closes #6669 
