### PR TITLE
fixes BLE HID Battery Level Indicator

### DIFF
--- a/libraries/BLE/src/BLEHIDDevice.cpp
+++ b/libraries/BLE/src/BLEHIDDevice.cpp
@@ -42,10 +42,10 @@ BLEHIDDevice::BLEHIDDevice(BLEServer* server) {
 
 	m_batteryLevelCharacteristic = m_batteryService->createCharacteristic((uint16_t) 0x2a19, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY);
 	m_batteryLevelCharacteristic->addDescriptor(batteryLevelDescriptor);
-    BLE2902 *batLevelIndicator = new BLE2902();
-    // Battery Level Notification is ON by default, making it work always on BLE Pairing and Bonding
-    batLevelIndicator->setNotifications(true);
-    m_batteryLevelCharacteristic->addDescriptor(batLevelIndicator);
+	BLE2902 *batLevelIndicator = new BLE2902();
+	// Battery Level Notification is ON by default, making it work always on BLE Pairing and Bonding
+	batLevelIndicator->setNotifications(true);
+	m_batteryLevelCharacteristic->addDescriptor(batLevelIndicator);
 
 	/*
 	 * This value is setup here because its default value in most usage cases, its very rare to use boot mode

--- a/libraries/BLE/src/BLEHIDDevice.cpp
+++ b/libraries/BLE/src/BLEHIDDevice.cpp
@@ -42,7 +42,10 @@ BLEHIDDevice::BLEHIDDevice(BLEServer* server) {
 
 	m_batteryLevelCharacteristic = m_batteryService->createCharacteristic((uint16_t) 0x2a19, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY);
 	m_batteryLevelCharacteristic->addDescriptor(batteryLevelDescriptor);
-	m_batteryLevelCharacteristic->addDescriptor(new BLE2902());
+    BLE2902 *batLevelIndicator = new BLE2902();
+    // Battery Level Notification is ON by default, making it work always on BLE Pairing and Bonding
+    batLevelIndicator->setNotifications(true);
+    m_batteryLevelCharacteristic->addDescriptor(batLevelIndicator);
 
 	/*
 	 * This value is setup here because its default value in most usage cases, its very rare to use boot mode


### PR DESCRIPTION
## Description of Change
BLE HID uses GATT Service to send Battery Level Indication.
It works fine on first time pairing and bonding, but on reconnect it doesn't update the Battery Level characteristic anymore. 
It is fixed by setting the Notification to be ON, by default at the Service Creation. 

## Tests scenarios
Tested with ESP32 using Bluedroid and NimBLE.

## Related links
Fixes #6708 