### PR TITLE
Add IOXESP32 board family and ATD1.47-S3 board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -25816,3 +25816,181 @@ ioxesp32ps.menu.EraseFlash.all=Enabled
 ioxesp32ps.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+
+atd147_s3.name=ATD1.47-S3
+atd147_s3.vid.0=0x303a
+atd147_s3.pid.0=0x1001
+
+atd147_s3.bootloader.tool=esptool_py
+atd147_s3.bootloader.tool.default=esptool_py
+
+atd147_s3.upload.tool=esptool_py
+atd147_s3.upload.tool.default=esptool_py
+atd147_s3.upload.tool.network=esp_ota
+
+atd147_s3.upload.maximum_size=1310720
+atd147_s3.upload.maximum_data_size=327680
+atd147_s3.upload.flags=
+atd147_s3.upload.extra_flags=
+atd147_s3.upload.use_1200bps_touch=false
+atd147_s3.upload.wait_for_upload_port=false
+
+atd147_s3.serial.disableDTR=false
+atd147_s3.serial.disableRTS=false
+
+atd147_s3.build.tarch=xtensa
+atd147_s3.build.bootloader_addr=0x0
+atd147_s3.build.target=esp32s3
+atd147_s3.build.mcu=esp32s3
+atd147_s3.build.core=esp32
+atd147_s3.build.variant=atd147_s3
+atd147_s3.build.board=ATD143_S3
+
+atd147_s3.build.usb_mode=1
+atd147_s3.build.cdc_on_boot=0
+atd147_s3.build.msc_on_boot=0
+atd147_s3.build.dfu_on_boot=0
+atd147_s3.build.f_cpu=240000000L
+atd147_s3.build.flash_size=8MB
+atd147_s3.build.flash_freq=80m
+atd147_s3.build.flash_mode=dio
+atd147_s3.build.boot=qio
+atd147_s3.build.boot_freq=80m
+atd147_s3.build.partitions=default_8MB
+atd147_s3.build.defines=
+atd147_s3.build.loop_core=
+atd147_s3.build.event_core=
+atd147_s3.build.psram_type=opi
+atd147_s3.build.memory_type={build.boot}_{build.psram_type}
+
+## IDE 2.0 Seems to not update the value
+atd147_s3.menu.JTAGAdapter.default=Disabled
+atd147_s3.menu.JTAGAdapter.default.build.copy_jtag_files=0
+atd147_s3.menu.JTAGAdapter.builtin=Integrated USB JTAG
+atd147_s3.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
+atd147_s3.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+atd147_s3.menu.JTAGAdapter.external=FTDI Adapter
+atd147_s3.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+atd147_s3.menu.JTAGAdapter.external.build.copy_jtag_files=1
+atd147_s3.menu.JTAGAdapter.bridge=ESP USB Bridge
+atd147_s3.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+atd147_s3.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+atd147_s3.menu.PSRAM.disabled=Disabled
+atd147_s3.menu.PSRAM.disabled.build.defines=
+atd147_s3.menu.PSRAM.disabled.build.psram_type=opi
+atd147_s3.menu.PSRAM.enabled=Enable
+atd147_s3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+atd147_s3.menu.PSRAM.enabled.build.psram_type=opi
+
+atd147_s3.menu.LoopCore.1=Core 1
+atd147_s3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+atd147_s3.menu.LoopCore.0=Core 0
+atd147_s3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+atd147_s3.menu.EventsCore.1=Core 1
+atd147_s3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+atd147_s3.menu.EventsCore.0=Core 0
+atd147_s3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+atd147_s3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+atd147_s3.menu.USBMode.hwcdc.build.usb_mode=1
+atd147_s3.menu.USBMode.default=USB-OTG (TinyUSB)
+atd147_s3.menu.USBMode.default.build.usb_mode=0
+
+atd147_s3.menu.CDCOnBoot.default=Disabled
+atd147_s3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+atd147_s3.menu.CDCOnBoot.cdc=Enabled
+atd147_s3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+atd147_s3.menu.MSCOnBoot.default=Disabled
+atd147_s3.menu.MSCOnBoot.default.build.msc_on_boot=0
+atd147_s3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+atd147_s3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+atd147_s3.menu.DFUOnBoot.default=Disabled
+atd147_s3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+atd147_s3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+atd147_s3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+atd147_s3.menu.UploadMode.default=UART0 / Hardware CDC
+atd147_s3.menu.UploadMode.default.upload.use_1200bps_touch=false
+atd147_s3.menu.UploadMode.default.upload.wait_for_upload_port=false
+atd147_s3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+atd147_s3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+atd147_s3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+atd147_s3.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+atd147_s3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+atd147_s3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+atd147_s3.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+atd147_s3.menu.PartitionScheme.minimal.build.partitions=minimal
+atd147_s3.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+atd147_s3.menu.PartitionScheme.no_ota.build.partitions=no_ota
+atd147_s3.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+atd147_s3.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+atd147_s3.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+atd147_s3.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+atd147_s3.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+atd147_s3.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+atd147_s3.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+atd147_s3.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+atd147_s3.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+atd147_s3.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+atd147_s3.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+atd147_s3.menu.PartitionScheme.huge_app.build.partitions=huge_app
+atd147_s3.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+atd147_s3.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+atd147_s3.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+atd147_s3.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+atd147_s3.menu.PartitionScheme.rainmaker=RainMaker
+atd147_s3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+atd147_s3.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+atd147_s3.menu.CPUFreq.240=240MHz (WiFi)
+atd147_s3.menu.CPUFreq.240.build.f_cpu=240000000L
+atd147_s3.menu.CPUFreq.160=160MHz (WiFi)
+atd147_s3.menu.CPUFreq.160.build.f_cpu=160000000L
+atd147_s3.menu.CPUFreq.80=80MHz (WiFi)
+atd147_s3.menu.CPUFreq.80.build.f_cpu=80000000L
+atd147_s3.menu.CPUFreq.40=40MHz
+atd147_s3.menu.CPUFreq.40.build.f_cpu=40000000L
+atd147_s3.menu.CPUFreq.20=20MHz
+atd147_s3.menu.CPUFreq.20.build.f_cpu=20000000L
+atd147_s3.menu.CPUFreq.10=10MHz
+atd147_s3.menu.CPUFreq.10.build.f_cpu=10000000L
+
+atd147_s3.menu.UploadSpeed.921600=921600
+atd147_s3.menu.UploadSpeed.921600.upload.speed=921600
+atd147_s3.menu.UploadSpeed.115200=115200
+atd147_s3.menu.UploadSpeed.115200.upload.speed=115200
+atd147_s3.menu.UploadSpeed.256000.windows=256000
+atd147_s3.menu.UploadSpeed.256000.upload.speed=256000
+atd147_s3.menu.UploadSpeed.230400.windows.upload.speed=256000
+atd147_s3.menu.UploadSpeed.230400=230400
+atd147_s3.menu.UploadSpeed.230400.upload.speed=230400
+atd147_s3.menu.UploadSpeed.460800.linux=460800
+atd147_s3.menu.UploadSpeed.460800.macosx=460800
+atd147_s3.menu.UploadSpeed.460800.upload.speed=460800
+atd147_s3.menu.UploadSpeed.512000.windows=512000
+atd147_s3.menu.UploadSpeed.512000.upload.speed=512000
+
+atd147_s3.menu.DebugLevel.none=None
+atd147_s3.menu.DebugLevel.none.build.code_debug=0
+atd147_s3.menu.DebugLevel.error=Error
+atd147_s3.menu.DebugLevel.error.build.code_debug=1
+atd147_s3.menu.DebugLevel.warn=Warn
+atd147_s3.menu.DebugLevel.warn.build.code_debug=2
+atd147_s3.menu.DebugLevel.info=Info
+atd147_s3.menu.DebugLevel.info.build.code_debug=3
+atd147_s3.menu.DebugLevel.debug=Debug
+atd147_s3.menu.DebugLevel.debug.build.code_debug=4
+atd147_s3.menu.DebugLevel.verbose=Verbose
+atd147_s3.menu.DebugLevel.verbose.build.code_debug=5
+
+atd147_s3.menu.EraseFlash.none=Disabled
+atd147_s3.menu.EraseFlash.none.upload.erase_cmd=
+atd147_s3.menu.EraseFlash.all=Enabled
+atd147_s3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -25601,3 +25601,218 @@ namino_arancio.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+ioxesp32.name=IOXESP32
+
+ioxesp32.bootloader.tool=esptool_py
+ioxesp32.bootloader.tool.default=esptool_py
+
+ioxesp32.upload.tool=esptool_py
+ioxesp32.upload.tool.default=esptool_py
+ioxesp32.upload.tool.network=esp_ota
+
+ioxesp32.upload.maximum_size=1310720
+ioxesp32.upload.maximum_data_size=327680
+ioxesp32.upload.flags=
+ioxesp32.upload.extra_flags=
+
+ioxesp32.serial.disableDTR=true
+ioxesp32.serial.disableRTS=true
+
+ioxesp32.build.tarch=xtensa
+ioxesp32.build.bootloader_addr=0x1000
+ioxesp32.build.target=esp32
+ioxesp32.build.mcu=esp32
+ioxesp32.build.core=esp32
+ioxesp32.build.variant=ioxesp32
+ioxesp32.build.board=IOXESP32
+
+ioxesp32.build.f_cpu=240000000L
+ioxesp32.build.flash_mode=dio
+ioxesp32.build.flash_size=4MB
+ioxesp32ps.build.flash_freq=40m
+ioxesp32.build.boot=dio
+ioxesp32.build.partitions=default
+ioxesp32.build.defines=
+ioxesp32.build.extra_libs=
+
+ioxesp32.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+ioxesp32.menu.PartitionScheme.default.build.partitions=default
+ioxesp32.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+ioxesp32.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+ioxesp32.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+ioxesp32.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+ioxesp32.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+ioxesp32.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+ioxesp32.menu.PartitionScheme.minimal.build.partitions=minimal
+ioxesp32.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+ioxesp32.menu.PartitionScheme.no_ota.build.partitions=no_ota
+ioxesp32.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+ioxesp32.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+ioxesp32.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+ioxesp32.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+ioxesp32.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+ioxesp32.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+ioxesp32.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+ioxesp32.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+ioxesp32.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+ioxesp32.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+ioxesp32.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+ioxesp32.menu.PartitionScheme.huge_app.build.partitions=huge_app
+ioxesp32.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+ioxesp32.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+ioxesp32.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+ioxesp32.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+ioxesp32.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+ioxesp32.menu.PartitionScheme.fatflash.build.partitions=ffat
+ioxesp32.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+ioxesp32.menu.PartitionScheme.rainmaker=RainMaker
+ioxesp32.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+ioxesp32.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+ioxesp32.menu.FlashFreq.80=80MHz
+ioxesp32.menu.FlashFreq.80.build.flash_freq=80m
+ioxesp32.menu.FlashFreq.40=40MHz
+ioxesp32.menu.FlashFreq.40.build.flash_freq=40m
+
+ioxesp32.menu.UploadSpeed.921600=921600
+ioxesp32.menu.UploadSpeed.921600.upload.speed=921600
+ioxesp32.menu.UploadSpeed.115200=115200
+ioxesp32.menu.UploadSpeed.115200.upload.speed=115200
+ioxesp32.menu.UploadSpeed.256000.windows=256000
+ioxesp32.menu.UploadSpeed.256000.upload.speed=256000
+ioxesp32.menu.UploadSpeed.230400.windows.upload.speed=256000
+ioxesp32.menu.UploadSpeed.230400=230400
+ioxesp32.menu.UploadSpeed.230400.upload.speed=230400
+ioxesp32.menu.UploadSpeed.460800.linux=460800
+ioxesp32.menu.UploadSpeed.460800.macosx=460800
+ioxesp32.menu.UploadSpeed.460800.upload.speed=460800
+ioxesp32.menu.UploadSpeed.512000.windows=512000
+ioxesp32.menu.UploadSpeed.512000.upload.speed=512000
+
+ioxesp32.menu.DebugLevel.none=None
+ioxesp32.menu.DebugLevel.none.build.code_debug=0
+ioxesp32.menu.DebugLevel.error=Error
+ioxesp32.menu.DebugLevel.error.build.code_debug=1
+ioxesp32.menu.DebugLevel.warn=Warn
+ioxesp32.menu.DebugLevel.warn.build.code_debug=2
+ioxesp32.menu.DebugLevel.info=Info
+ioxesp32.menu.DebugLevel.info.build.code_debug=3
+ioxesp32.menu.DebugLevel.debug=Debug
+ioxesp32.menu.DebugLevel.debug.build.code_debug=4
+ioxesp32.menu.DebugLevel.verbose=Verbose
+ioxesp32.menu.DebugLevel.verbose.build.code_debug=5
+
+ioxesp32.menu.EraseFlash.none=Disabled
+ioxesp32.menu.EraseFlash.none.upload.erase_cmd=
+ioxesp32.menu.EraseFlash.all=Enabled
+ioxesp32.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+ioxesp32ps.name=IOXESP32PS
+
+ioxesp32ps.bootloader.tool=esptool_py
+ioxesp32ps.bootloader.tool.default=esptool_py
+
+ioxesp32ps.upload.tool=esptool_py
+ioxesp32ps.upload.tool.default=esptool_py
+ioxesp32ps.upload.tool.network=esp_ota
+
+ioxesp32ps.upload.maximum_size=1310720
+ioxesp32ps.upload.maximum_data_size=327680
+ioxesp32ps.upload.flags=
+ioxesp32ps.upload.extra_flags=
+
+ioxesp32ps.serial.disableDTR=true
+ioxesp32ps.serial.disableRTS=true
+
+ioxesp32ps.build.tarch=xtensa
+ioxesp32ps.build.bootloader_addr=0x1000
+ioxesp32ps.build.target=esp32
+ioxesp32ps.build.mcu=esp32
+ioxesp32ps.build.core=esp32
+ioxesp32ps.build.variant=ioxesp32
+ioxesp32ps.build.board=IOXESP32PS
+
+ioxesp32ps.build.f_cpu=240000000L
+ioxesp32ps.build.flash_mode=dio
+ioxesp32ps.build.flash_size=4MB
+ioxesp32ps.build.flash_freq=40m
+ioxesp32ps.build.boot=dio
+ioxesp32ps.build.partitions=default
+ioxesp32ps.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+ioxesp32ps.build.extra_libs=
+
+ioxesp32ps.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+ioxesp32ps.menu.PartitionScheme.default.build.partitions=default
+ioxesp32ps.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+ioxesp32ps.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+ioxesp32ps.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+ioxesp32ps.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+ioxesp32ps.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+ioxesp32ps.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+ioxesp32ps.menu.PartitionScheme.minimal.build.partitions=minimal
+ioxesp32ps.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+ioxesp32ps.menu.PartitionScheme.no_ota.build.partitions=no_ota
+ioxesp32ps.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+ioxesp32ps.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+ioxesp32ps.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+ioxesp32ps.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+ioxesp32ps.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+ioxesp32ps.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+ioxesp32ps.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+ioxesp32ps.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+ioxesp32ps.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+ioxesp32ps.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+ioxesp32ps.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+ioxesp32ps.menu.PartitionScheme.huge_app.build.partitions=huge_app
+ioxesp32ps.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+ioxesp32ps.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+ioxesp32ps.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+ioxesp32ps.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+ioxesp32ps.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+ioxesp32ps.menu.PartitionScheme.fatflash.build.partitions=ffat
+ioxesp32ps.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+ioxesp32ps.menu.PartitionScheme.rainmaker=RainMaker
+ioxesp32ps.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+ioxesp32ps.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+ioxesp32ps.menu.FlashFreq.80=80MHz
+ioxesp32ps.menu.FlashFreq.80.build.flash_freq=80m
+ioxesp32ps.menu.FlashFreq.40=40MHz
+ioxesp32ps.menu.FlashFreq.40.build.flash_freq=40m
+
+ioxesp32ps.menu.UploadSpeed.921600=921600
+ioxesp32ps.menu.UploadSpeed.921600.upload.speed=921600
+ioxesp32ps.menu.UploadSpeed.115200=115200
+ioxesp32ps.menu.UploadSpeed.115200.upload.speed=115200
+ioxesp32ps.menu.UploadSpeed.256000.windows=256000
+ioxesp32ps.menu.UploadSpeed.256000.upload.speed=256000
+ioxesp32ps.menu.UploadSpeed.230400.windows.upload.speed=256000
+ioxesp32ps.menu.UploadSpeed.230400=230400
+ioxesp32ps.menu.UploadSpeed.230400.upload.speed=230400
+ioxesp32ps.menu.UploadSpeed.460800.linux=460800
+ioxesp32ps.menu.UploadSpeed.460800.macosx=460800
+ioxesp32ps.menu.UploadSpeed.460800.upload.speed=460800
+ioxesp32ps.menu.UploadSpeed.512000.windows=512000
+ioxesp32ps.menu.UploadSpeed.512000.upload.speed=512000
+
+ioxesp32ps.menu.DebugLevel.none=None
+ioxesp32ps.menu.DebugLevel.none.build.code_debug=0
+ioxesp32ps.menu.DebugLevel.error=Error
+ioxesp32ps.menu.DebugLevel.error.build.code_debug=1
+ioxesp32ps.menu.DebugLevel.warn=Warn
+ioxesp32ps.menu.DebugLevel.warn.build.code_debug=2
+ioxesp32ps.menu.DebugLevel.info=Info
+ioxesp32ps.menu.DebugLevel.info.build.code_debug=3
+ioxesp32ps.menu.DebugLevel.debug=Debug
+ioxesp32ps.menu.DebugLevel.debug.build.code_debug=4
+ioxesp32ps.menu.DebugLevel.verbose=Verbose
+ioxesp32ps.menu.DebugLevel.verbose.build.code_debug=5
+
+ioxesp32ps.menu.EraseFlash.none=Disabled
+ioxesp32ps.menu.EraseFlash.none.upload.erase_cmd=
+ioxesp32ps.menu.EraseFlash.all=Enabled
+ioxesp32ps.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/variants/atd147_s3/pins_arduino.h
+++ b/variants/atd147_s3/pins_arduino.h
@@ -1,0 +1,76 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        48
+#define NUM_ANALOG_INPUTS       20
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+static const uint8_t SS    = 10;
+static const uint8_t MOSI  = 11;
+static const uint8_t MISO  = 13;
+static const uint8_t SCK   = 12;
+
+#define LCD_CS SS
+#define LCD_SCK SCK
+#define LCD_SDA MOSI
+static const uint8_t LCD_DC = 21;
+static const uint8_t LCD_RES = 14;
+
+static const uint8_t BTN_A = 4;
+static const uint8_t BTN_B = 5;
+static const uint8_t BTN_C = 45;
+#define KEY_BUILTIN BTN_A
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/ioxesp32/pins_arduino.h
+++ b/variants/ioxesp32/pins_arduino.h
@@ -1,0 +1,62 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t LED_BUILTIN = 5;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN
+
+static const uint8_t KEY_BUILTIN = 0;
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change

Add IOXESP32 (no PSRAM, use ESP32-WROOM-32 module) and IOXESP32PS (has 4MB PSRAM, use ESP32-WROVER-IE module) if you stay in Thailand you can get it at https://www.artronshop.co.th/product/tag/ioxesp32

Add ATD1.47-S3 it use ESP32-S3 (ESP32-S3-WROOM-1U-N8R8) with TFT LCD 1.47 inch, We plan to release in next week.

## Tests scenarios
Tested Blink code on hardware and it work !

## Related links

for IOXESP32 board family you can get a lots of infomation at https://docs.ioxesp32.com

for ATD1.47-S3 now not release but we have demo video : https://www.facebook.com/100001449306817/videos/905405350650352/
