### PR TITLE
Fix ESP32-S3 cannot reset to bootrom when using USB OTG

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -40,6 +40,7 @@
 #include "esp32s2/rom/usb/chip_usb_dw_wrapper.h"
 #elif CONFIG_IDF_TARGET_ESP32S3
 #include "hal/usb_serial_jtag_ll.h"
+#include "hal/usb_phy_ll.h"
 #include "esp32s3/rom/usb/usb_persist.h"
 #include "esp32s3/rom/usb/usb_dc.h"
 #include "esp32s3/rom/usb/chip_usb_dw_wrapper.h"
@@ -415,6 +416,7 @@ static void usb_switch_to_cdc_jtag(){
     digitalWrite(USBPHY_DP_NUM, LOW);
 
     // Initialize CDC+JTAG ISR to listen for BUS_RESET
+    usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_BUS_RESET);


### PR DESCRIPTION
## Description of Change

This PR fixes an issue when GPIO20 (USB D+) pull-up is not enabled for usb jtag when we switch from OTG to Jtag when reset to bootrom. Which renders upload with OTG-USB is not possible and require manual hold BOOT and reset. The issue is introduced with IDF 4.4.3 specially from this commit https://github.com/espressif/esp-idf/commit/01143bd732992c97d5f31d0875a1d4c4c3fd1227 . As mentioned in the commit message, USB D+ should be re-enabled when setup/install usb jtag.

This has been causing lots of confusion and frustration for our user.
- https://forums.adafruit.com/viewtopic.php?p=959504
- https://forums.adafruit.com/viewtopic.php?p=959702

## Tests scenarios

Tested with Arduino core v2.0.6 on Espressif ESP32-S3 devkit (literally any S3 board). Steps to reproduce
- Open an Blink sketch/example
- Select "ESP32S3 Dev Module" board
- Select USB Mode to "USB-OTG (TinyUSB)"
- Select USB CDC on Boot to "Enabled"
- Select Upload Mode to "USB-OTG CDC (TinyUSB)"

Then only connect the USB OTG connector on the board and click upload. The first it could works, however after the code compiled with v2.0.6 is running. **Click upload again, board will disconnect but never re-appear as JTAG CDC since D+ pull up is overrided and disabled.** 

PS: @me-no-dev This issue is kind of critical since it affects lots of our users. If possible would you please include this in the upcoming release 2.0.7. Thanks.

@ladyada 

![Screenshot 2023-02-10 23:30:02](https://user-images.githubusercontent.com/249515/218156262-92dd9c15-e960-449b-914c-d866fb35ffcc.png)