### PR TITLE
Fixes all Board Variants issues for Arduino Core 3.0.0

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -23429,7 +23429,7 @@ unphone8.build.partitions=default_8MB
 unphone8.build.defines=-DBOARD_HAS_PSRAM -DUNPHONE_SPIN=8
 unphone8.build.loop_core=-DARDUINO_RUNNING_CORE=1
 unphone8.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-unphone8.build.flash_type=qspi
+unphone8.build.flash_type=qio
 unphone8.build.psram_type=qspi
 unphone8.build.memory_type={build.flash_type}_{build.psram_type}
 

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -129,6 +129,18 @@
 #define NOT_AN_INTERRUPT -1
 #define NOT_ON_TIMER 0
 
+// some defines generic for all SoC moved from variants/board_name/pins_arduino.h
+#define NUM_DIGITAL_PINS        SOC_GPIO_PIN_COUNT                                // All GPIOs
+#if SOC_ADC_PERIPH_NUM == 1
+#define NUM_ANALOG_INPUTS       (SOC_ADC_CHANNEL_NUM(0))                          // Depends on the SoC (ESP32C6, ESP32H2, ESP32C2, ESP32P4)
+#elif SOC_ADC_PERIPH_NUM == 2
+#define NUM_ANALOG_INPUTS       (SOC_ADC_CHANNEL_NUM(0)+SOC_ADC_CHANNEL_NUM(1))   // Depends on the SoC (ESP32, ESP32S2, ESP32S3, ESP32C3)
+#endif
+#define EXTERNAL_NUM_INTERRUPTS NUM_DIGITAL_PINS                                  // All GPIOs
+#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):NOT_AN_INTERRUPT)
+#define digitalPinHasPWM(p)         ((p)<NUM_DIGITAL_PINS)
+
 typedef bool boolean;
 typedef uint8_t byte;
 typedef unsigned int word;

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -196,6 +196,9 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
 {
     static bool interrupt_initialized = false;
 
+    // makes sure that pin -1 (255) will never work -- this follows Arduino standard
+    if (pin >= SOC_GPIO_PIN_COUNT) return;
+
     if(!interrupt_initialized) {
     	esp_err_t err = gpio_install_isr_service((int)ARDUINO_ISR_FLAG);
     	interrupt_initialized = (err == ESP_OK) || (err == ESP_ERR_INVALID_STATE);

--- a/variants/AirM2M_CORE_ESP32C3/pins_arduino.h
+++ b/variants/AirM2M_CORE_ESP32C3/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t LED_BUILTIN     = 12;
 #define BUILTIN_LED  LED_BUILTIN
 static const uint8_t LED_BUILTIN_AUX = 13;

--- a/variants/Aventen_S3_Sync/pins_arduino.h
+++ b/variants/Aventen_S3_Sync/pins_arduino.h
@@ -2,21 +2,12 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-#include "soc/soc_caps.h"
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 #define USB_MANUFACTURER "Aventen"
 #define USB_PRODUCT "Aventen S3 Sync"
 #define USB_SERIAL ""
-
-#define NUM_DIGITAL_PINS        SOC_GPIO_PIN_COUNT    // GPIO 0..48
-#define NUM_ANALOG_INPUTS       20                    // GPIO 1..20
-#define EXTERNAL_NUM_INTERRUPTS NUM_DIGITAL_PINS      // All GPIOs
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):NOT_AN_INTERRUPT)
-#define digitalPinHasPWM(p)         (p < NUM_DIGITAL_PINS)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/Bee_Data_Logger/pins_arduino.h
+++ b/variants/Bee_Data_Logger/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x815C
 #define USB_MANUFACTURER "Smart Bee Designs"
 #define USB_PRODUCT "Bee Data Logger"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        13
-#define NUM_ANALOG_INPUTS       7
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -74,5 +67,12 @@ static const uint8_t LDO2 = 34;
 static const uint8_t RGB_DATA = 40;
 static const uint8_t RGB_PWR = 34;
 
+#define PIN_NEOPIXEL RGB_DATA
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 #endif /* Pins_Arduino_h */

--- a/variants/Bee_Motion/pins_arduino.h
+++ b/variants/Bee_Motion/pins_arduino.h
@@ -9,14 +9,6 @@
 #define USB_PRODUCT "Bee Motion S3"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        21
-#define NUM_ANALOG_INPUTS       12
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/Bee_Motion_Mini/pins_arduino.h
+++ b/variants/Bee_Motion_Mini/pins_arduino.h
@@ -3,22 +3,26 @@
 
 #include <stdint.h>
 
-
-#define EXTERNAL_NUM_INTERRUPTS 4
-#define NUM_DIGITAL_PINS        4
-#define NUM_ANALOG_INPUTS       2
-
-#define analogInputToDigitalPin(p)  (((p)<6)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<22)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 22)
-
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
 
 static const uint8_t BOOT_BTN = 9;
 static const uint8_t PIR = 5;
 
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
 
+static const uint8_t SS    = 7;
+static const uint8_t MOSI  = 6;
+static const uint8_t MISO  = 5;
+static const uint8_t SCK   = 4;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
 
 #endif /* Pins_Arduino_h */
 

--- a/variants/Bee_Motion_S3/pins_arduino.h
+++ b/variants/Bee_Motion_S3/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x8113
 #define USB_MANUFACTURER "Smart Bee Designs"
 #define USB_PRODUCT "Bee Motion S3"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        27
-#define NUM_ANALOG_INPUTS       11
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -81,5 +74,12 @@ static const uint8_t LDO2 = 34;
 static const uint8_t RGB_DATA = 40;
 static const uint8_t RGB_PWR = 34;
 
+#define PIN_NEOPIXEL RGB_DATA
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 #endif /* Pins_Arduino_h */

--- a/variants/Bee_S3/pins_arduino.h
+++ b/variants/Bee_S3/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x8110
 #define USB_MANUFACTURER "Smart Bee Designs"
 #define USB_PRODUCT "BeeS3"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 45
-#define NUM_DIGITAL_PINS        15
-#define NUM_ANALOG_INPUTS       8
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -72,5 +65,13 @@ static const uint8_t VBAT_VOLTAGE = 1;
 
 static const uint8_t RGB_DATA = 48;
 static const uint8_t RGB_PWR = 34;
+
+#define PIN_NEOPIXEL RGB_DATA
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 #endif /* Pins_Arduino_h */

--- a/variants/ET-Board/pins_arduino.h
+++ b/variants/ET-Board/pins_arduino.h
@@ -3,19 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       7
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
-
 
 static const uint8_t TX = 34;
 static const uint8_t RX = 35;

--- a/variants/Edgebox-ESP-100/pins_arduino.h
+++ b/variants/Edgebox-ESP-100/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 34
-#define NUM_DIGITAL_PINS        34
-#define NUM_ANALOG_INPUTS       2
-
-#define analogInputToDigitalPin(p)  (((p)<2)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<34)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 //Programming and Debugging Port
 static const uint8_t TXD = 43;
 static const uint8_t RXD = 44;

--- a/variants/Microduino-esp32/pins_arduino.h
+++ b/variants/Microduino-esp32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       12
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = -1;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 #define MTDO 15
 #define MTDI 12

--- a/variants/Nebula_S3/pins_arduino.h
+++ b/variants/Nebula_S3/pins_arduino.h
@@ -6,18 +6,8 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 20
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<6)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<20)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 20)
-
-
 static const uint8_t LED_BUILTIN = 45;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
 

--- a/variants/S_ODI_Ultra_v1/pins_arduino.h
+++ b/variants/S_ODI_Ultra_v1/pins_arduino.h
@@ -3,18 +3,9 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 static const uint8_t LED_BUILTINB = 4;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define BUILTIN_LED2  LED_BUILTINB
 
 static const uint8_t TX = 1;

--- a/variants/VALTRACK_V4_MFW_ESP32_C3/pins_arduino.h
+++ b/variants/VALTRACK_V4_MFW_ESP32_C3/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
 

--- a/variants/VALTRACK_V4_VTS_ESP32_C3/pins_arduino.h
+++ b/variants/VALTRACK_V4_VTS_ESP32_C3/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
 

--- a/variants/XIAO_ESP32C3/pins_arduino.h
+++ b/variants/XIAO_ESP32C3/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
 

--- a/variants/XIAO_ESP32S3/pins_arduino.h
+++ b/variants/XIAO_ESP32S3/pins_arduino.h
@@ -7,17 +7,8 @@
 #define USB_VID 0x2886
 #define USB_PID 0x0056
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
 static const uint8_t LED_BUILTIN = 21;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/adafruit_feather_esp32_v2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32_v2/pins_arduino.h
@@ -4,15 +4,6 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-// Neopixel
-#define PIN_NEOPIXEL 0
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
-#define RGB_BRIGHTNESS 64
-
 static const uint8_t TX = 8;
 static const uint8_t RX = 7;
 #define TX1 TX
@@ -48,8 +39,16 @@ static const uint8_t A13 = 35;
 // internal switch
 #define BUTTON 38
 
+// User LED 
+static const uint8_t LED_BUILTIN = 13;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
 // Neopixel
 #define PIN_NEOPIXEL 0
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
+#define RGB_BRIGHTNESS 64
 
 // Neopixel & I2C power
 #define NEOPIXEL_I2C_POWER 2

