### PR TITLE
Add support for dfrobot firebeetle 2 esp32-e board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -6964,6 +6964,171 @@ dfrobot_beetle_esp32c3.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_beetle_esp32c3.menu.EraseFlash.all=Enabled
 dfrobot_beetle_esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
+
+##############################################################
+
+dfrobot_firebeetle2_esp32e.name=FireBeetle 2 ESP32-E
+
+dfrobot_firebeetle2_esp32e.upload.tool=esptool_py
+dfrobot_firebeetle2_esp32e.upload.maximum_size=1310720
+dfrobot_firebeetle2_esp32e.upload.maximum_data_size=327680
+dfrobot_firebeetle2_esp32e.upload.flags=
+dfrobot_firebeetle2_esp32e.upload.extra_flags=
+
+dfrobot_firebeetle2_esp32e.serial.disableDTR=true
+dfrobot_firebeetle2_esp32e.serial.disableRTS=true
+
+dfrobot_firebeetle2_esp32e.build.tarch=xtensa
+dfrobot_firebeetle2_esp32e.build.bootloader_addr=0x1000
+dfrobot_firebeetle2_esp32e.build.target=esp32
+dfrobot_firebeetle2_esp32e.build.mcu=esp32
+dfrobot_firebeetle2_esp32e.build.core=esp32
+dfrobot_firebeetle2_esp32e.build.variant=dfrobot_firebeetle2_esp32e
+dfrobot_firebeetle2_esp32e.build.board=DFROBOT_FIREBEETLE_2_ESP32E
+
+dfrobot_firebeetle2_esp32e.build.f_cpu=240000000L
+dfrobot_firebeetle2_esp32e.build.flash_size=4MB
+dfrobot_firebeetle2_esp32e.build.flash_freq=40m
+dfrobot_firebeetle2_esp32e.build.flash_mode=dio
+dfrobot_firebeetle2_esp32e.build.boot=dio
+dfrobot_firebeetle2_esp32e.build.partitions=default
+dfrobot_firebeetle2_esp32e.build.defines=
+dfrobot_firebeetle2_esp32e.build.loop_core=
+dfrobot_firebeetle2_esp32e.build.event_core=
+
+dfrobot_firebeetle2_esp32e.menu.PSRAM.disabled=Disabled
+dfrobot_firebeetle2_esp32e.menu.PSRAM.disabled.build.defines=
+dfrobot_firebeetle2_esp32e.menu.PSRAM.disabled.build.extra_libs=
+dfrobot_firebeetle2_esp32e.menu.PSRAM.enabled=Enabled
+dfrobot_firebeetle2_esp32e.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+dfrobot_firebeetle2_esp32e.menu.PSRAM.enabled.build.extra_libs=
+
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.default.build.partitions=default
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.minimal.build.partitions=minimal
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.no_ota.build.partitions=no_ota
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.huge_app.build.partitions=huge_app
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FAT)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.fatflash.build.partitions=ffat
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker=RainMaker
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.240=240MHz (WiFi/BT)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.240.build.f_cpu=240000000L
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.160=160MHz (WiFi/BT)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.160.build.f_cpu=160000000L
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.80=80MHz (WiFi/BT)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.80.build.f_cpu=80000000L
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.40=40MHz (40MHz XTAL)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.40.build.f_cpu=40000000L
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.26=26MHz (26MHz XTAL)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.26.build.f_cpu=26000000L
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.20=20MHz (40MHz XTAL)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.20.build.f_cpu=20000000L
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.13=13MHz (26MHz XTAL)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.13.build.f_cpu=13000000L
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.10=10MHz (40MHz XTAL)
+dfrobot_firebeetle2_esp32e.menu.CPUFreq.10.build.f_cpu=10000000L
+
+dfrobot_firebeetle2_esp32e.menu.FlashMode.qio=QIO
+dfrobot_firebeetle2_esp32e.menu.FlashMode.qio.build.flash_mode=dio
+dfrobot_firebeetle2_esp32e.menu.FlashMode.qio.build.boot=qio
+dfrobot_firebeetle2_esp32e.menu.FlashMode.dio=DIO
+dfrobot_firebeetle2_esp32e.menu.FlashMode.dio.build.flash_mode=dio
+dfrobot_firebeetle2_esp32e.menu.FlashMode.dio.build.boot=dio
+dfrobot_firebeetle2_esp32e.menu.FlashMode.qout=QOUT
+dfrobot_firebeetle2_esp32e.menu.FlashMode.qout.build.flash_mode=dout
+dfrobot_firebeetle2_esp32e.menu.FlashMode.qout.build.boot=qout
+dfrobot_firebeetle2_esp32e.menu.FlashMode.dout=DOUT
+dfrobot_firebeetle2_esp32e.menu.FlashMode.dout.build.flash_mode=dout
+dfrobot_firebeetle2_esp32e.menu.FlashMode.dout.build.boot=dout
+
+dfrobot_firebeetle2_esp32e.menu.FlashFreq.80=80MHz
+dfrobot_firebeetle2_esp32e.menu.FlashFreq.80.build.flash_freq=80m
+dfrobot_firebeetle2_esp32e.menu.FlashFreq.40=40MHz
+dfrobot_firebeetle2_esp32e.menu.FlashFreq.40.build.flash_freq=40m
+
+dfrobot_firebeetle2_esp32e.menu.FlashSize.4M=4MB (32Mb)
+dfrobot_firebeetle2_esp32e.menu.FlashSize.4M.build.flash_size=4MB
+dfrobot_firebeetle2_esp32e.menu.FlashSize.8M=8MB (64Mb)
+dfrobot_firebeetle2_esp32e.menu.FlashSize.8M.build.flash_size=8MB
+dfrobot_firebeetle2_esp32e.menu.FlashSize.8M.build.partitions=default_8MB
+dfrobot_firebeetle2_esp32e.menu.FlashSize.2M=2MB (16Mb)
+dfrobot_firebeetle2_esp32e.menu.FlashSize.2M.build.flash_size=2MB
+dfrobot_firebeetle2_esp32e.menu.FlashSize.2M.build.partitions=minimal
+dfrobot_firebeetle2_esp32e.menu.FlashSize.16M=16MB (128Mb)
+dfrobot_firebeetle2_esp32e.menu.FlashSize.16M.build.flash_size=16MB
+
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.921600=921600
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.921600.upload.speed=921600
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.115200=115200
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.115200.upload.speed=115200
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.256000.windows=256000
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.256000.upload.speed=256000
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.230400.windows.upload.speed=256000
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.230400=230400
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.230400.upload.speed=230400
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.460800.linux=460800
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.460800.macosx=460800
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.460800.upload.speed=460800
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.512000.windows=512000
+dfrobot_firebeetle2_esp32e.menu.UploadSpeed.512000.upload.speed=512000
+
+dfrobot_firebeetle2_esp32e.menu.LoopCore.1=Core 1
+dfrobot_firebeetle2_esp32e.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+dfrobot_firebeetle2_esp32e.menu.LoopCore.0=Core 0
+dfrobot_firebeetle2_esp32e.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+dfrobot_firebeetle2_esp32e.menu.EventsCore.1=Core 1
+dfrobot_firebeetle2_esp32e.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+dfrobot_firebeetle2_esp32e.menu.EventsCore.0=Core 0
+dfrobot_firebeetle2_esp32e.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.none=None
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.none.build.code_debug=0
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.error=Error
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.error.build.code_debug=1
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.warn=Warn
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.warn.build.code_debug=2
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.info=Info
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.info.build.code_debug=3
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.debug=Debug
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.debug.build.code_debug=4
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.verbose=Verbose
+dfrobot_firebeetle2_esp32e.menu.DebugLevel.verbose.build.code_debug=5
+
+dfrobot_firebeetle2_esp32e.menu.EraseFlash.none=Disabled
+dfrobot_firebeetle2_esp32e.menu.EraseFlash.none.upload.erase_cmd=
+dfrobot_firebeetle2_esp32e.menu.EraseFlash.all=Enabled
+dfrobot_firebeetle2_esp32e.menu.EraseFlash.all.upload.erase_cmd=-e
+
 ##############################################################
 
 dfrobot_firebeetle2_esp32s3.name=DFRobot Firebeetle 2 ESP32-S3

