### PR TITLE
removes delay(10) from HardwareSerial::end()

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -446,7 +446,7 @@ void HardwareSerial::end(bool fullyTerminate)
         _rxPin = _txPin = _ctsPin = _rtsPin = -1;
 
     }
-    delay(10);
+
     uartEnd(_uart);
     _uart = 0;
     _destroyEventTask();


### PR DESCRIPTION
## Description of Change
Back in April, 2021, a workaround PR #5047 was merged to fix #5043 by adding a `delay(10)` into `HardwareSerial::end()`
This is useless as pointed in https://github.com/espressif/arduino-esp32/discussions/8627

This PR removes such `delay()`

## Tests scenarios
Simple test with ESP32

## Related links
Closes #8627 