--- a/variants/adafruit_feather_esp32_v2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32_v2/pins_arduino.h
@@ -2,18 +2,16 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
-static const uint8_t LED_BUILTIN = 13;
+// Neopixel
+#define PIN_NEOPIXEL 0
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 8;
 static const uint8_t RX = 7;

--- a/variants/adafruit_feather_esp32s2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x80EB
@@ -10,18 +10,15 @@
 #define USB_PRODUCT        "Feather ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// Neopixel
+#define PIN_NEOPIXEL 33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN     13
-
-#define PIN_NEOPIXEL        33
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_feather_esp32s2/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2/pins_arduino.h
@@ -10,13 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// User LED 
+#define LED_BUILTIN 13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 // Neopixel
 #define PIN_NEOPIXEL 33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x80ED
@@ -10,18 +10,15 @@
 #define USB_PRODUCT        "Feather ESP32-S2 Reverse TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// Neopixel
+#define PIN_NEOPIXEL 33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN     13
-
-#define PIN_NEOPIXEL        33
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_reversetft/pins_arduino.h
@@ -10,13 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S2 Reverse TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// User LED 
+#define LED_BUILTIN 13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 // Neopixel
 #define PIN_NEOPIXEL 33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x810F
@@ -10,18 +10,15 @@
 #define USB_PRODUCT        "Feather ESP32-S2 TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// Neopixel
+#define PIN_NEOPIXEL 33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN     13
-
-#define PIN_NEOPIXEL        33
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      34    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s2_tft/pins_arduino.h
@@ -10,13 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S2 TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// User LED 
+#define LED_BUILTIN 13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 // Neopixel
 #define PIN_NEOPIXEL 33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/adafruit_feather_esp32s3/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x811B
@@ -9,17 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN         13
-
 #define PIN_NEOPIXEL        33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_feather_esp32s3/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3/pins_arduino.h
@@ -10,12 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define PIN_NEOPIXEL        33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+// User LED 
+#define LED_BUILTIN 13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+
+// Neopixel
+#define PIN_NEOPIXEL 33
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/adafruit_feather_esp32s3_nopsram/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_nopsram/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x8113
@@ -9,17 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3 No PSRAM"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN         13
-
 #define PIN_NEOPIXEL        33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_feather_esp32s3_nopsram/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_nopsram/pins_arduino.h
@@ -10,12 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3 No PSRAM"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define PIN_NEOPIXEL        33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+// User LED 
+#define LED_BUILTIN 13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+
+// Neopixel
+#define PIN_NEOPIXEL 33
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/adafruit_feather_esp32s3_reversetft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_reversetft/pins_arduino.h
@@ -10,12 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3 Reverse TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define PIN_NEOPIXEL        33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+// User LED 
+#define LED_BUILTIN 13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+
+// Neopixel
+#define PIN_NEOPIXEL 33
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/adafruit_feather_esp32s3_reversetft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_reversetft/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x8123
@@ -10,18 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3 Reverse TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN     13
-
 #define PIN_NEOPIXEL        33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
@@ -10,12 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3 TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define PIN_NEOPIXEL        33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+// User LED 
+#define LED_BUILTIN 13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+
+// Neopixel
+#define PIN_NEOPIXEL 33
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
+++ b/variants/adafruit_feather_esp32s3_tft/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x811D
@@ -10,18 +10,14 @@
 #define USB_PRODUCT        "Feather ESP32-S3 TFT"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN     13
-
 #define PIN_NEOPIXEL        33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      34    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_funhouse_esp32s2/pins_arduino.h
+++ b/variants/adafruit_funhouse_esp32s2/pins_arduino.h
@@ -11,6 +11,7 @@
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
 #define LED_BUILTIN   37
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 #define PIN_BUTTON1   3
 #define PIN_BUTTON2   4

--- a/variants/adafruit_funhouse_esp32s2/pins_arduino.h
+++ b/variants/adafruit_funhouse_esp32s2/pins_arduino.h
@@ -10,15 +10,6 @@
 #define USB_PRODUCT        "Funhouse ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 #define LED_BUILTIN   37
 
 #define PIN_BUTTON1   3

--- a/variants/adafruit_itsybitsy_esp32/pins_arduino.h
+++ b/variants/adafruit_itsybitsy_esp32/pins_arduino.h
@@ -4,13 +4,15 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
+// User LED 
+static const uint8_t LED_BUILTIN = 13;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
 // Neopixel
 static const uint8_t PIN_NEOPIXEL = 0;
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 static const uint8_t NEOPIXEL_POWER = 2;

--- a/variants/adafruit_itsybitsy_esp32/pins_arduino.h
+++ b/variants/adafruit_itsybitsy_esp32/pins_arduino.h
@@ -2,21 +2,17 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
-static const uint8_t LED_BUILTIN = 13;
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+#include "soc/soc_caps.h"
 
 // Neopixel
 static const uint8_t PIN_NEOPIXEL = 0;
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 static const uint8_t NEOPIXEL_POWER = 2;
 
 static const uint8_t TX = 20;

--- a/variants/adafruit_magtag29_esp32s2/pins_arduino.h
+++ b/variants/adafruit_magtag29_esp32s2/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x80E5
@@ -10,18 +10,15 @@
 #define USB_PRODUCT        "EPD MagTag 2.9\" ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN         13
-
+// Neopixel
 #define PIN_NEOPIXEL        1    // D1
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT); // Only 1 NeoPixel will be affected
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM        4    // number of neopixels
 #define NEOPIXEL_POWER      21   // power pin
 #define NEOPIXEL_POWER_ON   LOW  // power pin state when on

--- a/variants/adafruit_magtag29_esp32s2/pins_arduino.h
+++ b/variants/adafruit_magtag29_esp32s2/pins_arduino.h
@@ -10,13 +10,14 @@
 #define USB_PRODUCT        "EPD MagTag 2.9\" ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// User LED 
+#define LED_BUILTIN 13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 // Neopixel
 #define PIN_NEOPIXEL        1    // D1
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT); // Only 1 NeoPixel will be affected
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        4    // number of neopixels

--- a/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
+++ b/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
@@ -10,13 +10,14 @@
 #define USB_PRODUCT        "MatrixPortal ESP32-S3"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// User LED 
+#define LED_BUILTIN 13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 #define PIN_NEOPIXEL        4
 #define NEOPIXEL_PIN        4
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1

--- a/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
+++ b/variants/adafruit_matrixportal_esp32s3/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x8125
@@ -9,18 +10,15 @@
 #define USB_PRODUCT        "MatrixPortal ESP32-S3"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<EXTERNAL_NUM_INTERRUPTS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN         13
-
 #define PIN_NEOPIXEL        4
 #define NEOPIXEL_PIN        4
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM        1
 #define PIN_LIGHTSENSOR     A5
 

--- a/variants/adafruit_metro_esp32s2/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s2/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x80DF
@@ -10,17 +10,13 @@
 #define USB_PRODUCT        "Metro ESP32-S2"
 #define USB_SERIAL         ""   // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 #define LED_BUILTIN     42
 
 #define PIN_NEOPIXEL    45
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM    1
 
 #define PIN_BUTTON1     0  // BOOT0 switch

--- a/variants/adafruit_metro_esp32s2/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s2/pins_arduino.h
@@ -11,10 +11,12 @@
 #define USB_SERIAL         ""   // Empty string for MAC adddress
 
 #define LED_BUILTIN     42
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
+// Neopixel
 #define PIN_NEOPIXEL    45
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)  
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM    1

--- a/variants/adafruit_metro_esp32s3/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s3/pins_arduino.h
@@ -10,13 +10,13 @@
 #define USB_PRODUCT        "Metro ESP32-S3"
 #define USB_SERIAL         ""   // Empty string for MAC adddress
 
-#define PIN_NEOPIXEL    45
-#define NEOPIXEL_PIN    45
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define LED_BUILTIN     13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+
+// Neopixel
+#define PIN_NEOPIXEL    45
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM    1

--- a/variants/adafruit_metro_esp32s3/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s3/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x8145
@@ -9,18 +10,15 @@
 #define USB_PRODUCT        "Metro ESP32-S3"
 #define USB_SERIAL         ""   // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN     13
-
 #define PIN_NEOPIXEL    45
 #define NEOPIXEL_PIN    45
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM    1
 
 #define PIN_BUTTON1     0  // BOOT0 switch

--- a/variants/adafruit_qtpy_esp32/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32/pins_arduino.h
@@ -9,6 +9,8 @@
 // BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/adafruit_qtpy_esp32/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32/pins_arduino.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
+// Neopixel
+#define PIN_NEOPIXEL   5
 // BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility

--- a/variants/adafruit_qtpy_esp32/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32/pins_arduino.h
@@ -2,16 +2,15 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
-#define PIN_NEOPIXEL   5
 #define NEOPIXEL_POWER 8
 
 static const uint8_t TX = 32;

--- a/variants/adafruit_qtpy_esp32c3/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32c3/pins_arduino.h
@@ -5,10 +5,14 @@
 #include "soc/soc_caps.h"
 
 #define BUTTON 9
+
+// Neopixel
 #define PIN_NEOPIXEL 2
 // BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/adafruit_qtpy_esp32c3/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32c3/pins_arduino.h
@@ -2,17 +2,16 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
+#include "soc/soc_caps.h"
 
 #define BUTTON 9
 #define PIN_NEOPIXEL 2
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;

--- a/variants/adafruit_qtpy_esp32s2/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s2/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x239A
 #define USB_PID            0x8111
