### PR TITLE
[Chore] Add error name to EEPROMClass commit method's error log

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -183,20 +183,21 @@ void EEPROMClass::write(int address, uint8_t value) {
 bool EEPROMClass::commit() {
   bool ret = false;
   if (!_size) {
-      return false;
+    return false;
   }
   if (!_data) {
-      return false;
+    return false;
   }
   if (!_dirty) {
-      return true;
+    return true;
   }
 
-  if (ESP_OK != nvs_set_blob(_handle, _name, _data, _size)) {
-      log_e( "error in write");
+  esp_err_t err = nvs_set_blob(_handle, _name, _data, _size);
+  if (err != ESP_OK) {
+    log_e("error in write: %s", esp_err_to_name(err));
   } else {
-      _dirty = false;
-      ret = true;
+    _dirty = false;
+    ret = true;
   }
 
   return ret;


### PR DESCRIPTION
## Description of Change
Please describe your proposed Pull Request and it's impact.

I had a hard time figuring out why EEPROM kept failing when I tried to commit, so I tried to make a small improvement by adding the error name to the err log, and I finally found my answer. With this change, I hope it'll make the debugging experience much better. 

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

I have tested this with ESP32

## Related links
Please provide links to related issue, PRs etc.
-