### PR TITLE
hil.yml: Run the Event-file job only when the PR is labeled or the

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -110,7 +110,9 @@ jobs:
 
   event_file:
     name: "Event File"
-    if: ${{ always() }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'hil_test') ||
+      github.event_name == 'schedule'
     needs: Test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

## Description of Change
Run the Event-file job only when the PR is labeled or when the Workflow is scheduled.

It looks like the dependency on the Test job was not enough and the Event
job was triggering even without the label.

## Tests scenarios
Github Actions will test it.
## Related links
Other PRs have an unnecessary event job.
