### PR TITLE
Adding Lion:Bit S3 STEM Dev Board to boards.txt

### DIFF
--- a/.github/ISSUE_TEMPLATE/Issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/Issue-report.yml
@@ -41,6 +41,7 @@ body:
       options:
         - latest master (checkout manually)
         - latest development Release Candidate (RC-X)
+        - v2.0.10
         - v2.0.9
         - v2.0.8
         - v2.0.7


### PR DESCRIPTION
 
## Description of Change
lionbit.cc has developed new board call Lion:Bit S3 STEM Dev Board using esp32s3 add this to board file

## Tests scenarios
Tested all 
 
## Related links
lionbit.cc