### PR TITLE
new industrial boards namino rosso / namino arancio

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -24780,3 +24780,395 @@ gen4-ESP32-S3R8n16.menu.EraseFlash.all=Enabled
 gen4-ESP32-S3R8n16.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+# Namino Rosso
+
+namino_rosso.name=Namino Rosso
+namino_rosso.vid.0=0x303a
+namino_rosso.pid.0=0x1001
+
+namino_rosso.bootloader.tool=esptool_py
+namino_rosso.bootloader.tool.default=esptool_py
+
+namino_rosso.upload.tool=esptool_py
+namino_rosso.upload.tool.default=esptool_py
+namino_rosso.upload.tool.network=esp_ota
+
+namino_rosso.upload.maximum_size=1310720
+namino_rosso.upload.maximum_data_size=327680
+namino_rosso.upload.flags=
+namino_rosso.upload.extra_flags=
+namino_rosso.upload.use_1200bps_touch=true
+namino_rosso.upload.wait_for_upload_port=true
+
+namino_rosso.serial.disableDTR=false
+namino_rosso.serial.disableRTS=false
+
+namino_rosso.build.tarch=xtensa
+namino_rosso.build.bootloader_addr=0x0
+namino_rosso.build.target=esp32s3
+namino_rosso.build.mcu=esp32s3
+namino_rosso.build.core=esp32
+namino_rosso.build.variant=namino_rosso
+namino_rosso.build.board=NAMINO_ROSSO
+
+namino_rosso.build.usb_mode=0
+namino_rosso.build.cdc_on_boot=1
+namino_rosso.build.msc_on_boot=0
+namino_rosso.build.dfu_on_boot=0
+namino_rosso.build.f_cpu=240000000L
+namino_rosso.build.flash_size=4MB
+namino_rosso.build.flash_freq=80m
+namino_rosso.build.flash_mode=dio
+namino_rosso.build.boot=qio
+namino_rosso.build.partitions=default
+namino_rosso.build.defines=
+namino_rosso.build.loop_core=
+namino_rosso.build.event_core=
+namino_rosso.build.flash_type=qio
+namino_rosso.build.psram_type=qspi
+namino_rosso.build.memory_type={build.flash_type}_{build.psram_type}
+
+namino_rosso.menu.LoopCore.1=Core 1
+namino_rosso.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+namino_rosso.menu.LoopCore.0=Core 0
+namino_rosso.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+namino_rosso.menu.EventsCore.1=Core 1
+namino_rosso.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+namino_rosso.menu.EventsCore.0=Core 0
+namino_rosso.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+namino_rosso.menu.USBMode.default=USB-OTG (TinyUSB)
+namino_rosso.menu.USBMode.default.build.usb_mode=0
+namino_rosso.menu.USBMode.hwcdc=Hardware CDC and JTAG
+namino_rosso.menu.USBMode.hwcdc.build.usb_mode=1
+
+namino_rosso.menu.CDCOnBoot.cdc=Enabled
+namino_rosso.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+namino_rosso.menu.CDCOnBoot.default=Disabled
+namino_rosso.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+namino_rosso.menu.MSCOnBoot.default=Disabled
+namino_rosso.menu.MSCOnBoot.default.build.msc_on_boot=0
+namino_rosso.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+namino_rosso.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+namino_rosso.menu.DFUOnBoot.default=Disabled
+namino_rosso.menu.DFUOnBoot.default.build.dfu_on_boot=0
+namino_rosso.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+namino_rosso.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+namino_rosso.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+namino_rosso.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+namino_rosso.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+namino_rosso.menu.UploadMode.default=UART0 / Hardware CDC
+namino_rosso.menu.UploadMode.default.upload.use_1200bps_touch=false
+namino_rosso.menu.UploadMode.default.upload.wait_for_upload_port=false
+
+namino_rosso.menu.PSRAM.enabled=QSPI PSRAM
+namino_rosso.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+namino_rosso.menu.PSRAM.enabled.build.psram_type=qspi
+namino_rosso.menu.PSRAM.disabled=Disabled
+namino_rosso.menu.PSRAM.disabled.build.defines=
+namino_rosso.menu.PSRAM.disabled.build.psram_type=qspi
+namino_rosso.menu.PSRAM.opi=OPI PSRAM
+namino_rosso.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+namino_rosso.menu.PSRAM.opi.build.psram_type=opi
+
+namino_rosso.menu.PartitionScheme.tinyuf2=TinyUF2 4MB (1.3MB APP/960KB FATFS)
+namino_rosso.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader-tinyuf2
+namino_rosso.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions-4MB-tinyuf2
+namino_rosso.menu.PartitionScheme.tinyuf2.upload.maximum_size=1441792
+namino_rosso.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x2d0000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
+namino_rosso.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+namino_rosso.menu.PartitionScheme.default.build.partitions=default
+namino_rosso.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+namino_rosso.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+namino_rosso.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+namino_rosso.menu.PartitionScheme.minimal.build.partitions=minimal
+namino_rosso.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+namino_rosso.menu.PartitionScheme.no_ota.build.partitions=no_ota
+namino_rosso.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+namino_rosso.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+namino_rosso.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+namino_rosso.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+namino_rosso.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+namino_rosso.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+namino_rosso.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+namino_rosso.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+namino_rosso.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+namino_rosso.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+namino_rosso.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+namino_rosso.menu.PartitionScheme.huge_app.build.partitions=huge_app
+namino_rosso.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+namino_rosso.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+namino_rosso.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+namino_rosso.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+namino_rosso.menu.CPUFreq.240=240MHz (WiFi)
+namino_rosso.menu.CPUFreq.240.build.f_cpu=240000000L
+namino_rosso.menu.CPUFreq.160=160MHz (WiFi)
+namino_rosso.menu.CPUFreq.160.build.f_cpu=160000000L
+namino_rosso.menu.CPUFreq.80=80MHz (WiFi)
+namino_rosso.menu.CPUFreq.80.build.f_cpu=80000000L
+namino_rosso.menu.CPUFreq.40=40MHz
+namino_rosso.menu.CPUFreq.40.build.f_cpu=40000000L
+namino_rosso.menu.CPUFreq.20=20MHz
+namino_rosso.menu.CPUFreq.20.build.f_cpu=20000000L
+namino_rosso.menu.CPUFreq.10=10MHz
+namino_rosso.menu.CPUFreq.10.build.f_cpu=10000000L
+
+namino_rosso.menu.FlashMode.qio=QIO 80MHz
+namino_rosso.menu.FlashMode.qio.build.flash_mode=dio
+namino_rosso.menu.FlashMode.qio.build.boot=qio
+namino_rosso.menu.FlashMode.qio.build.boot_freq=80m
+namino_rosso.menu.FlashMode.qio.build.flash_freq=80m
+namino_rosso.menu.FlashMode.qio120=QIO 120MHz
+namino_rosso.menu.FlashMode.qio120.build.flash_mode=dio
+namino_rosso.menu.FlashMode.qio120.build.boot=qio
+namino_rosso.menu.FlashMode.qio120.build.boot_freq=120m
+namino_rosso.menu.FlashMode.qio120.build.flash_freq=80m
+namino_rosso.menu.FlashMode.dio=DIO 80MHz
+namino_rosso.menu.FlashMode.dio.build.flash_mode=dio
+namino_rosso.menu.FlashMode.dio.build.boot=dio
+namino_rosso.menu.FlashMode.dio.build.boot_freq=80m
+namino_rosso.menu.FlashMode.dio.build.flash_freq=80m
+namino_rosso.menu.FlashMode.opi=OPI 80MHz
+namino_rosso.menu.FlashMode.opi.build.flash_mode=dout
+namino_rosso.menu.FlashMode.opi.build.boot=opi
+namino_rosso.menu.FlashMode.opi.build.boot_freq=80m
+namino_rosso.menu.FlashMode.opi.build.flash_freq=80m
+
+namino_rosso.menu.FlashSize.4M=4MB (32Mb)
+namino_rosso.menu.FlashSize.4M.build.flash_size=4MB
+
+namino_rosso.menu.UploadSpeed.921600=921600
+namino_rosso.menu.UploadSpeed.921600.upload.speed=921600
+namino_rosso.menu.UploadSpeed.115200=115200
+namino_rosso.menu.UploadSpeed.115200.upload.speed=115200
+namino_rosso.menu.UploadSpeed.256000.windows=256000
+namino_rosso.menu.UploadSpeed.256000.upload.speed=256000
+namino_rosso.menu.UploadSpeed.230400.windows.upload.speed=256000
+namino_rosso.menu.UploadSpeed.230400=230400
+namino_rosso.menu.UploadSpeed.230400.upload.speed=230400
+namino_rosso.menu.UploadSpeed.460800.linux=460800
+namino_rosso.menu.UploadSpeed.460800.macosx=460800
+namino_rosso.menu.UploadSpeed.460800.upload.speed=460800
+namino_rosso.menu.UploadSpeed.512000.windows=512000
+namino_rosso.menu.UploadSpeed.512000.upload.speed=512000
+
+namino_rosso.menu.DebugLevel.none=None
+namino_rosso.menu.DebugLevel.none.build.code_debug=0
+namino_rosso.menu.DebugLevel.error=Error
+namino_rosso.menu.DebugLevel.error.build.code_debug=1
+namino_rosso.menu.DebugLevel.warn=Warn
+namino_rosso.menu.DebugLevel.warn.build.code_debug=2
+namino_rosso.menu.DebugLevel.info=Info
+namino_rosso.menu.DebugLevel.info.build.code_debug=3
+namino_rosso.menu.DebugLevel.debug=Debug
+namino_rosso.menu.DebugLevel.debug.build.code_debug=4
+namino_rosso.menu.DebugLevel.verbose=Verbose
+namino_rosso.menu.DebugLevel.verbose.build.code_debug=5
+
+namino_rosso.menu.EraseFlash.none=Disabled
+namino_rosso.menu.EraseFlash.none.upload.erase_cmd=
+namino_rosso.menu.EraseFlash.all=Enabled
+namino_rosso.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+# Namino Arancio
+
+namino_arancio.name=Namino Arancio
+namino_arancio.vid.0=0x303a
+namino_arancio.pid.0=0x1001
+
+namino_arancio.bootloader.tool=esptool_py
+namino_arancio.bootloader.tool.default=esptool_py
+
+namino_arancio.upload.tool=esptool_py
+namino_arancio.upload.tool.default=esptool_py
+namino_arancio.upload.tool.network=esp_ota
+
+namino_arancio.upload.maximum_size=1310720
+namino_arancio.upload.maximum_data_size=327680
+namino_arancio.upload.flags=
+namino_arancio.upload.extra_flags=
+namino_arancio.upload.use_1200bps_touch=true
+namino_arancio.upload.wait_for_upload_port=true
+
+namino_arancio.serial.disableDTR=false
+namino_arancio.serial.disableRTS=false
+
+namino_arancio.build.tarch=xtensa
+namino_arancio.build.bootloader_addr=0x0
+namino_arancio.build.target=esp32s3
+namino_arancio.build.mcu=esp32s3
+namino_arancio.build.core=esp32
+namino_arancio.build.variant=namino_arancio
+namino_arancio.build.board=NAMINO_ARANCIO
+
+namino_arancio.build.usb_mode=0
+namino_arancio.build.cdc_on_boot=1
+namino_arancio.build.msc_on_boot=0
+namino_arancio.build.dfu_on_boot=0
+namino_arancio.build.f_cpu=240000000L
+namino_arancio.build.flash_size=4MB
+namino_arancio.build.flash_freq=80m
+namino_arancio.build.flash_mode=dio
+namino_arancio.build.boot=qio
+namino_arancio.build.partitions=default
+namino_arancio.build.defines=
+namino_arancio.build.loop_core=
+namino_arancio.build.event_core=
+namino_arancio.build.flash_type=qio
+namino_arancio.build.psram_type=qspi
+namino_arancio.build.memory_type={build.flash_type}_{build.psram_type}
+
+namino_arancio.menu.LoopCore.1=Core 1
+namino_arancio.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+namino_arancio.menu.LoopCore.0=Core 0
+namino_arancio.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+namino_arancio.menu.EventsCore.1=Core 1
+namino_arancio.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+namino_arancio.menu.EventsCore.0=Core 0
+namino_arancio.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+namino_arancio.menu.USBMode.default=USB-OTG (TinyUSB)
+namino_arancio.menu.USBMode.default.build.usb_mode=0
+namino_arancio.menu.USBMode.hwcdc=Hardware CDC and JTAG
+namino_arancio.menu.USBMode.hwcdc.build.usb_mode=1
+
+namino_arancio.menu.CDCOnBoot.cdc=Enabled
+namino_arancio.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+namino_arancio.menu.CDCOnBoot.default=Disabled
+namino_arancio.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+namino_arancio.menu.MSCOnBoot.default=Disabled
+namino_arancio.menu.MSCOnBoot.default.build.msc_on_boot=0
+namino_arancio.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+namino_arancio.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+namino_arancio.menu.DFUOnBoot.default=Disabled
+namino_arancio.menu.DFUOnBoot.default.build.dfu_on_boot=0
+namino_arancio.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+namino_arancio.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+namino_arancio.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+namino_arancio.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+namino_arancio.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+namino_arancio.menu.UploadMode.default=UART0 / Hardware CDC
+namino_arancio.menu.UploadMode.default.upload.use_1200bps_touch=false
+namino_arancio.menu.UploadMode.default.upload.wait_for_upload_port=false
+
+namino_arancio.menu.PSRAM.enabled=QSPI PSRAM
+namino_arancio.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+namino_arancio.menu.PSRAM.enabled.build.psram_type=qspi
+namino_arancio.menu.PSRAM.disabled=Disabled
+namino_arancio.menu.PSRAM.disabled.build.defines=
+namino_arancio.menu.PSRAM.disabled.build.psram_type=qspi
+namino_arancio.menu.PSRAM.opi=OPI PSRAM
+namino_arancio.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+namino_arancio.menu.PSRAM.opi.build.psram_type=opi
+
+namino_arancio.menu.PartitionScheme.tinyuf2=TinyUF2 4MB (1.3MB APP/960KB FATFS)
+namino_arancio.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader-tinyuf2
+namino_arancio.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions-4MB-tinyuf2
+namino_arancio.menu.PartitionScheme.tinyuf2.upload.maximum_size=1441792
+namino_arancio.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x2d0000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
+namino_arancio.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+namino_arancio.menu.PartitionScheme.default.build.partitions=default
+namino_arancio.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+namino_arancio.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+namino_arancio.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+namino_arancio.menu.PartitionScheme.minimal.build.partitions=minimal
+namino_arancio.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+namino_arancio.menu.PartitionScheme.no_ota.build.partitions=no_ota
+namino_arancio.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+namino_arancio.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+namino_arancio.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+namino_arancio.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+namino_arancio.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+namino_arancio.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+namino_arancio.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+namino_arancio.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+namino_arancio.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+namino_arancio.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+namino_arancio.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+namino_arancio.menu.PartitionScheme.huge_app.build.partitions=huge_app
+namino_arancio.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+namino_arancio.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+namino_arancio.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+namino_arancio.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+namino_arancio.menu.CPUFreq.240=240MHz (WiFi)
+namino_arancio.menu.CPUFreq.240.build.f_cpu=240000000L
+namino_arancio.menu.CPUFreq.160=160MHz (WiFi)
+namino_arancio.menu.CPUFreq.160.build.f_cpu=160000000L
+namino_arancio.menu.CPUFreq.80=80MHz (WiFi)
+namino_arancio.menu.CPUFreq.80.build.f_cpu=80000000L
+namino_arancio.menu.CPUFreq.40=40MHz
+namino_arancio.menu.CPUFreq.40.build.f_cpu=40000000L
+namino_arancio.menu.CPUFreq.20=20MHz
+namino_arancio.menu.CPUFreq.20.build.f_cpu=20000000L
+namino_arancio.menu.CPUFreq.10=10MHz
+namino_arancio.menu.CPUFreq.10.build.f_cpu=10000000L
+
+namino_arancio.menu.FlashMode.qio=QIO 80MHz
+namino_arancio.menu.FlashMode.qio.build.flash_mode=dio
+namino_arancio.menu.FlashMode.qio.build.boot=qio
+namino_arancio.menu.FlashMode.qio.build.boot_freq=80m
+namino_arancio.menu.FlashMode.qio.build.flash_freq=80m
+namino_arancio.menu.FlashMode.qio120=QIO 120MHz
+namino_arancio.menu.FlashMode.qio120.build.flash_mode=dio
+namino_arancio.menu.FlashMode.qio120.build.boot=qio
+namino_arancio.menu.FlashMode.qio120.build.boot_freq=120m
+namino_arancio.menu.FlashMode.qio120.build.flash_freq=80m
+namino_arancio.menu.FlashMode.dio=DIO 80MHz
+namino_arancio.menu.FlashMode.dio.build.flash_mode=dio
+namino_arancio.menu.FlashMode.dio.build.boot=dio
+namino_arancio.menu.FlashMode.dio.build.boot_freq=80m
+namino_arancio.menu.FlashMode.dio.build.flash_freq=80m
+namino_arancio.menu.FlashMode.opi=OPI 80MHz
+namino_arancio.menu.FlashMode.opi.build.flash_mode=dout
+namino_arancio.menu.FlashMode.opi.build.boot=opi
+namino_arancio.menu.FlashMode.opi.build.boot_freq=80m
+namino_arancio.menu.FlashMode.opi.build.flash_freq=80m
+
+namino_arancio.menu.FlashSize.4M=4MB (32Mb)
+namino_arancio.menu.FlashSize.4M.build.flash_size=4MB
+
+namino_arancio.menu.UploadSpeed.921600=921600
+namino_arancio.menu.UploadSpeed.921600.upload.speed=921600
+namino_arancio.menu.UploadSpeed.115200=115200
+namino_arancio.menu.UploadSpeed.115200.upload.speed=115200
+namino_arancio.menu.UploadSpeed.256000.windows=256000
+namino_arancio.menu.UploadSpeed.256000.upload.speed=256000
+namino_arancio.menu.UploadSpeed.230400.windows.upload.speed=256000
+namino_arancio.menu.UploadSpeed.230400=230400
+namino_arancio.menu.UploadSpeed.230400.upload.speed=230400
+namino_arancio.menu.UploadSpeed.460800.linux=460800
+namino_arancio.menu.UploadSpeed.460800.macosx=460800
+namino_arancio.menu.UploadSpeed.460800.upload.speed=460800
+namino_arancio.menu.UploadSpeed.512000.windows=512000
+namino_arancio.menu.UploadSpeed.512000.upload.speed=512000
+
+namino_arancio.menu.DebugLevel.none=None
+namino_arancio.menu.DebugLevel.none.build.code_debug=0
+namino_arancio.menu.DebugLevel.error=Error
+namino_arancio.menu.DebugLevel.error.build.code_debug=1
+namino_arancio.menu.DebugLevel.warn=Warn
+namino_arancio.menu.DebugLevel.warn.build.code_debug=2
+namino_arancio.menu.DebugLevel.info=Info
+namino_arancio.menu.DebugLevel.info.build.code_debug=3
+namino_arancio.menu.DebugLevel.debug=Debug
+namino_arancio.menu.DebugLevel.debug.build.code_debug=4
+namino_arancio.menu.DebugLevel.verbose=Verbose
+namino_arancio.menu.DebugLevel.verbose.build.code_debug=5
+
+namino_arancio.menu.EraseFlash.none=Disabled
+namino_arancio.menu.EraseFlash.none.upload.erase_cmd=
+namino_arancio.menu.EraseFlash.all=Enabled
+namino_arancio.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/variants/namino_arancio/pins_arduino.h
+++ b/variants/namino_arancio/pins_arduino.h
@@ -13,6 +13,12 @@
 
 #define NAMINO_ARANCIO_BOARD
 
