### PR TITLE
Mirror I2C pin update from Heltec repository

### DIFF
--- a/variants/heltec_wifi_lora_32_V3/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V3/pins_arduino.h
@@ -29,8 +29,8 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 
-static const uint8_t SDA = 8;
-static const uint8_t SCL = 9;
+static const uint8_t SDA = 41;
+static const uint8_t SCL = 42;
 
 static const uint8_t SS    = 10;
 static const uint8_t MOSI  = 11;


### PR DESCRIPTION
## Description of Change
Heltec updated the I2C pins for the wifi_lora32_v3 in https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/commit/b10f4bf85d13fd01be80dcdb0eb59e6a8c8ba19a

This mirrors the commit over to this code.

## Tests scenarios

It was tested on a wifi lora v3 32 with a few i2c periphreals.

## Related links

(*eg. Closes #number of issue*)
