### PR TITLE
missing ESP32-D0WDR2-V3 added to getChipModel()

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -279,7 +279,7 @@ const char * EspClass::getChipModel(void)
             else
                 return "ESP32-D0WD";
         case EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5 :
-            return "ESP32-D2WDQ5";
+            return "ESP32-D2WD";
         case EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2 :
             return "ESP32-PICO-D2";
         case EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4 :

--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -280,6 +280,8 @@ const char * EspClass::getChipModel(void)
             return "ESP32-PICO-D4";
         case EFUSE_RD_CHIP_VER_PKG_ESP32PICOV302 :
             return "ESP32-PICO-V3-02";
+        case EFUSE_RD_CHIP_VER_PKG_ESP32D0WDR2V3 :
+            return "ESP32-D0WDR2-V3";
         default:
             return "Unknown";
     }

--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -269,9 +269,15 @@ const char * EspClass::getChipModel(void)
     uint32_t pkg_ver = chip_ver & 0x7;
     switch (pkg_ver) {
         case EFUSE_RD_CHIP_VER_PKG_ESP32D0WDQ6 :
-            return "ESP32-D0WDQ6";
+            if (getChipRevision() == 3)
+                return "ESP32-D0WDQ6-V3";  
+            else
+                return "ESP32-D0WDQ6";
         case EFUSE_RD_CHIP_VER_PKG_ESP32D0WDQ5 :
-            return "ESP32-D0WDQ5";
+            if (getChipRevision() == 3)
+                return "ESP32-D0WD-V3";  
+            else
+                return "ESP32-D0WD";
         case EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5 :
             return "ESP32-D2WDQ5";
         case EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2 :


### PR DESCRIPTION
Tested on ESP32-D0WDR2-V3 chip. It is now correctly detected by `getChipModel()`.