+#define NUM_DIGITAL_PINS            SOC_GPIO_PIN_COUNT    // GPIO 0..48
+#define NUM_ANALOG_INPUTS           20                    // GPIO 1..20
+#define EXTERNAL_NUM_INTERRUPTS     NUM_DIGITAL_PINS      // All GPIOs
+#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):NOT_AN_INTERRUPT)
+#define digitalPinHasPWM(p)         (p < NUM_DIGITAL_PINS)
 
 /* Begin Pins on ESP32-S3-WROOM-1U-N4R8 */
 static const uint8_t GPIO4       = 4;

--- a/variants/namino_arancio/pins_arduino.h
+++ b/variants/namino_arancio/pins_arduino.h
@@ -1,0 +1,199 @@
+//
+// Copyright (c) 2023 Namino Team, version: 1.0.19 @ 2023-07-24
+//
+//
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define NAMINO_ARANCIO_BOARD
+
+
+/* Begin Pins on ESP32-S3-WROOM-1U-N4R8 */
+static const uint8_t GPIO4       = 4;
+static const uint8_t GPIO5       = 5;
+static const uint8_t GPIO6       = 6;
+static const uint8_t GPIO7       = 7;
+static const uint8_t GPIO15      = 15;
+static const uint8_t GPIO16      = 16;
+static const uint8_t GPIO17      = 17;
+static const uint8_t GPIO18      = 18;
+static const uint8_t GPIO8       = 8;
+static const uint8_t GPIO19      = 19;
+static const uint8_t GPIO20      = 20;
+static const uint8_t GPIO3       = 3;
+static const uint8_t GPIO46      = 46;
+static const uint8_t GPIO9       = 9;
+static const uint8_t GPIO10      = 10;
+static const uint8_t GPIO11      = 11;
+static const uint8_t GPIO12      = 12;
+static const uint8_t GPIO13      = 13;
+static const uint8_t GPIO14      = 14;
+static const uint8_t GPIO21      = 21;
+static const uint8_t GPIO47      = 47;
+static const uint8_t GPIO48      = 48;
+static const uint8_t GPIO45      = 45;
+static const uint8_t GPIO0       = 0;
+static const uint8_t GPIO35      = 35;
+static const uint8_t GPIO36      = 36;
+static const uint8_t GPIO37      = 37;
+static const uint8_t GPIO38      = 38;
+static const uint8_t GPIO39      = 39;
+static const uint8_t GPIO40      = 40;
+static const uint8_t GPIO41      = 41;
+static const uint8_t GPIO42      = 42;
+static const uint8_t GPIO44      = 44;
+static const uint8_t GPIO43      = 43;
+static const uint8_t GPIO2       = 2;
+static const uint8_t GPIO1       = 1;
+
+static const uint8_t RESET_ADD_ON    = GPIO46;
+static const uint8_t SS              = GPIO10;
+static const uint8_t MOSI            = GPIO11;
+static const uint8_t MISO            = GPIO13;
+static const uint8_t SCK             = GPIO12;
+// SPI SD CARD
+static const uint8_t CS_SDCARD       = GPIO2;
+// prog pins
+static const uint8_t BOOT_MODE       = GPIO47;
+static const uint8_t ISP_TX          = GPIO17;
+static const uint8_t ISP_RX          = GPIO18;
+static const uint8_t NM_RESET        = GPIO48;
+/* End Pins on ESP32-S3-WROOM-1U-N4R8 */
+
+/* Begin Analog Pins on ESP32-S3-WROOM-1U-N4R8 */
+static const uint8_t ADC1_CH3        = GPIO4;
+static const uint8_t ADC1_CH4        = GPIO5;
+static const uint8_t ADC1_CH5        = GPIO6;
+static const uint8_t ADC1_CH6        = GPIO7;
+static const uint8_t ADC2_CH4        = GPIO15;
+static const uint8_t ADC2_CH5        = GPIO16;
+static const uint8_t ADC2_CH6        = GPIO17;
+static const uint8_t ADC2_CH7        = GPIO18;
+static const uint8_t ADC1_CH7        = GPIO8;
+static const uint8_t ADC2_CH8        = GPIO19;
+static const uint8_t ADC2_CH9        = GPIO20;
+static const uint8_t ADC1_CH2        = GPIO3;
+static const uint8_t ADC1_CH8        = GPIO9;
+static const uint8_t ADC1_CH9        = GPIO10;
+static const uint8_t ADC2_CH0        = GPIO11;
+static const uint8_t ADC2_CH1        = GPIO12;
+static const uint8_t ADC2_CH2        = GPIO13;
+static const uint8_t ADC2_CH3        = GPIO14;
+static const uint8_t ADC1_CH1        = GPIO2;
+static const uint8_t ADC1_CH0        = GPIO1;
+/* End Analog Pins on ESP32-S3-WROOM-1U-N4R8 */
+
+/* Begin Touch Pins on ESP32-S3-WROOM-1U-N4R8 */
+static const uint8_t TOUCH4          = GPIO4;
+static const uint8_t TOUCH5          = GPIO5;
+static const uint8_t TOUCH6          = GPIO6;
+static const uint8_t TOUCH7          = GPIO7;
+static const uint8_t TOUCH8          = GPIO8;
+static const uint8_t TOUCH3          = GPIO3;
+static const uint8_t TOUCH9          = GPIO9;
+static const uint8_t TOUCH10         = GPIO10;
+static const uint8_t TOUCH11         = GPIO11;
+static const uint8_t TOUCH12         = GPIO12;
+static const uint8_t TOUCH13         = GPIO13;
+static const uint8_t TOUCH14         = GPIO14;
+static const uint8_t TOUCH2          = GPIO2;
+static const uint8_t TOUCH1          = GPIO1;
+/* End Touch Pins on ESP32-S3-WROOM-1U-N4R8 */
+
+static const uint8_t TX              = GPIO17;
+static const uint8_t RX              = GPIO18;
+
+static const uint8_t SDA                     = GPIO1;
+static const uint8_t SCL                     = GPIO0;
+static const uint8_t NAMINO_ARANCIO_I2C_SDA  = SDA;
+static const uint8_t NAMINO_ARANCIO_I2C_SCL  = SCL;
+static const uint8_t NM_I2C_SDA              = SDA;
+static const uint8_t NM_I2C_SCL              = SCL;
+
+static const uint8_t A0              = ADC1_CH0;
+static const uint8_t A1              = ADC1_CH1;
+static const uint8_t A2              = ADC1_CH2;
+static const uint8_t A3              = ADC1_CH3;
+static const uint8_t A4              = ADC1_CH4;
+static const uint8_t A5              = ADC1_CH5;
+static const uint8_t A6              = ADC1_CH6;
+static const uint8_t A7              = ADC1_CH7;
+static const uint8_t A8              = ADC2_CH0;
+static const uint8_t A9              = ADC2_CH1;
+static const uint8_t A10             = ADC2_CH2;
+static const uint8_t A11             = ADC2_CH3;
+static const uint8_t A12             = ADC2_CH4;
+static const uint8_t A13             = ADC2_CH5;
+static const uint8_t A14             = ADC2_CH6;
+static const uint8_t A15             = ADC2_CH7;
+
+static const uint8_t DAC1            = 0;
+static const uint8_t DAC2            = 0;
+
+/* Begin Arduino naming */
+static const uint8_t RESET_ARDUINO   = GPIO46;
+static const uint8_t PC0             = GPIO3;
+static const uint8_t PC1             = GPIO4;
+static const uint8_t PC2             = GPIO5;
+static const uint8_t PC3             = GPIO6;
+static const uint8_t PC4             = GPIO7;
+static const uint8_t PC5             = GPIO8;
+static const uint8_t PB5             = GPIO35;
+static const uint8_t PB4             = GPIO36;
+static const uint8_t PB3             = GPIO37;
+static const uint8_t PB2             = GPIO38;
+static const uint8_t PB1             = GPIO39;
+static const uint8_t PB0             = GPIO40;
+static const uint8_t PD7             = GPIO41;
+static const uint8_t PD6             = GPIO42;
+static const uint8_t PD5             = GPIO21;
+static const uint8_t PD4             = GPIO16;
+static const uint8_t PD3             = GPIO14;
+static const uint8_t PD2             = GPIO9;
+static const uint8_t PD1             = GPIO17;
+static const uint8_t PD0             = GPIO18;
+/* End Arduino naming */
+
+/* Begin alternate naming */
+static const uint8_t J1_io0          = SCL;
+
+static const uint8_t J2_35           = PB5;
+static const uint8_t J2_36           = PB4;
+static const uint8_t J2_37           = PB3;
+static const uint8_t J2_38           = PB2;
+static const uint8_t J2_39           = PB1;
+static const uint8_t J2_40           = PB0;
+
+static const uint8_t J3_io8          = PD7;
+static const uint8_t J3_7            = PD6;
+static const uint8_t J3_21           = PD5;
+static const uint8_t J3_16           = PD4;
+static const uint8_t J3_14           = PD3;
+static const uint8_t J3_9            = PD2;  
+static const uint8_t J3_17           = TX;
+static const uint8_t J3_18           = RX;
+
+static const uint8_t J4_cs_io2       = CS_SDCARD;
+static const uint8_t J4_sclk         = SCK;
+static const uint8_t J4_mosi         = MOSI;
+static const uint8_t J4_miso         = MISO;
+
+static const uint8_t J9_io3          = PC0;
+static const uint8_t J9_4            = PC1;
+static const uint8_t J9_5            = PC2;
+static const uint8_t J9_6            = PC3;
+static const uint8_t J9_7            = PC4;
+static const uint8_t J9_8            = PC5;
+
+static const uint8_t J10_enc_A       = 0;
+static const uint8_t J10_enc_B       = 0;
+static const uint8_t J10_sw          = 0;
+/* End alternate naming */
+
+#endif /* Pins_Arduino_h */

