### PR TITLE
Avoid global defines for default ETH configs

### DIFF
--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -25,30 +25,6 @@
 #include "esp_system.h"
 #include "esp_eth.h"
 
-#ifndef ETH_PHY_ADDR
-#define ETH_PHY_ADDR 0
-#endif
-
-#ifndef ETH_PHY_TYPE
-#define ETH_PHY_TYPE ETH_PHY_LAN8720
-#endif
-
-#ifndef ETH_PHY_POWER
-#define ETH_PHY_POWER -1
-#endif
-
-#ifndef ETH_PHY_MDC
-#define ETH_PHY_MDC 23
-#endif
-
-#ifndef ETH_PHY_MDIO
-#define ETH_PHY_MDIO 18
-#endif
-
-#ifndef ETH_CLK_MODE
-#define ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
-#endif
-
 #if ESP_IDF_VERSION_MAJOR > 3
 typedef enum { ETH_CLOCK_GPIO0_IN, ETH_CLOCK_GPIO0_OUT, ETH_CLOCK_GPIO16_OUT, ETH_CLOCK_GPIO17_OUT } eth_clock_mode_t;
 #endif
@@ -74,7 +50,7 @@ class ETHClass {
         ETHClass();
         ~ETHClass();
 
-        bool begin(uint8_t phy_addr=ETH_PHY_ADDR, int power=ETH_PHY_POWER, int mdc=ETH_PHY_MDC, int mdio=ETH_PHY_MDIO, eth_phy_type_t type=ETH_PHY_TYPE, eth_clock_mode_t clk_mode=ETH_CLK_MODE, bool use_mac_from_efuse=false);
+        bool begin(uint8_t phy_addr=0, int power=-1, int mdc=23, int mdio=18, eth_phy_type_t type=ETH_PHY_LAN8720, eth_clock_mode_t clk_mode=ETH_CLOCK_GPIO0_IN, bool use_mac_from_efuse=false);
 
         bool config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1 = (uint32_t)0x00000000, IPAddress dns2 = (uint32_t)0x00000000);
 


### PR DESCRIPTION
I just moved the default values directly into the prototype, in order to delete the defines that are visible to the whole user project.