### PR TITLE
Add lock in Wire.cpp to protect concurrent i2c transactions performed by different tasks

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -48,7 +48,7 @@ TwoWire::TwoWire(uint8_t bus_num)
     ,_timeOutMillis(50)
     ,nonStop(false)
 #if !CONFIG_DISABLE_HAL_LOCKS
-    ,nonStopTask(NULL)
+    ,currentTaskHandle(NULL)
     ,lock(NULL)
 #endif
     ,is_slave(false)
@@ -412,15 +412,15 @@ void TwoWire::beginTransmission(uint16_t address)
         return;
     }
 #if !CONFIG_DISABLE_HAL_LOCKS
-    if(nonStop && nonStopTask == xTaskGetCurrentTaskHandle()){
-        log_e("Unfinished Repeated Start transaction! Expected requestFrom, not beginTransmission! Clearing...");
-        //release lock
-        xSemaphoreGive(lock);
-    }
-    //acquire lock
-    if(lock == NULL || xSemaphoreTake(lock, portMAX_DELAY) != pdTRUE){
-        log_e("could not acquire lock");
-        return;
+    TaskHandle_t task = xTaskGetCurrentTaskHandle();
+    if (currentTaskHandle != task)
+    {
+        //acquire lock
+        if(lock == NULL || xSemaphoreTake(lock, portMAX_DELAY) != pdTRUE){
+            log_e("could not acquire lock");
+            return;
+        }
+        currentTaskHandle = task;
     }
 #endif
     nonStop = false;
@@ -452,15 +452,13 @@ uint8_t TwoWire::endTransmission(bool sendStop)
     if(sendStop){
         err = i2cWrite(num, txAddress, txBuffer, txLength, _timeOutMillis);
 #if !CONFIG_DISABLE_HAL_LOCKS
+        currentTaskHandle = NULL;
         //release lock
         xSemaphoreGive(lock);
 #endif
     } else {
         //mark as non-stop
         nonStop = true;
-#if !CONFIG_DISABLE_HAL_LOCKS
-        nonStopTask = xTaskGetCurrentTaskHandle();
-#endif
     }
     switch(err){
         case ESP_OK: return 0;
@@ -482,13 +480,26 @@ size_t TwoWire::requestFrom(uint16_t address, size_t size, bool sendStop)
         return 0;
     }
     esp_err_t err = ESP_OK;
-    if(nonStop
 #if !CONFIG_DISABLE_HAL_LOCKS
-    && nonStopTask == xTaskGetCurrentTaskHandle()
-#endif
-    ){
+    TaskHandle_t task = xTaskGetCurrentTaskHandle();
+    if (currentTaskHandle != task)
+    {
+        //acquire lock
+        if(lock == NULL || xSemaphoreTake(lock, portMAX_DELAY) != pdTRUE){
+            log_e("could not acquire lock");
+            return 0;
+        }
+        currentTaskHandle = task;
+    }
+#endif  
+    if(nonStop){
         if(address != txAddress){
             log_e("Unfinished Repeated Start transaction! Expected address do not match! %u != %u", address, txAddress);
+#if !CONFIG_DISABLE_HAL_LOCKS
+            currentTaskHandle = NULL;
+            //release lock
+            xSemaphoreGive(lock);
+#endif
             return 0;
         }
         nonStop = false;
@@ -499,13 +510,6 @@ size_t TwoWire::requestFrom(uint16_t address, size_t size, bool sendStop)
             log_e("i2cWriteReadNonStop returned Error %d", err);
         }
     } else {
-#if !CONFIG_DISABLE_HAL_LOCKS
-        //acquire lock
-        if(lock == NULL || xSemaphoreTake(lock, portMAX_DELAY) != pdTRUE){
-            log_e("could not acquire lock");
-            return 0;
-        }
-#endif
         rxIndex = 0;
         rxLength = 0;
         err = i2cRead(num, address, rxBuffer, size, _timeOutMillis, &rxLength);
@@ -514,6 +518,7 @@ size_t TwoWire::requestFrom(uint16_t address, size_t size, bool sendStop)
         }
     }
 #if !CONFIG_DISABLE_HAL_LOCKS
+    currentTaskHandle = NULL;
     //release lock
     xSemaphoreGive(lock);
 #endif

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -64,7 +64,7 @@ protected:
     uint32_t _timeOutMillis;
     bool nonStop;
 #if !CONFIG_DISABLE_HAL_LOCKS
-    TaskHandle_t nonStopTask;
+    TaskHandle_t currentTaskHandle;
     SemaphoreHandle_t lock;
 #endif
 private:


### PR DESCRIPTION
## Description of Change
This is the problem. In my application, two different tasks access the i2c. 
Sometimes I get the following assert:

```
assert failed: xQueueGenericSend queue.c:832 (pxQueue->pcHead != ((void *)0) || pxQueue->u.xSemaphore.xMutexHolder == ((void *)0) || pxQueue->u.xSemaphore.xMutexHolder == xTaskGetCurrentTaskHandle())
...
0x40096eee: xQueueGenericSend at .../esp-idf/components/freertos/queue.c line 821 (discriminator 2)
0x400f05ed: TwoWire::beginTransmission(unsigned short) at .../libraries/Wire/src/Wire.cpp line 418
:  (inlined by) TwoWire::beginTransmission(unsigned short) at .../libraries/Wire/src/Wire.cpp line 408
0x400f076c: TwoWire::beginTransmission(unsigned char) at .../libraries/Wire/src/Wire.cpp line 637
```

This comes from this piece of code:

```cpp
    void TwoWire::beginTransmission(uint16_t address)
   ...
    if(nonStop && nonStopTask == xTaskGetCurrentTaskHandle()){
        log_e("Unfinished Repeated Start transaction! Expected requestFrom, not beginTransmission! Clearing...");
        //release lock
        xSemaphoreGive(lock);
    }
```

The xSemaphoreGive is not always correct, because I can't release a mutex if it is taken by another thread. 
The solution is to protect all i2c transaction, by taking the lock at the beginning of each transaction if the current task is different from the one already performing a i2c transaction.

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.8 with ESP32 Board with this scenario.

