### PR TITLE
Disable Ethernet library if CONFIG_ETH_ENABLED not defined in sdkconfig.h

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -18,6 +18,7 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "sdkconfig.h"
 #ifdef CONFIG_ETH_ENABLED
 
 #include "ETH.h"

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -18,6 +18,8 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef CONFIG_ETH_ENABLED
+
 #include "ETH.h"
 #include "esp_system.h"
 #if ESP_IDF_VERSION_MAJOR > 3
@@ -601,3 +603,5 @@ String ETHClass::macAddress(void)
 }
 
 ETHClass ETH;
+
+#endif  //  CONFIG_ETH_ENABLED

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -21,6 +21,8 @@
 #ifndef _ETH_H_
 #define _ETH_H_
 
+#ifdef CONFIG_ETH_ENABLED
+
 #include "WiFi.h"
 #include "esp_system.h"
 #include "esp_eth.h"
@@ -105,5 +107,7 @@ class ETHClass {
 };
 
 extern ETHClass ETH;
+
+#endif  //  CONFIG_ETH_ENABLED
 
 #endif /* _ETH_H_ */

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -21,6 +21,7 @@
 #ifndef _ETH_H_
 #define _ETH_H_
 
+#include "sdkconfig.h"
 #ifdef CONFIG_ETH_ENABLED
 
 #include "WiFi.h"

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -426,6 +426,7 @@ static void _arduino_event_cb(void* arg, esp_event_base_t event_base, int32_t ev
 	/*
 	 * ETH
 	 * */
+#ifdef CONFIG_ETH_ENABLED
 	} else if (event_base == ETH_EVENT && event_id == ETHERNET_EVENT_CONNECTED) {
 		log_v("Ethernet Link Up");
     	arduino_event.event_id = ARDUINO_EVENT_ETH_CONNECTED;
@@ -446,6 +447,7 @@ static void _arduino_event_cb(void* arg, esp_event_base_t event_base, int32_t ev
     	#endif
         arduino_event.event_id = ARDUINO_EVENT_ETH_GOT_IP;
     	memcpy(&arduino_event.event_info.got_ip, event_data, sizeof(ip_event_got_ip_t));
+#endif  //  CONFIG_ETH_ENABLED
 
 	/*
 	 * IPv6
@@ -594,10 +596,12 @@ static bool _start_network_event_task(){
         return false;
     }
 
+#ifdef CONFIG_ETH_ENABLED
     if(esp_event_handler_instance_register(ETH_EVENT, ESP_EVENT_ANY_ID, &_arduino_event_cb, NULL, NULL)){
         log_e("event_handler_instance_register for ETH_EVENT Failed!");
         return false;
     }
+#endif  //  CONFIG_ETH_ENABLED
 
     if(esp_event_handler_instance_register(WIFI_PROV_EVENT, ESP_EVENT_ANY_ID, &_arduino_event_cb, NULL, NULL)){
         log_e("event_handler_instance_register for WIFI_PROV_EVENT Failed!");

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -92,7 +92,9 @@ typedef union {
 	ip_event_got_ip_t got_ip;
 	ip_event_got_ip6_t got_ip6;
 	smartconfig_event_got_ssid_pswd_t sc_got_ssid_pswd;
+#ifdef CONFIG_ETH_ENABLED
 	esp_eth_handle_t eth_connected;
+#endif
 	wifi_sta_config_t prov_cred_recv;
 	wifi_prov_sta_fail_reason_t prov_fail_reason;
 } arduino_event_info_t;


### PR DESCRIPTION
## Description of Change
When used in Platform IO in a combined `arduino, espidf` platform setting, and disabling ETH component, the ETH library generates a lot of error messages

## Tests scenarios
Running previously running firmware that did not use Ethernet, but does use WiFi and BLE
Tested on esp32 pico d4 with Arduino 2.0.9, IDF 4.4.4
