### PR TITLE
allow HTTPClient to handle large payloads, in case the client (such as WifiClientSecure) does not

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -618,8 +618,13 @@ int HTTPClient::sendRequest(const char * type, uint8_t * payload, size_t size)
         }
 
         // send Payload if needed
-        if(payload && size > 0) {
-            if(_client->write(&payload[0], size) != size) {
+        if(payload && (size > 0)) {
+            size_t totalSent = 0;
+            while(_client->connected() && (totalSent < size))
+            {
+                totalSent += _client->write(&payload[totalSent], (size - totalSent));
+            }
+            if(totalSent != size) {
                 return returnError(HTTPC_ERROR_SEND_PAYLOAD_FAILED);
             }
         }


### PR DESCRIPTION
## Description of Change

WiFiClient handles large write() by breaking it down and sending the whole thing in pieces, but WiFiClientSecure may just do a partial send and return the partial size, causing this to fail and return HTTPC_ERROR_SEND_PAYLOAD_FAILED

## Tests scenarios

I have tested this successfully on an ESP32-S2 by posting a large jpeg file to an https server successfully.

