### PR TITLE
Fixed #7406 crash on WiFi STA_DISCONNECTED event with reason 0

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -947,6 +947,9 @@ esp_err_t WiFiGenericClass::_eventCallback(arduino_event_t *event)
         //esp_netif_create_ip6_linklocal(esp_netifs[ESP_IF_WIFI_STA]);
     } else if(event->event_id == ARDUINO_EVENT_WIFI_STA_DISCONNECTED) {
         uint8_t reason = event->event_info.wifi_sta_disconnected.reason;
+        // Reason 0 causes crash, use reason 1 (UNSPECIFIED) instead
+        if(!reason)
+	    reason = WIFI_REASON_UNSPECIFIED;
         log_w("Reason: %u - %s", reason, reason2str(reason));
         if(reason == WIFI_REASON_NO_AP_FOUND) {
             WiFiSTAClass::_setStatus(WL_NO_SSID_AVAIL);


### PR DESCRIPTION
## Description of Change
Fixed #7406 . The "reason2str" macro in WiFiGeneric.cpp tries to read memory from index "-1"  in "system_event_reasons" array when handling STA_DISCONNECTED event with reason 0. Dealing with reason 0 as a reason 1 (WIFI_REASON_UNSPECIFIED) will solve the problem (the reason for this event to arrive with reason 0 is unknown).
This proposed change has succesfuly solved the ESP32 Guru Meditation Error when hanling STA_DISCONNECTED event with reason 0.

## Tests scenarios
It has been tested on the ESP32 DevKitC V4 esp32-s3-devkitc-1 as well as the esp32-s3-devkitc-1, using PlatformIO with the Arduino-esp32 core v2.0.4.

## Related links
Closes #7406 of issue.
