### PR TITLE
bugfix: add <stdint.h> for uint8_t in FunctionalInterrupt.h to avoid compilation failure (GCC 11.2.0)

### DIFF
--- a/cores/esp32/FunctionalInterrupt.h
+++ b/cores/esp32/FunctionalInterrupt.h
@@ -9,6 +9,7 @@
 #define CORE_CORE_FUNCTIONALINTERRUPT_H_
 
 #include <functional>
+#include <stdint.h>
 
 struct InterruptArgStructure {
 	std::function<void(void)> interruptFunction;


### PR DESCRIPTION
## Description of Change
Fix compilation on latest Xtensa ESP32 GCC toolchain.

## Tests scenarios
ESP32-WROOM-32U built on Windows 11 64bit PlatformIO, the MKS TinyBee V1.0
