### PR TITLE
Nano ESP32: add pin numbering option

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -17,6 +17,7 @@ menu.EventsCore=Events Run On
 menu.MemoryType=Memory Type
 menu.EraseFlash=Erase All Flash Before Sketch Upload
 menu.JTAGAdapter=JTAG Adapter
+menu.PinNumbers=Pin Numbering
 
 # Custom options
 menu.Revision=Board Revision
@@ -24154,12 +24155,17 @@ nano_nora.build.flash_mode=dio
 nano_nora.build.boot=qio
 nano_nora.build.boot_freq=80m
 nano_nora.build.partitions=app3M_fat9M_fact512k_16MB
-nano_nora.build.defines=-DBOARD_HAS_PIN_REMAP -DBOARD_HAS_PSRAM '-DUSB_MANUFACTURER="Arduino"' '-DUSB_PRODUCT="Nano ESP32"'
+nano_nora.build.defines=-DBOARD_HAS_PIN_REMAP {build.disable_pin_remap} -DBOARD_HAS_PSRAM '-DUSB_MANUFACTURER="Arduino"' '-DUSB_PRODUCT="Nano ESP32"'
 nano_nora.build.loop_core=-DARDUINO_RUNNING_CORE=1
 nano_nora.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
 nano_nora.build.psram_type=opi
 nano_nora.build.memory_type={build.boot}_{build.psram_type}
+nano_nora.build.disable_pin_remap=
 
 nano_nora.tools.esptool_py.program.pattern_args=--chip {build.mcu} --port "{serial.port}" --before default_reset --after hard_reset write_flash -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} {build.bootloader_addr} "{build.path}/{build.project_name}.bootloader.bin" 0x8000 "{build.path}/{build.project_name}.partitions.bin" 0xe000 "{runtime.platform.path}/tools/partitions/boot_app0.bin" 0xf70000 "{build.variant.path}/extra/nora_recovery/nora_recovery.ino.bin" 0x10000 "{build.path}/{build.project_name}.bin"
+
+nano_nora.menu.PinNumbers.default=By Arduino pin (default)
+nano_nora.menu.PinNumbers.byGPIONumber=By GPIO number (legacy)
+nano_nora.menu.PinNumbers.byGPIONumber.build.disable_pin_remap=-DBOARD_USES_HW_GPIO_NUMBERS
 
 ##############################################################

--- a/cores/esp32/FunctionalInterrupt.h
+++ b/cores/esp32/FunctionalInterrupt.h
@@ -12,10 +12,11 @@
 #include <stdint.h>
 
 struct InterruptArgStructure {
-	std::function<void(void)> interruptFunction;
+    std::function<void(void)> interruptFunction;
 };
 
-void attachInterrupt(uint8_t pin, std::function<void(void)> intRoutine, int mode);
-
+// The extra set of parentheses here prevents macros defined
+// in io_pin_remap.h from applying to this declaration.
+void (attachInterrupt)(uint8_t pin, std::function<void(void)> intRoutine, int mode);
 
 #endif /* CORE_CORE_FUNCTIONALINTERRUPT_H_ */

--- a/cores/esp32/io_pin_remap.h
+++ b/cores/esp32/io_pin_remap.h
@@ -7,7 +7,7 @@
 
 // Pin remapping functions
 int8_t digitalPinToGPIONumber(int8_t digitalPin);
-int8_t digitalPinFromGPIONumber(int8_t gpioPin);
+int8_t digitalPinFromGPIONumber(int8_t gpioNumber);
 
 // Apply pin remapping to API only when building libraries and user sketch
 #ifndef ARDUINO_CORE_BUILD
@@ -15,10 +15,10 @@ int8_t digitalPinFromGPIONumber(int8_t gpioPin);
 // Override APIs requiring pin remapping
 
 // cores/esp32/Arduino.h
-#define pulseInLong(pin, state, timeout)    pulseInLong(digitalPinToGPIONumber(pin), state, timeout)
-#define pulseIn(pin, state, timeout)        pulseIn(digitalPinToGPIONumber(pin), state, timeout)
-#define noTone(_pin)                        noTone(digitalPinToGPIONumber(_pin))
-#define tone(_pin, args...)                 tone(digitalPinToGPIONumber(_pin), args)
+#define pulseInLong(pin, args...)   pulseInLong(digitalPinToGPIONumber(pin), args)
+#define pulseIn(pin, args...)       pulseIn(digitalPinToGPIONumber(pin), args)
+#define noTone(_pin)                noTone(digitalPinToGPIONumber(_pin))
+#define tone(_pin, args...)         tone(digitalPinToGPIONumber(_pin), args)
 
 // cores/esp32/esp32-hal.h
 #define analogGetChannel(pin)       analogGetChannel(digitalPinToGPIONumber(pin))

