### PR TITLE
Enforces more consistency into Peripheral Manager

### DIFF
--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -35,7 +35,7 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void * bus){
 	}
 	otype = pins[pin].type;
 	obus = pins[pin].bus;
-	if(type == otype && bus == obus){
+	if(type != ESP32_BUS_TYPE_INIT && type == otype && bus == obus){
 		log_i("Bus already set");
 		return true;
 	}

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -25,7 +25,7 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void * bus){
 		log_e("Invalid pin: %u", pin);
 		return false;
 	}
-	if(type >= ESP32_BUS_TYPE_MAX){
+	if(type >= ESP32_BUS_TYPE_MAX) {
 		log_e("Invalid type: %u", (unsigned int)type);
 		return false;
 	}
@@ -33,6 +33,10 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void * bus){
 		log_e("Bus is NULL");
 		return false;
 	}
+	if (type == ESP32_BUS_TYPE_INIT && bus != NULL) {
+		log_e("Can't set a Bus to INIT Type");
+		return false;
+	}	
 	otype = pins[pin].type;
 	obus = pins[pin].bus;
 	if(type != ESP32_BUS_TYPE_INIT && type == otype && bus == obus){
@@ -59,7 +63,7 @@ void * perimanGetPinBus(uint8_t pin, peripheral_bus_type_t type){
 		log_e("Invalid pin: %u", pin);
 		return NULL;
 	}
-	if(type >= ESP32_BUS_TYPE_MAX){
+	if(type >= ESP32_BUS_TYPE_MAX  || type  == ESP32_BUS_TYPE_INIT){
 		log_e("Invalid type: %u", (unsigned int)type);
 		return NULL;
 	}
@@ -78,7 +82,7 @@ peripheral_bus_type_t perimanGetPinBusType(uint8_t pin){
 }
 
 bool perimanSetBusDeinit(peripheral_bus_type_t type, peripheral_bus_deinit_cb_t cb){
-	if(type >= ESP32_BUS_TYPE_MAX){
+	if(type >= ESP32_BUS_TYPE_MAX || type == ESP32_BUS_TYPE_INIT){
 		log_e("Invalid type: %u", (unsigned int)type);
 		return false;
 	}

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -25,7 +25,7 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void * bus){
 		log_e("Invalid pin: %u", pin);
 		return false;
 	}
-	if(type >= ESP32_BUS_TYPE_MAX) {
+	if(type >= ESP32_BUS_TYPE_MAX){
 		log_e("Invalid type: %u", (unsigned int)type);
 		return false;
 	}
@@ -33,7 +33,7 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void * bus){
 		log_e("Bus is NULL");
 		return false;
 	}
-	if (type == ESP32_BUS_TYPE_INIT && bus != NULL) {
+	if (type == ESP32_BUS_TYPE_INIT && bus != NULL){
 		log_e("Can't set a Bus to INIT Type");
 		return false;
 	}	

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -39,8 +39,10 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void * bus){
 	}	
 	otype = pins[pin].type;
 	obus = pins[pin].bus;
-	if(type != ESP32_BUS_TYPE_INIT && type == otype && bus == obus){
-		log_i("Bus already set");
+	if(type == otype && bus == obus){
+		if (type != ESP32_BUS_TYPE_INIT) {
+		        log_i("Bus already set");
+		}
 		return true;
 	}
 	if(obus != NULL){


### PR DESCRIPTION
## Description of Change

This PR prevents any way of setting or getting a Bus from a ESP32_BUS_TYPE_INIT table entry. This prevents future sort of inconsistencies.

Right after ESP starts, all the Buses are in `ESP32_BUS_TYPE_INIT` state, thus, if `perimanSetPinBus(pin, ESP32_BUS_TYPE_INIT, NULL)`  is executed, it will issue a debug message (`perimanSetPinBus(): Bus already set`) that doesn't make full sense.

## Tests scenarios
Tested on ESP32/S2/S3 and C3

``` cpp
#include <Arduino.h>
#include <esp32-hal-periman.h>

#define PIN 2

static bool anyDetachBus(void * bus){
    log_e("This shall never happen...");
    return true;
}

int myBus = 7;

void setup() {
  // it is necessary to set debug level to INFO or higher.
  if (perimanSetPinBus(PWM_PIN, ESP32_BUS_TYPE_INIT, NULL)) log_i("1- OK");
  else log_i("1- Fail"); 
  if (perimanSetBusDeinit(ESP32_BUS_TYPE_INIT, anyDetachBus)) log_i("2- OK");
  else log_i("2- Fail"); 
  if (perimanSetPinBus(PWM_PIN, ESP32_BUS_TYPE_INIT, &myBus)) log_i("3- OK");
  else log_i("3- Fail"); 
  if (perimanGetPinBus(PWM_PIN, ESP32_BUS_TYPE_INIT)) log_i("4- OK");
  else log_i("4- Fail"); 
  if (perimanSetPinBus(PWM_PIN, ESP32_BUS_TYPE_INIT, NULL)) log_i("5- OK");
  else log_i("5- Fail"); 
}

void loop() { }
```

### Actual Output:
```
[    62][I][esp32-hal-periman.c:39] perimanSetPinBus(): Bus already set
[    68][I][periMgrPr_Test.ino:21] setup(): 1- OK
[    77][I][periMgrPr_Test.ino:23] setup(): 2- OK
[    85][I][periMgrPr_Test.ino:25] setup(): 3- OK
[    94][I][periMgrPr_Test.ino:27] setup(): 4- OK
[   103][E][periMgrPr_Test.ino:7] anyDetachBus(): This shall never happen...
[   114][I][periMgrPr_Test.ino:29] setup(): 5- OK
```
### Expected Output (after aplying the PR):
```
[    62][I][periMgrPr_Test.ino:21] setup(): 1- OK
[    70][E][esp32-hal-periman.c:86] perimanSetBusDeinit(): Invalid type: 0
[    77][I][periMgrPr_Test.ino:24] setup(): 2- Fail
[    86][E][esp32-hal-periman.c:37] perimanSetPinBus(): Can't set a Bus to INIT Type
[    93][I][periMgrPr_Test.ino:26] setup(): 3- Fail
[   102][E][esp32-hal-periman.c:67] perimanGetPinBus(): Invalid type: 0
[   108][I][periMgrPr_Test.ino:28] setup(): 4- Fail
[   117][I][periMgrPr_Test.ino:29] setup(): 5- OK
```

## Related links
https://github.com/espressif/arduino-esp32/pull/7994/files/cb0444f5775d6950ce47bc7f023a47d7220b4225#r1190106856