### PR TITLE
Add support for new unphone boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -16736,7 +16736,380 @@ Bee_S3.menu.DebugLevel.debug.build.code_debug=4
 Bee_S3.menu.DebugLevel.verbose=Verbose
 Bee_S3.menu.DebugLevel.verbose.build.code_debug=5
 
+##############################################################
+
+unphone7.name=unPhone 7
+
+unphone7.bootloader.tool=esptool_py
+unphone7.bootloader.tool.default=esptool_py
+
+unphone7.upload.tool=esptool_py
+unphone7.upload.tool.default=esptool_py
+unphone7.upload.tool.network=esp_ota
+
+unphone7.upload.maximum_size=1310720
+unphone7.upload.maximum_data_size=327680
+unphone7.upload.flags=
+unphone7.upload.extra_flags=
+
+unphone7.serial.disableDTR=true
+unphone7.serial.disableRTS=true
+
+unphone7.build.tarch=xtensa
+unphone7.build.bootloader_addr=0x1000
+unphone7.build.target=esp32
+unphone7.build.mcu=esp32
+unphone7.build.core=esp32
+unphone7.build.variant=feather_esp32
+unphone7.build.board=FEATHER_ESP32
+
+unphone7.build.f_cpu=240000000L
+unphone7.build.flash_mode=dio
+unphone7.build.flash_size=4MB
+unphone7.build.boot=dio
+unphone7.build.partitions=default
+unphone7.build.defines=-DUNPHONE_SPIN=7
+
+unphone7.menu.FlashFreq.80=80MHz
+unphone7.menu.FlashFreq.80.build.flash_freq=80m
+unphone7.menu.FlashFreq.40=40MHz
+unphone7.menu.FlashFreq.40.build.flash_freq=40m
+
+unphone7.menu.UploadSpeed.921600=921600
+unphone7.menu.UploadSpeed.921600.upload.speed=921600
+unphone7.menu.UploadSpeed.115200=115200
+unphone7.menu.UploadSpeed.115200.upload.speed=115200
+unphone7.menu.UploadSpeed.256000.windows=256000
+unphone7.menu.UploadSpeed.256000.upload.speed=256000
+unphone7.menu.UploadSpeed.230400.windows.upload.speed=256000
+unphone7.menu.UploadSpeed.230400=230400
+unphone7.menu.UploadSpeed.230400.upload.speed=230400
+unphone7.menu.UploadSpeed.460800.linux=460800
+unphone7.menu.UploadSpeed.460800.macosx=460800
+unphone7.menu.UploadSpeed.460800.upload.speed=460800
+unphone7.menu.UploadSpeed.512000.windows=512000
+unphone7.menu.UploadSpeed.512000.upload.speed=512000
+
+unphone7.menu.DebugLevel.none=None
+unphone7.menu.DebugLevel.none.build.code_debug=0
+unphone7.menu.DebugLevel.error=Error
+unphone7.menu.DebugLevel.error.build.code_debug=1
+unphone7.menu.DebugLevel.warn=Warn
+unphone7.menu.DebugLevel.warn.build.code_debug=2
+unphone7.menu.DebugLevel.info=Info
+unphone7.menu.DebugLevel.info.build.code_debug=3
+unphone7.menu.DebugLevel.debug=Debug
+unphone7.menu.DebugLevel.debug.build.code_debug=4
+unphone7.menu.DebugLevel.verbose=Verbose
+unphone7.menu.DebugLevel.verbose.build.code_debug=5
+
+unphone7.menu.PartitionScheme.default=Default
+unphone7.menu.PartitionScheme.default.build.partitions=default
+unphone7.menu.PartitionScheme.no_ota=No OTA (Large APP)
+unphone7.menu.PartitionScheme.no_ota.build.partitions=no_ota
+unphone7.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+unphone7.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+unphone7.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+unphone7.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+##############################################################
+
+unphone8.name=unPhone 8
+unphone8.vid.0=0x16D0
+unphone8.pid.0=0x1178
+
+unphone8.bootloader.tool=esptool_py
+unphone8.bootloader.tool.default=esptool_py
+
+unphone8.upload.tool=esptool_py
+unphone8.upload.tool.default=esptool_py
+unphone8.upload.tool.network=esp_ota
+
+unphone8.upload.maximum_size=8323072
+unphone8.upload.maximum_data_size=2424832
+unphone8.upload.flags=
+unphone8.upload.extra_flags=
+unphone8.upload.use_1200bps_touch=false
+unphone8.upload.wait_for_upload_port=false
+
+unphone8.serial.disableDTR=false
+unphone8.serial.disableRTS=false
+
+unphone8.build.tarch=xtensa
+unphone8.build.bootloader_addr=0x0
+unphone8.build.target=esp32s3
+unphone8.build.mcu=esp32s3
+unphone8.build.core=esp32
+unphone8.build.variant=unphone8
+unphone8.build.board=unphone8
+
+unphone8.build.usb_mode=1
+unphone8.build.cdc_on_boot=0
+unphone8.build.msc_on_boot=0
+unphone8.build.dfu_on_boot=0
+unphone8.build.f_cpu=240000000L
+unphone8.build.flash_size=8MB
+unphone8.build.flash_freq=80m
+unphone8.build.flash_mode=dio
+unphone8.build.boot=qio
+unphone8.build.boot_freq=80m
+unphone8.build.partitions=default_8MB
+unphone8.build.defines=-DBOARD_HAS_PSRAM -DUNPHONE_SPIN=8
+unphone8.build.loop_core=-DARDUINO_RUNNING_CORE=1
+unphone8.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+unphone8.build.flash_type=qspi
+unphone8.build.psram_type=qspi
+unphone8.build.memory_type={build.flash_type}_{build.psram_type}
+
+unphone8.menu.USBMode.default=Hardware CDC and JTAG
+unphone8.menu.USBMode.default.build.usb_mode=1
+unphone8.menu.USBMode.hwcdc=USB-OTG (TinyUSB)
+unphone8.menu.USBMode.hwcdc.build.usb_mode=0
+
+unphone8.menu.CDCOnBoot.default=Disabled
+unphone8.menu.CDCOnBoot.default.build.cdc_on_boot=0
+unphone8.menu.CDCOnBoot.cdc=Enabled
+unphone8.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+unphone8.menu.MSCOnBoot.default=Disabled
+unphone8.menu.MSCOnBoot.default.build.msc_on_boot=0
+unphone8.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+unphone8.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+unphone8.menu.DFUOnBoot.default=Disabled
+unphone8.menu.DFUOnBoot.default.build.dfu_on_boot=0
+unphone8.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+unphone8.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+unphone8.menu.UploadMode.default=UART0 / Hardware CDC
+unphone8.menu.UploadMode.default.upload.use_1200bps_touch=false
+unphone8.menu.UploadMode.default.upload.wait_for_upload_port=false
+unphone8.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+unphone8.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+unphone8.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+unphone8.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+unphone8.menu.PartitionScheme.default.build.partitions=default
+unphone8.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+unphone8.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+unphone8.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+unphone8.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+unphone8.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+unphone8.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+unphone8.menu.PartitionScheme.minimal.build.partitions=minimal
+unphone8.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+unphone8.menu.PartitionScheme.no_ota.build.partitions=no_ota
+unphone8.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+unphone8.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+unphone8.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+unphone8.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+unphone8.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+unphone8.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+unphone8.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+unphone8.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+unphone8.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+unphone8.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+unphone8.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+unphone8.menu.PartitionScheme.huge_app.build.partitions=huge_app
+unphone8.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+unphone8.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+unphone8.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+unphone8.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+unphone8.menu.PartitionScheme.rainmaker=RainMaker
+unphone8.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+unphone8.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+unphone8.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
+unphone8.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
+
+unphone8.menu.CPUFreq.240=240MHz (WiFi)
+unphone8.menu.CPUFreq.240.build.f_cpu=240000000L
+unphone8.menu.CPUFreq.160=160MHz (WiFi)
+unphone8.menu.CPUFreq.160.build.f_cpu=160000000L
+unphone8.menu.CPUFreq.80=80MHz (WiFi)
+unphone8.menu.CPUFreq.80.build.f_cpu=80000000L
+unphone8.menu.CPUFreq.40=40MHz
+unphone8.menu.CPUFreq.40.build.f_cpu=40000000L
+unphone8.menu.CPUFreq.20=20MHz
+unphone8.menu.CPUFreq.20.build.f_cpu=20000000L
+unphone8.menu.CPUFreq.10=10MHz
+unphone8.menu.CPUFreq.10.build.f_cpu=10000000L
+
+unphone8.menu.UploadSpeed.921600=921600
+unphone8.menu.UploadSpeed.921600.upload.speed=921600
+unphone8.menu.UploadSpeed.115200=115200
+unphone8.menu.UploadSpeed.115200.upload.speed=115200
+unphone8.menu.UploadSpeed.256000.windows=256000
+unphone8.menu.UploadSpeed.256000.upload.speed=256000
+unphone8.menu.UploadSpeed.230400.windows.upload.speed=256000
+unphone8.menu.UploadSpeed.230400=230400
+unphone8.menu.UploadSpeed.230400.upload.speed=230400
+unphone8.menu.UploadSpeed.460800.linux=460800
+unphone8.menu.UploadSpeed.460800.macosx=460800
+unphone8.menu.UploadSpeed.460800.upload.speed=460800
+unphone8.menu.UploadSpeed.512000.windows=512000
+unphone8.menu.UploadSpeed.512000.upload.speed=512000
+
+unphone8.menu.DebugLevel.none=None
+unphone8.menu.DebugLevel.none.build.code_debug=0
+unphone8.menu.DebugLevel.error=Error
+unphone8.menu.DebugLevel.error.build.code_debug=1
+unphone8.menu.DebugLevel.warn=Warn
+unphone8.menu.DebugLevel.warn.build.code_debug=2
+unphone8.menu.DebugLevel.info=Info
+unphone8.menu.DebugLevel.info.build.code_debug=3
+unphone8.menu.DebugLevel.debug=Debug
+unphone8.menu.DebugLevel.debug.build.code_debug=4
+unphone8.menu.DebugLevel.verbose=Verbose
+unphone8.menu.DebugLevel.verbose.build.code_debug=5
+
+#############################################################
+
+unphone9.name=unPhone 9
+unphone9.vid.0=0x16D0
+unphone9.pid.0=0x1178
+
+unphone9.bootloader.tool=esptool_py
+unphone9.bootloader.tool.default=esptool_py
+
+unphone9.upload.tool=esptool_py
+unphone9.upload.tool.default=esptool_py
+unphone9.upload.tool.network=esp_ota
+
+unphone9.upload.maximum_size=8323072
+unphone9.upload.maximum_data_size=8716288
+unphone9.upload.flags=
+unphone9.upload.extra_flags=
+unphone9.upload.use_1200bps_touch=false
+unphone9.upload.wait_for_upload_port=false
+
+unphone9.serial.disableDTR=false
+unphone9.serial.disableRTS=false
+
+unphone9.build.tarch=xtensa
+unphone9.build.bootloader_addr=0x0
+unphone9.build.target=esp32s3
+unphone9.build.mcu=esp32s3
+unphone9.build.core=esp32
+unphone9.build.variant=unphone9
+unphone9.build.board=unphone9
+
+unphone9.build.usb_mode=1
+unphone9.build.cdc_on_boot=1
+unphone9.build.msc_on_boot=0
+unphone9.build.dfu_on_boot=0
+unphone9.build.f_cpu=240000000L
+unphone9.build.flash_size=8MB
+unphone9.build.flash_freq=80m
+unphone9.build.flash_mode=dio
+unphone9.build.boot=qio
+unphone9.build.boot_freq=80m
+unphone9.build.partitions=default_8MB
+unphone9.build.defines=-DBOARD_HAS_PSRAM -DUNPHONE_SPIN=9
+unphone9.build.loop_core=-DARDUINO_RUNNING_CORE=1
+unphone9.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+unphone9.build.flash_type=qspi
+unphone9.build.psram_type=qspi
+unphone9.build.memory_type={build.flash_type}_{build.psram_type}
+
+unphone9.menu.USBMode.default=Hardware CDC and JTAG
+unphone9.menu.USBMode.default.build.usb_mode=1
+unphone9.menu.USBMode.hwcdc=USB-OTG (TinyUSB)
+unphone9.menu.USBMode.hwcdc.build.usb_mode=0
+
+unphone9.menu.CDCOnBoot.default=Enabled
+unphone9.menu.CDCOnBoot.default.build.cdc_on_boot=1
+unphone9.menu.CDCOnBoot.cdc=Disabled
+unphone9.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+unphone9.menu.MSCOnBoot.default=Disabled
+unphone9.menu.MSCOnBoot.default.build.msc_on_boot=0
+unphone9.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+unphone9.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+unphone9.menu.DFUOnBoot.default=Disabled
+unphone9.menu.DFUOnBoot.default.build.dfu_on_boot=0
+unphone9.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+unphone9.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+unphone9.menu.UploadMode.default=UART0 / Hardware CDC
+unphone9.menu.UploadMode.default.upload.use_1200bps_touch=false
+unphone9.menu.UploadMode.default.upload.wait_for_upload_port=false
+unphone9.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+unphone9.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+unphone9.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+unphone9.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+unphone9.menu.PartitionScheme.default.build.partitions=default
+unphone9.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+unphone9.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+unphone9.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+unphone9.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+unphone9.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+unphone9.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+unphone9.menu.PartitionScheme.minimal.build.partitions=minimal
+unphone9.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+unphone9.menu.PartitionScheme.no_ota.build.partitions=no_ota
+unphone9.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+unphone9.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+unphone9.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+unphone9.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+unphone9.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+unphone9.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+unphone9.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+unphone9.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+unphone9.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+unphone9.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+unphone9.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+unphone9.menu.PartitionScheme.huge_app.build.partitions=huge_app
+unphone9.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+unphone9.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+unphone9.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+unphone9.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+unphone9.menu.PartitionScheme.rainmaker=RainMaker
+unphone9.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+unphone9.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+unphone9.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
+unphone9.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
+
+unphone9.menu.CPUFreq.240=240MHz (WiFi)
+unphone9.menu.CPUFreq.240.build.f_cpu=240000000L
+unphone9.menu.CPUFreq.160=160MHz (WiFi)
+unphone9.menu.CPUFreq.160.build.f_cpu=160000000L
+unphone9.menu.CPUFreq.80=80MHz (WiFi)
+unphone9.menu.CPUFreq.80.build.f_cpu=80000000L
+unphone9.menu.CPUFreq.40=40MHz
+unphone9.menu.CPUFreq.40.build.f_cpu=40000000L
+unphone9.menu.CPUFreq.20=20MHz
+unphone9.menu.CPUFreq.20.build.f_cpu=20000000L
+unphone9.menu.CPUFreq.10=10MHz
+unphone9.menu.CPUFreq.10.build.f_cpu=10000000L
+
+unphone9.menu.UploadSpeed.921600=921600
+unphone9.menu.UploadSpeed.921600.upload.speed=921600
+unphone9.menu.UploadSpeed.115200=115200
+unphone9.menu.UploadSpeed.115200.upload.speed=115200
+unphone9.menu.UploadSpeed.256000.windows=256000
+unphone9.menu.UploadSpeed.256000.upload.speed=256000
+unphone9.menu.UploadSpeed.230400.windows.upload.speed=256000
+unphone9.menu.UploadSpeed.230400=230400
+unphone9.menu.UploadSpeed.230400.upload.speed=230400
+unphone9.menu.UploadSpeed.460800.linux=460800
+unphone9.menu.UploadSpeed.460800.macosx=460800
+unphone9.menu.UploadSpeed.460800.upload.speed=460800
+unphone9.menu.UploadSpeed.512000.windows=512000
+unphone9.menu.UploadSpeed.512000.upload.speed=512000
+
+unphone9.menu.DebugLevel.none=None
+unphone9.menu.DebugLevel.none.build.code_debug=0
+unphone9.menu.DebugLevel.error=Error
+unphone9.menu.DebugLevel.error.build.code_debug=1
+unphone9.menu.DebugLevel.warn=Warn
+unphone9.menu.DebugLevel.warn.build.code_debug=2
+unphone9.menu.DebugLevel.info=Info
+unphone9.menu.DebugLevel.info.build.code_debug=3
+unphone9.menu.DebugLevel.debug=Debug
+unphone9.menu.DebugLevel.debug.build.code_debug=4
+unphone9.menu.DebugLevel.verbose=Verbose
+unphone9.menu.DebugLevel.verbose.build.code_debug=5
+
 ###############################################################
