### PR TITLE
Sets the UART pins internally

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -568,10 +568,10 @@ bool HardwareSerial::setPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t r
     // uartSetPins() checks if pins are valid for each function and for the SoC
     bool retCode = uartSetPins(_uart, rxPin, txPin, ctsPin, rtsPin);
     if (retCode) {
-        _txPin = _txPin >= 0 ? txPin : _txPin;
-        _rxPin = _rxPin >= 0 ? rxPin : _rxPin;
-        _rtsPin = _rtsPin >= 0 ? rtsPin : _rtsPin;
-        _ctsPin = _ctsPin >= 0 ? ctsPin : _ctsPin;
+        _txPin = txPin >= 0 ? txPin : _txPin;
+        _rxPin = rxPin >= 0 ? rxPin : _rxPin;
+        _rtsPin = rtsPin >= 0 ? rtsPin : _rtsPin;
+        _ctsPin = ctsPin >= 0 ? ctsPin : _ctsPin;
     } else {
         log_e("Error when setting Serial port Pins. Invalid Pin.\n");
     }

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -568,6 +568,12 @@ bool HardwareSerial::setPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t r
     // uartSetPins() checks if pins are valid for each function and for the SoC
     bool retCode = uartSetPins(_uart, rxPin, txPin, ctsPin, rtsPin);
     if (retCode) {
+	// detach previous attached UART pins if not set as same as before
+	if (_rxPin > 0 && _rxPin != rxPin) uartDetachPins(_uart, _rxPin, -1, -1, -1);
+	if (_txPin > 0 && _txPin != txPin) uartDetachPins(_uart, -1, _txPin, -1, -1);
+	if (_ctsPin > 0 && _ctsPin != ctsPin) uartDetachPins(_uart, -1, -1, _ctsPin, -1);
+	if (_rtsPin > 0 && _rtsPin != rtsPin) uartDetachPins(_uart, -1, -1, -1, _rtsPin);
+	// set new pins for a future end() or a setPins()    
         _txPin = txPin >= 0 ? txPin : _txPin;
         _rxPin = rxPin >= 0 ? rxPin : _rxPin;
         _rtsPin = rtsPin >= 0 ? rtsPin : _rtsPin;

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -569,10 +569,10 @@ bool HardwareSerial::setPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t r
     bool retCode = uartSetPins(_uart, rxPin, txPin, ctsPin, rtsPin);
     if (retCode) {
 	// detach previous attached UART pins if not set as same as before
-	if (_rxPin > 0 && _rxPin != rxPin) uartDetachPins(_uart, _rxPin, -1, -1, -1);
-	if (_txPin > 0 && _txPin != txPin) uartDetachPins(_uart, -1, _txPin, -1, -1);
-	if (_ctsPin > 0 && _ctsPin != ctsPin) uartDetachPins(_uart, -1, -1, _ctsPin, -1);
-	if (_rtsPin > 0 && _rtsPin != rtsPin) uartDetachPins(_uart, -1, -1, -1, _rtsPin);
+	if (_rxPin >= 0 && _rxPin != rxPin) uartDetachPins(_uart, _rxPin, -1, -1, -1);
+	if (_txPin >= 0 && _txPin != txPin) uartDetachPins(_uart, -1, _txPin, -1, -1);
+	if (_ctsPin >= 0 && _ctsPin != ctsPin) uartDetachPins(_uart, -1, -1, _ctsPin, -1);
+	if (_rtsPin >= 0 && _rtsPin != rtsPin) uartDetachPins(_uart, -1, -1, -1, _rtsPin);
 	// set new pins for a future end() or a setPins()    
         _txPin = txPin >= 0 ? txPin : _txPin;
         _rxPin = rxPin >= 0 ? rxPin : _rxPin;


### PR DESCRIPTION
## Description of Change
There is a bug in `HardwareSerial::setPins()` that sets the UART pins internally to the wrong value at the end of the operation, which may lead to errors in `HardwareSerial::end()`, not dettaching the right GPIO from UART.

This PR also makes sure that sequential `HardwareSerial::setPins()` will always detach previous attached GPIOs.

## Tests scenarios
``` cpp

// Check previous GPIOs with a Logic Analyzer
void setup() {
  Serial.begin(115200);  // sets default RX and TX
  Serial.println("This will go out in the default TX pin");
  Serial.flush();
  
  Serial.setPins(-1, 2);  // Now TX shall be GPIO2 and default TX GPIO can't send any data
  Serial.println("This line can't be seen in the default TX GPIO!");
  Serial.flush();
}

void loop(){
}
```

## Related links
Closes #8607 