### PR TITLE
getNextFileName: Get info wether filename is a file or directory

### DIFF
--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -203,6 +203,15 @@ String File::getNextFileName(void)
 
 }
 
+String File::getNextFileName(bool *isDir)
+{
+    if (!_p) {
+        return ""; 
+    }
+    return _p->getNextFileName(isDir);
+
+}
+
 void File::rewindDirectory(void)
 {
     if (!*this) {

--- a/libraries/FS/src/FS.h
+++ b/libraries/FS/src/FS.h
@@ -81,6 +81,7 @@ public:
     boolean seekDir(long position);
     File openNextFile(const char* mode = FILE_READ);
     String getNextFileName(void);
+    String getNextFileName(boolean *isDir);
     void rewindDirectory(void);
 
 protected:

--- a/libraries/FS/src/FSImpl.h
+++ b/libraries/FS/src/FSImpl.h
@@ -45,6 +45,7 @@ public:
     virtual FileImplPtr openNextFile(const char* mode) = 0;
     virtual boolean seekDir(long position);
     virtual String getNextFileName(void);
+    virtual String getNextFileName(bool *isDir);
     virtual void rewindDirectory(void) = 0;
     virtual operator bool() = 0;
 };

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -559,7 +559,9 @@ String VFSFileImpl::getNextFileName(bool *isDir)
     }
     name += fname;
 	// check entry is a directory
-	*isDir = (file->d_type == DT_DIR);
+	if(isDir) {
+		*isDir = (file->d_type == DT_DIR);
+	}
     return name;
 }
 

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -558,10 +558,11 @@ String VFSFileImpl::getNextFileName(bool *isDir)
         name += "/";
     }
     name += fname;
-	// check entry is a directory
-	if(isDir) {
-		*isDir = (file->d_type == DT_DIR);
-	}
+
+    // check entry is a directory
+    if (isDir) {
+        *isDir = (file->d_type == DT_DIR);
+    }
     return name;
 }
 

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -540,6 +540,29 @@ String VFSFileImpl::getNextFileName()
     return name;
 }
 
+String VFSFileImpl::getNextFileName(bool *isDir)
+{
+    if (!_isDirectory || !_d) {
+        return "";
+    }
+    struct dirent *file = readdir(_d);
+    if (file == NULL) {
+        return "";
+    }
+    if (file->d_type != DT_REG && file->d_type != DT_DIR) {
+        return "";
+    }
+    String fname = String(file->d_name);
+    String name = String(_path);
+    if (!fname.startsWith("/") && !name.endsWith("/")) {
+        name += "/";
+    }
+    name += fname;
+	// check entry is a directory
+	*isDir = (file->d_type == DT_DIR);
+    return name;
+}
+
 void VFSFileImpl::rewindDirectory(void)
 {
     if(!_isDirectory || !_d) {

--- a/libraries/FS/src/vfs_api.h
+++ b/libraries/FS/src/vfs_api.h
@@ -73,6 +73,7 @@ public:
     boolean     isDirectory(void) override;
     boolean     seekDir(long position) override;
     String      getNextFileName(void) override;
+    String      getNextFileName(bool *isDir) override;
     FileImplPtr openNextFile(const char* mode) override;
     void        rewindDirectory(void) override;
     operator    bool();


### PR DESCRIPTION
Hi Arduino-ESP32 team,

the FS function `getNextFilename()` has been merged since 2.0.6 and speeds-up directory listing by factor >20 (many files on SD-card).
Thank's for this improvement!

Unfortunately, this function can only be used to a limited extent because it is not possible to distinguish whether the returned name is a file or a directory. This may have been overlooked in PR #7229 , see discussion. 
A concrete use case is an SD card web server that delivers a JSON file/directory structure for given path. 

I have overloaded the function with a new return parameter isDir. This returns true if it is a directory:

```
    String getNextFileName(void);
    String getNextFileName(boolean *isDir);
```

Changes are minimal & this PR should be fully backwards compatible.

Thank's
Dirk

Directory listing in the browser with `openNextFile()`. Loading one directory-level takes 2s:


![Slow](https://user-images.githubusercontent.com/11274319/231485280-392b3dfc-7f70-41a8-bdb2-229f16761a14.gif)

Directory listing in the browser with `getNextFileName(boolean *isDir)`. Loading one directory-level takes 20ms:

![Fast](https://user-images.githubusercontent.com/11274319/231485886-270d044d-ea2d-4a8d-bb39-26d5d3bb7a3f.gif)

