### PR TITLE
include ctime

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
+#include <ctime>
 
 #include "pins_arduino.h"
 #include "HardwareSerial.h"


### PR DESCRIPTION
without compile will fail with newer GCC version. GCC v13.2 will not compile without

Currently not yet a problem ;-)

Replaces #8655 / target branch changed
