### PR TITLE
Add support for Connaxio's Espoir devboard

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -14547,3 +14547,116 @@ SEEED_XIAO_WIFI.menu.DebugLevel.verbose=Verbose
 SEEED_XIAO_WIFI.menu.DebugLevel.verbose.build.code_debug=5
 
 ##############################################################
+
+connaxio_espoir.name=Connaxio's Espoir
+connaxio_espoir.vid.0=0x10C4
+connaxio_espoir.pid.0=0x8D9A
+
+connaxio_espoir.bootloader.tool=esptool_py
+connaxio_espoir.bootloader.tool.default=esptool_py
+
+connaxio_espoir.upload.tool=esptool_py
+connaxio_espoir.upload.tool.default=esptool_py
+connaxio_espoir.upload.tool.network=esp_ota
+
+connaxio_espoir.upload.maximum_size=1310720
+connaxio_espoir.upload.maximum_data_size=327680
+connaxio_espoir.upload.flags=
+connaxio_espoir.upload.extra_flags=
+
+connaxio_espoir.serial.disableDTR=true
+connaxio_espoir.serial.disableRTS=true
+
+connaxio_espoir.build.tarch=xtensa
+connaxio_espoir.build.bootloader_addr=0x1000
+connaxio_espoir.build.target=esp32
+connaxio_espoir.build.mcu=esp32
+connaxio_espoir.build.core=esp32
+connaxio_espoir.build.variant=connaxio_espoir
+connaxio_espoir.build.board=connaxio_espoir
+
+connaxio_espoir.build.f_cpu=240000000L
+connaxio_espoir.build.flash_size=4MB
+connaxio_espoir.build.flash_freq=80m
+connaxio_espoir.build.flash_mode=dio
+connaxio_espoir.build.boot=dio
+connaxio_espoir.build.partitions=default
+connaxio_espoir.build.defines=
+connaxio_espoir.build.loop_core=
+connaxio_espoir.build.event_core=
+
+connaxio_espoir.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+connaxio_espoir.menu.PartitionScheme.default.build.partitions=default
+connaxio_espoir.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+connaxio_espoir.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+connaxio_espoir.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+connaxio_espoir.menu.PartitionScheme.minimal.build.partitions=minimal
+connaxio_espoir.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+connaxio_espoir.menu.PartitionScheme.no_ota.build.partitions=no_ota
+connaxio_espoir.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+connaxio_espoir.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+connaxio_espoir.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+connaxio_espoir.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+connaxio_espoir.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+connaxio_espoir.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+connaxio_espoir.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+connaxio_espoir.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+connaxio_espoir.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+connaxio_espoir.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+connaxio_espoir.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+connaxio_espoir.menu.PartitionScheme.huge_app.build.partitions=huge_app
+connaxio_espoir.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+connaxio_espoir.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+connaxio_espoir.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+connaxio_espoir.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+connaxio_espoir.menu.PartitionScheme.rainmaker=RainMaker
+connaxio_espoir.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+connaxio_espoir.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+connaxio_espoir.menu.CPUFreq.240=240MHz (WiFi/BT)
+connaxio_espoir.menu.CPUFreq.240.build.f_cpu=240000000L
+connaxio_espoir.menu.CPUFreq.160=160MHz (WiFi/BT)
+connaxio_espoir.menu.CPUFreq.160.build.f_cpu=160000000L
+connaxio_espoir.menu.CPUFreq.80=80MHz (WiFi/BT)
+connaxio_espoir.menu.CPUFreq.80.build.f_cpu=80000000L
+connaxio_espoir.menu.CPUFreq.40=40MHz
+connaxio_espoir.menu.CPUFreq.40.build.f_cpu=40000000L
+connaxio_espoir.menu.CPUFreq.20=20MHz
+connaxio_espoir.menu.CPUFreq.20.build.f_cpu=20000000L
+connaxio_espoir.menu.CPUFreq.10=10MHz
+connaxio_espoir.menu.CPUFreq.10.build.f_cpu=10000000L
+
+connaxio_espoir.menu.FlashFreq.80=80MHz
+connaxio_espoir.menu.FlashFreq.80.build.flash_freq=80m
+connaxio_espoir.menu.FlashFreq.40=40MHz
+connaxio_espoir.menu.FlashFreq.40.build.flash_freq=40m
+
+connaxio_espoir.menu.UploadSpeed.921600=921600
+connaxio_espoir.menu.UploadSpeed.921600.upload.speed=921600
+connaxio_espoir.menu.UploadSpeed.512000.windows=512000
+connaxio_espoir.menu.UploadSpeed.512000.upload.speed=512000
+connaxio_espoir.menu.UploadSpeed.460800.linux=460800
+connaxio_espoir.menu.UploadSpeed.460800.macosx=460800
+connaxio_espoir.menu.UploadSpeed.460800.upload.speed=460800
+connaxio_espoir.menu.UploadSpeed.256000.windows=256000
+connaxio_espoir.menu.UploadSpeed.256000.upload.speed=256000
+connaxio_espoir.menu.UploadSpeed.230400.windows.upload.speed=256000
+connaxio_espoir.menu.UploadSpeed.230400=230400
+connaxio_espoir.menu.UploadSpeed.230400.upload.speed=230400
+connaxio_espoir.menu.UploadSpeed.115200=115200
+connaxio_espoir.menu.UploadSpeed.115200.upload.speed=115200
+
+connaxio_espoir.menu.DebugLevel.none=None
+connaxio_espoir.menu.DebugLevel.none.build.code_debug=0
+connaxio_espoir.menu.DebugLevel.error=Error
+connaxio_espoir.menu.DebugLevel.error.build.code_debug=1
+connaxio_espoir.menu.DebugLevel.warn=Warn
+connaxio_espoir.menu.DebugLevel.warn.build.code_debug=2
+connaxio_espoir.menu.DebugLevel.info=Info
+connaxio_espoir.menu.DebugLevel.info.build.code_debug=3
+connaxio_espoir.menu.DebugLevel.debug=Debug
+connaxio_espoir.menu.DebugLevel.debug.build.code_debug=4
+connaxio_espoir.menu.DebugLevel.verbose=Verbose
+connaxio_espoir.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################

