### PR TITLE
Add protocol-explicit `upload.tool` properties required for pluggable discovery compatibility

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -13121,7 +13121,7 @@ oroca_edubot.menu.EraseFlash.all.upload.erase_cmd=-e
 
 fm-devkit.name=ESP32 FM DevKit
 
-fm-devkit.upload.tool=esptool
+fm-devkit.upload.tool=esptool_py
 fm-devkit.upload.maximum_size=1310720
 fm-devkit.upload.maximum_data_size=327680
 fm-devkit.upload.flags=

--- a/boards.txt
+++ b/boards.txt
@@ -2209,6 +2209,9 @@ rmp.vid.0=0x303a
 rmp.pid.0=0x80F6
 
 rmp.upload.tool=esptool_py
+rmp.upload.tool.default=esptool_py
+rmp.upload.tool.network=esp_ota
+
 rmp.upload.maximum_size=1310720
 rmp.upload.maximum_data_size=327680
 rmp.upload.flags=
@@ -9968,6 +9971,9 @@ esp32doit-devkit-v1.menu.EraseFlash.all.upload.erase_cmd=-e
 esp32doit-espduino.name=DOIT ESPduino32
 
 esp32doit-espduino.upload.tool=esptool_py
+esp32doit-espduino.upload.tool.default=esptool_py
+esp32doit-espduino.upload.tool.network=esp_ota
+
 esp32doit-espduino.upload.maximum_size=1310720
 esp32doit-espduino.upload.maximum_data_size=327680
 esp32doit-espduino.upload.wait_for_upload_port=true
@@ -13122,6 +13128,9 @@ oroca_edubot.menu.EraseFlash.all.upload.erase_cmd=-e
 fm-devkit.name=ESP32 FM DevKit
 
 fm-devkit.upload.tool=esptool_py
+fm-devkit.upload.tool.default=esptool_py
+fm-devkit.upload.tool.network=esp_ota
+
 fm-devkit.upload.maximum_size=1310720
 fm-devkit.upload.maximum_data_size=327680
 fm-devkit.upload.flags=


### PR DESCRIPTION
## Description of Change

A new flexible and powerful ["pluggable discovery" system](https://arduino.github.io/arduino-cli/0.27/platform-specification/#pluggable-discovery) was added to the Arduino boards platform framework. This system makes it easy for Arduino boards platform authors to use any arbitrary communication channel between the board and development tools.

Boards platform configurations that use the old property syntax are automatically translated to the new syntax by Arduino CLI:

https://arduino.github.io/arduino-cli/latest/platform-specification/#sketch-upload-configuration

> For backward compatibility with IDE 1.8.15 and older the previous syntax is still supported

This translation is only done in platforms that use the old syntax exclusively. If `pluggable_discovery` properties are defined for the platform then the new pluggable discovery-style `upload.tool.<protocol_name>` properties must be defined for each board as well.

This platform was converted to use the new pluggable discovery platform properties syntax (https://github.com/espressif/arduino-esp32/pull/6506), so those properties are now required. Although such properties were added to board definitions at the time the syntax was changed, some board definitions were missed at that time, or added later without the required properties (https://github.com/espressif/arduino-esp32/pull/6630).

Those missing properties caused uploads to fail for users of the recent versions of Arduino IDE and Arduino CLI with an error of the form:

```text
Error during Upload: Property 'upload.tool.<protocol_name>' is undefined
```

(where `<protocol_name>` is the protocol of the selected port, if any)

It is also important to provide compatibility with versions of Arduino development tools from before the introduction of the modern pluggable discovery system. For this reason, the old style `<board ID>.upload.tool` properties are retained. Old versions of the development tools will treat the `<board ID>.upload.tool.<protocol_name>` properties as an unused arbitrary user defined property with no special significance and the new versions of the development tools will do the same for the `<board ID>.upload.tool` properties.

## Tests scenarios

Upload to each of the boards via Arduino IDE 2.0.2 without encountering `Property 'upload.tool.serial' is undefined` error:

- DOIT ESPduino32
- ESP32 FM DevKit
- UM RMP
