### PR TITLE
M5CoreS3 board and partitions update

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -12636,7 +12636,7 @@ m5stack-core2.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-m5stack-cores3.name=M5Stack-CoreS3
+m5stack-cores3.name=M5Stack CoreS3
 m5stack-cores3.vid.0=0x303a
 m5stack-cores3.pid.0=0x1001
 
@@ -12649,6 +12649,7 @@ m5stack-cores3.upload.tool.network=esp_ota
 
 m5stack-cores3.upload.maximum_size=1310720
 m5stack-cores3.upload.maximum_data_size=327680
+m5stack-cores3.upload.speed=921600
 m5stack-cores3.upload.flags=
 m5stack-cores3.upload.extra_flags=
 m5stack-cores3.upload.use_1200bps_touch=false
@@ -12666,21 +12667,20 @@ m5stack-cores3.build.variant=m5stack_cores3
 m5stack-cores3.build.board=M5STACK_CORES3
 
 m5stack-cores3.build.usb_mode=1
-m5stack-cores3.build.cdc_on_boot=0
+m5stack-cores3.build.cdc_on_boot=1
 m5stack-cores3.build.msc_on_boot=0
 m5stack-cores3.build.dfu_on_boot=0
 m5stack-cores3.build.f_cpu=240000000L
-m5stack-cores3.build.flash_size=4MB
+m5stack-cores3.build.flash_size=16MB
 m5stack-cores3.build.flash_freq=80m
 m5stack-cores3.build.flash_mode=dio
 m5stack-cores3.build.boot=qio
-m5stack-cores3.build.boot_freq=80m
-m5stack-cores3.build.partitions=default
-m5stack-cores3.build.defines=
-m5stack-cores3.build.loop_core=
-m5stack-cores3.build.event_core=
+m5stack-cores3.build.partitions=default_16MB
+m5stack-cores3.build.defines=-DBOARD_HAS_PSRAM
 m5stack-cores3.build.psram_type=qspi
-m5stack-cores3.build.memory_type={build.boot}_{build.psram_type}
+m5stack-cores3.build.memory_type=qio_qspi
+m5stack-cores3.build.loop_core=-DARDUINO_RUNNING_CORE=1
+m5stack-cores3.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
 
 m5stack-cores3.menu.JTAGAdapter.default=Disabled
 m5stack-cores3.menu.JTAGAdapter.default.build.copy_jtag_files=0
@@ -12725,15 +12725,14 @@ m5stack-cores3.menu.FlashMode.opi.build.boot=opi
 m5stack-cores3.menu.FlashMode.opi.build.boot_freq=80m
 m5stack-cores3.menu.FlashMode.opi.build.flash_freq=80m
 
+m5stack-cores3.menu.FlashSize.16M=16MB (128Mb)
+m5stack-cores3.menu.FlashSize.16M.build.flash_size=16MB
+m5stack-cores3.menu.FlashSize.16M.build.partitions=default_16MB
 m5stack-cores3.menu.FlashSize.4M=4MB (32Mb)
 m5stack-cores3.menu.FlashSize.4M.build.flash_size=4MB
 m5stack-cores3.menu.FlashSize.8M=8MB (64Mb)
 m5stack-cores3.menu.FlashSize.8M.build.flash_size=8MB
 m5stack-cores3.menu.FlashSize.8M.build.partitions=default_8MB
-m5stack-cores3.menu.FlashSize.16M=16MB (128Mb)
-m5stack-cores3.menu.FlashSize.16M.build.flash_size=16MB
-#m5stack-cores3.menu.FlashSize.32M=32MB (256Mb)
-#m5stack-cores3.menu.FlashSize.32M.build.flash_size=32MB
 
 m5stack-cores3.menu.LoopCore.1=Core 1
 m5stack-cores3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
@@ -12747,13 +12746,17 @@ m5stack-cores3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
 m5stack-cores3.menu.USBMode.hwcdc=Hardware CDC and JTAG
 m5stack-cores3.menu.USBMode.hwcdc.build.usb_mode=1
-m5stack-cores3.menu.USBMode.default=USB-OTG (TinyUSB)
+m5stack-cores3.menu.USBMode.hwcdc.upload.use_1200bps_touch=false
+m5stack-cores3.menu.USBMode.hwcdc.upload.wait_for_upload_port=false
+m5stack-cores3.menu.USBMode.default=USB-OTG
 m5stack-cores3.menu.USBMode.default.build.usb_mode=0
+m5stack-cores3.menu.USBMode.default.upload.use_1200bps_touch=true
+m5stack-cores3.menu.USBMode.default.upload.wait_for_upload_port=true
 
-m5stack-cores3.menu.CDCOnBoot.default=Disabled
-m5stack-cores3.menu.CDCOnBoot.default.build.cdc_on_boot=0
 m5stack-cores3.menu.CDCOnBoot.cdc=Enabled
 m5stack-cores3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+m5stack-cores3.menu.CDCOnBoot.default=Disabled
+m5stack-cores3.menu.CDCOnBoot.default.build.cdc_on_boot=0
 
 m5stack-cores3.menu.MSCOnBoot.default=Disabled
 m5stack-cores3.menu.MSCOnBoot.default.build.msc_on_boot=0
