### PR TITLE
Use enum for C++ to avoid macro pitfalls in esp32_hal_uart.h

### DIFF
--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -25,6 +25,34 @@ extern "C" {
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
+#ifdef __cplusplus
+enum SerialConfig {
+SERIAL_5N1 = 0x8000010,
+SERIAL_6N1 = 0x8000014,
+SERIAL_7N1 = 0x8000018,
+SERIAL_8N1 = 0x800001c,
+SERIAL_5N2 = 0x8000030,
+SERIAL_6N2 = 0x8000034,
+SERIAL_7N2 = 0x8000038,
+SERIAL_8N2 = 0x800003c,
+SERIAL_5E1 = 0x8000012,
+SERIAL_6E1 = 0x8000016,
+SERIAL_7E1 = 0x800001a,
+SERIAL_8E1 = 0x800001e,
+SERIAL_5E2 = 0x8000032,
+SERIAL_6E2 = 0x8000036,
+SERIAL_7E2 = 0x800003a,
+SERIAL_8E2 = 0x800003e,
+SERIAL_5O1 = 0x8000013,
+SERIAL_6O1 = 0x8000017,
+SERIAL_7O1 = 0x800001b,
+SERIAL_8O1 = 0x800001f,
+SERIAL_5O2 = 0x8000033,
+SERIAL_6O2 = 0x8000037,
+SERIAL_7O2 = 0x800003b,
+SERIAL_8O2 = 0x800003f
+};
+#else
 #define SERIAL_5N1 0x8000010
 #define SERIAL_6N1 0x8000014
 #define SERIAL_7N1 0x8000018
@@ -49,6 +77,7 @@ extern "C" {
 #define SERIAL_6O2 0x8000037
 #define SERIAL_7O2 0x800003b
 #define SERIAL_8O2 0x800003f
+#endif // __cplusplus
 
 // These are Hardware Flow Contol possible usage
 // equivalent to UDF enum uart_hw_flowcontrol_t from 


### PR DESCRIPTION

C prepropressor macros are generally considered deprecated in C++, in this particular case, their use for the serial configuration breaks the enum from the EspSoftwareSerial library, release 8.0.0 onward.

This merge request provides the previous macro defines for C language builds, but replaces them functionally identical with a C++ enumeration for C++ builds, which is the default Arduino language anyway.

The ESP8266 Arduino Core uses a C++ enum already.

