### PR TITLE
Added function timerAttachInterruptFlag to timer api

### DIFF
--- a/cores/esp32/esp32-hal-timer.c
+++ b/cores/esp32/esp32-hal-timer.c
@@ -221,11 +221,15 @@ bool IRAM_ATTR timerFnWrapper(void *arg){
     return false;
 }
 
-void timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge){
+void timerAttachInterruptFlag(hw_timer_t *timer, void (*fn)(void), bool edge, int intr_alloc_flags){
     if(edge){
         log_w("EDGE timer interrupt is not supported! Setting to LEVEL...");
     }
-    timer_isr_callback_add(timer->group, timer->num, timerFnWrapper, fn, 0);
+    timer_isr_callback_add(timer->group, timer->num, timerFnWrapper, fn, intr_alloc_flags);
+}
+
+void timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge){
+    timerAttachInterruptFlag(timer, fn, edge, 0);
 }
 
 void timerDetachInterrupt(hw_timer_t *timer){

--- a/cores/esp32/esp32-hal-timer.h
+++ b/cores/esp32/esp32-hal-timer.h
@@ -36,6 +36,7 @@ void timerEnd(hw_timer_t *timer);
 void timerSetConfig(hw_timer_t *timer, uint32_t config);
 uint32_t timerGetConfig(hw_timer_t *timer);
 
+void timerAttachInterruptFlag(hw_timer_t *timer, void (*fn)(void), bool edge, int intr_alloc_flags);
 void timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge);
 void timerDetachInterrupt(hw_timer_t *timer);
 


### PR DESCRIPTION
## Description of Change
Added function timerAttachInterruptFlag to timer api, which allows passing interrupt allocation flags. For example ESP_INTR_FLAG_IRAM for low latency application.

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.6 with ESP32