### PR TITLE
Add support for the TTGO T-Call board

### DIFF
--- a/variants/ttgo-t-call/pins_arduino.h
+++ b/variants/ttgo-t-call/pins_arduino.h
@@ -1,0 +1,60 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        20
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+// Sim800
+#define SIM800_TX 26
+#define SIM800_RX 27
+#define PWKEY 4
+#define SIM800_RST 5
+#define SIM800_POWER 23
+
+
+static const uint8_t LED_BUILTIN = 13;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+ 
+static const uint8_t SS    = 18;
+static const uint8_t MOSI  = 27;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 5;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A14 = 13;
+static const uint8_t A16 = 14;
+static const uint8_t A18 = 25;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T4 = 13;
+static const uint8_t T6 = 14;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
I added the pins_arduino.h for the TTGO T-Call board in the variants folder.

## Tests scenarios
Tested on a TTGO T-Call

## Related links
Aims to add support in platformio:
https://github.com/platformio/platform-espressif32/issues/333
https://github.com/platformio/platform-espressif32/issues/219