### PR TITLE
Hide get.py download percent when not interactive

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -53,10 +53,11 @@ def mkdir_p(path):
             raise
 
 def report_progress(count, blockSize, totalSize):
-    percent = int(count*blockSize*100/totalSize)
-    percent = min(100, percent)
-    sys.stdout.write("\r%d%%" % percent)
-    sys.stdout.flush()
+    if sys.stdout.isatty():
+        percent = int(count*blockSize*100/totalSize)
+        percent = min(100, percent)
+        sys.stdout.write("\r%d%%" % percent)
+        sys.stdout.flush()
 
 def unpack(filename, destination):
     dirname = ''


### PR DESCRIPTION
## Description of Change
When get.py is run in a script the percent-update printouts shown while
downloading the toolchain end up as 100s to 1000s of lines in log files.

When stdout is not a terminal, avoid printing these percentages and
shrink logfiles significantly.  Errors/etc. are still reported as normal.

*This is a "nice to have" and does not impact functionality.*

## Tests scenarios
Run `cd tools; rm -f dist/*; python3 get.py > log` on a clean installation
and open the log in `vi log` and see:
````
M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0%^M0....
````

In GitHub CI logs you'll end up with 100s of lines like
````
Downloading riscv32-esp-elf-gcc8_4_0-esp-2021r2-patch3-linux-amd64.tar.gz ...

0%
0%
0%
0%
0%
0%
0%
0%
0%
0%
````

With this change, the output is simply:
````
System: Linux, Bits: 64, Info: Linux-5.13.0-44-generic-x86_64-with-glibc2.29
Platform: x86_64-pc-linux-gnu
Downloading riscv32-esp-elf-gcc8_4_0-esp-2021r2-patch3-linux-amd64.tar.gz ...
Done
Extracting riscv32-esp-elf-gcc8_4_0-esp-2021r2-patch3-linux-amd64.tar.gz ...
````

## Related links
<none>