### PR TITLE
Fixes wrong #define for BUTTON

### DIFF
--- a/variants/adafruit_feather_esp32_v2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32_v2/pins_arduino.h
@@ -48,7 +48,7 @@ static const uint8_t A13 = 35;
 #define BATT_MONITOR 35
 
 // internal switch
-#define BUTTON = 38;
+#define BUTTON 38
 
 // Neopixel
 #define PIN_NEOPIXEL 0


### PR DESCRIPTION
## Description of Change
Very simple fix regarding a possible typo/edit on a `#define BUTTON = 38;` declaration.

## Tests scenarios
None

## Related links
Fixes #6939