### PR TITLE
Fixes UART pin detach on Serial.end()

### DIFF
--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -176,6 +176,7 @@ protected:
 #if !CONFIG_DISABLE_HAL_LOCKS
     SemaphoreHandle_t _lock;
 #endif
+    int8_t _rxPin, _txPin, _ctsPin, _rtsPin;
 
     void _createEventTask(void *args);
     void _destroyEventTask(void);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -91,8 +91,9 @@ int uartGetDebug();
 
 bool uartIsDriverInstalled(uart_t* uart);
 
-// Negative Pin Number will keep it unmodified, thus this function can set individual pins
-void uartSetPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
+// Negative Pin Number will keep it unmodified, thus this function can set/reset individual pins
+bool uartSetPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
+void uartDetachPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
 
 // Enables or disables HW Flow Control function -- needs also to set CTS and/or RTS pins
 void uartSetHwFlowCtrlMode(uart_t *uart, uint8_t mode, uint8_t threshold);


### PR DESCRIPTION
## Description of Change
When `Serial.end()` is executed, the UART driver doesn't detach RX/TX/CTS/RTS pins.
As consequense, those pins pads connected using IOMUX by IDF layer will continue to send/receive data to/from the peripheral, causing the impression that Serial is still working.

This PR fixes it by adding a pin detach function used in `Serial.end()`.  

## Tests scenarios
Tested using ESP32 and ESP32C3.

Necessary to use Arduino Serial Monitor for the default Board Serial port (Serial) and then some other UART<->USB converter board for reading the messages from pin 5 (new TX). 

```cpp
#define New_RX 4   // ESP32, S2, S3, C3
#define New_TX 5   // ESP32, S2, S3, C3

HardwareSerial NewSerial(0);

void setup() {
  Serial.begin(115200);
  delay(2000);

  Serial.println("\n\nStarting on Serial, default pins, and ending Serial");
  Serial.flush();
  Serial.end();
  delay(2000);

  NewSerial.begin(115200, SERIAL_8N1, New_RX, New_TX);
  delay(2000);
  
  NewSerial.println("\n\n...now printing on NewSerial, others pins .. " );
  NewSerial.println(" but the message appears also on Serial Monitor ... " );
  NewSerial.flush();
  Serial.println("\n\n printing on Serial");  // No output: OK serial is closed
  Serial.flush();
  NewSerial.println("\n\n and once more printing on NewSerial");
  NewSerial.flush();
}

void loop() {
  // put your main code here, to run repeatedly:
}
```

## Related links
Fixes #7359 