### PR TITLE
Fixes Maximum BLE Device Length

### DIFF
--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -414,7 +414,7 @@ gatts_event_handler BLEDevice::m_customGattsHandler = nullptr;
 		// makes sure it fails with any device name that has more than the possible advertising payload length
 		if (deviceName.length() > ESP_BLE_ADV_DATA_LEN_MAX - 2) {  // 1 byte for Length + 1 bytes for ID
 			deviceName = "bad length name: max 29 bytes";
-			errRC = ESP_ERR_INVALID_ARG;
+			errRc = ESP_ERR_INVALID_ARG;
 		} else
 		        errRc = ::esp_ble_gap_set_device_name(deviceName.c_str());
 		}

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -415,7 +415,7 @@ gatts_event_handler BLEDevice::m_customGattsHandler = nullptr;
 		if (deviceName.length() > ESP_BLE_ADV_DATA_LEN_MAX - 2) {  // 1 byte for Length + 1 bytes for ID
 			deviceName = "bad length name: max 29 bytes";
 			errRc = ESP_ERR_INVALID_ARG;
-		} else
+		} else {
 		        errRc = ::esp_ble_gap_set_device_name(deviceName.c_str());
 		}
 		if (errRc != ESP_OK) {

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -410,8 +410,14 @@ gatts_event_handler BLEDevice::m_customGattsHandler = nullptr;
 			return;
 		}
 #endif   // CONFIG_GATTS_ENABLE
-
-		errRc = ::esp_ble_gap_set_device_name(deviceName.c_str());
+		
+		// makes sure it fails with any device name that has more than the possible advertising payload length
+		if (deviceName.length() > ESP_BLE_ADV_DATA_LEN_MAX - 2) {  // 1 byte for Length + 1 bytes for ID
+			deviceName = "bad length name: max 29 bytes";
+			errRC = ESP_ERR_INVALID_ARG;
+		} else
+		        errRc = ::esp_ble_gap_set_device_name(deviceName.c_str());
+		}
 		if (errRc != ESP_OK) {
 			log_e("esp_ble_gap_set_device_name: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 			return;

--- a/libraries/BLE/src/BLEDevice.h
+++ b/libraries/BLE/src/BLEDevice.h
@@ -36,7 +36,7 @@ public:
 	static BLEAddress  getAddress();      // Retrieve our own local BD address.
 	static BLEScan*    getScan();         // Get the scan object
 	static std::string getValue(BLEAddress bdAddress, BLEUUID serviceUUID, BLEUUID characteristicUUID);	  // Get the value of a characteristic of a service on a server.
-	static void        init(std::string deviceName);   // Initialize the local BLE environment.
+	static bool        init(std::string deviceName);   // Initialize the local BLE environment.
 	static void        setPower(esp_power_level_t powerLevel, esp_ble_power_type_t powerType=ESP_BLE_PWR_TYPE_DEFAULT);  // Set our power level.
 	static void        setValue(BLEAddress bdAddress, BLEUUID serviceUUID, BLEUUID characteristicUUID, std::string value);   // Set the value of a characteristic on a service on a server.
 	static std::string toString();        // Return a string representation of our device.


### PR DESCRIPTION
## Description of Change
Fixes IDF esp_ble_gap_set_device_name() that allows name length bigger than Advertsing payload space.

The device name must have the maximum length of 29 characters.
If the device name has between 30 and 32 characters long, an error of Stack smashing protect failure! + ABORT & RESET will occur

If the device name has a length of 33 or more, it won't reset the board, but the last valid device name will be used.
Also, an error message will be displayed in the Serial Console.
`[BLEDevice.cpp:416] init(): esp_ble_gap_set_device_name: rc=258 Unknown ESP_ERR error `

There is a "gap" that allows name with 30 to 32 bytes to move forward and it leads to abort and reset the board.
Changing the device name to something that call Arduino User attention may also help.
Another way to heko the Arduino User, would be to change `void BLEDevice::init(std::string deviceName)` to return a bool in case of failure in order to allow the Sketch to identify it and take some action.

## Tests scenarios

Testing case from #7894 

New `bool BLEDevice::init()` shall allow testing if it was successful.
``` cpp 
    if (!BLEDevice::init("MZ_MZL-FC-E-XX-999999-C8F09EE7C0CC")) {
       log_e("BLE Initialization Failure!");
       while(1) delay(1000); // halts execution.
   }

```

This code demonstrates the initial issue:
``` cpp
#include <Arduino.h>
#include <BLEDevice.h>
#include <BLEServer.h>
#include <BLEUtils.h>
#include <BLE2902.h>

uint8_t txValue = 0;
BLEServer *pServer = NULL;                   //BLEServer指针 pServer
BLECharacteristic *pTxCharacteristic = NULL; //BLECharacteristic指针 pTxCharacteristic
bool deviceBleConnected = false;             //本次连接状态
bool oldDeviceConnected = false;             //上次连接状态

// See the following for generating UUIDs: https://www.uuidgenerator.net/
#define SERVICE_UUID "83677baa-3eb8-4866-b6b6-96e5ed5cc48d" // UART service UUID
#define CHARACTERISTIC_UUID_RX "f5d2b3fe-e6b5-49b5-aa5f-a00bb4156d1d"
#define CHARACTERISTIC_UUID_TX "6f588463-f8f1-44f8-bdae-a1272a1b0f6e"


class MyServerCallbacks : public BLEServerCallbacks
{
    void onConnect(BLEServer *pServer) {};
    void onDisconnect(BLEServer *pServer) {}
};

//ble相关
class MyBLECallbacks : public BLECharacteristicCallbacks {
  void onWrite(BLECharacteristic *pCharacteristic) {}
};

void setup() {
  Serial.begin(115200);
  Serial.println("START >>>>>>>>>>>>>>>>>>>> ");

  BLEDevice::init(String("MZ_MZL-FC-E-XX-999999-C8F09EE7C0CC").c_str());

  // 创建一个 BLE 服务
  pServer = BLEDevice::createServer();
  pServer->setCallbacks(new MyServerCallbacks()); //设置回调
  BLEService *pService = pServer->createService(SERVICE_UUID);

  // 创建一个 BLE 特征
  pTxCharacteristic = pService->createCharacteristic(CHARACTERISTIC_UUID_TX, BLECharacteristic::PROPERTY_NOTIFY);
  pTxCharacteristic->addDescriptor(new BLE2902());
  BLECharacteristic *pRxCharacteristic = pService->createCharacteristic(CHARACTERISTIC_UUID_RX, 
  BLECharacteristic::PROPERTY_WRITE);
  pRxCharacteristic->setCallbacks(new MyBLECallbacks()); //设置回调

  BLEAdvertisementData d = BLEAdvertisementData();
  d.setManufacturerData("123");

  pService->start();                  // 开始服务
  pServer->getAdvertising()->setAdvertisementData(d);

  pServer->getAdvertising()->start(); // 开始广播
  Serial.println("ble inited, waiting for connection.....");
}

void loop() {
}
```

## Related links

Fixes #7894 