### PR TITLE
HardwareSerial: fix begin() lock issue on error path

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -367,6 +367,7 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
 #endif
             default:
                 log_e("Bad UART Number");
+                HSERIAL_MUTEX_UNLOCK();
                 return;
         }
     }

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -365,10 +365,6 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
                 }
             break;
 #endif
-            default:
-                log_e("Bad UART Number");
-                HSERIAL_MUTEX_UNLOCK();
-                return;
         }
     }
 


### PR DESCRIPTION
If the user supplied a wrong UART number, the `begin()` method would return without releasing the lock. Add missing `UNLOCK()` call.

No other unbalanced locks exist in this file. 