### PR TITLE
rm duplicate entry "bootloader_offset" in `platformio-build.py`

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -118,7 +118,6 @@ def get_patched_bootloader_image(original_bootloader_image, bootloader_offset):
                     board_config.get("upload.flash_size", "4MB"),
                     "--target-offset",
                     bootloader_offset,
-                    bootloader_offset,
                     "$SOURCE",
                 ]
             ),


### PR DESCRIPTION
in function `get_patched_bootloader_image` used to generate a valid bootloader image for debug.
The bootloader offset has to be there but only one time.

The duplicate entry may result in malfunction of the routine.