### PR TITLE
Doc: Update deprecation of `setAutoConnect`, etc..

### DIFF
--- a/docs/source/api/wifi.rst
+++ b/docs/source/api/wifi.rst
@@ -446,26 +446,12 @@ Return the connection state.
 setAutoConnect
 **************
 
-Function used to set the automatic connection.
-
-.. code-block:: arduino
-
-    bool setAutoConnect(bool autoConnect);
-
-Where:
-
-* ``bool autoConnect`` is set to ``true`` to enable this option.
+Function is deprecated.
 
 getAutoConnect
 **************
 
-Function used to get the automatic connection setting value.
-
-.. code-block:: arduino
-
-    bool getAutoConnect();
-
-The function will return ``true`` if the setting is enabled.
+Function is deprecated.
 
 setAutoReconnect
 ****************
@@ -484,11 +470,12 @@ getAutoReconnect
 ****************
 
 Function used to get the automatic reconnection if the connection is lost.
+
 .. code-block:: arduino
 
     bool getAutoReconnect();
 
-    The function will return ``true`` if this setting is enabled.
+The function will return ``true`` if this setting is enabled.
 
 WiFiMulti
 ---------

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -452,12 +452,20 @@ bool WiFiSTAClass::getAutoConnect()
     return false;//now deprecated
 }
 
+/**
+ * Function used to set the automatic reconnection if the connection is lost. 
+ * @param autoReconnect `true` to enable this option.
+ * @return true 
+ */
 bool WiFiSTAClass::setAutoReconnect(bool autoReconnect)
 {
     _autoReconnect = autoReconnect;
     return true;
 }
-
+/**
+ * Function used to get the automatic reconnection if the connection is lost.
+ * @return The function will return `true` if this setting is enabled.
+ */
 bool WiFiSTAClass::getAutoReconnect()
 {
     return _autoReconnect;

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -430,8 +430,9 @@ void WiFiSTAClass::setSortMethod(wifi_sort_method_t sortMethod)
 }
 
 /**
- * Setting the ESP32 station to connect to the AP (which is recorded)
+ * Deprecated. Setting the ESP32 station to connect to the AP (which is recorded)
  * automatically or not when powered on. Enable auto-connect by default.
+ * @deprecated use `setAutoReconnect`
  * @param autoConnect bool
  * @return if saved
  */
@@ -441,8 +442,9 @@ bool WiFiSTAClass::setAutoConnect(bool autoConnect)
 }
 
 /**
- * Checks if ESP32 station mode will connect to AP
+ * Deprecated. Checks if ESP32 station mode will connect to AP
  * automatically or not when it is powered on.
+ * @deprecated use `getAutoReconnect`
  * @return auto connect
  */
 bool WiFiSTAClass::getAutoConnect()


### PR DESCRIPTION
## Description of Change

The code marks `setAutoConnect`, etc to be deprecated, but the documentation does not reflect this. Therefore, the documentation was updated.

## Tests scenarios

Generate doc.

## Related links

No known.