@@ -12772,13 +12775,25 @@ m5stack-cores3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
 m5stack-cores3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
 m5stack-cores3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 
-m5stack-cores3.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+m5stack-cores3.menu.PartitionScheme.default_16MB=Default 16MB with spiffs (2x 6.5 MB APP/3.6MB SPIFFS)
+m5stack-cores3.menu.PartitionScheme.default_16MB.build.partitions=default_16MB
+m5stack-cores3.menu.PartitionScheme.default_16MB.upload.maximum_size=6553600
+m5stack-cores3.menu.PartitionScheme.default=4MB with spiffs (2x 1.2MB APP/1.5MB SPIFFS)
 m5stack-cores3.menu.PartitionScheme.default.build.partitions=default
-m5stack-cores3.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+m5stack-cores3.menu.PartitionScheme.defaultffat=4MB with ffat (2x 1.2MB APP/1.5MB FATFS)
 m5stack-cores3.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-m5stack-cores3.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+m5stack-cores3.menu.PartitionScheme.default_8MB=8M with spiffs (2x 3MB APP/1.5MB SPIFFS)
 m5stack-cores3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
 m5stack-cores3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+m5stack-cores3.menu.PartitionScheme.large_spiffs=16MB with Large SPIFFS (2x 4MB APP/7MB SPIFFS)
+m5stack-cores3.menu.PartitionScheme.large_spiffs.build.partitions=large_spiffs_16MB
+m5stack-cores3.menu.PartitionScheme.large_spiffs.upload.maximum_size=4685824
+m5stack-cores3.menu.PartitionScheme.factory_4apps=16MB+Factory (4x 3MB APP/2MB SPIFFS)
+m5stack-cores3.menu.PartitionScheme.factory_4apps.build.custom_partitions=partitions-16MB-factory-4-apps
+m5stack-cores3.menu.PartitionScheme.factory_4apps.upload.maximum_size=3145728
+m5stack-cores3.menu.PartitionScheme.factory_6apps=16MB+Factory (6x 2MB APP/2MB SPIFFS)
+m5stack-cores3.menu.PartitionScheme.factory_6apps.build.custom_partitions=partitions-16MB-factory-6-apps
+m5stack-cores3.menu.PartitionScheme.factory_6apps.upload.maximum_size=2097152
 
 m5stack-cores3.menu.CPUFreq.240=240MHz (WiFi)
 m5stack-cores3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -12807,6 +12822,8 @@ m5stack-cores3.menu.UploadSpeed.460800.macosx=460800
 m5stack-cores3.menu.UploadSpeed.460800.upload.speed=460800
 m5stack-cores3.menu.UploadSpeed.512000.windows=512000
 m5stack-cores3.menu.UploadSpeed.512000.upload.speed=512000
+m5stack-cores3.menu.UploadSpeed.1500000=1500000
+m5stack-cores3.menu.UploadSpeed.1500000.upload.speed=1500000
 
 m5stack-cores3.menu.DebugLevel.none=None
 m5stack-cores3.menu.DebugLevel.none.build.code_debug=0

--- a/variants/m5stack_cores3/partitions-16MB-factory-4-apps.csv
+++ b/variants/m5stack_cores3/partitions-16MB-factory-4-apps.csv
@@ -1,0 +1,11 @@
+## 4 Apps + Factory
+## Name,   Type, SubType,    Offset,     Size
+nvs,      data, nvs,        0x9000,   0x5000
+otadata,  data, ota,        0xe000,   0x2000
+ota_0,    0,    ota_0,     0x10000, 0x300000
+ota_1,    0,    ota_1,    0x310000, 0x300000
+ota_2,    0,    ota_2,    0x610000, 0x300000
+ota_3,    0,    ota_3,    0x910000, 0x300000
+firmware, app,  factory,  0xC10000, 0x0F0000
+spiffs,   data, spiffs,   0xD00000, 0x2F0000
+coredump, data, coredump, 0xFF0000,  0x10000

--- a/variants/m5stack_cores3/partitions-16MB-factory-6-apps.csv
+++ b/variants/m5stack_cores3/partitions-16MB-factory-6-apps.csv
@@ -1,0 +1,13 @@
+# 6 Apps + Factory
+# Name,   Type, SubType,    Offset,     Size
+nvs,      data, nvs,        0x9000,   0x5000
+otadata,  data, ota,        0xe000,   0x2000
+ota_0,    0,    ota_0,     0x10000, 0x200000
+ota_1,    0,    ota_1,    0x210000, 0x200000
+ota_2,    0,    ota_2,    0x410000, 0x200000
+ota_3,    0,    ota_3,    0x610000, 0x200000
+ota_4,    0,    ota_4,    0x810000, 0x200000
+ota_5,    0,    ota_5,    0xA10000, 0x200000
+firmware, app,  factory,  0xC10000, 0x0F0000
+spiffs,   data, spiffs,   0xD00000, 0x2F0000
+coredump, data, coredump, 0xFF0000,  0x10000


### PR DESCRIPTION
followup to #8161 

- adjusted default build values
    1) cdc default enabled
    2) 16MB flash + partition scheme copied from Core2 default selected
- added missing sections 
- added two custom partitions schemes to the variant folder

the new custom partitions layout is open for discussions.

[link to clean diff](https://github.com/espressif/arduino-esp32/pull/8274/files?w=1)

