### PR TITLE
fix: compiler warnings about printf-format for pointers in `esp32-hal-cpu.c`

### DIFF
--- a/cores/esp32/Tone.cpp
+++ b/cores/esp32/Tone.cpp
@@ -28,7 +28,7 @@ static void tone_task(void*){
     xQueueReceive(_tone_queue, &tone_msg, portMAX_DELAY);
     switch(tone_msg.tone_cmd){
       case TONE_START:
-        log_d("Task received from queue TONE_START: _pin=%d, frequency=%u Hz, duration=%u ms", tone_msg.pin, tone_msg.frequency, tone_msg.duration);
+        log_d("Task received from queue TONE_START: _pin=%d, frequency=%u Hz, duration=%lu ms", tone_msg.pin, tone_msg.frequency, tone_msg.duration);
 
         log_d("Setup LED controll on channel %d", _channel);
         // ledcSetup(_channel, tone_msg.frequency, 11);
@@ -118,7 +118,7 @@ void noTone(uint8_t _pin){
 // duration - time in ms - how long will the signal be outputted.
 //   If not provided, or 0 you must manually call noTone to end output
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration){
-  log_d("_pin=%d, frequency=%u Hz, duration=%u ms", _pin, frequency, duration);
+  log_d("_pin=%d, frequency=%u Hz, duration=%lu ms", _pin, frequency, duration);
   if(tone_init()){
     tone_msg_t tone_msg = {
       .tone_cmd = TONE_START,

--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -107,7 +107,7 @@ bool addApbChangeCallback(void * arg, apb_change_cb_t cb){
         // look for duplicate callbacks
         while( (r != NULL ) && !((r->cb == cb) && ( r->arg == arg))) r = r->next;
         if (r) {
-            log_e("duplicate func=%08X arg=%08X",c->cb,c->arg);
+            log_e("duplicate func=%8p arg=%8p",c->cb,c->arg);
             free(c);
             xSemaphoreGive(apb_change_lock);
             return false;
@@ -129,7 +129,7 @@ bool removeApbChangeCallback(void * arg, apb_change_cb_t cb){
     // look for matching callback
     while( (r != NULL ) && !((r->cb == cb) && ( r->arg == arg))) r = r->next;
     if ( r == NULL ) {
-        log_e("not found func=%08X arg=%08X",cb,arg);
+        log_e("not found func=%8p arg=%8p",cb,arg);
         xSemaphoreGive(apb_change_lock);
         return false;
         }


### PR DESCRIPTION
the compiler complains about these 2 places in `esp32-hal-cpu.cpp` of miss-matching %X to function & void pointers,
and x2 in `Tone.cpp` miss-matching `uint` with `long uint.

Sample warning messages:

```
.../framework-arduinoespressif32/cores/esp32/esp32-hal-cpu.c:132:9: note: in expansion of macro 'log_e'
         log_e("not found func=%08X arg=%08X",cb,arg);
         ^~~~~
.../framework-arduinoespressif32/tools/sdk/esp32/include/log/include/esp_log.h:276:27: warning: format '%X' expects argument of type 'unsigned int', but argument 7 has type 'void *' [-Wformat=]
```

I believe the correct should be `%p`, but i preserved the 8-width in my PR.
(cannot really test the code, this fix just stops the compiler warnings).

## Steps to Reproduce

To get those warnings, i had to enable `-Wformat` build-flag and define `DUSE_ESP_IDF_LOG 1`,
so the _esp_idf_ log-routines to apply, that they are appropriately marked with `__attribute__ (( format(...) ))`).