@@ -10,18 +10,15 @@
 #define USB_PRODUCT        "QT Py ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-//#define LED_BUILTIN     13
-
 #define PIN_NEOPIXEL        39
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      38    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/adafruit_qtpy_esp32s2/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s2/pins_arduino.h
@@ -10,14 +10,14 @@
 #define USB_PRODUCT        "QT Py ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
+// Neopixel
 #define PIN_NEOPIXEL        39
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)  
-#define RGB_BRIGHTNESS 64
-
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN  LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      38    // power pin

--- a/variants/adafruit_qtpy_esp32s3_n4r2/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s3_n4r2/pins_arduino.h
@@ -17,6 +17,7 @@
 
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN  LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/adafruit_qtpy_esp32s3_n4r2/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s3_n4r2/pins_arduino.h
@@ -10,14 +10,6 @@
 #define USB_PRODUCT        "QT Py ESP32-S3 (4MB Flash 2MB PSRAM)"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 #define PIN_NEOPIXEL        39
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      38    // power pin
@@ -25,7 +17,7 @@
 
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN  LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN  LED_BUILTIN
 #define RGB_BRIGHTNESS 64
 

--- a/variants/adafruit_qtpy_esp32s3_nopsram/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s3_nopsram/pins_arduino.h
@@ -10,22 +10,15 @@
 #define USB_PRODUCT        "QT Py ESP32-S3 No PSRAM"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 #define PIN_NEOPIXEL        39
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      38    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on
 
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN  LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN  LED_BUILTIN
 #define RGB_BRIGHTNESS 64
 

--- a/variants/adafruit_qtpy_esp32s3_nopsram/pins_arduino.h
+++ b/variants/adafruit_qtpy_esp32s3_nopsram/pins_arduino.h
@@ -15,9 +15,9 @@
 #define NEOPIXEL_POWER      38    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on
 
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN  LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/alksesp32/pins_arduino.h
+++ b/variants/alksesp32/pins_arduino.h
@@ -3,19 +3,10 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 #define ALKSESP32 // tell library to not map pins again
 
 static const uint8_t LED_BUILTIN = 23;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/atmegazero_esp32s2/pins_arduino.h
+++ b/variants/atmegazero_esp32s2/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x239A
 #define USB_PID 0x800A
@@ -9,15 +10,14 @@
 #define USB_PRODUCT "ATMZ-ESP32S2"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t NEOPIXEL = 40;
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 static const uint8_t PD5 = 0;
 
 static const uint8_t TX = 43;

--- a/variants/bpi-bit/pins_arduino.h
+++ b/variants/bpi-bit/pins_arduino.h
@@ -2,22 +2,22 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS 40
-#define NUM_ANALOG_INPUTS 16
-
-#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
-#define digitalPinHasPWM(p) (p < 34)
+#include "soc/soc_caps.h"
 
 static const uint8_t BUZZER = 25;
 
 static const uint8_t BUTTON_A = 35;
 static const uint8_t BUTTON_B = 27;
 
+// NeoPixel Matrix 5 x 5
 static const uint8_t RGB_LED = 4;
 
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+#define LED_BUILTIN (RGB_LED + SOC_GPIO_PIN_COUNT) // Just a single LED in the Matrix
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 static const uint8_t LIGHT_SENSOR1 = 36;
 static const uint8_t LIGHT_SENSOR2 = 39;
 

--- a/variants/bpi_leaf_s3/pins_arduino.h
+++ b/variants/bpi_leaf_s3/pins_arduino.h
@@ -10,22 +10,16 @@
 #define USB_PRODUCT "BPI-Leaf-S3"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
 // Some boards have too low voltage on this pin (board design bug)
 // Use different pin with 3V and connect with 48
 // and change this setup for the chosen pin (for example 38)
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
+#define PIN_NEOPIXEL 48
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 25
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/ch_denky/pins_arduino.h
+++ b/variants/ch_denky/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/cnrs_aw2eth/pins_arduino.h
+++ b/variants/cnrs_aw2eth/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/connaxio_espoir/pins_arduino.h
+++ b/variants/connaxio_espoir/pins_arduino.h
@@ -8,14 +8,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 /* USB UART */
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/crabik_slot_esp32_s3/pins_arduino.h
+++ b/variants/crabik_slot_esp32_s3/pins_arduino.h
@@ -9,17 +9,8 @@
 #define USB_PRODUCT "Slot ESP32-S3"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = 21;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t S1  = 1;
 static const uint8_t S2  = 12;

--- a/variants/cytron_maker_feather_aiot_s3/pins_arduino.h
+++ b/variants/cytron_maker_feather_aiot_s3/pins_arduino.h
@@ -10,23 +10,11 @@
 #define USB_PRODUCT        "Maker Feather AIoT S3"
 #define USB_SERIAL         ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       12
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-
-
 static const uint8_t LED_BUILTIN = 2;                           // Status LED.
 static const uint8_t RGB_BUILTIN = SOC_GPIO_PIN_COUNT + 46;     // RGB LED.
 
 #define BUILTIN_LED     LED_BUILTIN                             // Backward compatibility
-#define LED_BUILTIN     LED_BUILTIN
 #define LED             LED_BUILTIN
-#define RGB_BUILTIN     RGB_BUILTIN
 #define RGB             RGB_BUILTIN
 #define NEOPIXEL        RGB_BUILTIN
 #define RGB_BRIGHTNESS  65

--- a/variants/d-duino-32/pins_arduino.h
+++ b/variants/d-duino-32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/d1_mini32/pins_arduino.h
+++ b/variants/d1_mini32/pins_arduino.h
@@ -6,7 +6,6 @@
 
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 static const uint8_t _VBAT = 35; // battery voltage
 
 #define PIN_WIRE_SDA SDA // backward compatibility

--- a/variants/d1_uno32/pins_arduino.h
+++ b/variants/d1_uno32/pins_arduino.h
@@ -5,15 +5,6 @@
 
 #include <stdint.h>
 
-
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
@@ -34,7 +25,6 @@ static const uint8_t A5 = 39;
 
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 #define PIN_WIRE_SDA SDA // backward compatibility
 #define PIN_WIRE_SCL SCL // backward compatibility

--- a/variants/d32/d32_core.h
+++ b/variants/d32/d32_core.h
@@ -1,14 +1,6 @@
 #ifndef _D32_CORE_H_
 #define _D32_CORE_H_
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/d32/pins_arduino.h
+++ b/variants/d32/pins_arduino.h
@@ -6,7 +6,6 @@
 
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 static const uint8_t _VBAT = 35; // battery voltage
 
 #endif /* Pins_Arduino_h */

--- a/variants/d32_pro/pins_arduino.h
+++ b/variants/d32_pro/pins_arduino.h
@@ -6,7 +6,6 @@
 
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 static const uint8_t _VBAT = 35; // battery voltage
 
 #define TF_CS   4  // TF (Micro SD Card) CS pin

--- a/variants/deneyapkart/pins_arduino.h
+++ b/variants/deneyapkart/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 4;
 #define BUILTIN_LED LED_BUILTIN
-#define LED_BUILTIN LED_BUILTIN
 #define LEDB        LED_BUILTIN
 #define LEDR 3
 #define LEDG 1

--- a/variants/deneyapkart1A/pins_arduino.h
+++ b/variants/deneyapkart1A/pins_arduino.h
@@ -4,17 +4,8 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+13;
 #define BUILTIN_LED LED_BUILTIN
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGBLED      LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/deneyapkart1Av2/pins_arduino.h
+++ b/variants/deneyapkart1Av2/pins_arduino.h
@@ -10,17 +10,8 @@
 #define USB_PRODUCT        "DENEYAP KART 1A v2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS	46
-#define NUM_DIGITAL_PINS	48
-#define NUM_ANALOG_INPUTS	20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define BUILTIN_LED LED_BUILTIN
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGBLED      LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/deneyapkartg/pins_arduino.h
+++ b/variants/deneyapkartg/pins_arduino.h
@@ -10,17 +10,8 @@
 #define USB_PRODUCT        "DENEYAP KART G"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+10;
 #define BUILTIN_LED LED_BUILTIN
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGBLED      LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/deneyapmini/pins_arduino.h
+++ b/variants/deneyapmini/pins_arduino.h
@@ -9,17 +9,8 @@
 #define USB_PRODUCT        "DENEYAP MINI"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = 35;
 #define BUILTIN_LED LED_BUILTIN
-#define LED_BUILTIN LED_BUILTIN
 #define LEDB        LED_BUILTIN
 #define LEDR 34
 #define LEDG 33

--- a/variants/deneyapminiv2/pins_arduino.h
+++ b/variants/deneyapminiv2/pins_arduino.h
@@ -10,17 +10,8 @@
 #define USB_PRODUCT        "DENEYAP MINI v2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+33;
 #define BUILTIN_LED LED_BUILTIN
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGBLED      LED_BUILTIN
 #define RGB_BRIGHTNESS 64

--- a/variants/department_of_alchemy_minimain_esp32s2/pins_arduino.h
+++ b/variants/department_of_alchemy_minimain_esp32s2/pins_arduino.h
@@ -10,12 +10,14 @@
 #define USB_PRODUCT        "MiniMain ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define PIN_NEOPIXEL        33
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+// User LED 
+#define LED_BUILTIN 13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
-#define RGB_BUILTIN LED_BUILTIN
+
+// Neopixel
+#define PIN_NEOPIXEL        33
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite() and digitalWrite() for blinking
+#define RGB_BUILTIN (PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 
 #define NEOPIXEL_NUM        1     // number of neopixels

