### PR TITLE
Added onDisconnect with gatt parameters to BLEServerCallbacks, equivalent to the existing onConnect

### DIFF
--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -374,6 +374,12 @@ void BLEServerCallbacks::onDisconnect(BLEServer* pServer) {
 	log_d("BLEServerCallbacks", "<< onDisconnect()");
 } // onDisconnect
 
+void BLEServerCallbacks::onDisconnect(BLEServer* pServer, esp_ble_gatts_cb_param_t* param) {
+	log_d("BLEServerCallbacks", ">> onDisconnect(): Default");
+	log_d("BLEServerCallbacks", "Device: %s", BLEDevice::toString().c_str());
+	log_d("BLEServerCallbacks", "<< onDisconnect()");
+} // onDisconnect
+
 void BLEServerCallbacks::onMtuChanged(BLEServer* pServer, esp_ble_gatts_cb_param_t* param) {
 	log_d("BLEServerCallbacks", ">> onMtuChanged(): Default");
 	log_d("BLEServerCallbacks", "Device: %s MTU: %d", BLEDevice::toString().c_str(), param->mtu.mtu);

--- a/libraries/BLE/src/BLEServer.h
+++ b/libraries/BLE/src/BLEServer.h
@@ -134,6 +134,7 @@ public:
 	 * @param [in] pServer A reference to the %BLE server that received the existing client disconnection.
 	 */
 	virtual void onDisconnect(BLEServer* pServer);
+	virtual void onDisconnect(BLEServer* pServer, esp_ble_gatts_cb_param_t *param);
 
 	/**
 	 * @brief Handle a new client connection.


### PR DESCRIPTION
-----------
## Description of Change
This change adds a onDisconnect with parameters to BLEServerCallbacks, equivalent to onDisconnect, which allows the code to know which (of the multiple connections) is disconnecting. Similar to how onConnect can be used with esp_ble_gatts_cb_param_t now.



## Tests scenarios
Tested on ESP32-S3-DevKitC-1, Platform-IO 5.1.1 (framework=Arduino), while connecting with 2 BLE devices (android and ios) simultaneous, reconnecting them one at a time.

## Related links

Closes #6008