### PR TITLE
Fixes RMT filter & idle timing and setup

### DIFF
--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -494,11 +494,7 @@ bool rmtInit(int pin, rmt_ch_dir_t channel_direction, rmt_reserve_memsize_t mem_
     // TX Channel
     rmt_tx_channel_config_t tx_cfg;
     tx_cfg.gpio_num = pin;
-#if CONFIG_IDF_TARGET_ESP32C6
-    tx_cfg.clk_src = RMT_CLK_SRC_DEFAULT;
-#else
     tx_cfg.clk_src = RMT_CLK_SRC_APB;
-#endif
     tx_cfg.resolution_hz = frequency_Hz;
     tx_cfg.mem_block_symbols = SOC_RMT_MEM_WORDS_PER_CHANNEL * mem_size;
     tx_cfg.trans_queue_depth = 10;   // maximum allowed
@@ -523,11 +519,7 @@ bool rmtInit(int pin, rmt_ch_dir_t channel_direction, rmt_reserve_memsize_t mem_
     // RX Channel
     rmt_rx_channel_config_t rx_cfg;
     rx_cfg.gpio_num = pin;
-#if CONFIG_IDF_TARGET_ESP32C6
-    rx_cfg.clk_src = RMT_CLK_SRC_DEFAULT;
-#else
     rx_cfg.clk_src = RMT_CLK_SRC_APB;
-#endif
     rx_cfg.resolution_hz = frequency_Hz;
     rx_cfg.mem_block_symbols = SOC_RMT_MEM_WORDS_PER_CHANNEL * mem_size;
     rx_cfg.flags.invert_in = 0;

--- a/cores/esp32/esp32-hal-rmt.h
+++ b/cores/esp32/esp32-hal-rmt.h
@@ -174,14 +174,14 @@ bool rmtReadAsync(int pin, rmt_data_t* data, size_t *num_rmt_symbols);
 bool rmtReceiveCompleted(int pin);
 
 /**
-   Function used to set a threshold for the time used to consider that a data reception has ended.
-   In receive mode, when no edge is detected on the input signal for longer than idle_thres 
-   channel clock cycles, the receiving process is finished and the Data is made available by 
+   Function used to set a threshold for the time (ns) used to consider that a data reception has ended.
+   In receive mode, when no edge is detected on the input signal for longer than idle_thres_ns 
+   time, the receiving process is finished and the Data is made available by 
    the rmtRead/Async functions. Note that this time (in RMT channel frequency cycles) will also
    define how many low bits are read at the end of the received data.
    The function returns <true> if it is correctly executed, <false> otherwise.
 */
-bool rmtSetRxThreshold(int pin, uint16_t value);
+bool rmtSetRxThreshold(int pin, uint32_t idle_thres_ns);
 
 /**
    Parameters changed in Arduino Core 3: low and high (ticks) are now expressed in Carrier Freq in Hz and
@@ -199,10 +199,10 @@ bool rmtSetCarrier(int pin, bool carrier_en, bool carrier_level, uint32_t freque
 /**
    Function used to filter input noise in the RX channel.
    In receiving mode, channel will ignore any input pulse which width is smaller than <filter_pulse_ns>
-   If <filter_level> is Zero, it will to disable the filter.
+   If <filter_pulse_ns> is Zero, it will to disable the filter.
    The function returns <true> if it is correctly executed, <false> otherwise.
 */
-bool rmtSetFilter(int pin, uint8_t filter_level);
+bool rmtSetFilter(int pin, uint32_t filter_pulse_ns);
 
 /**
    Deinitializes the driver and releases all allocated memory


### PR DESCRIPTION
## Description of Change
Initial values of Filter and IDLE time for RMT RX functions were not working correctly.
This PR fixes it and sets it to minimum and maximum limits by default.
It also verifiy the values before setting them to make warn possible problems in the console.

## Tests scenarios
Tested with ESP32S3 using a HC-SR04 sketch

``` cpp
const uint8_t TRIG_PIN = 11;
const uint8_t ECHO_PIN = 12;

uint32_t getEcho(){
  rmt_data_t trig_pulse = {
    .duration0 = 10,
    .level0 = 1,
    .duration1 = 10,
    .level1 = 0
  };
  if(!rmtWriteAsync(TRIG_PIN, &trig_pulse, 1)){
    Serial.println("Send Trig Failed!");
    return 0;
  }
  
  rmt_data_t echo_pulse;
  size_t received = 1;
  if(!rmtRead(ECHO_PIN, &echo_pulse, &received, 1000) || !received){
    Serial.println("Read Echo Failed!");
    return 0;
  }
  Serial.printf("  P[0]: ticks: %u, level: %u\n", echo_pulse.duration0, echo_pulse.level0);
  Serial.printf("  P[1]: ticks: %u, level: %u\n", echo_pulse.duration1, echo_pulse.level1);

  if(echo_pulse.level0){
    return echo_pulse.duration0;
  }
  return echo_pulse.duration1;
}

void setup() {
  Serial.begin(115200);
  Serial.setDebugOutput(true);
  rmtInit(TRIG_PIN, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 500000);
  rmtInit(ECHO_PIN, RMT_RX_MODE, RMT_MEM_NUM_BLOCKS_1, 500000);
}

void loop() {
  float cm = (0.034 * getEcho());
  Serial.print("Distance: ");
  Serial.print(cm, 3);
  Serial.println(" cm");
  delay(1000);
}
```

## Related links
None