### PR TITLE
Remove (useless) trailing semicolon from Print.cpp

### DIFF
--- a/cores/esp32/Print.cpp
+++ b/cores/esp32/Print.cpp
@@ -57,7 +57,7 @@ size_t Print::printf(const char *format, ...)
     if(len < 0) {
         va_end(arg);
         return 0;
-    };
+    }
     if(len >= (int)sizeof(loc_buf)){  // comparation of same sign type for the compiler
         temp = (char*) malloc(len+1);
         if(temp == NULL) {


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
