### PR TITLE
Uart detach 2.0.13

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -580,12 +580,12 @@ bool HardwareSerial::setPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t r
     // uartSetPins() checks if pins are valid for each function and for the SoC
     bool retCode = uartSetPins(_uart_nr, rxPin, txPin, ctsPin, rtsPin);
     if (retCode) {
- 	    // detach previous attached UART pins if not set as same as before
-	    if (_rxPin >= 0 && _rxPin != rxPin) uartDetachPins(_uart_nr, _rxPin, -1, -1, -1);
-	    if (_txPin >= 0 && _txPin != txPin) uartDetachPins(_uart_nr, -1, _txPin, -1, -1);
-	    if (_ctsPin >= 0 && _ctsPin != ctsPin) uartDetachPins(_uart_nr, -1, -1, _ctsPin, -1);
-	    if (_rtsPin >= 0 && _rtsPin != rtsPin) uartDetachPins(_uart_nr, -1, -1, -1, _rtsPin);
-	    // set new pins for a future end() or a setPins()    
+        // detach previous attached UART pins if not set as same as before
+        if (_rxPin >= 0 && _rxPin != rxPin) uartDetachPins(_uart_nr, _rxPin, -1, -1, -1);
+        if (_txPin >= 0 && _txPin != txPin) uartDetachPins(_uart_nr, -1, _txPin, -1, -1);
+        if (_ctsPin >= 0 && _ctsPin != ctsPin) uartDetachPins(_uart_nr, -1, -1, _ctsPin, -1);
+        if (_rtsPin >= 0 && _rtsPin != rtsPin) uartDetachPins(_uart_nr, -1, -1, -1, _rtsPin);
+        // set new pins for a future end() or a setPins()    
         _txPin = txPin >= 0 ? txPin : _txPin;
         _rxPin = rxPin >= 0 ? rxPin : _rxPin;
         _rtsPin = rtsPin >= 0 ? rtsPin : _rtsPin;

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -568,10 +568,16 @@ bool HardwareSerial::setPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t r
     // uartSetPins() checks if pins are valid for each function and for the SoC
     bool retCode = uartSetPins(_uart, rxPin, txPin, ctsPin, rtsPin);
     if (retCode) {
-        _txPin = _txPin >= 0 ? txPin : _txPin;
-        _rxPin = _rxPin >= 0 ? rxPin : _rxPin;
-        _rtsPin = _rtsPin >= 0 ? rtsPin : _rtsPin;
-        _ctsPin = _ctsPin >= 0 ? ctsPin : _ctsPin;
+ 	    // detach previous attached UART pins if not set as same as before
+	    if (_rxPin >= 0 && _rxPin != rxPin) uartDetachPins(_uart, _rxPin, -1, -1, -1);
+	    if (_txPin >= 0 && _txPin != txPin) uartDetachPins(_uart, -1, _txPin, -1, -1);
+	    if (_ctsPin >= 0 && _ctsPin != ctsPin) uartDetachPins(_uart, -1, -1, _ctsPin, -1);
+	    if (_rtsPin >= 0 && _rtsPin != rtsPin) uartDetachPins(_uart, -1, -1, -1, _rtsPin);
+	    // set new pins for a future end() or a setPins()    
+        _txPin = txPin >= 0 ? txPin : _txPin;
+        _rxPin = rxPin >= 0 ? rxPin : _rxPin;
+        _rtsPin = rtsPin >= 0 ? rtsPin : _rtsPin;
+        _ctsPin = ctsPin >= 0 ? ctsPin : _ctsPin;       
     } else {
         log_e("Error when setting Serial port Pins. Invalid Pin.\n");
     }

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -71,7 +71,7 @@ typedef std::function<void(hardwareSerial_error_t)> OnReceiveErrorCb;
 class HardwareSerial: public Stream
 {
 public:
-    HardwareSerial(int uart_nr);
+    HardwareSerial(uint8_t uart_nr);
     ~HardwareSerial();
 
     // setRxTimeout sets the timeout after which onReceive callback will be called (after receiving data, it waits for this time of UART rx inactivity to call the callback fnc)
@@ -170,7 +170,7 @@ public:
     size_t setTxBufferSize(size_t new_size);
 
 protected:
-    int _uart_nr;
+    uint8_t _uart_nr;
     uart_t* _uart;
     size_t _rxBufferSize;
     size_t _txBufferSize;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -79,13 +79,13 @@ static uart_t _uart_bus_array[] = {
 // be seen in the previous pins and new pins as well. 
 // Valid pin UART_PIN_NO_CHANGE is defined to (-1)
 // Negative Pin Number will keep it unmodified, thus this function can detach individual pins
-void uartDetachPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
+void uartDetachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
 {
-    if(uart == NULL) {
+    if(uart_num >= SOC_UART_NUM) {
+        log_e("Serial number is invalid, please use numers from 0 to %u", SOC_UART_NUM - 1);
         return;
     }
 
-    UART_MUTEX_LOCK();
     if (txPin >= 0) {
         gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[txPin], PIN_FUNC_GPIO);
         esp_rom_gpio_connect_out_signal(txPin, SIG_GPIO_OUT_IDX, false, false);
@@ -93,7 +93,7 @@ void uartDetachPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int
 
     if (rxPin >= 0) {
         gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[rxPin], PIN_FUNC_GPIO);
-        esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart->num, SOC_UART_RX_PIN_IDX), false);
+        esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
     }
 
     if (rtsPin >= 0) {
@@ -103,9 +103,8 @@ void uartDetachPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int
 
     if (ctsPin >= 0) {
         gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[ctsPin], PIN_FUNC_GPIO);
-        esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart->num, SOC_UART_CTS_PIN_IDX), false);
+        esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart_num, SOC_UART_CTS_PIN_IDX), false);
     }