--- a/variants/connaxio_espoir/pins_arduino.h
+++ b/variants/connaxio_espoir/pins_arduino.h
@@ -1,0 +1,85 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+/* variant: Espoir
+ * vendor: Connaxio
+ * url: https://www.connaxio.com/electronics/espoir/
+ */
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+/* USB UART */
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+/* mikroBUS UART */
+static const uint8_t TX1 = 10;
+static const uint8_t RX1 = 9;
+
+/* mikroBUS I2C */
+static const uint8_t SDA = 23;
+static const uint8_t SCL = 18;
+
+/* mikroBUS SPI */
+static const uint8_t SS   = 15;
+static const uint8_t MOSI = 13;
+static const uint8_t MISO = 12;
+static const uint8_t SCK  = 14;
+
+/* Default analog pins */
+static const uint8_t A0 = 36;
+static const uint8_t A1 = 37;
+static const uint8_t A2 = 38;
+static const uint8_t A3 = 39;
+static const uint8_t A6 = 34;
+
+/* Alternative analog pins */
+static const uint8_t A10 = 4;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+
+/* Touch pins */
+static const uint8_t T0 = 4;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+
+/* Other pin names */
+static const uint8_t AN  = 36;
+static const uint8_t RST = 5;
+static const uint8_t PWM = 2;
+static const uint8_t INT = 4;
+static const uint8_t CS  = 15;
+static const uint8_t SDO = 13;
+static const uint8_t SDI = 12;
+
+/* Ethernet interface */
+static const uint8_t ETH_INT = 35;
+#define ETH_PHY_ADDR  0
+#define ETH_PHY_POWER -1
+#define ETH_PHY_MDC   32
+#define ETH_PHY_MDIO  33
+#define ETH_PHY_TYPE  ETH_PHY_KSZ8081
+#define ETH_CLK_MODE  ETH_CLOCK_GPIO0_IN
+
+/* USB interface */
+#define USB_VID          0x10C4     // Silabs's VID
+#define USB_PID          0x8D9A     // Espoir's PID, requires Silab USB PHY
+#define USB_MANUFACTURER "Connaxio"
+#define USB_PRODUCT      "Espoir"
+#define USB_SERIAL       ""
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
This PR adds support for Espoir, a mikroBUS PoE+ devboard, by Connaxio inc. However, the ESP32-MINI-1 is a single core CPU, so Connaxio will provide the builds for its devboard until single core CPUs are officially supported. Adding these modifications to the official repository will limit discrepancies between Connaxio's fork and the main repo.

## Tests scenarios
Tests include Ethernet, SPI, USB, I2C, UART (1-wire).

More info: https://www.connaxio.com/electronics/espoir/