### PR TITLE
MD5 memory leak fix

### DIFF
--- a/cores/esp32/MD5Builder.cpp
+++ b/cores/esp32/MD5Builder.cpp
@@ -78,6 +78,7 @@ bool MD5Builder::addStream(Stream & stream, const size_t maxLen)
         // read data and check if we got something
         int numBytesRead = stream.readBytes(buf, readBytes);
         if(numBytesRead< 1) {
+            free(buf);
             return false;
         }
 


### PR DESCRIPTION
## Description of Change
Fixes a memory leak in `MD5Builder::addStream()`.

## Tests scenarios
None - simple fix.

## Related links
Closes #8472 