-    UART_MUTEX_UNLOCK();  
 }
 
 // solves issue https://github.com/espressif/arduino-esp32/issues/6032
@@ -147,15 +146,15 @@ bool uartIsDriverInstalled(uart_t* uart)
 
 // Valid pin UART_PIN_NO_CHANGE is defined to (-1)
 // Negative Pin Number will keep it unmodified, thus this function can set individual pins
-bool uartSetPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
+bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin)
 {
-    if(uart == NULL) {
-        return false;
+    if(uart_num >= SOC_UART_NUM) {
+        log_e("Serial number is invalid, please use numers from 0 to %u", SOC_UART_NUM - 1);
+        return;
     }
-    UART_MUTEX_LOCK();
+
     // IDF uart_set_pin() will issue necessary Error Message and take care of all GPIO Number validation.
-    bool retCode = uart_set_pin(uart->num, txPin, rxPin, rtsPin, ctsPin) == ESP_OK; 
-    UART_MUTEX_UNLOCK();  
+    bool retCode = uart_set_pin(uart_num, txPin, rxPin, rtsPin, ctsPin) == ESP_OK; 
     return retCode;
 }
 

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -131,8 +131,8 @@ int uartGetDebug();
 bool uartIsDriverInstalled(uart_t* uart);
 
 // Negative Pin Number will keep it unmodified, thus this function can set/reset individual pins
-bool uartSetPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
-void uartDetachPins(uart_t* uart, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
+bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
+void uartDetachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin);
 
 // Enables or disables HW Flow Control function -- needs also to set CTS and/or RTS pins
 bool uartSetHwFlowCtrlMode(uart_t *uart, uint8_t mode, uint8_t threshold);


### PR DESCRIPTION
## Description of Change
There is a bug in `HardwareSerial::setPins()` that sets the UART pins internally to the wrong value at the end of the operation, which may lead to errors in `HardwareSerial::end()`, not dettaching the right GPIO from UART.

This PR also makes sure that `HardwareSerial::setPins()` will always detach previous attached GPIOs.

ESP32 SoCs attach RX0 and TX0 console pins in boot time, connecting those GPIOs to IOMUX or GPIO Matrix.
The PR makes sure that if the application calls `Serial.begin(baud, rxPin, txPin)` at first to setup UART, it will detach Console RX0/TX0.
The same, if the user calls `HardwareSerial::setPins()` or `HardwareSerial::end()` with no previous `HardwareSerial::begin()`,

Other improvements/fixes:
1- `setPins()` can be called before `begin()`, or in any order.
2- `end()` can be called at any time, even before `begin()` detaching UART Pins.
3- Once RX/TX are set with `begin(baud, rx, tx)` or with `setPins()`, calling `begin(baud)` will not force setting default board's RX/TX.

## Tests scenarios
Use Cases:
0) First time calling end() or setPins() todetach default RX0/TX0 
1) First time calling begin(baud) --> it will use SoC default RX/TX pins
2) First calls begin(baud, rx, tx) then calls begin(baud) --> it will keep rx, tx from previous begin() +  detaches default RX/TX
3) First calls begin(baud), then setPin(rx, tx), then calls begin(baud) --> NEEDS #8620 :: detaches default RX/TX + attaches rx/tx in second begin()
4) First calls begin(baud), then end(), then calls begin(baud, rx, tx) --> it will use rx/tx pins + detaches default RX/TX 
5) First calls begin(baud) then begin(baud, rx, tx) --> it will use rx/tx from second begin() + detaches default RX/TX
6) First calls begin(baud, rx, tx) --> detaches default RX/TX (UART0 only) + attachs RX/TX from begin()
7) First calls begin(baud, rx1, tx1) then calls begin(baud, rx2, tx2) --> detaches rx1/tx1 + attachs rx2/tx2
8) First calls begin(baud) then calls begin(baud, -1, tx) --> detaches default TX, attaches tx and default RX 
9) First calls begin(baud, -1, tx) --> attaches tx, leaves RX unchenged, but in UART0.end(), it will force dettach default RX
10) First calls begin(baud, rx) --> attaches rx, leaves TX unchanged, but in UART0.end(), it will force dettahc default TX
11) First calls begin(baud, rx) then calls begin(baud, rx2, tx2) --> detaches default RX/TX (UART0 only) + detaches rx + attaches rx2/tx2  

