### PR TITLE
Add Adafruit new board feather esp32s2 reserve tft

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -8257,6 +8257,177 @@ adafruit_feather_esp32s2_tft.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s2_tft.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+# Adafruit Feather ESP32-S2 Reverse TFT
+
+adafruit_feather_esp32s2_reversetft.name=Adafruit Feather ESP32-S2 Reverse TFT
+adafruit_feather_esp32s2_reversetft.vid.0=0x239A
+adafruit_feather_esp32s2_reversetft.pid.0=0x80ED
+adafruit_feather_esp32s2_reversetft.vid.1=0x239A
+adafruit_feather_esp32s2_reversetft.pid.1=0x00ED
+adafruit_feather_esp32s2_reversetft.vid.2=0x239A
+adafruit_feather_esp32s2_reversetft.pid.2=0x80EE
+
+adafruit_feather_esp32s2_reversetft.bootloader.tool=esptool_py
+adafruit_feather_esp32s2_reversetft.bootloader.tool.default=esptool_py
+
+adafruit_feather_esp32s2_reversetft.upload.tool=esptool_py
+adafruit_feather_esp32s2_reversetft.upload.tool.default=esptool_py
+adafruit_feather_esp32s2_reversetft.upload.tool.network=esp_ota
+
+adafruit_feather_esp32s2_reversetft.upload.maximum_size=1310720
+adafruit_feather_esp32s2_reversetft.upload.maximum_data_size=327680
+adafruit_feather_esp32s2_reversetft.upload.flags=
+adafruit_feather_esp32s2_reversetft.upload.extra_flags=
+adafruit_feather_esp32s2_reversetft.upload.use_1200bps_touch=true
+adafruit_feather_esp32s2_reversetft.upload.wait_for_upload_port=true
+
+adafruit_feather_esp32s2_reversetft.serial.disableDTR=false
+adafruit_feather_esp32s2_reversetft.serial.disableRTS=false
+
+adafruit_feather_esp32s2_reversetft.build.tarch=xtensa
+adafruit_feather_esp32s2_reversetft.build.bootloader_addr=0x1000
+adafruit_feather_esp32s2_reversetft.build.target=esp32s2
+adafruit_feather_esp32s2_reversetft.build.mcu=esp32s2
+adafruit_feather_esp32s2_reversetft.build.core=esp32
+adafruit_feather_esp32s2_reversetft.build.variant=adafruit_feather_esp32s2_reversetft
+adafruit_feather_esp32s2_reversetft.build.board=ADAFRUIT_FEATHER_ESP32S2_REVTFT
+
+adafruit_feather_esp32s2_reversetft.build.cdc_on_boot=1
+adafruit_feather_esp32s2_reversetft.build.msc_on_boot=0
+adafruit_feather_esp32s2_reversetft.build.dfu_on_boot=0
+adafruit_feather_esp32s2_reversetft.build.f_cpu=240000000L
+adafruit_feather_esp32s2_reversetft.build.flash_size=4MB
+adafruit_feather_esp32s2_reversetft.build.flash_freq=80m
+adafruit_feather_esp32s2_reversetft.build.flash_mode=dio
+adafruit_feather_esp32s2_reversetft.build.boot=qio
+adafruit_feather_esp32s2_reversetft.build.partitions=default
+adafruit_feather_esp32s2_reversetft.build.defines=
+
+adafruit_feather_esp32s2_reversetft.menu.CDCOnBoot.cdc=Enabled
+adafruit_feather_esp32s2_reversetft.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+adafruit_feather_esp32s2_reversetft.menu.CDCOnBoot.default=Disabled
+adafruit_feather_esp32s2_reversetft.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+adafruit_feather_esp32s2_reversetft.menu.MSCOnBoot.default=Disabled
+adafruit_feather_esp32s2_reversetft.menu.MSCOnBoot.default.build.msc_on_boot=0
+adafruit_feather_esp32s2_reversetft.menu.MSCOnBoot.msc=Enabled
+adafruit_feather_esp32s2_reversetft.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+adafruit_feather_esp32s2_reversetft.menu.DFUOnBoot.default=Disabled
+adafruit_feather_esp32s2_reversetft.menu.DFUOnBoot.default.build.dfu_on_boot=0
+adafruit_feather_esp32s2_reversetft.menu.DFUOnBoot.dfu=Enabled
+adafruit_feather_esp32s2_reversetft.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+adafruit_feather_esp32s2_reversetft.menu.UploadMode.cdc=Internal USB
+adafruit_feather_esp32s2_reversetft.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+adafruit_feather_esp32s2_reversetft.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+adafruit_feather_esp32s2_reversetft.menu.UploadMode.default=UART0
+adafruit_feather_esp32s2_reversetft.menu.UploadMode.default.upload.use_1200bps_touch=false
+adafruit_feather_esp32s2_reversetft.menu.UploadMode.default.upload.wait_for_upload_port=false
+
+adafruit_feather_esp32s2_reversetft.menu.PSRAM.enabled=Enabled
+adafruit_feather_esp32s2_reversetft.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+adafruit_feather_esp32s2_reversetft.menu.PSRAM.disabled=Disabled
+adafruit_feather_esp32s2_reversetft.menu.PSRAM.disabled.build.defines=
+
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.tinyuf2=TinyUF2 4MB (1.3MB APP/960KB FFAT)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader-tinyuf2
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions-4MB-tinyuf2
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.tinyuf2.upload.maximum_size=1441792
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x2d0000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.default.build.partitions=default
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.minimal.build.partitions=minimal
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.no_ota.build.partitions=no_ota
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.huge_app.build.partitions=huge_app
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+adafruit_feather_esp32s2_reversetft.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.240=240MHz (WiFi)
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.240.build.f_cpu=240000000L
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.160=160MHz (WiFi)
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.160.build.f_cpu=160000000L
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.80=80MHz (WiFi)
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.80.build.f_cpu=80000000L
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.40=40MHz
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.40.build.f_cpu=40000000L
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.20=20MHz
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.20.build.f_cpu=20000000L
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.10=10MHz
+adafruit_feather_esp32s2_reversetft.menu.CPUFreq.10.build.f_cpu=10000000L
+
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.qio=QIO
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.qio.build.flash_mode=dio
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.qio.build.boot=qio
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.dio=DIO
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.dio.build.flash_mode=dio
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.dio.build.boot=dio
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.qout=QOUT
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.qout.build.flash_mode=dout
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.qout.build.boot=qout
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.dout=DOUT
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.dout.build.flash_mode=dout
+adafruit_feather_esp32s2_reversetft.menu.FlashMode.dout.build.boot=dout
+
+adafruit_feather_esp32s2_reversetft.menu.FlashFreq.80=80MHz
+adafruit_feather_esp32s2_reversetft.menu.FlashFreq.80.build.flash_freq=80m
+adafruit_feather_esp32s2_reversetft.menu.FlashFreq.40=40MHz
+adafruit_feather_esp32s2_reversetft.menu.FlashFreq.40.build.flash_freq=40m
+
+adafruit_feather_esp32s2_reversetft.menu.FlashSize.4M=4MB (32Mb)
+adafruit_feather_esp32s2_reversetft.menu.FlashSize.4M.build.flash_size=4MB
+
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.921600=921600
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.921600.upload.speed=921600
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.115200=115200
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.115200.upload.speed=115200
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.256000.windows=256000
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.256000.upload.speed=256000
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.230400.windows.upload.speed=256000
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.230400=230400
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.230400.upload.speed=230400
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.460800.linux=460800
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.460800.macosx=460800
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.460800.upload.speed=460800
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.512000.windows=512000
+adafruit_feather_esp32s2_reversetft.menu.UploadSpeed.512000.upload.speed=512000
+
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.none=None
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.none.build.code_debug=0
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.error=Error
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.error.build.code_debug=1
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.warn=Warn
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.warn.build.code_debug=2
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.info=Info
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.info.build.code_debug=3
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.debug=Debug
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.debug.build.code_debug=4
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.verbose=Verbose
+adafruit_feather_esp32s2_reversetft.menu.DebugLevel.verbose.build.code_debug=5
+
+adafruit_feather_esp32s2_reversetft.menu.EraseFlash.none=Disabled
+adafruit_feather_esp32s2_reversetft.menu.EraseFlash.none.upload.erase_cmd=
+adafruit_feather_esp32s2_reversetft.menu.EraseFlash.all=Enabled
+adafruit_feather_esp32s2_reversetft.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
 # Adafruit QT Py ESP32-S2
 
 adafruit_qtpy_esp32s2.name=Adafruit QT Py ESP32-S2

--- a/variants/adafruit_feather_esp32s2_reversetft/variant.cpp
+++ b/variants/adafruit_feather_esp32s2_reversetft/variant.cpp
@@ -31,7 +31,12 @@ extern "C" {
 // Initialize variant/board, called before setup()
 void initVariant(void)
 {
-
+  // This board has power control pins, and we must set them to output and high
+  // in order to enable the NeoPixels, TFT & I2C
+  pinMode(NEOPIXEL_POWER, OUTPUT);
+  digitalWrite(NEOPIXEL_POWER, HIGH);
+  pinMode(TFT_I2C_POWER, OUTPUT);
+  digitalWrite(TFT_I2C_POWER, HIGH);
 }
 
 }


### PR DESCRIPTION
## Description of Change
This PR add new board from Adafruit: Feather ESP32-S2 Reverse TFT https://www.adafruit.com/product/5345 . This should have no impact to other core and other boards functionality.

## Tests scenarios
Tested with master commit of arduino-esp32 and new board

@ladyada 
