### PR TITLE
Revert FlashStringHelper Macros

### DIFF
--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -34,8 +34,8 @@
 // A pure abstract class forward used as a means to proide a unique pointer type
 // but really is never defined.
 class __FlashStringHelper;
-#define FPSTR(pstr_pointer) (pstr_pointer)
-#define F(string_literal) (string_literal)
+#define FPSTR(pstr_pointer) (reinterpret_cast<const __FlashStringHelper *>(pstr_pointer))
+#define F(string_literal) (FPSTR(PSTR(string_literal)))
 
 // An inherited class for holding the result of a concatenation.  These
 // result objects are assumed to be writable by subsequent concatenations.


### PR DESCRIPTION
## Description of Change
Revert to previous definition of `FPSTR` and `F` macros.

## Tests scenarios
Tested on arduino-esp32 core v2.0.8 with Adafruit Huzzah32 (Feather ESP32).
Tested on Win11 computer with VSCode+PIO.

```
#include <Arduino.h>

const __FlashStringHelper * testfunc(void)
{
  return F("test");
}

void setup() {
  Serial.begin(115200);
  
}

void loop() {
  String s;

  // put your main code here, to run repeatedly:
  delay(1000);
  s = testfunc();
  Serial.println(s);
}
```

Results:
```
ets Jul 29 2019 12:21:46

rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00       
mode:DIO, clock div:1
load:0x3fff0030,len:1184
load:0x40078000,len:13220
ho 0 tail 12 room 4
load:0x40080400,len:3028
entry 0x400805e4
test
test
test
```

## Related links
Closes #8108 
