### PR TITLE
fixed names on the VID and PID for my boards in boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -17114,8 +17114,8 @@ department_of_alchemy_minimain_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 ##############################################################
 
 Bee_Motion_S3.name=Bee Motion S3
-Bee_Motion_Mini.vid.0=0x303a
-Bee_Motion_Mini.pid.0=0x8113
+Bee_Motion_S3.vid.0=0x303a
+Bee_Motion_S3.pid.0=0x8113
 
 Bee_Motion_S3.bootloader.tool=esptool_py
 Bee_Motion_S3.bootloader.tool.default=esptool_py
@@ -17223,8 +17223,8 @@ Bee_Motion_S3.menu.EraseFlash.all.upload.erase_cmd=-e
 ########################################################################
 
 Bee_Motion.name=Bee Motion
-Bee_Motion_Mini.vid.0=0x303a
-Bee_Motion_Mini.pid.0=0x810D
+Bee_Motion.vid.0=0x303a
+Bee_Motion.pid.0=0x810D
 
 Bee_Motion.bootloader.tool=esptool_py
 Bee_Motion.bootloader.tool.default=esptool_py
@@ -17440,8 +17440,8 @@ Bee_Motion_Mini.menu.EraseFlash.all.upload.erase_cmd=-e
 ###############################################################
 
 Bee_S3.name=Bee S3
-Bee_Motion_Mini.vid.0=0x303a
-Bee_Motion_Mini.pid.0=0x8110
+Bee_S3.vid.0=0x303a
+Bee_S3.pid.0=0x8110
 
 Bee_S3.bootloader.tool=esptool_py
 Bee_S3.bootloader.tool.default=esptool_py


### PR DESCRIPTION
i somehow had duplicated the same name across all my boards for the PIDs and VIDs. the PID's and VID's themselves were correct, but the name was the same for all of them. that is fixed now.
