### PR TITLE
Changed Rainmaker WiFi/Factory reset time.

### DIFF
--- a/libraries/RainMaker/src/RMakerUtils.cpp
+++ b/libraries/RainMaker/src/RMakerUtils.cpp
@@ -1,12 +1,13 @@
 #include "RMakerUtils.h"
 #ifdef CONFIG_ESP_RMAKER_WORK_QUEUE_TASK_STACK
-void RMakerFactoryReset(int seconds)
+#define RESET_DELAY_SEC 2
+void RMakerFactoryReset(int reboot_seconds)
 {
-    esp_rmaker_factory_reset(0, seconds);
+    esp_rmaker_factory_reset(RESET_DELAY_SEC, reboot_seconds);
 }
 
-void RMakerWiFiReset(int seconds)
+void RMakerWiFiReset(int reboot_seconds)
 {
-    esp_rmaker_wifi_reset(0, seconds);
+    esp_rmaker_wifi_reset(RESET_DELAY_SEC, reboot_seconds);    
 }
 #endif


### PR DESCRIPTION
## Description of Change
The Rainmaker C library went through changes that would improve user experience. The Rainmaker App will show the device status as offline immediately after a WiFi reset and remove the device from the app on a Factory Reset. The following changes in the Arduino core will bring these enhancements to Arduino developers.

## Tests scenarios
I have tested this PR on Rainmaker Switch Example on ESP32.

