### PR TITLE
Added the JSON file URL from github.io

### DIFF
--- a/docs/source/api/espnow.rst
+++ b/docs/source/api/espnow.rst
@@ -13,13 +13,13 @@ Examples
 ESP-NOW Master
 **************
 
-.. literalinclude:: ../../../libraries/ESP32/examples/ESPNow/Basic/Master/Master.ino
+.. literalinclude:: ../../../libraries/ESP32/examples/ESPNow/ESPNow_Basic_Master/ESPNow_Basic_Master.ino
     :language: arduino
 
 ESP-NOW Slave
 *************
 
-.. literalinclude:: ../../../libraries/ESP32/examples/ESPNow/Basic/Slave/Slave.ino
+.. literalinclude:: ../../../libraries/ESP32/examples/ESPNow/ESPNow_Basic_Slave/ESPNow_Basic_Slave.ino
     :language: arduino
 
 Resources

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -25,11 +25,11 @@ This is the way to install Arduino-ESP32 directly from the Arduino IDE.
 
 - Stable release link::
 
-   https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+   https://espressif.github.io/arduino-esp32/package_esp32_index.json
 
 - Development release link::
 
-   https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
+   https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json
 
 
 .. note::


### PR DESCRIPTION
## Description of Change

Update on the install guide to change JSON files URLs to github.io.

New links:

- Stable release link::
   https://espressif.github.io/arduino-esp32/package_esp32_index.json

- Development release link::
   https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json

The old link still works.

## Tests scenarios

N/A

## Related links

https://github.com/espressif/arduino-esp32/issues/3505