### PR TITLE
Fixes crash when calling twice HWCDC::end()

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -218,10 +218,10 @@ void HWCDC::setTxTimeoutMs(uint32_t timeout){
 
 size_t HWCDC::setTxBufferSize(size_t tx_queue_len){
     if(tx_ring_buf){
-        if(!tx_queue_len){
-            vRingbufferDelete(tx_ring_buf);
-            tx_ring_buf = NULL;
-        }
+        vRingbufferDelete(tx_ring_buf);
+        tx_ring_buf = NULL;
+    }
+    if(!tx_queue_len){
         return 0;
     }
     tx_ring_buf = xRingbufferCreate(tx_queue_len, RINGBUF_TYPE_BYTEBUF);
@@ -319,18 +319,15 @@ void HWCDC::flush(void)
 
 size_t HWCDC::setRxBufferSize(size_t rx_queue_len){
     if(rx_queue){
-        if(!rx_queue_len){
-            vQueueDelete(rx_queue);
-            rx_queue = NULL;
-        }
+        vQueueDelete(rx_queue);
+        rx_queue = NULL;
+    }
+    if(!rx_queue_len){
         return 0;
     }
     rx_queue = xQueueCreate(rx_queue_len, sizeof(uint8_t));
     if(!rx_queue){
         return 0;
-    }
-    if(!tx_ring_buf){
-        tx_ring_buf = xRingbufferCreate(rx_queue_len, RINGBUF_TYPE_BYTEBUF);
     }
     return rx_queue_len;
 }


### PR DESCRIPTION
## Description of Change

JTAG/CDC `Serial` interface crashes when `Serial.end()` is called twice. 
This PR shall be applied to Arduino Core 2.0.10 and 3.0.0.

## Tests scenarios
Tested with ESP32-C3 and ESP32-S3.

``` cpp
// MUST USE USB Mode "CDC/JTAG" and "CDC on Boot: Enabled"
void setup() {
  // No need to initialize the RGB LED
  Serial.begin();
  delay(500);
  Serial.println("First Print Testing");
  Serial.flush();
  
  Serial.end();
  Serial.end();  // Second end() causes crash.

  Serial.begin();
  log_d("LOG printing after end-begin");
  Serial.println("Second Print Testing");
  Serial.flush();
}

void loop() {
}
```

## Related links
Fix #8326 