### PR TITLE
Update boards.txt file to fix some of the broken board.build entries that should be upper case

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -3831,7 +3831,7 @@ ttgo-t-oi-plus.build.target=esp
 ttgo-t-oi-plus.build.mcu=esp32c3
 ttgo-t-oi-plus.build.core=esp32
 ttgo-t-oi-plus.build.variant=ttgo-t-oi-plus
-ttgo-t-oi-plus.build.board=TTGO-T-OI-PLUS_DEV
+ttgo-t-oi-plus.build.board=TTGO_T_OI_PLUS_DEV
 ttgo-t-oi-plus.build.bootloader_addr=0x0
 
 ttgo-t-oi-plus.build.cdc_on_boot=0
@@ -19251,7 +19251,7 @@ lionbit.build.target=esp32
 lionbit.build.mcu=esp32
 lionbit.build.core=esp32
 lionbit.build.variant=lionbit
-lionbit.build.board=Lion:BIT_DEV_BOARD
+lionbit.build.board=LIONBIT_DEV_BOARD
 
 lionbit.build.f_cpu=240000000L
 lionbit.build.flash_size=4MB


### PR DESCRIPTION
Fix some of the board.build entries that are lower case to make them upper case. In particular, the Heltec boards were broken in the Arduino IDE with version 2.0.7  or the ESP32 library when they were changed from HELTEC_WIFI_32 to heltec_wifi_32, etc.

-----------
## Description of Change
Changes many, but not all of the incorrectly lowecase board.build names to be uppercase. When they were changed to lowercase, they broke conditional compiles based on board type. The standard since these are constants, is to be upper case.

## Tests scenarios
Arduino IDE 1.8.09 and 2.0.4. Tested with the Heltec wifi board and wifi board v3

## Partially fixes issue

Fixes https://github.com/espressif/arduino-esp32/issues/7943