--- a/variants/department_of_alchemy_minimain_esp32s2/pins_arduino.h
+++ b/variants/department_of_alchemy_minimain_esp32s2/pins_arduino.h
@@ -2,7 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
+#include "soc/soc_caps.h"
 
 #define USB_VID            0x303a
 #define USB_PID            0x80FF
@@ -10,18 +10,14 @@
 #define USB_PRODUCT        "MiniMain ESP32-S2"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-#define LED_BUILTIN     13
-
 #define PIN_NEOPIXEL        33
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
 #define NEOPIXEL_NUM        1     // number of neopixels
 #define NEOPIXEL_POWER      21    // power pin
 #define NEOPIXEL_POWER_ON   HIGH  // power pin state when on

--- a/variants/dfrobot_beetle_esp32c3/pins_arduino.h
+++ b/variants/dfrobot_beetle_esp32c3/pins_arduino.h
@@ -9,16 +9,8 @@
 #define USB_PRODUCT        "Beetle ESP32-C3"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t LED_BUILTIN = 10;
+#define BUILTIN_LED LED_BUILTIN // backward compatibility
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;

--- a/variants/dfrobot_firebeetle2_esp32e/pins_arduino.h
+++ b/variants/dfrobot_firebeetle2_esp32e/pins_arduino.h
@@ -3,21 +3,10 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 typedef unsigned char uint8_t;
 
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
-
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/dfrobot_firebeetle2_esp32s3/pins_arduino.h
+++ b/variants/dfrobot_firebeetle2_esp32s3/pins_arduino.h
@@ -9,15 +9,6 @@
 #define USB_PRODUCT        "FireBeetle 2 ESP32-S3"
 #define USB_SERIAL         "" // Empty string for MAC adddress
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/dfrobot_romeo_esp32s3/pins_arduino.h
+++ b/variants/dfrobot_romeo_esp32s3/pins_arduino.h
@@ -3,17 +3,6 @@
 
 #include <stdint.h>
 
-
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/doitESP32devkitV1/pins_arduino.h
+++ b/variants/doitESP32devkitV1/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/doitESPduino32/pins_arduino.h
+++ b/variants/doitESPduino32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/dpu_esp32/pins_arduino.h
+++ b/variants/dpu_esp32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/esp32-devkit-lipo/pins_arduino.h
+++ b/variants/esp32-devkit-lipo/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/esp32-evb/pins_arduino.h
+++ b/variants/esp32-evb/pins_arduino.h
@@ -3,15 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
-
 static const uint8_t KEY_BUILTIN = 34;
 
 static const uint8_t TX = 1;

--- a/variants/esp32-gateway/pins_arduino.h
+++ b/variants/esp32-gateway/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 #if	defined (ARDUINO_ESP32_GATEWAY_E) || defined (ARDUINO_ESP32_GATEWAY_F)
 #define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
 #define ETH_PHY_POWER 5
@@ -18,7 +10,6 @@
 
 static const uint8_t LED_BUILTIN = 33;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 34;
 

--- a/variants/esp32-poe-iso/pins_arduino.h
+++ b/variants/esp32-poe-iso/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 #define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
 #define ETH_PHY_POWER 12
 

--- a/variants/esp32-poe/pins_arduino.h
+++ b/variants/esp32-poe/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 #define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
 #define ETH_PHY_POWER 12
 

--- a/variants/esp32-trueverit-iot-driver-mkii/pins_arduino.h
+++ b/variants/esp32-trueverit-iot-driver-mkii/pins_arduino.h
@@ -6,14 +6,6 @@
 static const uint8_t LED_BUILTIN = 18;
 #define BUILTIN_LED LED_BUILTIN // backward compatibility
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS 40
-#define NUM_ANALOG_INPUTS 16
-
-#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
-#define digitalPinHasPWM(p) (p < 34)
-
 #define TX1 12
 #define RX1 13
 #define TX2 33

--- a/variants/esp32-trueverit-iot-driver-mkiii/pins_arduino.h
+++ b/variants/esp32-trueverit-iot-driver-mkiii/pins_arduino.h
@@ -6,14 +6,6 @@
 static const uint8_t LED_BUILTIN = 18;
 #define BUILTIN_LED LED_BUILTIN // backward compatibility
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS 40
-#define NUM_ANALOG_INPUTS 16
-
-#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
-#define digitalPinHasPWM(p) (p < 34)
-
 #define TX1 12
 #define RX1 13
 #define TX2 33

--- a/variants/esp32-trueverit-iot-driver/pins_arduino.h
+++ b/variants/esp32-trueverit-iot-driver/pins_arduino.h
@@ -6,14 +6,6 @@
 static const uint8_t LED_BUILTIN = 18;
 #define BUILTIN_LED LED_BUILTIN // backward compatibility
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS 40
-#define NUM_ANALOG_INPUTS 16
-
-#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
-#define digitalPinHasPWM(p) (p < 34)
-
 #define TX1 12
 #define RX1 13
 #define TX2 33

--- a/variants/esp32/pins_arduino.h
+++ b/variants/esp32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/esp320/pins_arduino.h
+++ b/variants/esp320/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 11
-#define NUM_DIGITAL_PINS        12
-#define NUM_ANALOG_INPUTS       5
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/esp32_s3r8n16/pins_arduino.h
+++ b/variants/esp32_s3r8n16/pins_arduino.h
@@ -10,14 +10,6 @@
 #define USB_PRODUCT 		"4D Systems gen4-ESP32 16MB Modules (ESP32-S3R8n16)"
 //#define USB_CLASS 2
 
-#define EXTERNAL_NUM_INTERRUPTS 46 
-#define NUM_DIGITAL_PINS        48 
-#define NUM_ANALOG_INPUTS       20 
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/esp32c3/pins_arduino.h
+++ b/variants/esp32c3/pins_arduino.h
@@ -4,19 +4,13 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+8;
+#define PIN_NEOPIXEL        8
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;

--- a/variants/esp32c6/pins_arduino.h
+++ b/variants/esp32c6/pins_arduino.h
@@ -4,19 +4,13 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 24
-#define NUM_DIGITAL_PINS        24
-#define NUM_ANALOG_INPUTS       7
-
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+8;
+#define PIN_NEOPIXEL        8
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 
 static const uint8_t TX = 16;
 static const uint8_t RX = 17;

--- a/variants/esp32da/pins_arduino.h
+++ b/variants/esp32da/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/esp32h2/pins_arduino.h
+++ b/variants/esp32h2/pins_arduino.h
@@ -4,19 +4,13 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 28
-#define NUM_DIGITAL_PINS        28
-#define NUM_ANALOG_INPUTS       5
-
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+8;
+#define PIN_NEOPIXEL        8
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 
 static const uint8_t TX = 24;
 static const uint8_t RX = 23;

--- a/variants/esp32micromod/pins_arduino.h
+++ b/variants/esp32micromod/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
@@ -71,5 +63,6 @@ static const uint8_t DAC1 = 25;
 static const uint8_t DAC2 = 26;
 
 static const uint8_t LED_BUILTIN = 2;
+#define BUILTIN_LED LED_BUILTIN // backward compatibility
 
 #endif /* Pins_Arduino_h */

--- a/variants/esp32s2/pins_arduino.h
+++ b/variants/esp32s2/pins_arduino.h
@@ -4,20 +4,16 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+18; // GPIO pin for Saola-1 & DevKitM-1 = 18
-//static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+45; // GPIO pin for Kaluga = 45
+// GPIO pin for Saola-1 & DevKitM-1 = 18
+#define PIN_NEOPIXEL        18
+// GPIO pin for Kaluga = 45
+//#define PIN_NEOPIXEL 45
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/esp32s2thing_plus/pins_arduino.h
+++ b/variants/esp32s2thing_plus/pins_arduino.h
@@ -9,14 +9,6 @@
 #define USB_PRODUCT "ESP32-S2 Thing Plus"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = 13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/esp32s2usb/pins_arduino.h
+++ b/variants/esp32s2usb/pins_arduino.h
@@ -19,15 +19,6 @@
 #define USB_FW_MSC_VOLUME_NAME 		"S2-Firmware" 	//max 11 chars
 #define USB_FW_MSC_SERIAL_NUMBER 	0x00000000
 
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/esp32s3/pins_arduino.h
+++ b/variants/esp32s3/pins_arduino.h
@@ -7,22 +7,17 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
 // Some boards have too low voltage on this pin (board design bug)
 // Use different pin with 3V and connect with 48
 // and change this setup for the chosen pin (for example 38)
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
+#define PIN_NEOPIXEL        48
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
 
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/esp32s3box/pins_arduino.h
+++ b/variants/esp32s3box/pins_arduino.h
@@ -6,14 +6,6 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/esp32s3camlcd/pins_arduino.h
+++ b/variants/esp32s3camlcd/pins_arduino.h
@@ -6,14 +6,6 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/esp32s3usbotg/pins_arduino.h
+++ b/variants/esp32s3usbotg/pins_arduino.h
@@ -6,14 +6,6 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/esp32thing/pins_arduino.h
+++ b/variants/esp32thing/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/esp32thing_plus/pins_arduino.h
+++ b/variants/esp32thing_plus/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 17;
 static const uint8_t RX = 16;

