### PR TITLE
Fixed switch rename issue in examples espressif/esp-rainmaker#152

### DIFF
--- a/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
+++ b/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
@@ -31,12 +31,12 @@ LightSwitch switch_ch1 = {gpio_switch1, false};
 LightSwitch switch_ch2 = {gpio_switch2, false};
 
 //The framework provides some standard device types like switch, lightbulb, fan, temperature sensor.
-static Switch my_switch1("Switch_ch1", &gpio_relay1);
-static Switch my_switch2("Switch_ch2", &gpio_relay2);
+static Switch my_switch1;
+static Switch my_switch2;
 
 void sysProvEvent(arduino_event_t *sys_event)
 {
-    switch (sys_event->event_id) {      
+    switch (sys_event->event_id) {
         case ARDUINO_EVENT_PROV_START:
 #if CONFIG_IDF_TARGET_ESP32
         Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
@@ -44,7 +44,7 @@ void sysProvEvent(arduino_event_t *sys_event)
 #else
         Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
         printQR(service_name, pop, "softap");
-#endif        
+#endif
         break;
         case ARDUINO_EVENT_WIFI_STA_CONNECTED:
         Serial.printf("\nConnected to Wi-Fi!\n");
@@ -60,18 +60,18 @@ void write_callback(Device *device, Param *param, const param_val_t val, void *p
     const char *param_name = param->getParamName();
 
     if(strcmp(device_name, "Switch_ch1") == 0) {
-      
+
       Serial.printf("Lightbulb = %s\n", val.val.b? "true" : "false");
-      
+
       if(strcmp(param_name, "Power") == 0) {
           Serial.printf("Received value = %s for %s - %s\n", val.val.b? "true" : "false", device_name, param_name);
         switch_state_ch1 = val.val.b;
         (switch_state_ch1 == false) ? digitalWrite(gpio_relay1, LOW) : digitalWrite(gpio_relay1, HIGH);
         param->updateAndReport(val);
       }
-      
+
     } else if(strcmp(device_name, "Switch_ch2") == 0) {
-      
+
       Serial.printf("Switch value = %s\n", val.val.b? "true" : "false");
 
       if(strcmp(param_name, "Power") == 0) {
@@ -80,9 +80,9 @@ void write_callback(Device *device, Param *param, const param_val_t val, void *p
         (switch_state_ch2 == false) ? digitalWrite(gpio_relay2, LOW) : digitalWrite(gpio_relay2, HIGH);
         param->updateAndReport(val);
       }
-  
+
     }
- 
+
 }
 
 void ARDUINO_ISR_ATTR isr(void* arg) {
@@ -92,8 +92,9 @@ void ARDUINO_ISR_ATTR isr(void* arg) {
 
 void setup()
 {
+
     uint32_t chipId = 0;
-    
+
     Serial.begin(115200);
 
     // Configure the input GPIOs
@@ -102,7 +103,7 @@ void setup()
     attachInterruptArg(switch_ch1.pin, isr, &switch_ch1, CHANGE);
     pinMode(switch_ch2.pin, INPUT_PULLUP);
     attachInterruptArg(switch_ch2.pin, isr, &switch_ch2, CHANGE);
-    
+
     // Set the Relays GPIOs as output mode
     pinMode(gpio_relay1, OUTPUT);
     pinMode(gpio_relay2, OUTPUT);
@@ -112,20 +113,24 @@ void setup()
     digitalWrite(gpio_relay2, DEFAULT_POWER_MODE);
     digitalWrite(gpio_led, false);
 
-    Node my_node;    
+    Node my_node;
     my_node = RMaker.initNode("Sonoff Dual R3");
+
+    //Initialize switch device
+    my_switch1 = Switch("Switch_ch1", &gpio_relay1);
+    my_switch2 = Switch("Switch_ch2", &gpio_relay2);
 
     //Standard switch device
     my_switch1.addCb(write_callback);
     my_switch2.addCb(write_callback);
 
-    //Add switch device to the node   
+    //Add switch device to the node
     my_node.addDevice(my_switch1);
     my_node.addDevice(my_switch2);
 
-    //This is optional 
+    //This is optional
     RMaker.enableOTA(OTA_USING_PARAMS);
-    //If you want to enable scheduling, set time zone for your region using setTimeZone(). 
+    //If you want to enable scheduling, set time zone for your region using setTimeZone().
     //The list of available values are provided here https://rainmaker.espressif.com/docs/time-service.html
     // RMaker.setTimeZone("Asia/Shanghai");
     // Alternatively, enable the Timezone service and let the phone apps set the appropriate timezone

--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -21,11 +21,11 @@ static int gpio_switch = 16;
 bool switch_state = true;
 
 //The framework provides some standard device types like switch, lightbulb, fan, temperaturesensor.
-static Switch my_switch("Switch", &gpio_switch);
+static Switch my_switch;
 
 void sysProvEvent(arduino_event_t *sys_event)
 {
-    switch (sys_event->event_id) {      
+    switch (sys_event->event_id) {
         case ARDUINO_EVENT_PROV_START:
 #if CONFIG_IDF_TARGET_ESP32S2
         Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
@@ -33,7 +33,7 @@ void sysProvEvent(arduino_event_t *sys_event)
 #else
         Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
         printQR(service_name, pop, "ble");
-#endif         
+#endif
         break;
         default:;
     }
@@ -59,18 +59,21 @@ void setup()
     pinMode(gpio_switch, OUTPUT);
     digitalWrite(gpio_switch, DEFAULT_POWER_MODE);
 
-    Node my_node;    
+    Node my_node;
     my_node = RMaker.initNode("ESP RainMaker Node");
+
+    //Initialize switch device
+    my_switch = Switch("Switch", &gpio_switch);
 
     //Standard switch device
     my_switch.addCb(write_callback);
-    
-    //Add switch device to the node   
+
+    //Add switch device to the node
     my_node.addDevice(my_switch);
 
-    //This is optional 
+    //This is optional
     RMaker.enableOTA(OTA_USING_PARAMS);
-    //If you want to enable scheduling, set time zone for your region using setTimeZone(). 
+    //If you want to enable scheduling, set time zone for your region using setTimeZone().
     //The list of available values are provided here https://rainmaker.espressif.com/docs/time-service.html
     // RMaker.setTimeZone("Asia/Shanghai");
     // Alternatively, enable the Timezone service and let the phone apps set the appropriate timezone


### PR DESCRIPTION
Fixed issue wherein changing the name of switches was not getting reflected in the phone app after the device reboots.
I have tested this on ESP32 using Arduino 2.0.3 and Rainmaker Android app
Closes espressif/esp-rainmaker#152