--- a/variants/namino_rosso/pins_arduino.h
+++ b/variants/namino_rosso/pins_arduino.h
@@ -1,0 +1,199 @@
+//
+// Copyright (c) 2023 Namino Team, version: 1.0.19 @ 2023-07-24
+//
+//
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define NAMINO_ROSSO_BOARD
+
+
+/* Begin Pins on ESP32-S3-WROOM-1U-N4R8 */
+static const uint8_t GPIO4       = 4;
+static const uint8_t GPIO5       = 5;
+static const uint8_t GPIO6       = 6;
+static const uint8_t GPIO7       = 7;
+static const uint8_t GPIO15      = 15;
+static const uint8_t GPIO16      = 16;
+static const uint8_t GPIO17      = 17;
+static const uint8_t GPIO18      = 18;
+static const uint8_t GPIO8       = 8;
+static const uint8_t GPIO19      = 19;
+static const uint8_t GPIO20      = 20;
+static const uint8_t GPIO3       = 3;
+static const uint8_t GPIO46      = 46;
+static const uint8_t GPIO9       = 9;
+static const uint8_t GPIO10      = 10;
+static const uint8_t GPIO11      = 11;
+static const uint8_t GPIO12      = 12;
+static const uint8_t GPIO13      = 13;
+static const uint8_t GPIO14      = 14;
+static const uint8_t GPIO21      = 21;
+static const uint8_t GPIO47      = 47;
+static const uint8_t GPIO48      = 48;
+static const uint8_t GPIO45      = 45;
+static const uint8_t GPIO0       = 0;
+static const uint8_t GPIO35      = 35;
+static const uint8_t GPIO36      = 36;
+static const uint8_t GPIO37      = 37;
+static const uint8_t GPIO38      = 38;
+static const uint8_t GPIO39      = 39;
+static const uint8_t GPIO40      = 40;
+static const uint8_t GPIO41      = 41;
+static const uint8_t GPIO42      = 42;
+static const uint8_t GPIO44      = 44;
+static const uint8_t GPIO43      = 43;
+static const uint8_t GPIO2       = 2;
+static const uint8_t GPIO1       = 1;
+
+static const uint8_t RESET_ADD_ON    = GPIO46;
+static const uint8_t SS              = GPIO10;
+static const uint8_t MOSI            = GPIO11;
+static const uint8_t MISO            = GPIO13;
+static const uint8_t SCK             = GPIO12;
+// SPI SD CARD
+static const uint8_t CS_SDCARD       = GPIO2;
+// prog pins
+static const uint8_t BOOT_MODE       = GPIO47;
+static const uint8_t ISP_TX          = GPIO17;
+static const uint8_t ISP_RX          = GPIO18;
+static const uint8_t NM_RESET        = GPIO48;
+/* End Pins on ESP32-S3-WROOM-1U-N4R8 */
+
+/* Begin Analog Pins on ESP32-S3-WROOM-1U-N4R8 */
+static const uint8_t ADC1_CH3        = GPIO4;
+static const uint8_t ADC1_CH4        = GPIO5;
+static const uint8_t ADC1_CH5        = GPIO6;
+static const uint8_t ADC1_CH6        = GPIO7;
+static const uint8_t ADC2_CH4        = GPIO15;
+static const uint8_t ADC2_CH5        = GPIO16;
+static const uint8_t ADC2_CH6        = GPIO17;
+static const uint8_t ADC2_CH7        = GPIO18;
+static const uint8_t ADC1_CH7        = GPIO8;
+static const uint8_t ADC2_CH8        = GPIO19;
+static const uint8_t ADC2_CH9        = GPIO20;
+static const uint8_t ADC1_CH2        = GPIO3;
+static const uint8_t ADC1_CH8        = GPIO9;
+static const uint8_t ADC1_CH9        = GPIO10;
+static const uint8_t ADC2_CH0        = GPIO11;
+static const uint8_t ADC2_CH1        = GPIO12;
+static const uint8_t ADC2_CH2        = GPIO13;
+static const uint8_t ADC2_CH3        = GPIO14;
+static const uint8_t ADC1_CH1        = GPIO2;
+static const uint8_t ADC1_CH0        = GPIO1;
+/* End Analog Pins on ESP32-S3-WROOM-1U-N4R8 */
+
+/* Begin Touch Pins on ESP32-S3-WROOM-1U-N4R8 */
+static const uint8_t TOUCH4          = GPIO4;
+static const uint8_t TOUCH5          = GPIO5;
+static const uint8_t TOUCH6          = GPIO6;
+static const uint8_t TOUCH7          = GPIO7;
+static const uint8_t TOUCH8          = GPIO8;
+static const uint8_t TOUCH3          = GPIO3;
+static const uint8_t TOUCH9          = GPIO9;
+static const uint8_t TOUCH10         = GPIO10;
+static const uint8_t TOUCH11         = GPIO11;
+static const uint8_t TOUCH12         = GPIO12;
+static const uint8_t TOUCH13         = GPIO13;
+static const uint8_t TOUCH14         = GPIO14;
+static const uint8_t TOUCH2          = GPIO2;
+static const uint8_t TOUCH1          = GPIO1;
+/* End Touch Pins on ESP32-S3-WROOM-1U-N4R8 */
+
+static const uint8_t TX              = GPIO17;
+static const uint8_t RX              = GPIO18;
+
+static const uint8_t SDA                     = GPIO1;
+static const uint8_t SCL                     = GPIO0;
+static const uint8_t NAMINO_ARANCIO_I2C_SDA  = SDA;
+static const uint8_t NAMINO_ARANCIO_I2C_SCL  = SCL;
+static const uint8_t NM_I2C_SDA              = SDA;
+static const uint8_t NM_I2C_SCL              = SCL;
+
+static const uint8_t A0              = ADC1_CH0;
+static const uint8_t A1              = ADC1_CH1;
+static const uint8_t A2              = ADC1_CH2;
+static const uint8_t A3              = ADC1_CH3;
+static const uint8_t A4              = ADC1_CH4;
+static const uint8_t A5              = ADC1_CH5;
+static const uint8_t A6              = ADC1_CH6;
+static const uint8_t A7              = ADC1_CH7;
+static const uint8_t A8              = ADC2_CH0;
+static const uint8_t A9              = ADC2_CH1;
+static const uint8_t A10             = ADC2_CH2;
+static const uint8_t A11             = ADC2_CH3;
+static const uint8_t A12             = ADC2_CH4;
+static const uint8_t A13             = ADC2_CH5;
+static const uint8_t A14             = ADC2_CH6;
+static const uint8_t A15             = ADC2_CH7;
+
+static const uint8_t DAC1            = 0;
+static const uint8_t DAC2            = 0;
+
+/* Begin Arduino naming */
+static const uint8_t RESET_ARDUINO   = GPIO46;
+static const uint8_t PC0             = GPIO3;
+static const uint8_t PC1             = GPIO4;
+static const uint8_t PC2             = GPIO5;
+static const uint8_t PC3             = GPIO6;
+static const uint8_t PC4             = GPIO7;
+static const uint8_t PC5             = GPIO8;
+static const uint8_t PB5             = GPIO35;
+static const uint8_t PB4             = GPIO36;
+static const uint8_t PB3             = GPIO37;
+static const uint8_t PB2             = GPIO38;
+static const uint8_t PB1             = GPIO39;
+static const uint8_t PB0             = GPIO40;
+static const uint8_t PD7             = GPIO41;
+static const uint8_t PD6             = GPIO42;
+static const uint8_t PD5             = GPIO21;
+static const uint8_t PD4             = GPIO16;
+static const uint8_t PD3             = GPIO14;
+static const uint8_t PD2             = GPIO9;
+static const uint8_t PD1             = GPIO17;
+static const uint8_t PD0             = GPIO18;
+/* End Arduino naming */
+
+/* Begin alternate naming */
+static const uint8_t J1_io0          = SCL;
+
+static const uint8_t J2_35           = PB5;
+static const uint8_t J2_36           = PB4;
+static const uint8_t J2_37           = PB3;
+static const uint8_t J2_38           = PB2;
+static const uint8_t J2_39           = PB1;
+static const uint8_t J2_40           = PB0;
+
+static const uint8_t J3_io8          = PD7;
+static const uint8_t J3_7            = PD6;
+static const uint8_t J3_21           = PD5;
+static const uint8_t J3_16           = PD4;
+static const uint8_t J3_14           = PD3;
+static const uint8_t J3_9            = PD2;  
+static const uint8_t J3_17           = TX;
+static const uint8_t J3_18           = RX;
+
+static const uint8_t J4_cs_io2       = CS_SDCARD;
+static const uint8_t J4_sclk         = SCK;
+static const uint8_t J4_mosi         = MOSI;
+static const uint8_t J4_miso         = MISO;
+
+static const uint8_t J9_io3          = PC0;
+static const uint8_t J9_4            = PC1;
+static const uint8_t J9_5            = PC2;
+static const uint8_t J9_6            = PC3;
+static const uint8_t J9_7            = PC4;
+static const uint8_t J9_8            = PC5;
+
+static const uint8_t J10_enc_A       = 0;
+static const uint8_t J10_enc_B       = 0;
+static const uint8_t J10_sw          = 0;
+/* End alternate naming */
+
+#endif /* Pins_Arduino_h */

