### PR TITLE
Add default SPI pin definitions if not defined in pins_arduino.h

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -30,54 +30,6 @@
 #define SPI_PARAM_UNLOCK()
 #endif
 
-#ifndef SCK
-#if CONFIG_IDF_TARGET_ESP32
-#define SCK 18
-#elif CONFIG_IDF_TARGET_ESP32S2
-#define SCK 36
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define SCK 12
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define SCK 4
-#endif
-#endif
-
-#ifndef MISO
-#if CONFIG_IDF_TARGET_ESP32
-#define MISO 19
-#elif CONFIG_IDF_TARGET_ESP32S2
-#define MISO 37
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define MISO 13
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define MISO 5
-#endif
-#endif
-
-#ifndef MOSI
-#if CONFIG_IDF_TARGET_ESP32
-#define MOSI 23
-#elif CONFIG_IDF_TARGET_ESP32S2
-#define MOSI 35
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define MOSI 11
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define MOSI 6
-#endif
-#endif
-
-#ifndef SS
-#if CONFIG_IDF_TARGET_ESP32
-#define SS 5
-#elif CONFIG_IDF_TARGET_ESP32S2
-#define SS 34
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define SS 10
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define SS 7
-#endif
-#endif
-
 SPIClass::SPIClass(uint8_t spi_bus)
     :_spi_num(spi_bus)
     ,_spi(NULL)

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -30,6 +30,54 @@
 #define SPI_PARAM_UNLOCK()
 #endif
 
+#ifndef SCK
+#if CONFIG_IDF_TARGET_ESP32
+#define SCK 18
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define SCK 36
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define SCK 12
+#elif CONFIG_IDF_TARGET_ESP32C3
+#define SCK 4
+#endif
+#endif
+
+#ifndef MISO
+#if CONFIG_IDF_TARGET_ESP32
+#define MISO 19
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define MISO 37
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define MISO 13
+#elif CONFIG_IDF_TARGET_ESP32C3
+#define MISO 5
+#endif
+#endif
+
+#ifndef MOSI
+#if CONFIG_IDF_TARGET_ESP32
+#define MOSI 23
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define MOSI 35
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define MOSI 11
+#elif CONFIG_IDF_TARGET_ESP32C3
+#define MOSI 6
+#endif
+#endif
+
+#ifndef SS
+#if CONFIG_IDF_TARGET_ESP32
+#define SS 5
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define SS 34
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define SS 10
+#elif CONFIG_IDF_TARGET_ESP32C3
+#define SS 7
+#endif
+#endif
+
 SPIClass::SPIClass(uint8_t spi_bus)
     :_spi_num(spi_bus)
     ,_spi(NULL)

--- a/variants/d32_pro/pins_arduino.h
+++ b/variants/d32_pro/pins_arduino.h
@@ -9,6 +9,10 @@ static const uint8_t LED_BUILTIN = 5;
 #define LED_BUILTIN LED_BUILTIN
 static const uint8_t _VBAT = 35; // battery voltage
 
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
 
 #define TF_CS   4  // TF (Micro SD Card) CS pin
 #define TS_CS   12 // Touch Screen CS pin

--- a/variants/d32_pro/pins_arduino.h
+++ b/variants/d32_pro/pins_arduino.h
@@ -9,11 +9,6 @@ static const uint8_t LED_BUILTIN = 5;
 #define LED_BUILTIN LED_BUILTIN
 static const uint8_t _VBAT = 35; // battery voltage
 
-static const uint8_t SS    = 5;
-static const uint8_t MOSI  = 23;
-static const uint8_t MISO  = 19;
-static const uint8_t SCK   = 18;
-
 #define TF_CS   4  // TF (Micro SD Card) CS pin
 #define TS_CS   12 // Touch Screen CS pin
 #define TFT_CS  14 // TFT CS pin

--- a/variants/metro_esp-32/pins_arduino.h
+++ b/variants/metro_esp-32/pins_arduino.h
@@ -22,4 +22,9 @@ static const uint8_t SCL = 22;
 
 static const uint8_t ADR = 12;
 
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
 #endif /* Pins_Arduino_h */

--- a/variants/wt32-eth01/pins_arduino.h
+++ b/variants/wt32-eth01/pins_arduino.h
@@ -52,4 +52,14 @@ static const uint8_t RXD2 = 5, RXD = 5;
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
+//SPI VSPI default pins
+static const uint8_t SS    = -1;
+static const uint8_t MOSI  = 15;
+static const uint8_t MISO  = 12;
+static const uint8_t SCK   = 14;
+
+//I2C default pins
+static const uint8_t SDA = 2;
+static const uint8_t SCL = 4;
+
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Added to some boards missing default pin declaration for SPI in `pins_arduino.h` + some I2C. Fixing SPI error in compilation.

Boards:
metro_esp-32
wt32-eth01

## Tests scenarios
Variant [wt32-eth01](https://github.com/espressif/arduino-esp32/tree/master/variants/wt32-eth01)

## Related links
Closes #7160 
