### PR TITLE
Pass tag to the Github action uncomponent upload action

### DIFF
--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -12,8 +12,9 @@ jobs:
           submodules: "recursive"
 
       - name: Upload components to the component registry
-        uses: espressif/github-actions/upload_components@master
+        uses: espressif/upload-components-ci-action@v1
         with:
           name: arduino-esp32
+          version: ${{ github.ref_name }}
           namespace: espressif
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
## Description of Change

By default `actions/checkout@v2` makes a shallow clone and doesn't fetch tags. There are 2 ways to overcome it: 
- Fetch tags 
- Use `github.ref_name`  which will contain tag value if the workflow is started for a tag.

This PR uses the latter option. It also updates the action repo for proper action versioning.