### PR TITLE
ADD: New variant Edgebox-ESP-100

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -20649,3 +20649,210 @@ esp32c3m1IKit.menu.EraseFlash.all=Enabled
 esp32c3m1IKit.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+
+Edgebox-ESP-100.name=Edgebox-ESP-100
+
+Edgebox-ESP-100.bootloader.tool=esptool_py
+Edgebox-ESP-100.bootloader.tool.default=esptool_py
+
+Edgebox-ESP-100.upload.tool=esptool_py
+Edgebox-ESP-100.upload.tool.default=esptool_py
+Edgebox-ESP-100.upload.tool.network=esp_ota
+
+Edgebox-ESP-100.upload.maximum_size=1310720
+Edgebox-ESP-100.upload.maximum_data_size=327680
+Edgebox-ESP-100.upload.flags=
+Edgebox-ESP-100.upload.extra_flags=
+Edgebox-ESP-100.upload.use_1200bps_touch=false
+Edgebox-ESP-100.upload.wait_for_upload_port=false
+
+Edgebox-ESP-100.serial.disableDTR=false
+Edgebox-ESP-100.serial.disableRTS=false
+
+Edgebox-ESP-100.build.tarch=xtensa
+Edgebox-ESP-100.build.bootloader_addr=0x0
+Edgebox-ESP-100.build.target=esp32s3
+Edgebox-ESP-100.build.mcu=esp32s3
+Edgebox-ESP-100.build.core=esp32
+Edgebox-ESP-100.build.variant=Edgebox-ESP-100
+Edgebox-ESP-100.build.board=Edgebox-ESP-100
+
+Edgebox-ESP-100.build.usb_mode=0
+Edgebox-ESP-100.build.cdc_on_boot=0
+Edgebox-ESP-100.build.msc_on_boot=0
+Edgebox-ESP-100.build.dfu_on_boot=0
+Edgebox-ESP-100.build.f_cpu=240000000L
+Edgebox-ESP-100.build.flash_size=4MB
+Edgebox-ESP-100.build.flash_freq=80m
+Edgebox-ESP-100.build.flash_mode=dio
+Edgebox-ESP-100.build.boot=qio
+Edgebox-ESP-100.build.boot_freq=80m
+Edgebox-ESP-100.build.partitions=default
+Edgebox-ESP-100.build.defines=
+Edgebox-ESP-100.build.loop_core=
+Edgebox-ESP-100.build.event_core=
+Edgebox-ESP-100.build.psram_type=qspi
+Edgebox-ESP-100.build.memory_type={build.boot}_{build.psram_type}
+
+Edgebox-ESP-100.menu.PSRAM.disabled=Disabled
+Edgebox-ESP-100.menu.PSRAM.disabled.build.defines=
+Edgebox-ESP-100.menu.PSRAM.disabled.build.psram_type=qspi
+Edgebox-ESP-100.menu.PSRAM.enabled=QSPI PSRAM
+Edgebox-ESP-100.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+Edgebox-ESP-100.menu.PSRAM.enabled.build.psram_type=qspi
+Edgebox-ESP-100.menu.PSRAM.opi=OPI PSRAM
+Edgebox-ESP-100.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+Edgebox-ESP-100.menu.PSRAM.opi.build.psram_type=opi
+
+Edgebox-ESP-100.menu.FlashMode.qio=QIO 80MHz
+Edgebox-ESP-100.menu.FlashMode.qio.build.flash_mode=dio
+Edgebox-ESP-100.menu.FlashMode.qio.build.boot=qio
+Edgebox-ESP-100.menu.FlashMode.qio.build.boot_freq=80m
+Edgebox-ESP-100.menu.FlashMode.qio.build.flash_freq=80m
+Edgebox-ESP-100.menu.FlashMode.qio120=QIO 120MHz
+Edgebox-ESP-100.menu.FlashMode.qio120.build.flash_mode=dio
+Edgebox-ESP-100.menu.FlashMode.qio120.build.boot=qio
+Edgebox-ESP-100.menu.FlashMode.qio120.build.boot_freq=120m
+Edgebox-ESP-100.menu.FlashMode.qio120.build.flash_freq=80m
+Edgebox-ESP-100.menu.FlashMode.dio=DIO 80MHz
+Edgebox-ESP-100.menu.FlashMode.dio.build.flash_mode=dio
+Edgebox-ESP-100.menu.FlashMode.dio.build.boot=dio
+Edgebox-ESP-100.menu.FlashMode.dio.build.boot_freq=80m
+Edgebox-ESP-100.menu.FlashMode.dio.build.flash_freq=80m
+Edgebox-ESP-100.menu.FlashMode.opi=OPI 80MHz
+Edgebox-ESP-100.menu.FlashMode.opi.build.flash_mode=dout
+Edgebox-ESP-100.menu.FlashMode.opi.build.boot=opi
+Edgebox-ESP-100.menu.FlashMode.opi.build.boot_freq=80m
+Edgebox-ESP-100.menu.FlashMode.opi.build.flash_freq=80m
+
+Edgebox-ESP-100.menu.FlashSize.4M=4MB (32Mb)
+Edgebox-ESP-100.menu.FlashSize.4M.build.flash_size=4MB
+Edgebox-ESP-100.menu.FlashSize.8M=8MB (64Mb)
+Edgebox-ESP-100.menu.FlashSize.8M.build.flash_size=8MB
+Edgebox-ESP-100.menu.FlashSize.8M.build.partitions=default_8MB
+Edgebox-ESP-100.menu.FlashSize.16M=16MB (128Mb)
+Edgebox-ESP-100.menu.FlashSize.16M.build.flash_size=16MB
+#Edgebox-ESP-100.menu.FlashSize.32M=32MB (256Mb)
+#Edgebox-ESP-100.menu.FlashSize.32M.build.flash_size=32MB
+
+Edgebox-ESP-100.menu.LoopCore.1=Core 1
+Edgebox-ESP-100.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+Edgebox-ESP-100.menu.LoopCore.0=Core 0
+Edgebox-ESP-100.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+Edgebox-ESP-100.menu.EventsCore.1=Core 1
+Edgebox-ESP-100.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+Edgebox-ESP-100.menu.EventsCore.0=Core 0
+Edgebox-ESP-100.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+Edgebox-ESP-100.menu.USBMode.default=Hardware CDC and JTAG
+Edgebox-ESP-100.menu.USBMode.default.build.usb_mode=0
+Edgebox-ESP-100.menu.USBMode.hwcdc=USB-OTG (TinyUSB)
+Edgebox-ESP-100.menu.USBMode.hwcdc.build.usb_mode=1
+
+Edgebox-ESP-100.menu.CDCOnBoot.default=Disabled
+Edgebox-ESP-100.menu.CDCOnBoot.default.build.cdc_on_boot=0
+Edgebox-ESP-100.menu.CDCOnBoot.cdc=Enabled
+Edgebox-ESP-100.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+Edgebox-ESP-100.menu.MSCOnBoot.default=Disabled
+Edgebox-ESP-100.menu.MSCOnBoot.default.build.msc_on_boot=0
+Edgebox-ESP-100.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+Edgebox-ESP-100.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+Edgebox-ESP-100.menu.DFUOnBoot.default=Disabled
+Edgebox-ESP-100.menu.DFUOnBoot.default.build.dfu_on_boot=0
+Edgebox-ESP-100.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+Edgebox-ESP-100.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+Edgebox-ESP-100.menu.UploadMode.default=UART0 / Hardware CDC
+Edgebox-ESP-100.menu.UploadMode.default.upload.use_1200bps_touch=false
+Edgebox-ESP-100.menu.UploadMode.default.upload.wait_for_upload_port=false
+Edgebox-ESP-100.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+Edgebox-ESP-100.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+Edgebox-ESP-100.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+Edgebox-ESP-100.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+Edgebox-ESP-100.menu.PartitionScheme.default.build.partitions=default
+Edgebox-ESP-100.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+Edgebox-ESP-100.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+Edgebox-ESP-100.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+Edgebox-ESP-100.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+Edgebox-ESP-100.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+Edgebox-ESP-100.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+Edgebox-ESP-100.menu.PartitionScheme.minimal.build.partitions=minimal
+Edgebox-ESP-100.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+Edgebox-ESP-100.menu.PartitionScheme.no_ota.build.partitions=no_ota
+Edgebox-ESP-100.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+Edgebox-ESP-100.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+Edgebox-ESP-100.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+Edgebox-ESP-100.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+Edgebox-ESP-100.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+Edgebox-ESP-100.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+Edgebox-ESP-100.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+Edgebox-ESP-100.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+Edgebox-ESP-100.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+Edgebox-ESP-100.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+Edgebox-ESP-100.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+Edgebox-ESP-100.menu.PartitionScheme.huge_app.build.partitions=huge_app
+Edgebox-ESP-100.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+Edgebox-ESP-100.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+Edgebox-ESP-100.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+Edgebox-ESP-100.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+Edgebox-ESP-100.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+Edgebox-ESP-100.menu.PartitionScheme.fatflash.build.partitions=ffat
+Edgebox-ESP-100.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+Edgebox-ESP-100.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+Edgebox-ESP-100.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+Edgebox-ESP-100.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+Edgebox-ESP-100.menu.PartitionScheme.rainmaker=RainMaker
+Edgebox-ESP-100.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+Edgebox-ESP-100.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+Edgebox-ESP-100.menu.CPUFreq.240=240MHz (WiFi)
+Edgebox-ESP-100.menu.CPUFreq.240.build.f_cpu=240000000L
+Edgebox-ESP-100.menu.CPUFreq.160=160MHz (WiFi)
+Edgebox-ESP-100.menu.CPUFreq.160.build.f_cpu=160000000L
+Edgebox-ESP-100.menu.CPUFreq.80=80MHz (WiFi)
+Edgebox-ESP-100.menu.CPUFreq.80.build.f_cpu=80000000L
+Edgebox-ESP-100.menu.CPUFreq.40=40MHz
+Edgebox-ESP-100.menu.CPUFreq.40.build.f_cpu=40000000L
+Edgebox-ESP-100.menu.CPUFreq.20=20MHz
+Edgebox-ESP-100.menu.CPUFreq.20.build.f_cpu=20000000L
+Edgebox-ESP-100.menu.CPUFreq.10=10MHz
+Edgebox-ESP-100.menu.CPUFreq.10.build.f_cpu=10000000L
+
+Edgebox-ESP-100.menu.UploadSpeed.921600=921600
+Edgebox-ESP-100.menu.UploadSpeed.921600.upload.speed=921600
+Edgebox-ESP-100.menu.UploadSpeed.115200=115200
+Edgebox-ESP-100.menu.UploadSpeed.115200.upload.speed=115200
+Edgebox-ESP-100.menu.UploadSpeed.256000.windows=256000
+Edgebox-ESP-100.menu.UploadSpeed.256000.upload.speed=256000
+Edgebox-ESP-100.menu.UploadSpeed.230400.windows.upload.speed=256000
+Edgebox-ESP-100.menu.UploadSpeed.230400=230400
+Edgebox-ESP-100.menu.UploadSpeed.230400.upload.speed=230400
+Edgebox-ESP-100.menu.UploadSpeed.460800.linux=460800
+Edgebox-ESP-100.menu.UploadSpeed.460800.macosx=460800
+Edgebox-ESP-100.menu.UploadSpeed.460800.upload.speed=460800
+Edgebox-ESP-100.menu.UploadSpeed.512000.windows=512000
+Edgebox-ESP-100.menu.UploadSpeed.512000.upload.speed=512000
+
+Edgebox-ESP-100.menu.DebugLevel.none=None
+Edgebox-ESP-100.menu.DebugLevel.none.build.code_debug=0
+Edgebox-ESP-100.menu.DebugLevel.error=Error
+Edgebox-ESP-100.menu.DebugLevel.error.build.code_debug=1
+Edgebox-ESP-100.menu.DebugLevel.warn=Warn
+Edgebox-ESP-100.menu.DebugLevel.warn.build.code_debug=2
+Edgebox-ESP-100.menu.DebugLevel.info=Info
+Edgebox-ESP-100.menu.DebugLevel.info.build.code_debug=3
+Edgebox-ESP-100.menu.DebugLevel.debug=Debug
+Edgebox-ESP-100.menu.DebugLevel.debug.build.code_debug=4
+Edgebox-ESP-100.menu.DebugLevel.verbose=Verbose
+Edgebox-ESP-100.menu.DebugLevel.verbose.build.code_debug=5
+
+Edgebox-ESP-100.menu.EraseFlash.none=Disabled
+Edgebox-ESP-100.menu.EraseFlash.none.upload.erase_cmd=
+Edgebox-ESP-100.menu.EraseFlash.all=Enabled
+Edgebox-ESP-100.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -20677,7 +20677,7 @@ Edgebox-ESP-100.build.core=esp32
 Edgebox-ESP-100.build.variant=Edgebox-ESP-100
 Edgebox-ESP-100.build.board=Edgebox-ESP-100
 
