### PR TITLE
[CI] Added New Board Test

### DIFF
--- a/.github/scripts/find_new_boards.sh
+++ b/.github/scripts/find_new_boards.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Get inputs from command
+owner_repository=$1
+pr_number=$2
+
+url="https://api.github.com/repos/$owner_repository/pulls/$pr_number/files"
+echo $url
+
+# Get changes in boards.txt file from PR
+Patch=$(curl $url | jq -r '.[] | select(.filename == "boards.txt") | .patch ')
+
+# Extract only changed lines number and count
+substring_patch=$(echo "$Patch" | grep -o '@@[^@]*@@')
+
+params_array=()
+
+IFS=$'\n' read -d '' -ra params <<< $(echo "$substring_patch" | grep -oE '[-+][0-9]+,[0-9]+')
+
+for param in "${params[@]}"
+do
+    echo "The parameter is $param"
+    params_array+=("$param")
+done
+
+boards_array=()
+previous_board=""
+file="boards.txt"
+
+# Loop through boards.txt file and extract all boards that were added
+for (( c=0; c<${#params_array[@]}; c+=2 ))
+do
+    deletion_count=$( echo "${params_array[c]}" | cut -d',' -f2 | cut -d' ' -f1 )
+    addition_line=$( echo "${params_array[c+1]}" | cut -d'+' -f2 | cut -d',' -f1 )
+    addition_count=$( echo "${params_array[c+1]}" | cut -d'+' -f2 | cut -d',' -f2 | cut -d' ' -f1 )
+    addition_end=$(($addition_line+$addition_count))
+    
+    addition_line=$(($addition_line + 3))
+    addition_end=$(($addition_end - $deletion_count))
+
+    echo $addition_line
+    echo $addition_end
+
+    i=0
+
+    while read -r line
+    do
+    i=$((i+1))
+    if [ $i -lt $addition_line ]
+    then
+    continue
+    elif [ $i -gt $addition_end ]
+    then
+    break
+    fi
+    board_name=$(echo "$line" | cut -d '.' -f1 | cut -d '#' -f1)
+    if [ "$board_name" != "" ]
+    then
+        if [ "$board_name" != "$previous_board" ]
+        then
+            boards_array+=("espressif:esp32:$board_name")
+            previous_board="$board_name"
+            echo "Added 'espressif:esp32:$board_name' to array"
+        fi
+    fi
+    done < "$file"
+done
+
+# Create JSON like string with all boards found and pass it to env variable
+board_count=${#boards_array[@]}
+
+json_matrix='{"fqbn": ['
+for board in ${boards_array[@]}
+do
+    json_matrix+='"'$board'"'
+    if [ $board_count -gt 1 ]
+    then
+        json_matrix+=","
+    fi
+    board_count=$(($board_count - 1))
+done
+json_matrix+=']}'
+
+echo $json_matrix
+echo "FQBNS=${json_matrix}" >> $GITHUB_ENV

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -1,0 +1,63 @@
+name: New Board Test
+
+# The workflow will run on schedule and labeled pull requests
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+env:
+  # It's convenient to set variables for values used multiple times in the workflow
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  find-boards:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'board_test')
+    runs-on: ubuntu-latest
+
+    outputs:
+      fqbns: ${{ env.FQBNS }}
+
+    steps:
+      # This step makes the contents of the repository available to the workflow
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup jq
+        uses: dcarbone/install-jq-action@v1.0.1
+
+      - name: Get board name
+        run: 
+          bash .github/scripts/find_new_boards.sh ${{ github.repository }} ${{github.event.number}}
+
+  test-boards:
+    needs: find-boards
+    runs-on: ubuntu-latest
+
+    env:
+      REPOSITORY: |
+        - source-path: '.'
+          name: "espressif:esp32"
+
+    strategy:
+      matrix: ${{ fromJson(needs.find-boards.outputs.fqbns) }}
+
+    steps:
+      # This step makes the contents of the repository available to the workflow
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Compile sketch
+        uses: P-R-O-C-H-Y/compile-sketches@main
+        with:
+          platforms: |
+            ${{ env.REPOSITORY }}
+          fqbn: ${{ matrix.fqbn }}
+          use-json-file: false
+          enable-deltas-report: false
+          enable-warnings-report: false
+          cli-compile-flags: |
+            - --warnings="all"
+          exit-on-fail: true
+          sketch-paths:
+            "- ./libraries/ESP32/examples/ChipID/GetChipID/GetChipID.ino"


### PR DESCRIPTION
## Description of Change
Added new workflow, which can help with reviewing new board additions to the board.txt file. The workflow will run on PR, if the label `board_test` is added. CI will take a look to the changes of PR and get all new boards that were added (yes, work for multiple boards) as a `FQBN` which is the input for the compile-sketch action. Action will try to compile `GetChipID.ino` sketch against the new board(s). 

## Tests scenarios
Tested on PR with new board addition to boards.txt on my fork.

## Related links
