### PR TITLE
wifi: fix esp32 dual antenna issue

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1338,8 +1338,8 @@ bool WiFiGenericClass::setDualAntennaConfig(uint8_t gpio_ant1, uint8_t gpio_ant2
         .rx_ant_mode = WIFI_ANT_MODE_AUTO,
         .rx_ant_default = WIFI_ANT_MAX, // Ignored in AUTO mode
         .tx_ant_mode = WIFI_ANT_MODE_AUTO,
-        .enabled_ant0 = 0,
-        .enabled_ant1 = 1,
+        .enabled_ant0 = 1,
+        .enabled_ant1 = 2,
     };
 
     switch (rx_mode)


### PR DESCRIPTION
## Background

- Issue background : https://www.youtube.com/watch?v=F0u5qIwwY1k

## Issue Descrition
![image](https://user-images.githubusercontent.com/20188571/172581444-d5a86d8f-7cdd-440d-b56e-df7cb9e4c5f8.png)

![image](https://user-images.githubusercontent.com/20188571/172583244-0c5e3dda-c7cf-4d57-9e56-065cc4e9f6d7.png)

According to the schematics of ESP32-WROOM-DA, there is no inverter chip(SN74AUP1G04 is NC), which means that we should use two gpio(pin 2 & pin 25) to control RTC6603SP. 
While the true table of RTC6603SP shows that we only input with 1 & 0 or 0 & 1, 0 & 0 or 1 & 1 are invalid.
According to idf docs: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html?highlight=antenna#wi-fi-multiple-antennas , below sample code means(comments inline):

```
wifi_ant_gpio_config_t ant_gpio_config = {
    // ESP32-WROOM-DA boards default antenna pins
    .gpio_cfg[0] = { .gpio_select = 1, .gpio_num = 2 },
    .gpio_cfg[1] = { .gpio_select = 1, .gpio_num = 25 },
};

wifi_ant_config_t ant_config = {
    .rx_ant_mode = WIFI_ANT_MODE_ANT0,
    .rx_ant_default = WIFI_ANT_ANT0, // only used when rx_ant_mode = auto
    .tx_ant_mode = WIFI_ANT_MODE_ANT1,
    .enabled_ant0 = 1, // When internal ant0 enabled, then gpio_cfg = 1 = 0b0001 -> pin 2 high level
    .enabled_ant1 = 2  // When internal ant1 enabled, then gpio_cfg = 2 = 0b0010 -> pin 25 high level
};
```

## Description of Change
WiFi: fix esp32 dual antenna not real work issue.

## Tests scenarios

Since the gpio 2 is not led out to the module, so we test with gpio 18 & 25.
```
wifi_ant_gpio_config_t ant_gpio_config = {
    // ESP32-WROOM-DA boards default antenna pins
    .gpio_cfg[0] = { .gpio_select = 1, .gpio_num = 18 },
    .gpio_cfg[1] = { .gpio_select = 1, .gpio_num = 25 },
};

wifi_ant_config_t ant_config = {
    .rx_ant_mode = WIFI_ANT_MODE_ANT0,
    .rx_ant_default = WIFI_ANT_ANT0, // only used when rx_ant_mode = auto
    .tx_ant_mode = WIFI_ANT_MODE_ANT1,
    .enabled_ant0 = 1, // When internal ant0 enabled, then gpio_cfg = 1 = 0b0001 -> pin 2 high level
    .enabled_ant1 = 2  // When internal ant1 enabled, then gpio_cfg = 2 = 0b0010 -> pin 25 high level
};
```
Test Result

![016](https://user-images.githubusercontent.com/20188571/172588298-fff1e06b-f5af-49cf-bafa-fe6e91308b8d.png)
[pin18_and_pin25.csv](https://github.com/espressif/arduino-esp32/files/8860477/pin18_and_pin25.csv)

## Related links

https://www.youtube.com/watch?v=F0u5qIwwY1k

https://github.com/espressif/esp-idf/issues/8824

