### PR TITLE
Removed duplicate TX1 define for H2

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -79,7 +79,7 @@ void serialEvent(void) {}
 #define TX1 19
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define TX1 16
-#elif CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2
+#elif CONFIG_IDF_TARGET_ESP32C6
 #define TX1 4
 #elif CONFIG_IDF_TARGET_ESP32H2
 #define TX1 1
@@ -95,7 +95,7 @@ void serialEvent1(void) {}
 #if CONFIG_IDF_TARGET_ESP32
 #define RX2 16
 #elif CONFIG_IDF_TARGET_ESP32S3
-#define RX2 19 
+#define RX2 19
 #endif
 #endif
 
@@ -144,16 +144,16 @@ void serialEventRun(void)
 #define HSERIAL_MUTEX_LOCK()    do {} while (xSemaphoreTake(_lock, portMAX_DELAY) != pdPASS)
 #define HSERIAL_MUTEX_UNLOCK()  xSemaphoreGive(_lock)
 #else
-#define HSERIAL_MUTEX_LOCK()    
-#define HSERIAL_MUTEX_UNLOCK()  
+#define HSERIAL_MUTEX_LOCK()
+#define HSERIAL_MUTEX_UNLOCK()
 #endif
 
-HardwareSerial::HardwareSerial(int uart_nr) : 
-_uart_nr(uart_nr), 
+HardwareSerial::HardwareSerial(int uart_nr) :
+_uart_nr(uart_nr),
 _uart(NULL),
 _rxBufferSize(256),
-_txBufferSize(0), 
-_onReceiveCB(NULL), 
+_txBufferSize(0),
+_onReceiveCB(NULL),
 _onReceiveErrorCB(NULL),
 _onReceiveTimeout(false),
 _rxTimeout(2),
@@ -202,10 +202,10 @@ void HardwareSerial::_destroyEventTask(void)
     }
 }
 
