### PR TITLE
Adds noInterrupt() and interrupt() functionality

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -80,8 +80,10 @@
 #define sq(x) ((x)*(x))
 
 // ESP32xx runs FreeRTOS... disabling interrupts can lead to issues, such as Watchdog Timeout
-#define interrupts() portENABLE_INTERRUPTS()
-#define noInterrupts() portDISABLE_INTERRUPTS()
+#define sei() portENABLE_INTERRUPTS()
+#define cli() portDISABLE_INTERRUPTS()
+#define interrupts() sei()
+#define noInterrupts() cli()
 
 #define clockCyclesPerMicrosecond() ( (long int)getCpuFrequencyMhz() )
 #define clockCyclesToMicroseconds(a) ( (a) / clockCyclesPerMicrosecond() )

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -79,10 +79,9 @@
 #define degrees(rad) ((rad)*RAD_TO_DEG)
 #define sq(x) ((x)*(x))
 
-#define sei()
-#define cli()
-#define interrupts() sei()
-#define noInterrupts() cli()
+// ESP32xx runs FreeRTOS... disabling interrupts can lead to issues, such as Watchdog Timeout
+#define interrupts() portENABLE_INTERRUPTS()
+#define noInterrupts() portDISABLE_INTERRUPTS()
 
 #define clockCyclesPerMicrosecond() ( (long int)getCpuFrequencyMhz() )
 #define clockCyclesToMicroseconds(a) ( (a) / clockCyclesPerMicrosecond() )


### PR DESCRIPTION
## Description of Change
Adds noInterrupt() and interrupt() to Arduino. 
This must be used carefully because ESP32 Arduino runs under FreeRTOS and it is easy to get Watchdog Timeout error if it is no correctly used.

## Tests scenarios
Tested with this sketch (as suggested in the issue)

``` cpp
//  To run the example sketch to demonstrate the issue, 
//  two digital pins need to be connected together somehow. 
//  This was done on a breadboard using a jumper wire.

#define OUT_PIN 14
#define IN_PIN 32

int count = 0;

void counter() {
  count++;
}

void setup() {
  Serial.begin(115200);

  pinMode(OUT_PIN, OUTPUT);
  digitalWrite(OUT_PIN, LOW);
  pinMode(IN_PIN, INPUT);

  attachInterrupt(digitalPinToInterrupt(IN_PIN), counter, RISING);

  for (int i=0; i<50; i++) {
    digitalWrite(OUT_PIN, HIGH);
    digitalWrite(OUT_PIN, LOW);
  }

  noInterrupts();
  
  for (int i=0; i<50; i++) {
    digitalWrite(OUT_PIN, HIGH);
    digitalWrite(OUT_PIN, LOW);
  }
  
  interrupts();

  Serial.print("count = "); Serial.println(count);
}

void loop() {
}
```

#### Expected output:
```
ets Jun  8 2016 00:22:57

rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:1
load:0x3fff0030,len:1344
load:0x40078000,len:13864
load:0x40080400,len:3608
entry 0x400805f0
count = 50
```
wrong output (before this PR) says `count = 100`

## Related links
Fixes #7211 