### PR TITLE
Adds pseudo random numbers generation

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -137,9 +137,19 @@ typedef unsigned int word;
 void setup(void);
 void loop(void);
 
+// The default is using Real Hardware random number generator  
+// But when randomSeed() is called, it turns to Psedo random
+// generator, exactly as done in Arduino mainstream
+long random(long);
 long random(long, long);
-#endif
+// Calling randomSeed() will make random()
+// using pseudo random like in Arduino
 void randomSeed(unsigned long);
+// Allow the Application to decide if the random generator
+// will use Real Hardware random generation (true - default)
+// or Pseudo random generation (false) as in Arduino MainStream
+void useRealRandomGenerator(bool useRandomHW);
+#endif
 long map(long, long, long, long, long);
 
 #ifdef __cplusplus
@@ -207,8 +217,6 @@ void setToneChannel(uint8_t channel = 0);
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);
 
-// WMath prototypes
-long random(long);
 #endif /* __cplusplus */
 
 #include "pins_arduino.h"

--- a/cores/esp32/WMath.cpp
+++ b/cores/esp32/WMath.cpp
@@ -29,10 +29,22 @@ extern "C" {
 }
 #include "esp32-hal-log.h"
 
+// Allows the user to choose between Real Hardware
+// or Software Pseudo random generators for the
+// Arduino random() functions
+static bool s_useRandomHW = true;
+void useRealRandomGenerator(bool useRandomHW) {
+  s_useRandomHW = useRandomHW;
+}
+
+// Calling randomSeed() will force the
+// Pseudo Random generator like in 
+// Arduino mainstream API
 void randomSeed(unsigned long seed)
 {
     if(seed != 0) {
         srand(seed);
+        s_useRandomHW = false;
     }
 }
 
@@ -46,7 +58,9 @@ long random( long howbig )
   if (howbig < 0) {
     return (random(0, -howbig));
   }
-  return esp_random() % howbig;
+  // if randomSeed was called, fall back to software PRNG
+  uint32_t val = (s_useRandomHW) ? esp_random() : rand();
+  return val % howbig;
 }
 
 long random(long howsmall, long howbig)


### PR DESCRIPTION
## Description of Change
Currently `radom()` uses a real hardware generator.
Arduino mainstream `random()` uses a software pseudo generator that always returns the same pseudo random sequence based on a seed defined with `randomSeed()`

This PR implements a similar behavior as the ESP8266 Arduino:
1) By default, `random()` will use the ESP32 Hardware real random generator
2) If the Sketch calls `randomSeed()`, the Arduino Core will understand that it wants to follow Arduino behavior and it will generate a Pseudo Random number based on that seed.
3) Adds a new function `void useRealRandomGenerator(bool useRandomHW)` that, at any time, tells Arduino if `random()` shall use Hardware or Software random generator.

## Tests scenarios
Tested on ESP32 

testing sketch:
``` cpp
void printRandomSequence(int val1, int val2) {
//  Serial.printf("random(%d, %d) ::\n", val1, val2);
  Serial.print(random(val1, val2));
  for (uint8_t i = 0; i < 9; i++) {
    Serial.printf(" | %d", random(val1, val2));
  }
  Serial.println();
  
}

void setup() {
  Serial.begin(115200);
  delay(1000); // time for opening the Serial Monitor
  
  Serial.println("\n======\nRandom Testing with random(1, 5)\n======");
  
  Serial.println("\nDefault Hardware Random sequence generation 2x (different seq.)");
  printRandomSequence(1, 5);
  printRandomSequence(1, 5);
  
  Serial.println("\nPseudo Random sequence generation - Seed(100) 2x (same seq.)");
  randomSeed(100); 
  printRandomSequence(1, 5);
  randomSeed(100); 
  printRandomSequence(1, 5);
  
  Serial.println("\nuseRealRandomGenerator(true):: random sequence generation 2x (different seq.)");
  useRealRandomGenerator(true); 
  printRandomSequence(1, 5);
  printRandomSequence(1, 5);

  Serial.println("\nuseRealRandomGenerator(false):: random sequence generation 2x (same seq. - after reboot)");
  useRealRandomGenerator(false); 
  printRandomSequence(1, 5);
  printRandomSequence(1, 5);

  delay(5000);
  Serial.println("\n---Compare the sequences through rebooting...\n");
  esp_restart();
}

void loop() {
// nothing here.  
}
```

## Related links
Fix #7404