### PR TITLE
SDMMC - Peripheral manager implementation

### DIFF
--- a/libraries/SD_MMC/src/SD_MMC.h
+++ b/libraries/SD_MMC/src/SD_MMC.h
@@ -45,6 +45,7 @@ protected:
     int8_t _pin_d2 = -1;
     int8_t _pin_d3 = -1;
 #endif
+    bool _mode1bit = false;
 
 public:
     SDMMCFS(FSImplPtr impl);
@@ -56,6 +57,9 @@ public:
     uint64_t cardSize();
     uint64_t totalBytes();
     uint64_t usedBytes();
+    
+private:
+    static bool sdmmcDetachBus(void * bus_pointer);
 };
 
 }

--- a/libraries/SD_MMC/src/SD_MMC.h
+++ b/libraries/SD_MMC/src/SD_MMC.h
@@ -36,15 +36,12 @@ class SDMMCFS : public FS
 {
 protected:
     sdmmc_card_t* _card;
-
-#ifdef SOC_SDMMC_USE_GPIO_MATRIX
     int8_t _pin_clk = -1;
     int8_t _pin_cmd = -1;
     int8_t _pin_d0 = -1;
     int8_t _pin_d1 = -1;
     int8_t _pin_d2 = -1;
     int8_t _pin_d3 = -1;
-#endif
     bool _mode1bit = false;
 
 public:


### PR DESCRIPTION
## Description of Change
Implemented peripheral manager into SDMMC class.

## Tests scenarios
Tested on:
ESP32S3-EYE board with 1-line SDMMC.
ESP32-WROVER-KIT board with 4-line SDMMC.

## Related links