### PR TITLE
Update littlefsbuilder.py

### DIFF
--- a/libraries/LittleFS/examples/LITTLEFS_PlatformIO/littlefsbuilder.py
+++ b/libraries/LittleFS/examples/LITTLEFS_PlatformIO/littlefsbuilder.py
@@ -1,2 +1,2 @@
 Import("env")
-env.Replace( MKSPIFFSTOOL=env.get("PROJECT_DIR") + '/mklittlefs' )
+env.Replace( MKSPIFFSTOOL=env.get("PROJECT_DIR") + '/mklittlefs' )  # PlatformIO now believes it has actually created a SPIFFS


### PR DESCRIPTION
add a comment to make it clear, since platformIO still creating the `spiffs.bin` for LittleFS filesystem image. The file name `spiffs.bin` is so much CONFUSING! it makes the user fill the LittleFS creating is fail.
