### PR TITLE
Fix wrong environment variable in libraries/LittleFS/examples/LITTLEFS_PlatformIO/littlefsbuilder.py.

### DIFF
--- a/libraries/LittleFS/examples/LITTLEFS_PlatformIO/littlefsbuilder.py
+++ b/libraries/LittleFS/examples/LITTLEFS_PlatformIO/littlefsbuilder.py
@@ -1,2 +1,2 @@
 Import("env")
-env.Replace( MKSPIFFSTOOL=env.get("PROJECT_DIR") + '/mklittlefs' )  # PlatformIO now believes it has actually created a SPIFFS
+env.Replace( MKFSTOOL=env.get("PROJECT_DIR") + '/mklittlefs' )  # PlatformIO now believes it has actually created a SPIFFS


### PR DESCRIPTION

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
MKSPIFFSTOOL in PlatformIO has been changed to MKFSTOOL.

## Tests scenarios
I have tested my Pull Request on PlatformIO Core, version 6.1.5 .
