### PR TITLE
added lilygo t-display (esp32-based) board definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2958,6 +2958,162 @@ S_ODI_Ultra.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+lilygo_t_display.name=LilyGo T-Display
+lilygo_t_display.vid.0=0x1a86
+lilygo_t_display.pid.0=0x55d4
+
+lilygo_t_display.upload.tool=esptool_py
+lilygo_t_display.upload.tool.default=esptool_py
+lilygo_t_display.upload.tool.network=esp_ota
+lilygo_t_display.upload.maximum_size=1310720
+lilygo_t_display.upload.maximum_data_size=327680
+lilygo_t_display.upload.wait_for_upload_port=true
+lilygo_t_display.upload.speed=460800
+
+lilygo_t_display.bootloader.tool=esptool_py
+lilygo_t_display.bootloader.tool.default=esptool_py
+
+lilygo_t_display.serial.disableDTR=true
+lilygo_t_display.serial.disableRTS=true
+
+lilygo_t_display.build.mcu=esp32
+lilygo_t_display.build.core=esp32
+lilygo_t_display.build.variant=lilygo_t_display
+lilygo_t_display.build.board=LILYGO_T_DISPLAY
+
+lilygo_t_display.build.f_cpu=240000000L
+lilygo_t_display.build.flash_size=4MB
+lilygo_t_display.build.flash_freq=80m
+lilygo_t_display.build.flash_mode=dio
+lilygo_t_display.build.boot=dio
+lilygo_t_display.build.partitions=default
+
+lilygo_t_display.menu.PSRAM.disabled=Disabled
+lilygo_t_display.menu.PSRAM.disabled.build.defines=
+lilygo_t_display.menu.PSRAM.enabled=Enabled
+lilygo_t_display.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+lilygo_t_display.menu.PSRAM.enabled.build.extra_libs=
+
+lilygo_t_display.menu.LoopCore.1=Core 1
+lilygo_t_display.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+lilygo_t_display.menu.LoopCore.0=Core 0
+lilygo_t_display.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+lilygo_t_display.menu.EventsCore.1=Core 1
+lilygo_t_display.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+lilygo_t_display.menu.EventsCore.0=Core 0
+lilygo_t_display.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+lilygo_t_display.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+lilygo_t_display.menu.PartitionScheme.default.build.partitions=default
+lilygo_t_display.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+lilygo_t_display.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+lilygo_t_display.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+lilygo_t_display.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+lilygo_t_display.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+lilygo_t_display.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+lilygo_t_display.menu.PartitionScheme.minimal.build.partitions=minimal
+lilygo_t_display.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+lilygo_t_display.menu.PartitionScheme.no_ota.build.partitions=no_ota
+lilygo_t_display.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+lilygo_t_display.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+lilygo_t_display.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+lilygo_t_display.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+lilygo_t_display.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+lilygo_t_display.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+lilygo_t_display.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+lilygo_t_display.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+lilygo_t_display.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+lilygo_t_display.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+lilygo_t_display.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+lilygo_t_display.menu.PartitionScheme.huge_app.build.partitions=huge_app
+lilygo_t_display.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+lilygo_t_display.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+lilygo_t_display.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+lilygo_t_display.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+lilygo_t_display.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FAT)
+lilygo_t_display.menu.PartitionScheme.fatflash.build.partitions=ffat
+lilygo_t_display.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+lilygo_t_display.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
+lilygo_t_display.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+lilygo_t_display.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+lilygo_t_display.menu.CPUFreq.240=240MHz (WiFi/BT)
+lilygo_t_display.menu.CPUFreq.240.build.f_cpu=240000000L
+lilygo_t_display.menu.CPUFreq.160=160MHz (WiFi/BT)
+lilygo_t_display.menu.CPUFreq.160.build.f_cpu=160000000L
+lilygo_t_display.menu.CPUFreq.80=80MHz (WiFi/BT)
+lilygo_t_display.menu.CPUFreq.80.build.f_cpu=80000000L
+lilygo_t_display.menu.CPUFreq.40=40MHz (40MHz XTAL)
+lilygo_t_display.menu.CPUFreq.40.build.f_cpu=40000000L
+lilygo_t_display.menu.CPUFreq.26=26MHz (26MHz XTAL)
+lilygo_t_display.menu.CPUFreq.26.build.f_cpu=26000000L
+lilygo_t_display.menu.CPUFreq.20=20MHz (40MHz XTAL)
+lilygo_t_display.menu.CPUFreq.20.build.f_cpu=20000000L
+lilygo_t_display.menu.CPUFreq.13=13MHz (26MHz XTAL)
+lilygo_t_display.menu.CPUFreq.13.build.f_cpu=13000000L
+lilygo_t_display.menu.CPUFreq.10=10MHz (40MHz XTAL)
+lilygo_t_display.menu.CPUFreq.10.build.f_cpu=10000000L
+
+lilygo_t_display.menu.FlashMode.qio=QIO
+lilygo_t_display.menu.FlashMode.qio.build.flash_mode=dio
+lilygo_t_display.menu.FlashMode.qio.build.boot=qio
+lilygo_t_display.menu.FlashMode.dio=DIO
+lilygo_t_display.menu.FlashMode.dio.build.flash_mode=dio
+lilygo_t_display.menu.FlashMode.dio.build.boot=dio
+lilygo_t_display.menu.FlashMode.qout=QOUT
+lilygo_t_display.menu.FlashMode.qout.build.flash_mode=dout
+lilygo_t_display.menu.FlashMode.qout.build.boot=qout
+lilygo_t_display.menu.FlashMode.dout=DOUT
+lilygo_t_display.menu.FlashMode.dout.build.flash_mode=dout
+lilygo_t_display.menu.FlashMode.dout.build.boot=dout
+
+lilygo_t_display.menu.FlashFreq.80=80MHz
+lilygo_t_display.menu.FlashFreq.80.build.flash_freq=80m
+lilygo_t_display.menu.FlashFreq.40=40MHz
+lilygo_t_display.menu.FlashFreq.40.build.flash_freq=40m
+
+lilygo_t_display.menu.FlashSize.4M=4MB (32Mb)
+lilygo_t_display.menu.FlashSize.4M.build.flash_size=4MB
+lilygo_t_display.menu.FlashSize.8M=8MB (64Mb)
+lilygo_t_display.menu.FlashSize.8M.build.flash_size=8MB
+lilygo_t_display.menu.FlashSize.8M.build.partitions=default_8MB
+lilygo_t_display.menu.FlashSize.2M=2MB (16Mb)
+lilygo_t_display.menu.FlashSize.2M.build.flash_size=2MB
+lilygo_t_display.menu.FlashSize.2M.build.partitions=minimal
+lilygo_t_display.menu.FlashSize.16M=16MB (128Mb)
+lilygo_t_display.menu.FlashSize.16M.build.flash_size=16MB
+
+lilygo_t_display.menu.UploadSpeed.921600=921600
+lilygo_t_display.menu.UploadSpeed.921600.upload.speed=921600
+lilygo_t_display.menu.UploadSpeed.115200=115200
+lilygo_t_display.menu.UploadSpeed.115200.upload.speed=115200
+lilygo_t_display.menu.UploadSpeed.256000.windows=256000
+lilygo_t_display.menu.UploadSpeed.256000.upload.speed=256000
+lilygo_t_display.menu.UploadSpeed.230400.windows.upload.speed=256000
+lilygo_t_display.menu.UploadSpeed.230400=230400
+lilygo_t_display.menu.UploadSpeed.230400.upload.speed=230400
+lilygo_t_display.menu.UploadSpeed.460800.linux=460800
+lilygo_t_display.menu.UploadSpeed.460800.macosx=460800
+lilygo_t_display.menu.UploadSpeed.460800.upload.speed=460800
+lilygo_t_display.menu.UploadSpeed.512000.windows=512000
+lilygo_t_display.menu.UploadSpeed.512000.upload.speed=512000
+
+lilygo_t_display.menu.DebugLevel.none=None
+lilygo_t_display.menu.DebugLevel.none.build.code_debug=0
+lilygo_t_display.menu.DebugLevel.error=Error
+lilygo_t_display.menu.DebugLevel.error.build.code_debug=1
+lilygo_t_display.menu.DebugLevel.warn=Warn
+lilygo_t_display.menu.DebugLevel.warn.build.code_debug=2
+lilygo_t_display.menu.DebugLevel.info=Info
+lilygo_t_display.menu.DebugLevel.info.build.code_debug=3
+lilygo_t_display.menu.DebugLevel.debug=Debug
+lilygo_t_display.menu.DebugLevel.debug.build.code_debug=4
+lilygo_t_display.menu.DebugLevel.verbose=Verbose
+lilygo_t_display.menu.DebugLevel.verbose.build.code_debug=5
+
+##############################################################
+
 lilygo_t_display_s3.name=LilyGo T-Display-S3
 lilygo_t_display_s3.vid.0=0x303a
 lilygo_t_display_s3.pid.0=0x1001

