### PR TITLE
Adding Lion:Bit S3 STEM Dev Board  to boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -24159,7 +24159,7 @@ lionbits3.build.event_core=
 lionbits3.build.psram_type=qspi
 lionbits3.build.memory_type={build.boot}_{build.psram_type}
 
-
+## IDE 2.0 Seems to not update the value
 lionbits3.menu.JTAGAdapter.default=Disabled
 lionbits3.menu.JTAGAdapter.default.build.copy_jtag_files=0
 lionbits3.menu.JTAGAdapter.builtin=Integrated USB JTAG

--- a/boards.txt
+++ b/boards.txt
@@ -24112,3 +24112,225 @@ nebulas3.menu.EraseFlash.all=Enabled
 nebulas3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+lionbits3.name=Lion:Bit S3 STEM Dev Board
+lionbits3.vid.0=0x303a
+lionbits3.pid.0=0x1001
+
+lionbits3.bootloader.tool=esptool_py
+lionbits3.bootloader.tool.default=esptool_py
+
+lionbits3.upload.tool=esptool_py
+lionbits3.upload.tool.default=esptool_py
+lionbits3.upload.tool.network=esp_ota
+
+lionbits3.upload.maximum_size=1310720
+lionbits3.upload.maximum_data_size=327680
+lionbits3.upload.flags=
+lionbits3.upload.extra_flags=
+lionbits3.upload.use_1200bps_touch=false
+lionbits3.upload.wait_for_upload_port=false
+
+lionbits3.serial.disableDTR=false
+lionbits3.serial.disableRTS=false
+
+lionbits3.build.tarch=xtensa
+lionbits3.build.bootloader_addr=0x0
+lionbits3.build.target=esp32s3
+lionbits3.build.mcu=esp32s3
+lionbits3.build.core=esp32
+lionbits3.build.variant=lionbits3
+lionbits3.build.board=LIONBITS3_DEV
+
+
+lionbits3.build.usb_mode=1
+lionbits3.build.cdc_on_boot=0
+lionbits3.build.msc_on_boot=0
+lionbits3.build.dfu_on_boot=0
+lionbits3.build.f_cpu=240000000L
+lionbits3.build.flash_size=4MB
+lionbits3.build.flash_freq=80m
+lionbits3.build.flash_mode=dio
+lionbits3.build.boot=qio
+lionbits3.build.boot_freq=80m
+lionbits3.build.partitions=default
+lionbits3.build.defines=
+lionbits3.build.loop_core=
+lionbits3.build.event_core=
+lionbits3.build.psram_type=qspi
+lionbits3.build.memory_type={build.boot}_{build.psram_type}
+
+
+lionbits3.menu.JTAGAdapter.default=Disabled
+lionbits3.menu.JTAGAdapter.default.build.copy_jtag_files=0
+lionbits3.menu.JTAGAdapter.builtin=Integrated USB JTAG
+lionbits3.menu.JTAGAdapter.builtin.build.openocdscript=lionbits3-builtin.cfg
+lionbits3.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+lionbits3.menu.JTAGAdapter.external=FTDI Adapter
+lionbits3.menu.JTAGAdapter.external.build.openocdscript=lionbits3-ftdi.cfg
+lionbits3.menu.JTAGAdapter.external.build.copy_jtag_files=1
+lionbits3.menu.JTAGAdapter.bridge=ESP USB Bridge
+lionbits3.menu.JTAGAdapter.bridge.build.openocdscript=lionbits3-bridge.cfg
+lionbits3.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+lionbits3.menu.PSRAM.disabled=Disabled
+lionbits3.menu.PSRAM.disabled.build.defines=
+lionbits3.menu.PSRAM.disabled.build.psram_type=qspi
+lionbits3.menu.PSRAM.enabled=QSPI PSRAM
+lionbits3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+lionbits3.menu.PSRAM.enabled.build.psram_type=qspi
+lionbits3.menu.PSRAM.opi=OPI PSRAM
+lionbits3.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+lionbits3.menu.PSRAM.opi.build.psram_type=opi
+
+lionbits3.menu.FlashMode.qio=QIO 80MHz
+lionbits3.menu.FlashMode.qio.build.flash_mode=dio
+lionbits3.menu.FlashMode.qio.build.boot=qio
+lionbits3.menu.FlashMode.qio.build.boot_freq=80m
+lionbits3.menu.FlashMode.qio.build.flash_freq=80m
+lionbits3.menu.FlashMode.qio120=QIO 120MHz
+lionbits3.menu.FlashMode.qio120.build.flash_mode=dio
+lionbits3.menu.FlashMode.qio120.build.boot=qio
+lionbits3.menu.FlashMode.qio120.build.boot_freq=120m
+lionbits3.menu.FlashMode.qio120.build.flash_freq=80m
+lionbits3.menu.FlashMode.dio=DIO 80MHz
+lionbits3.menu.FlashMode.dio.build.flash_mode=dio
+lionbits3.menu.FlashMode.dio.build.boot=dio
+lionbits3.menu.FlashMode.dio.build.boot_freq=80m
+lionbits3.menu.FlashMode.dio.build.flash_freq=80m
+lionbits3.menu.FlashMode.opi=OPI 80MHz
+lionbits3.menu.FlashMode.opi.build.flash_mode=dout
+lionbits3.menu.FlashMode.opi.build.boot=opi
+lionbits3.menu.FlashMode.opi.build.boot_freq=80m
+lionbits3.menu.FlashMode.opi.build.flash_freq=80m
+
+lionbits3.menu.FlashSize.4M=4MB (32Mb)
+lionbits3.menu.FlashSize.4M.build.flash_size=4MB
+lionbits3.menu.FlashSize.8M=8MB (64Mb)
+lionbits3.menu.FlashSize.8M.build.flash_size=8MB
+lionbits3.menu.FlashSize.8M.build.partitions=default_8MB
+lionbits3.menu.FlashSize.16M=16MB (128Mb)
+lionbits3.menu.FlashSize.16M.build.flash_size=16MB
+#lionbits3.menu.FlashSize.32M=32MB (256Mb)
+#lionbits3.menu.FlashSize.32M.build.flash_size=32MB
+
+lionbits3.menu.LoopCore.1=Core 1
+lionbits3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+lionbits3.menu.LoopCore.0=Core 0
+lionbits3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+lionbits3.menu.EventsCore.1=Core 1
+lionbits3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+lionbits3.menu.EventsCore.0=Core 0
+lionbits3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+lionbits3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+lionbits3.menu.USBMode.hwcdc.build.usb_mode=1
+lionbits3.menu.USBMode.default=USB-OTG (TinyUSB)
+lionbits3.menu.USBMode.default.build.usb_mode=0
+
+lionbits3.menu.CDCOnBoot.default=Disabled
+lionbits3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+lionbits3.menu.CDCOnBoot.cdc=Enabled
+lionbits3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+lionbits3.menu.MSCOnBoot.default=Disabled
+lionbits3.menu.MSCOnBoot.default.build.msc_on_boot=0
+lionbits3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+lionbits3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+lionbits3.menu.DFUOnBoot.default=Disabled
+lionbits3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+lionbits3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+lionbits3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+lionbits3.menu.UploadMode.default=UART0 / Hardware CDC
+lionbits3.menu.UploadMode.default.upload.use_1200bps_touch=false
+lionbits3.menu.UploadMode.default.upload.wait_for_upload_port=false
+lionbits3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+lionbits3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+lionbits3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+lionbits3.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+lionbits3.menu.PartitionScheme.default.build.partitions=default
+lionbits3.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+lionbits3.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+lionbits3.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+lionbits3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+lionbits3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+lionbits3.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+lionbits3.menu.PartitionScheme.minimal.build.partitions=minimal
+lionbits3.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+lionbits3.menu.PartitionScheme.no_ota.build.partitions=no_ota
+lionbits3.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+lionbits3.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+lionbits3.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+lionbits3.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+lionbits3.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+lionbits3.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+lionbits3.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+lionbits3.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+lionbits3.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+lionbits3.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+lionbits3.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+lionbits3.menu.PartitionScheme.huge_app.build.partitions=huge_app
+lionbits3.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+lionbits3.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+lionbits3.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+lionbits3.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+lionbits3.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+lionbits3.menu.PartitionScheme.fatflash.build.partitions=ffat
+lionbits3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+lionbits3.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+lionbits3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+lionbits3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+lionbits3.menu.PartitionScheme.rainmaker=RainMaker
+lionbits3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+lionbits3.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+lionbits3.menu.CPUFreq.240=240MHz (WiFi)
+lionbits3.menu.CPUFreq.240.build.f_cpu=240000000L
+lionbits3.menu.CPUFreq.160=160MHz (WiFi)
+lionbits3.menu.CPUFreq.160.build.f_cpu=160000000L
+lionbits3.menu.CPUFreq.80=80MHz (WiFi)
+lionbits3.menu.CPUFreq.80.build.f_cpu=80000000L
+lionbits3.menu.CPUFreq.40=40MHz
+lionbits3.menu.CPUFreq.40.build.f_cpu=40000000L
+lionbits3.menu.CPUFreq.20=20MHz
+lionbits3.menu.CPUFreq.20.build.f_cpu=20000000L
+lionbits3.menu.CPUFreq.10=10MHz
+lionbits3.menu.CPUFreq.10.build.f_cpu=10000000L
+
+lionbits3.menu.UploadSpeed.921600=921600
+lionbits3.menu.UploadSpeed.921600.upload.speed=921600
+lionbits3.menu.UploadSpeed.115200=115200
+lionbits3.menu.UploadSpeed.115200.upload.speed=115200
+lionbits3.menu.UploadSpeed.256000.windows=256000
+lionbits3.menu.UploadSpeed.256000.upload.speed=256000
+lionbits3.menu.UploadSpeed.230400.windows.upload.speed=256000
+lionbits3.menu.UploadSpeed.230400=230400
+lionbits3.menu.UploadSpeed.230400.upload.speed=230400
+lionbits3.menu.UploadSpeed.460800.linux=460800
+lionbits3.menu.UploadSpeed.460800.macosx=460800
+lionbits3.menu.UploadSpeed.460800.upload.speed=460800
+lionbits3.menu.UploadSpeed.512000.windows=512000
+lionbits3.menu.UploadSpeed.512000.upload.speed=512000
+
+lionbits3.menu.DebugLevel.none=None
+lionbits3.menu.DebugLevel.none.build.code_debug=0
+lionbits3.menu.DebugLevel.error=Error
+lionbits3.menu.DebugLevel.error.build.code_debug=1
+lionbits3.menu.DebugLevel.warn=Warn
+lionbits3.menu.DebugLevel.warn.build.code_debug=2
+lionbits3.menu.DebugLevel.info=Info
+lionbits3.menu.DebugLevel.info.build.code_debug=3
+lionbits3.menu.DebugLevel.debug=Debug
+lionbits3.menu.DebugLevel.debug.build.code_debug=4
+lionbits3.menu.DebugLevel.verbose=Verbose
+lionbits3.menu.DebugLevel.verbose.build.code_debug=5
+
+lionbits3.menu.EraseFlash.none=Disabled
+lionbits3.menu.EraseFlash.none.upload.erase_cmd=
+lionbits3.menu.EraseFlash.all=Enabled
+lionbits3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################


### PR DESCRIPTION
lionbit.cc has developed new board call Lion:Bit S3 STEM Dev Board using esp32s3 add this to board file

-----------
## Description of Change
Lion:Bit S3 STEM Dev Board adding

## Tests scenarios
Tested and works fine
 
## Related links
lionbit.cc


