### PR TITLE
fix path for bootloaders, changed from `sdk` to `esp32-arduino-libs`

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -86,7 +86,7 @@ def get_bootloader_image(variants_dir):
             join(
                 FRAMEWORK_DIR,
                 "tools",
-                "sdk",
+                "esp32-arduino-libs",
                 build_mcu,
                 "bin",
                 "bootloader_${__get_board_boot_mode(__env__)}_${__get_board_f_flash(__env__)}.elf",


### PR DESCRIPTION
without the needed bootloader files are not found.

@me-no-dev 
Supporting development with Platformio is currently nearly impossible since the toolchains 12.2.0 are not available in Platformio registry. https://github.com/espressif/crosstool-NG/issues/41
