### PR TITLE
Revert macros in #7941, but simplify.

### DIFF
--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -34,8 +34,8 @@
 // A pure abstract class forward used as a means to proide a unique pointer type
 // but really is never defined.
 class __FlashStringHelper;
-#define FPSTR(pstr_pointer) (pstr_pointer)
-#define F(string_literal) (string_literal)
+#define FPSTR(str_pointer) (reinterpret_cast<const __FlashStringHelper *>(str_pointer))
+#define F(string_literal) (FPSTR(string_literal))
 
 // An inherited class for holding the result of a concatenation.  These
 // result objects are assumed to be writable by subsequent concatenations.


### PR DESCRIPTION
@me-no-dev As requested, this is the first part of fixing #7941 for some third party libs. It's actually too much work to do 100% correctly - the splitting up part, not the more monolithic PR, which I have reviewed and tested. I hope this here one is OK on its own :-(