### PR TITLE
in BluetoothSerial.setTimeout also set timeout for parent class Stream.

### DIFF
--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -838,6 +838,7 @@ int BluetoothSerial::read()
  */
 void BluetoothSerial::setTimeout(int timeoutMS)
 {
+    Stream::setTimeout(timeoutMS);
     this->timeoutTicks=timeoutMS / portTICK_PERIOD_MS;
 }
 


### PR DESCRIPTION
## Description of Change
In the BluetoothSerial.setTimeout function the setTimeout function of the parent Class Stream should also be called.
Without this it is not possible to set the timeout used in for example the ReadString function of an instance of BluetoothSerial. The ReadString function is not overwritten and uses the Stream timeout.

The error was discovered because something like the example Code below would just ignore the timeout and wait the default 1000 ms on readString()

```cpp
MyBluetoothSerial SerialBT;
...
SerialBT.setTimeout(5);
String temp = SerialBT.readString();
```