``` cpp
void setup() {
  ets_printf("\nThis Line is printed fine because it uses TX Pin attached in Boot Time.\n\n");
  Serial.end();                 // shall detach default UART0 RX/TX
  ets_printf("1:: This Log line shall not be displayed!\n"); // using IDF console ets_printf() -- TX unattached!
  
  Serial.begin(115200);  // set default RX/TX pin because nothing was defined in the call
  Serial.println("2:: This line shall be seen.");
  Serial.flush();

  Serial.setPins(-1, 2);    // shall set UART0 to GPIO2 and detach default TX -- DEPENDS on MERGING #8619 
  Serial.println("3:: This line shall NOT be seen.");  // default TX is no longer attached
  Serial.flush();
  
  Serial.end();
  Serial.setPins(-1, 2); // it has not effect because Serial is ended... 
  Serial.begin(115200);  // This shall not set default TX pin because the previous setPin() was executed
  Serial.println("4:: This line shall NOT be seen.");  // default TX is no longer attached
  Serial.flush();
}

void loop() {}
```

``` cpp

// Check previous GPIOs with a Logic Analyzer
void setup() {
  Serial.begin(115200);  // sets default RX and TX
  Serial.println("This will go out in the default TX pin");
  Serial.flush();
  
  Serial.setPins(-1, 2);  // Now TX shall be GPIO2 and default TX GPIO can't send any data
  Serial.println("This line can't be seen in the default TX GPIO!");
  Serial.flush();
}

void loop(){
}
```


## Related links
Closes #8324
Closes #8573 
Closes #8607
