### PR TITLE
Use `flash_mode` for `memory_type` when `memory_type` is not set for …

### DIFF
--- a/tools/platformio-build-esp32.py
+++ b/tools/platformio-build-esp32.py
@@ -303,14 +303,14 @@ env.Append(
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "include", "esp32-camera", "driver", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "include", "esp32-camera", "conversions", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "include", "fb_gfx", "include"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32", env.BoardConfig().get("build.arduino.memory_type", "qio_qspi"), "include"),
+        join(FRAMEWORK_DIR, "tools", "sdk", "esp32", env.BoardConfig().get("build.arduino.memory_type", (env.BoardConfig().get("build.flash_mode", "dout") + "_qspi")), "include"),
         join(FRAMEWORK_DIR, "cores", env.BoardConfig().get("build.core"))
     ],
 
     LIBPATH=[
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "lib"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32", "ld"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32", env.BoardConfig().get("build.arduino.memory_type", "qio_qspi"))
+        join(FRAMEWORK_DIR, "tools", "sdk", "esp32", env.BoardConfig().get("build.arduino.memory_type", (env.BoardConfig().get("build.flash_mode", "dout") + "_qspi")))
     ],
 
     LIBS=[

--- a/tools/platformio-build-esp32c3.py
+++ b/tools/platformio-build-esp32c3.py
@@ -298,14 +298,14 @@ env.Append(
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "include", "esp32-camera", "driver", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "include", "esp32-camera", "conversions", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "include", "fb_gfx", "include"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", env.BoardConfig().get("build.arduino.memory_type", "qio_qspi"), "include"),
+        join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", env.BoardConfig().get("build.arduino.memory_type", (env.BoardConfig().get("build.flash_mode", "dout") + "_qspi")), "include"),
         join(FRAMEWORK_DIR, "cores", env.BoardConfig().get("build.core"))
     ],
 
     LIBPATH=[
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "lib"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", "ld"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", env.BoardConfig().get("build.arduino.memory_type", "qio_qspi"))
+        join(FRAMEWORK_DIR, "tools", "sdk", "esp32c3", env.BoardConfig().get("build.arduino.memory_type", (env.BoardConfig().get("build.flash_mode", "dout") + "_qspi")))
     ],
 
     LIBS=[

--- a/tools/platformio-build-esp32s2.py
+++ b/tools/platformio-build-esp32s2.py
@@ -286,14 +286,14 @@ env.Append(
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "include", "esp32-camera", "driver", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "include", "esp32-camera", "conversions", "include"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "include", "fb_gfx", "include"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", env.BoardConfig().get("build.arduino.memory_type", "qio_qspi"), "include"),
+        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", env.BoardConfig().get("build.arduino.memory_type", (env.BoardConfig().get("build.flash_mode", "dout") + "_qspi")), "include"),
         join(FRAMEWORK_DIR, "cores", env.BoardConfig().get("build.core"))
     ],
 
     LIBPATH=[
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "lib"),
         join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", "ld"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", env.BoardConfig().get("build.arduino.memory_type", "qio_qspi"))
+        join(FRAMEWORK_DIR, "tools", "sdk", "esp32s2", env.BoardConfig().get("build.arduino.memory_type", (env.BoardConfig().get("build.flash_mode", "dout") + "_qspi")))
     ],
 
     LIBS=[


### PR DESCRIPTION
…ESP32, C3 and S2 when using Platformio

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Without this change always the lib from path "tools", "sdk", "esp32<xx>", "qio_qspi" is included for ESP32, C3 and S2
The PR uses for memory_mode the setting from `flash_mode`. There are no other memory_modes for this devices.
The behaviour for S3 is not changed since it needs a correct set `memory_type` to work.

## Related links
Solves https://github.com/platformio/platform-espressif32/issues/877

(*eg. Closes #number of issue*)