-
-
-

--- a/tools/partitions/max_app_8MB.csv
+++ b/tools/partitions/max_app_8MB.csv
@@ -1,0 +1,4 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  factory,   0x10000, 0x7F0000,

--- a/variants/unphone8/pins_arduino.h
+++ b/variants/unphone8/pins_arduino.h
@@ -1,0 +1,67 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID            0x16D0
+#define USB_PID            0x1178
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        48
+#define NUM_ANALOG_INPUTS       20
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
+
+#define LED_BUILTIN         13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
+static const uint8_t TX = 37;
+static const uint8_t RX = 36;
+
+static const uint8_t SDA = 1;
+static const uint8_t SCL = 2;
+
+static const uint8_t SS    = 3;
+static const uint8_t MOSI  = 39;
+static const uint8_t MISO  = 40;
+static const uint8_t SCK   = 38;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 8;
+static const uint8_t A3 = 9;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 14;
+static const uint8_t A7 = 7;
+static const uint8_t A8 = 15;
+static const uint8_t A9 = 33;
+static const uint8_t A10 = 27;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 2;
+static const uint8_t T2 = 8;
+static const uint8_t T3 = 9;
+static const uint8_t T4 = 5;
+static const uint8_t T5 = 6;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 15;
+static const uint8_t T9 = 33;
+static const uint8_t T10 = 27;
+static const uint8_t T11 = 12;
+static const uint8_t T12 = 13;
+static const uint8_t T13 = 14;
+static const uint8_t T14 = 15;
+
+#endif /* Pins_Arduino_h */

