### PR TITLE
Fix for timeout issues on WebServer.cpp

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -285,17 +285,16 @@ void WebServer::serveStatic(const char* uri, FS& fs, const char* path, const cha
 
 void WebServer::handleClient() {
   if (_currentStatus == HC_NONE) {
-    WiFiClient client = _server.available();
-    if (!client) {
+    _currentClient = _server.available();
+    if (!_currentClient) {
       if (_nullDelay) {
         delay(1);
       }
       return;
     }
 
-    log_v("New client: client.localIP()=%s", client.localIP().toString().c_str());
+    log_v("New client: client.localIP()=%s", _currentClient.localIP().toString().c_str());
 
-    _currentClient = client;
     _currentStatus = HC_WAIT_READ;
     _statusChange = millis();
   }


### PR DESCRIPTION

## Description of Change
Removing client temporary variable. Arduino doesn't like copying objects. And for the logisch de class variable _currentClient can be used from the start of the method

## Tests scenarios
My openHAB server calls 3 ESP32 devices every minute. In the openHAB log about 5-10% fails on a timeout (3000 ms is set timeout on openHAB). With above code modification none (running for 3 days now) of the calls failed.

## Related links
https://github.com/espressif/arduino-esp32/issues/8318

(same issue and resolution for ESP8266, check https://github.com/esp8266/Arduino/issues/8941 )