### PR TITLE
Remove unnecessary xSemaphoreTake() of USBHID semaphore

### DIFF
--- a/libraries/USB/src/USBHID.cpp
+++ b/libraries/USB/src/USBHID.cpp
@@ -331,11 +331,16 @@ bool USBHID::SendReport(uint8_t id, const void* data, size_t len, uint32_t timeo
     if(!res){
         log_e("not ready");
     } else {
+        // The semaphore may be given if the last SendReport() timed out waiting for the report to
+        // be sent. Or, tud_hid_report_complete_cb() may be called an extra time, causing the
+        // semaphore to be given. In these cases, take the semaphore to clear its state so that
+        // we can wait for it to be given after calling tud_hid_n_report().
+        xSemaphoreTake(tinyusb_hid_device_input_sem, 0);
+
         res = tud_hid_n_report(0, id, data, len);
         if(!res){
             log_e("report %u failed", id);
         } else {
-            xSemaphoreTake(tinyusb_hid_device_input_sem, 0);
             if(xSemaphoreTake(tinyusb_hid_device_input_sem, timeout_ms / portTICK_PERIOD_MS) != pdTRUE){
                 log_e("report %u wait failed", id);
                 res = false;


### PR DESCRIPTION
## Description of Change
The HID semaphore allows `USBHID::SendReport()` to wait for the completion of
report sending. There seemed to be an extra call to `xSemaphoreTake()` of this
semaphore that served no purpose.

With this extra call, occasionally, the following would happening:

1. `USBHID::SendReport()` would send a report by calling `tud_hid_n_report()`.
2. The send would complete and (presumably on another thread)
   `tud_hid_report_complete_cb()` would be called and it would `xSemaphoreGive()`
   the semaphore.
3. In `USBHID::SendReport()`, the extra `xSemaphoreTake(sem, 0)` would succeed,
   taking the semaphore.
4. On the next line, `xSemaphoreTake(sem, timeout_ms ...)` would timeout
   because the semaphore was already taken by the previous line of code.

The result would be waiting `timeout_ms` for no reason.

The fix is to eliminate the extra unnecessary call to `xSemaphoreTake()`.

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.4 with ESP32-S2 Board with this scenario.

While testing, I used `millis()` to time how long the calls to `xSemaphoreTake()` would take.
