### PR TITLE
TTGO T-OI-Plus: pins LED_BUILTIN & BAT_ADC_PIN

### DIFF
--- a/variants/ttgo-t-oi-plus/pins_arduino.h
+++ b/variants/ttgo-t-oi-plus/pins_arduino.h
@@ -11,6 +11,8 @@
 #define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
 #define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 
+static const uint8_t LED_BUILTIN = 3;
+
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
 
@@ -25,5 +27,7 @@ static const uint8_t SCK = 4;
 static const uint8_t A1 = 2;
 static const uint8_t A2 = 4;
 static const uint8_t A3 = 5;
+
+static const uint8_t BAT_ADC_PIN = 2;
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
The pins for LED_BUILTIN and battery voltage ADC are defined for TTGO T-OI-Plus

## Tests scenarios
Tested on TTGO T-OI-Plus, other boards are not affected

## Related links
* https://github.com/Xinyuan-LilyGO/LilyGo-T-OI-PLUS/blob/main/example/battery_voltage/battery_voltage.ino
