### PR TITLE
SD library: reduce stack size requirement by 4k by moving work buffer to heap

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -801,8 +801,13 @@ bool sdcard_mount(uint8_t pdrv, const char* path, uint8_t max_files, bool format
     if (res != FR_OK) {
         log_e("f_mount failed: %s", fferr2str[res]);
         if(res == 13 && format_if_empty){
-            BYTE work[FF_MAX_SS];
+            BYTE* work = (BYTE*) malloc(sizeof(BYTE) * FF_MAX_SS);
+            if (!work) {
+              log_e("alloc for f_mkfs failed");
+              return false;
+            }
             res = f_mkfs(drv, FM_ANY, 0, work, sizeof(work));
+            free(work);
             if (res != FR_OK) {
                 log_e("f_mkfs failed: %s", fferr2str[res]);
                 esp_vfs_fat_unregister_path(path);


### PR DESCRIPTION
## Description of Change
The stack requirement of this library is huge due to a work buffer allocated for f_mkfs in sdcard_mount. The work buffer is only needed if argument format_if_empty is set true (which is by default false) and the card was empty. 

This change is quite important if you plan to use this library in a task. as now it increases the tasks stacks size by 4k, even this work memory is never used (due to format_if_empty is set false). If users are not aware of the large stack requirement during init this library they may have seen various side effects caused by the original code. the other variables in this function may have written addresses that were outside its valid stack range.

## Tests scenarios
This issue was detected ESP32 when SD.begin was called from a task with a 2k stack (with format_if_empty set false).
Before this change either the stack of the task would have to been increased to 6k. Before it would show random crashed depending on time SD.begin was executed. 