### PR TITLE
Set MATRIX_DETACH_* values based on TRM

### DIFF
--- a/cores/esp32/esp32-hal-matrix.c
+++ b/cores/esp32/esp32-hal-matrix.c
@@ -17,8 +17,8 @@
 
 #include "esp_system.h"
 #ifdef ESP_IDF_VERSION_MAJOR // IDF 4+
+#include "soc/gpio_pins.h"
 #if CONFIG_IDF_TARGET_ESP32 // ESP32/PICO-D4
-#include "esp32/rom/gpio.h"
 #elif CONFIG_IDF_TARGET_ESP32S2
 #include "esp32s2/rom/gpio.h"
 #elif CONFIG_IDF_TARGET_ESP32S3
@@ -30,11 +30,10 @@
 #endif
 #else // ESP32 Before IDF 4.0
 #include "rom/gpio.h"
+#define GPIO_MATRIX_CONST_ZERO_INPUT GPIO_FUNC_IN_LOW
+#define GPIO_MATRIX_CONST_ONE_INPUT GPIO_FUNC_IN_HIGH
 #endif
 
-#define MATRIX_DETACH_OUT_SIG 0x100
-#define MATRIX_DETACH_IN_LOW_PIN 0x30
-#define MATRIX_DETACH_IN_LOW_HIGH 0x38
 
 void ARDUINO_ISR_ATTR pinMatrixOutAttach(uint8_t pin, uint8_t function, bool invertOut, bool invertEnable)
 {
@@ -43,7 +42,7 @@ void ARDUINO_ISR_ATTR pinMatrixOutAttach(uint8_t pin, uint8_t function, bool inv
 
 void ARDUINO_ISR_ATTR pinMatrixOutDetach(uint8_t pin, bool invertOut, bool invertEnable)
 {
-    gpio_matrix_out(pin, MATRIX_DETACH_OUT_SIG, invertOut, invertEnable);
+    gpio_matrix_out(pin, SIG_GPIO_OUT_IDX, invertOut, invertEnable);
 }
 
 void ARDUINO_ISR_ATTR pinMatrixInAttach(uint8_t pin, uint8_t signal, bool inverted)
@@ -53,7 +52,7 @@ void ARDUINO_ISR_ATTR pinMatrixInAttach(uint8_t pin, uint8_t signal, bool invert
 
 void ARDUINO_ISR_ATTR pinMatrixInDetach(uint8_t signal, bool high, bool inverted)
 {
-    gpio_matrix_in(high?MATRIX_DETACH_IN_LOW_HIGH:MATRIX_DETACH_IN_LOW_PIN, signal, inverted);
+    gpio_matrix_in(high?GPIO_MATRIX_CONST_ONE_INPUT:GPIO_MATRIX_CONST_ZERO_INPUT, signal, inverted);
 }
 /*
 void ARDUINO_ISR_ATTR intrMatrixAttach(uint32_t source, uint32_t inum){


### PR DESCRIPTION
## Description of Change
The MATRIX_DETACH_* values vary by platform, which is not documented in the gpio_matrix_out or gpio_matrix_in functions (https://github.com/espressif/esp-idf/issues/11737).  Use the SDK macros that contain the correct values for all platforms.

## Tests scenarios
Tested on an Adafruit Qt Py ESP32-C3 board.  

Tested `pinMatrixInDetach` by using `pinMatrixInAttach` to connect an input pin to the `cpu_gpio_in0` signal, then use `pinMatrixInDetach` with low and high values and verified that they propagated to `cpu_gpio_in0` read with the CSRR instruction on CSR 0x804.

Tested `pinMatrixOutDetach` on an output pin and verified that it was still driven.

Without this patch both tests fail.

Tested with ESP-IDF 4.4.3 and arduino-esp32 72c41d09538663ebef80d29eb986cd5bc3395c2d.

## Related links
https://github.com/espressif/esp-idf/issues/11737