### PR TITLE
WiFiClient - Properly initialize and check _rxBuffer

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -182,7 +182,7 @@ public:
     }
 };
 
-WiFiClient::WiFiClient():_connected(false),_timeout(WIFI_CLIENT_DEF_CONN_TIMEOUT_MS),next(NULL)
+WiFiClient::WiFiClient():_rxBuffer(nullptr),_connected(false),_timeout(WIFI_CLIENT_DEF_CONN_TIMEOUT_MS),next(NULL)
 {
 }
 
@@ -508,7 +508,9 @@ int WiFiClient::available()
 // Though flushing means to send all pending data,
 // seems that in Arduino it also means to clear RX
 void WiFiClient::flush() {
-    _rxBuffer->flush();
+    if (_rxBuffer != nullptr) {
+        _rxBuffer->flush();
+    }
 }
 
 uint8_t WiFiClient::connected()


### PR DESCRIPTION
## Description of Change
Fixes `LoadProhibited` exception (introduced in #8541) by properly initializing and checking the `_rxBuffer` pointer in the WiFiClient.

## Tests scenarios
Tested on ESP32-DevKitC using the following sketch:

```
#include <Arduino.h>
#include <WiFi.h>

WiFiClient client;

void loop() {
  delay(1000);
  Serial.println(".");
}

void setup() {
  Serial.begin(115200);
  Serial.println("READY");
  delay(1000);
  Serial.println("Flush WiFiClient client...");
  client.flush();
  delay(2000);
  Serial.println("Setup complete");
}
```

## Related links

Closes #8681
