### PR TITLE
fixes ESP32-C3 WiFiProv and btInUse()

### DIFF
--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -16,7 +16,8 @@
 
 #ifdef CONFIG_BT_ENABLED
 
-bool btInUse(){ return true; }
+// user may want to change it to free resources
+__attribute__((weak)) bool btInUse(){ return true; }
 
 #include "esp_bt.h"
 

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -209,9 +209,8 @@ bool verifyRollbackLater() { return false; }
 #endif
 
 #ifdef CONFIG_BT_ENABLED
-//overwritten in esp32-hal-bt.c
-bool btInUse() __attribute__((weak));
-bool btInUse(){ return false; }
+//from esp32-hal-bt.c
+extern bool btInUse();
 #endif
 
 void initArduino()


### PR DESCRIPTION
## Description of Change

This change is necessary within Arduino Core 2.0.x and 3.0.x.

When testing ESP32-C3 with WiFiProv.ino example to use Bluetooth provisioning, it fails because `btInUse()` returns false due to a weak/strong symbol resolving within the linker.

This PR sets the origin of the `btInUse()` function to be with `esp32-hal-bt.c` and its symbol is an external one for `esp32-hal-misc.c` making possible for the user to redefine it, is necessary. This solves the Core library C3 linker issue.

## Tests scenarios
The PR is tested by using `WiFiProv.ino` example by removing the `#if CONFIG_IDF_TARGET_ESP32` in order to use it with the C3.
This shall use this call: `    WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, "abcd1234", "Prov_123");`

Tested with ESP32, ESP32-C3, ESP32-S3.

## Related links
Fix https://github.com/espressif/arduino-esp32/issues/7903