### PR TITLE
Allows changing HW CDC Buffer Size after or before begin()

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -173,9 +173,18 @@ void HWCDC::begin(unsigned long baud)
     if(tx_lock == NULL) {
         tx_lock = xSemaphoreCreateMutex();
     }
-    setRxBufferSize(256);//default if not preset
-    setTxBufferSize(256);//default if not preset
-
+    //RX Buffer default has 256 bytes if not preset
+    if(rx_queue == NULL) {
+        if (!setRxBufferSize(256)) {
+            log_e("HW CDC RX Buffer error");
+        }
+    }
+    //TX Buffer default has 256 bytes if not preset
+    if (tx_ring_buf == NULL) {
+        if (!setTxBufferSize(256)) {
+            log_e("HW CDC TX Buffer error");
+        }    
+    }
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY | USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT | USB_SERIAL_JTAG_INTR_BUS_RESET);


### PR DESCRIPTION
## Description of Change
This PR fixes HW CDC for the C3 and S3 in order to keep the buffer size already set after calling `HWCDC::begin()`. In case no size was set before `HWCDC:begin()`, it will use a default RX/TX buffer size of 256 bytes.
`HWCDC::setTxBufferSize()` and `HWCDC::setRxBufferSize()` will set the buffer size if called at any time and it won't change until a new call to this function.
`HWCDC:begin()` will only set a default buffer size if none has been set already. If `HWCDC::setTxBufferSize()` and/or `HWCDC::setRxBufferSize()` was called before, it won't change the buffer size as set by the user. If those functions are called after `HWCDC::begin()` a new buffer will be allocated with the proper new size.

Therefore, the RX/TX buffer size can be set at any time, after or before `HWCDC::begin()` is called, even more than one time, in any order. 
Previous memory will be released and a new buffer is allocated.

## Tests scenarios
Tested with the ESP32-C3 and ESP32-S3 using HW Serial (HW USB CDC).

Sending 100, 200, 400, 500 and 1000 bytes using the Arduino IDE Serial Monitor.

``` cpp
void setup() {
  Serial.begin(115200);
  Serial.setRxBufferSize(1024);
  Serial.setTxBufferSize(1024);
  Serial.begin(115200);
}

#define MAX_INPUT_BUFFER_SIZE 4096

uint32_t inputBufferPos = 0;
uint8_t inputBuffer[MAX_INPUT_BUFFER_SIZE + 1];

void loop() {
  uint32_t readInLoopCount = 0;
  while (Serial.available()) {
    uint8_t readByte = Serial.read();
    inputBuffer[inputBufferPos] = readByte;
    inputBufferPos += 1;
    readInLoopCount += 1;

    if (readByte == '\n') {
      inputBuffer[inputBufferPos] = 0;
      // Serial.print((char*)inputBuffer);
      Serial.printf("GOT: %d\n", strlen((char*)inputBuffer));
      inputBufferPos = 0;
    }
    if (inputBufferPos >= MAX_INPUT_BUFFER_SIZE) {
      Serial.println("ERR INPUT TOO LONG");
      inputBufferPos = 0;
    }
  }

  if (readInLoopCount > 0) {
    Serial.printf("GOT IN LOOP: %d\n", readInLoopCount);
  }
}
```

## Related links

Closes #8522 
Related to #8528 
