### PR TITLE
Extends String to print 64-bit integers

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -137,6 +137,24 @@ String::String(double value, unsigned int decimalPlaces) {
     }
 }
 
+String::String(long long value, unsigned char base) {
+    init();
+    char buf[2 + 8 * sizeof(long long)];
+    if (base==10) {
+        sprintf(buf, "%lld", value);   // NOT SURE - NewLib Nano ... does it support %lld? 
+    } else {
+        lltoa(value, buf, base);
+    }
+    *this = buf;
+}
+
+String::String(unsigned long long value, unsigned char base) {
+    init();
+    char buf[1 + 8 * sizeof(unsigned long long)];
+    ulltoa(value, buf, base);
+    *this = buf;
+}
+
 String::~String() {
     invalidate();
 }
@@ -408,6 +426,17 @@ unsigned char String::concat(double num) {
     return concat(string, strlen(string));
 }
 
+unsigned char String::concat(long long num) {
+    char buf[2 + 3 * sizeof(long long)];
+    return concat(buf, sprintf(buf, "%lld", num));    // NOT SURE - NewLib Nano ... does it support %lld?
+}
+
+unsigned char String::concat(unsigned long long num) {
+    char buf[1 + 3 * sizeof(unsigned long long)];
+    ulltoa(num, buf, 10);
+    return concat(buf, strlen(buf));
+}
+
 unsigned char String::concat(const __FlashStringHelper * str) {
     if (!str) return 0;
     int length = strlen_P((PGM_P)str);
@@ -487,6 +516,20 @@ StringSumHelper & operator +(const StringSumHelper &lhs, float num) {
 }
 
 StringSumHelper & operator +(const StringSumHelper &lhs, double num) {
+    StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+    if(!a.concat(num))
+        a.invalidate();
+    return a;
+}
+
+StringSumHelper & operator +(const StringSumHelper &lhs, long long num) {
+    StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+    if(!a.concat(num))
+        a.invalidate();
+    return a;
+}
+
+StringSumHelper & operator +(const StringSumHelper &lhs, unsigned long long num) {
     StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
     if(!a.concat(num))
         a.invalidate();

--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -73,6 +73,8 @@ class String {
         explicit String(unsigned long, unsigned char base = 10);
         explicit String(float, unsigned int decimalPlaces = 2);
         explicit String(double, unsigned int decimalPlaces = 2);
+        explicit String(long long, unsigned char base = 10);
+        explicit String(unsigned long long, unsigned char base = 10);
         ~String(void);
 
         // memory management
@@ -122,6 +124,8 @@ class String {
         unsigned char concat(unsigned long num);
         unsigned char concat(float num);
         unsigned char concat(double num);
+        unsigned char concat(long long num);
+        unsigned char concat(unsigned long long num);
         unsigned char concat(const __FlashStringHelper * str);
 
         // if there's not enough memory for the concatenated value, the string
@@ -166,6 +170,14 @@ class String {
             concat(num);
             return (*this);
         }
+        String & operator +=(long long num) {
+            concat(num);
+            return (*this);
+        }
+        String & operator +=(unsigned long long num) {
+            concat(num);
+            return (*this);
+        }
         String & operator += (const __FlashStringHelper *str){
             concat(str);
             return (*this);
@@ -182,6 +194,8 @@ class String {
         friend StringSumHelper & operator +(const StringSumHelper &lhs, float num);
         friend StringSumHelper & operator +(const StringSumHelper &lhs, double num);
         friend StringSumHelper & operator +(const StringSumHelper &lhs, const __FlashStringHelper *rhs);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, long long num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned long long num);
 
         // comparison (only works w/ Strings and "strings")
         operator StringIfHelperType() const {
@@ -371,6 +385,12 @@ class StringSumHelper: public String {
                 String(num) {
         }
         StringSumHelper(double num) :
+                String(num) {
+        }
+        StringSumHelper(long long num) :
+                String(num) {
+        }
+        StringSumHelper(unsigned long long num) :
                 String(num) {
         }
 };

--- a/cores/esp32/stdlib_noniso.c
+++ b/cores/esp32/stdlib_noniso.c
@@ -67,6 +67,31 @@ char* ltoa(long value, char* result, int base) {
     return result;
 }
 
+char* lltoa (long long val, char* result, int base) {
+    if(base < 2 || base > 16) {
+        *result = 0;
+        return result;
+    }
+
+    char* out = result;
+    long long quotient = val > 0 ? val : -val;
+
+    do {
+        const long long tmp = quotient / base;
+        *out = "0123456789abcdef"[quotient - (tmp * base)];
+        ++out;
+        quotient = tmp;
+    } while(quotient);
+
+    // Apply negative sign
+    if(val < 0)
+        *out++ = '-';
+
+    reverse(result, out);
+    *out = 0;
+    return result;
+}
+
 char* ultoa(unsigned long value, char* result, int base) {
     if(base < 2 || base > 16) {
         *result = 0;
@@ -78,6 +103,27 @@ char* ultoa(unsigned long value, char* result, int base) {
 
     do {
         const unsigned long tmp = quotient / base;
+        *out = "0123456789abcdef"[quotient - (tmp * base)];
+        ++out;
+        quotient = tmp;
+    } while(quotient);
+
+    reverse(result, out);
+    *out = 0;
+    return result;
+}
+
+char* ulltoa (unsigned long long val, char* result, int base) {
+    if(base < 2 || base > 16) {
+        *result = 0;
+        return result;
+    }
+
+    char* out = result;
+    unsigned long long quotient = val;
+
+    do {
+        const unsigned long long tmp = quotient / base;
         *out = "0123456789abcdef"[quotient - (tmp * base)];
         ++out;
         quotient = tmp;
@@ -160,3 +206,5 @@ char * dtostrf(double number, signed int width, unsigned int prec, char *s) {
     *out = 0;
     return s;
 }
+
+

--- a/cores/esp32/stdlib_noniso.h
+++ b/cores/esp32/stdlib_noniso.h
@@ -35,9 +35,13 @@ char* itoa (int val, char *s, int radix);
 
 char* ltoa (long val, char *s, int radix);
 
+char* lltoa (long long val, char* s, int radix);
+
 char* utoa (unsigned int val, char *s, int radix);
 
 char* ultoa (unsigned long val, char *s, int radix);
+
+char* ulltoa (unsigned long long val, char* s, int radix);
 
 char* dtostrf (double val, signed int width, unsigned int prec, char *s);
 


### PR DESCRIPTION
## Description of Change
This PR adds support to long long (64 bits) numbers to Arduino String Class.

## Tests scenarios
Tested with this sketch:

``` cpp
void setup()
{
  Serial.begin(115200);
  Serial.println();

  // highest signed long long 2^63 - 1 = 9223372036854775807
  // highest unsigned long long 2^64 = 18446744073709551615
  signed long long ll = -9223372036854775807;
  unsigned long long ull = 18446744073709551615;
  
  String ss(ll);
  Serial.println(ss);
  String uss(ull);
  Serial.println(uss);

  String txt("This is the highest signed long long: ");
  txt += -ll;
  Serial.println(txt);
}
```


## Related links
Fixes #5672 