### PR TITLE
add flash frequency to patched firmware

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -112,6 +112,8 @@ def get_patched_bootloader_image(original_bootloader_image, bootloader_offset):
                     "$TARGET",
                     "--flash_mode",
                     "${__get_board_flash_mode(__env__)}",
+                    "--flash_freq",
+                    "${__get_board_f_flash(__env__)}",
                     "--flash_size",
                     board_config.get("upload.flash_size", "4MB"),
                     "--target-offset",


### PR DESCRIPTION
## Description of Change
Since it can be different and should be correct set like flash mode and flash size.
Same reasons why #7200 is made. [Align](https://github.com/espressif/arduino-esp32/blob/master/platform.txt#L214) Platformio with ArduinoIDE

## Tests scenarios
Issues when target has a different flash frequency than guessed. 
(*eg. Closes #number of issue*)
