### PR TITLE
Improves time for setting touch interrupt

### DIFF
--- a/cores/esp32/esp32-hal-touch.c
+++ b/cores/esp32/esp32-hal-touch.c
@@ -220,11 +220,7 @@ static void __touchConfigInterrupt(uint8_t pin, void (*userFunc)(void), void *Ar
         __touchInterruptHandlers[pad].arg = Args;
     }
 
-#if SOC_TOUCH_VERSION_1                         // ESP32
-    touch_pad_config(pad, threshold);
-#elif SOC_TOUCH_VERSION_2                       // ESP32S2, ESP32S3
     touch_pad_set_thresh(pad, threshold);
-#endif
 }
 
 // it keeps backwards compatibility

--- a/cores/esp32/esp32-hal-touch.c
+++ b/cores/esp32/esp32-hal-touch.c
@@ -212,9 +212,7 @@ static void __touchConfigInterrupt(uint8_t pin, void (*userFunc)(void), void *Ar
     } else {
         // attach ISR User Call
         __touchInit();
-        #if SOC_TOUCH_VERSION_2                 // ESP32S2, ESP32S3
         __touchChannelInit(pad);
-        #endif
         __touchInterruptHandlers[pad].fn = userFunc;
         __touchInterruptHandlers[pad].callWithArgs = callWithArgs;
         __touchInterruptHandlers[pad].arg = Args;


### PR DESCRIPTION
## Description of Change
Fixes and improves the time it takes to set an interrupt with Touchpads in ESP32.

## Tests scenarios
With ESP32 as reported in #7097 

``` cpp
long beginDur = 0;

void IRAM_ATTR gotTouch() {}

void setup() {
    Serial.begin(115200);
}

void loop() {
    beginDur = millis();
    touchAttachInterrupt(4, gotTouch, 30);
    Serial.println("dur: " + String(millis() - beginDur));
}
```

Espected output shall report 0 as time.

## Related links
Fixes #7097 