### PR TITLE
Fixes LwIP INADDR_NONE conflict with softAPConfig()

### DIFF
--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -38,7 +38,7 @@ class WiFiAPClass
 public:
 
     bool softAP(const char* ssid, const char* passphrase = NULL, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false);
-    bool softAPConfig(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dhcp_lease_start = INADDR_NONE);
+    bool softAPConfig(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dhcp_lease_start = (uint32_t) 0);
     bool softAPdisconnect(bool wifioff = false);
 
     uint8_t softAPgetStationNum();


### PR DESCRIPTION
## Description of Change
The header for softAPConfig() uses INADDR_NONE symbol that may conflict with LWIP defenition for the same symbol depending on the order to files included in a sketch, as describer in #6981 

## Tests scenarios
ESP32

## Related links
Fixes #6981 