### PR TITLE
io_pin_remap fixes for the Arduino Nano ESP32

### DIFF
--- a/cores/esp32/io_pin_remap.h
+++ b/cores/esp32/io_pin_remap.h
@@ -18,7 +18,7 @@ int8_t digitalPinFromGPIONumber(int8_t gpioPin);
 #define pulseInLong(pin, state, timeout)    pulseInLong(digitalPinToGPIONumber(pin), state, timeout)
 #define pulseIn(pin, state, timeout)        pulseIn(digitalPinToGPIONumber(pin), state, timeout)
 #define noTone(_pin)                        noTone(digitalPinToGPIONumber(_pin))
-#define tone(_pin, frequency, duration)     tone(digitalPinToGPIONumber(_pin), frequency, duration)
+#define tone(_pin, args...)                 tone(digitalPinToGPIONumber(_pin), args)
 
 // cores/esp32/esp32-hal.h
 #define analogGetChannel(pin)       analogGetChannel(digitalPinToGPIONumber(pin))

--- a/variants/arduino_nano_nora/io_pin_remap.cpp
+++ b/variants/arduino_nano_nora/io_pin_remap.cpp
@@ -1,4 +1,20 @@
-#ifndef BOARD_USES_HW_GPIO_NUMBERS
+#if defined(BOARD_HAS_PIN_REMAP) && !defined(ARDUINO_CORE_BUILD)
+// -DARDUINO_CORE_BUILD must be set for core files only, to avoid extra
+// remapping steps that would create all sorts of issues in the core.
+// Removing -DBOARD_HAS_PIN_REMAP at least does correctly restore the
+// use of GPIO numbers in the API.
+#error This build system is not supported. Please rebuild without BOARD_HAS_PIN_REMAP.
+#endif
+
+#if !defined(BOARD_HAS_PIN_REMAP)
+// This board uses pin mapping but the build system has disabled it
+#warning The build system forces the Arduino API to use GPIO numbers on a board that has custom pin mapping.
+#elif defined(BOARD_USES_HW_GPIO_NUMBERS)
+// The user has chosen to disable pin mappin.
+#warning The Arduino API will use GPIO numbers for this build.
+#endif
+
+#if defined(BOARD_HAS_PIN_REMAP) && !defined(BOARD_USES_HW_GPIO_NUMBERS)
 
 #include "Arduino.h"
 


### PR DESCRIPTION
@me-no-dev 

## Description of Change

* dec6db6 fixes a minor issue: the pin-remapping macros force `tone()` to have 3 parameters, while the Arduino API dictates the third is optional.

* 9b402f0 adds an error and warnings to detect issues with bad or non-standard `#define` combinations for the variants with defined custom pin-mapping. No noticeable effects on a normal core build.

## Tests scenarios
Applicable to Arduino Nano ESP32 board only (other variants not using custom pin numbering are unaffected).
Tested that now:
- Removing the `-DARDUINO_CORE_BUILD` lines in `platform.txt` stops the build with an error
- Removing the `-DBOARD_HAS_PIN_REMAP` macro in `boards.txt` triggers a warning
- Defining the `-DBOARD_USES_HW_GPIO_PIN_NUMBERS` macro at compile time triggers a warning

## Related links
The changes have been discussed in the PlatformIO repo [here](https://github.com/platformio/platform-espressif32/issues/1162) and is related to PR #8488 (fixing the original issue).