--- a/variants/arduino_nano_nora/pins_arduino.h
+++ b/variants/arduino_nano_nora/pins_arduino.h
@@ -7,19 +7,23 @@
 #define USB_VID 0x2341
 #define USB_PID 0x0070
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        25
-#define NUM_ANALOG_INPUTS       8
-
-#define analogInputToDigitalPin(p)  (p)
-#define digitalPinToInterrupt(p)    ((((uint8_t)digitalPinToGPIONumber(p)) < 48)? digitalPinToGPIONumber(p) : -1)
-#define digitalPinHasPWM(p)         (((uint8_t)digitalPinToGPIONumber(p)) < 46)
-
 #ifndef __cplusplus
 #define constexpr const
 #endif
 
 // primary pin names
+
+#if defined(BOARD_HAS_PIN_REMAP) && !defined(BOARD_USES_HW_GPIO_NUMBERS)
+
+// Arduino style definitions (API uses Dx)
+
+#define analogInputToDigitalPin(p)  (p)
+#define digitalPinToInterrupt(p)    ((((uint8_t)digitalPinToGPIONumber(p)) < 48)? digitalPinToGPIONumber(p) : -1)
+#define digitalPinHasPWM(p)         (((uint8_t)digitalPinToGPIONumber(p)) < 46)
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        25
+#define NUM_ANALOG_INPUTS       8
 
 static constexpr uint8_t D0         = 0; // also RX
 static constexpr uint8_t D1         = 1; // also TX
@@ -47,6 +51,47 @@ static constexpr uint8_t A4         = 21; // also SDA
 static constexpr uint8_t A5         = 22; // also SCL
 static constexpr uint8_t A6         = 23;
 static constexpr uint8_t A7         = 24;
+
+#else
+
+// ESP32-style definitions (API uses GPIOx)
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        48
+#define NUM_ANALOG_INPUTS       20
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
+
+static constexpr uint8_t D0         = 44; // also RX
+static constexpr uint8_t D1         = 43; // also TX
+static constexpr uint8_t D2         = 5;
+static constexpr uint8_t D3         = 6;  // also CTS
+static constexpr uint8_t D4         = 7;  // also DSR
+static constexpr uint8_t D5         = 8;
+static constexpr uint8_t D6         = 9;
+static constexpr uint8_t D7         = 10;
+static constexpr uint8_t D8         = 17;
+static constexpr uint8_t D9         = 18;
+static constexpr uint8_t D10        = 21; // also SS
+static constexpr uint8_t D11        = 38; // also MOSI
+static constexpr uint8_t D12        = 47; // also MISO
+static constexpr uint8_t D13        = 48; // also SCK, LED_BUILTIN
+static constexpr uint8_t LED_RED    = 46;
+static constexpr uint8_t LED_GREEN  = 0;
+static constexpr uint8_t LED_BLUE   = 45; // also RTS
+
+static constexpr uint8_t A0         = 1;  // also DTR
+static constexpr uint8_t A1         = 2;
+static constexpr uint8_t A2         = 3;
+static constexpr uint8_t A3         = 4;
+static constexpr uint8_t A4         = 11; // also SDA
+static constexpr uint8_t A5         = 12; // also SCL
+static constexpr uint8_t A6         = 13;
+static constexpr uint8_t A7         = 14;
+
+#endif
 
 // alternate pin functions
 

--- a/variants/arduino_nano_nora/variant.cpp
+++ b/variants/arduino_nano_nora/variant.cpp
@@ -9,30 +9,13 @@
 #include <esp_ota_ops.h>
 #include <esp_partition.h>
 
+// defined in io_pin_remap.cpp
+extern void _nano_nora_reset_gpio_matrix(void);
+
 extern "C" {
     void initVariant() {
         // FIXME: fix issues with GPIO matrix not being soft reset properly
-        for (int pin = 0; pin<NUM_DIGITAL_PINS; ++pin) {
-            switch (pin) {
-                case LED_RED:
-                case LED_GREEN:
-                case LED_BLUE:
-                    // set RGB pins to dig outputs, HIGH=off
-                    pinMode(pin, OUTPUT);
-                    digitalWrite(pin, HIGH);
-                    break;
-
-                case TX:
-                case RX:
-                    // leave UART pins alone
-                    break;
-
-                default:
-                    // initialize other pins to dig inputs
-                    pinMode(pin, INPUT);
-                    break;
-            }
-        }
+        _nano_nora_reset_gpio_matrix();
     }
 }
 


### PR DESCRIPTION
## Description of Change
This addresses issues faced by some Arduino customers when trying to use third party libraries designed for ESP32 targets with no pin remapping. 

This changeset introduces a Pin Numbering menu option and enables it for the Arduino Nano ESP32 only. The default keeps the current Arduino pin numbered API, but when users select the "By GPIO number" option, the API will revert to the ESP32 common GPIO-based numbering for maximum compatibility with existing projects and libraries. 

61d867bc also fixes some compile time issues when some specific functions are called while pin remapping is enabled. 

## Tests scenarios
Tested with the Arduino Nano ESP32. Sketches where pins are used by symbol ("`D6`") access the same physical pins regardless of menu selection, even if  the symbols have different values (Arduino pin number or GPIO number).   

## Related links
One example of broken library is [ESP32Servo](https://github.com/madhephaestus/ESP32Servo) which reimplements core functions such as `analogWrite()` in library files, confusing the pin remapping semantics. 
