### PR TITLE
add esp_partition requirement to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ set(includedirs
 
 set(srcs ${CORE_SRCS} ${LIBRARY_SRCS} ${BLE_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash mbedtls mdns wifi_provisioning wpa_supplicant esp_adc esp_eth http_parser)
+set(requires spi_flash mbedtls mdns wifi_provisioning wpa_supplicant esp_adc esp_eth esp_partition http_parser)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid)
 
 idf_component_register(INCLUDE_DIRS ${includedirs} PRIV_INCLUDE_DIRS ${priv_includes} SRCS ${srcs} REQUIRES ${requires} PRIV_REQUIRES ${priv_requires})


### PR DESCRIPTION
Build fails otherwise with
```
cores/esp32/Esp.h:24:10: fatal error: esp_partition.h: No such file or directory
```