### PR TITLE
Fixes analogWrite

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -223,7 +223,8 @@ void analogWrite(uint8_t pin, int value) {
           log_e("No more analogWrite channels available! You can have maximum %u", LEDC_CHANNELS);
           return;
       }
-      channel = cnt_channel - 1;
+      cnt_channel--;
+      channel = cnt_channel;
     } else {
       channel = analogGetChannel(pin);
     }

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -215,28 +215,28 @@ static int cnt_channel = LEDC_CHANNELS;
 static uint8_t analog_resolution = 8;
 static int analog_frequency = 1000;
 void analogWrite(uint8_t pin, int value) {
-  // Use ledc hardware for internal pins
-  if (pin < SOC_GPIO_PIN_COUNT) {
-    int8_t channel = -1;
-    if (pin_to_channel[pin] == 0) {
-      if (!cnt_channel) {
-          log_e("No more analogWrite channels available! You can have maximum %u", LEDC_CHANNELS);
-          return;
-      }
-      cnt_channel--;
-      channel = cnt_channel;
-    } else {
-      channel = analogGetChannel(pin);
+    // Use ledc hardware for internal pins
+    if (pin < SOC_GPIO_PIN_COUNT) {
+        int8_t channel = -1;
+        if (pin_to_channel[pin] == 0) {
+            if (!cnt_channel) {
+                log_e("No more analogWrite channels available! You can have maximum %u", LEDC_CHANNELS);
+                return;
+            }
+            cnt_channel--;
+            channel = cnt_channel;
+        } else {
+            channel = analogGetChannel(pin);
+        }
+        log_v("GPIO %d - Using Channel %d, Value = %d", pin, channel, value);
+        if(ledcSetup(channel, analog_frequency, analog_resolution) == 0){
+            log_e("analogWrite setup failed (freq = %u, resolution = %u). Try setting different resolution or frequency");
+            return;
+        }
+        ledcAttachPin(pin, channel);
+        pin_to_channel[pin] = channel;
+        ledcWrite(channel, value);
     }
-    log_v("GPIO %d - Using Channel %d, Value = %d", pin, channel, value);
-    if(ledcSetup(channel, analog_frequency, analog_resolution) == 0){
-        log_e("analogWrite setup failed (freq = %u, resolution = %u). Try setting different resolution or frequency");
-        return;
-    }
-    ledcAttachPin(pin, channel);
-    pin_to_channel[pin] = channel;
-    ledcWrite(channel, value);
-  }
 }
 
 int8_t analogGetChannel(uint8_t pin) {


### PR DESCRIPTION
## Description of Change
If  `analogWrite(pin, val)`  is called a second time after a `pinMode()`, it doesn't work.

## Tests scenarios
Tested with ESP32

``` cpp
#define PWM_PIN 2

void setup() {
  pinMode(PWM_PIN, OUTPUT);
  analogWrite(PWM_PIN, 255);
  delay(2000);
  pinMode(PWM_PIN, INPUT);
  analogWrite(PWM_PIN, 64);
  delay(2000);
  pinMode(PWM_PIN, OUTPUT);
  analogWrite(PWM_PIN, 16);
  delay(2000);
  pinMode(PWM_PIN, OUTPUT); // it goes to Low as default
}

void loop() {
  delay(100);
}
```

## Related links
Fixes #8106