### PR TITLE
add 'NO_GLOBAL_UPDATE' define to disable global UpdateClass instance

### DIFF
--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -190,6 +190,8 @@ class UpdateClass {
     uint8_t _ledOn;
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_UPDATE)
 extern UpdateClass Update;
+#endif
 
 #endif

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -414,4 +414,6 @@ bool UpdateClass::_chkDataInBlock(const uint8_t *data, size_t len) const {
     return false;
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_UPDATE)
 UpdateClass Update;
+#endif


### PR DESCRIPTION
Saves 180 bytes of RAM if UpdateClass instance is not required in project
follows same semantics as for
`NO_GLOBAL_HTTPUPDATE`
`NO_GLOBAL_ARDUINOOTA`

P.S. I could come up with PR for refactored `UpdateClass` where `MD5Builder _md5` member is created on-demand allocating from a heap for the duration of update. Could save about 100 bytes for global UpdateClass instance. but I'm not sure it worth the efforts and would be accepted. Let me know.