### PR TITLE
workflows/hil.yml: Don't run the scheduled HIL workflow on forks.

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -18,7 +18,7 @@ jobs:
   gen_chunks:
     if: |
       contains(github.event.pull_request.labels.*.name, 'hil_test') ||
-      github.event_name == 'schedule'
+      (github.event_name == 'schedule' && github.repository == 'espressif/arduino-esp32')
     name: Generate Chunks matrix
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Description of Change
I see that some of the test jobs in forks will get canceled. Although the reason reported by Github Actions is concurrency related, I believe they just couldn't find a runner since it's only in the Espressif organisation.

## Tests scenarios
N/A

## Related links
https://github.com/Ouss4/arduino-esp32/actions/runs/2325963816
