### PR TITLE
Improve RGB driver in pull #6808; solves #6968

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -91,9 +91,9 @@ static InterruptHandle_t __pinInterruptHandlers[SOC_GPIO_PIN_COUNT] = {0,};
 
 extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 {
-#ifdef BOARD_HAS_NEOPIXEL
-    if (pin == LED_BUILTIN){
-        __pinMode(LED_BUILTIN-SOC_GPIO_PIN_COUNT, mode);
+#ifdef RGB_BUILTIN
+    if (pin == RGB_BUILTIN){
+        __pinMode(RGB_BUILTIN-SOC_GPIO_PIN_COUNT, mode);
         return;
     }
 #endif
@@ -134,11 +134,11 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 
 extern void ARDUINO_ISR_ATTR __digitalWrite(uint8_t pin, uint8_t val)
 {
-    #ifdef BOARD_HAS_NEOPIXEL
-        if(pin == LED_BUILTIN){
+    #ifdef RGB_BUILTIN
+        if(pin == RGB_BUILTIN){
             //use RMT to set all channels on/off
-            const uint8_t comm_val = val != 0 ? LED_BRIGHTNESS : 0;
-            neopixelWrite(LED_BUILTIN, comm_val, comm_val, comm_val);
+            const uint8_t comm_val = val != 0 ? RGB_BRIGHTNESS : 0;
+            neopixelWrite(RGB_BUILTIN, comm_val, comm_val, comm_val);
             return;
         }
     #endif

--- a/cores/esp32/esp32-hal-rgb-led.c
+++ b/cores/esp32/esp32-hal-rgb-led.c
@@ -7,9 +7,9 @@ void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue
   static bool initialized = false;
 
   uint8_t _pin = pin;
-#ifdef BOARD_HAS_NEOPIXEL
-  if(pin == LED_BUILTIN){
-    _pin = LED_BUILTIN-SOC_GPIO_PIN_COUNT;
+#ifdef RGB_BUILTIN
+  if(pin == RGB_BUILTIN){
+    _pin = RGB_BUILTIN-SOC_GPIO_PIN_COUNT;
   }
 #endif
 

--- a/cores/esp32/esp32-hal-rgb-led.h
+++ b/cores/esp32/esp32-hal-rgb-led.h
@@ -7,8 +7,8 @@ extern "C" {
 
 #include "esp32-hal.h"
 
-#ifndef LED_BRIGHTNESS
-  #define LED_BRIGHTNESS 64
+#ifndef RGB_BRIGHTNESS
+  #define RGB_BRIGHTNESS 64
 #endif
 
 void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue_val);

--- a/libraries/ESP32/examples/GPIO/BlinkRGB/BlinkRGB.ino
+++ b/libraries/ESP32/examples/GPIO/BlinkRGB/BlinkRGB.ino
@@ -3,7 +3,7 @@
 
   Demonstrates usage of onboard RGB LED on some ESP dev boards.
 
-  Calling digitalWrite(LED_BUILTIN, HIGH) will use hidden RGB driver.
+  Calling digitalWrite(RGB_BUILTIN, HIGH) will use hidden RGB driver.
     
   RGBLedWrite demonstrates controll of each channel:
   void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue_val)
@@ -11,7 +11,7 @@
   WARNING: After using digitalWrite to drive RGB LED it will be impossible to drive the same pin
     with normal HIGH/LOW level
 */
-//#define LED_BRIGHTNESS 64 // Change white brightness (max 255)
+//#define RGB_BRIGHTNESS 64 // Change white brightness (max 255)
 
 // the setup function runs once when you press reset or power the board
 
@@ -21,19 +21,19 @@ void setup() {
 
 // the loop function runs over and over again forever
 void loop() {
-#ifdef BOARD_HAS_NEOPIXEL
-  digitalWrite(LED_BUILTIN, HIGH);   // Turn the RGB LED white
+#ifdef RGB_BUILTIN
+  digitalWrite(RGB_BUILTIN, HIGH);   // Turn the RGB LED white
   delay(1000);
-  digitalWrite(LED_BUILTIN, LOW);    // Turn the RGB LED off
+  digitalWrite(RGB_BUILTIN, LOW);    // Turn the RGB LED off
   delay(1000);
 
-  neopixelWrite(LED_BUILTIN,LED_BRIGHTNESS,0,0); // Red
+  neopixelWrite(RGB_BUILTIN,RGB_BRIGHTNESS,0,0); // Red
   delay(1000);
-  neopixelWrite(LED_BUILTIN,0,LED_BRIGHTNESS,0); // Green
+  neopixelWrite(RGB_BUILTIN,0,RGB_BRIGHTNESS,0); // Green
   delay(1000);
-  neopixelWrite(LED_BUILTIN,0,0,LED_BRIGHTNESS); // Blue
+  neopixelWrite(RGB_BUILTIN,0,0,RGB_BRIGHTNESS); // Blue
   delay(1000);
-  neopixelWrite(LED_BUILTIN,0,0,0); // Off / black
+  neopixelWrite(RGB_BUILTIN,0,0,0); // Off / black
   delay(1000);
 #endif
 }

--- a/variants/esp32c3/pins_arduino.h
+++ b/variants/esp32c3/pins_arduino.h
@@ -11,8 +11,8 @@
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+8;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
-#define BOARD_HAS_NEOPIXEL
-#define LED_BRIGHTNESS 64
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)

--- a/variants/esp32s2/pins_arduino.h
+++ b/variants/esp32s2/pins_arduino.h
@@ -12,8 +12,8 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+18; // GPIO pin for Saola-
 //static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+45; // GPIO pin for Kaluga = 45
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
-#define BOARD_HAS_NEOPIXEL
-#define LED_BRIGHTNESS 64
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)

--- a/variants/esp32s3/pins_arduino.h
+++ b/variants/esp32s3/pins_arduino.h
@@ -17,8 +17,8 @@
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
-#define BOARD_HAS_NEOPIXEL
-#define LED_BRIGHTNESS 64
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------

## Description of Change
This solution adds a `RGB_BUILTIN` variable to pull request https://github.com/espressif/arduino-esp32/pull/6808. With the original solution (https://github.com/espressif/arduino-esp32/pull/6808), users were limited to controlling a single built-in LED. By creating a new variable `RGB_BUILTIN`, users are able to control a regular LED and RGB LED with the `digitalWrite()` function, separately from each other.

* Replaces the use of the `LED_BUILTIN` variable for the RGB LED
* Removes the need for `BOARD_HAS_NEOPIXEL`
* Also, renames `LED_BRIGHTNESS` to match new variable name `RGB_BRIGHTNESS`

For boards that have a regular LED and RGB LED on their board, users can define the pin configuration *(below)* and the `Blink.ino` and `BlinkRGB.ino` example sketches would operate on the regular and RGB LEDs separately.

```
static const uint8_t LED_BUILTIN = 13;
static const uint8_t RGB_BUILTIN = SOC_GPIO_PIN_COUNT+2;
#define BUILTIN_LED  LED_BUILTIN // backward compatibility
#define LED_BUILTIN LED_BUILTIN
#define RGB_BUILTIN RGB_BUILTIN
#define RGB_BRIGHTNESS 65
```


## Tests scenarios
I have tested the proposed changes with the regular [`Blink.ino`](https://github.com/arduino/Arduino/blob/master/app/testdata/sketches/Blink/Blink.ino) and the **ESP32**>**GPIO**>[`BlinkRGB.ino`](https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/GPIO/BlinkRGB/BlinkRGB.ino) example sketches. These tests were performed on an ESP32-WROOM board with a regular LED and RGB LED. The sketches were also tested for the following pin configurations:

* Regular and RGB LED:
    * `Blink.ino` only controls regular LED
    * `BlinkRGB.ino` only controls the RGB LED
    ```
    static const uint8_t LED_BUILTIN = 13;
    static const uint8_t RGB_BUILTIN = SOC_GPIO_PIN_COUNT+2;
    #define BUILTIN_LED  LED_BUILTIN // backward compatibility
    #define LED_BUILTIN LED_BUILTIN
    #define RGB_BUILTIN RGB_BUILTIN
    #define RGB_BRIGHTNESS 65
    ```
* Only RGB LED:
    * `Blink.ino` and `BlinkRGB.ino` both control the RGB LED
    ```
    static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+2;
    #define BUILTIN_LED  LED_BUILTIN // backward compatibility
    #define LED_BUILTIN LED_BUILTIN
    #define RGB_BUILTIN LED_BUILTIN
    #define RGB_BRIGHTNESS 65
    ```
* Only regular LED:
    * Only `Blink.ino` works with the regular LED
    ```
    static const uint8_t LED_BUILTIN = 13;
    #define BUILTIN_LED  LED_BUILTIN // backward compatibility
    #define LED_BUILTIN LED_BUILTIN
    ```


## Related links
Closes https://github.com/espressif/arduino-esp32/issues/6968
*\*Based on original pull request (https://github.com/espressif/arduino-esp32/pull/6808) and issue (https://github.com/espressif/arduino-esp32/issues/6783)*