--- a/variants/esp32thing_plus_c/pins_arduino.h
+++ b/variants/esp32thing_plus_c/pins_arduino.h
@@ -4,20 +4,11 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 static const uint8_t RGB_BUILTIN = SOC_GPIO_PIN_COUNT+2;
-#define RGB_BUILTIN RGB_BUILTIN
 #define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 17;

--- a/variants/esp32vn-iot-uno/pins_arduino.h
+++ b/variants/esp32vn-iot-uno/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/esp_c3_m1_i_kit/pins_arduino.h
+++ b/variants/esp_c3_m1_i_kit/pins_arduino.h
@@ -8,14 +8,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 // User LEDs are also connected to USB D- and D+
 static const uint8_t LED_WARM = 18;
 static const uint8_t LED_COLD = 19;

--- a/variants/espea32/pins_arduino.h
+++ b/variants/espea32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/espectro32/pins_arduino.h
+++ b/variants/espectro32/pins_arduino.h
@@ -7,17 +7,8 @@
 #define ESPECTRO32_VERSION 1
 #endif 
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 15;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/espino32/pins_arduino.h
+++ b/variants/espino32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        38
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 16;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t BUILTIN_KEY = 0;
 

--- a/variants/feather_esp32/pins_arduino.h
+++ b/variants/feather_esp32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 17;
 static const uint8_t RX = 16;

--- a/variants/firebeetle32/pins_arduino.h
+++ b/variants/firebeetle32/pins_arduino.h
@@ -3,21 +3,10 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 typedef unsigned char uint8_t;
 
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
-
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/fm-devkit/pins_arduino.h
+++ b/variants/fm-devkit/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/franzininho_wifi_esp32s2/pins_arduino.h
+++ b/variants/franzininho_wifi_esp32s2/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID             0x303A
 #define USB_PID             0x80A9
@@ -10,15 +11,13 @@
 #define USB_SERIAL 			"0"
 #define USB_WEBUSB_ENABLED	false
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t PIN_NEOPIXEL = 18;
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/franzininho_wifi_msc_esp32s2/pins_arduino.h
+++ b/variants/franzininho_wifi_msc_esp32s2/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID             0x303A
 #define USB_PID             0x80A9
@@ -17,15 +18,13 @@
 #define USB_FW_MSC_VOLUME_NAME 		"S2-Firmware" 	//max 11 chars
 #define USB_FW_MSC_SERIAL_NUMBER 	0x00000000
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t PIN_NEOPIXEL = 18;
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/frog32/pins_arduino.h
+++ b/variants/frog32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/gpy/pins_arduino.h
+++ b/variants/gpy/pins_arduino.h
@@ -2,14 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       18
-
-#define analogInputToDigitalPin(p)  (((p)<40)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
+#include "soc/soc_caps.h"
 
 // Sequans Monarch LTE Cat M1/NB1 modem
 // NOTE: The Pycom pinout as well as spec sheet block diagram / pin details
@@ -22,9 +15,13 @@
 #define LTE_WAKE 27 // GPIO27 - Sequans modem wake-up interrupt
 #define LTE_BAUD 921600
 
-static const uint8_t LED_BUILTIN = 0; // ->2812 RGB !!!
+// Neopixel
+#define PIN_NEOPIXEL 0 // ->2812 RGB !!!
+static const uint8_t LED_BUILTIN = PIN_NEOPIXEL; 
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)
+#define RGB_BRIGHTNESS 64
 
 #define ANT_SELECT 21   // GPIO21 - WiFi external / internal antenna switch
 

--- a/variants/healthypi4/pins_arduino.h
+++ b/variants/healthypi4/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 15;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 17;
 

--- a/variants/heltec_wifi_kit_32/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32/pins_arduino.h
@@ -7,17 +7,8 @@
 #define DISPLAY_HEIGHT 64
 #define DISPLAY_WIDTH  128
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 25;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/heltec_wifi_kit_32_V3/pins_arduino.h
+++ b/variants/heltec_wifi_kit_32_V3/pins_arduino.h
@@ -2,23 +2,19 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define WIFI_Kit_32_V3	true
 #define DISPLAY_HEIGHT 64
 #define DISPLAY_WIDTH  128
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
-static const uint8_t LED_BUILTIN = 35;
+#define PIN_NEOPIXEL        35
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 static const uint8_t KEY_BUILTIN = 0;
 
 static const uint8_t TX = 43;

--- a/variants/heltec_wifi_lora_32/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32/pins_arduino.h
@@ -7,17 +7,8 @@
 #define DISPLAY_HEIGHT 64
 #define DISPLAY_WIDTH  128
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 25;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/heltec_wifi_lora_32_V2/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V2/pins_arduino.h
@@ -7,17 +7,8 @@
 #define DISPLAY_HEIGHT 64
 #define DISPLAY_WIDTH  128
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 25;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/heltec_wifi_lora_32_V3/pins_arduino.h
+++ b/variants/heltec_wifi_lora_32_V3/pins_arduino.h
@@ -11,22 +11,8 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-// Some boards have too low voltage on this pin (board design bug)
-// Use different pin with 3V and connect with 48
-// and change this setup for the chosen pin (for example 38)
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
+static const uint8_t LED_BUILTIN = 35;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-#define RGB_BUILTIN LED_BUILTIN
-#define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/heltec_wireless_stick/pins_arduino.h
+++ b/variants/heltec_wireless_stick/pins_arduino.h
@@ -7,17 +7,8 @@
 #define DISPLAY_HEIGHT 32
 #define DISPLAY_WIDTH  64
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 25;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/heltec_wireless_stick_lite/pins_arduino.h
+++ b/variants/heltec_wireless_stick_lite/pins_arduino.h
@@ -7,17 +7,8 @@
 #define DISPLAY_HEIGHT 0
 #define DISPLAY_WIDTH  0
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 25;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/heltec_wireless_stick_lite_v3/pins_arduino.h
+++ b/variants/heltec_wireless_stick_lite_v3/pins_arduino.h
@@ -7,17 +7,8 @@
 #define DISPLAY_HEIGHT 0
 #define DISPLAY_WIDTH  0
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       15
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 35;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/honeylemon/pins_arduino.h
+++ b/variants/honeylemon/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        38
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t BUILTIN_KEY = 0;
 

--- a/variants/hornbill32dev/pins_arduino.h
+++ b/variants/hornbill32dev/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/hornbill32minima/pins_arduino.h
+++ b/variants/hornbill32minima/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;  //taken out on pgm header
 static const uint8_t RX = 3;  //taken out on pgm header
 

--- a/variants/imbrios-logsens-v1p1/pins_arduino.h
+++ b/variants/imbrios-logsens-v1p1/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        9
-#define NUM_ANALOG_INPUTS       7
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 // Renaming few signals
 #define SPI_CLK	SCK			// IO14
 #define SPI_MISO	MISO			// IO12
@@ -23,7 +15,6 @@
 /* LED_BUILTIN is kept for compatibility reason; mapped to LED2 on the LogSens V1.1 Board */
 static const uint8_t LED_BUILTIN = 33;
 #define BUILTIN_LED  LED_BUILTIN 	// backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 /* UART0: Serial Port for Programming and Debugging on the LogSens V1.1 Board */
 static const uint8_t TX = 1;

--- a/variants/intorobot-fig/pins_arduino.h
+++ b/variants/intorobot-fig/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        7
-#define NUM_ANALOG_INPUTS       10
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 4;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t RGB_R_BUILTIN = 27;
 static const uint8_t RGB_G_BUILTIN = 21;

--- a/variants/lilygo_t_display/pins_arduino.h
+++ b/variants/lilygo_t_display/pins_arduino.h
@@ -9,14 +9,6 @@
 #define USB_PRODUCT "T-Display"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/lilygo_t_display_s3/pins_arduino.h
+++ b/variants/lilygo_t_display_s3/pins_arduino.h
@@ -7,14 +7,6 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t BUTTON_1 = 0;
 static const uint8_t BUTTON_2 = 14;
 static const uint8_t BAT_VOLT = 4;

--- a/variants/lionbit/pins_arduino.h
+++ b/variants/lionbit/pins_arduino.h
@@ -3,15 +3,9 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS 40
-#define NUM_ANALOG_INPUTS 16
-
-#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
-#define digitalPinHasPWM(p) (p < 34)
-
 static const uint8_t LED_BUILTIN = 0; // GPIO0, ADC2_CH1, TOUCH1, RTC_GPIO11, CLK_OUT1,EMAC_TX_CLK
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t SWITCH_A = 2;    //  GPIO2, ADC2_CH2, TOUCH2, RTC_GPIO12, HSPIWP, HS2_DATA0,SD_DATA0
 static const uint8_t SWITCH_B = 4;    //  GPIO4, ADC2_CH0, TOUCH0, RTC_GPIO10, HSPIHD, HS2_DATA1,SD_DATA1, EMAC_TX_ER
 

--- a/variants/lionbits3/pins_arduino.h
+++ b/variants/lionbits3/pins_arduino.h
@@ -3,15 +3,9 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS 40
-#define NUM_ANALOG_INPUTS 16
-
-#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
-#define digitalPinHasPWM(p) (p < 34)
-
 static const uint8_t LED_BUILTIN = 0;  //GPIO0, 
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t SWITCH_A = 46;    //GPIO46, 
 static const uint8_t SWITCH_B = 47;    //GPIO47, 
 //Wifi and Bluetooth LEDs

