### PR TITLE
Fixes set pins return value in 2.0.13

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -150,7 +150,7 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
 {
     if(uart_num >= SOC_UART_NUM) {
         log_e("Serial number is invalid, please use numers from 0 to %u", SOC_UART_NUM - 1);
-        return;
+        return false;
     }
 
     // IDF uart_set_pin() will issue necessary Error Message and take care of all GPIO Number validation.


### PR DESCRIPTION
## Description of Change
Fixes a lack of return value in the `uartSetPins()` function. It doesn't prevent to build the firmware, but prints a warning message. With this fix, the warning message won't be displayed anymore.

This issue doesn't affect the `uartSetPins()` function because it only happens in the case that the HAL level is used with a UART number higher than the limit, which is very improbable.

``` cpp
    if(uart_num >= SOC_UART_NUM) {
        log_e("Serial number is invalid, please use numers from 0 to %u", SOC_UART_NUM - 1);
        return false;
    }
```

## Tests scenarios
Just compiling and checking that the warning message is gone.

## Related links
Closes #8641 