### PR TITLE
fixes preprocessor test

### DIFF
--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -62,7 +62,7 @@ void setup() {
   Serial.begin(115200);
   WiFi.onEvent(SysProvEvent);
 
-#if CONFIG_IDF_TARGET_ESP32 && CONFIG_BLUEDROID_ENABLED && not USE_SOFT_AP
+#if CONFIG_IDF_TARGET_ESP32 && CONFIG_BLUEDROID_ENABLED && !defined(USE_SOFT_AP)
     Serial.println("Begin Provisioning using BLE");
     // Sample uuid that user can pass during provisioning using BLE
     uint8_t uuid[16] = {0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf,
@@ -73,7 +73,7 @@ void setup() {
     WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name, service_key);
 #endif
 
-  #if CONFIG_BLUEDROID_ENABLED && not USE_SOFT_AP
+  #if CONFIG_BLUEDROID_ENABLED && !defined(USE_SOFT_AP)
     log_d("ble qr");
     WiFiProv.printQR(service_name, pop, "ble");
   #else

--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -62,24 +62,21 @@ void setup() {
   Serial.begin(115200);
   WiFi.onEvent(SysProvEvent);
 
-#if CONFIG_IDF_TARGET_ESP32 && CONFIG_BLUEDROID_ENABLED && !defined(USE_SOFT_AP)
+// BLE Provisioning using the ESP SoftAP Prov works fine for any BLE SoC, incuding ESP32, ESP32S3 and ESP32C3.
+#if CONFIG_BLUEDROID_ENABLED && !defined(USE_SOFT_AP)
     Serial.println("Begin Provisioning using BLE");
     // Sample uuid that user can pass during provisioning using BLE
     uint8_t uuid[16] = {0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf,
                         0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02 };
     WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name, service_key, uuid, reset_provisioned);
+    log_d("ble qr");
+    WiFiProv.printQR(service_name, pop, "ble");
 #else
     Serial.println("Begin Provisioning using Soft AP");
     WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name, service_key);
-#endif
-
-  #if CONFIG_BLUEDROID_ENABLED && !defined(USE_SOFT_AP)
-    log_d("ble qr");
-    WiFiProv.printQR(service_name, pop, "ble");
-  #else
     log_d("wifi qr");
     WiFiProv.printQR(service_name, pop, "softap");
-  #endif
+#endif
 }
 
 void loop() {


### PR DESCRIPTION
## Description of Change
When using `#define USE_SOFT_AP` in the example it causes a compilation error. 
Changed `&& not USE_SOFT_AP` ==> `&& !defined(USE_SOFT_AP)`

Removed the ESP32-only restriction in the example. It works with any BLE SoC.

## Tests scenarios
Teste with the ESP32, ESP32S3, ESP32C3 and ESP32S2.
ESP32S2 has only the SoftAP provisioning mode available.
The ESP32, S3 and C3 can work with BLE and SoftAP modes.

## Related links
fixes #8483 