### PR TITLE
Adds HardwareSerial to Peripheral Manager - Arduino 3.0.0

### DIFF
--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -183,7 +183,6 @@ protected:
 #if !CONFIG_DISABLE_HAL_LOCKS
     SemaphoreHandle_t _lock;
 #endif
-    int8_t _rxPin, _txPin, _ctsPin, _rtsPin;
 
     void _createEventTask(void *args);
     void _destroyEventTask(void);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2015-2023 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -132,7 +132,6 @@ bool uartIsDriverInstalled(uart_t* uart);
 
 // Negative Pin Number will keep it unmodified, thus this function can set/reset individual pins
 bool uartSetPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
-void uartDetachPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
 
 // Enables or disables HW Flow Control function -- needs also to set CTS and/or RTS pins
 bool uartSetHwFlowCtrlMode(uart_t *uart, uint8_t mode, uint8_t threshold);


### PR DESCRIPTION
## Description of Change

Adds UART to the Peripheral Manager. 
Moved all UART GPIO information to ESP32-HAL layer.

`Serial.end()` will detach all UART GPIOs.
When another Peripheral uses any UART GPIO (Rx/Tx/Rts/Cts), the UART driver is terminated and all the GPIOs are detached.


## Tests scenarios
Tested with ESP32 and ESP32S3.

## Related links
None.