-Edgebox-ESP-100.build.usb_mode=0
+Edgebox-ESP-100.build.usb_mode=1
 Edgebox-ESP-100.build.cdc_on_boot=0
 Edgebox-ESP-100.build.msc_on_boot=0
 Edgebox-ESP-100.build.dfu_on_boot=0
@@ -20746,9 +20746,9 @@ Edgebox-ESP-100.menu.EventsCore.0=Core 0
 Edgebox-ESP-100.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
 Edgebox-ESP-100.menu.USBMode.default=Hardware CDC and JTAG
-Edgebox-ESP-100.menu.USBMode.default.build.usb_mode=0
+Edgebox-ESP-100.menu.USBMode.default.build.usb_mode=1
 Edgebox-ESP-100.menu.USBMode.hwcdc=USB-OTG (TinyUSB)
-Edgebox-ESP-100.menu.USBMode.hwcdc.build.usb_mode=1
+Edgebox-ESP-100.menu.USBMode.hwcdc.build.usb_mode=0
 
 Edgebox-ESP-100.menu.CDCOnBoot.default=Disabled
 Edgebox-ESP-100.menu.CDCOnBoot.default.build.cdc_on_boot=0

--- a/variants/Edgebox-ESP-100/pins_arduino.h
+++ b/variants/Edgebox-ESP-100/pins_arduino.h
@@ -1,0 +1,67 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 34
+#define NUM_DIGITAL_PINS        34
+#define NUM_ANALOG_INPUTS       2
+
+#define analogInputToDigitalPin(p)  (((p)<2)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<34)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+//Programming and Debugging Port
+static const uint8_t TXD = 43;
+static const uint8_t RXD = 44;
+static const uint8_t RST = 0;
+
+//I2C 
+static const uint8_t SDA = 20;
+static const uint8_t SCL = 19;
+
+//I2C INT fro RTC PCF8563
+static const uint8_t I2C_INT = 9;
+
+//SPI BUS for W5500 Ethernet Port Driver
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 12;
+static const uint8_t MISO = 11;
+static const uint8_t SCK = 13;
+static const uint8_t ETH_INT = 14;
+static const uint8_t ETH_RST = 15;
+
+//A7670G
+static const uint8_t LTE_PWR_EN = 16;
+static const uint8_t LTE_PWR_KEY = 21;
+static const uint8_t LTE_TXD = 48;
+static const uint8_t LTE_RXD = 47;
+
+//RS485
+static const uint8_t RS485_TXD = 17;
+static const uint8_t RS485_RXD = 18;
+static const uint8_t RS485_RTS = 8;
+
+//CAN BUS
+static const uint8_t CAN_TXD = 1;
+static const uint8_t CAN_RXD = 2;
+
+//BUZZER
+static const uint8_t BUZZER = 45;
+
+static const uint8_t DO0 = 40;
+static const uint8_t DO1 = 39;
+static const uint8_t DO2 = 38;
+static const uint8_t DO3 = 37;
+static const uint8_t DO4 = 36;
+static const uint8_t DO5 = 35;
+
+static const uint8_t DI0 = 4;
+static const uint8_t DI1 = 5;
+static const uint8_t DI2 = 6;
+static const uint8_t DI3 = 7;
+
+static const uint8_t AO0 = 42;
+static const uint8_t AO1 = 41;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Hi, I would like to add [Edgebox-ESP-100](https://files.seeedstudio.com/wiki/edge_box_esp/EdgeBox-ESP-100-User_Manual.pdf) which is an PLC device equipped with ESP32-S3-WROOM-1U

## Changes:
1. added the Edgebox-ESP-100 board config setting to the end of the **"boards.txt"** file 
2. added Edgebox-ESP-100 folder in  **"/varient/Edgebox-ESP-100"**
3. added **"pin_arduino.h"** in  **"/varient/Edgebox-ESP-100"** folder for the pin configurations.

## Tests scenarios

### Hardware Test
I have tested my Pull Request on Arduino-esp32 core v2.0.6 with Edgebox-ESP-100 with successful verify and upload example sketches by using a usb-to-serial tool and connected to the Serial Programming & Debugging port of the Edgebox-ESP-100, The reset button need to be pressed or GPIO0 of the Serial Programming & Debugging port need to be pull down before the board powering up, so the ESP32-S3 module could boot to programming mode on next powering up.

Hardware Wiring:
![IMG20230129143749](https://user-images.githubusercontent.com/4452826/215309860-4ac8fe07-c1e4-4438-a73f-3fbecedb9cc3.jpg)
![IMG20230129143613](https://user-images.githubusercontent.com/4452826/215309878-17306d41-364b-44ec-8b7f-08e6c856d5c6.jpg)

Uploading Program:
![2023-01-29_14-35](https://user-images.githubusercontent.com/4452826/215309691-dac62d14-11a2-44a5-98fa-674695ea9930.png)

Serial Monitor Result: 
![2023-01-29_14-39](https://user-images.githubusercontent.com/4452826/215309714-3f6bac95-e251-40b2-9fb0-886cdfef1d4b.png)

### CI TEST
Passed the CI Test
![2023-01-30_15-04](https://user-images.githubusercontent.com/4452826/215409821-bf1aea76-93a7-4209-93ee-4d564ca9d324.png)

Thanks.
Peter