### PR TITLE
Workaround for when USB CDC is unplugged

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -32,7 +32,7 @@ static uint8_t rx_data_buf[64];
 static intr_handle_t intr_handle = NULL;
 static volatile bool initial_empty = false;
 static xSemaphoreHandle tx_lock = NULL;
-static uint32_t tx_timeout_ms = 200;
+static uint32_t tx_timeout_ms = 0;  // workaround for when USB CDC is not connected
 static esp_event_loop_handle_t arduino_hw_cdc_event_loop_handle = NULL;
 
 static esp_err_t arduino_hw_cdc_event_post(esp_event_base_t event_base, int32_t event_id, void *event_data, size_t event_data_size, BaseType_t *task_unblocked){


### PR DESCRIPTION
## Description of Change
By default Tx Timeout is 200 and it causes a delay every time that HW  USB CDC is written when the USB is unplugged.
Setting it to 0 by default solves this issue and it has no side effect.
As stated in the issue #6983, it affects boards that use Batteries and are not connected to a USB port.

## Tests scenarios
This issue affects ESP32-C2 and ESP32-S3 with HW Serial.

## Related links
Fix #6983