### PR TITLE
Fixes ESP32 BT Memory Releasing

### DIFF
--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -16,8 +16,12 @@
 
 #ifdef CONFIG_BT_ENABLED
 
+#if CONFIG_IDF_TARGET_ESP32
+bool btInUse(){ return true; }
+#else
 // user may want to change it to free resources
 __attribute__((weak)) bool btInUse(){ return true; }
+#endif
 
 #include "esp_bt.h"
 

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -209,8 +209,14 @@ bool verifyRollbackLater() { return false; }
 #endif
 
 #ifdef CONFIG_BT_ENABLED
+#if CONFIG_IDF_TARGET_ESP32
+//overwritten in esp32-hal-bt.c
+bool btInUse() __attribute__((weak));
+bool btInUse(){ return false; }
+#else
 //from esp32-hal-bt.c
 extern bool btInUse();
+#endif
 #endif
 
 void initArduino()


### PR DESCRIPTION
## Description of Change
This is related to a change done in PR #8243 to fix Arduino with RainMaker + BLE Provisioning.
The PR #8243 works correctly for the C3 and S3 with no side effects.
But for the ESP32, it causes a problem with the linker that never allows it to release the BT memory whenever the sketch doesn't use BT/BLE.

Therefore, this PR **_just reverts the PR#8243 for the ESP32_**, making it work fine as before.

## Tests scenarios
Tested with ESP32, ESP32-S3 and ESP32-C3 within the following sketches:

#### Doesn't use BT/BLE and prints the HEAP.
``` cpp
void setup() {
  Serial.begin(115200);
  Serial.printf("Total Heap Size: %d\n", ESP.getHeapSize());
  Serial.printf("Available Heap: %d\n", ESP.getFreeHeap());
  Serial.printf("Lowest level of heap since boot: %d\n", ESP.getMinFreeHeap());
  Serial.printf("Largest block of heap that can be allocated at once: %d\n", ESP.getMaxAllocHeap());
}

void loop() {}
```

#### The same BLE_server.ino example, but also prints HEAP information.
``` cpp
#include <BLEDevice.h>
#include <BLEUtils.h>
#include <BLEServer.h>

// See the following for generating UUIDs:
// https://www.uuidgenerator.net/

#define SERVICE_UUID        "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
#define CHARACTERISTIC_UUID "beb5483e-36e1-4688-b7f5-ea07361b26a8"

void setup() {
  Serial.begin(115200);
  delay(1000);
  Serial.printf("Total Heap Size: %d\n", ESP.getHeapSize());
  Serial.printf("Available Heap: %d\n", ESP.getFreeHeap());
  Serial.printf("Lowest level of heap since boot: %d\n", ESP.getMinFreeHeap());
  Serial.printf("Largest block of heap that can be allocated at once: %d\n", ESP.getMaxAllocHeap());

  Serial.println("Starting BLE work!");

  BLEDevice::init("Long name works now");
  BLEServer *pServer = BLEDevice::createServer();
  BLEService *pService = pServer->createService(SERVICE_UUID);
  BLECharacteristic *pCharacteristic = pService->createCharacteristic(
                                         CHARACTERISTIC_UUID,
                                         BLECharacteristic::PROPERTY_READ |
                                         BLECharacteristic::PROPERTY_WRITE
                                       );

  pCharacteristic->setValue("Hello World says Neil");
  pService->start();
  // BLEAdvertising *pAdvertising = pServer->getAdvertising();  // this still is working for backward compatibility
  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
  pAdvertising->addServiceUUID(SERVICE_UUID);
  pAdvertising->setScanResponse(true);
  pAdvertising->setMinPreferred(0x06);  // functions that help with iPhone connections issue
  pAdvertising->setMinPreferred(0x12);
  BLEDevice::startAdvertising();
  Serial.println("Characteristic defined! Now you can read it in your phone!");
}

void loop() {
  // put your main code here, to run repeatedly:
  delay(2000);
}
```

#### The sketch from the Issue #7903 

#### The sketch example using WiFiProv.ino, but adjusted to use BLE provisioning.
https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino

## Related links

Closes #8482 
Related to #7903 #8243 #8528