### PR TITLE
Adding u-blox NORA-W10 series (ESP32-S3)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -4914,7 +4914,7 @@ nora_w10.menu.FlashSize.8M=8MB (64Mb)
 nora_w10.menu.FlashSize.8M.build.flash_size=8MB
 nora_w10.menu.FlashSize.8M.build.partitions=default_8MB
 #nora_w10.menu.FlashSize.16M=16MB (128Mb)
-#ßnora_w10.menu.FlashSize.16M.build.flash_size=16MB
+#nora_w10.menu.FlashSize.16M.build.flash_size=16MB
 #nora_w10.menu.FlashSize.32M=32MB (256Mb)
 #nora_w10.menu.FlashSize.32M.build.flash_size=32MB
 

--- a/boards.txt
+++ b/boards.txt
@@ -4831,6 +4831,210 @@ nina_w10.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+nora_w10.name=u-blox NORA-W10 series (ESP32-S3)
+nora_w10.vid.0=0x303a
+nora_w10.pid.0=0x1001
+
+nora_w10.bootloader.tool=esptool_py
+nora_w10.bootloader.tool.default=esptool_py
+
+nora_w10.upload.tool=esptool_py
+nora_w10.upload.tool.default=esptool_py
+nora_w10.upload.tool.network=esp_ota
+
+nora_w10.upload.maximum_size=1310720
+nora_w10.upload.maximum_data_size=327680
+nora_w10.upload.flags=
+nora_w10.upload.extra_flags=
+nora_w10.upload.use_1200bps_touch=false
+nora_w10.upload.wait_for_upload_port=false
+
+nora_w10.serial.disableDTR=false
+nora_w10.serial.disableRTS=false
+
+nora_w10.build.tarch=xtensa
+nora_w10.build.bootloader_addr=0x0
+nora_w10.build.target=esp32s3
+nora_w10.build.mcu=esp32s3
+nora_w10.build.core=esp32
+nora_w10.build.variant=nora_w10
+nora_w10.build.board=UBLOX_NORA_W10
+
+nora_w10.build.usb_mode=1
+nora_w10.build.cdc_on_boot=0
+nora_w10.build.msc_on_boot=0
+nora_w10.build.dfu_on_boot=0
+nora_w10.build.f_cpu=240000000L
+nora_w10.build.flash_size=4MB
+nora_w10.build.flash_freq=80m
+nora_w10.build.flash_mode=dio
+nora_w10.build.boot=qio
+nora_w10.build.boot_freq=80m
+nora_w10.build.partitions=default
+nora_w10.build.defines=
+nora_w10.build.loop_core=
+nora_w10.build.event_core=
+nora_w10.build.psram_type=qspi
+nora_w10.build.memory_type={build.boot}_{build.psram_type}
+
+nora_w10.menu.PSRAM.disabled=Disabled
+nora_w10.menu.PSRAM.disabled.build.defines=
+nora_w10.menu.PSRAM.disabled.build.psram_type=qspi
+nora_w10.menu.PSRAM.enabled=QSPI PSRAM
+nora_w10.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+nora_w10.menu.PSRAM.enabled.build.psram_type=qspi
+nora_w10.menu.PSRAM.opi=OPI PSRAM
+nora_w10.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+nora_w10.menu.PSRAM.opi.build.psram_type=opi
+
+nora_w10.menu.FlashMode.qio=QIO 80MHz
+nora_w10.menu.FlashMode.qio.build.flash_mode=dio
+nora_w10.menu.FlashMode.qio.build.boot=qio
+nora_w10.menu.FlashMode.qio.build.boot_freq=80m
+nora_w10.menu.FlashMode.qio.build.flash_freq=80m
+nora_w10.menu.FlashMode.qio120=QIO 120MHz
+nora_w10.menu.FlashMode.qio120.build.flash_mode=dio
+nora_w10.menu.FlashMode.qio120.build.boot=qio
+nora_w10.menu.FlashMode.qio120.build.boot_freq=120m
+nora_w10.menu.FlashMode.qio120.build.flash_freq=80m
+nora_w10.menu.FlashMode.dio=DIO 80MHz
+nora_w10.menu.FlashMode.dio.build.flash_mode=dio
+nora_w10.menu.FlashMode.dio.build.boot=dio
+nora_w10.menu.FlashMode.dio.build.boot_freq=80m
+nora_w10.menu.FlashMode.dio.build.flash_freq=80m
+nora_w10.menu.FlashMode.opi=OPI 80MHz
+nora_w10.menu.FlashMode.opi.build.flash_mode=dout
+nora_w10.menu.FlashMode.opi.build.boot=opi
+nora_w10.menu.FlashMode.opi.build.boot_freq=80m
+nora_w10.menu.FlashMode.opi.build.flash_freq=80m
+
+nora_w10.menu.FlashSize.4M=4MB (32Mb)
+nora_w10.menu.FlashSize.4M.build.flash_size=4MB
+nora_w10.menu.FlashSize.8M=8MB (64Mb)
+nora_w10.menu.FlashSize.8M.build.flash_size=8MB
+nora_w10.menu.FlashSize.8M.build.partitions=default_8MB
+#nora_w10.menu.FlashSize.16M=16MB (128Mb)
+#ßnora_w10.menu.FlashSize.16M.build.flash_size=16MB
+#nora_w10.menu.FlashSize.32M=32MB (256Mb)
+#nora_w10.menu.FlashSize.32M.build.flash_size=32MB
+
+nora_w10.menu.LoopCore.1=Core 1
+nora_w10.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+nora_w10.menu.LoopCore.0=Core 0
+nora_w10.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+nora_w10.menu.EventsCore.1=Core 1
+nora_w10.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+nora_w10.menu.EventsCore.0=Core 0
+nora_w10.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+nora_w10.menu.USBMode.hwcdc=Hardware CDC and JTAG
+nora_w10.menu.USBMode.hwcdc.build.usb_mode=1
+nora_w10.menu.USBMode.default=USB-OTG (TinyUSB)
+nora_w10.menu.USBMode.default.build.usb_mode=0
+
+nora_w10.menu.CDCOnBoot.default=Disabled
+nora_w10.menu.CDCOnBoot.default.build.cdc_on_boot=0
+nora_w10.menu.CDCOnBoot.cdc=Enabled
+nora_w10.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+nora_w10.menu.MSCOnBoot.default=Disabled
+nora_w10.menu.MSCOnBoot.default.build.msc_on_boot=0
+nora_w10.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+nora_w10.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+nora_w10.menu.DFUOnBoot.default=Disabled
+nora_w10.menu.DFUOnBoot.default.build.dfu_on_boot=0
+nora_w10.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+nora_w10.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+nora_w10.menu.UploadMode.default=UART0 / Hardware CDC
+nora_w10.menu.UploadMode.default.upload.use_1200bps_touch=false
+nora_w10.menu.UploadMode.default.upload.wait_for_upload_port=false
+nora_w10.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+nora_w10.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+nora_w10.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+nora_w10.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+nora_w10.menu.PartitionScheme.default.build.partitions=default
+nora_w10.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+nora_w10.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+nora_w10.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+nora_w10.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+nora_w10.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+nora_w10.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+nora_w10.menu.PartitionScheme.minimal.build.partitions=minimal
+nora_w10.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+nora_w10.menu.PartitionScheme.no_ota.build.partitions=no_ota
+nora_w10.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+nora_w10.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+nora_w10.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+nora_w10.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+nora_w10.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+nora_w10.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+nora_w10.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+nora_w10.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+nora_w10.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+nora_w10.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+nora_w10.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+nora_w10.menu.PartitionScheme.huge_app.build.partitions=huge_app
+nora_w10.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+nora_w10.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+nora_w10.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+nora_w10.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+#nora_w10.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FAT)
+#nora_w10.menu.PartitionScheme.fatflash.build.partitions=ffat
+#nora_w10.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+#nora_w10.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
+#nora_w10.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+#nora_w10.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+nora_w10.menu.PartitionScheme.rainmaker=RainMaker
+nora_w10.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+nora_w10.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+nora_w10.menu.CPUFreq.240=240MHz (WiFi)
+nora_w10.menu.CPUFreq.240.build.f_cpu=240000000L
+nora_w10.menu.CPUFreq.160=160MHz (WiFi)
+nora_w10.menu.CPUFreq.160.build.f_cpu=160000000L
+nora_w10.menu.CPUFreq.80=80MHz (WiFi)
+nora_w10.menu.CPUFreq.80.build.f_cpu=80000000L
+nora_w10.menu.CPUFreq.40=40MHz
+nora_w10.menu.CPUFreq.40.build.f_cpu=40000000L
+nora_w10.menu.CPUFreq.20=20MHz
+nora_w10.menu.CPUFreq.20.build.f_cpu=20000000L
+nora_w10.menu.CPUFreq.10=10MHz
+nora_w10.menu.CPUFreq.10.build.f_cpu=10000000L
+
+nora_w10.menu.UploadSpeed.921600=921600
+nora_w10.menu.UploadSpeed.921600.upload.speed=921600
+nora_w10.menu.UploadSpeed.115200=115200
+nora_w10.menu.UploadSpeed.115200.upload.speed=115200
+nora_w10.menu.UploadSpeed.256000.windows=256000
+nora_w10.menu.UploadSpeed.256000.upload.speed=256000
+nora_w10.menu.UploadSpeed.230400.windows.upload.speed=256000
+nora_w10.menu.UploadSpeed.230400=230400
+nora_w10.menu.UploadSpeed.230400.upload.speed=230400
+nora_w10.menu.UploadSpeed.460800.linux=460800
+nora_w10.menu.UploadSpeed.460800.macosx=460800
+nora_w10.menu.UploadSpeed.460800.upload.speed=460800
+nora_w10.menu.UploadSpeed.512000.windows=512000
+nora_w10.menu.UploadSpeed.512000.upload.speed=512000
+
+nora_w10.menu.DebugLevel.none=None
+nora_w10.menu.DebugLevel.none.build.code_debug=0
+nora_w10.menu.DebugLevel.error=Error
+nora_w10.menu.DebugLevel.error.build.code_debug=1
+nora_w10.menu.DebugLevel.warn=Warn
+nora_w10.menu.DebugLevel.warn.build.code_debug=2
+nora_w10.menu.DebugLevel.info=Info
+nora_w10.menu.DebugLevel.info.build.code_debug=3
+nora_w10.menu.DebugLevel.debug=Debug
+nora_w10.menu.DebugLevel.debug.build.code_debug=4
+nora_w10.menu.DebugLevel.verbose=Verbose
+nora_w10.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 widora-air.name=Widora AIR
 
 widora-air.bootloader.tool=esptool_py

