### PR TITLE
Doc: update wifi encryption description

### DIFF
--- a/libraries/WiFi/examples/SimpleWiFiServer/SimpleWiFiServer.ino
+++ b/libraries/WiFi/examples/SimpleWiFiServer/SimpleWiFiServer.ino
@@ -10,8 +10,8 @@
  http://yourAddress/H turns the LED on
  http://yourAddress/L turns it off
 
- This example is written for a network using WPA encryption. For
- WEP or WPA, change the Wifi.begin() call accordingly.
+ This example is written for a network using WPA2 encryption. For insecure
+ WEP or WPA, change the Wifi.begin() call and use Wifi.setMinSecurity() accordingly.
 
  Circuit:
  * WiFi shield attached


### PR DESCRIPTION
## Description of Change
Update documentation:

* By default `WPA2` is minimum required. The old insecure encryption must be explicitly enabled.
* Avoid confusion of new user who tries to connect to old insecure `WPA` wifi. 

## Tests scenarios
None.

## Related links
None.
