### PR TITLE
HardwareSerial::end(bool) review + Baud Rate detection review and example

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -884,12 +884,18 @@ void uartStartDetectBaudrate(uart_t *uart) {
         return;
     }
 
-#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2
+// Baud rate detection only works for ESP32 and ESP32S2
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+    uart_dev_t *hw = UART_LL_GET_HW(uart->num);
+    hw->auto_baud.glitch_filt = 0x08;
+    hw->auto_baud.en = 0;
+    hw->auto_baud.en = 1;
+#else
     
     // ESP32-C3 requires further testing
     // Baud rate detection returns wrong values 
    
-    log_e("ESP32-C3 baud rate detection is not supported.");
+    log_e("baud rate detection for this SoC is not supported.");
     return;
 
     // Code bellow for C3 kept for future recall
@@ -897,19 +903,10 @@ void uartStartDetectBaudrate(uart_t *uart) {
     //hw->rx_filt.glitch_filt_en = 1;
     //hw->conf0.autobaud_en = 0;
     //hw->conf0.autobaud_en = 1;
-#elif CONFIG_IDF_TARGET_ESP32S3
-    log_e("ESP32-S3 baud rate detection is not supported.");
-    return;
-#else
-    uart_dev_t *hw = UART_LL_GET_HW(uart->num);
-    hw->auto_baud.glitch_filt = 0x08;
-    hw->auto_baud.en = 0;
-    hw->auto_baud.en = 1;
 #endif
 }
  
-unsigned long
-uartDetectBaudrate(uart_t *uart)
+unsigned long uartDetectBaudrate(uart_t *uart)
 {
     if(uart == NULL) {
         return 0;
@@ -955,11 +952,7 @@ uartDetectBaudrate(uart_t *uart)
 
     return default_rates[i];
 #else
-#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2
-    log_e("ESP32-C3 baud rate detection is not supported.");
-#else
-    log_e("ESP32-S3 baud rate detection is not supported.");
-#endif
+    log_e("baud rate detection this SoC is not supported.");
     return 0;
 #endif
 }

--- a/libraries/ESP32/examples/Serial/BaudRateDetect_Demo/BaudRateDetect_Demo.ino
+++ b/libraries/ESP32/examples/Serial/BaudRateDetect_Demo/BaudRateDetect_Demo.ino
@@ -1,0 +1,37 @@
+/*
+   This Sketch demonstrates how to detect and set the baud rate when the UART0 is connected to
+   some port that is sending data. It can be used with the Arduino IDE Serial Monitor to send the data.
+
+   Serial.begin(0) will start the baud rate detection. Valid range is 300 to 230400 baud.
+   It will try to detect for 20 seconds, by default, while reading RX.
+   This timeout of 20 seconds can be changed in the begin() function through <<timeout_ms>> parameter:
+   
+   void HardwareSerial::begin(baud, config, rxPin, txPin, invert, <<timeout_ms>>, rxfifo_full_thrhd)
+
+   It is necessary that the other end sends some data within <<timeout_ms>>, otherwise the detection won't work.
+
+   IMPORTANT NOTE: baud rate detection seem to only work with ESP32 and ESP32-S2. 
+   In other other SoCs, it doesn't work.
+
+*/
+
+// Open the Serial Monitor with testing baud start typing and sending caracters
+void setup() {
+  Serial.begin(0); // it will try to detect the baud rate for 20 seconds
+  
+  Serial.print("\n==>The baud rate is ");
+  Serial.println(Serial.baudRate()); 
+  
+  //after 20 seconds timeout, when not detected, it will return zero - in this case, we set it back to 115200.
+  if (Serial.baudRate() == 0) {
+    // Trying to set Serial to a safe state at 115200
+    Serial.end();
+    Serial.begin(115200);
+    Serial.setDebugOutput(true);
+    delay(1000);
+    log_e("Baud rate detection failed.");
+  }
+ }
+
+void loop() {
+}


### PR DESCRIPTION
## Description of Change
This PR removes UART pins detaching whenever it is used to detect baud rate.
Such feature only works with ESP32 and ESP32-S2. 
It also fixes error message when trying to use ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-H2 with baud rate detection.

In addition the PR also add an example about how to use baud rate detection feature.

## Tests scenarios
Tested with ESP32 and ESP32-S2 UART0 using the Example provided in this PR.

## Related links
None
