### PR TITLE
fix set/getSocketOption inheritance

### DIFF
--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -84,7 +84,7 @@ public:
         return !this->operator==(rhs);
     };
 
-    int fd() const;
+    virtual int fd() const;
 
     int setSocketOption(int option, char* value, size_t len);
     int setSocketOption(int level, int option, const void* value, size_t len);

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -376,16 +376,8 @@ int WiFiClientSecure::setTimeout(uint32_t seconds)
         return 0;
     }
 }
-int WiFiClientSecure::setSocketOption(int option, char* value, size_t len)
-{
-    return setSocketOption(SOL_SOCKET, option, (const void*)value, len);
-}
 
-int WiFiClientSecure::setSocketOption(int level, int option, const void* value, size_t len)
+int WiFiClientSecure::fd() const
 {
-    int res = setsockopt(sslclient->socket, level, option, value, len);
-    if(res < 0) {
-        log_e("fail on %d, errno: %d, \"%s\"", sslclient->socket, errno, strerror(errno));
-    }
-    return res;
+    return sslclient->socket;
 }

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.h
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.h
@@ -80,8 +80,7 @@ public:
     const mbedtls_x509_crt* getPeerCertificate() { return mbedtls_ssl_get_peer_cert(&sslclient->ssl_ctx); };
     bool getFingerprintSHA256(uint8_t sha256_result[32]) { return get_peer_fingerprint(sslclient, sha256_result); };
     int setTimeout(uint32_t seconds);
-    int setSocketOption(int option, char* value, size_t len);
-    int setSocketOption(int level, int option, const void* value, size_t len);
+    int fd() const;
 
     operator bool()
     {


### PR DESCRIPTION
## Description of Change
- changed `int WiFiClient::fd() const` to `virtual int WiFiClient::fd() const`
- created `int WiFiClientSecure::fd() const`
- removed `setSocketOption`, `getSocketOption` from `WiFiClientSecure` to deduplicate the code.

`setSocketOption`, `getSocketOption`, `getOption`, and `setOption` in `WiFiClient` operate on `fd()`. With this fix they all operate on the correct socket.

`setNoDelay` and `getNoDelay` now also works for `WiFiClientSecure`.

## Tests scenarios
tested using WiFiclientSecure and WiFiClient on esp32devkit v1, connected and setNoDelay.
Tested using the MQTT client as referenced to in the issue #7244 

## Related links
Closes #7244 
