### PR TITLE
Updated warning message displayed when building as IDF component

### DIFF
--- a/libraries/WiFiClientSecure/src/ssl_client.cpp
+++ b/libraries/WiFiClientSecure/src/ssl_client.cpp
@@ -21,7 +21,7 @@
 #include "WiFi.h"
 
 #if !defined(MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED) && !defined(MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED)
-#  warning "Please configure IDF framework to include mbedTLS -> Enable PSK based ciphersuite modes (MBEDTLS_KEY_EXCHANGE_PSK) and activate at least one cipher"
+#  warning "Please call `idf.py menuconfig` then go to Component config -> mbedTLS -> TLS Key Exchange Methods -> Enable pre-shared-key ciphersuites and then check `Enable PSK based cyphersuite modes`. Save and Quit."
 #else
 
 const char *pers = "esp32-tls";


### PR DESCRIPTION
## Description of Change
Updated warning message displayed when building as IDF component.
The previous message was not helpful.
New message lead the user through `menuconfig`

## Tests scenarios
none

## Related links
none