### PR TITLE
Documentation update in `preferences.rst` : fix return value of `getBytes`

### DIFF
--- a/docs/source/api/preferences.rst
+++ b/docs/source/api/preferences.rst
@@ -578,7 +578,7 @@ Copy a series of bytes stored against a given key in the currently open namespac
          - the number of bytes to be written to the buffer pointed to by ``buf``
 
    **Returns**
-      * if successful, the number of bytes equal to ``len`` is written to buffer ``buf``, and the method returns ``1``.
+      * if successful, the number of bytes equal to ``len`` is written to buffer ``buf``, and the method returns ``len``.
       * if the method fails, nothing is written to the buffer and the method returns ``0``.
 
    **Notes**


### PR DESCRIPTION
## Description of Change

The `getBytes` seems to return the number of bytes copied and not just 1.

## Tests scenarios

n/a

## Related links

Source file:

https://github.com/espressif/arduino-esp32/blob/0d84018d969309addacbcc3e3782c1fadc95fbc8/libraries/Preferences/src/Preferences.cpp#L509