### PR TITLE
Soft-AP: get subnet mask

### DIFF
--- a/docs/source/api/wifi.rst
+++ b/docs/source/api/wifi.rst
@@ -222,6 +222,15 @@ Get the softAP subnet CIDR.
 
     uint8_t softAPSubnetCIDR();
 
+softAPSubnetMask
+****************
+
+Get the softAP subnet mask.
+
+.. code-block:: arduino
+
+    IPAddress softAPSubnetMask();
+
 softAPenableIpV6
 ****************
 

--- a/libraries/WiFi/src/WiFiAP.cpp
+++ b/libraries/WiFi/src/WiFiAP.cpp
@@ -304,20 +304,29 @@ IPAddress WiFiAPClass::softAPNetworkID()
 }
 
 /**
+ * Get the softAP subnet mask.
+ * @return IPAddress subnetMask
+ */
+IPAddress WiFiAPClass::softAPSubnetMask()
+{
+    esp_netif_ip_info_t ip;
+    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
+        return IPAddress();
+    }
+    if(esp_netif_get_ip_info(get_esp_interface_netif(ESP_IF_WIFI_AP), &ip) != ESP_OK){
+        log_e("Netif Get IP Failed!");
+        return IPAddress();
+    }
+    return IPAddress(ip.netmask.addr);
+}
+
+/**
  * Get the softAP subnet CIDR.
  * @return uint8_t softAP subnetCIDR
  */
 uint8_t WiFiAPClass::softAPSubnetCIDR()
 {
-	esp_netif_ip_info_t ip;
-    if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
-        return IPAddress();
-    }
-    if(esp_netif_get_ip_info(get_esp_interface_netif(ESP_IF_WIFI_AP), &ip) != ESP_OK){
-    	log_e("Netif Get IP Failed!");
-    	return IPAddress();
-    }
-    return WiFiGenericClass::calculateSubnetCIDR(IPAddress(ip.netmask.addr));
+    return WiFiGenericClass::calculateSubnetCIDR(softAPSubnetMask());
 }
 
 /**

--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -51,6 +51,7 @@ public:
 
     IPAddress softAPBroadcastIP();
     IPAddress softAPNetworkID();
+    IPAddress softAPSubnetMask();
     uint8_t softAPSubnetCIDR();
 
     bool softAPenableIpV6();


### PR DESCRIPTION
In WiFiSTA you can ask for the subnet mask, but not in WiFiAP. Only the subnet CIDR is reported.
Therefor the missing method is added to have the same features in softAP as well.

-----------
## Description of Change
Have an equal API for WiFi STA and WiFi AP. In WiFiAP only the subnet CIDR is reported. To have the subnet mask one has to inverse the CIDR function.

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.9 with ESP32 Board with this scenario.

## Related links
https://github.com/rstephan/ArtnetnodeWifi/issues/23
