### PR TITLE
Rainmaker: Added missing standard ui types and standard parameter types and functions

### DIFF
--- a/libraries/RainMaker/src/RMakerParam.cpp
+++ b/libraries/RainMaker/src/RMakerParam.cpp
@@ -30,4 +30,13 @@ esp_err_t Param::updateAndReport(param_val_t val)
     }
     return err;
 }
+
+esp_err_t Param::addValidStrList(const char** str_list)
+{
+    err = esp_rmaker_param_add_valid_str_list(str_list);
+    if (err != ESP_OK) {
+        log_e("Add string list error");
+    }
+    return err;
+}
 #endif

--- a/libraries/RainMaker/src/RMakerParam.h
+++ b/libraries/RainMaker/src/RMakerParam.h
@@ -47,5 +47,6 @@ class Param
         esp_err_t addUIType(const char *ui_type);
         esp_err_t addBounds(param_val_t min, param_val_t max, param_val_t step);
         esp_err_t updateAndReport(param_val_t val);
+        esp_err_t addValidStrList(const char** str_list);
 };
 #endif

--- a/libraries/RainMaker/src/RMakerType.cpp
+++ b/libraries/RainMaker/src/RMakerType.cpp
@@ -21,4 +21,9 @@ param_val_t value(float fval)
 {
     return esp_rmaker_float(fval);
 }
+
+param_val_t value(const char* sval)
+{
+    return esp_rmaker_str(sval);
+}
 #endif

--- a/libraries/RainMaker/src/RMakerType.h
+++ b/libraries/RainMaker/src/RMakerType.h
@@ -33,4 +33,5 @@ param_val_t value(int);
 param_val_t value(bool);
 param_val_t value(char *);
 param_val_t value(float);
+param_val_t value(const char*);
 #endif

--- a/tools/sdk/esp32/include/esp_rainmaker/include/esp_rmaker_standard_types.h
+++ b/tools/sdk/esp32/include/esp_rainmaker/include/esp_rmaker_standard_types.h
@@ -25,6 +25,10 @@ extern "C"
 #define ESP_RMAKER_UI_DROPDOWN          "esp.ui.dropdown"
 #define ESP_RMAKER_UI_TEXT              "esp.ui.text"
 #define ESP_RMAKER_UI_HUE_SLIDER        "esp.ui.hue-slider"
+#define ESP_RMAKER_UI_HUE_CIRCLE        "esp.ui.hue-circle"
+#define ESP_RMAKER_UI_PUSHBUTTON        "esp.ui.push-btn-big"
+#define ESP_RMAKER_UI_TRIGGER           "esp.ui.trigger"
+#define ESP_RMAKER_UI_HIDDEN            "esp.ui.hidden"
 
 /********** STANDARD PARAM TYPES **********/
 
@@ -50,7 +54,13 @@ extern "C"
 #define ESP_RMAKER_PARAM_WIFI_RESET     "esp.param.wifi-reset"
 #define ESP_RMAKER_PARAM_LOCAL_CONTROL_POP      "esp.param.local_control_pop"
 #define ESP_RMAKER_PARAM_LOCAL_CONTROL_TYPE     "esp.param.local_control_type"
-
+#define ESP_RMAKER_PARAM_TOGGLE         "esp.param.toggle"
+#define ESP_RMAKER_PARAM_RANGE          "esp.param.range"
+#define ESP_RMAKER_PARAM_MODE           "esp.param.mode"
+#define ESP_RMAKER_PARAM_BLINDS_POS     "esp.param.blinds-position"
+#define ESP_RMAKER_PARAM_GARAGE_POS     "esp.param.garage-position"
+#define ESP_RMAKER_PARAM_LIGHT_MODE     "esp.param.light-mode"
+#define ESP_RMAKER_PARAM_AC_MODE        "esp.param.ac-mode"
 
 /********** STANDARD DEVICE TYPES **********/
 
@@ -58,7 +68,6 @@ extern "C"
 #define ESP_RMAKER_DEVICE_LIGHTBULB     "esp.device.lightbulb"
 #define ESP_RMAKER_DEVICE_FAN           "esp.device.fan"
 #define ESP_RMAKER_DEVICE_TEMP_SENSOR   "esp.device.temperature-sensor"
-
 
 /********** STANDARD SERVICE TYPES **********/
 #define ESP_RMAKER_SERVICE_OTA          "esp.service.ota"


### PR DESCRIPTION
## Description of Change
The Arduino implementation is missing some standard UI types and standard parameter types.
Also, the `addValidStrList` function is missing to be able to implement a mode controller parameter.
Additionally, a new overload of the `value` function with `const char*` parameter type has been added.

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.3 with ESP32 

## Related links
Missing types: [Standard Predefined Types](https://rainmaker.espressif.com/docs/standard-types.html)
Missing function: `addValidStrList`: [3rd Party Integrations](https://rainmaker.espressif.com/docs/3rd-party.html) example code for "Generic Mode Parameter"