### PR TITLE
TouchRead examples, Fix typo T0 -> T1

### DIFF
--- a/libraries/ESP32/examples/Touch/TouchRead/TouchRead.ino
+++ b/libraries/ESP32/examples/Touch/TouchRead/TouchRead.ino
@@ -10,6 +10,6 @@ void setup()
 
 void loop()
 {
-  Serial.println(touchRead(T1));  // get value using T0
+  Serial.println(touchRead(T1));  // get value using T1
   delay(1000);
 }


### PR DESCRIPTION
## Description of Change

Match comments with code.

```c
Serial.println(touchRead(T1));  // get value using T0 
```
to
```c
Serial.println(touchRead(T1));  // get value using T1
```
