### PR TITLE
AcquireSPI on ff_sd_status

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -616,6 +616,9 @@ unknown_card:
 
 DSTATUS ff_sd_status(uint8_t pdrv)
 {
+    ardu_sdcard_t * card = s_cards[pdrv];
+    AcquireSPI lock(card);
+    
     if(sdTransaction(pdrv, SEND_STATUS, 0, NULL))
     {
         log_e("Check status failed");


### PR DESCRIPTION
## Description of Change
Added missing `AcquireSPI` lock in `ff_sd_status` function in SD library. Fixing conflict when sharing the same SPI bus in multi tasks. Thanks @LeoYan for providing the fix in issue #8534

Should be merged to both 2.x release branch and 5.1-libs branch.
## Tests scenarios

## Related links
Closing #8534
