### PR TITLE
Fix missing options in board.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,3 +1,4 @@
+# Official Espressif options
 menu.UploadSpeed=Upload Speed
 menu.USBMode=USB Mode
 menu.CDCOnBoot=USB CDC On Boot
@@ -11,14 +12,18 @@ menu.FlashSize=Flash Size
 menu.PartitionScheme=Partition Scheme
 menu.DebugLevel=Core Debug Level
 menu.PSRAM=PSRAM
-menu.Revision=Board Revision
-menu.LORAWAN_REGION=LoRaWan Region
-menu.LoRaWanDebugLevel=LoRaWan Debug Level
 menu.LoopCore=Arduino Runs On
 menu.EventsCore=Events Run On
 menu.MemoryType=Memory Type
 menu.EraseFlash=Erase All Flash Before Sketch Upload
 menu.JTAGAdapter=JTAG Adapter
+
+# Custom options
+menu.Revision=Board Revision
+menu.LORAWAN_REGION=LoRaWan Region
+menu.LoRaWanDebugLevel=LoRaWan Debug Level
+menu.LORAWAN_DEVEUI=LoRaWan DevEUI
+menu.LORAWAN_PREAMBLE_LENGTH=LoRaWan Preamble Length
 
 ##############################################################
 ### DO NOT PUT BOARDS ABOVE THE OFFICIAL ESPRESSIF BOARDS! ###
@@ -12008,8 +12013,8 @@ heltec_wifi_lora_32_V3.build.bootloader_addr=0x0
 heltec_wifi_lora_32_V3.build.target=esp32s3
 heltec_wifi_lora_32_V3.build.mcu=esp32s3
 heltec_wifi_lora_32_V3.build.core=esp32
-heltec_wifi_lora_32_V3.build.variant=heltec_heltec_wifi_lora_32_V3
-heltec_wifi_lora_32_V3.build.board=heltec_heltec_wifi_32_lora_V3
+heltec_wifi_lora_32_V3.build.variant=heltec_wifi_lora_32_V3
+heltec_wifi_lora_32_V3.build.board=heltec_wifi_32_lora_V3
 
 heltec_wifi_lora_32_V3.build.usb_mode=1
 heltec_wifi_lora_32_V3.build.cdc_on_boot=0
@@ -12119,7 +12124,6 @@ heltec_wifi_lora_32_V3.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
 heltec_wifi_lora_32_V3.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
 
 heltec_wifi_lora_32_V3.build.defines=-D{build.band} -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
-heltec_wifi_lora_32_V3.build.extra_libs=-lheltec
 
 heltec_wifi_lora_32_V3.menu.EraseFlash.none=Disabled
 heltec_wifi_lora_32_V3.menu.EraseFlash.none.upload.erase_cmd=


### PR DESCRIPTION
## Description of Change
1.) Added missing `menu.` options on top of board.txt causing issues with arduino-cli.
2.) Split `menu.` options on top of board.txt to 2 sections (Official Espressif options / Custom options) to be easier to manage.
3.) Fixed Heltec Wifi Lora 32 (V3) board to compile.

## Tests scenarios
Tested by building simple sketch for Heltec Wifi Lora 32 (V3) board.

## Related links
Closes #7684 
