### PR TITLE
Update heltec wifi v3 pin definitions

### DIFF
--- a/variants/heltec_wifi_kit_32_v3/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32_v3/pins_arduino.h
@@ -7,13 +7,13 @@
 #define DISPLAY_HEIGHT 64
 #define DISPLAY_WIDTH  128
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        48
+#define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = 35;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
@@ -73,5 +73,7 @@ static const uint8_t LED  = 35;
 static const uint8_t RST_OLED = 21;
 static const uint8_t SCL_OLED = 18;
 static const uint8_t SDA_OLED = 17;
+
+static const uint8_t DIO0 = 14;
 
 #endif /* Pins_Arduino_h */

--- a/variants/heltec_wifi_lora_32_V3/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V3/pins_arduino.h
@@ -5,6 +5,8 @@
 #include "soc/soc_caps.h"
 
 #define WIFI_LoRa_32_V3 true
+#define DISPLAY_HEIGHT 64
+#define DISPLAY_WIDTH  128
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
@@ -78,5 +80,9 @@ static const uint8_t LED  = 35;
 static const uint8_t RST_OLED = 21;
 static const uint8_t SCL_OLED = 18;
 static const uint8_t SDA_OLED = 17;
+
+static const uint8_t RST_LoRa = 12;
+static const uint8_t BUSY_LoRa = 13;
+static const uint8_t DIO0 = 14;
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change

This PR corrects the definitions for: `WIFI_LoRa_32_V3`, and `WIFI_Kit_32_V3` boards.

Without macros defined like `DISPLAY_HEIGHT`, `DISPLAY_WIDTH`, and `DIO0`, some features on the Heltec V3 boards won't initialize properly. This also makes these heltec boards more consistent with earlier board versions definitions.


## Tests scenarios

Tested on the actual boards. These changes are necessary to make the display work.


## Related links

Follow on to #7846 after further testing.

Thanks!!