--- a/variants/lolin32-lite/pins_arduino.h
+++ b/variants/lolin32-lite/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/lolin32/pins_arduino.h
+++ b/variants/lolin32/pins_arduino.h
@@ -3,19 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
-
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/lolin_c3_mini/pins_arduino.h
+++ b/variants/lolin_c3_mini/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t LED_BUILTIN = 7;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/lolin_s2_mini/pins_arduino.h
+++ b/variants/lolin_s2_mini/pins_arduino.h
@@ -18,14 +18,6 @@
 #define USB_FW_MSC_VOLUME_NAME 		"S2-Firmware" 	//max 11 chars
 #define USB_FW_MSC_SERIAL_NUMBER 	0x00000000
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = 15;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/lolin_s2_pico/pins_arduino.h
+++ b/variants/lolin_s2_pico/pins_arduino.h
@@ -18,14 +18,6 @@
 #define USB_FW_MSC_VOLUME_NAME 		"S2-Firmware" 	//max 11 chars
 #define USB_FW_MSC_SERIAL_NUMBER 	0x00000000
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = 10;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/lolin_s3/pins_arduino.h
+++ b/variants/lolin_s3/pins_arduino.h
@@ -6,20 +6,10 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       18
-
-
 static const uint8_t LED_BUILTIN = 38;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/lolin_s3_mini/pins_arduino.h
+++ b/variants/lolin_s3_mini/pins_arduino.h
@@ -6,20 +6,10 @@
 #define USB_VID 0x303a
 #define USB_PID 0x8167
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       18
-
-
 static const uint8_t LED_BUILTIN = 47;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/lolin_s3_pro/pins_arduino.h
+++ b/variants/lolin_s3_pro/pins_arduino.h
@@ -6,20 +6,10 @@
 #define USB_VID 0x303a
 #define USB_PID 0x8161
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       18
-
-
 static const uint8_t LED_BUILTIN = 38;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/lopy/pins_arduino.h
+++ b/variants/lopy/pins_arduino.h
@@ -2,14 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       18
-
-#define analogInputToDigitalPin(p)  (((p)<40)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
+#include "soc/soc_caps.h"
 
 // SPI LoRa Radio
 #define LORA_SCK 5      // GPIO5  - SX1276 SCK
@@ -22,9 +15,13 @@
 #define LORA_IO1 LORA_IRQ  // tied by diode to IO0
 #define LORA_IO2 LORA_IRQ  // tied by diode to IO0
 
-static const uint8_t LED_BUILTIN = 0; // ->2812 RGB !!!
+// Neopixel
+#define PIN_NEOPIXEL 0 // ->2812 RGB !!!
+static const uint8_t LED_BUILTIN = PIN_NEOPIXEL; 
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)
+#define RGB_BRIGHTNESS 64
 
 #define ANT_SELECT 16   // GPIO16 - External Antenna Switch
 

--- a/variants/lopy4/pins_arduino.h
+++ b/variants/lopy4/pins_arduino.h
@@ -2,14 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       18
-
-#define analogInputToDigitalPin(p)  (((p)<40)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
+#include "soc/soc_caps.h"
 
 // SPI LoRa Radio
 #define LORA_SCK 5      // GPIO5  - SX1276 SCK
@@ -22,9 +15,13 @@
 #define LORA_IO2 LORA_IRQ   // tied by diode to IO0
 #define LORA_RST NOT_A_PIN
 
-static const uint8_t LED_BUILTIN = 0; // ->2812 RGB !!!
+// Neopixel
+#define PIN_NEOPIXEL 0 // ->2812 RGB !!!
+static const uint8_t LED_BUILTIN = PIN_NEOPIXEL; 
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)
+#define RGB_BRIGHTNESS 64
 
 #define ANT_SELECT 21   // GPIO21 - External Antenna Switch
 

--- a/variants/m5stack_atom/pins_arduino.h
+++ b/variants/m5stack_atom/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/m5stack_atoms3/pins_arduino.h
+++ b/variants/m5stack_atoms3/pins_arduino.h
@@ -7,23 +7,10 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-// Some boards have too low voltage on this pin (board design bug)
-// Use different pin with 3V and connect with 48
-// and change this setup for the chosen pin (for example 38)
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + 48;
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + 35;
 #define BUILTIN_LED    LED_BUILTIN  // backward compatibility
-#define LED_BUILTIN    LED_BUILTIN
 #define RGB_BUILTIN    LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p) \
-    (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
-#define digitalPinHasPWM(p)      (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/m5stack_core2/pins_arduino.h
+++ b/variants/m5stack_core2/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 #define TX2 14
 #define RX2 13
 

--- a/variants/m5stack_core_esp32/pins_arduino.h
+++ b/variants/m5stack_core_esp32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/m5stack_coreink/pins_arduino.h
+++ b/variants/m5stack_coreink/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 #define TX2 14
 #define RX2 13
 

--- a/variants/m5stack_cores3/pins_arduino.h
+++ b/variants/m5stack_cores3/pins_arduino.h
@@ -7,23 +7,13 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
 // Some boards have too low voltage on this pin (board design bug)
 // Use different pin with 3V and connect with 48
 // and change this setup for the chosen pin (for example 38)
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + 48;
 #define BUILTIN_LED    LED_BUILTIN  // backward compatibility
-#define LED_BUILTIN    LED_BUILTIN
 #define RGB_BUILTIN    LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p) \
-    (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
-#define digitalPinHasPWM(p)      (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/m5stack_fire/pins_arduino.h
+++ b/variants/m5stack_fire/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/m5stack_stamp_pico/pins_arduino.h
+++ b/variants/m5stack_stamp_pico/pins_arduino.h
@@ -3,15 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/m5stack_stamp_s3/pins_arduino.h
+++ b/variants/m5stack_stamp_s3/pins_arduino.h
@@ -7,15 +7,6 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 23
-#define NUM_DIGITAL_PINS        46
-#define NUM_ANALOG_INPUTS       15
-
-#define analogInputToDigitalPin(p) \
-    (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
-#define digitalPinHasPWM(p)      (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/m5stack_station/pins_arduino.h
+++ b/variants/m5stack_station/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)   (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)        (p<34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/m5stack_timer_cam/pins_arduino.h
+++ b/variants/m5stack_timer_cam/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/m5stick_c/pins_arduino.h
+++ b/variants/m5stick_c/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/magicbit/pins_arduino.h
+++ b/variants/magicbit/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
@@ -66,6 +58,8 @@ static const uint8_t MOTOR1A = 27;
 static const uint8_t MOTOR1B = 18;
 static const uint8_t MOTOR2A = 16;
 static const uint8_t MOTOR2B = 17;
+
 static const uint8_t LED_BUILTIN=16;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 #endif /* Pins_Arduino_h */

--- a/variants/metro_esp-32/pins_arduino.h
+++ b/variants/metro_esp-32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/mgbot-iotik32a/pins_arduino.h
+++ b/variants/mgbot-iotik32a/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 4;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/mgbot-iotik32b/pins_arduino.h
+++ b/variants/mgbot-iotik32b/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 18;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 // IR receiver
 static const uint8_t IR = 27;

--- a/variants/mhetesp32devkit/pins_arduino.h
+++ b/variants/mhetesp32devkit/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN 
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/mhetesp32minikit/pins_arduino.h
+++ b/variants/mhetesp32minikit/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN 
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/micro_s2/pins_arduino.h
+++ b/variants/micro_s2/pins_arduino.h
@@ -9,14 +9,6 @@
 #define USB_PRODUCT "microS2"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 
@@ -71,7 +63,12 @@ static const uint8_t DAC2 = 18;
 
 static const uint8_t LED_BUILTIN =  21;
 #define BUILTIN_LED  LED_BUILTIN    // backward compatibility
+
 static const uint8_t PIXEL_BUILTIN = 33;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (PIXEL_BUILTIN + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+
 static const uint8_t BUTTON_BUILTIN = 0;
 
 #endif /* Pins_Arduino_h */

--- a/variants/mpython/pins_arduino.h
+++ b/variants/mpython/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/namino_arancio/pins_arduino.h
+++ b/variants/namino_arancio/pins_arduino.h
@@ -6,19 +6,11 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-#include "soc/soc_caps.h"
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
 #define NAMINO_ARANCIO_BOARD
-
-#define NUM_DIGITAL_PINS            SOC_GPIO_PIN_COUNT    // GPIO 0..48
-#define NUM_ANALOG_INPUTS           20                    // GPIO 1..20
-#define EXTERNAL_NUM_INTERRUPTS     NUM_DIGITAL_PINS      // All GPIOs
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):NOT_AN_INTERRUPT)
-#define digitalPinHasPWM(p)         (p < NUM_DIGITAL_PINS)
 
 /* Begin Pins on ESP32-S3-WROOM-1U-N4R8 */
 static const uint8_t GPIO4       = 4;

--- a/variants/namino_rosso/pins_arduino.h
+++ b/variants/namino_rosso/pins_arduino.h
@@ -6,19 +6,11 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-#include "soc/soc_caps.h"
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
 #define NAMINO_ROSSO_BOARD
-
-#define NUM_DIGITAL_PINS            SOC_GPIO_PIN_COUNT    // GPIO 0..48
-#define NUM_ANALOG_INPUTS           20                    // GPIO 1..20
-#define EXTERNAL_NUM_INTERRUPTS     NUM_DIGITAL_PINS      // All GPIOs
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):NOT_AN_INTERRUPT)
-#define digitalPinHasPWM(p)         (p < NUM_DIGITAL_PINS)
 
 /* Begin Pins on ESP32-S3-WROOM-1U-N4R8 */
 static const uint8_t GPIO4       = 4;

