### PR TITLE
Avoid starting AP Mode even when the password is too short

### DIFF
--- a/libraries/WiFi/examples/WiFiAccessPoint/WiFiAccessPoint.ino
+++ b/libraries/WiFi/examples/WiFiAccessPoint/WiFiAccessPoint.ino
@@ -32,7 +32,11 @@ void setup() {
   Serial.println("Configuring access point...");
 
   // You can remove the password parameter if you want the AP to be open.
-  WiFi.softAP(ssid, password);
+  // a valid password must have more than 7 characters
+  if (!WiFi.softAP(ssid, password)) {
+    log_e("Soft AP creation failed.");
+    while(1);
+  }
   IPAddress myIP = WiFi.softAPIP();
   Serial.print("AP IP address: ");
   Serial.println(myIP);

--- a/libraries/WiFi/src/WiFiAP.cpp
+++ b/libraries/WiFi/src/WiFiAP.cpp
@@ -136,12 +136,6 @@ void wifi_softap_config(wifi_config_t *wifi_config, const char * ssid=NULL, cons
 bool WiFiAPClass::softAP(const char* ssid, const char* passphrase, int channel, int ssid_hidden, int max_connection, bool ftm_responder)
 {
 
-    if(!WiFi.enableAP(true)) {
-        // enable AP failed
-        log_e("enable AP first!");
-        return false;
-    }
-
     if(!ssid || *ssid == 0) {
         // fail SSID missing
         log_e("SSID missing!");
@@ -151,6 +145,13 @@ bool WiFiAPClass::softAP(const char* ssid, const char* passphrase, int channel, 
     if(passphrase && (strlen(passphrase) > 0 && strlen(passphrase) < 8)) {
         // fail passphrase too short
         log_e("passphrase too short!");
+        return false;
+    }
+
+    // last step after checking the SSID and password
+    if(!WiFi.enableAP(true)) {
+        // enable AP failed
+        log_e("enable AP first!");
         return false;
     }
 


### PR DESCRIPTION
## Description of Change
Using Arduino 2.0.6 with the WiFiAccessPoint example, if the password is changed to have between 1 and 7 characters, an error message is sent, but even though the AP starts to work.

It will start with a different SSID and no password, which should not happen given that the `WiFiAPClass::softAP()` returned `false` and failed with an error message.

This PR fixes it by changing the order of the parameter verification to happen before setting the AP mode.

## Tests scenarios
Tested with ESP32

## Related links
Fix #7831