### PR TITLE
Remove GCC -Wextra warnings from build process

### DIFF
--- a/cores/esp32/Tone.cpp
+++ b/cores/esp32/Tone.cpp
@@ -95,6 +95,9 @@ void setToneChannel(uint8_t channel){
   if(tone_init()){
     tone_msg_t tone_msg = {
       .tone_cmd = TONE_SET_CHANNEL,
+      .pin = 0, // Ignored
+      .frequency = 0, // Ignored
+      .duration = 0, // Ignored
       .channel = channel
     };
     xQueueSend(_tone_queue, &tone_msg, portMAX_DELAY);
@@ -106,7 +109,10 @@ void noTone(uint8_t _pin){
   if(tone_init()){
     tone_msg_t tone_msg = {
       .tone_cmd = TONE_END,
-      .pin = _pin
+      .pin = _pin,
+      .frequency = 0, // Ignored
+      .duration = 0, // Ignored
+      .channel = 0 // Ignored
     };
     xQueueSend(_tone_queue, &tone_msg, portMAX_DELAY);
   }
@@ -124,7 +130,8 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration){
       .tone_cmd = TONE_START,
       .pin = _pin,
       .frequency = frequency,
-      .duration = duration
+      .duration = duration,
+      .channel = 0 // Ignored
     };
     xQueueSend(_tone_queue, &tone_msg, portMAX_DELAY);
   }

--- a/cores/esp32/libb64/cdecode.c
+++ b/cores/esp32/libb64/cdecode.c
@@ -40,6 +40,7 @@ static int base64_decode_block_signed(const int8_t* code_in, const int length_in
           fragment = (int8_t)base64_decode_value_signed(*codechar++);
         } while (fragment < 0);
         *plainchar    = (fragment & 0x03f) << 2;
+        // fall through
       case step_b:
         do {
           if (codechar == code_in+length_in){
@@ -51,6 +52,7 @@ static int base64_decode_block_signed(const int8_t* code_in, const int length_in
         } while (fragment < 0);
         *plainchar++ |= (fragment & 0x030) >> 4;
         *plainchar    = (fragment & 0x00f) << 4;
+        // fall through
       case step_c:
         do {
           if (codechar == code_in+length_in){
@@ -62,6 +64,7 @@ static int base64_decode_block_signed(const int8_t* code_in, const int length_in
         } while (fragment < 0);
         *plainchar++ |= (fragment & 0x03c) >> 2;
         *plainchar    = (fragment & 0x003) << 6;
+        // fall through
       case step_d:
         do {
           if (codechar == code_in+length_in){

--- a/cores/esp32/libb64/cencode.c
+++ b/cores/esp32/libb64/cencode.c
@@ -44,6 +44,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
             result = (fragment & 0x0fc) >> 2;
             *codechar++ = base64_encode_value(result);
             result = (fragment & 0x003) << 4;
+            // fall through
         case step_B:
             if (plainchar == plaintextend) {
                 state_in->result = result;
@@ -54,6 +55,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
             result |= (fragment & 0x0f0) >> 4;
             *codechar++ = base64_encode_value(result);
             result = (fragment & 0x00f) << 2;
+            // fall through
         case step_C:
             if (plainchar == plaintextend) {
                 state_in->result = result;

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1327,6 +1327,7 @@ bool WiFiGenericClass::setDualAntennaConfig(uint8_t gpio_ant1, uint8_t gpio_ant2
     // Set antenna default configuration
     wifi_ant_config_t ant_config = {
         .rx_ant_mode = WIFI_ANT_MODE_AUTO,
+        .rx_ant_default = WIFI_ANT_MAX, // Ignored in AUTO mode
         .tx_ant_mode = WIFI_ANT_MODE_AUTO,
         .enabled_ant0 = 0,
         .enabled_ant1 = 1,


### PR DESCRIPTION
## Description of Change

When building the core with `-Wextra` a few locations have `case:`
fall throughs or skipped field initializers.

Add proper comments for B64 cases to avoid GCC warnings

Initialized unused fields in Tone and WiFiGeneric to avoid missing
field initializer warnings.

## Tests scenarios

Builds from the IDE with `File->Preferences->Compiler Warnings->All` show warnings shown below

````
2022-05-19T17:40:42.2280300Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cdecode.c: In function 'base64_decode_block_signed':
2022-05-19T17:40:42.2282122Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cdecode.c:42:23: warning: this statement may fall through [-Wimplicit-fallthrough=]
2022-05-19T17:40:42.2283247Z          *plainchar    = (fragment & 0x03f) << 2;
2022-05-19T17:40:42.2284240Z          ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
2022-05-19T17:40:42.2285087Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cdecode.c:43:7: note: here
2022-05-19T17:40:42.2285435Z        case step_b:
2022-05-19T17:40:42.2285691Z        ^~~~
2022-05-19T17:40:42.2286515Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cdecode.c:53:23: warning: this statement may fall through [-Wimplicit-fallthrough=]
2022-05-19T17:40:42.2286932Z          *plainchar    = (fragment & 0x00f) << 4;
2022-05-19T17:40:42.2287219Z          ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
2022-05-19T17:40:42.2287609Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cdecode.c:54:7: note: here
2022-05-19T17:40:42.2287909Z        case step_c:
2022-05-19T17:40:42.2288200Z        ^~~~
2022-05-19T17:40:42.2288972Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cdecode.c:64:23: warning: this statement may fall through [-Wimplicit-fallthrough=]
2022-05-19T17:40:42.2289491Z          *plainchar    = (fragment & 0x003) << 6;
2022-05-19T17:40:42.2289745Z          ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
2022-05-19T17:40:42.2290162Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cdecode.c:65:7: note: here
2022-05-19T17:40:42.2290509Z        case step_d:
2022-05-19T17:40:42.2290714Z        ^~~~
2022-05-19T17:40:42.2482744Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cencode.c: In function 'base64_encode_block':
2022-05-19T17:40:42.2484713Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cencode.c:46:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
2022-05-19T17:40:42.2485415Z              result = (fragment & 0x003) << 4;
2022-05-19T17:40:42.2486713Z              ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
2022-05-19T17:40:42.2487696Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cencode.c:47:9: note: here
2022-05-19T17:40:42.2488519Z          case step_B:
2022-05-19T17:40:42.2489175Z          ^~~~
2022-05-19T17:40:42.2492458Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cencode.c:56:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
2022-05-19T17:40:42.2493351Z              result = (fragment & 0x00f) << 2;
2022-05-19T17:40:42.2494227Z              ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
2022-05-19T17:40:42.2496324Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/libb64/cencode.c:57:9: note: here
2022-05-19T17:40:42.2496937Z          case step_C:
2022-05-19T17:40:42.2497261Z          ^~~~
2022-05-19T17:40:44.6354962Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp: In function 'void setToneChannel(uint8_t)':
2022-05-19T17:40:44.6356417Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp:99:5: warning: missing initializer for member 'tone_msg_t::pin' [-Wmissing-field-initializers]
2022-05-19T17:40:44.6357120Z      };
2022-05-19T17:40:44.6358732Z      ^
2022-05-19T17:40:44.6364470Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp:99:5: warning: missing initializer for member 'tone_msg_t::frequency' [-Wmissing-field-initializers]
2022-05-19T17:40:44.6367914Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp:99:5: warning: missing initializer for member 'tone_msg_t::duration' [-Wmissing-field-initializers]
2022-05-19T17:40:44.6372875Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp: In function 'void noTone(uint8_t)':
2022-05-19T17:40:44.6373943Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp:110:5: warning: missing initializer for member 'tone_msg_t::frequency' [-Wmissing-field-initializers]
2022-05-19T17:40:44.6375154Z      };
2022-05-19T17:40:44.6375825Z      ^
2022-05-19T17:40:44.6379852Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp:110:5: warning: missing initializer for member 'tone_msg_t::duration' [-Wmissing-field-initializers]
2022-05-19T17:40:44.6383291Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp:110:5: warning: missing initializer for member 'tone_msg_t::channel' [-Wmissing-field-initializers]
2022-05-19T17:40:44.6388688Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp: In function 'void tone(uint8_t, unsigned int, long unsigned int)':
2022-05-19T17:40:44.6389829Z /home/runner/arduino_ide/hardware/espressif/esp32/cores/esp32/Tone.cpp:128:5: warning: missing initializer for member 'tone_msg_t::channel' [-Wmissing-field-initializers]
2022-05-19T17:40:44.6390677Z      };
2022-05-19T17:40:44.6391420Z      ^
2022-05-19T17:42:00.6768353Z /home/runner/arduino_ide/hardware/espressif/esp32/libraries/WiFi/src/WiFiGeneric.cpp: In static member function 'static bool WiFiGenericClass::setDualAntennaConfig(uint8_t, uint8_t, wifi_rx_ant_t, wifi_tx_ant_t)':
2022-05-19T17:42:00.6769293Z /home/runner/arduino_ide/hardware/espressif/esp32/libraries/WiFi/src/WiFiGeneric.cpp:1333:5: warning: missing initializer for member 'wifi_ant_config_t::rx_ant_default' [-Wmissing-field-initializers]
2022-05-19T17:42:00.6769658Z      };
2022-05-19T17:42:00.6769824Z      ^
````

After applying this patch they disappear.