### PR TITLE
Add printf method with FlashStringHelper argument

### DIFF
--- a/cores/esp32/Print.cpp
+++ b/cores/esp32/Print.cpp
@@ -44,13 +44,11 @@ size_t Print::write(const uint8_t *buffer, size_t size)
     return n;
 }
 
-size_t Print::printf(const char *format, ...)
+size_t Print::vprintf(const char *format, va_list arg)
 {
     char loc_buf[64];
     char * temp = loc_buf;
-    va_list arg;
     va_list copy;
-    va_start(arg, format);
     va_copy(copy, arg);
     int len = vsnprintf(temp, sizeof(loc_buf), format, copy);
     va_end(copy);
@@ -72,6 +70,25 @@ size_t Print::printf(const char *format, ...)
         free(temp);
     }
     return len;
+}
+
+size_t Print::printf(const __FlashStringHelper *ifsh, ...)
+{
+   va_list arg;
+   va_start(arg, ifsh);
+   const char * format = (reinterpret_cast<const char *>(ifsh));
+   size_t ret = vprintf(format, arg);
+   va_end(arg);
+   return ret;
+}
+
+size_t Print::printf(const char *format, ...)
+{
+    va_list arg;
+    va_start(arg, format);
+    size_t ret = vprintf(format, arg);
+    va_end(arg);
+    return ret;
 }
 
 size_t Print::print(const String &s)

--- a/cores/esp32/Print.h
+++ b/cores/esp32/Print.h
@@ -21,6 +21,7 @@
 #define Print_h
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stddef.h>
 
 #include "WString.h"
@@ -72,7 +73,10 @@ public:
         return write((const uint8_t *) buffer, size);
     }
 
+    size_t vprintf(const char *format, va_list arg);
+
     size_t printf(const char * format, ...)  __attribute__ ((format (printf, 2, 3)));
+    size_t printf(const __FlashStringHelper *ifsh, ...);
 
     // add availableForWrite to make compatible with Arduino Print.h
     // default to zero, meaning "a single write may block"


### PR DESCRIPTION
## Description of Change

Added `vprintf`, modified `printf` to use `vprintf` and added new `printf` overload that uses a `FlashStringHelper` argument (This doesn't support compile time checks. Idk if this is a good idea)

## Tests scenarios

Tested using ESP32-DevKitC

## Related links

Closes #7392