### PR TITLE
FreeRTOS.ino: fix usage of vTaskDelay

### DIFF
--- a/libraries/ESP32/examples/FreeRTOS/FreeRTOS.ino
+++ b/libraries/ESP32/examples/FreeRTOS/FreeRTOS.ino
@@ -67,9 +67,11 @@ void TaskBlink(void *pvParameters)  // This is a task.
   for (;;) // A Task shall never return or exit.
   {
     digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
-    vTaskDelay(100);  // one tick delay (15ms) in between reads for stability
+    // arduino-esp32 has FreeRTOS configured to have a tick-rate of 1000Hz and portTICK_PERIOD_MS
+    // refers to how many milliseconds the period between each ticks is, ie. 1ms.
+    vTaskDelay(1000 / portTICK_PERIOD_MS );  // vTaskDelay wants ticks, not milliseconds
     digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
-    vTaskDelay(100);  // one tick delay (15ms) in between reads for stability
+    vTaskDelay(1000 / portTICK_PERIOD_MS); // 1 second delay
   }
 }
 
@@ -92,6 +94,6 @@ void TaskAnalogReadA3(void *pvParameters)  // This is a task.
     int sensorValueA3 = analogRead(A3);
     // print out the value you read:
     Serial.println(sensorValueA3);
-    vTaskDelay(10);  // one tick delay (15ms) in between reads for stability
+    vTaskDelay(100 / portTICK_PERIOD_MS);  // 100ms delay
   }
 }


### PR DESCRIPTION
The original code assumes 100Hz FreeRTOS tick rate and just supplies vTaskDelay with the assumed number of ticks required for the wanted delay. This patch simply fixes it to use portTICK_PERIOD_MS, thereby working correctly regardless of what tick rate FreeRTOS has been configured to run at.

Signed-off-by: Nita Vesa <werecatf@outlook.com>