### PR TITLE
HW Testing - Pytest update

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -95,7 +95,7 @@ jobs:
        - name: Install dependencies
          run: |
            pip install -U pip
-           pip install -r tests/requirements.txt
+           pip install -r tests/requirements.txt --extra-index-url https://dl.espressif.com/pypi
            apt update && apt install -y -qq jq
 
        - name: Run Tests

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -72,6 +72,7 @@ jobs:
       - ESP32-S3
       - ESP32-C3
       - ESP32-C6
+      - ESP32-H2
 
     strategy:
       fail-fast: false

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,6 @@
 pyserial>=3.0
-esptool>=3.1
+esptool>=4.6
+
 pytest-cov
-cryptography<3.4; platform_machine == "armv7l"
-
-pytest>=6.2.0
-pexpect>=4.4
-
-pytest-embedded>=0.5.1
-pytest-embedded-serial>=0.5.1
-pytest-embedded-serial-esp>=0.5.1
-pytest-embedded-arduino>=0.5.1
-
+pytest-embedded-serial-esp>=1.3.3
+pytest-embedded-arduino>=1.3.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,3 @@
-pyserial>=3.0
-esptool>=4.6
-
 pytest-cov
 pytest-embedded-serial-esp>=1.3.3
 pytest-embedded-arduino>=1.3.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest-cov
-pytest-embedded-serial-esp>=1.3.3
-pytest-embedded-arduino>=1.3.3
+pytest-embedded-serial-esp>=1.3.4
+pytest-embedded-arduino>=1.3.4


### PR DESCRIPTION
## Description of Change
Updated pytest and its components to newest version in order to support C6 and H2.

~~DRAFT: Waiting for [patch](https://github.com/espressif/pytest-embedded/pull/220) to be merged and new version is released.~~
Patch merged and 1.3.4 released.

## Tests scenarios
Tested locally on C6 - working
Tested locally on H2 - working ~~with local [patch](https://github.com/espressif/pytest-embedded/pull/220) of pytest-embedded~~

## Related links