-void HardwareSerial::onReceiveError(OnReceiveErrorCb function) 
+void HardwareSerial::onReceiveError(OnReceiveErrorCb function)
 {
     HSERIAL_MUTEX_LOCK();
-    // function may be NULL to cancel onReceive() from its respective task 
+    // function may be NULL to cancel onReceive() from its respective task
     _onReceiveErrorCB = function;
     // this can be called after Serial.begin(), therefore it shall create the event task
     if (function != NULL && _uart != NULL && _eventTask == NULL) {
@@ -217,7 +217,7 @@ void HardwareSerial::onReceiveError(OnReceiveErrorCb function)
 void HardwareSerial::onReceive(OnReceiveCb function, bool onlyOnTimeout)
 {
     HSERIAL_MUTEX_LOCK();
-    // function may be NULL to cancel onReceive() from its respective task 
+    // function may be NULL to cancel onReceive() from its respective task
     _onReceiveCB = function;
 
     // setting the callback to NULL will just disable it
@@ -265,14 +265,14 @@ bool HardwareSerial::setRxFIFOFull(uint8_t fifoBytes)
 bool HardwareSerial::setRxTimeout(uint8_t symbols_timeout)
 {
     HSERIAL_MUTEX_LOCK();
-    
+
     // Zero disables timeout, thus, onReceive callback will only be called when RX FIFO reaches 120 bytes
-    // Any non-zero value will activate onReceive callback based on UART baudrate with about 11 bits per symbol 
-    _rxTimeout = symbols_timeout;   
-    if (!symbols_timeout) _onReceiveTimeout = false;  // only when RX timeout is disabled, we also must disable this flag 
+    // Any non-zero value will activate onReceive callback based on UART baudrate with about 11 bits per symbol
+    _rxTimeout = symbols_timeout;
+    if (!symbols_timeout) _onReceiveTimeout = false;  // only when RX timeout is disabled, we also must disable this flag
 
     bool retCode = uartSetRxTimeout(_uart, _rxTimeout); // Set new timeout
-    
+
     HSERIAL_MUTEX_UNLOCK();
     return retCode;
 }
@@ -281,7 +281,7 @@ void HardwareSerial::eventQueueReset()
 {
     QueueHandle_t uartEventQueue = NULL;
     if (_uart == NULL) {
-	    return;
+      return;
     }
     uartGetEventQueue(_uart, &uartEventQueue);
     if (uartEventQueue != NULL) {
@@ -302,8 +302,8 @@ void HardwareSerial::_uartEventTask(void *args)
                 hardwareSerial_error_t currentErr = UART_NO_ERROR;
                 switch(event.type) {
                     case UART_DATA:
-                        if(uart->_onReceiveCB && uart->available() > 0 && 
-                            ((uart->_onReceiveTimeout && event.timeout_flag) || !uart->_onReceiveTimeout) ) 
+                        if(uart->_onReceiveCB && uart->available() > 0 &&
+                            ((uart->_onReceiveTimeout && event.timeout_flag) || !uart->_onReceiveTimeout) )
                                 uart->_onReceiveCB();
                         break;
                     case UART_FIFO_OVF:
@@ -410,7 +410,7 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
         }
     }
     // create a task to deal with Serial Events when, for example, calling begin() twice to change the baudrate,
-    // or when setting the callback before calling begin() 
+    // or when setting the callback before calling begin()
     if (_uart != NULL && (_onReceiveCB != NULL || _onReceiveErrorCB != NULL) && _eventTask == NULL) {
         _createEventTask(this);
     }
@@ -418,10 +418,10 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
     // Set UART RX timeout
     uartSetRxTimeout(_uart, _rxTimeout);
 
-    // Set UART FIFO Full depending on the baud rate. 
+    // Set UART FIFO Full depending on the baud rate.
     // Lower baud rates will force to emulate byte-by-byte reading
     // Higher baud rates will keep IDF default of 120 bytes for FIFO FULL Interrupt
-    // It can also be changed by the application at any time 
+    // It can also be changed by the application at any time
     if (!_rxFIFOFull) {    // it has not being changed before calling begin()
       //  set a default FIFO Full value for the IDF driver
       uint8_t fifoFull = 1;
@@ -437,12 +437,12 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
 
 void HardwareSerial::updateBaudRate(unsigned long baud)
 {
-	uartSetBaudRate(_uart, baud);
+  uartSetBaudRate(_uart, baud);
 }
 
 void HardwareSerial::end(bool fullyTerminate)
 {
-    // default Serial.end() will completely disable HardwareSerial, 
+    // default Serial.end() will completely disable HardwareSerial,
     // including any tasks or debug message channel (log_x()) - but not for IDF log messages!
     if(fullyTerminate) {
         _onReceiveCB = NULL;
@@ -450,10 +450,10 @@ void HardwareSerial::end(bool fullyTerminate)
         if (uartGetDebug() == _uart_nr) {
             uartSetDebug(0);
         }
-        _rxFIFOFull = 0; 
+        _rxFIFOFull = 0;
         uartEnd(_uart);  // fully detach all pins and delete the UART driver
     } else {
-      // do not invalidate callbacks, detach pins, invalidate DBG output 
+      // do not invalidate callbacks, detach pins, invalidate DBG output
       uart_driver_delete(_uart_nr);
     }
     _uart = 0;
@@ -540,7 +540,7 @@ size_t HardwareSerial::write(const uint8_t *buffer, size_t size)
 uint32_t  HardwareSerial::baudRate()
 
 {
-	return uartGetBaudRate(_uart);
+  return uartGetBaudRate(_uart);
 }
 HardwareSerial::operator bool() const
 {


### PR DESCRIPTION
https://github.com/espressif/arduino-esp32/blob/esp-idf-v5.1-libs/cores/esp32/HardwareSerial.cpp
changed this
```
#elif CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2
#define TX1 4
#elif CONFIG_IDF_TARGET_ESP32H2
#define TX1 1

```
to this
```

#elif CONFIG_IDF_TARGET_ESP32C6
#define TX1 4
#elif CONFIG_IDF_TARGET_ESP32H2
#define TX1 1
```