### PR TITLE
Add missing function getsocketoption

### DIFF
--- a/docs/source/guides/core_debug.rst
+++ b/docs/source/guides/core_debug.rst
@@ -35,7 +35,4 @@ Then simply build the libs for all SoCs or one specific SoC. Note that building 
       - ``esp32s3``
       - Example: ``./build.sh -t esp32``
       - A wrong format or non-existing SoC will result in the error sed: can't read sdkconfig: No such file or directory
-   - **Option 3**: Build for multiple SoCs (not all) - simply write them down separated with space: ``./build.sh -t <soc1> <soc2> <soc3>``
-
-      - Example: ``./build.sh -t esp32 esp32-c3``
 

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -231,7 +231,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, int32_t timeout)
     FD_ZERO(&fdset);
     FD_SET(sockfd, &fdset);
     tv.tv_sec = _timeout / 1000;
-    tv.tv_usec = 0;
+    tv.tv_usec = (_timeout  % 1000) * 1000;
 
 #ifdef ESP_IDF_VERSION_MAJOR
     int res = lwip_connect(sockfd, (struct sockaddr*)&serveraddr, sizeof(serveraddr));
@@ -314,6 +314,16 @@ int WiFiClient::setSocketOption(int level, int option, const void* value, size_t
     }
     return res;
 }
+
+int WiFiClient::getSocketOption(int level, int option, const void* value, size_t size)
+{
+    int res = getsockopt(fd(), level, option, (char *)value, &size);
+    if(res < 0) {
+        log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
+    }
+    return res;
+}
+
 
 int WiFiClient::setTimeout(uint32_t seconds)
 {

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -343,7 +343,7 @@
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/arduino-esp32/releases/download/2.0.4/esptool-3.3-linux.tar.gz",
+              "url": "https://github.com/espressif/arduino-esp32/releases/download/2.0.4/esptool-4.2.1-linux.tar.gz",
               "archiveFileName": "esptool-4.2.1-linux.tar.gz",
               "checksum": "SHA-256:5a45fb77eb6574554ec2f45230d0b350f26f9c24ab3b6c13c4031ebdf72a34ab",
               "size": "90123"


### PR DESCRIPTION
WiFimanager.cpp connect function truncated all connnect timeout values below 1000ms to 0ms and rounded timeouts to the full second, e.g. 2.5 seconds became 2 seconds. For timeouts below 1000ms,  the connect function failed. This fix handles timeouts correctly, by putting the fractional part of the timeout into the timeout_us variable.

Added function getsocketoptions, it was missing. 