### PR TITLE
2.0.10 escaping fix

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -189,12 +189,12 @@ recipe.hooks.prebuild.6.pattern.windows=cmd /c if not exist "{build.path}\build_
 # Set -DARDUINO_CORE_BUILD only on core file compilation
 file_opts.path={build.path}/file_opts
 recipe.hooks.prebuild.set_core_build_flag.pattern=bash -c ": > {file_opts.path}"
-recipe.hooks.core.prebuild.set_core_build_flag.pattern=bash -c "echo '-DARDUINO_CORE_BUILD' > {file_opts.path}"
+recipe.hooks.core.prebuild.set_core_build_flag.pattern=bash -c "echo -DARDUINO_CORE_BUILD > {file_opts.path}"
 recipe.hooks.core.postbuild.set_core_build_flag.pattern=bash -c ": > {file_opts.path}"
 
-recipe.hooks.prebuild.set_core_build_flag.pattern.windows=cmd /c type nul > {file_opts.path}
-recipe.hooks.core.prebuild.set_core_build_flag.pattern.windows=cmd /c echo "-DARDUINO_CORE_BUILD" > {file_opts.path}
-recipe.hooks.core.postbuild.set_core_build_flag.pattern.windows=cmd /c type nul > {file_opts.path}
+recipe.hooks.prebuild.set_core_build_flag.pattern.windows=cmd /c type nul > "{file_opts.path}"
+recipe.hooks.core.prebuild.set_core_build_flag.pattern.windows=cmd /c echo "-DARDUINO_CORE_BUILD" > "{file_opts.path}"
+recipe.hooks.core.postbuild.set_core_build_flag.pattern.windows=cmd /c type nul > "{file_opts.path}"
 
 # Generate debug.cfg (must be postbuild)
 recipe.hooks.postbuild.1.pattern=bash -c "[ {build.copy_jtag_files} -eq 0 ] || cp -f "{debug.server.openocd.scripts_dir}"board/{build.openocdscript} "{build.source.path}"/debug.cfg"


### PR DESCRIPTION
## Description of Change
Fix escaping issues on 2.0.10 (Windows path and IDE 1.x). 

## Tests scenarios
Tested on clean Windows 11 box, Arduino IDE 2.1.1, username with spaces, 2.0.10. The issue is present and is fixed by these commits.
Includes patch by @pennam fixing #8424 for IDE 1.8.x.  

## Related links
Closes #8424 and fixes Windows path issues reported in Arduino forums e.g. [here](https://forum.arduino.cc/t/compilation-error-exit-status-1/1149342) and [here](https://forum.arduino.cc/t/compiling-for-esp32-fails-access-is-denied/1149574)