--- a/variants/namino_rosso/pins_arduino.h
+++ b/variants/namino_rosso/pins_arduino.h
@@ -13,6 +13,12 @@
 
 #define NAMINO_ROSSO_BOARD
 
+#define NUM_DIGITAL_PINS            SOC_GPIO_PIN_COUNT    // GPIO 0..48
+#define NUM_ANALOG_INPUTS           20                    // GPIO 1..20
+#define EXTERNAL_NUM_INTERRUPTS     NUM_DIGITAL_PINS      // All GPIOs
+#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):NOT_AN_INTERRUPT)
+#define digitalPinHasPWM(p)         (p < NUM_DIGITAL_PINS)
 
 /* Begin Pins on ESP32-S3-WROOM-1U-N4R8 */
 static const uint8_t GPIO4       = 4;


### PR DESCRIPTION
Namino Boards: Namino combines the industrial world with the world of makers by making digital analog inputs, outputs and compatible Arduino shields available on the same board.

CPU: ESP32-S3-WROOM-1U-N4R8
```

NAMINO ROSSO provides the following input/output lines:
8 PNP digital inputs (up to 24Vdc)
1 knob input and button
8 PNP digital outputs (up to 24Vdc) of which 1 for stepper motor command with total current 200mA
1 SPDT relay output of 5A
8 single ended analog inputs (0-10V or 0-20mA) or 4 thermometric (NTC, PTC, PT1000) or 4 thermocouples (J, K, T) or 2 load cells, software configurable
1 analog output jumper configurable: 0-10V or 0-20mA
ARDUINO UNO compatible shield interface 


NAMINO ARANCIO provides the following input/output lines:
8 PNP digital inputs (up to 24Vdc)
1 knob input and button
8 PNP digital outputs (up to 24Vdc) of which 1 for stepper motor command with total current 200mA
1 SPDT relay output of 5A
4 analog inputs (0-10V or 0-20mA) software configurable
1 input for NTC (10kΩ) or board temperature reading
1 analog output jumper configurable: 0-10V or 0-20mA
ARDUINO UNO compatible shield interface 
```

## Related links
[namino main information site](https://namino.cc/)
[namino rosso board](https://namino.cc/boards/namino-rosso/)
[namino arancio board](https://namino.cc/boards/namino-arancio/)