### PR TITLE
[CI] External Libraries Test - Results file relocation

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -106,6 +106,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          git checkout gh-pages
           git add ${{ env.RESULT_LIBRARY_TEST_FILE }}
           git commit -m "Generated External Libraries Test Results"
           git push

--- a/LIBRARIES_TEST.md
+++ b/LIBRARIES_TEST.md
@@ -1,1 +1,0 @@
-Empty file

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Finally, if you are sure no one else had the issue, follow the **Issue template*
 
 ### External libraries compilation test
 
-We have set-up CI testing for external libraries for ESP32 Arduino core. You can check test results in the file [LIBRARIES_TEST](https://github.com/espressif/arduino-esp32/blob/master/LIBRARIES_TEST.md).
+We have set-up CI testing for external libraries for ESP32 Arduino core. You can check test results in the file [LIBRARIES_TEST](https://github.com/espressif/arduino-esp32/blob/gh-pages/LIBRARIES_TEST.md).
 For more information and how to add your library to the test see [external library testing](https://docs.espressif.com/projects/arduino-esp32/en/latest/external_libraries_test.html) in the documentation.
 
 ### Contributing

--- a/docs/source/external_libraries_test.rst
+++ b/docs/source/external_libraries_test.rst
@@ -128,5 +128,5 @@ In the table the results are in order ``BEFORE -> AFTER``.
    :height: 2ex
    :class: no-scaled-link
 
-.. _LIBRARIES_TEST.md: https://github.com/espressif/arduino-esp32/LIBRARIES_TEST.md
+.. _LIBRARIES_TEST.md: https://github.com/espressif/arduino-esp32/blob/gh-pages/LIBRARIES_TEST.md
 .. _lib.json: https://github.com/espressif/arduino-esp32/.github/workflow/lib.json


### PR DESCRIPTION
## Description of Change
As the CI has no permissions to push directly to master branch, we decided to relocate the `LIBRARIES_TEST.md` file to the `gh-pages` branch.

## Tests scenarios

## Related links
