### PR TITLE
Fix for confusing overload of Wire::begin

### DIFF
--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -77,6 +77,10 @@ public:
     bool setPins(int sda, int scl);
     
     bool begin(int sda=-1, int scl=-1, uint32_t frequency=0); // returns true, if successful init of i2c bus
+    inline bool begin(uint8_t sda, uint8_t scl, uint32_t frequency=0) 
+    {
+        return begin(static_cast<int>(sda), static_cast<int>(scl), frequency);
+    }
     bool begin(uint8_t slaveAddr, int sda=-1, int scl=-1, uint32_t frequency=0);
     bool end();
 


### PR DESCRIPTION
Closes #6616

SDA and SCL are defined as `uint8_t`, and when it is used, library try initialize itself in slave mode

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
