### PR TITLE
Fix missing 't' in the name 'Department' for the MiniMain ESP32-S2 in boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -17976,7 +17976,7 @@ aw2eth.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-department_of_alchemy_minimain_esp32s2.name=Deparment of Alchemy MiniMain ESP32-S2
+department_of_alchemy_minimain_esp32s2.name=Department of Alchemy MiniMain ESP32-S2
 department_of_alchemy_minimain_esp32s2.vid.0=0x303A
 department_of_alchemy_minimain_esp32s2.pid.0=0x80FF
 


### PR DESCRIPTION
## Description of Change
Please describe your proposed Pull Request and it's impact.

Fix a typo in the name of the MiniMain ESP32-S2 board. The 't' is missing from the name 'Department'.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

Visually inspected boards.txt to verify that "Department of Alchemy" is now spelled correctly.

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
