### PR TITLE
Fix linking to make initVariant() work

### DIFF
--- a/tools/platformio-build-esp32.py
+++ b/tools/platformio-build-esp32.py
@@ -357,10 +357,10 @@ if "build.variant" in env.BoardConfig():
             join(variants_dir, env.BoardConfig().get("build.variant"))
         ]
     )
-    libs.append(env.BuildLibrary(
+    env.BuildSources(
         join("$BUILD_DIR", "FrameworkArduinoVariant"),
         join(variants_dir, env.BoardConfig().get("build.variant"))
-    ))
+    )
 
 envsafe = env.Clone()
 

--- a/tools/platformio-build-esp32c3.py
+++ b/tools/platformio-build-esp32c3.py
@@ -350,10 +350,10 @@ if "build.variant" in env.BoardConfig():
             join(variants_dir, env.BoardConfig().get("build.variant"))
         ]
     )
-    libs.append(env.BuildLibrary(
+    env.BuildSources(
         join("$BUILD_DIR", "FrameworkArduinoVariant"),
         join(variants_dir, env.BoardConfig().get("build.variant"))
-    ))
+    )
 
 envsafe = env.Clone()
 

--- a/tools/platformio-build-esp32s2.py
+++ b/tools/platformio-build-esp32s2.py
@@ -352,10 +352,10 @@ if "build.variant" in env.BoardConfig():
             join(variants_dir, env.BoardConfig().get("build.variant"))
         ]
     )
-    libs.append(env.BuildLibrary(
+    env.BuildSources(
         join("$BUILD_DIR", "FrameworkArduinoVariant"),
         join(variants_dir, env.BoardConfig().get("build.variant"))
-    ))
+    )
 
 envsafe = env.Clone()
 

--- a/tools/platformio-build-esp32s3.py
+++ b/tools/platformio-build-esp32s3.py
@@ -369,10 +369,10 @@ if "build.variant" in env.BoardConfig():
             join(variants_dir, env.BoardConfig().get("build.variant"))
         ]
     )
-    libs.append(env.BuildLibrary(
+    env.BuildSources(
         join("$BUILD_DIR", "FrameworkArduinoVariant"),
         join(variants_dir, env.BoardConfig().get("build.variant"))
-    ))
+    )
 
 envsafe = env.Clone()
 


### PR DESCRIPTION
## Description of Change

The builder script compiles the sources of the variant folder to a `.a` library (`env.BuildLibary()`) which is then linked into the final `.elf` firmware in the order `<variant .a> <core .a>`. 

> -Wl,--start-group .pio\build\adafruit_feather_esp32_v2\libFrameworkArduinoVariant.a .pio\build\adafruit_feather_esp32_v2\libFrameworkArduino.a 

This however prevents the `_weak` [initVariant()](https://github.com/espressif/arduino-esp32/blob/1a7962ece8a4c6ffa1d64c5a86ed8ee58dde10ba/cores/esp32/esp32-hal-misc.c#L197-L267) function to be linked properly and be executed. This effectively means that the initVariant() code of some boards, which is very critical for e.g. [powering up the I2C bus](https://github.com/espressif/arduino-esp32/blob/master/variants/adafruit_feather_esp32s2/variant.cpp#L32-L46) or [Neopixels](https://github.com/espressif/arduino-esp32/blob/2.0.3/variants/adafruit_feather_esp32_v2/variant.cpp) on some Adafruit boards is not executed, and so the same sketch code behaves differently between the Arduino IDE and PlatformIO. This was noticed in the I2C case in https://github.com/platformio/platform-espressif32/issues/815.

The Arduino IDE links the variant sources as an object file as can be seen in the verbose compile commands 

>-Wl,--start-group "C:\\Users\\Max\\AppData\\Local\\Temp\\arduino_build_77852\\sketch\\sketch_may26a.ino.cpp.o" "C:\\Users\\Max\\AppData\\Local\\Temp\\arduino_build_77852\\core\\variant.cpp.o" "C:\\Users\\Max\\AppData\\Local\\Temp\\arduino_build_77852\\core\\core.a"

With this fix *applied*, i.e., using `env.BuildSources()` instead of `env.BuildLibrary()`, the PlatformIO linker process now uses object files too

>.pio\build\adafruit_feather_esp32_v2\FrameworkArduinoVariant\variant.cpp.o .pio\build\adafruit_feather_esp32_v2\src\main.cpp.o [...] -Wl,--start-group .pio\build\adafruit_feather_esp32_v2\libFrameworkArduino.a

And the `initVariant()` function is called again properly.

## Tests scenarios

I have tested my Pull Request on Arduino-esp32 core v2.0.3 with configuration
```ini
[env:adafruit_feather_esp32_v2]
platform = espressif32
board = adafruit_feather_esp32_v2
framework = arduino
monitor_speed = 115200
board_upload.flash_size = 4MB
```

on a regular ESP32Dev board. The code

```cpp
#include <Arduino.h>

void setup() {
    Serial.begin(115200);
}

void loop() {
    Serial.print("I2C power pin state: ");
    Serial.println(digitalRead(NEOPIXEL_I2C_POWER));
    delay(3000);
}
```
prints "0" before the fix, indicating that the [initVariant](https://github.com/espressif/arduino-esp32/blob/2.0.3/variants/adafruit_feather_esp32_v2/variant.cpp) code for this boardw as not executed since the Neopixel I2C power pin is still at LOW. 

Prints "1" after the fix, indicating initVariant() is now properly called and the pin is now HIGH.

## Related links

Actually resolves issue https://github.com/platformio/platform-espressif32/issues/815.