### PR TITLE
Added overload on send to cleanly handle char arrays in WebServer

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -430,10 +430,30 @@ void WebServer::send(int code, const char* content_type, const String& content) 
     // Can we asume the following?
     //if(code == 200 && content.length() == 0 && _contentLength == CONTENT_LENGTH_NOT_SET)
     //  _contentLength = CONTENT_LENGTH_UNKNOWN;
+    if (content.length() == 0) {
+        log_w("content length is zero");
+    }
     _prepareHeader(header, code, content_type, content.length());
     _currentClientWrite(header.c_str(), header.length());
     if(content.length())
       sendContent(content);
+}
+
+void WebServer::send(int code, char* content_type, const String& content) {
+  send(code, (const char*)content_type, content);
+}
+
+void WebServer::send(int code, const String& content_type, const String& content) {
+  send(code, (const char*)content_type.c_str(), content);
+}
+
+void WebServer::send(int code, const char* content_type, const char* content)
+{
+    const String passStr = (String)content;
+    if (strlen(content) != passStr.length()) {
+       log_e("String cast failed.  Use send_P for long arrays");
+    }
+    send(code, content_type, passStr);
 }
 
 void WebServer::send_P(int code, PGM_P content_type, PGM_P content) {
@@ -458,14 +478,6 @@ void WebServer::send_P(int code, PGM_P content_type, PGM_P content, size_t conte
     _prepareHeader(header, code, (const char* )type, contentLength);
     sendContent(header);
     sendContent_P(content, contentLength);
-}
-
-void WebServer::send(int code, char* content_type, const String& content) {
-  send(code, (const char*)content_type, content);
-}
-
-void WebServer::send(int code, const String& content_type, const String& content) {
-  send(code, (const char*)content_type.c_str(), content);
 }
 
 void WebServer::sendContent(const String& content) {

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -120,6 +120,8 @@ public:
   void send(int code, const char* content_type = NULL, const String& content = String(""));
   void send(int code, char* content_type, const String& content);
   void send(int code, const String& content_type, const String& content);
+  void send(int code, const char* content_type, const char* content);
+
   void send_P(int code, PGM_P content_type, PGM_P content);
   void send_P(int code, PGM_P content_type, PGM_P content, size_t contentLength);
 


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [X ] Please **update relevant Documentation** if applicable
4. [X ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Multiple issues have been opened about users having strings "disappear" on send.  This seem to be caused by feeding WebServer::send() a char array.  This gets cast into a const String, and if the size exceeds the maximum possible allocation, there is a silent fail and an empty String gets sent out. While not truly a fix, this will raise an error message if the String allocation fails.

## Tests scenarios
Tested on esp32-c3 dev board, current master, but seems very generalized.

## Related links
Fixes #6704
