### PR TITLE
eraseAP

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -367,6 +367,22 @@ bool WiFiSTAClass::disconnect(bool wifioff, bool eraseap)
 }
 
 /**
+ * @brief  Reset WiFi settings in NVS to default values.
+ * @return true if erase succeeded
+ * @note: Resets SSID, password, protocol, mode, etc.
+ * These settings are maintained by WiFi driver in IDF.
+ * WiFi driver must be initialized.
+ */
+bool WiFiSTAClass::eraseAP(void) {
+    if(WiFi.getMode()==WIFI_MODE_NULL) {
+        if(!WiFi.enableSTA(true))
+            return false;
+    }
+
+    return esp_wifi_restore()==ESP_OK;
+}
+
+/**
  * Change IP configuration settings disabling the dhcp client
  * @param local_ip   Static ip configuration
  * @param gateway    Static gateway configuration

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -53,6 +53,7 @@ public:
 
     bool reconnect();
     bool disconnect(bool wifioff = false, bool eraseap = false);
+    bool eraseAP(void);
 
     bool isConnected();
 


### PR DESCRIPTION
## Description of Change
Allows user to reset saved WiFi settings to defaults.

## Tests scenarios
Tested on arduino-esp32 v2.0.7 with ESP32-WROOM-32UE on custom PCB.

## Related links
Closes #8067 
