### PR TITLE
GPIO - Peripheral manager implementation

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "esp32-hal-gpio.h"
+#include "esp32-hal-periman.h"
 #include "hal/gpio_hal.h"
 #include "soc/soc_caps.h"
 
@@ -89,6 +90,10 @@ static InterruptHandle_t __pinInterruptHandlers[SOC_GPIO_PIN_COUNT] = {0,};
 
 #include "driver/rtc_io.h"
 
+static bool gpioDetachBus(void * bus){
+    return true;
+}
+
 extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 {
 #ifdef RGB_BUILTIN
@@ -101,6 +106,14 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
     if (pin >= SOC_GPIO_PIN_COUNT) {
         log_e("Invalid pin selected");
         return;
+    }
+
+    if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
+        perimanSetBusDeinit(ESP32_BUS_TYPE_GPIO, gpioDetachBus);
+        if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_INIT, NULL)){
+            log_e("Deinit of previous bus failed");
+            return;
+        }
     }
     
     gpio_hal_context_t gpiohal;
@@ -130,24 +143,41 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
         log_e("GPIO config failed");
         return;
     }
+    if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
+        if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_GPIO, (void *)(pin+1))){
+            //gpioDetachBus((void *)(pin+1));
+            return;
+        }
+    }
 }
 
 extern void ARDUINO_ISR_ATTR __digitalWrite(uint8_t pin, uint8_t val)
 {
-    #ifdef RGB_BUILTIN
-        if(pin == RGB_BUILTIN){
-            //use RMT to set all channels on/off
-            const uint8_t comm_val = val != 0 ? RGB_BRIGHTNESS : 0;
-            neopixelWrite(RGB_BUILTIN, comm_val, comm_val, comm_val);
-            return;
-        }
-    #endif
-	gpio_set_level((gpio_num_t)pin, val);
+    if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) != NULL){
+        #ifdef RGB_BUILTIN
+            if(pin == RGB_BUILTIN){
+                //use RMT to set all channels on/off
+                const uint8_t comm_val = val != 0 ? RGB_BRIGHTNESS : 0;
+                neopixelWrite(RGB_BUILTIN, comm_val, comm_val, comm_val);
+                return;
+            }
+        #endif
+        gpio_set_level((gpio_num_t)pin, val);
+    }
+    else {
+        log_e("Pin is not set as GPIO.");
+    }
 }
 
 extern int ARDUINO_ISR_ATTR __digitalRead(uint8_t pin)
 {
-	return gpio_get_level((gpio_num_t)pin);
+    if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) != NULL){
+	    return gpio_get_level((gpio_num_t)pin);
+    }
+    else {
+        log_e("Pin is not set as GPIO.");
+        return 0;
+    }
 }
 
 static void ARDUINO_ISR_ATTR __onPinInterrupt(void * arg) {


### PR DESCRIPTION
## Description of Change
Implemented peripheral manager into gpio driver.
As gpio functions are already using pins as input, there was no need to change any API, just added gpioDetachBus function that is required for the Peripheral manager, which just returns true.

## Tests scenarios

## Related links