--- a/boards.txt
+++ b/boards.txt
@@ -3008,9 +3008,6 @@ lilygo_t_display.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP
 lilygo_t_display.menu.PartitionScheme.default.build.partitions=default
 lilygo_t_display.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
 lilygo_t_display.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-lilygo_t_display.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
-lilygo_t_display.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
-lilygo_t_display.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 lilygo_t_display.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
 lilygo_t_display.menu.PartitionScheme.minimal.build.partitions=minimal
 lilygo_t_display.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
@@ -3075,12 +3072,6 @@ lilygo_t_display.menu.FlashFreq.40.build.flash_freq=40m
 
 lilygo_t_display.menu.FlashSize.4M=4MB (32Mb)
 lilygo_t_display.menu.FlashSize.4M.build.flash_size=4MB
-lilygo_t_display.menu.FlashSize.8M=8MB (64Mb)
-lilygo_t_display.menu.FlashSize.8M.build.flash_size=8MB
-lilygo_t_display.menu.FlashSize.8M.build.partitions=default_8MB
-lilygo_t_display.menu.FlashSize.2M=2MB (16Mb)
-lilygo_t_display.menu.FlashSize.2M.build.flash_size=2MB
-lilygo_t_display.menu.FlashSize.2M.build.partitions=minimal
 lilygo_t_display.menu.FlashSize.16M=16MB (128Mb)
 lilygo_t_display.menu.FlashSize.16M.build.flash_size=16MB
 
