### PR TITLE
Fix CameraWebserver.ino CI Warning

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
@@ -60,8 +60,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;


### PR DESCRIPTION
## Description of Change
Resolves deprecation warnings in CameraWebServer.ino.
pin_sscb_sda -> pin_sccb_sda.  (note the change from `ss` to `sc`)
pin_sscb_scl -> pin_sccb_scl.

## Issue
```
Building Sketch Index 16 - CameraWebServer ....
/CameraWebServer.ino:63:10: warning: 'camera_config_t::<unnamed union>::pin_sscb_sda' is deprecated: please use pin_sccb_sda instead ....
   config.pin_sscb_sda = SIOD_GPIO_NUM;
....
/CameraWebServer.ino:64:10: warning: 'camera_config_t::<unnamed union>::pin_sscb_scl' is deprecated: please use pin_sccb_scl instead ....
   config.pin_sscb_scl = SIOC_GPIO_NUM;
```

## Tests scenarios
This is a simple variable rename.   The variables are in the same union and are identical.

## Related links
"esp32/tools/sdk/esp32s2/include/esp32-camera/driver/include/esp_camera.h"

Helps advance PR #7060 
