### PR TITLE
feature(m5stack-atom): allow events and loop on core0 in boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -12488,6 +12488,16 @@ m5stack-atom.build.boot=dio
 m5stack-atom.build.partitions=default
 m5stack-atom.build.defines=
 
+m5stack-atom.menu.LoopCore.1=Core 1
+m5stack-atom.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+m5stack-atom.menu.LoopCore.0=Core 0
+m5stack-atom.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+m5stack-atom.menu.EventsCore.1=Core 1
+m5stack-atom.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+m5stack-atom.menu.EventsCore.0=Core 0
+m5stack-atom.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
 m5stack-atom.menu.PartitionScheme.default=Default
 m5stack-atom.menu.PartitionScheme.default.build.partitions=default
 m5stack-atom.menu.PartitionScheme.no_ota=No OTA (Large APP)


### PR DESCRIPTION
## Description of Change
make following options available in the Tools menu for board M5stack-ATOM.

- Events Run On
- Loop Run On

## Tests scenarios
Tested
- on M5Stack-ATOM 
- Arduino IDE 2.1.1
- Arduino-esp32 core v.2.0.11

Closes #8461

