### PR TITLE
Makes Gamepad example able to be tested with Windows 10/11

### DIFF
--- a/libraries/USB/examples/Gamepad/Gamepad.ino
+++ b/libraries/USB/examples/Gamepad/Gamepad.ino
@@ -7,7 +7,9 @@ void loop(){}
 #include "USBHIDGamepad.h"
 USBHIDGamepad Gamepad;
 
-const int buttonPin = 0;
+// This sketch works correctly for the ESP32-S2 and ESP32-S3 in OTG mode (TinyUSB)
+
+const int buttonPin = 0;  // GPIO 0 is the BOOT button of the board
 int previousButtonState = HIGH;
 
 void setup() {
@@ -18,9 +20,14 @@ void setup() {
 
 void loop() {
   int buttonState = digitalRead(buttonPin);
-  if ((buttonState != previousButtonState) && (buttonState == LOW)) {
-    Gamepad.pressButton(BUTTON_START);
-    Gamepad.releaseButton(BUTTON_START);
+  if (buttonState != previousButtonState) {
+    if (buttonState == LOW) { // BOOT Button pressed
+      // changes many states
+      Gamepad.send(-100, 100, 50, 100, -100, -50, HAT_DOWN_RIGHT, BUTTON_TL);
+    } else {
+      // restores neutral states
+      Gamepad.send(0, 0, 0, 0, 0, 0, 0, 0);
+    }
   }
   previousButtonState = buttonState;
 }


### PR DESCRIPTION
## Description of Change
Initial example code had no effect with Win10/11 because BUTTON_START was not recognized. 
This PR makes it visible in the Windows Game Controller Testing TAB.


## Tests scenarios
ESP32-S2 and ESP32-S3 (OTG mode)

## Related links
https://github.com/espressif/arduino-esp32/issues/6922#issuecomment-1500791745
https://github.com/espressif/arduino-esp32/issues/6922#issuecomment-1501858344