### PR TITLE
fix flash mode read out for C6

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -366,7 +366,7 @@ FlashMode_t EspClass::getFlashChipMode(void)
    #if CONFIG_IDF_TARGET_ESP32S2
    uint32_t spi_ctrl = REG_READ(PERIPHS_SPI_FLASH_CTRL);
    #else
-   #if CONFIG_IDF_TARGET_ESP32H2
+   #if CONFIG_IDF_TARGET_ESP32H2 || CONFIG_IDF_TARGET_ESP32C6
    uint32_t spi_ctrl = REG_READ(DR_REG_SPI0_BASE + 0x8);
    #else
    uint32_t spi_ctrl = REG_READ(SPI_CTRL_REG(0));


### PR DESCRIPTION
Currently the flash mode for the C6 always is `QOUT`. This is fixed by the PR. Now the correct flash mode is returned
@me-no-dev 