### PR TITLE
adds verbose message for WPA3

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -261,6 +261,15 @@ static const char * auth_mode_str(int authmode)
     case WIFI_AUTH_WPA2_ENTERPRISE:
     	return ("WPA2_ENTERPRISE");
         break;
+    case WIFI_AUTH_WPA3_PSK:
+    	return ("WPA3_PSK");
+        break;
+    case WIFI_AUTH_WPA2_WPA3_PSK:
+    	return ("WPA2_WPA3_PSK");
+        break;
+    case WIFI_AUTH_WAPI_PSK:
+    	return ("WPAPI_PSK");
+        break;
     default:
         break;
     }


### PR DESCRIPTION
## Description of Change
Just adds ouput messages for WPA3 WiFi for verbose debug.

## Tests scenarios
Simple test with ESP32.

## Related links
Fixes #6792 