### PR TITLE
Update heltec_wifi v3 pins

### DIFF
--- a/variants/heltec_wifi_kit_32_v3/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32_v3/pins_arduino.h
@@ -15,56 +15,58 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
-static const uint8_t LED_BUILTIN = 25;
+static const uint8_t LED_BUILTIN = 35;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 
-static const uint8_t TX = 1;
-static const uint8_t RX = 3;
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
 
 static const uint8_t SDA = 21;
 static const uint8_t SCL = 22;
 
-static const uint8_t SS    = 5;
-static const uint8_t MOSI  = 23;
-static const uint8_t MISO  = 19;
-static const uint8_t SCK   = 18;
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 10;
+static const uint8_t MISO = 11;
+static const uint8_t SCK = 9;
 
-static const uint8_t A0 = 36;
-static const uint8_t A1 = 37;
-static const uint8_t A2 = 38;
-static const uint8_t A3 = 39;
-static const uint8_t A4 = 32;
-static const uint8_t A5 = 33;
-static const uint8_t A6 = 34;
-static const uint8_t A7 = 35;
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
 
-static const uint8_t A10 = 4;
-static const uint8_t A11 = 0;
-static const uint8_t A12 = 2;
-static const uint8_t A13 = 15;
-static const uint8_t A14 = 13;
-static const uint8_t A15 = 12;
-static const uint8_t A16 = 14;
-static const uint8_t A17 = 27;
-static const uint8_t A18 = 25;
-static const uint8_t A19 = 26;
-
-static const uint8_t T0 = 4;
-static const uint8_t T1 = 0;
+static const uint8_t T1 = 1;
 static const uint8_t T2 = 2;
-static const uint8_t T3 = 15;
-static const uint8_t T4 = 13;
-static const uint8_t T5 = 12;
-static const uint8_t T6 = 14;
-static const uint8_t T7 = 27;
-static const uint8_t T8 = 33;
-static const uint8_t T9 = 32;
-
-static const uint8_t DAC1 = 25;
-static const uint8_t DAC2 = 26;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
 
 static const uint8_t Vext = 36;
 static const uint8_t LED  = 35;

--- a/variants/heltec_wifi_lora_32_V3/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V3/pins_arduino.h
@@ -32,10 +32,10 @@ static const uint8_t RX = 44;
 static const uint8_t SDA = 41;
 static const uint8_t SCL = 42;
 
-static const uint8_t SS    = 10;
-static const uint8_t MOSI  = 11;
-static const uint8_t MISO  = 13;
-static const uint8_t SCK   = 12;
+static const uint8_t SS    = 8;
+static const uint8_t MOSI  = 10;
+static const uint8_t MISO  = 11;
+static const uint8_t SCK   = 9;
 
 static const uint8_t A0 = 1;
 static const uint8_t A1 = 2;


### PR DESCRIPTION
### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

-----------
## Description of Change

Update `heltec_wifi_kit_32_v3` and `heltec_wifi_kit_32_v3` pin headers. @smerkadidit noticed that the pins were not correct for V3. This PR fixes that.

This PR copies over changes from the upstream repo:
https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series

## Tests scenarios

I have both Heltec boards, and checked that the new pins were correct.

I also read through the [pinout](https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WiFi%20kit32_V3(Rev1.1).pdf) diagram, and [schematic](https://resource.heltec.cn/download/WiFi_Kit_32_V3/HTIT-WB32_V3_Schematic_Diagram.pdf) drawings for these boards to confirm the correct pins.

## Related links

Fixes Issue #7737

This will also unblock these boards in platformio:
https://github.com/platformio/platform-espressif32/issues/1018

See this merged PR for additional documentation, including links to DataSheets, Schematics and Reference manuals:
https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/pull/163
