### PR TITLE
GPIO - make pin mode output_open_drain state readable

### DIFF
--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -51,7 +51,7 @@ extern "C" {
 #define PULLDOWN          0x08
 #define INPUT_PULLDOWN    0x09
 #define OPEN_DRAIN        0x10
-#define OUTPUT_OPEN_DRAIN 0x12
+#define OUTPUT_OPEN_DRAIN 0x13
 #define ANALOG            0xC0
 
 //Interrupt Modes


### PR DESCRIPTION
## Description of Change
Changed gpio `OUTPUT_OPEN_DRAIN` mode to act as input/output the same way, it have been changed for `OUTPUT` mode to have pin state readable by `digitalRead()`

## Tests scenarios
Tested just on esp32s3, should not have any impact.

## Related links
Close #8590 
Close #7022
