### PR TITLE
Reimplemented flush in WiFiClient

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -508,7 +508,6 @@ int WiFiClient::available()
 // Though flushing means to send all pending data,
 // seems that in Arduino it also means to clear RX
 void WiFiClient::flush() {
-#ifdef ARDUINO_DEBUG_LEVEL
     _rxBuffer->flush();
 }
 

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -153,6 +153,13 @@ public:
     size_t available(){
         return _fill - _pos + r_available();
     }
+
+    void flush(){
+        if(r_available()){
+            fillBuffer();
+        }
+        _pos = _fill;
+    }
 };
 
 class WiFiClientSocketHandle {
@@ -501,26 +508,8 @@ int WiFiClient::available()
 // Though flushing means to send all pending data,
 // seems that in Arduino it also means to clear RX
 void WiFiClient::flush() {
-    int res;
-    size_t a = available(), toRead = 0;
-    if(!a){
-        return;//nothing to flush
-    }
-    uint8_t * buf = (uint8_t *)malloc(WIFI_CLIENT_FLUSH_BUFFER_SIZE);
-    if(!buf){
-        return;//memory error
-    }
-    while(a){
-        toRead = (a>WIFI_CLIENT_FLUSH_BUFFER_SIZE)?WIFI_CLIENT_FLUSH_BUFFER_SIZE:a;
-        res = recv(fd(), buf, toRead, MSG_DONTWAIT);
-        if(res < 0) {
-            log_e("fail on fd %d, errno: %d, \"%s\"", fd(), errno, strerror(errno));
-            stop();
-            break;
-        }
-        a -= res;
-    }
-    free(buf);
+#ifdef ARDUINO_DEBUG_LEVEL
+    _rxBuffer->flush();
 }
 
 uint8_t WiFiClient::connected()


### PR DESCRIPTION
The WiFiClient doesn't seem responsible for the actual reading, yet the function `WiFiClient::flush` was calling `recv()`.
This resulted in errors.
I have reimplemented the `WiFiClient::flush` functionality into the `WiFiClientRxBuffer` and the `WiFiClient::flush` simply calls that: `_rxBuffer->flush();`
Solves #6129