### PR TITLE
Fixes HWCDC::end()

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -195,6 +195,7 @@ void HWCDC::end()
     intr_handle = NULL;
     if(tx_lock != NULL) {
         vSemaphoreDelete(tx_lock);
+        tx_lock = NULL;
     }
     setRxBufferSize(0);
     setTxBufferSize(0);

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -28,7 +28,7 @@ ESP_EVENT_DEFINE_BASE(ARDUINO_HW_CDC_EVENTS);
 
 static RingbufHandle_t tx_ring_buf = NULL;
 static xQueueHandle rx_queue = NULL;
-static uint8_t rx_data_buf[64];
+static uint8_t rx_data_buf[64] = {0};
 static intr_handle_t intr_handle = NULL;
 static volatile bool initial_empty = false;
 static xSemaphoreHandle tx_lock = NULL;


### PR DESCRIPTION
## Description of Change

If we call `serial.end()` followed by `serial.begin` using JTAG/CDC interface, it will never initialize the semaphore `tx_lock` and it will reset the board when data is written.
There is a missing `tx_lock = NULL;` in the `HWCDC::end()` function.

## Tests scenarios
Tested with C3 and S3.

## Related links
Fixes #8224 