--- a/variants/dfrobot_firebeetle2_esp32e/pins_arduino.h
+++ b/variants/dfrobot_firebeetle2_esp32e/pins_arduino.h
@@ -1,0 +1,80 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+typedef unsigned char uint8_t;
+
+static const uint8_t LED_BUILTIN = 2;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN
+
+
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+static const uint8_t TX2 = 17;
+static const uint8_t RX2 = 16;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t D0 = 3;
+static const uint8_t D1 = 1;
+static const uint8_t D2 = 25;
+static const uint8_t D3 = 26;
+static const uint8_t D4 = 27;
+static const uint8_t D5 = 0;
+static const uint8_t D6 = 14;
+static const uint8_t D7 = 13;
+static const uint8_t D8 = 5;
+static const uint8_t D9 = 2;
+static const uint8_t D10 = 17;
+static const uint8_t D11 = 16;
+static const uint8_t D12 = 4;
+static const uint8_t D13 = 12;
+
+static const uint8_t A0 = 36;
+static const uint8_t A1 = 39;
+static const uint8_t A2 = 34;
+static const uint8_t A3 = 35;
+static const uint8_t A4 = 15;
+static const uint8_t A5 = 35;
+static const uint8_t A6 = 4;
+static const uint8_t A7 = 0;
+static const uint8_t A8 = 2;
+static const uint8_t A9 = 13;
+static const uint8_t A10 = 12;
+static const uint8_t A11 = 14;
+static const uint8_t A12 = 27;
+static const uint8_t A13 = 25;
+static const uint8_t A14 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
This PR adds support for the DFRobot FireBeetle 2 ESP32-E board. (https://wiki.dfrobot.com/FireBeetle_Board_ESP32_E_SKU_DFR0654) No impact to other boards.

## Tests scenarios
I have tested my Pull Request on master with dfrobot firebeetle 2 esp32-e board. Successfully uploads sketches.
