### PR TITLE
Adds an error message to HardwareSerial::setPins()

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -491,7 +491,7 @@ void HardwareSerial::setRxInvert(bool invert)
 // negative Pin value will keep it unmodified
 void HardwareSerial::setPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
 {
-    if(uart == NULL) {
+    if(_uart == NULL) {
         log_e("setPins() shall be called after begin() - nothing done");
         return;
     }

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -491,6 +491,10 @@ void HardwareSerial::setRxInvert(bool invert)
 // negative Pin value will keep it unmodified
 void HardwareSerial::setPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
 {
+    if(uart == NULL) {
+        log_e("setPins() shall be called after begin() - nothing done");
+        return;
+    }
     uartSetPins(_uart, rxPin, txPin, ctsPin, rtsPin);
 }
 


### PR DESCRIPTION
## Description of Change
`HardwareSerial::setPins()` shall issue a message in case it is used before initializing the UART with `HardwareSerial::begin()`

## Tests scenarios
Tested with ESP32

## Related links
