### PR TITLE
ledc.c: Fix analogWrite() last channel available verification

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -210,7 +210,7 @@ uint32_t ledcChangeFrequency(uint8_t chan, uint32_t freq, uint8_t bit_num)
     return ledc_get_freq(group,timer);
 }
 
-static int8_t pin_to_channel[SOC_GPIO_PIN_COUNT] = { 0 };
+static int8_t pin_to_channel[SOC_GPIO_PIN_COUNT] = { -1 };
 static int cnt_channel = LEDC_CHANNELS;
 static uint8_t analog_resolution = 8;
 static int analog_frequency = 1000;
@@ -218,7 +218,7 @@ void analogWrite(uint8_t pin, int value) {
     // Use ledc hardware for internal pins
     if (pin < SOC_GPIO_PIN_COUNT) {
         int8_t channel = -1;
-        if (pin_to_channel[pin] == 0) {
+        if (pin_to_channel[pin] == -1) {
             if (!cnt_channel) {
                 log_e("No more analogWrite channels available! You can have maximum %u", LEDC_CHANNELS);
                 return;

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -210,7 +210,7 @@ uint32_t ledcChangeFrequency(uint8_t chan, uint32_t freq, uint8_t bit_num)
     return ledc_get_freq(group,timer);
 }
 
-static int8_t pin_to_channel[SOC_GPIO_PIN_COUNT] = { -1 };
+static int8_t pin_to_channel[SOC_GPIO_PIN_COUNT] = { 0 };
 static int cnt_channel = LEDC_CHANNELS;
 static uint8_t analog_resolution = 8;
 static int analog_frequency = 1000;
@@ -218,7 +218,7 @@ void analogWrite(uint8_t pin, int value) {
     // Use ledc hardware for internal pins
     if (pin < SOC_GPIO_PIN_COUNT) {
         int8_t channel = -1;
-        if (pin_to_channel[pin] == -1) {
+        if (pin_to_channel[pin] == 0) {
             if (!cnt_channel) {
                 log_e("No more analogWrite channels available! You can have maximum %u", LEDC_CHANNELS);
                 return;
@@ -234,13 +234,13 @@ void analogWrite(uint8_t pin, int value) {
             return;
         }
         ledcAttachPin(pin, channel);
-        pin_to_channel[pin] = channel;
+        pin_to_channel[pin] = channel + 1;
         ledcWrite(channel, value);
     }
 }
 
 int8_t analogGetChannel(uint8_t pin) {
-    return pin_to_channel[pin];
+    return pin_to_channel[pin] - 1;
 }
 
 void analogWriteFrequency(uint32_t freq) {


### PR DESCRIPTION
## Description of Change
The last channel allocated is number 0, which conflicted with the value given to an uninitialized pin, giving the "No more analogWrite channels available!" error when trying to use it.

Pins are now given the value -1 to indicate that they are not used so channel 0 can be used without errors.

## Tests scenarios
Tested on a custom board with ESP32-S3-WROOM-1 module (8 ledc channels available.)