### PR TITLE
TIMER - add timer_started flag, fix timerEnd() + timer HW test

### DIFF
--- a/cores/esp32/esp32-hal-timer.c
+++ b/cores/esp32/esp32-hal-timer.c
@@ -28,6 +28,7 @@ typedef struct {
 struct timer_struct_t {
     gptimer_handle_t timer_handle;
     interrupt_config_t interrupt_handle;
+    bool timer_started;
 };
 
 inline uint64_t timerRead(hw_timer_t * timer){
@@ -62,10 +63,12 @@ uint32_t timerGetFrequency(hw_timer_t * timer){
 
 void timerStart(hw_timer_t * timer){
     gptimer_start(timer->timer_handle);
+    timer->timer_started = true;
 }
 
 void timerStop(hw_timer_t * timer){
     gptimer_stop(timer->timer_handle);
+    timer->timer_started = false;
 }
 
 void timerRestart(hw_timer_t * timer){
@@ -111,11 +114,15 @@ hw_timer_t * timerBegin(uint32_t frequency){
     } 
     gptimer_enable(timer->timer_handle);
     gptimer_start(timer->timer_handle);
+    timer->timer_started = true;
     return timer;
 }
 
 void timerEnd(hw_timer_t * timer){
     esp_err_t err = ESP_OK;
+    if(timer->timer_started == true){
+        gptimer_stop(timer->timer_handle);
+    }
     gptimer_disable(timer->timer_handle);
     err = gptimer_del_timer(timer->timer_handle);
     if (err != ESP_OK){
@@ -147,14 +154,20 @@ void timerAttachInterruptFunctionalArg(hw_timer_t * timer, void (*userFunc)(void
     timer->interrupt_handle.fn = (voidFuncPtr)userFunc;
     timer->interrupt_handle.arg = arg;
 
+    if(timer->timer_started == true){
+        gptimer_stop(timer->timer_handle);
+    }
     gptimer_disable(timer->timer_handle);
     err = gptimer_register_event_callbacks(timer->timer_handle, &cbs, &timer->interrupt_handle);
     if (err != ESP_OK){
         log_e("Timer Attach Interrupt failed, error num=%d", err);
     } 
     gptimer_enable(timer->timer_handle);
-}
+    if(timer->timer_started == true){
+        gptimer_start(timer->timer_handle);
+    }
 
+}
 
 void timerAttachInterruptArg(hw_timer_t * timer, void (*userFunc)(void*), void * arg){
     timerAttachInterruptFunctionalArg(timer, userFunc, arg);

--- a/tests/timer/timer.ino
+++ b/tests/timer/timer.ino
@@ -11,31 +11,29 @@
  * S3 - APB + XTAL clk
  */
 
-hw_timer_t * timer = NULL;
-hw_timer_t * timer_XTAL = NULL;
+static hw_timer_t * timer = NULL;
 static volatile bool alarm_flag;
 
-/* These functions are intended to be called before and after each test. */
+/* setUp / tearDown functions are intended to be called before / after each test. */
 void setUp(void) {
   timer = timerBegin(TIMER_FREQUENCY);
+  if(timer == NULL){
+     TEST_FAIL_MESSAGE("Timer init failed in setUp()");
+  }
   timerStop(timer);
   timerRestart(timer);
 }
 
 void tearDown(void){
   timerEnd(timer);
-  timer = NULL;
 }
-
-
 
 void ARDUINO_ISR_ATTR onTimer(){
   alarm_flag = true;
 }
 
-
 void timer_interrupt_test(void){
-  
+
   alarm_flag = false;
   timerAttachInterrupt(timer, &onTimer);
   timerAlarm(timer, (1.2 * TIMER_FREQUENCY), true, 0);
@@ -67,9 +65,11 @@ void timer_divider_test(void){
 
   // compare divider  16 and 8, value should be double
   timerEnd(timer);
-  timer = NULL;
 
   timer = timerBegin(2 * TIMER_FREQUENCY);
+  if(timer == NULL){
+     TEST_FAIL_MESSAGE("Timer init failed!");
+  }
   timerRestart(timer);
   delay(1000);        
   comp_time_val = timerRead(timer);
@@ -79,9 +79,11 @@ void timer_divider_test(void){
 
   // divider is 256, value should be 2^4
   timerEnd(timer);
-  timer = NULL;
 
   timer = timerBegin(TIMER_FREQUENCY / 16);
+  if(timer == NULL){
+     TEST_FAIL_MESSAGE("Timer init failed!");
+  }
   timerRestart(timer);
   delay(1000);       
   comp_time_val = timerRead(timer);
@@ -103,13 +105,10 @@ void timer_read_test(void){
 
 void timer_clock_select_test(void){
   // Set timer frequency that can be achieved using XTAL clock source (autoselected)
-  timer_XTAL = timerBegin(TIMER_FREQUENCY_XTAL_CLK);
+  timer = timerBegin(TIMER_FREQUENCY_XTAL_CLK);
   
-  uint32_t resolution = timerGetFrequency(timer_XTAL);
+  uint32_t resolution = timerGetFrequency(timer);
   TEST_ASSERT_EQUAL(TIMER_FREQUENCY_XTAL_CLK,resolution);
-  
-  timerEnd(timer_XTAL);
-  timer_XTAL = NULL;
 }
 
 void setup(){


### PR DESCRIPTION
## Description of Change
Added timer_started flag to determine, if there is a need to call `gptimer_stop()` before `gptimer_disable()`.
Fixed `timerEnd()` by calling `gptimer_stop()` if needed.
Fixed HW timer test.

## Tests scenarios
HW test tested on all supported chips.

## Related links
