### PR TITLE
fixed AirM2M_CORE_ESP32C3 upload.tool.serial & write_flash error

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -17530,6 +17530,8 @@ AirM2M_CORE_ESP32C3.vid.0=0x303a
 AirM2M_CORE_ESP32C3.pid.0=0x1001
 
 AirM2M_CORE_ESP32C3.upload.tool=esptool_py
+AirM2M_CORE_ESP32C3.upload.tool.default=esptool_py
+AirM2M_CORE_ESP32C3.upload.tool.network=esp_ota
 AirM2M_CORE_ESP32C3.upload.maximum_size=1310720
 AirM2M_CORE_ESP32C3.upload.maximum_data_size=327680
 AirM2M_CORE_ESP32C3.upload.flags=
@@ -17623,6 +17625,11 @@ AirM2M_CORE_ESP32C3.menu.DebugLevel.debug=Debug
 AirM2M_CORE_ESP32C3.menu.DebugLevel.debug.build.code_debug=4
 AirM2M_CORE_ESP32C3.menu.DebugLevel.verbose=Verbose
 AirM2M_CORE_ESP32C3.menu.DebugLevel.verbose.build.code_debug=5
+
+AirM2M_CORE_ESP32C3.menu.EraseFlash.none=Disabled
+AirM2M_CORE_ESP32C3.menu.EraseFlash.none.upload.erase_cmd=
+AirM2M_CORE_ESP32C3.menu.EraseFlash.all=Enabled
+AirM2M_CORE_ESP32C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 #############################################################
 


### PR DESCRIPTION
-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

This PR fix 2 errors so that we can upload the compiled firmware successfully to AirM2M_CORE_ESP32C3 board.
1. `Property 'upload.tool.serial' is undefined`
2.  esptool write_flash: error: argument <address> <filename>: Address "{upload.erase_cmd}" must be a number
Failed uploading: uploading error: exit status 2

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

I have tested my Pull Request on Arduino-esp32 core v2.0.5 with AirM2M_CORE_ESP32C3 Board with this scenario.

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
