### PR TITLE
Compile error if CONFIG_FREERTOS_HZ != 1000

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -104,4 +104,5 @@ jobs:
         run: |
           . ${IDF_PATH}/export.sh
           idf.py create-project test
+          echo CONFIG_FREERTOS_HZ=1000 > test/sdkconfig.defaults
           idf.py -C test -DEXTRA_COMPONENT_DIRS=$PWD/components build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,12 @@ set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support openssl b
 
 idf_component_register(INCLUDE_DIRS ${includedirs} PRIV_INCLUDE_DIRS ${priv_includes} SRCS ${srcs} REQUIRES ${requires} PRIV_REQUIRES ${priv_requires})
 
+if(NOT CONFIG_FREERTOS_HZ EQUAL 1000 AND NOT "$ENV{ARDUINO_SKIP_TICK_CHECK}")
+    # See delay() in cores/esp32/esp32-hal-misc.c.
+    message(FATAL_ERROR "esp32-arduino requires CONFIG_FREERTOS_HZ=1000 "
+                        "(currently ${CONFIG_FREERTOS_HZ}")
+endif()
+
 string(TOUPPER ${CONFIG_ARDUINO_VARIANT} idf_target_caps)
 target_compile_options(${COMPONENT_TARGET} PUBLIC
     -DARDUINO=10812

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ idf_component_register(INCLUDE_DIRS ${includedirs} PRIV_INCLUDE_DIRS ${priv_incl
 if(NOT CONFIG_FREERTOS_HZ EQUAL 1000 AND NOT "$ENV{ARDUINO_SKIP_TICK_CHECK}")
     # See delay() in cores/esp32/esp32-hal-misc.c.
     message(FATAL_ERROR "esp32-arduino requires CONFIG_FREERTOS_HZ=1000 "
-                        "(currently ${CONFIG_FREERTOS_HZ}")
+                        "(currently ${CONFIG_FREERTOS_HZ})")
 endif()
 
 string(TOUPPER ${CONFIG_ARDUINO_VARIANT} idf_target_caps)

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -175,10 +175,6 @@ unsigned long ARDUINO_ISR_ATTR millis()
 
 void delay(uint32_t ms)
 {
-    _Static_assert(
-        portTICK_PERIOD_MS == 1,
-        "esp32-arduino requires 1ms tick (CONFIG_FREERTOS_HZ=1000)"
-    );
     vTaskDelay(ms / portTICK_PERIOD_MS);
 }
 

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -175,6 +175,10 @@ unsigned long ARDUINO_ISR_ATTR millis()
 
 void delay(uint32_t ms)
 {
+    _Static_assert(
+        portTICK_PERIOD_MS == 1,
+        "esp32-arduino requires 1ms tick (CONFIG_FREERTOS_HZ=1000)"
+    );
     vTaskDelay(ms / portTICK_PERIOD_MS);
 }
 

--- a/docs/source/esp-idf_component.rst
+++ b/docs/source/esp-idf_component.rst
@@ -140,8 +140,7 @@ If you are writing code that does not require Arduino to compile and you want yo
 FreeRTOS Tick Rate (Hz)
 -----------------------
 
-You might notice that Arduino-esp32's `delay()` function will only work in multiples of 10ms. That is because, by default, esp-idf handles task events 100 times per second.
-To fix that behavior, you need to set FreeRTOS tick rate to 1000Hz in `make menuconfig` -> `Component config` -> `FreeRTOS` -> `Tick rate`.
+The Arduino component requires the FreeRTOS tick rate `CONFIG_FREERTOS_HZ` set to 1000Hz in `make menuconfig` -> `Component config` -> `FreeRTOS` -> `Tick rate`.
 
 Compilation Errors
 ------------------


### PR DESCRIPTION
## Description of Change
Since `delay()` won't work properly with `CONFIG_FREERTOS_HZ` not set to 1000, this adds a `_Static_assert` to verify that fact. (The standard Arduino build already sets the value properly; this is for people using the Arduino platform as a component within their own ESP-IDF build.)

## Tests scenarios
Tested with a platformio build that left `CONFIG_FREERTOS_HZ` at the default (100) and verified build failure.
Then added `CONFIG_FREERTOS_HZ=1000` to `config.defaults`, erased `config.esp32` and built again, verifying success this time.

(This particular build happens to be for the OLIMEX ESP32-POE, but none of this has any impact on runtime-- runtime code is unchanged.)

## Related links
Addresses https://github.com/espressif/arduino-esp32/issues/6946