### PR TITLE
Fixes BLE Server descriptor update

### DIFF
--- a/libraries/BLE/src/BLE2902.cpp
+++ b/libraries/BLE/src/BLE2902.cpp
@@ -46,6 +46,7 @@ void BLE2902::setIndications(bool flag) {
 	uint8_t *pValue = getValue();
 	if (flag) pValue[0] |= 1 << 1;
 	else pValue[0] &= ~(1 << 1);
+	setValue(pValue, 2);
 } // setIndications
 
 
@@ -57,6 +58,7 @@ void BLE2902::setNotifications(bool flag) {
 	uint8_t *pValue = getValue();
 	if (flag) pValue[0] |= 1 << 0;
 	else pValue[0] &= ~(1 << 0);
+	setValue(pValue, 2);
 } // setNotifications
 
 #endif

--- a/libraries/BLE/src/BLEDescriptor.cpp
+++ b/libraries/BLE/src/BLEDescriptor.cpp
@@ -185,9 +185,9 @@ void BLEDescriptor::handleGATTServerEvent(
 		case ESP_GATTS_READ_EVT: {
 			if (param->read.handle == m_handle) {  // If this event is for this descriptor ... process it
 
-					if (m_pCallback != nullptr) {   // If we have a user supplied callback, invoke it now.
-						m_pCallback->onRead(this);    // Invoke the onRead callback method in the callback handler.
-					}
+				if (m_pCallback != nullptr) {   // If we have a user supplied callback, invoke it now.
+					m_pCallback->onRead(this);    // Invoke the onRead callback method in the callback handler.
+				}
 
 			} // End of this is our handle
 			break;

--- a/libraries/BLE/src/BLEDescriptor.cpp
+++ b/libraries/BLE/src/BLEDescriptor.cpp
@@ -32,7 +32,7 @@ BLEDescriptor::BLEDescriptor(const char* uuid, uint16_t len) : BLEDescriptor(BLE
 BLEDescriptor::BLEDescriptor(BLEUUID uuid, uint16_t max_len) {
 	m_bleUUID            = uuid;
 	m_value.attr_len     = 0;                                         // Initial length is 0.
-	m_value.attr_max_len = max_len;                     // Maximum length of the data.
+	m_value.attr_max_len = max_len;                     			  // Maximum length of the data.
 	m_handle             = NULL_HANDLE;                               // Handle is initially unknown.
 	m_pCharacteristic    = nullptr;                                   // No initial characteristic.
 	m_pCallback          = nullptr;                                   // No initial callback.
@@ -185,9 +185,9 @@ void BLEDescriptor::handleGATTServerEvent(
 		case ESP_GATTS_READ_EVT: {
 			if (param->read.handle == m_handle) {  // If this event is for this descriptor ... process it
 
-				if (m_pCallback != nullptr) {   // If we have a user supplied callback, invoke it now.
-					m_pCallback->onRead(this);    // Invoke the onRead callback method in the callback handler.
-				}
+					if (m_pCallback != nullptr) {   // If we have a user supplied callback, invoke it now.
+						m_pCallback->onRead(this);    // Invoke the onRead callback method in the callback handler.
+					}
 
 			} // End of this is our handle
 			break;
@@ -235,6 +235,10 @@ void BLEDescriptor::setValue(uint8_t* data, size_t length) {
 	}
 	m_value.attr_len = length;
 	memcpy(m_value.attr_value, data, length);
+	if (m_handle != NULL_HANDLE) {
+		esp_ble_gatts_set_attr_value(m_handle, length, (const uint8_t *)data);
+		log_d("Set the value in the GATTS database using handle 0x%x", m_handle);
+	}
 } // setValue
 
 

--- a/libraries/BLE/src/BLEDescriptor.h
+++ b/libraries/BLE/src/BLEDescriptor.h
@@ -51,7 +51,7 @@ private:
 	uint16_t                m_handle;
 	BLEDescriptorCallbacks* m_pCallback;
 	BLECharacteristic*      m_pCharacteristic;
-	esp_gatt_perm_t			m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
+	esp_gatt_perm_t		m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
 	FreeRTOS::Semaphore     m_semaphoreCreateEvt = FreeRTOS::Semaphore("CreateEvt");
 	esp_attr_value_t        m_value;
 

--- a/libraries/BLE/src/BLEDescriptor.h
+++ b/libraries/BLE/src/BLEDescriptor.h
@@ -48,9 +48,9 @@ private:
 	friend class BLEDescriptorMap;
 	friend class BLECharacteristic;
 	BLEUUID                 m_bleUUID;
-	uint16_t                m_handle;
-	BLEDescriptorCallbacks* m_pCallback;
-	BLECharacteristic*      m_pCharacteristic;
+	uint16_t		m_handle;
+	BLEDescriptorCallbacks*	m_pCallback;
+	BLECharacteristic*	m_pCharacteristic;
 	esp_gatt_perm_t		m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
 	FreeRTOS::Semaphore     m_semaphoreCreateEvt = FreeRTOS::Semaphore("CreateEvt");
 	esp_attr_value_t        m_value;

--- a/libraries/BLE/src/BLEDescriptor.h
+++ b/libraries/BLE/src/BLEDescriptor.h
@@ -48,10 +48,10 @@ private:
 	friend class BLEDescriptorMap;
 	friend class BLECharacteristic;
 	BLEUUID                 m_bleUUID;
-	uint16_t		m_handle;
-	BLEDescriptorCallbacks*	m_pCallback;
-	BLECharacteristic*	m_pCharacteristic;
-	esp_gatt_perm_t		m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
+	uint16_t                m_handle;
+	BLEDescriptorCallbacks* m_pCallback;
+	BLECharacteristic*      m_pCharacteristic;
+	esp_gatt_perm_t         m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
 	FreeRTOS::Semaphore     m_semaphoreCreateEvt = FreeRTOS::Semaphore("CreateEvt");
 	esp_attr_value_t        m_value;
 

--- a/libraries/BLE/src/BLEDescriptor.h
+++ b/libraries/BLE/src/BLEDescriptor.h
@@ -51,7 +51,7 @@ private:
 	uint16_t                m_handle;
 	BLEDescriptorCallbacks* m_pCallback;
 	BLECharacteristic*      m_pCharacteristic;
-	esp_gatt_perm_t				  m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
+	esp_gatt_perm_t			m_permissions = ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE;
 	FreeRTOS::Semaphore     m_semaphoreCreateEvt = FreeRTOS::Semaphore("CreateEvt");
 	esp_attr_value_t        m_value;
 


### PR DESCRIPTION
## Description of Change
This PR fixes an issue related to BLE Server and Descriptors.

The issue:
If the BLE Server code changes its own descriptors, it is not reflected in the GATTS database.
BLE2902 CCCD also didn't reflect any changes to the GATTS database.
Because of this issue, the client could never read the real Descriptor values from the remote Server.


## Tests scenarios
Tested with ESP32.

## Related links
Fixes #6863 
Fixes #6868
