### PR TITLE
Remove nonexisting folder from include path

### DIFF
--- a/tools/platformio-build-esp32.py
+++ b/tools/platformio-build-esp32.py
@@ -117,7 +117,6 @@ env.Append(
     ],
 
     CPPPATH=[
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "include", "config"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "include", "newlib", "platform_include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "include", "freertos", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "include", "freertos", "include", "esp_additions", "freertos"),

--- a/tools/platformio-build-esp32c3.py
+++ b/tools/platformio-build-esp32c3.py
@@ -116,7 +116,6 @@ env.Append(
     ],
 
     CPPPATH=[
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "include", "config"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "include", "newlib", "platform_include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "include", "freertos", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "include", "freertos", "include", "esp_additions", "freertos"),

--- a/tools/platformio-build-esp32s2.py
+++ b/tools/platformio-build-esp32s2.py
@@ -113,7 +113,6 @@ env.Append(
     ],
 
     CPPPATH=[
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "include", "config"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "include", "newlib", "platform_include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "include", "freertos", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "include", "freertos", "include", "esp_additions", "freertos"),

--- a/tools/platformio-build-esp32s3.py
+++ b/tools/platformio-build-esp32s3.py
@@ -113,7 +113,6 @@ env.Append(
     ],
 
     CPPPATH=[
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", "include", "config"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", "include", "newlib", "platform_include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", "include", "freertos", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s3", "include", "freertos", "include", "esp_additions", "freertos"),


### PR DESCRIPTION
## Description of Change

The PlatformIO builder scripts attempt to include `tools/sdk/esp32/include/config` to the include path (and similiarly for the other MCU types), but this folder does not exist anymore.

VSCode emits a "Problem" warning for non-existing folders declared in the therefrom created `.vscode/c_cpp_properties.json`.

![grafik](https://user-images.githubusercontent.com/26485477/170255998-22c4d48b-0b33-4673-80e9-5bd298b64b53.png)

The fix trivially removes these folders from the include path. If the `include/config` folder was renamed and is not yet in the PlatformIO builder script, let me know.

## Tests scenarios
Tested with PlatformIO using

```ini
[env:esp32dev]
platform = espressif32
board = esp32dev
framework = arduino
platform_packages = 
   framework-arduinoespressif32@https://github.com/maxgerhardt/arduino-esp32.git#patch-2
```

and the "Problems" view cleared out.

![grafik](https://user-images.githubusercontent.com/26485477/170256432-b74f98ff-e69a-498e-a0dd-dc918d5c84f8.png)

## Related links
None.