--- a/variants/nora_w10/pins_arduino.h
+++ b/variants/nora_w10/pins_arduino.h
@@ -1,0 +1,93 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        48
+#define NUM_ANALOG_INPUTS       20
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
+
+// The pin assignments in this file are based on u-blox EVK-NORA-W1, a Arduino compatible board.
+// For your own module design you can freely chose the pins available on the module module pins
+
+static const uint8_t TX   = 43;
+static const uint8_t RX   = 44;
+static const uint8_t RTS  = 45;
+static const uint8_t CTS  =  6;
+static const uint8_t DTR  =  1; 
+static const uint8_t DSR  =  7; 
+
+static const uint8_t SW1  = 46;
+static const uint8_t SW2  =  0; // BOOT
+static const uint8_t SW3  = 47; 
+static const uint8_t SW4  = 48; 
+
+static const uint8_t LED_RED 	= 5;
+static const uint8_t LED_GREEN 	= 2;
+static const uint8_t LED_BLUE	= 8;
+#define BUILTIN_LED  LED_BLUE 	// backward compatibility
+#define LED_BUILTIN  LED_BLUE
+
+static const uint8_t SS   = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 13;
+static const uint8_t SCK  = 12;
+
+static const uint8_t A0   = 11;
+static const uint8_t A1   = 12;
+static const uint8_t A2   = 13;
+static const uint8_t A3   =  5;
+static const uint8_t A4   = 15;
+static const uint8_t A5   = 16;
+
+static const uint8_t D0   = 44; // RX0
+static const uint8_t D1   = 43; // TX0
+static const uint8_t D2   = 46; 
+static const uint8_t D3   =  4;
+static const uint8_t D4   =  3;
+static const uint8_t D5   =  2;
+static const uint8_t D6   = 14;
+static const uint8_t D7   = 10;
+
+static const uint8_t D8   = 33;
+static const uint8_t D9   = 38;	
+static const uint8_t D10  = 34; // SS
+static const uint8_t D11  = 35; // MOSI
+static const uint8_t D12  = 37; // MISO
+static const uint8_t D13  = 36; // SCK
+static const uint8_t SDA1 = 21;	
+static const uint8_t SCL1 =  0;
+
+static const uint8_t D14  = 45; // RTS
+static const uint8_t D15  =  6; // CTS
+static const uint8_t D16  =  1;	// DTR 
+static const uint8_t D17  =  7;	// DSR
+static const uint8_t D18  = 47;
+static const uint8_t D19  = 48;
+static const uint8_t SDA  = 18;
+static const uint8_t SCL  = 17;
+
+static const uint8_t T1   =  1;
+static const uint8_t T2   =  2;
+static const uint8_t T3   =  3;
+static const uint8_t T4   =  4;
+static const uint8_t T5   =  5;
+static const uint8_t T6   =  6;
+static const uint8_t T7   =  7;
+static const uint8_t T8   =  8;
+static const uint8_t T9   =  9;
+static const uint8_t T10  = 10;
+static const uint8_t T11  = 11;
+static const uint8_t T12  = 12;
+static const uint8_t T13  = 13;
+static const uint8_t T14  = 14;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Adding support for the small 10x14mm ESP32-S3 based u-blox NORA-W106 and NORA-W101 industrial module. 

- Default peripheral pins assignment is based on the EVK-NORA-W1 Arduino compatible board.
- NORA-W1 series has a 8MB flash, so therefore 16MB flash sizes removed from the menu.

## Tests scenarios
Tested on EVK-NORA-W106 evaluation kit and USB-NORA-W1 USB stick breakout board. 

## Related links

[u-blox NORA-W1 webpage and documentation](https://www.u-blox.com/en/product/NORA-W10-series)
