### PR TITLE
Adds softAp(String) to make it compatible with ESP8266

### DIFF
--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -38,6 +38,10 @@ class WiFiAPClass
 public:
 
     bool softAP(const char* ssid, const char* passphrase = NULL, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false);
+    bool softAP(const String& ssid, const String& passphrase = emptyString, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false) {
+       return softAP(ssid.c_str(), passphrase.c_str(), channel, ssid_hidden, max_connection, ftm_responder);
+    }
+
     bool softAPConfig(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dhcp_lease_start = (uint32_t) 0);
     bool softAPdisconnect(bool wifioff = false);
 


### PR DESCRIPTION
## Description of Change
Adds API compatibility of WiFi.softAP() with ESP8266, by adding `String` as possible overload parameters.

## Tests scenarios
Using ESP32 works correctly. 

## Related links
Fix #7780
