### PR TITLE
use gcc-ar

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -60,7 +60,7 @@ compiler.cpp.cmd={compiler.prefix}g++
 compiler.S.cmd={compiler.prefix}gcc
 compiler.c.elf.cmd={compiler.prefix}g++
 compiler.as.cmd={compiler.prefix}as
-compiler.ar.cmd={compiler.prefix}ar
+compiler.ar.cmd={compiler.prefix}gcc-ar
 compiler.size.cmd={compiler.prefix}size
 
 # These can be overridden in platform.local.txt


### PR DESCRIPTION
to make use of `LTO` possible. Discussed here https://github.com/platformio/platform-espressif32/pull/702#issuecomment-1460519144
@me-no-dev 

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
