### PR TITLE
Heltec WiFi LoRa 32(V3) typo in boards.txt preventing compilation fix

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -11797,8 +11797,8 @@ heltec_wifi_lora_32_V3.build.bootloader_addr=0x0
 heltec_wifi_lora_32_V3.build.target=esp32s3
 heltec_wifi_lora_32_V3.build.mcu=esp32s3
 heltec_wifi_lora_32_V3.build.core=esp32
-heltec_wifi_lora_32_V3.build.variant=heltec_heltec_wifi_lora_32_V3
-heltec_wifi_lora_32_V3.build.board=heltec_heltec_wifi_32_lora_V3
+heltec_wifi_lora_32_V3.build.variant=heltec_wifi_lora_32_V3
+heltec_wifi_lora_32_V3.build.board=heltec_wifi_32_lora_V3
 
 heltec_wifi_lora_32_V3.build.usb_mode=1
 heltec_wifi_lora_32_V3.build.cdc_on_boot=0


### PR DESCRIPTION
Fixing variant reference for Heltec WiFi LoRa 32(V3).

## Description of Change
Typo in boards.txt preventing compilation fix

## Tests scenarios
Compile with Heltec WiFi LoRa 32(V3)