### PR TITLE
Doc addition: How to compile libs with different debug level

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -11,3 +11,7 @@ To use the arduino-esp32 core with a modified sdkconfig option, you need to use 
 
 Note that modifying ``sdkconfig`` or ``sdkconfig.h`` files found in the arduino-esp32 project tree **does not** result in changes to these options. This is because ESP-IDF libraries are included into the arduino-esp32 project tree as pre-built libraries.
 
+How to compile libs with different debug level?
+-----------------------------------------------
+
+The short answer is ``esp32-arduino-lib-builder/configs/defconfig.common:44``. A guide explaining the process can be found here <guides/core_debug>

--- a/docs/source/guides/core_debug.rst
+++ b/docs/source/guides/core_debug.rst
@@ -22,7 +22,6 @@ Edit **line 44** containing by default ``CONFIG_LOG_DEFAULT_LEVEL_ERROR=y`` to o
 
 Then simply build the libs for all SoCs or one specific SoC. Note that building for all SoCs takes a lot of time, so if you are working only with specific SoC(s), build only for those.
 
-
 .. note::
    If you have copied the ``defconfig`` file and the debug settings are in file ``configs/defconfig.debug`` add flag ``debug`` to compilation command.
    Example : ``./build.sh debug``

--- a/docs/source/guides/core_debug.rst
+++ b/docs/source/guides/core_debug.rst
@@ -1,0 +1,42 @@
+##################################
+Compile Arduino libs with ESP_LOGx
+##################################
+
+There 2 basic aproaches. Both of them involve editting file ``configs/defconfig.common``.
+Edit the file directly and then build.
+Later you can ``git restore configs/defconfig.common`` to go back.
+Copy the file ``cp configs/defconfig.common configs/defconfig.debug`` and edit the debug version.
+
+``vim configs/defconfig.common`` or ``vim configs/defconfig.debug``
+
+Edit **line 44** containing by default ``CONFIG_LOG_DEFAULT_LEVEL_ERROR=y`` to one of the following lines depending on your desired log level:
+
+.. code-block:: bash
+
+   CONFIG_LOG_DEFAULT_LEVEL_NONE=y # No output
+   CONFIG_LOG_DEFAULT_LEVEL_ERROR=y # Errors - default
+   CONFIG_LOG_DEFAULT_LEVEL_WARN=y # Warnings
+   CONFIG_LOG_DEFAULT_LEVEL_INFO=y # Info
+   CONFIG_LOG_DEFAULT_LEVEL_DEBUG=y # Debug
+   CONFIG_LOG_DEFAULT_LEVEL_VERBOSE=y # Verbose
+
+Then simply build the libs for all SoCs or one specific SoC. Note that building for all SoCs takes a lot of time, so if you are working only with specific SoC(s), build only for those.
+
+
+.. note::
+   If you have copied the ``defconfig`` file and the debug settings are in file ``configs/defconfig.debug`` add flag ``debug`` to compilation command.
+   Example : ``./build.sh debug``
+
+   - **Option 1**: Build for all SoCs: ``./build.sh``
+   - **Option 2**: Build for one SoC: ``./build.sh -t <soc>``. The exact text to choose the SoC:
+
+      - ``esp32``
+      - ``esp32s2``
+      - ``esp32c3``
+      - ``esp32s3``
+      - Example: ``./build.sh -t esp32``
+      - A wrong format or non-existing SoC will result in the error sed: can't read sdkconfig: No such file or directory
+   - **Option 3**: Build for multiple SoCs (not all) - simply write them down separated with space: ``./build.sh -t <soc1> <soc2> <soc3>``
+
+      - Example: ``./build.sh -t esp32 esp32-c3``
+

--- a/docs/source/guides/core_debug.rst
+++ b/docs/source/guides/core_debug.rst
@@ -2,7 +2,7 @@
 Compile Arduino libs with ESP_LOGx
 ##################################
 
-There 2 basic aproaches. Both of them involve editting file ``configs/defconfig.common``.
+There are 2 primary approaches and both of them involve editing file ``configs/defconfig.common``.
 Edit the file directly and then build.
 Later you can ``git restore configs/defconfig.common`` to go back.
 Copy the file ``cp configs/defconfig.common configs/defconfig.debug`` and edit the debug version.


### PR DESCRIPTION
## Description of Change

- Added new file `docs/source/guides/core_debug.rst` explaining in detail how to modify libuilder to compile with different log level.
- Added minimal tip + link into FAQ

## Tests scenarios
Tested only an rst preview, but I don't know how will it actually draw on a web page.

## Related links
https://github.com/espressif/esp32-arduino-lib-builder/issues/79