### PR TITLE
[CI] External Libraries Test - Results file push fix

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -15,6 +15,8 @@ env:
   SKETCHES_REPORTS_ARTIFACT_NAME: libraries-report
   RESULT_LIBRARY_TEST_FILE: LIBRARIES_TEST.md
   JSON_LIBRARY_LIST_FILE: .github/workflows/lib.json
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
 jobs:
   compile-sketch:
     if: |
@@ -80,6 +82,13 @@ jobs:
       # Check out repository
       - name: Checkout repository    
         uses: actions/checkout@v3
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          fetch-depth: '0'
+
+      - name: Switch branch
+        run:
+          git checkout remotes/origin/gh-pages
 
       # This step is needed to get the size data produced by the compile jobs
       - name: Download sketches reports artifact
@@ -95,22 +104,17 @@ jobs:
           destination-file: ${{ env.RESULT_LIBRARY_TEST_FILE }}
 
       - name: Append file with action URL
-        uses: DamianReeves/write-file-action@master
-        with:
-          path: ${{ env.RESULT_LIBRARY_TEST_FILE }}
-          contents: |
-            / [GitHub Action Link](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
-          write-mode: append
+        run:
+          echo "/ [GitHub Action Link](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})" >> ${{ env.RESULT_LIBRARY_TEST_FILE }}
 
       - name: Push to github repo
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git checkout gh-pages
           git add ${{ env.RESULT_LIBRARY_TEST_FILE }}
           git commit -m "Generated External Libraries Test Results"
-          git push
-
+          git push origin HEAD:gh-pages
+          
   event_file:
     name: "Event File"
     if: |


### PR DESCRIPTION
## Description of Change
This PR fixes pushing the `LIBRARIES_TEST.md` file to the `gh-pages` branch.

## Tests scenarios
Tested on forked repository.

## Related links
