### PR TITLE
Corrected pins_arduino.h for Lolin_s3

### DIFF
--- a/variants/lolin_s3/pins_arduino.h
+++ b/variants/lolin_s3/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
@@ -11,13 +12,13 @@
 #define NUM_ANALOG_INPUTS       18
 
 
-static const uint8_t LED_BUILTIN = 38;
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+38;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define analogInputToDigitalPin(p)  (((p)<18)?(analogChannelToDigitalPin(p)):-1)
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 


### PR DESCRIPTION
-----------
## Description of Change
Corrected Analog I/O, BUILTIN_LED and added missing soc/soc_caps.h. (RMT CAPS)

https://www.wemos.cc/en/latest/s3/s3.html

The S3 MINI should also have the same problem, but I do not have this board to verify.

## Tests scenarios
Before neopixelWrite(); on a Wemos Lolin_s3 end up in none working onboard RGB LED (aka NeoPixel).

```
E (31449) rmt: rmt_set_gpio(526): RMT GPIO ERROR
E (31450) rmt: rmt_config(686): set gpio for RMT driver failed
[ 31353][D][esp32-hal-rmt.c:615] rmtInit():  -- TX RMT - CH 1 - 1 RAM Blocks - pin 245
[ 31359][E][esp32-hal-rmt.c:631] rmtInit(): RMT failed to initilize.
[ 31365][E][esp32-hal-rgb-led.c:18] neopixelWrite(): RGB LED driver initialization failed!
```

After the change, the neopixel worked as expected.


## Related links
[theelims/ESP32-sveltekit/issues/9
](https://github.com/theelims/ESP32-sveltekit/issues/9)