### PR TITLE
Fixed bug for LilyGo T-display on boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -3678,6 +3678,8 @@ lilygo_t_display.upload.maximum_size=1310720
 lilygo_t_display.upload.maximum_data_size=327680
 lilygo_t_display.upload.wait_for_upload_port=true
 lilygo_t_display.upload.speed=460800
+lilygo_t_display.upload.flags=
+lilygo_t_display.upload.extra_flags=
 
 lilygo_t_display.bootloader.tool=esptool_py
 lilygo_t_display.bootloader.tool.default=esptool_py


### PR DESCRIPTION
Fixed bug by adding upload.flags and upload.extra_flags to LilyGo T-display

Fixed same issue as #5589 
