### PR TITLE
Added maxOpenFiles to SDMMC

### DIFF
--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -84,7 +84,7 @@ bool SDMMCFS::setPins(int clk, int cmd, int d0, int d1, int d2, int d3)
 #endif
 }
 
-bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount_failed, int sdmmc_frequency)
+bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount_failed, int sdmmc_frequency, uint8_t maxOpenFiles)
 {
     if(_card) {
         return true;
@@ -122,7 +122,7 @@ bool SDMMCFS::begin(const char * mountpoint, bool mode1bit, bool format_if_mount
 
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
         .format_if_mount_failed = format_if_mount_failed,
-        .max_files = 5,
+        .max_files = maxOpenFiles,
         .allocation_unit_size = 0
     };
 

--- a/libraries/SD_MMC/src/SD_MMC.h
+++ b/libraries/SD_MMC/src/SD_MMC.h
@@ -50,7 +50,7 @@ public:
     SDMMCFS(FSImplPtr impl);
     bool setPins(int clk, int cmd, int d0);
     bool setPins(int clk, int cmd, int d0, int d1, int d2, int d3);
-    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false, int sdmmc_frequency=BOARD_MAX_SDMMC_FREQ);
+    bool begin(const char * mountpoint="/sdcard", bool mode1bit=false, bool format_if_mount_failed=false, int sdmmc_frequency=BOARD_MAX_SDMMC_FREQ, uint8_t maxOpenFiles = 5);
     void end();
     sdcard_type_t cardType();
     uint64_t cardSize();


### PR DESCRIPTION
## Description of Change
Adds another parameter to SD_MMC.begin to change maximum open files.

## Tests scenarios
Untested on any hardware, but compiles on esp32 dev board, latest master (2.0.4 pre)

## Related links
Requested in #6911 
