### PR TITLE
log_printf: Restructured log_printf for wrapping

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -496,21 +496,18 @@ int uartGetDebug()
     return s_uart_debug_nr;
 }
 
-int log_printf(const char *format, ...)
+int log_printfv(const char *format, va_list arg)
 {
     static char loc_buf[64];
     char * temp = loc_buf;
     int len;
-    va_list arg;
     va_list copy;
-    va_start(arg, format);
     va_copy(copy, arg);
     len = vsnprintf(NULL, 0, format, copy);
     va_end(copy);
     if(len >= sizeof(loc_buf)){
         temp = (char*)malloc(len+1);
         if(temp == NULL) {
-            va_end(arg);
             return 0;
         }
     }
@@ -528,10 +525,19 @@ int log_printf(const char *format, ...)
         xSemaphoreGive(_uart_bus_array[s_uart_debug_nr].lock);
     }
 #endif
-    va_end(arg);
     if(len >= sizeof(loc_buf)){
         free(temp);
     }
+    return len;
+}
+
+int log_printf(const char *format, ...)
+{
+    int len;
+    va_list arg;
+    va_start(arg, format);
+    len = log_printfv(format, arg);
+    va_end(arg);
     return len;
 }
 


### PR DESCRIPTION
## Description of Change
ESP Insights wraps log functions for capturing errors/warnings. In the case of IDF, the application uses `esp_log_write()` and `esp_log_writev()` for logging. In Arduino, we use `log_printf()` so Insights cannot capture logs coming from the Arduino core.

## Tests scenarios
I have tested this on esp32 using the [examples](https://github.com/espressif/arduino-esp32/pull/7566) created in the Insights library

## Related links
Other Insights for Arduino PRs
https://github.com/espressif/arduino-esp32/pull/7566

Insights code for wrapping log methods
[Wrapping IDF log methods](https://github.com/espressif/esp-insights/blob/aa8beceb7385936710bb6d0ae9a86094dc8c8773/components/esp_diagnostics/src/esp_diagnostics_log_hook.c#L450)