### PR TITLE
Nano ESP32: add debug support

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -24173,4 +24173,11 @@ nano_nora.menu.PinNumbers.default=By Arduino pin (default)
 nano_nora.menu.PinNumbers.byGPIONumber=By GPIO number (legacy)
 nano_nora.menu.PinNumbers.byGPIONumber.build.disable_pin_remap=-DBOARD_USES_HW_GPIO_NUMBERS
 
+nano_nora.menu.USBMode.default=Normal mode (TinyUSB)
+nano_nora.menu.USBMode.hwcdc=Debug mode (Hardware CDC)
+nano_nora.menu.USBMode.hwcdc.build.usb_mode=1
+nano_nora.menu.USBMode.hwcdc.build.copy_jtag_files=1
+nano_nora.menu.USBMode.hwcdc.build.openocdscript=esp32s3-builtin.cfg
+nano_nora.menu.USBMode.hwcdc.build.debugconfig=esp32s3-arduino.json
+
 ##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -24173,8 +24173,4 @@ nano_nora.menu.PinNumbers.default=By Arduino pin (default)
 nano_nora.menu.PinNumbers.byGPIONumber=By GPIO number (legacy)
 nano_nora.menu.PinNumbers.byGPIONumber.build.disable_pin_remap=-DBOARD_USES_HW_GPIO_NUMBERS
 
-nano_nora.menu.PinNumbers.default=By Arduino pin (default)
-nano_nora.menu.PinNumbers.byGPIONumber=By GPIO number (legacy)
-nano_nora.menu.PinNumbers.byGPIONumber.build.disable_pin_remap=-DBOARD_USES_HW_GPIO_NUMBERS
-
 ##############################################################

--- a/platform.txt
+++ b/platform.txt
@@ -160,6 +160,9 @@ build.openocdscript.esp32s3=esp32s3-builtin.cfg
 build.openocdscript.esp32c3=esp32c3-builtin.cfg
 build.openocdscript={build.openocdscript.{build.mcu}}
 
+# Debug plugin configuration
+build.debugconfig={build.mcu}.json
+
 # Custom build options
 build.opt.name=build_opt.h
 build.opt.path={build.path}/{build.opt.name}
@@ -201,8 +204,8 @@ recipe.hooks.postbuild.1.pattern=bash -c "[ {build.copy_jtag_files} -eq 0 ] || c
 recipe.hooks.postbuild.1.pattern.windows=cmd /c IF {build.copy_jtag_files}==1 COPY /y "{debug.server.openocd.scripts_dir}board\{build.openocdscript}" "{build.source.path}\debug.cfg"
 
 # Generate debug_custom.json
-recipe.hooks.postbuild.2.pattern=bash -c "[ {build.copy_jtag_files} -eq 0 ] || cp -f "{runtime.platform.path}"/tools/ide-debug/{build.mcu}.json "{build.source.path}"/debug_custom.json"
-recipe.hooks.postbuild.2.pattern.windows=cmd /c IF {build.copy_jtag_files}==1 COPY /y "{runtime.platform.path}\tools\ide-debug\{build.mcu}.json" "{build.source.path}\debug_custom.json"
+recipe.hooks.postbuild.2.pattern=bash -c "[ {build.copy_jtag_files} -eq 0 ] || cp -f "{runtime.platform.path}"/tools/ide-debug/{build.debugconfig} "{build.source.path}"/debug_custom.json"
+recipe.hooks.postbuild.2.pattern.windows=cmd /c IF {build.copy_jtag_files}==1 COPY /y "{runtime.platform.path}\tools\ide-debug\{build.debugconfig}" "{build.source.path}\debug_custom.json"
 
 # Generate chip.svd
 recipe.hooks.postbuild.3.pattern=bash -c "[ {build.copy_jtag_files} -eq 0 ] || cp -f "{runtime.platform.path}"/tools/ide-debug/svd/{build.mcu}.svd "{build.source.path}"/debug.svd"

--- a/platform.txt
+++ b/platform.txt
@@ -266,7 +266,7 @@ pluggable_monitor.required.serial=builtin:serial-monitor
 debug.executable={build.path}/{build.project_name}.elf
 debug.toolchain=gcc
 debug.toolchain.path={tools.{build.tarch}-esp-elf-gdb.path}/bin/
-debug.toolchain.prefix={build.tarch}-{build.target}-elf
+debug.toolchain.prefix={build.tarch}-{build.target}-elf-
 debug.server=openocd
 debug.server.openocd.script=debug.cfg
 

--- a/platform.txt
+++ b/platform.txt
@@ -181,7 +181,7 @@ recipe.hooks.prebuild.4.pattern.windows=cmd /c IF EXIST "{build.source.path}\boo
 
 # Check if custom build options exist in the sketch folder
 recipe.hooks.prebuild.5.pattern=bash -c "[ ! -f "{build.source.path}"/build_opt.h ] || cp -f "{build.source.path}"/build_opt.h "{build.path}"/build_opt.h"
-recipe.hooks.prebuild.6.pattern=bash -c "[ -f "{build.path}"/build_opt.h ] || touch "{build.path}"/build_opt.h"
+recipe.hooks.prebuild.6.pattern=bash -c "[ -f "{build.path}"/build_opt.h ] || : > "{build.path}"/build_opt.h"
 
 recipe.hooks.prebuild.5.pattern.windows=cmd /c if exist "{build.source.path}\build_opt.h" COPY /y "{build.source.path}\build_opt.h" "{build.path}\build_opt.h"
 recipe.hooks.prebuild.6.pattern.windows=cmd /c if not exist "{build.path}\build_opt.h" type nul > "{build.path}\build_opt.h"

--- a/tools/ide-debug/esp32s3-arduino.json
+++ b/tools/ide-debug/esp32s3-arduino.json
@@ -1,0 +1,18 @@
+{
+	"name":"Arduino on ESP32-S3",
+	"toolchainPrefix":"xtensa-esp32s3-elf",
+	"svdFile":"debug.svd",
+	"request":"attach",
+	"overrideAttachCommands":[
+		"set remote hardware-watchpoint-limit 2",
+		"monitor reset halt",
+		"monitor gdb_sync",
+		"thb setup",
+		"interrupt"
+	],
+	"overrideRestartCommands":[
+		"monitor reset halt",
+		"monitor gdb_sync",
+		"interrupt"
+	]
+}


### PR DESCRIPTION
## Description of Change
This adds debugging capability to the Arduino Nano ESP32 board, by allowing the user to use the Hardware CDC USB peripheral.

* 5a48caa fixes a minor issue with the `build_opt.h` file.
* 4119409 makes the debug configuration file customizable by board, to allow special instructions on the Arduino Nano ESP32
* 53fc5f63 fixes the shared prefix in `platform.txt` (even though it is overwritten by `debug_custom.json`) 
* 1feca59c adds the actual menu and related options to the Nano ESP32. 

## Tests scenarios
Tested with an Arduino Nano ESP32 on Mac, Windows and Linux with a recent Arduino IDE ([nightly builds](https://www.arduino.cc/en/software)). 

## Related links
Includes commits from #8565 and #8566 to avoid conflicts on `boards.txt`. 