### PR TITLE
Fixed failure paths not setting socket to -1 consistently, changed close to lwip_close to resolve assert

### DIFF
--- a/libraries/WiFiClientSecure/src/ssl_client.cpp
+++ b/libraries/WiFiClientSecure/src/ssl_client.cpp
@@ -100,18 +100,21 @@ int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t p
     int res = lwip_connect(ssl_client->socket, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
     if (res < 0 && errno != EINPROGRESS) {
         log_e("connect on fd %d, errno: %d, \"%s\"", ssl_client->socket, errno, strerror(errno));
-        close(ssl_client->socket);
+        lwip_close(ssl_client->socket);
+        ssl_client->socket = -1;
         return -1;
     }
 
     res = select(ssl_client->socket + 1, nullptr, &fdset, nullptr, timeout<0 ? nullptr : &tv);
     if (res < 0) {
         log_e("select on fd %d, errno: %d, \"%s\"", ssl_client->socket, errno, strerror(errno));
-        close(ssl_client->socket);
+        lwip_close(ssl_client->socket);
+        ssl_client->socket = -1;
         return -1;
     } else if (res == 0) {
         log_i("select returned due to timeout %d ms for fd %d", timeout, ssl_client->socket);
-        close(ssl_client->socket);
+        lwip_close(ssl_client->socket);
+        ssl_client->socket = -1;
         return -1;
     } else {
         int sockerr;
@@ -120,13 +123,15 @@ int start_ssl_client(sslclient_context *ssl_client, const char *host, uint32_t p
 
         if (res < 0) {
             log_e("getsockopt on fd %d, errno: %d, \"%s\"", ssl_client->socket, errno, strerror(errno));
-            close(ssl_client->socket);
+            lwip_close(ssl_client->socket);
+            ssl_client->socket = -1;
             return -1;
         }
 
         if (sockerr != 0) {
             log_e("socket error on fd %d, errno: %d, \"%s\"", ssl_client->socket, sockerr, strerror(sockerr));
-            close(ssl_client->socket);
+            lwip_close(ssl_client->socket);
+            ssl_client->socket = -1;
             return -1;
         }
     }
@@ -319,7 +324,7 @@ void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, cons
     log_v("Cleaning SSL connection.");
 
     if (ssl_client->socket >= 0) {
-        close(ssl_client->socket);
+        lwip_close(ssl_client->socket);
         ssl_client->socket = -1;
     }
 


### PR DESCRIPTION
## Description of Change

Ran into an issue where an assert would be cause from WebClientSecure stopping after extended uptime (typically happened after 4 days, and usually in conjunction with heavy SD card access).  Assert would manifest like this:

assert failed: lock_release_generic locks.c:186 (h)

0x400843d9: panic_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/panic.c line 402
0x4008eb9d: esp_system_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/esp_system.c line 128
0x4009432d: __assert_func at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/assert.c line 85
0x40085df3: lock_release_generic at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/locks.c line 181
0x40085ee9: _lock_release at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/locks.c line 207
0x4014184c: vfs_fat_close at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/fatfs/vfs/vfs_fat.c line 513
0x40118c73: esp_vfs_close at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/vfs/vfs.c line 498
0x400faef5: WiFiClientSecure::stop() at C:\Users\Mark\AppData\Local\Arduino15\packages\esp32\hardware\esp32\2.0.3\libraries\WiFiClientSecure\src\WiFiClientSecure.cpp line 93

Looked like it was two issues; one less common, but not all of the failure cases of start_ssl_client would set ssl_client->socket to -1, as it does with the first failure cases as well as in stop_ssl_socket.  Second was more specific to the above assert, and that was changing close() to lwip_close().  With these two changes it's back to weeks of uptime, only restarting when I manually take action.

## Tests scenarios
M5StickC, several custom ESP32-WROOM-32D boards, Espressif DevKitC board.  The test software writes data to an SD card at the rate of 1 sample (typically ~80 chars) every 5 seconds, and sends data to a cloud HTTPS server once every 5 minutes.  Previous versions on 1.0.6 had uptimes in months+, but switching to 2.0.3 dropped uptime to hours or a day or two at best.  With these changes I've had it reliably run for 2+ weeks (haven't had a device up for longer yet).

## Related links
None (to my knowledge).