### PR TITLE
[WiFi] Clarify arduino wifi debug output

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -250,7 +250,7 @@ static const char * auth_mode_str(int authmode)
     	return ("WEP");
         break;
     case WIFI_AUTH_WPA_PSK:
-    	return ("PSK");
+    	return ("WPA_PSK");
         break;
     case WIFI_AUTH_WPA2_PSK:
     	return ("WPA2_PSK");


### PR DESCRIPTION
## Description of Change

`PSK` can concern different ciphers. Make it clear that it belongs to `WPA`.

Renamed output `PSK` to `WPA_PSK`.

## Tests scenarios

Enable debugging and check output.

## Related links

None.
