### PR TITLE
airm2m_core_esp32c3 board Add LED_BUILTIN* definitions and initialization for LEDs

### DIFF
--- a/variants/AirM2M_CORE_ESP32C3/pins_arduino.h
+++ b/variants/AirM2M_CORE_ESP32C3/pins_arduino.h
@@ -11,6 +11,10 @@
 #define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
 #define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 
+static const uint8_t LED_BUILTIN     = 12;
+#define BUILTIN_LED  LED_BUILTIN
+static const uint8_t LED_BUILTIN_AUX = 13;
+
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
 

--- a/variants/AirM2M_CORE_ESP32C3/variant.cpp
+++ b/variants/AirM2M_CORE_ESP32C3/variant.cpp
@@ -1,0 +1,7 @@
+#include "Arduino.h"
+
+extern "C" void initVariant(void){
+	// Stop LEDs floating
+	pinMode(LED_BUILTIN, OUTPUT); digitalWrite(LED_BUILTIN, LOW);
+	pinMode(LED_BUILTIN_AUX, OUTPUT); digitalWrite(LED_BUILTIN_AUX, LOW);
+}


### PR DESCRIPTION
## Description of Change
Add missing definitions for AirM2M CORE ESP32C3 onboard LEDs and initialize them to stop them floating and flickering.
LED D4 defined as LED_BUILTIN
LED D5 defined as LED_BUILTIN_AUX (per another dual LED board)

## Tests scenarios
Tested with airm2m_core_esp32c3 using standard Arduino blink sketch.

## Related links
LED GPIOs taken from here: https://wiki.luatos.com/chips/esp32c3/board.html