### PR TITLE
Add SparkFun ESP32-C6 Qwiic Pocket Development Board Variant

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -5749,6 +5749,171 @@ sparkfun_esp32_iot_redboard.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+sparkfun_esp32c6_qwiic_pocket.name=SparkFun ESP32-C6 Qwiic Pocket
+sparkfun_esp32c6_qwiic_pocket.vid.0=0x303a
+sparkfun_esp32c6_qwiic_pocket.pid.0=0x1001
+
+sparkfun_esp32c6_qwiic_pocket.bootloader.tool=esptool_py
+sparkfun_esp32c6_qwiic_pocket.bootloader.tool.default=esptool_py
+
+sparkfun_esp32c6_qwiic_pocket.upload.tool=esptool_py
+sparkfun_esp32c6_qwiic_pocket.upload.tool.default=esptool_py
+sparkfun_esp32c6_qwiic_pocket.upload.tool.network=esp_ota
+
+sparkfun_esp32c6_qwiic_pocket.upload.maximum_size=1310720
+sparkfun_esp32c6_qwiic_pocket.upload.maximum_data_size=327680
+sparkfun_esp32c6_qwiic_pocket.upload.flags=
+sparkfun_esp32c6_qwiic_pocket.upload.extra_flags=
+sparkfun_esp32c6_qwiic_pocket.upload.use_1200bps_touch=false
+sparkfun_esp32c6_qwiic_pocket.upload.wait_for_upload_port=false
+
+sparkfun_esp32c6_qwiic_pocket.serial.disableDTR=false
+sparkfun_esp32c6_qwiic_pocket.serial.disableRTS=false
+
+sparkfun_esp32c6_qwiic_pocket.build.tarch=riscv32
+sparkfun_esp32c6_qwiic_pocket.build.target=esp
+sparkfun_esp32c6_qwiic_pocket.build.mcu=esp32c6
+sparkfun_esp32c6_qwiic_pocket.build.core=esp32
+sparkfun_esp32c6_qwiic_pocket.build.variant=sparkfun_esp32c6_qwiic_pocket
+sparkfun_esp32c6_qwiic_pocket.build.board=ESP32C6_QWIIC_POCKET
+sparkfun_esp32c6_qwiic_pocket.build.bootloader_addr=0x0
+
+sparkfun_esp32c6_qwiic_pocket.build.cdc_on_boot=0
+sparkfun_esp32c6_qwiic_pocket.build.f_cpu=160000000L
+sparkfun_esp32c6_qwiic_pocket.build.flash_size=4MB
+sparkfun_esp32c6_qwiic_pocket.build.flash_freq=80m
+sparkfun_esp32c6_qwiic_pocket.build.flash_mode=qio
+sparkfun_esp32c6_qwiic_pocket.build.boot=qio
+sparkfun_esp32c6_qwiic_pocket.build.partitions=default
+sparkfun_esp32c6_qwiic_pocket.build.defines=
+
+## IDE 2.0 Seems to not update the value
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.default=Disabled
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.default.build.copy_jtag_files=0
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.builtin=Integrated USB JTAG
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.builtin.build.openocdscript=esp32c6-builtin.cfg
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.external=FTDI Adapter
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.external.build.openocdscript=esp32c6-ftdi.cfg
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.external.build.copy_jtag_files=1
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.bridge=ESP USB Bridge
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.bridge.build.openocdscript=esp32c6-bridge.cfg
+sparkfun_esp32c6_qwiic_pocket.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+sparkfun_esp32c6_qwiic_pocket.menu.CDCOnBoot.default=Enabled
+sparkfun_esp32c6_qwiic_pocket.menu.CDCOnBoot.default.build.cdc_on_boot=1
+sparkfun_esp32c6_qwiic_pocket.menu.CDCOnBoot.cdc=Disabled
+sparkfun_esp32c6_qwiic_pocket.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.default.build.partitions=default
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.minimal.build.partitions=minimal
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.no_ota.build.partitions=no_ota
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.huge_app.build.partitions=huge_app
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.fatflash.build.partitions=ffat
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker=RainMaker
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.custom=Custom
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.custom.build.partitions=
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.160=160MHz (WiFi)
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.160.build.f_cpu=160000000L
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.80=80MHz (WiFi)
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.80.build.f_cpu=80000000L
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.40=40MHz
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.40.build.f_cpu=40000000L
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.20=20MHz
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.20.build.f_cpu=20000000L
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.10=10MHz
+sparkfun_esp32c6_qwiic_pocket.menu.CPUFreq.10.build.f_cpu=10000000L
+
+sparkfun_esp32c6_qwiic_pocket.menu.FlashMode.qio=QIO
+sparkfun_esp32c6_qwiic_pocket.menu.FlashMode.qio.build.flash_mode=dio
+sparkfun_esp32c6_qwiic_pocket.menu.FlashMode.qio.build.boot=qio
+sparkfun_esp32c6_qwiic_pocket.menu.FlashMode.dio=DIO
+sparkfun_esp32c6_qwiic_pocket.menu.FlashMode.dio.build.flash_mode=dio
+sparkfun_esp32c6_qwiic_pocket.menu.FlashMode.dio.build.boot=dio
+
+sparkfun_esp32c6_qwiic_pocket.menu.FlashFreq.80=80MHz
+sparkfun_esp32c6_qwiic_pocket.menu.FlashFreq.80.build.flash_freq=80m
+sparkfun_esp32c6_qwiic_pocket.menu.FlashFreq.40=40MHz
+sparkfun_esp32c6_qwiic_pocket.menu.FlashFreq.40.build.flash_freq=40m
+
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.4M=4MB (32Mb)
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.4M.build.flash_size=4MB
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.8M=8MB (64Mb)
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.8M.build.flash_size=8MB
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.8M.build.partitions=default_8MB
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.2M=2MB (16Mb)
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.2M.build.flash_size=2MB
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.2M.build.partitions=minimal
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.16M=16MB (128Mb)
+sparkfun_esp32c6_qwiic_pocket.menu.FlashSize.16M.build.flash_size=16MB
+
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.921600=921600
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.921600.upload.speed=921600
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.115200=115200
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.115200.upload.speed=115200
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.256000.windows=256000
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.256000.upload.speed=256000
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.230400.windows.upload.speed=256000
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.230400=230400
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.230400.upload.speed=230400
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.460800.linux=460800
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.460800.macosx=460800
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.460800.upload.speed=460800
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.512000.windows=512000
+sparkfun_esp32c6_qwiic_pocket.menu.UploadSpeed.512000.upload.speed=512000
+
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.none=None
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.none.build.code_debug=0
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.error=Error
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.error.build.code_debug=1
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.warn=Warn
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.warn.build.code_debug=2
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.info=Info
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.info.build.code_debug=3
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.debug=Debug
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.debug.build.code_debug=4
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.verbose=Verbose
+sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.verbose.build.code_debug=5
+
+sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.none=Disabled
+sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.none.upload.erase_cmd=
+sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.all=Enabled
+sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 nina_w10.name=u-blox NINA-W10 series (ESP32)
 
 nina_w10.bootloader.tool=esptool_py

--- a/variants/sparkfun_esp32c6_qwiic_pocket/pins_arduino.h
+++ b/variants/sparkfun_esp32c6_qwiic_pocket/pins_arduino.h
@@ -1,0 +1,31 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = 23;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 16;
+static const uint8_t RX = 17;
+
+static const uint8_t SDA = 6;
+static const uint8_t SCL = 7;
+
+static const uint8_t SS   = 2;
+static const uint8_t MOSI = 3;
+static const uint8_t MISO = 4;
+static const uint8_t SCK  = 5;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+static const uint8_t A6 = 6;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Add new SparkFun ESP32-C6 Qwiic Pocket Development Board variant.

## Tests scenarios
Tested with [v3.0.0 Alpha Release](https://github.com/espressif/arduino-esp32/releases/tag/3.0.0-alpha1).

## Related links
Product is not live yet, but I can update with a link to the product page once it is live if requested!
