### PR TITLE
DNSServer fix custom code replies

### DIFF
--- a/libraries/DNSServer/src/DNSServer.cpp
+++ b/libraries/DNSServer/src/DNSServer.cpp
@@ -175,8 +175,6 @@ String DNSServer::getDomainNameWithoutWwwPrefix()
 
 void DNSServer::replyWithIP()
 {
-  if (_buffer == NULL) return;
-  
   _udp.beginPacket(_udp.remoteIP(), _udp.remotePort());
   
   // Change the type of message to a response and set the number of answers equal to 
@@ -215,12 +213,11 @@ void DNSServer::replyWithIP()
 
 void DNSServer::replyWithCustomCode()
 {
-  if (_buffer == NULL) return;
   _dnsHeader->QR = DNS_QR_RESPONSE;
   _dnsHeader->RCode = (unsigned char)_errorReplyCode;
   _dnsHeader->QDCount = 0;
 
   _udp.beginPacket(_udp.remoteIP(), _udp.remotePort());
-  _udp.write(_buffer, sizeof(DNSHeader));
+  _udp.write((unsigned char*)_dnsHeader, sizeof(DNSHeader));
   _udp.endPacket();
 }


### PR DESCRIPTION
custom code reply was sending garbage from a buffer instead of crafted DNS header