### PR TITLE
HTTPClient - Fix case sensitiveness for header keys

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1081,7 +1081,7 @@ void HTTPClient::collectHeaders(const char* headerKeys[], const size_t headerKey
 String HTTPClient::header(const char* name)
 {
     for(size_t i = 0; i < _headerKeysCount; ++i) {
-        if(_currentHeaders[i].key == name) {
+        if(_currentHeaders[i].key.equalsIgnoreCase(name)) {
             return _currentHeaders[i].value;
         }
     }
@@ -1112,7 +1112,7 @@ int HTTPClient::headers()
 bool HTTPClient::hasHeader(const char* name)
 {
     for(size_t i = 0; i < _headerKeysCount; ++i) {
-        if((_currentHeaders[i].key == name) && (_currentHeaders[i].value.length() > 0)) {
+        if((_currentHeaders[i].key.equalsIgnoreCase(name)) && (_currentHeaders[i].value.length() > 0)) {
             return true;
         }
     }


### PR DESCRIPTION
Redo for: https://github.com/espressif/arduino-esp32/pull/8630



## Description of Change
According to the [RFC](https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2), header keys for HTTP/1.x should be treated as case-insensitive.

`String HTTPClient::header(const char* name)` and `bool HTTPClient::hasHeader(const char* name)` will, incorrectly, perform case-sensitive comparisons.

This PR makes HTTPClient comparisons for header keys case-insensitive. 

## Tests scenarios
Tested using the following sketch on ESP32:

```cpp
#include <Arduino.h>

#include <WiFi.h>
#include <WiFiMulti.h>

#include <HTTPClient.h>

#define USE_SERIAL Serial

WiFiMulti wifiMulti;

void setup() {

    USE_SERIAL.begin(115200);

    USE_SERIAL.println();
    USE_SERIAL.println();
    USE_SERIAL.println();

    for(uint8_t t = 4; t > 0; t--) {
        USE_SERIAL.printf("[SETUP] WAIT %d...\n", t);
        USE_SERIAL.flush();
        delay(1000);
    }

    wifiMulti.addAP("myssid", "mypassword");

}

void loop() {
    // wait for WiFi connection
    if((wifiMulti.run() == WL_CONNECTED)) {

        HTTPClient http;
        const char *headerKeys[] = {"Last-Modified"};
        const size_t headerKeysCount = sizeof(headerKeys) / sizeof(headerKeys[0]);

        USE_SERIAL.print("[HTTP] begin...\n");
        http.begin("http://example.com/index.html"); //HTTP

        USE_SERIAL.print("[HTTP] GET...\n");
        
        http.collectHeaders(headerKeys, headerKeysCount);

        // start connection and send HTTP header
        int httpCode = http.GET();

        // httpCode will be negative on error
        if(httpCode > 0) {
            // HTTP header has been send and Server response header has been handled
            USE_SERIAL.printf("[HTTP] GET... code: %d\n", httpCode);

            // file found at server
            if(httpCode == HTTP_CODE_OK) {
                USE_SERIAL.println();
                USE_SERIAL.print("Header Count: ");
                USE_SERIAL.println(http.headers());
                for (int i = 0; i < http.headers(); ++i) {
                    USE_SERIAL.print(http.headerName(i));
                    USE_SERIAL.print(": ");
                    USE_SERIAL.println(http.header(i));
                }
                USE_SERIAL.println();
                USE_SERIAL.print("last-modified value: ");
                USE_SERIAL.println(http.header("last-modified"));
                USE_SERIAL.print("Header has last-modified: ");
                USE_SERIAL.println(http.hasHeader("last-modified"));
                USE_SERIAL.println();
            }
        } else {
            USE_SERIAL.printf("[HTTP] GET... failed, error: %s\n", http.errorToString(httpCode).c_str());
        }

        http.end();
    }

    delay(60000);
}
```

### Output

```
[SETUP] WAIT 4...
[SETUP] WAIT 3...
[SETUP] WAIT 2...
[SETUP] WAIT 1...
[HTTP] begin...
[HTTP] GET...
[HTTP] GET... code: 200

Header Count: 1
Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT

last-modified value: Thu, 17 Oct 2019 07:18:26 GMT
Header has last-modified: 1
```

## Related links

Closes #8524
