### PR TITLE
When FFat is mounted before SD, then filesystem reports wrong system sizes

### DIFF
--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -95,9 +95,9 @@ uint64_t SDFS::totalBytes()
 {
 	FATFS* fsinfo;
 	DWORD fre_clust;
-    char drv[3] = {(char)(48+_pdrv), ':', 0};
+	char drv[3] = {(char)(48+_pdrv), ':', 0};
 	if(f_getfree(drv,&fre_clust,&fsinfo)!= 0) return 0;
-    uint64_t size = ((uint64_t)(fsinfo->csize))*(fsinfo->n_fatent - 2)
+	uint64_t size = ((uint64_t)(fsinfo->csize))*(fsinfo->n_fatent - 2)
 #if _MAX_SS != 512
         *(fsinfo->ssize);
 #else
@@ -110,7 +110,7 @@ uint64_t SDFS::usedBytes()
 {
 	FATFS* fsinfo;
 	DWORD fre_clust;
-    char drv[3] = {(char)(48+_pdrv), ':', 0};
+	char drv[3] = {(char)(48+_pdrv), ':', 0};
 	if(f_getfree(drv,&fre_clust,&fsinfo)!= 0) return 0;
 	uint64_t size = ((uint64_t)(fsinfo->csize))*((fsinfo->n_fatent - 2) - (fsinfo->free_clst))
 #if _MAX_SS != 512

--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -95,7 +95,8 @@ uint64_t SDFS::totalBytes()
 {
 	FATFS* fsinfo;
 	DWORD fre_clust;
-	if(f_getfree("0:",&fre_clust,&fsinfo)!= 0) return 0;
+    char drv[3] = {(char)(48+_pdrv), ':', 0};
+	if(f_getfree(drv,&fre_clust,&fsinfo)!= 0) return 0;
     uint64_t size = ((uint64_t)(fsinfo->csize))*(fsinfo->n_fatent - 2)
 #if _MAX_SS != 512
         *(fsinfo->ssize);
@@ -109,7 +110,8 @@ uint64_t SDFS::usedBytes()
 {
 	FATFS* fsinfo;
 	DWORD fre_clust;
-	if(f_getfree("0:",&fre_clust,&fsinfo)!= 0) return 0;
+    char drv[3] = {(char)(48+_pdrv), ':', 0};
+	if(f_getfree(drv,&fre_clust,&fsinfo)!= 0) return 0;
 	uint64_t size = ((uint64_t)(fsinfo->csize))*((fsinfo->n_fatent - 2) - (fsinfo->free_clst))
 #if _MAX_SS != 512
         *(fsinfo->ssize);


### PR DESCRIPTION
Depending on filesystem init order, SD reports wrong usedBytes()/totalBytes() results.

The reason was a fixed drive id.

See:

https://github.com/espressif/arduino-esp32/issues/3546#issuecomment-1676429313