### PR TITLE
Change SPI::transfer signature to match official Arduino API

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -265,9 +265,9 @@ void SPIClass::writeBytes(const uint8_t * data, uint32_t size)
     spiEndTransaction(_spi);
 }
 
-void SPIClass::transfer(uint8_t * data, uint32_t size) 
+void SPIClass::transfer(void * data, uint32_t size) 
 { 
-	transferBytes(data, data, size); 
+	transferBytes((const uint8_t *)data, (uint8_t *)data, size); 
 }
 
 /**

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -73,7 +73,7 @@ public:
 
     void beginTransaction(SPISettings settings);
     void endTransaction(void);
-    void transfer(uint8_t * data, uint32_t size);
+    void transfer(void * data, uint32_t size);
     uint8_t transfer(uint8_t data);
     uint16_t transfer16(uint16_t data);
     uint32_t transfer32(uint32_t data);


### PR DESCRIPTION
Fixes: https://github.com/espressif/arduino-esp32/issues/5787
