### PR TITLE
Revert FlashStringHelper Macros

### DIFF
--- a/cores/esp32/WString.h
+++ b/cores/esp32/WString.h
@@ -34,8 +34,8 @@
 // A pure abstract class forward used as a means to proide a unique pointer type
 // but really is never defined.
 class __FlashStringHelper;
-#define FPSTR(pstr_pointer) (pstr_pointer)
-#define F(string_literal) (string_literal)
+#define FPSTR(pstr_pointer) (reinterpret_cast<const __FlashStringHelper *>(pstr_pointer))
+#define F(string_literal) (FPSTR(PSTR(string_literal)))
 
 // An inherited class for holding the result of a concatenation.  These
 // result objects are assumed to be writable by subsequent concatenations.


### PR DESCRIPTION
## Description of Change
Revert to previous definition of `FPSTR` and `F` macros.
Same as #8143. This PR targets master instead of 2.x branch.

## Related links
Closes #8108 
