### PR TITLE
Cookie(set-cookie) Value are case sensitive

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1551,8 +1551,6 @@ void HTTPClient::setCookie(String date, String headerValue)
     String value;
     int pos1, pos2;
 
-    headerValue.toLowerCase();
-
     struct tm tm;
     strptime(date.c_str(), HTTP_TIME_PATTERN, &tm);
     cookie.date = mktime(&tm);


### PR DESCRIPTION
Cookie(set-cookie) Value are case sensitive, fix HTTPClient.setCookie() , remove headerValue.toLowCase(). (#7112)(#7076)

