### PR TITLE
LEDC - Memory fix

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -63,6 +63,7 @@ static bool ledcDetachBus(void * bus){
     ledc_channel_handle_t handle = (ledc_channel_handle_t)bus;
     ledc_handle.used_channels &= ~(1UL << handle->channel);
     pinMatrixOutDetach(handle->pin, false, false);
+    free(handle);
     return true;
 }
 


### PR DESCRIPTION
## Description of Change
Added free() to the detach function to fix memory leaks.

## Tests scenarios
```
void setup() {
  Serial.begin(115200);
}

void loop() 
{
  ledcAttach(4,1000,8);
  Serial.println((unsigned long)ESP.getFreeHeap());
  pinMode(4,OUTPUT);
  delay(1000);
}
```

```
OUTPUT before:
349512
349492
349472
349452

OUTPUT with fix:
349512
349512
349512
349512
```

## Related links
#8126 
