### PR TITLE
Update of "Arduino Style Guide" link on contributing.rst

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -135,4 +135,4 @@ Legal Part
 
 Before a contribution can be accepted, you will need to sign our contributor agreement. You will be prompted for this automatically as part of the Pull Request process.
 
-.. _Arduino style guide: https://www.arduino.cc/en/Reference/StyleGuide
+.. _Arduino style guide: https://docs.arduino.cc/learn/contributions/arduino-writing-style-guide


### PR DESCRIPTION
## Description of Change

The link to the "Arduino Style Guide for Writing Content" was changed in November 2021.
