### PR TITLE
S3 gpio48

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -168,7 +168,7 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
     static bool interrupt_initialized = false;
 
     // makes sure that pin -1 (255) will never work -- this follows Arduino standard
-    if (pin >= NUM_DIGITAL_PINS) return;
+    if (pin >= SOC_GPIO_PIN_COUNT) return;
 
     if(!interrupt_initialized) {
     	esp_err_t err = gpio_install_isr_service((int)ARDUINO_ISR_FLAG);

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -167,6 +167,9 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
 {
     static bool interrupt_initialized = false;
 
+    // makes sure that pin -1 (255) will never work -- this follows Arduino standard
+    if (pin >= NUM_DIGITAL_PINS) return;
+
     if(!interrupt_initialized) {
     	esp_err_t err = gpio_install_isr_service((int)ARDUINO_ISR_FLAG);
     	interrupt_initialized = (err == ESP_OK) || (err == ESP_ERR_INVALID_STATE);

--- a/variants/Bee_Data_Logger/pins_arduino.h
+++ b/variants/Bee_Data_Logger/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       7
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/Bee_Motion/pins_arduino.h
+++ b/variants/Bee_Motion/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       12
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/Bee_Motion_S3/pins_arduino.h
+++ b/variants/Bee_Motion_S3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       11
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/Bee_S3/pins_arduino.h
+++ b/variants/Bee_S3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       8
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/Edgebox-ESP-100/pins_arduino.h
+++ b/variants/Edgebox-ESP-100/pins_arduino.h
@@ -8,7 +8,7 @@
 #define NUM_ANALOG_INPUTS       2
 
 #define analogInputToDigitalPin(p)  (((p)<2)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<34)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
 //Programming and Debugging Port

--- a/variants/Nebula_S3/pins_arduino.h
+++ b/variants/Nebula_S3/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_ANALOG_INPUTS       6
 
 #define analogInputToDigitalPin(p)  (((p)<6)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<20)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 20)
 
 

--- a/variants/XIAO_ESP32S3/pins_arduino.h
+++ b/variants/XIAO_ESP32S3/pins_arduino.h
@@ -7,8 +7,8 @@
 #define USB_VID 0x2886
 #define USB_PID 0x0056
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
+#define EXTERNAL_NUM_INTERRUPTS 49
+#define NUM_DIGITAL_PINS        49
 #define NUM_ANALOG_INPUTS       20
 
 static const uint8_t LED_BUILTIN = 21;

--- a/variants/adafruit_feather_esp32s3/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define LED_BUILTIN         13

--- a/variants/adafruit_feather_esp32s3_nopsram/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_nopsram/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define LED_BUILTIN         13

--- a/variants/adafruit_feather_esp32s3_reversetft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_reversetft/pins_arduino.h
@@ -16,7 +16,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define LED_BUILTIN     13

--- a/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
@@ -16,7 +16,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define LED_BUILTIN     13

--- a/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
+++ b/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
@@ -10,7 +10,7 @@
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
 #define EXTERNAL_NUM_INTERRUPTS 49
-#define NUM_DIGITAL_PINS        48
+#define NUM_DIGITAL_PINS        49
 #define NUM_ANALOG_INPUTS       6
 
 #define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)

--- a/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
+++ b/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
@@ -9,7 +9,7 @@
 #define USB_PRODUCT        "MatrixPortal ESP32-S3"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
+#define EXTERNAL_NUM_INTERRUPTS 49
 #define NUM_DIGITAL_PINS        48
 #define NUM_ANALOG_INPUTS       6
 

--- a/variants/adafruit_metro_esp32s3/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define LED_BUILTIN     13

--- a/variants/adafruit_qtpy_esp32s3_n4r2/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s3_n4r2/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define PIN_NEOPIXEL        39

--- a/variants/adafruit_qtpy_esp32s3_nopsram/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s3_nopsram/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define PIN_NEOPIXEL        39

--- a/variants/bpi_leaf_s3/pins_arduino.h
+++ b/variants/bpi_leaf_s3/pins_arduino.h
@@ -24,7 +24,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define RGB_BRIGHTNESS 25
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/crabik_slot_esp32_s3/pins_arduino.h
+++ b/variants/crabik_slot_esp32_s3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = 21;

--- a/variants/cytron_maker_feather_aiot_s3/pins_arduino.h
+++ b/variants/cytron_maker_feather_aiot_s3/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_ANALOG_INPUTS       12
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 

--- a/variants/deneyapkart1Av2/pins_arduino.h
+++ b/variants/deneyapkart1Av2/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_ANALOG_INPUTS	20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;

--- a/variants/deneyapmini/pins_arduino.h
+++ b/variants/deneyapmini/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = 35;

--- a/variants/deneyapminiv2/pins_arduino.h
+++ b/variants/deneyapminiv2/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+33;

--- a/variants/dfrobot_firebeetle2_esp32s3/pins_arduino.h
+++ b/variants/dfrobot_firebeetle2_esp32s3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 

--- a/variants/dfrobot_romeo_esp32s3/pins_arduino.h
+++ b/variants/dfrobot_romeo_esp32s3/pins_arduino.h
@@ -10,7 +10,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 

--- a/variants/esp32_s3r8n16/pins_arduino.h
+++ b/variants/esp32_s3r8n16/pins_arduino.h
@@ -15,7 +15,7 @@
 #define NUM_ANALOG_INPUTS       20 
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/esp32s3/pins_arduino.h
+++ b/variants/esp32s3/pins_arduino.h
@@ -21,7 +21,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/esp32s3box/pins_arduino.h
+++ b/variants/esp32s3box/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/esp32s3camlcd/pins_arduino.h
+++ b/variants/esp32s3camlcd/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/esp32s3usbotg/pins_arduino.h
+++ b/variants/esp32s3usbotg/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/heltec_wifi_kit_32_v3/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32_v3/pins_arduino.h
@@ -12,7 +12,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = 35;

--- a/variants/heltec_wifi_lora_32_V3/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V3/pins_arduino.h
@@ -25,7 +25,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/heltec_wireless_stick_lite_v3/pins_arduino.h
+++ b/variants/heltec_wireless_stick_lite_v3/pins_arduino.h
@@ -12,7 +12,7 @@
 #define NUM_ANALOG_INPUTS       15
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
 static const uint8_t LED_BUILTIN = 35;

--- a/variants/lilygo_t_display_s3/pins_arduino.h
+++ b/variants/lilygo_t_display_s3/pins_arduino.h
@@ -12,7 +12,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t BUTTON_1 = 0;

--- a/variants/lionbits3/pins_arduino.h
+++ b/variants/lionbits3/pins_arduino.h
@@ -8,7 +8,7 @@
 #define NUM_ANALOG_INPUTS 16
 
 #define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
+#define digitalPinToInterrupt(p) (((p) < 49) ? (p) : -1)
 #define digitalPinHasPWM(p) (p < 34)
 
 static const uint8_t LED_BUILTIN = 0;  //GPIO0, 

--- a/variants/lolin_s3/pins_arduino.h
+++ b/variants/lolin_s3/pins_arduino.h
@@ -18,7 +18,7 @@ static const uint8_t LED_BUILTIN = 38;
 #define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/lolin_s3_mini/pins_arduino.h
+++ b/variants/lolin_s3_mini/pins_arduino.h
@@ -18,7 +18,7 @@ static const uint8_t LED_BUILTIN = 47;
 #define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/lolin_s3_pro/pins_arduino.h
+++ b/variants/lolin_s3_pro/pins_arduino.h
@@ -18,7 +18,7 @@ static const uint8_t LED_BUILTIN = 38;
 #define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/m5stack_atoms3/pins_arduino.h
+++ b/variants/m5stack_atoms3/pins_arduino.h
@@ -22,7 +22,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + 48;
 
 #define analogInputToDigitalPin(p) \
     (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
+#define digitalPinToInterrupt(p) (((p) < 49) ? (p) : -1)
 #define digitalPinHasPWM(p)      (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/m5stack_cores3/pins_arduino.h
+++ b/variants/m5stack_cores3/pins_arduino.h
@@ -22,7 +22,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + 48;
 
 #define analogInputToDigitalPin(p) \
     (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
+#define digitalPinToInterrupt(p) (((p) < 49) ? (p) : -1)
 #define digitalPinHasPWM(p)      (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/m5stack_stamp_s3/pins_arduino.h
+++ b/variants/m5stack_stamp_s3/pins_arduino.h
@@ -13,7 +13,7 @@
 
 #define analogInputToDigitalPin(p) \
     (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
+#define digitalPinToInterrupt(p) (((p) < 49) ? (p) : -1)
 #define digitalPinHasPWM(p)      (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/nora_w10/pins_arduino.h
+++ b/variants/nora_w10/pins_arduino.h
@@ -12,7 +12,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 // The pin assignments in this file are based on u-blox EVK-NORA-W1, a Arduino compatible board.

--- a/variants/redpill_esp32s3/pins_arduino.h
+++ b/variants/redpill_esp32s3/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t LED_BUILTIN = 3;

--- a/variants/tamc_termod_s3/pins_arduino.h
+++ b/variants/tamc_termod_s3/pins_arduino.h
@@ -21,7 +21,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define RGB_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/um_feathers3/pins_arduino.h
+++ b/variants/um_feathers3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       13
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/um_nanos3/pins_arduino.h
+++ b/variants/um_nanos3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       9
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/um_pros3/pins_arduino.h
+++ b/variants/um_pros3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       14
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/um_tinys3/pins_arduino.h
+++ b/variants/um_tinys3/pins_arduino.h
@@ -14,7 +14,7 @@
 #define NUM_ANALOG_INPUTS       9
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;

--- a/variants/unphone8/pins_arduino.h
+++ b/variants/unphone8/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define LED_BUILTIN         13

--- a/variants/unphone9/pins_arduino.h
+++ b/variants/unphone9/pins_arduino.h
@@ -11,7 +11,7 @@
 #define NUM_ANALOG_INPUTS       20
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 #define LED_BUILTIN         13

--- a/variants/wifiduino32s3/pins_arduino.h
+++ b/variants/wifiduino32s3/pins_arduino.h
@@ -21,7 +21,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define LED_BRIGHTNESS 64
 
 #define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinToInterrupt(p)    (((p)<49)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 45;


### PR DESCRIPTION
## Description of Change
Fixes an issue with `attachInterrupt(digitalPinToInterrupt(48))` that prevented it from setting GPIO48 as Interruptable.

## Tests scenarios
Only using ESP32-S3, as described in #8560  

## Related links
Fixes #8560 

