### PR TITLE
Default Console UART Rx Tx defined in HardwareSerial Constructor

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -97,14 +97,18 @@ void serialEvent2(void) {}
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
 #if ARDUINO_USB_CDC_ON_BOOT //Serial used for USB CDC
-HardwareSerial Serial0(0);
+// sets UART0 (default console) RX/TX default pins already configured in boot
+HardwareSerial Serial0(0, SOC_RX0, SOC_TX0);
 #else
-HardwareSerial Serial(0);
+// sets UART0 (default console) RX/TX default pins already configured in boot
+HardwareSerial Serial(0, SOC_RX0, SOC_TX0);
 #endif
 #if SOC_UART_NUM > 1
+// UART1 is not initialized in boot
 HardwareSerial Serial1(1);
 #endif
 #if SOC_UART_NUM > 2
+// UART2 is not initialized in boot
 HardwareSerial Serial2(2);
 #endif
 
@@ -132,7 +136,11 @@ void serialEventRun(void)
 #define HSERIAL_MUTEX_UNLOCK()  
 #endif
 
-HardwareSerial::HardwareSerial(int uart_nr) : 
+// Adds the default rxPin and txPin whenever it is already initialized in Boot Time (UART0)
+// default values are -1, -1 for UART1 and UART2
+// This will allow user to call HardwareSerial::end() with no previous HardwareSerial::begin()
+// detahing RX and TX attached in boot time. It also shall detach console pins when using HardwareSerial::setPins()
+HardwareSerial::HardwareSerial(int uart_nr, int8_t rxPin, int8_t txPin) : 
 _uart_nr(uart_nr), 
 _uart(NULL),
 _rxBufferSize(256),
@@ -146,8 +154,8 @@ _eventTask(NULL)
 #if !CONFIG_DISABLE_HAL_LOCKS
     ,_lock(NULL)
 #endif
-,_rxPin(-1) 
-,_txPin(-1)
+,_rxPin(rxPin) 
+,_txPin(txPin)
 ,_ctsPin(-1)
 ,_rtsPin(-1)
 {

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -71,7 +71,9 @@ typedef std::function<void(hardwareSerial_error_t)> OnReceiveErrorCb;
 class HardwareSerial: public Stream
 {
 public:
-    HardwareSerial(int uart_nr);
+    // UART0 (cosole) has its RX/TX pins initialized in boot
+    // it shall set default pins when user calls HardwareSerial.end() with no previous begin()
+    HardwareSerial(int uart_nr, int8_t rxPin = -1, int8_t txPin = -1);
     ~HardwareSerial();
 
     // setRxTimeout sets the timeout after which onReceive callback will be called (after receiving data, it waits for this time of UART rx inactivity to call the callback fnc)


### PR DESCRIPTION
## Description of Change
ESP32 SoCs attach RX and TX pins in boot time, conneting those GPIOs to IOMUX or GPIO Matrix.
Therefore, if the user calls `HardwareSerial::setPins()` or `HardwareSerial::end()` with no previous `HardwareSerial::begin()`,
those default already attached pins won't be detached, preventing them to be used for other purpose.

This PR shall be merged along with #8619 in order to make full effect with `HardwareSerial::setPins()`

## Tests scenarios
``` cpp
void setup() {
  ets_printf("\nThis Line is printed fine because it uses TX Pin attached in Boot Time.\n\n");
  Serial.end();                 // shall detach default UART0 RX/TX
  ets_printf("1:: This Log line shall not be displayed!\n"); // using IDF console ets_printf() -- TX unattached!
  
  Serial.begin(115200);  // set default RX/TX pin because nothing was defined in the call
  Serial.println("2:: This line shall be seen.");
  Serial.flush();

  Serial.setPins(-1, 2);    // shall set UART0 to GPIO2 and detach default TX -- DEPENDS on MERGING #8619 
  Serial.println("3:: This line shall NOT be seen.");  // default TX is no longer attached
  Serial.flush();
  
  Serial.end();
  Serial.setPins(-1, 2); // it has not effect because Serial is ended... 
  Serial.begin(115200);  // This shall not set default TX pin because the previous setPin() was executed
  Serial.println("4:: This line shall NOT be seen.");  // default TX is no longer attached
  Serial.flush();
}

void loop() {}
```

## Related links
Closes #8324
Closes #8573 