### PR TITLE
Adds Arduino standard macro-functions

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -70,11 +70,11 @@
 #endif
 
 // can't define max() / min() because of conflicts with C++
-#define _min(a,b) ((a)<(b)?(a):(b))
+#define _min(a,b) ((a)<(b)?(a):(b))  
 #define _max(a,b) ((a)>(b)?(a):(b))
-//#define abs(x) ((x)>0?(x):-(x))  // abs() comes from stdlib
+#define _abs(x) ((x)>0?(x):-(x))  // abs() comes from STL
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
-#define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
+#define _round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))  // round() comes from STL
 #define radians(deg) ((deg)*DEG_TO_RAD)
 #define degrees(rad) ((rad)*RAD_TO_DEG)
 #define sq(x) ((x)*(x))

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -69,7 +69,12 @@
 #define __STRINGIFY(a) #a
 #endif
 
+// can't define max() / min() because of conflicts with C++
+#define _min(a,b) ((a)<(b)?(a):(b))
+#define _max(a,b) ((a)>(b)?(a):(b))
+//#define abs(x) ((x)>0?(x):-(x))  // abs() comes from stdlib
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+#define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #define radians(deg) ((deg)*DEG_TO_RAD)
 #define degrees(rad) ((rad)*RAD_TO_DEG)
 #define sq(x) ((x)*(x))
@@ -89,6 +94,7 @@
 #define bitRead(value, bit) (((value) >> (bit)) & 0x01)
 #define bitSet(value, bit) ((value) |= (1UL << (bit)))
 #define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
+#define bitToggle(value, bit) ((value) ^= (1UL << (bit)))
 #define bitWrite(value, bit, bitvalue) ((bitvalue) ? bitSet(value, bit) : bitClear(value, bit))
 
 // avr-libc defines _NOP() since 1.6.2
@@ -168,12 +174,13 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 #include "Esp.h"
 #include "esp32/spiram.h"
 
+// Use float-compatible stl abs() and round(), we don't use Arduino macros to avoid issues with the C++ libraries
 using std::abs;
 using std::isinf;
 using std::isnan;
 using std::max;
 using std::min;
-using ::round;
+using std::round;
 
 uint16_t makeWord(uint16_t w);
 uint16_t makeWord(uint8_t h, uint8_t l);
@@ -202,9 +209,6 @@ void noTone(uint8_t _pin);
 // WMath prototypes
 long random(long);
 #endif /* __cplusplus */
-
-#define _min(a,b) ((a)<(b)?(a):(b))
-#define _max(a,b) ((a)>(b)?(a):(b))
 
 #include "pins_arduino.h"
 


### PR DESCRIPTION
## Description of Change
This is a review of macro basic functions from Arduino.h that were missing from the original Arduino version.
This PR adds some missing functions to ESP32 Arduino.h

## Tests scenarios
Tested using ESP32 and a few examples. The main target of testing was to make sure that there is no compiling conflicts.
Also searched for such macro on the source code to verify that those functions are not included anywhere else.

## Related links

Closes #6623 