### PR TITLE
Fixed compiler warning

### DIFF
--- a/tools/sdk/esp32/include/esp-dl/include/math/dl_math.hpp
+++ b/tools/sdk/esp32/include/esp-dl/include/math/dl_math.hpp
@@ -38,8 +38,15 @@ namespace dl
          */
         inline float sqrt_quick(float x)
         {
-            const int result = 0x1fbb4000 + (*(int *)&x >> 1);
-            return *(float *)&result;
+            union
+            {
+                float f;
+                int i;
+            } pun;
+
+            pun.f = x;
+            pun.i = 0x1fbb4000 + (pun.i >> 1);
+            return pun.f;
         }
 
         /**
@@ -51,9 +58,10 @@ namespace dl
         inline float sqrt_reciprocal_quick(float x)
         {
             float xhalf = 0.5f * x;
-            int i = *(int *)&x;             // get bits for floating value
+            int i;
+            memcpy(&i, &x, sizeof(float));  // copy the bits of x into an integer
             i = 0x5f375a86 - (i >> 1);      // gives initial guess y0
-            x = *(float *)&i;               // convert bits back to float
+            memcpy(&x, &i, sizeof(float));  // copy the integer bits back into x
             x = x * (1.5f - xhalf * x * x); // Newton step, repeating increases accuracy
             return x;
         }

--- a/tools/sdk/esp32c3/include/esp-dl/include/math/dl_math.hpp
+++ b/tools/sdk/esp32c3/include/esp-dl/include/math/dl_math.hpp
@@ -38,8 +38,15 @@ namespace dl
          */
         inline float sqrt_quick(float x)
         {
-            const int result = 0x1fbb4000 + (*(int *)&x >> 1);
-            return *(float *)&result;
+            union
+            {
+                float f;
+                int i;
+            } pun;
+
+            pun.f = x;
+            pun.i = 0x1fbb4000 + (pun.i >> 1);
+            return pun.f;
         }
 
         /**
@@ -51,9 +58,10 @@ namespace dl
         inline float sqrt_reciprocal_quick(float x)
         {
             float xhalf = 0.5f * x;
-            int i = *(int *)&x;             // get bits for floating value
+            int i;
+            memcpy(&i, &x, sizeof(float));  // copy the bits of x into an integer
             i = 0x5f375a86 - (i >> 1);      // gives initial guess y0
-            x = *(float *)&i;               // convert bits back to float
+            memcpy(&x, &i, sizeof(float));  // copy the integer bits back into x
             x = x * (1.5f - xhalf * x * x); // Newton step, repeating increases accuracy
             return x;
         }

--- a/tools/sdk/esp32s2/include/esp-dl/include/math/dl_math.hpp
+++ b/tools/sdk/esp32s2/include/esp-dl/include/math/dl_math.hpp
@@ -38,8 +38,15 @@ namespace dl
          */
         inline float sqrt_quick(float x)
         {
-            const int result = 0x1fbb4000 + (*(int *)&x >> 1);
-            return *(float *)&result;
+            union
+            {
+                float f;
+                int i;
+            } pun;
+
+            pun.f = x;
+            pun.i = 0x1fbb4000 + (pun.i >> 1);
+            return pun.f;
         }
 
         /**
@@ -51,9 +58,10 @@ namespace dl
         inline float sqrt_reciprocal_quick(float x)
         {
             float xhalf = 0.5f * x;
-            int i = *(int *)&x;             // get bits for floating value
+            int i;
+            memcpy(&i, &x, sizeof(float));  // copy the bits of x into an integer
             i = 0x5f375a86 - (i >> 1);      // gives initial guess y0
-            x = *(float *)&i;               // convert bits back to float
+            memcpy(&x, &i, sizeof(float));  // copy the integer bits back into x
             x = x * (1.5f - xhalf * x * x); // Newton step, repeating increases accuracy
             return x;
         }

--- a/tools/sdk/esp32s3/include/esp-dl/include/math/dl_math.hpp
+++ b/tools/sdk/esp32s3/include/esp-dl/include/math/dl_math.hpp
@@ -38,8 +38,15 @@ namespace dl
          */
         inline float sqrt_quick(float x)
         {
-            const int result = 0x1fbb4000 + (*(int *)&x >> 1);
-            return *(float *)&result;
+            union
+            {
+                float f;
+                int i;
+            } pun;
+
+            pun.f = x;
+            pun.i = 0x1fbb4000 + (pun.i >> 1);
+            return pun.f;
         }
 
         /**
@@ -51,9 +58,10 @@ namespace dl
         inline float sqrt_reciprocal_quick(float x)
         {
             float xhalf = 0.5f * x;
-            int i = *(int *)&x;             // get bits for floating value
+            int i;
+            memcpy(&i, &x, sizeof(float));  // copy the bits of x into an integer
             i = 0x5f375a86 - (i >> 1);      // gives initial guess y0
-            x = *(float *)&i;               // convert bits back to float
+            memcpy(&x, &i, sizeof(float));  // copy the integer bits back into x
             x = x * (1.5f - xhalf * x * x); // Newton step, repeating increases accuracy
             return x;
         }


### PR DESCRIPTION
fixed warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]

-----------
## Description of Change

When `dl_math.hpp` is used [`#include "dl_math.hpp"`], compiler generates warnings because the implemented functions `sqrt_quick()` and `sqrt_reciprocal_quick()` violate the strict aliasing rules of C/C++ language standard. To avoid the warning and adhere to strict aliasing rules, a type-safe approach is used in this commit.

## Tests scenarios

The pull request is built for ESP32, ESP32-C3, ESP32-S2 and ESP32-S3 chips and tested on ESP32-S3 dev module.

Furthermore, as a reference, the following C++ code can be used to verify the underlying math.

`g++ main.cpp -o main`

`./main`


```
#include <cmath>
#include <iostream>

inline float sqrt_quick(float x)
{
    //    const int result = 0x1fbb4000 + (*(int *)&x >> 1);
    //    return *(float *)&result;
    union
    {
        float f;
        int i;
    } pun;

    pun.f = x;
    pun.i = 0x1fbb4000 + (pun.i >> 1);
    return pun.f;
}

inline float sqrt_reciprocal_quick(float x)
{
    float xhalf = 0.5f * x;
    // int i = *(int *)&x;             // get bits for floating value
    int i;
    memcpy(&i, &x, sizeof(float));
    i = 0x5f375a86 - (i >> 1); // gives initial guess y0
    // x = *(float *)&i;               // convert bits back to float
    memcpy(&x, &i, sizeof(float));
    x = x * (1.5f - xhalf * x * x); // Newton step, repeating increases accuracy
    return x;
}

int main()
{
    // test cases for sqrt_quick()
    float inputs0[] = {4.0f, 9.0f, 16.0f, 25.0f, 100.0f};
    float expectedResults0[] = {2.0f, 3.0f, 4.0f, 5.0f, 10.0f};

    int numTests0 = sizeof(inputs0) / sizeof(inputs0[0]);

    for (int i = 0; i < numTests0; i++)
    {
        float input = inputs0[i];
        float expectedResult = expectedResults0[i];

        // call the function under test
        float result = sqrt_quick(input);

        // check if the result matches the expected result
        if (std::abs(result - expectedResult) < 0.1f)
        {
            std::cout << "Test case " << i + 1 << " passed!" << std::endl;
        }
        else
        {
            std::cout << "Test case " << i + 1 << " failed!" << std::endl;
            std::cout << "Expected: " << expectedResult << ", Got: " << result << std::endl;
        }
    }

    // test cases for sqrt_reciprocal_quick()
    float inputs1[] = {4.0f, 9.0f, 16.0f, 25.0f, 100.0f};
    float expectedResults1[] = {0.5f, .33f, .25f, .2f, 0.1f};

    int numTests1 = sizeof(inputs1) / sizeof(inputs1[0]);

    for (int i = 0; i < numTests1; i++)
    {
        float input = inputs1[i];
        float expectedResult = expectedResults1[i];

        // call the function under test
        float result = sqrt_reciprocal_quick(input);

        // check if the result matches the expected result
        if (std::abs(result - expectedResult) < 0.01f)
        {
            std::cout << "Test case " << i + 1 << " passed!" << std::endl;
        }
        else
        {
            std::cout << "Test case " << i + 1 << " failed!" << std::endl;
            std::cout << "Expected: " << expectedResult << ", Got: " << result << std::endl;
        }
    }

    return 0;
}
```
