### PR TITLE
Allow additional configuration of the PWM channel assigned to the Pin 

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -226,3 +226,7 @@ void analogWrite(uint8_t pin, int value) {
     ledcWrite(pin_to_channel[pin] - 1, value);
   }
 }
+
+int8_t analogGetChannel(uint8_t pin) {
+    return pin_to_channel[pin] - 1;
+}

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -92,6 +92,7 @@ void yield(void);
 #include "esp32-hal-cpu.h"
 
 void analogWrite(uint8_t pin, int value);
+int8_t analogGetChannel(uint8_t pin);
 
 //returns chip temperature in Celsius
 float temperatureRead();


### PR DESCRIPTION
## Description of Change
In current code, after calling analogWrite(), pin is automatically assigned a channel. It is also configured. But:

- There is **no way to change the channel configurations** since one does not have access to the channel assigned to the pin - [arduino-esp32/cores/esp32/esp32-hal-ledc.c:212](https://github.com/VasilyRakche/arduino-esp32/blob/e9f8c3ce357fa68ef52ad77aa8292c7574a2d5f3/cores/esp32/esp32-hal-ledc.c#L212)
- Of course one can just use bare *ledc* functions, but there is no way to make it compatible with analogWrite(). If user calls the analogWrite() until it reaches the channel limit, original *ledc* configuration will be overwritten

### Example. Better compatibility between *ledc* and native Arduino
```
#define PIN 20

// simple usage
analogWrite(PIN, 0);

// advanced user configuration update
channel = analogGetChannel(PIN);
int new_freq = 20000;
int new_bit_num = 9;
ledcSetup(channel, new_freq, new_bit_num);  

```
