### PR TITLE
Fix BTAdvertisedDeviceSet::toString() method output

### DIFF
--- a/libraries/BluetoothSerial/src/BTAdvertisedDeviceSet.cpp
+++ b/libraries/BluetoothSerial/src/BTAdvertisedDeviceSet.cpp
@@ -41,9 +41,9 @@ bool        BTAdvertisedDeviceSet::haveRSSI() const { return m_haveRSSI; }
 std::string BTAdvertisedDeviceSet::toString() {
 	std::string res = "Name: " + getName() + ", Address: " + std::string(getAddress().toString().c_str(), getAddress().toString().length());
 	if (haveCOD()) {
-		char val[6];
-		snprintf(val, sizeof(val), "%d", getCOD());
-		res += ", cod: ";
+		char val[7]; //6 hex digits + null
+		snprintf(val, sizeof(val), "%06x", getCOD() & 0xFFFFFF);
+		res += ", cod: 0x";
 		res += val;
 	}
 	if (haveRSSI()) {


### PR DESCRIPTION
## Description of Change
Correctly prints the BT COD in hex without chopping the end of the number.

## Related links

Closes #8684