--- a/variants/nano32/pins_arduino.h
+++ b/variants/nano32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        38
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 16;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t BUILTIN_KEY = 0;
 

--- a/variants/nina_w10/pins_arduino.h
+++ b/variants/nina_w10/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_GREEN = 33;
 static const uint8_t LED_RED = 23;
 static const uint8_t LED_BLUE = 21;

--- a/variants/node32s/pins_arduino.h
+++ b/variants/node32s/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/nodemcu-32s/pins_arduino.h
+++ b/variants/nodemcu-32s/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/nora_w10/pins_arduino.h
+++ b/variants/nora_w10/pins_arduino.h
@@ -2,18 +2,9 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-#include "soc/soc_caps.h"
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 // The pin assignments in this file are based on u-blox EVK-NORA-W1, a Arduino compatible board.
 // For your own module design you can freely chose the pins available on the module module pins

--- a/variants/odroid_esp32/pins_arduino.h
+++ b/variants/odroid_esp32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/onehorse32dev/pins_arduino.h
+++ b/variants/onehorse32dev/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/openkb/pins_arduino.h
+++ b/variants/openkb/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        38
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 16;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/oroca_edubot/pins_arduino.h
+++ b/variants/oroca_edubot/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 17;
 static const uint8_t RX = 16;

--- a/variants/pico32/pins_arduino.h
+++ b/variants/pico32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/piranha_esp-32/pins_arduino.h
+++ b/variants/piranha_esp-32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/pocket_32/pins_arduino.h
+++ b/variants/pocket_32/pins_arduino.h
@@ -3,19 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 16;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
-
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/quantum/pins_arduino.h
+++ b/variants/quantum/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/redpill_esp32s3/pins_arduino.h
+++ b/variants/redpill_esp32s3/pins_arduino.h
@@ -6,17 +6,8 @@
 #define USB_VID 0x303A
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t LED_BUILTIN = 3;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
 

--- a/variants/roboheart_hercules/pins_arduino.h
+++ b/variants/roboheart_hercules/pins_arduino.h
@@ -3,15 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
-
 // Motor driver pins 
 #define MOTOR_A_IN1 25  //  PHASE/IN1
 #define MOTOR_A_IN2 26  //  ENABLE/IN2

--- a/variants/sonoff_dualr3/pins_arduino.h
+++ b/variants/sonoff_dualr3/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/sparkfun_esp32_iot_redboard/pins_arduino.h
+++ b/variants/sparkfun_esp32_iot_redboard/pins_arduino.h
@@ -4,20 +4,11 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 18;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
-static const uint8_t RGB_BUILTIN = SOC_GPIO_PIN_COUNT+2;
-#define RGB_BUILTIN RGB_BUILTIN
+#define NEO_PIXEL 2 //WS2812 LED
+static const uint8_t RGB_BUILTIN = (SOC_GPIO_PIN_COUNT+NEO_PIXEL);
 #define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 1;

--- a/variants/sparkfun_lora_gateway_1-channel/pins_arduino.h
+++ b/variants/sparkfun_lora_gateway_1-channel/pins_arduino.h
@@ -3,15 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const int LED_BUILTIN = 17;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/tamc_termod_s3/pins_arduino.h
+++ b/variants/tamc_termod_s3/pins_arduino.h
@@ -7,22 +7,13 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
 // Some boards have too low voltage on this pin (board design bug)
 // Use different pin with 3V and connect with 48
 // and change this setup for the chosen pin (for example 38)
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define RGB_BUILTIN LED_BUILTIN
 #define RGB_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/tbeam/pins_arduino.h
+++ b/variants/tbeam/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 // SPI LoRa Radio
 #define LORA_SCK 5      // GPIO5  - SX1276 SCK
 #define LORA_MISO 19    // GPIO19 - SX1276 MISO
@@ -26,7 +18,6 @@ static const uint8_t KEY_BUILTIN = 39;
 
 static const uint8_t LED_BUILTIN = 14;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/ttgo-lora32-v1/pins_arduino.h
+++ b/variants/ttgo-lora32-v1/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 // I2C OLED Display works with SSD1306 driver
 #define OLED_SDA 4
 #define OLED_SCL 15
@@ -26,7 +18,6 @@
 
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/ttgo-lora32-v2/pins_arduino.h
+++ b/variants/ttgo-lora32-v2/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 // I2C OLED Display works with SSD1306 driver
 #define OLED_SDA    21
 #define OLED_SCL    22
@@ -32,7 +24,6 @@
 
 static const uint8_t LED_BUILTIN =  22;
 #define BUILTIN_LED  LED_BUILTIN    // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN =  0;
 

--- a/variants/ttgo-lora32-v21new/pins_arduino.h
+++ b/variants/ttgo-lora32-v21new/pins_arduino.h
@@ -9,14 +9,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 // I2C OLED Display works with SSD1306 driver
 #define OLED_SDA    21
 #define OLED_SCL    22
@@ -38,9 +30,8 @@
 #define SD_MOSI 15
 #define SD_CS   13
 
-static const uint8_t LED_BUILTIN = 25  ;
+static const uint8_t LED_BUILTIN = 25;
 #define BUILTIN_LED  LED_BUILTIN    // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN =  0;
 

--- a/variants/ttgo-t-oi-plus/pins_arduino.h
+++ b/variants/ttgo-t-oi-plus/pins_arduino.h
@@ -3,15 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 12
-#define NUM_DIGITAL_PINS        12
-#define NUM_ANALOG_INPUTS       3
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
-
 static const uint8_t LED_BUILTIN = 3;
+#define BUILTIN_LED  LED_BUILTIN    // backward compatibility
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;

--- a/variants/ttgo-t1/pins_arduino.h
+++ b/variants/ttgo-t1/pins_arduino.h
@@ -3,20 +3,11 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
 static const uint8_t LED_BUILTIN = 22;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t SDA = 21;
 // Despite the many diagrams from TTGO showing SCL on pin 22, due to the on-board LED

--- a/variants/ttgo-t7-v13-mini32/pins_arduino.h
+++ b/variants/ttgo-t7-v13-mini32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/ttgo-t7-v14-mini32/pins_arduino.h
+++ b/variants/ttgo-t7-v14-mini32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/turta_iot_node/pins_arduino.h
+++ b/variants/turta_iot_node/pins_arduino.h
@@ -3,18 +3,9 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 20
-#define NUM_DIGITAL_PINS        21
-#define NUM_ANALOG_INPUTS       9
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 // LED
 static const uint8_t LED_BUILTIN = 13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 // UART
 static const uint8_t TX = 10;

--- a/variants/twatch/pins_arduino.h
+++ b/variants/twatch/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        20
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 // touch screen
 #define TP_SDA              23
 #define TP_SCL              32

--- a/variants/uPesy_esp32_wroom_devkit/pins_arduino.h
+++ b/variants/uPesy_esp32_wroom_devkit/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/uPesy_esp32_wrover_devkit/pins_arduino.h
+++ b/variants/uPesy_esp32_wrover_devkit/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/um_feathers2/pins_arduino.h
+++ b/variants/um_feathers2/pins_arduino.h
@@ -9,14 +9,6 @@
 #define USB_PRODUCT "FeatherS2"
 #define USB_SERIAL ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 

--- a/variants/um_feathers2neo/pins_arduino.h
+++ b/variants/um_feathers2neo/pins_arduino.h
@@ -52,6 +52,9 @@ static const uint8_t DAC1 = 17;
 static const uint8_t DAC2 = 18;
 
 static const uint8_t NEOPIXEL_MATRIX_DATA = 21;
+static const uint8_t NEOPIXEL_MATRIX_PWR = 4;
+
+static const uint8_t NEOPIXEL_DATA = 40;
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN (NEOPIXEL_DATA + SOC_GPIO_PIN_COUNT)  
 #define RGB_BRIGHTNESS 64
@@ -59,9 +62,6 @@ static const uint8_t NEOPIXEL_MATRIX_DATA = 21;
 static const uint8_t LED_BUILTIN = RGB_BUILTIN;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
-static const uint8_t NEOPIXEL_MATRIX_PWR = 4;
-
-static const uint8_t NEOPIXEL_DATA = 40;
 static const uint8_t NEOPIXEL_PWR = 39;
 
 static const uint8_t VBAT_SENSE = 2;

