### PR TITLE
Adds USB to Peripheral Manager - Arduino Core 3.0.0

### DIFF
--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -42,6 +42,9 @@ typedef union {
 
 class HWCDC: public Stream
 {
+private:
+    static bool deinit(void * busptr);
+    
 public:
     HWCDC();
     ~HWCDC();

--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -32,6 +32,7 @@
 #include "esp_rom_gpio.h"
 
 #include "esp32-hal.h"
+#include "esp32-hal-periman.h"
 
 #include "esp32-hal-tinyusb.h"
 #if CONFIG_IDF_TARGET_ESP32S2
@@ -56,6 +57,11 @@ typedef struct {
     bool external_phy;
 } tinyusb_config_t;
 
+static bool usb_otg_deinit(void * busptr) {
+    // Once USB OTG is initialized, its GPIOs are assigned and it shall never be deinited
+    return false;
+}
+
 static void configure_pins(usb_hal_context_t *usb)
 {
     for (const usb_iopin_dsc_t *iopin = usb_periph_iopins; iopin->pin != -1; ++iopin) {
@@ -75,6 +81,13 @@ static void configure_pins(usb_hal_context_t *usb)
     if (!usb->use_external_phy) {
         gpio_set_drive_capability(USBPHY_DM_NUM, GPIO_DRIVE_CAP_3);
         gpio_set_drive_capability(USBPHY_DP_NUM, GPIO_DRIVE_CAP_3);
+        if (perimanSetBusDeinit(ESP32_BUS_TYPE_USB, usb_otg_deinit)) {
+            // Bus Pointer is not used anyway - once the USB GPIOs are assigned, they can't be detached
+            perimanSetPinBus(USBPHY_DM_NUM, ESP32_BUS_TYPE_USB, (void *) usb);
+            perimanSetPinBus(USBPHY_DP_NUM, ESP32_BUS_TYPE_USB, (void *) usb);
+        } else {
+            log_e("USB OTG Pins can't be set into Peripheral Manager.");
+        }
     }
 }
 


### PR DESCRIPTION
## Description of Change
This PR adds Peripheral Manager control to the USB OTG (TinyUSB) and USB Serial JTAG peripherals.
For USB OTG (TinyUSB), after initializing it, it won't be possible to use the D+/D- GPIOs for other peripherals, therefore, any attempt to use these GPIOs will fail.
In the case of the Serial JTAG D+/D-, it is possible to start the CDC and latter change the GPIOs to something else, or even restart the USB CDC again. The problem with doing it would be that the USB Host would renumerate the it again, whenever it is restarted. 

## Tests scenarios
Tested with ESP32-S3 and ESP32-S2.

## Related links
None.