### PR TITLE
Fixes BLE data printing

### DIFF
--- a/libraries/BLE/examples/BLE_client/BLE_client.ino
+++ b/libraries/BLE/examples/BLE_client/BLE_client.ino
@@ -29,7 +29,10 @@ static void notifyCallback(
     Serial.print(" of data length ");
     Serial.println(length);
     Serial.print("data: ");
-    Serial.println((char*)pData);
+    for (size_t i = 0; i < length; i++) {
+      Serial.print((char)pData[i]);
+    }
+    Serial.println();
 }
 
 class MyClientCallback : public BLEClientCallbacks {


### PR DESCRIPTION
## Description of Change
BLE data has no '\0' terminator, therefore it can't be printed as a regular C string. This fix just prints the BLE data based on its length.

## Tests scenarios
ESP32 using BLE Client and Server

## Related links
Fix #7637