### PR TITLE
Add protocol-explicit upload.tool properties required for pluggable discovery compatibility

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -7314,6 +7314,7 @@ dfrobot_beetle_esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 dfrobot_firebeetle2_esp32e.name=FireBeetle 2 ESP32-E
 
 dfrobot_firebeetle2_esp32e.upload.tool=esptool_py
+dfrobot_firebeetle2_esp32e.upload.tool.default=esptool_py
 dfrobot_firebeetle2_esp32e.upload.maximum_size=1310720
 dfrobot_firebeetle2_esp32e.upload.maximum_data_size=327680
 dfrobot_firebeetle2_esp32e.upload.flags=
@@ -22259,6 +22260,7 @@ esp32c3m1IKit.menu.EraseFlash.all.upload.erase_cmd=-e
 roboheart_hercules.name=RoboHeart Hercules
 
 roboheart_hercules.upload.tool=esptool_py
+roboheart_hercules.upload.tool.default=esptool_py
 roboheart_hercules.upload.maximum_size=1310720
 roboheart_hercules.upload.maximum_data_size=327680
 roboheart_hercules.upload.wait_for_upload_port=true


### PR DESCRIPTION
## Description of Change

A new flexible and powerful ["pluggable discovery" system](https://arduino.github.io/arduino-cli/0.27/platform-specification/#pluggable-discovery) was added to the Arduino boards platform framework. This system makes it easy for Arduino boards platform authors to use any arbitrary communication channel between the board and development tools.

Boards platform configurations that use the old property syntax are automatically translated to the new syntax by Arduino CLI:

https://arduino.github.io/arduino-cli/latest/platform-specification/#sketch-upload-configuration

> For backward compatibility with IDE 1.8.15 and older the previous syntax is still supported

This translation is only done in platforms that use the old syntax exclusively. If `pluggable_discovery` properties are defined for the platform then the new pluggable discovery-style `upload.tool.<protocol_name>` properties must be defined for each board as well.

This platform was converted to use the new pluggable discovery platform properties syntax (https://github.com/espressif/arduino-esp32/pull/6506), so those properties are now required. Although such properties were added to board definitions at the time the syntax was changed, new board definitions without the required properties were added later (https://github.com/espressif/arduino-esp32/pull/7672, https://github.com/espressif/arduino-esp32/pull/7835).

Those missing properties caused uploads to fail for users of the recent versions of Arduino IDE and Arduino CLI with an error of the form:

```text
Error during Upload: Property 'upload.tool.serial' is undefined
```

It is also important to provide compatibility with versions of Arduino development tools from before the introduction of the modern pluggable discovery system. For this reason, the old style `<board ID>.upload.tool` properties are retained. Old versions of the development tools will treat the `<board ID>.upload.tool.default` properties as an unused arbitrary user defined property with no special significance and the new versions of the development tools will do the same for the `<board ID>.upload.tool` properties.

## Tests scenarios

Upload to each of the boards via Arduino IDE 2.1.0 without encountering `Property 'upload.tool.serial' is undefined` error:

- FireBeetle 2 ESP32-E
- RoboHeart Hercules

## Related links

Originally reported at https://forum.arduino.cc/t/upload-to-firebeetle-2-esp-32e-results-in-the-error-property-upload-tool-serial-is-undefined/1122426

Related: https://github.com/espressif/arduino-esp32/pull/7517
