### PR TITLE
Correct Spelling of addTemperatureParam in ESP Rainmaker

### DIFF
--- a/libraries/RainMaker/README.md
+++ b/libraries/RainMaker/README.md
@@ -309,7 +309,7 @@ esp_err_t addIntensityParam(int val, const char *param_name = ESP_RMAKER_DEF_INT
 esp_err_t addCCTParam(int val, const char *param_name = ESP_RMAKER_DEF_CCT_NAME);
 esp_err_t addDirectionParam(int val, const char *param_name = ESP_RMAKER_DEF_DIRECTION_NAME);
 esp_err_t addSpeedParam(int val, const char *param_name = ESP_RMAKER_DEF_SPEED_NAME);
-esp_err_t addTempratureParam(float val, const char *param_name = ESP_RMAKER_DEF_TEMPERATURE_NAME);
+esp_err_t addTemperatureParam(float val, const char *param_name = ESP_RMAKER_DEF_TEMPERATURE_NAME);
 ```
 * **Standard Parameters**
 

--- a/libraries/RainMaker/src/RMakerDevice.cpp
+++ b/libraries/RainMaker/src/RMakerDevice.cpp
@@ -125,7 +125,7 @@ esp_err_t Device::addSpeedParam(int val, const char *param_name)
     return esp_rmaker_device_add_param(getDeviceHandle(), param);
 }
 
-esp_err_t Device::addTempratureParam(float val, const char *param_name)
+esp_err_t Device::addTemperatureParam(float val, const char *param_name)
 {   
     param_handle_t *param = esp_rmaker_temperature_param_create(param_name, val);
     return esp_rmaker_device_add_param(getDeviceHandle(), param);

--- a/libraries/RainMaker/src/RMakerDevice.h
+++ b/libraries/RainMaker/src/RMakerDevice.h
@@ -71,7 +71,7 @@ class Device
         esp_err_t addCCTParam(int val, const char *param_name = ESP_RMAKER_DEF_CCT_NAME);
         esp_err_t addDirectionParam(int val, const char *param_name = ESP_RMAKER_DEF_DIRECTION_NAME);
         esp_err_t addSpeedParam(int val, const char *param_name = ESP_RMAKER_DEF_SPEED_NAME);
-        esp_err_t addTempratureParam(float val, const char *param_name = ESP_RMAKER_DEF_TEMPERATURE_NAME);
+        esp_err_t addTemperatureParam(float val, const char *param_name = ESP_RMAKER_DEF_TEMPERATURE_NAME);
           
         //Update Parameter
         esp_err_t updateAndReportParam(const char *param_name, bool val);


### PR DESCRIPTION
## Description of Change
Update ESP Rainmaker RMakerDevice.h and .cpp to change spelling of addTemperatureParam

## Tests scenarios
none

## Related links
None found

