### PR TITLE
Adds missing pinMode

### DIFF
--- a/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
+++ b/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
@@ -166,6 +166,8 @@ void setup() {
   HWSerial.begin(115200);
   HWSerial.setDebugOutput(true);
   
+  pinMode(buttonPin, INPUT_PULLUP);
+  
   USB.onEvent(usbEventCallback);
   USBSerial.onEvent(usbEventCallback);
   MSC_Update.onEvent(usbEventCallback);

--- a/libraries/USB/examples/Keyboard/KeyboardLogout/KeyboardLogout.ino
+++ b/libraries/USB/examples/Keyboard/KeyboardLogout/KeyboardLogout.ino
@@ -41,16 +41,18 @@ USBHIDKeyboard Keyboard;
 // change this to match your platform:
 int platform = OSX;
 
+const int buttonPin = 0;          // input pin for pushbutton
+
 void setup() {
   // make pin 0 an input and turn on the pull-up resistor so it goes high unless
   // connected to ground:
-  pinMode(0, INPUT_PULLUP);
+  pinMode(buttonPin, INPUT_PULLUP);
   Keyboard.begin();
   USB.begin();
 }
 
 void loop() {
-  while (digitalRead(0) == HIGH) {
+  while (digitalRead(buttonPin) == HIGH) {
     // do nothing until pin 2 goes low
     delay(500);
   }

--- a/libraries/USB/examples/Keyboard/KeyboardReprogram/KeyboardReprogram.ino
+++ b/libraries/USB/examples/Keyboard/KeyboardReprogram/KeyboardReprogram.ino
@@ -34,6 +34,8 @@ void loop(){}
 #include "USBHIDKeyboard.h"
 USBHIDKeyboard Keyboard;
 
+const int buttonPin = 0;          // input pin for pushbutton
+
 // use this option for OSX.
 // Comment it out if using Windows or Linux:
 char ctrlKey = KEY_LEFT_GUI;
@@ -45,14 +47,14 @@ char ctrlKey = KEY_LEFT_GUI;
 void setup() {
   // make pin 0 an input and turn on the pull-up resistor so it goes high unless
   // connected to ground:
-  pinMode(0, INPUT_PULLUP);
+  pinMode(buttonPin, INPUT_PULLUP);
   // initialize control over the keyboard:
   Keyboard.begin();
   USB.begin();
 }
 
 void loop() {
-  while (digitalRead(0) == HIGH) {
+  while (digitalRead(buttonPin) == HIGH) {
     // do nothing until pin 0 goes low
     delay(500);
   }


### PR DESCRIPTION
## Description of Change
The example code lacks a pinMode() to initialize the GPIO 0 (button). 
In Arduino Core 3.0.0, it can't read the button and also prints an error message when trying to read a not initialized GPIO.

`[E][esp32-hal-gpio.c:177] __digitalRead(): Pin is not set as GPIO.` 

This PR also adds `const int buttonPin = 0;` to some examples to keep a standard and make it more readable and clear.

## Tests scenarios
ESP32S2/ESP32S3.

## Related links
None