### PR TITLE
Fix linker failure when using SPIFFS or LittleFS with Arduino as component

### DIFF
--- a/libraries/FS/src/FSImpl.h
+++ b/libraries/FS/src/FSImpl.h
@@ -43,9 +43,9 @@ public:
     virtual const char* name() const = 0;
     virtual boolean isDirectory(void) = 0;
     virtual FileImplPtr openNextFile(const char* mode) = 0;
-    virtual boolean seekDir(long position);
-    virtual String getNextFileName(void);
-    virtual String getNextFileName(bool *isDir);
+    virtual boolean seekDir(long position) = 0;
+    virtual String getNextFileName(void) = 0;
+    virtual String getNextFileName(bool *isDir) = 0;
     virtual void rewindDirectory(void) = 0;
     virtual operator bool() = 0;
 };


### PR DESCRIPTION
## Description of Change
This fixes this linker error:

```
c:/users/david/.platformio/packages/toolchain-xtensa-esp32/bin/../lib/gcc/xtensa-esp32-elf/12.2.0/../../../../xtensa-esp32-elf/bin/ld.exe: .pio\build\esp32dev\esp-idf\framework-arduinoespressif32\libframework-arduinoespressif32.a(vfs_api.o):(.literal._ZN11VFSFileImplD2Ev+0x4): undefined reference to `vtable for fs::FileImpl'

```

## Tests scenarios
It can be tested on any of the examples of SPIFFS or LittleFS. 
For some reason it only happens when using Arduino as component on the latest version which uses IDF 5.1, no idea why a normal Arduino project links fine, because we are declaring a virtual function on the base class, but not defining it in the same class, so we should create a empty definition or just make it pure-virtual.

```
    if(!LittleFS.begin()){
        Serial.println("LittleFS Mount Failed");
        return;
    }
```