### PR TITLE
Fix TIMER timer_dev definition

### DIFF
--- a/cores/esp32/esp32-hal-timer.c
+++ b/cores/esp32/esp32-hal-timer.c
@@ -47,7 +47,7 @@ typedef struct hw_timer_s
 
 // Works for all chips
 static hw_timer_t timer_dev[4] = {
-    {0,0}, {1,0},  {1,0},  {1,1}
+    {0,0}, {1,0},  {0,1},  {1,1}
 };
 
 // NOTE: (in IDF 5.0 there wont be need to know groups/numbers 


### PR DESCRIPTION
## Description of Change
In esp32-hal-timer.c fixed the timer_dev definition, where was timer 1 and timer 2 the same.
Now you can you all timers at the same time.

Thank you for reporting this issue [AkiHigashi](https://github.com/AkiHigashi)

## Tests scenarios

## Related links
Related PR with issue -> #5931 
