### PR TITLE
add mising TX1 RX1 for adafruit boards

### DIFF
--- a/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
@@ -49,8 +49,8 @@ static const uint8_t A5 = 8;
 
 static const uint8_t TX = 39;
 static const uint8_t RX = 38;
-static const uint8_t TX1 = 39;
-static const uint8_t RX1 = 38;
+#define TX1 TX
+#define RX1 RX
 
 static const uint8_t T5 = 5;
 static const uint8_t T6 = 6;

--- a/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
@@ -49,6 +49,8 @@ static const uint8_t A5 = 8;
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 2;
+#define TX1 TX
+#define RX1 RX
 
 static const uint8_t T1 = 1;
 static const uint8_t T2 = 2;

--- a/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
@@ -49,6 +49,8 @@ static const uint8_t A5 = 8;
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 2;
+#define TX1 TX
+#define RX1 RX
 
 static const uint8_t T1 = 1;
 static const uint8_t T2 = 2;

--- a/variants/adafruit_funhouse_esp32s2/pins_arduino.h
+++ b/variants/adafruit_funhouse_esp32s2/pins_arduino.h
@@ -60,6 +60,8 @@ static const uint8_t A3 = 18; // light sensor
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
+#define TX1 TX
+#define RX1 RX
 
 static const uint8_t T6 = 6;
 static const uint8_t T7 = 7;

--- a/variants/adafruit_magtag29_esp32s2/pins_arduino.h
+++ b/variants/adafruit_magtag29_esp32s2/pins_arduino.h
@@ -63,7 +63,8 @@ static const uint8_t MISO  = 37;
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
-
+#define TX1 TX
+#define RX1 RX
 
 static const uint8_t A0 = 17;
 static const uint8_t A1 = 18;

--- a/variants/adafruit_metro_esp32s2/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s2/pins_arduino.h
@@ -27,6 +27,8 @@
 
 static const uint8_t TX = 5;
 static const uint8_t RX = 6;
+#define TX1 TX
+#define RX1 RX
 
 static const uint8_t SDA = 33;
 static const uint8_t SCL = 34;


### PR DESCRIPTION
## Description of Change
This PR add missing symbol TX1 and RX1 for Adafruit boards, which fixed issue reported by Adafruit user here https://forums.adafruit.com/viewtopic.php?p=954722

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core (master branch 2.0.6) with Adafruit Feather ESP32-S2 TFT with SerialPassThrough example.

@ladyada 