@@ -3111,6 +3102,11 @@ lilygo_t_display.menu.DebugLevel.debug=Debug
 lilygo_t_display.menu.DebugLevel.debug.build.code_debug=4
 lilygo_t_display.menu.DebugLevel.verbose=Verbose
 lilygo_t_display.menu.DebugLevel.verbose.build.code_debug=5
+
+lilygo_t_display.menu.EraseFlash.none=Disabled
+lilygo_t_display.menu.EraseFlash.none.upload.erase_cmd=
+lilygo_t_display.menu.EraseFlash.all=Enabled
+lilygo_t_display.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 

--- a/boards.txt
+++ b/boards.txt
@@ -2976,8 +2976,11 @@ lilygo_t_display.bootloader.tool.default=esptool_py
 lilygo_t_display.serial.disableDTR=true
 lilygo_t_display.serial.disableRTS=true
 
+lilygo_t_display.build.tarch=xtensa
+lilygo_t_display.build.bootloader_addr=0x1000
 lilygo_t_display.build.mcu=esp32
 lilygo_t_display.build.core=esp32
+lilygo_t_display.build.target=esp32
 lilygo_t_display.build.variant=lilygo_t_display
 lilygo_t_display.build.board=LILYGO_T_DISPLAY
 

--- a/variants/lilygo_t_display/pins_arduino.h.txt
+++ b/variants/lilygo_t_display/pins_arduino.h.txt
@@ -1,0 +1,67 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x1A86
+#define USB_PID 0x55D4
+#define USB_MANUFACTURER "Lilygo"
+#define USB_PRODUCT "T-Display"
+#define USB_SERIAL ""
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+static const uint8_t VBAT = 34;
+
+static const uint8_t RIGHT_BUTTON = 35;
+static const uint8_t LEFT_BUTTON = 0;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change

This change adds a new board lilygo-t-display based on esp32. Board variants have 4 MB or 16 MB flash memory. All boards come with a TFT display. This board is the predecessor to the already included lilygo-t-display-s3.

[Manufacturer Board webpage](https://www.lilygo.cc/products/lilygo%C2%AE-ttgo-t-display-1-14-inch-lcd-esp32-control-board)

[Pinmap](https://github.com/Xinyuan-LilyGO/TTGO-T-Display/blob/master/image/pinmap.jpg)

## Tests scenarios

I have tested my pull request with a Lilygo TDisplay HW rev 1.1 by configuring PlatformIO to use the platform in https://github.com/PBrunot/arduino-esp32#feature-lilygo-tdisplay as framework for arduino-esp32, and uploading a sketch to a destination board successfully. Testing sketch is using serial, TFT display over SPI.

platformio.used for testing
```
[env:T-Display]
platform = https://github.com/platformio/platform-espressif32.git
board = lilygo_t-display
framework = arduino
monitor_speed = 115200
build_flags = -D ARDUINO_LILYGO_T_DISPLAY_S3
platform_packages =
    framework-arduinoespressif32 @ https://github.com/PBrunot/arduino-esp32#feature-lilygo-tdisplay
lib_deps = 
	moononournation/GFX Library for Arduino@^1.3.7
	Wire
	SPI
```

## Related links

This is required to add support in platformio for the same board, as per platformio esp32 policies : https://github.com/platformio/platform-espressif32/issues/209

