### PR TITLE
Fixes BLEScanResults to be used by reference 

### DIFF
--- a/libraries/BLE/examples/Beacon_Scanner/Beacon_Scanner.ino
+++ b/libraries/BLE/examples/Beacon_Scanner/Beacon_Scanner.ino
@@ -111,9 +111,9 @@ void setup()
 void loop()
 {
   // put your main code here, to run repeatedly:
-  BLEScanResults foundDevices = pBLEScan->start(scanTime, false);
+  BLEScanResults *foundDevices = pBLEScan->start(scanTime, false);
   Serial.print("Devices found: ");
-  Serial.println(foundDevices.getCount());
+  Serial.println(foundDevices->getCount());
   Serial.println("Scan done!");
   pBLEScan->clearResults(); // delete results fromBLEScan buffer to release memory
   delay(2000);

--- a/libraries/BLE/examples/Scan/Scan.ino
+++ b/libraries/BLE/examples/Scan/Scan.ino
@@ -31,9 +31,9 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
-  BLEScanResults foundDevices = pBLEScan->start(scanTime, false);
+  BLEScanResults *foundDevices = pBLEScan->start(scanTime, false);
   Serial.print("Devices found: ");
-  Serial.println(foundDevices.getCount());
+  Serial.println(foundDevices->getCount());
   Serial.println("Scan done!");
   pBLEScan->clearResults();   // delete results fromBLEScan buffer to release memory
   delay(2000);

--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -426,11 +426,11 @@ bool BLEScan::start(uint32_t duration, void (*scanCompleteCB)(BLEScanResults), b
  * @param [in] duration The duration in seconds for which to scan.
  * @return The BLEScanResults.
  */
-BLEScanResults BLEScan::start(uint32_t duration, bool is_continue) {
+BLEScanResults* BLEScan::start(uint32_t duration, bool is_continue) {
 	if(start(duration, nullptr, is_continue)) {
 		m_semaphoreScanEnd.wait("start");   // Wait for the semaphore to release.
 	}
-	return m_scanResults;
+	return &m_scanResults;
 } // start
 
 
@@ -500,8 +500,8 @@ BLEAdvertisedDevice BLEScanResults::getDevice(uint32_t i) {
 	return dev;
 }
 
-BLEScanResults BLEScan::getResults() {
-	return m_scanResults;
+BLEScanResults* BLEScan::getResults() {
+	return &m_scanResults;
 }
 
 void BLEScan::clearResults() {

--- a/libraries/BLE/src/BLEScan.h
+++ b/libraries/BLE/src/BLEScan.h
@@ -71,10 +71,10 @@ public:
 	void           setInterval(uint16_t intervalMSecs);
 	void           setWindow(uint16_t windowMSecs);
 	bool           start(uint32_t duration, void (*scanCompleteCB)(BLEScanResults), bool is_continue = false);
-	BLEScanResults start(uint32_t duration, bool is_continue = false);
+	BLEScanResults* start(uint32_t duration, bool is_continue = false);
 	void           stop();
 	void 		   erase(BLEAddress address);
-	BLEScanResults getResults();
+	BLEScanResults* getResults();
 	void			clearResults();
 
 #ifdef SOC_BLE_50_SUPPORTED


### PR DESCRIPTION
## Description of Change
A `BLEScanResults` object is returned from `BLEScan` methods, causing issues because its same copy is released more than one time, causing HEAP corruption. 

To fix it BLEScanResults should be used as a contained class, by reference and not copy.
This is the same done with `BLEScan*`, for instance.

## Tests scenarios
Tested with ESP32 using this sketch that causes the issue, before the change is done (previous version):

```cpp
#include <BLEDevice.h>
#include <BLEUtils.h>
#include <BLEScan.h>
#include <BLEAdvertisedDevice.h>

int scanTime = 5; //In seconds
BLEScan* pBLEScan;

void setup() {
  Serial.begin(115200);
  Serial.println("Scanning...");

  BLEDevice::init("");
  pBLEScan = BLEDevice::getScan(); //create new scan
  pBLEScan->setActiveScan(true); //active scan uses more power, but get results faster
  pBLEScan->setInterval(100);
  pBLEScan->setWindow(99);  // less or equal setInterval value
}

void myBLEScanFunction() {
  BLEScanResults foundDevices = pBLEScan->start(scanTime, false);
  Serial.print("Devices found: ");
  Serial.println(foundDevices.getCount());
  Serial.println("Scan done!");
  pBLEScan->clearResults();   // delete results fromBLEScan buffer to release memory
}

void loop() {
 myBLEScanFunction(); // crashes when returning from the function with corrupted HEAP
 delay(2000);
}
```

After the fix, it shall use a `BLEScanResults *` as reference, instead of the copy of the object as before.

```cpp
void myBLEScanFunction() {
  BLEScanResults *foundDevices = pBLEScan->start(scanTime, false);
  Serial.print("Devices found: ");
  Serial.println(foundDevices->getCount());
  Serial.println("Scan done!");
  pBLEScan->clearResults();   // delete results fromBLEScan buffer to release memory
}
```

## Related links

Fix #8751 