--- a/variants/unphone9/pins_arduino.h
+++ b/variants/unphone9/pins_arduino.h
@@ -1,0 +1,67 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID            0x16D0
+#define USB_PID            0x1178
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        48
+#define NUM_ANALOG_INPUTS       20
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
+
+#define LED_BUILTIN         13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 3;
+static const uint8_t SCL = 4;
+
+static const uint8_t SS    = 13;
+static const uint8_t MOSI  = 40;
+static const uint8_t MISO  = 41;
+static const uint8_t SCK   = 39;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 8;
+static const uint8_t A3 = 9;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 14;
+static const uint8_t A7 = 7;
+static const uint8_t A8 = 15;
+static const uint8_t A9 = 33;
+static const uint8_t A10 = 27;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 2;
+static const uint8_t T2 = 8;
+static const uint8_t T3 = 9;
+static const uint8_t T4 = 5;
+static const uint8_t T5 = 6;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 15;
+static const uint8_t T9 = 33;
+static const uint8_t T10 = 27;
+static const uint8_t T11 = 12;
+static const uint8_t T12 = 13;
+static const uint8_t T13 = 14;
+static const uint8_t T14 = 15;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Second time doing this - accidentally closed previous #7058 in error!

Is adding a new partition scheme acceptable? 

Please advise if any changes or clarification needed.

Thanks!

Description of Change:
Adds two new pin maps for the unPhone spin 8 and spin 9 to variants/unphone8 and variants/unphone9
Updated boards.txt to add definitions for unphone7 (based on Adafruit ESP32 feather) and unphone 8 and 9 (ESP32-S3)
Added a new partition scheme for 8MB flash variant of ESP32-S3 with maximum program size (7.9MB)

Tests scenarios:
Tested on our prototype hardware with a variety of test sketches, pin assignments seem correct.

Related links:
Hardware description at [unphone.net](https://unphone.net/the-unphone/) and software at https://gitlab.com/hamishcunningham/unphone