### PR TITLE
Added dont_mount option to LittleFS conf initialization

### DIFF
--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -81,7 +81,8 @@ bool LittleFSFS::begin(bool formatOnFail, const char * basePath, uint8_t maxOpen
     esp_vfs_littlefs_conf_t conf = {
       .base_path = basePath,
       .partition_label = partitionLabel_,
-      .format_if_mount_failed = false
+      .format_if_mount_failed = false,
+      .dont_mount = false
     };
 
     esp_err_t err = esp_vfs_littlefs_register(&conf);


### PR DESCRIPTION

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [X] Please **update relevant Documentation** if applicable
4. [X] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
With recent compiler update, the following warning is generated: 

packages/esp32/hardware/esp32/2.0.4/libraries/LittleFS/src/LittleFS.cpp:85:5: warning: missing initializer for member 'esp_vfs_littlefs_conf_t::dont_mount' [-Wmissing-field-initializers]

This commit adds the missing identifier.

## Tests scenarios
Adafruit Huzzah32

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
