### PR TITLE
Replace new with malloc for non-class calls

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -225,30 +225,31 @@ String EspClass::getSketchMD5()
     const esp_partition_t *running = esp_ota_get_running_partition();
     if (!running) {
         log_e("Partition could not be found");
-
         return String();
     }
+
     const size_t bufSize = SPI_FLASH_SEC_SIZE;
-    std::unique_ptr<uint8_t[]> buf(new uint8_t[bufSize]);
-    uint32_t offset = 0;
-    if(!buf.get()) {
+    uint8_t *pb = (uint8_t *)malloc(bufSize);
+    if(!pb) {
         log_e("Not enough memory to allocate buffer");
-
         return String();
     }
+    uint32_t offset = 0;
+
     MD5Builder md5;
     md5.begin();
-    while( lengthLeft > 0) {
+    while(lengthLeft > 0) {
         size_t readBytes = (lengthLeft < bufSize) ? lengthLeft : bufSize;
-        if (!ESP.flashRead(running->address + offset, reinterpret_cast<uint32_t*>(buf.get()), (readBytes + 3) & ~3)) {
+        if (!ESP.flashRead(running->address + offset, (uint32_t *)pb, (readBytes + 3) & ~3)) {
+            free(pb);
             log_e("Could not read buffer from flash");
-
             return String();
         }
-        md5.add(buf.get(), readBytes);
+        md5.add(pb, readBytes);
         lengthLeft -= readBytes;
         offset += readBytes;
     }
+    free(pb);
     md5.calculate();
     result = md5.toString();
     return result;

--- a/libraries/BLE/src/BLEAdvertising.cpp
+++ b/libraries/BLE/src/BLEAdvertising.cpp
@@ -196,7 +196,12 @@ void BLEAdvertising::start() {
 	int numServices = m_serviceUUIDs.size();
 	if (numServices > 0) {
 		m_advData.service_uuid_len = 16 * numServices;
-		m_advData.p_service_uuid = new uint8_t[m_advData.service_uuid_len];
+		m_advData.p_service_uuid = (uint8_t *)malloc(m_advData.service_uuid_len);
+		if(!m_advData.p_service_uuid) {
+			log_e(">> start failed: out of memory");
+			return;
+		}
+
 		uint8_t* p = m_advData.p_service_uuid;
 		for (int i = 0; i < numServices; i++) {
 			log_d("- advertising service: %s", m_serviceUUIDs[i].toString().c_str());
@@ -241,10 +246,8 @@ void BLEAdvertising::start() {
 
 	// If we had services to advertise then we previously allocated some storage for them.
 	// Here we release that storage.
-	if (m_advData.service_uuid_len > 0) {
-		delete[] m_advData.p_service_uuid;
-		m_advData.p_service_uuid = nullptr;
-	}
+	free(m_advData.p_service_uuid); //TODO change this variable to local scope?
+	m_advData.p_service_uuid = nullptr;
 
 	// Start advertising.
 	errRc = ::esp_ble_gap_start_advertising(&m_advParams);

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -134,26 +134,26 @@ bool WebServer::authenticate(const char * username, const char * password){
       authReq = authReq.substring(6);
       authReq.trim();
       char toencodeLen = strlen(username)+strlen(password)+1;
-      char *toencode = new char[toencodeLen + 1];
+      char *toencode = (char *)malloc[toencodeLen + 1];
       if(toencode == NULL){
         authReq = "";
         return false;
       }
-      char *encoded = new char[base64_encode_expected_len(toencodeLen)+1];
+      char *encoded = (char *)malloc(base64_encode_expected_len(toencodeLen)+1);
       if(encoded == NULL){
         authReq = "";
-        delete[] toencode;
+        free(toencode);
         return false;
       }
       sprintf(toencode, "%s:%s", username, password);
       if(base64_encode_chars(toencode, toencodeLen, encoded) > 0 && authReq.equalsConstantTime(encoded)) {
         authReq = "";
-        delete[] toencode;
-        delete[] encoded;
+        free(toencode);
+        free(encoded);
         return true;
       }
-      delete[] toencode;
-      delete[] encoded;
+      free(toencode);
+      free(encoded);;
     } else if(authReq.startsWith(F("Digest"))) {
       authReq = authReq.substring(7);
       log_v("%s", authReq.c_str());

--- a/libraries/WiFi/src/WiFiUdp.cpp
+++ b/libraries/WiFi/src/WiFiUdp.cpp
@@ -44,11 +44,12 @@ uint8_t WiFiUDP::begin(IPAddress address, uint16_t port){
 
   server_port = port;
 
-  tx_buffer = new char[1460];
+  tx_buffer = (char *)malloc(1460);
   if(!tx_buffer){
     log_e("could not create tx buffer: %d", errno);
     return 0;
   }
+  tx_buffer_len = 0;
 
   if ((udp_server=socket(AF_INET, SOCK_DGRAM, 0)) == -1){
     log_e("could not create socket: %d", errno);
@@ -100,7 +101,7 @@ uint8_t WiFiUDP::beginMulticast(IPAddress a, uint16_t p){
 
 void WiFiUDP::stop(){
   if(tx_buffer){
-    delete[] tx_buffer;
+    free(tx_buffer);
     tx_buffer = NULL;
   }
   tx_buffer_len = 0;
@@ -136,13 +137,12 @@ int WiFiUDP::beginPacket(){
 
   // allocate tx_buffer if is necessary
   if(!tx_buffer){
-    tx_buffer = new char[1460];
+    tx_buffer = (char *)malloc(1460);
     if(!tx_buffer){
       log_e("could not create tx buffer: %d", errno);
       return 0;
     }
   }
-
   tx_buffer_len = 0;
 
   // check whereas socket is already open


### PR DESCRIPTION
## Description of Change
This PR resolves potential crashing issues when allocating memory using `new` keyword.  Will be replacing with `malloc` for non-class calls. Targeting 3.0.x branch.

## Tests scenarios
arduino-esp32 core v2.0.7 with Adafruit Feather ESP32.

## Related links
Please provide links to related issue, PRs etc.

Started by issue #7558.  PR #8065 will fix the issue on 2.x branch. 
