### PR TITLE
Added link to external examples to the doc

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -133,6 +133,7 @@ in the examples menu or inside each library folder.
 
     https://github.com/espressif/arduino-esp32/tree/master/libraries
 
+There is also a `list of examples <https://techtutorialsx.com/category/esp32/>`_ managed outside of Espressif, so check them out.
 
 .. include:: common/datasheet.inc
 


### PR DESCRIPTION
This minimalistic PR simply adds a link to external examples to the doc.
Related "for reference" issue: https://github.com/espressif/arduino-esp32/issues/360