### PR TITLE
rainmaker: multiple device callbacks not getting registered

### DIFF
--- a/libraries/RainMaker/src/RMakerDevice.h
+++ b/libraries/RainMaker/src/RMakerDevice.h
@@ -21,17 +21,42 @@
 
 class Device
 {
+    public:
+    typedef void (*deviceWriteCb)(Device*, Param*, const param_val_t val, void *priv_data, write_ctx_t *ctx);
+    typedef void (*deviceReadCb)(Device*, Param*, void *priv_data, read_ctx_t *ctx);
+    typedef struct {
+        void *priv_data;
+        deviceWriteCb write_cb;
+        deviceReadCb read_cb;
+    } RMakerDevicePrivT;
     private:
         const device_handle_t *device_handle;
+        RMakerDevicePrivT private_data;
 
+    protected:
+        void setPrivateData(void *priv_data) {
+            this->private_data.priv_data = priv_data;
+        }
+        
+        const RMakerDevicePrivT* getDevicePrivateData()
+        {
+            return &this->private_data;
+        }
     public:
         Device()
         {
             device_handle = NULL;
-        }        
+            this->private_data.priv_data = NULL;
+            this->private_data.write_cb = NULL;
+            this->private_data.read_cb = NULL;
+        }
+
         Device(const char *dev_name, const char *dev_type = NULL, void *priv_data = NULL)
         {
-            device_handle = esp_rmaker_device_create(dev_name, dev_type, priv_data);
+            this->private_data.priv_data = priv_data;
+            this->private_data.write_cb = NULL;
+            this->private_data.read_cb = NULL;
+            device_handle = esp_rmaker_device_create(dev_name, dev_type, &this->private_data);
             if(device_handle == NULL){
                 log_e("Device create error");
             }   
@@ -48,9 +73,6 @@ class Device
         {
             return device_handle;
         }
-        
-        typedef void (*deviceWriteCb)(Device*, Param*, const param_val_t val, void *priv_data, write_ctx_t *ctx);
-        typedef void (*deviceReadCb)(Device*, Param*, void *priv_data, read_ctx_t *ctx);
 
         esp_err_t deleteDevice();
         void addCb(deviceWriteCb write_cb, deviceReadCb read_cb = NULL);
@@ -94,7 +116,8 @@ class Switch : public Device
         }
         void standardSwitchDevice(const char *dev_name, void *priv_data, bool power)
         {
-            esp_rmaker_device_t *dev_handle = esp_rmaker_switch_device_create(dev_name, priv_data, power);
+            this->setPrivateData(priv_data);
+            esp_rmaker_device_t *dev_handle = esp_rmaker_switch_device_create(dev_name, (void *)this->getDevicePrivateData(), power);
             setDeviceHandle(dev_handle);
             if(dev_handle == NULL){
                 log_e("Switch device not created");
@@ -115,7 +138,8 @@ class LightBulb : public Device
         }
         void standardLightBulbDevice(const char *dev_name, void *priv_data, bool power)
         {
-            esp_rmaker_device_t *dev_handle = esp_rmaker_lightbulb_device_create(dev_name, priv_data, power);
+            this->setPrivateData(priv_data);
+            esp_rmaker_device_t *dev_handle = esp_rmaker_lightbulb_device_create(dev_name, (void *)this->getDevicePrivateData(), power);
             setDeviceHandle(dev_handle);
             if(dev_handle == NULL){
                 log_e("Light device not created");
@@ -157,7 +181,8 @@ class TemperatureSensor : public Device
         }
         void standardTemperatureSensorDevice(const char *dev_name, void *priv_data, float temp)
         {
-            esp_rmaker_device_t *dev_handle = esp_rmaker_temp_sensor_device_create(dev_name, priv_data, temp);
+            this->setPrivateData(priv_data);
+            esp_rmaker_device_t *dev_handle = esp_rmaker_temp_sensor_device_create(dev_name, (void *)this->getDevicePrivateData(), temp);
             setDeviceHandle(dev_handle);
             if(dev_handle == NULL){
                 log_e("Temperature Sensor device not created");


### PR DESCRIPTION
## Description of Change
This PR fixes an issue of multiple device callbacks (one callback per device) were not getting registered and invoked.
Consider an example where I create two devices, a switch and a fan; each of them having their own write callbacks. On controlling either switch/fan through Rainmaker app, the callback that got registered at last gets invoked. This is also seen in the issue reported [here](https://github.com/espressif/arduino-esp32/issues/8231)
## Test Scenarios
I have tested this PR by creating four devices; Switch, Lightbulb, Temp. sensor and Fan; each of them having their own callback. On controlling the device through app, respective callbacks were getting invoked.

## Related links
Closes https://github.com/espressif/arduino-esp32/issues/8231
