### PR TITLE
[NORA-W1] Fix SPI pin assignments to match Arduino pinout.

### DIFF
--- a/variants/nina_w10/pins_arduino.h
+++ b/variants/nina_w10/pins_arduino.h
@@ -23,10 +23,10 @@ static const uint8_t RX = 3;
 static const uint8_t SDA = 12;
 static const uint8_t SCL = 13;
 
-static const uint8_t SS    = 5;
-static const uint8_t MOSI  = 23;
-static const uint8_t MISO  = 19;
-static const uint8_t SCK   = 18;
+static const uint8_t SS    = 34;
+static const uint8_t MOSI  = 35;
+static const uint8_t MISO  = 37;
+static const uint8_t SCK   = 36;
 
 static const uint8_t A0 = 36;
 static const uint8_t A3 = 39;


### PR DESCRIPTION
## Description of Change
- fixing the default pin assignment for the SPI peripheral for target added Yesterday.  
 
## Tests scenarios
- tested on EVK-NORA-W10