### PR TITLE
Adds onDisconnect() BLE param

### DIFF
--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -207,6 +207,7 @@ void BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t 
 		case ESP_GATTS_DISCONNECT_EVT: {
 			if (m_pServerCallbacks != nullptr) {         // If we have callbacks, call now.
 				m_pServerCallbacks->onDisconnect(this);
+				m_pServerCallbacks->onDisconnect(this, param);
 			}
             if(m_connId == ESP_GATT_IF_NONE) {
                 return;


### PR DESCRIPTION
## Description of Change
PR #7559 was incomplete when compared to issue #6008
This is pointed out in issue #7741

There is a missing call to `onDisconnect(this, param);`

## Tests scenarios
Tested with ESP32-S3 sketch (below) and a mobile BLE APP (iOS or Android). 

``` cpp
#include <BLEDevice.h>
#include <BLEUtils.h>
#include <BLEServer.h>
#include <BLEAddress.h>

#define SERVICE_UUID        "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
#define CHARACTERISTIC_UUID "beb5483e-36e1-4688-b7f5-ea07361b26a8"

bool deviceConnected = false;

class MyServerCallbacks: public BLEServerCallbacks {
    void onConnect(BLEServer* pServer) {
      deviceConnected = true;
    };

    void onDisconnect(BLEServer* server, esp_ble_gatts_cb_param_t* param) {
      BLEAddress remote_addr(param->disconnect.remote_bda);
      
      Serial.printf("ble::onDisconnect reason: %s | Connection ID: %d | Link Role: %s | Remote Address: %s\n",
                      BLEUtils::gattCloseReasonToString(param->disconnect.reason).c_str(),
                      param->disconnect.conn_id, 
                      param->disconnect.link_role ? "SLAVE" : "MASTER",
                      remote_addr.toString().c_str()
       ); 
    }
    
    void onDisconnect(BLEServer* pServer) {
      deviceConnected = false;
    }
};

void setup() {
  Serial.begin(115200);
  Serial.println("Starting BLE work!");

  BLEDevice::init("Long name works now");
  BLEServer *pServer = BLEDevice::createServer();
  pServer->setCallbacks(new MyServerCallbacks());
  BLEService *pService = pServer->createService(SERVICE_UUID);
  BLECharacteristic *pCharacteristic = pService->createCharacteristic(
                                         CHARACTERISTIC_UUID,
                                         BLECharacteristic::PROPERTY_READ |
                                         BLECharacteristic::PROPERTY_WRITE
                                       );

  pCharacteristic->setValue("Hello World says Neil");
  pService->start();
  // BLEAdvertising *pAdvertising = pServer->getAdvertising();  // this still is working for backward compatibility
  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
  pAdvertising->addServiceUUID(SERVICE_UUID);
  pAdvertising->setScanResponse(true);
  pAdvertising->setMinPreferred(0x06);  // functions that help with iPhone connections issue
  pAdvertising->setMinPreferred(0x12);
  BLEDevice::startAdvertising();
  Serial.println("Characteristic defined! Now you can read it in your phone!");
}

void loop() {
  // put your main code here, to run repeatedly:
  delay(2000);
  Serial.printf("Server is %s\n", deviceConnected ? "Connected" : "Disconnected");
}
```

## Related links
Fix #7741
Close #7115