--- a/variants/um_feathers2neo/pins_arduino.h
+++ b/variants/um_feathers2neo/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x239A
 #define USB_PID 0x80B4
 #define USB_MANUFACTURER "Unexpected Maker"
 #define USB_PRODUCT "FeatherS2 Neo"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       11
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -59,6 +52,13 @@ static const uint8_t DAC1 = 17;
 static const uint8_t DAC2 = 18;
 
 static const uint8_t NEOPIXEL_MATRIX_DATA = 21;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (NEOPIXEL_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t NEOPIXEL_MATRIX_PWR = 4;
 
 static const uint8_t NEOPIXEL_DATA = 40;

--- a/variants/um_feathers3/pins_arduino.h
+++ b/variants/um_feathers3/pins_arduino.h
@@ -52,13 +52,14 @@ static const uint8_t T14 = 14;
 static const uint8_t VBAT_SENSE = 2;
 static const uint8_t VBUS_SENSE = 34;
 
+// User LED 
+#define LED_BUILTIN 13
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t RGB_DATA = 40;
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
 #define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
 #define RGB_BRIGHTNESS 64
-// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = RGB_BUILTIN;
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t RGB_PWR = 39;
 static const uint8_t LDO2 = 39;

--- a/variants/um_feathers3/pins_arduino.h
+++ b/variants/um_feathers3/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x80D6
 #define USB_MANUFACTURER "Unexpected Maker"
 #define USB_PRODUCT "FeatherS3"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        21
-#define NUM_ANALOG_INPUTS       13
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -60,6 +53,13 @@ static const uint8_t VBAT_SENSE = 2;
 static const uint8_t VBUS_SENSE = 34;
 
 static const uint8_t RGB_DATA = 40;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t RGB_PWR = 39;
 static const uint8_t LDO2 = 39;
 static const uint8_t LED_BUILTIN = 13;

--- a/variants/um_feathers3/pins_arduino.h
+++ b/variants/um_feathers3/pins_arduino.h
@@ -62,7 +62,6 @@ static const uint8_t LED_BUILTIN = RGB_BUILTIN;
 
 static const uint8_t RGB_PWR = 39;
 static const uint8_t LDO2 = 39;
-static const uint8_t LED_BUILTIN = 13;
 static const uint8_t LED = 13;
 
 #endif /* Pins_Arduino_h */

--- a/variants/um_nanos3/pins_arduino.h
+++ b/variants/um_nanos3/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x8179
 #define USB_MANUFACTURER "Unexpected Maker"
 #define USB_PRODUCT "Nanos3"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        17
-#define NUM_ANALOG_INPUTS       9
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -51,6 +44,13 @@ static const uint8_t T8 = 8;
 static const uint8_t T9 = 9;
 
 static const uint8_t RGB_DATA = 41;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t RGB_PWR = 42;
 
 #endif /* Pins_Arduino_h */

--- a/variants/um_pros3/pins_arduino.h
+++ b/variants/um_pros3/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x80D3
 #define USB_MANUFACTURER "Unexpected Maker"
 #define USB_PRODUCT "ProS3"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        27
-#define NUM_ANALOG_INPUTS       14
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -62,6 +55,13 @@ static const uint8_t VBAT_SENSE = 10;
 static const uint8_t VBUS_SENSE = 33;
 
 static const uint8_t RGB_DATA = 18;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t RGB_PWR = 17;
 static const uint8_t LDO2 = 17;
 

--- a/variants/um_rmp/pins_arduino.h
+++ b/variants/um_rmp/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x8001
 #define USB_MANUFACTURER "Unexpected Maker"
 #define USB_PRODUCT "RM Pro"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -73,6 +66,13 @@ static const uint8_t VBAT_SENSE = 3;
 static const uint8_t VBUS_SENSE = 21;
 
 static const uint8_t RGB_DATA = 1;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t RGB_PWR = 2;
 
 #endif /* Pins_Arduino_h */

--- a/variants/um_tinypico/pins_arduino.h
+++ b/variants/um_tinypico/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/um_tinys2/pins_arduino.h
+++ b/variants/um_tinys2/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x8001
 #define USB_MANUFACTURER "Unexpected Maker"
 #define USB_PRODUCT "TinyS2"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -73,6 +66,13 @@ static const uint8_t VBAT_SENSE = 3;
 static const uint8_t VBUS_SENSE = 21;
 
 static const uint8_t RGB_DATA = 1;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t RGB_PWR = 2;
 
 #endif /* Pins_Arduino_h */

--- a/variants/um_tinys3/pins_arduino.h
+++ b/variants/um_tinys3/pins_arduino.h
@@ -2,20 +2,13 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
 #define USB_PID 0x80D0
 #define USB_MANUFACTURER "Unexpected Maker"
 #define USB_PRODUCT "TinyS3"
 #define USB_SERIAL ""
-
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        17
-#define NUM_ANALOG_INPUTS       9
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
@@ -54,6 +47,13 @@ static const uint8_t VBAT_SENSE = 10;
 static const uint8_t VBUS_SENSE = 33;
 
 static const uint8_t RGB_DATA = 18;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t RGB_PWR = 17;
 
 #endif /* Pins_Arduino_h */

--- a/variants/unphone8/pins_arduino.h
+++ b/variants/unphone8/pins_arduino.h
@@ -6,14 +6,6 @@
 #define USB_VID            0x16D0
 #define USB_PID            0x1178
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 #define LED_BUILTIN         13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/unphone9/pins_arduino.h
+++ b/variants/unphone9/pins_arduino.h
@@ -6,14 +6,6 @@
 #define USB_VID            0x16D0
 #define USB_PID            0x1178
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 #define LED_BUILTIN         13
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 

--- a/variants/vintlabsdevkitv1/pins_arduino.h
+++ b/variants/vintlabsdevkitv1/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;

--- a/variants/watchy/pins_arduino.h
+++ b/variants/watchy/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 

--- a/variants/wesp32/pins_arduino.h
+++ b/variants/wesp32/pins_arduino.h
@@ -3,14 +3,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 #define TX1   12
 #define RX1   13
 #define TX2   33

--- a/variants/widora-air/pins_arduino.h
+++ b/variants/widora-air/pins_arduino.h
@@ -3,18 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        7
-#define NUM_ANALOG_INPUTS       10
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 25;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
-
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/wifiduino32/pins_arduino.h
+++ b/variants/wifiduino32/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 2;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t KEY_BUILTIN = 0;
 

--- a/variants/wifiduino32s3/pins_arduino.h
+++ b/variants/wifiduino32s3/pins_arduino.h
@@ -7,22 +7,13 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        48
-#define NUM_ANALOG_INPUTS       20
-
 // Some boards have too low voltage on this pin (board design bug)
 // Use different pin with 3V and connect with 48
 // and change this setup for the chosen pin (for example 38)
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+48;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define BOARD_HAS_NEOPIXEL
 #define LED_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
 
 static const uint8_t TX = 45;
 static const uint8_t RX = 44;

--- a/variants/wifiduinov2/pins_arduino.h
+++ b/variants/wifiduinov2/pins_arduino.h
@@ -4,19 +4,10 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 22
-#define NUM_DIGITAL_PINS        22
-#define NUM_ANALOG_INPUTS       6
-
 static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+13;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 #define BOARD_HAS_NEOPIXEL
 #define LED_BRIGHTNESS 64
-
-#define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<NUM_DIGITAL_PINS)?(p):-1)
-#define digitalPinHasPWM(p)         (p < EXTERNAL_NUM_INTERRUPTS)
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;

--- a/variants/wipy3/pins_arduino.h
+++ b/variants/wipy3/pins_arduino.h
@@ -2,18 +2,16 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       18
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
-static const uint8_t LED_BUILTIN = 0; // ->2812 RGB !!!
+// Neopixel
+#define PIN_NEOPIXEL 0 // ->2812 RGB !!!
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT);
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (PIN_NEOPIXEL + SOC_GPIO_PIN_COUNT)
+#define RGB_BRIGHTNESS 64
 
 #define ANT_SELECT 21   // GPIO21 - External Antenna Switch
 

--- a/variants/wt32-eth01/pins_arduino.h
+++ b/variants/wt32-eth01/pins_arduino.h
@@ -9,14 +9,6 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS 40
-#define NUM_ANALOG_INPUTS 16
-
-#define analogInputToDigitalPin(p) (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
-#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
-#define digitalPinHasPWM(p) (p < 34)
-
 // interface to Ethernet PHY (LAN8720A)
 #define ETH_PHY_ADDR 1
 #define ETH_PHY_POWER 16

--- a/variants/xinabox/pins_arduino.h
+++ b/variants/xinabox/pins_arduino.h
@@ -3,17 +3,8 @@
 
 #include <stdint.h>
 
-#define EXTERNAL_NUM_INTERRUPTS 16
-#define NUM_DIGITAL_PINS        40
-#define NUM_ANALOG_INPUTS       16
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 34)
-
 static const uint8_t LED_BUILTIN = 27;
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
-#define LED_BUILTIN LED_BUILTIN
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;


### PR DESCRIPTION
## Description of Change
This PR follows #8600 and #8562 changes for all necessary variant files / boards.txt.
It also fixes the #8560 issue in the Arduino Core 3.0.0
The PR moves common macros and defines to `Arduino.h`, not necessary in `pins_arduino.h` file anymore.
It also adds NEO_LED macros and constants in order to allow using it in a `digitalWrite()` for Blinking as in the example:
https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/GPIO/BlinkRGB/BlinkRGB.ino


## Tests scenarios
Passed boards CI https://github.com/SuGlider/arduino-esp32/actions/runs/6413632411

Testing compilation of a sketch using the new `Arduino.h` and its changes:
``` cpp
void setup() {
  int a = NUM_DIGITAL_PINS;
  int b = NUM_ANALOG_INPUTS;
  int c = EXTERNAL_NUM_INTERRUPTS;
  int d = analogInputToDigitalPin(1);
  int e = digitalPinToInterrupt(2);
  bool f = digitalPinHasPWM(3);
}
void loop() { 
}
```

Tested the sketch from #8560 
``` cpp
// Not a working sketch - Using ESP32-S3

void IRAM_ATTR Callback() {
}

void setup() {
  //This does not work:
  attachInterrupt(digitalPinToInterrupt(48), Callback, FALLING);
  //This works:
  attachInterrupt(48, Callback, FALLING);
}
```

## Related links

Fix #8560 