### PR TITLE
Fix incorrect flash_type in unphone9 board definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -18904,7 +18904,7 @@ unphone9.build.partitions=default_8MB
 unphone9.build.defines=-DBOARD_HAS_PSRAM -DUNPHONE_SPIN=9
 unphone9.build.loop_core=-DARDUINO_RUNNING_CORE=1
 unphone9.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-unphone9.build.flash_type=qspi
+unphone9.build.flash_type=qio
 unphone9.build.psram_type=qspi
 unphone9.build.memory_type={build.flash_type}_{build.psram_type}
 


### PR DESCRIPTION
As per #6962 we have another case of build.flash_type incorrectly named qspi; this commit fixes the issue for the unphone9 board.

There are no implications for any other board or code.