### PR TITLE
[BLE Client] Fix deadlock if connection loss while readValue

### DIFF
--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -247,6 +247,8 @@ void BLERemoteCharacteristic::gattClientEventHandler(esp_gattc_cb_event_t event,
 			break;
 
 		case ESP_GATTC_DISCONNECT_EVT:
+			// Cleanup semaphores to avoid deadlocks.
+			m_semaphoreReadCharEvt.give(1);
 			m_semaphoreWriteCharEvt.give(1);
 			break;
 			


### PR DESCRIPTION
## Description of Change

Releases BLE read semaphore on BLE target disconnect to avoid deadlock on read process.

## Tests scenarios

Tested with heltec_wifi_kit_32 and BLE target.

## Related links

Fixes #7318

