### PR TITLE
Fix BluetoothSerial compilation caused by upstream change

### DIFF
--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -54,7 +54,7 @@ static TaskHandle_t _spp_task_handle = NULL;
 static EventGroupHandle_t _spp_event_group = NULL;
 static EventGroupHandle_t _bt_event_group = NULL;
 static boolean secondConnectionAttempt;
-static esp_spp_cb_t * custom_spp_callback = NULL;
+static esp_spp_cb_t custom_spp_callback = NULL;
 static BluetoothSerialDataCb custom_data_callback = NULL;
 static esp_bd_addr_t current_bd_addr;
 static ConfirmRequestCb confirm_request_callback = NULL;
@@ -886,7 +886,7 @@ void BluetoothSerial::confirmReply(boolean confirm)
 }
 
 
-esp_err_t BluetoothSerial::register_callback(esp_spp_cb_t * callback)
+esp_err_t BluetoothSerial::register_callback(esp_spp_cb_t callback)
 {
     custom_spp_callback = callback;
     return ESP_OK;

--- a/libraries/BluetoothSerial/src/BluetoothSerial.h
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.h
@@ -53,7 +53,7 @@ class BluetoothSerial: public Stream
         void end(void);
         void setTimeout(int timeoutMS);
         void onData(BluetoothSerialDataCb cb);
-        esp_err_t register_callback(esp_spp_cb_t * callback);
+        esp_err_t register_callback(esp_spp_cb_t callback);
         
         void onConfirmRequest(ConfirmRequestCb cb);
         void onAuthComplete(AuthCompleteCb cb);


### PR DESCRIPTION
Fixes: https://github.com/espressif/arduino-esp32/issues/7675

The signature of `esp_spp_cb_t` has changed in recent ESP-IDF v4.4.3, so this fix targets to accomodate that change in Arduino
