### PR TITLE
docs: add FAQ entry about modifying sdkconfig options

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,3 +1,13 @@
 ##########################
 Frequently Asked Questions
 ##########################
+
+How to modify an sdkconfig option in Arduino?
+---------------------------------------------
+
+Arduino-esp32 project is based on ESP-IDF. While ESP-IDF supports configuration of various compile-time options (known as "Kconfig options" or "sdkconfig options") via a "menuconfig" tool, this feature is not available in Arduino IDE.
+
+To use the arduino-esp32 core with a modified sdkconfig option, you need to use ESP-IDF to compile Arduino libraries. Please see :doc:`esp-idf_component` and :doc:`lib_builder` for the two solutions available.
+
+Note that modifying ``sdkconfig`` or ``sdkconfig.h`` files found in the arduino-esp32 project tree **does not** result in changes to these options. This is because ESP-IDF libraries are included into the arduino-esp32 project tree as pre-built libraries.
+


### PR DESCRIPTION
## Description of Change
Added an FAQ entry about modifying the configuration options. This question seems to come up pretty often, so it's useful to have the answer ready.

## Tests scenarios
Docs changes only, no tests performed.

## Related links
* https://github.com/espressif/arduino-esp32/issues/6011#issuecomment-991888693
* https://github.com/espressif/arduino-esp32/issues/2830#issuecomment-496345988
* https://github.com/espressif/arduino-esp32/issues/1752
* and probably others
