### PR TITLE
Fix call to HTTPClient::setTimeout

### DIFF
--- a/libraries/WiFiClientSecure/examples/WiFiClientShowPeerCredentials/WiFiClientShowPeerCredentials.ino
+++ b/libraries/WiFiClientSecure/examples/WiFiClientShowPeerCredentials/WiFiClientShowPeerCredentials.ino
@@ -34,7 +34,7 @@ void demo() {
     return;
   };
 
-  https.setTimeout(5000);
+  https.setTimeout(5);
 
   int httpCode = https.GET();
   if (httpCode != 200) {


### PR DESCRIPTION
Public facing network classes use seconds instead of ms for setTimeout().