### PR TITLE
Get real Flash Chip Size via API call

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -305,13 +305,17 @@ const char * EspClass::getSdkVersion(void)
     return esp_get_idf_version();
 }
 
+uint32_t ESP_getFlashChipId(void)
+{
+  uint32_t id = g_rom_flashchip.device_id;
+  id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
+  return id;
+}
+
 uint32_t EspClass::getFlashChipSize(void)
 {
-    esp_image_header_t fhdr;
-    if(flashRead(ESP_FLASH_IMAGE_BASE, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
-        return 0;
-    }
-    return magicFlashChipSize(fhdr.spi_size);
+  uint32_t id = (ESP_getFlashChipId() >> 16) & 0xFF;
+  return 2 << (id - 1);
 }
 
 uint32_t EspClass::getFlashChipSpeed(void)


### PR DESCRIPTION
actually only the value from the IDE which has been set is read from magic header.
Now the real size is read from the flash chip.

Credits got to @Staars

Fixes #7157

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

