### PR TITLE
Reword "ESP-IDF as Component" in readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can use the [Arduino-ESP32 Online Documentation](https://docs.espressif.com/
 * [Getting Started](https://docs.espressif.com/projects/arduino-esp32/en/latest/getting_started.html)
 * [Installing (Windows, Linux and macOS)](https://docs.espressif.com/projects/arduino-esp32/en/latest/installing.html)
 * [Libraries](https://docs.espressif.com/projects/arduino-esp32/en/latest/libraries.html)
-* [ESP-IDF as Component](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html)
+* [Arduino as an ESP-IDF component](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html)
 * [FAQ](https://docs.espressif.com/projects/arduino-esp32/en/latest/faq.html)
 * [Troubleshooting](https://docs.espressif.com/projects/arduino-esp32/en/latest/troubleshooting.html)
 


### PR DESCRIPTION
## Description of Change
I think "Arduino as an ESP-IDF component" or just "As ESP-IDF component" instead of  "ESP-IDF as Component" are a more correct ways to name [the link in the readme about Arduino as an IDF component.](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html)

1. "ESP-IDF as Component" would imply that ESP-IDF is some sort of library for Arduino, which is IMO misleading, because it's true the other way around.
2. It's written as "Arduino as an ESP-IDF component" on the webpage it points to as well.

Also I removed the capitalization from "Component" as I have not found a reason why is it capitalized.

## Related links
[https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html)