### PR TITLE
[UART/SERIAL] CTS / RTS pins were swapped in this API

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -115,7 +115,7 @@ void uartSetPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t
     }
     UART_MUTEX_LOCK();
     // IDF uart_set_pin() will issue necessary Error Message and take care of all GPIO Number validation.
-    uart_set_pin(uart->num, txPin, rxPin, ctsPin, rtsPin); 
+    uart_set_pin(uart->num, txPin, rxPin, rtsPin, ctsPin); 
     UART_MUTEX_UNLOCK();  
 }
 


### PR DESCRIPTION
## Description of Change

espressif/esp-idf / components/driver/include/driver/uart.h defines the API:
esp_err_t uart_set_pin(uart_port_t uart_num, int tx_io_num, int rx_io_num, int **rts_io_num**, int **cts_io_num**);

uartSetPins uses that api but alls it with swapped CTS/RTS pins as its API uses a different pin ordering: 
uart_set_pin(uart->num, txPin, rxPin, **ctsPin**, **rtsPin**); 

This fixes the wrong order in the function uartSetPins

Users that have so far successfully used the API so far will need to change their code. Another possibility would be to swap the arguments in the functions uartSetPins of the cores/esp32/esp32-hal-uart.c driver and up in the HardwareSerial. But then the order of the arguments is less logic: as TX/RX is different in arduino and esp_idf but handled correctly in this function.

