### PR TITLE
Update gpio.rst Documentation: typo in function name 'attachInterrupt'

### DIFF
--- a/docs/source/api/gpio.rst
+++ b/docs/source/api/gpio.rst
@@ -87,7 +87,7 @@ The GPIO peripheral on the ESP32 supports interruptions.
 attachInterrupt
 ***************
 
-The function ``attachInterruptArg`` is used to attach the interrupt to the defined pin.
+The function ``attachInterrupt`` is used to attach the interrupt to the defined pin.
 
 .. code-block:: arduino
 


### PR DESCRIPTION
## Description of Change
In the documentation of gpio-api, in section 'attachInterrupt' the function was wrongly named 'attachInterruptArg' in the descriptive sentence. Corrected to 'attachInterrupt'
