### PR TITLE
SPI - fix attach pin for ESP32-S3

### DIFF
--- a/.github/ISSUE_TEMPLATE/Issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/Issue-report.yml
@@ -41,6 +41,7 @@ body:
       options:
         - latest master (checkout manually)
         - latest development Release Candidate (RC-X)
+        - v2.0.11
         - v2.0.10
         - v2.0.9
         - v2.0.8

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -240,7 +240,7 @@ void spiAttachMOSI(spi_t * spi, int8_t mosi)
         return;
     }
     if(mosi < 0) {
-#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#if CONFIG_IDF_TARGET_ESP32S2
         if(spi->num == FSPI) {
             mosi = 35;
         } else {
@@ -277,7 +277,7 @@ void spiDetachSCK(spi_t * spi, int8_t sck)
         return;
     }
     if(sck < 0) {
-#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#if CONFIG_IDF_TARGET_ESP32S2
         if(spi->num == FSPI) {
             sck = 36;
         } else {
@@ -314,7 +314,7 @@ void spiDetachMISO(spi_t * spi, int8_t miso)
         return;
     }
     if(miso < 0) {
-#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#if CONFIG_IDF_TARGET_ESP32S2
         if(spi->num == FSPI) {
             miso = 37;
         } else {
@@ -351,7 +351,7 @@ void spiDetachMOSI(spi_t * spi, int8_t mosi)
         return;
     }
     if(mosi < 0) {
-#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#if CONFIG_IDF_TARGET_ESP32S2
         if(spi->num == FSPI) {
             mosi = 35;
         } else {


### PR DESCRIPTION
## Description of Change
This PR fixes attaching/detaching some of the SPI pins for S3. Probably a leftover when new chip was added.
In 5.1-libs branch, this part of code no longer exists, so no issue there.

## Tests scenarios
checked agains variant if pins are correct.

## Related links
Closes #8508 
