### PR TITLE
Fixing UART1 pins for esp-idf-v5.1-libs 

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -64,7 +64,7 @@ void serialEvent(void) {}
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define RX1 15
 #elif CONFIG_IDF_TARGET_ESP32C6
-#define RX1 5
+#define RX1 4
 #elif CONFIG_IDF_TARGET_ESP32H2
 #define RX1 0
 #endif
@@ -80,7 +80,7 @@ void serialEvent(void) {}
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define TX1 16
 #elif CONFIG_IDF_TARGET_ESP32C6
-#define TX1 4
+#define TX1 5
 #elif CONFIG_IDF_TARGET_ESP32H2
 #define TX1 1
 #endif


### PR DESCRIPTION
## Description of Change
Changing pins of UART1 to be consistent with C6 documentation, RX=GPIO4, TX=GPIO5.
See https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/_images/esp32-c6-devkitc-1-pin-layout.png

Notice that existing pin configuration ALSO works, but requires wiring that is inconsistent with the official doc of the C6.

## Tests scenarios
Tested on ESP32-C6-DevKitC-1 connected to a SP3485 used (and tested) for MODBUS communication.

## Related links
[Please provide links to related issue, PRs etc.](https://github.com/espressif/arduino-esp32/issues/7713#issuecomment-1659866557)
