### PR TITLE
Add the DFRobot Beetle ESP32C6 and the DFRobot FireBeetle2 ESP32C6 as two development boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -8339,6 +8339,153 @@ dfrobot_beetle_esp32c3.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_beetle_esp32c3.menu.EraseFlash.all=Enabled
 dfrobot_beetle_esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
+##############################################################
+
+dfrobot_beetle_esp32c6.name=DFRobot Beetle ESP32-C6
+dfrobot_beetle_esp32c6.vid.0=0x303a
+dfrobot_beetle_esp32c6.pid.0=0x1001
+
+dfrobot_beetle_esp32c6.bootloader.tool=esptool_py
+dfrobot_beetle_esp32c6.bootloader.tool.default=esptool_py
+
+dfrobot_beetle_esp32c6.upload.tool=esptool_py
+dfrobot_beetle_esp32c6.upload.tool.default=esptool_py
+dfrobot_beetle_esp32c6.upload.tool.network=esp_ota
+
+dfrobot_beetle_esp32c6.upload.maximum_size=1310720
+dfrobot_beetle_esp32c6.upload.maximum_data_size=327680
+dfrobot_beetle_esp32c6.upload.flags=
+dfrobot_beetle_esp32c6.upload.extra_flags=
+dfrobot_beetle_esp32c6.upload.use_1200bps_touch=false
+dfrobot_beetle_esp32c6.upload.wait_for_upload_port=false
+
+dfrobot_beetle_esp32c6.serial.disableDTR=false
+dfrobot_beetle_esp32c6.serial.disableRTS=false
+
+dfrobot_beetle_esp32c6.build.tarch=riscv32
+dfrobot_beetle_esp32c6.build.target=esp
+dfrobot_beetle_esp32c6.build.mcu=esp32c6
+dfrobot_beetle_esp32c6.build.core=esp32
+dfrobot_beetle_esp32c6.build.variant=dfrobot_beetle_esp32c6
+dfrobot_beetle_esp32c6.build.board=DFROBOT_BEETLE_ESP32C6
+dfrobot_beetle_esp32c6.build.bootloader_addr=0x0
+
+dfrobot_beetle_esp32c6.build.cdc_on_boot=0
+dfrobot_beetle_esp32c6.build.f_cpu=160000000L
+dfrobot_beetle_esp32c6.build.flash_size=4MB
+dfrobot_beetle_esp32c6.build.flash_freq=80m
+dfrobot_beetle_esp32c6.build.flash_mode=qio
+dfrobot_beetle_esp32c6.build.boot=qio
+dfrobot_beetle_esp32c6.build.partitions=default
+dfrobot_beetle_esp32c6.build.defines=
+
+## IDE 2.0 Seems to not update the value
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.default=Disabled
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.default.build.copy_jtag_files=0
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.builtin=Integrated USB JTAG
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.builtin.build.openocdscript=esp32c6-builtin.cfg
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.external=FTDI Adapter
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.external.build.openocdscript=esp32c6-ftdi.cfg
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.external.build.copy_jtag_files=1
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.bridge=ESP USB Bridge
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.bridge.build.openocdscript=esp32c6-bridge.cfg
+dfrobot_beetle_esp32c6.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+dfrobot_beetle_esp32c6.menu.CDCOnBoot.default=Disabled
+dfrobot_beetle_esp32c6.menu.CDCOnBoot.default.build.cdc_on_boot=0
+dfrobot_beetle_esp32c6.menu.CDCOnBoot.cdc=Enabled
+dfrobot_beetle_esp32c6.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+dfrobot_beetle_esp32c6.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.default.build.partitions=default
+dfrobot_beetle_esp32c6.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+dfrobot_beetle_esp32c6.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.minimal.build.partitions=minimal
+dfrobot_beetle_esp32c6.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.no_ota.build.partitions=no_ota
+dfrobot_beetle_esp32c6.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+dfrobot_beetle_esp32c6.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+dfrobot_beetle_esp32c6.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.huge_app.build.partitions=huge_app
+dfrobot_beetle_esp32c6.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+dfrobot_beetle_esp32c6.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+dfrobot_beetle_esp32c6.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+dfrobot_beetle_esp32c6.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+dfrobot_beetle_esp32c6.menu.PartitionScheme.rainmaker=RainMaker
+dfrobot_beetle_esp32c6.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+dfrobot_beetle_esp32c6.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+dfrobot_beetle_esp32c6.menu.PartitionScheme.custom=Custom
+dfrobot_beetle_esp32c6.menu.PartitionScheme.custom.build.partitions=
+dfrobot_beetle_esp32c6.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+dfrobot_beetle_esp32c6.menu.CPUFreq.160=160MHz (WiFi)
+dfrobot_beetle_esp32c6.menu.CPUFreq.160.build.f_cpu=160000000L
+dfrobot_beetle_esp32c6.menu.CPUFreq.80=80MHz (WiFi)
+dfrobot_beetle_esp32c6.menu.CPUFreq.80.build.f_cpu=80000000L
+dfrobot_beetle_esp32c6.menu.CPUFreq.40=40MHz
+dfrobot_beetle_esp32c6.menu.CPUFreq.40.build.f_cpu=40000000L
+dfrobot_beetle_esp32c6.menu.CPUFreq.20=20MHz
+dfrobot_beetle_esp32c6.menu.CPUFreq.20.build.f_cpu=20000000L
+dfrobot_beetle_esp32c6.menu.CPUFreq.10=10MHz
+dfrobot_beetle_esp32c6.menu.CPUFreq.10.build.f_cpu=10000000L
+
+dfrobot_beetle_esp32c6.menu.FlashMode.qio=QIO
+dfrobot_beetle_esp32c6.menu.FlashMode.qio.build.flash_mode=dio
+dfrobot_beetle_esp32c6.menu.FlashMode.qio.build.boot=qio
+dfrobot_beetle_esp32c6.menu.FlashMode.dio=DIO
+dfrobot_beetle_esp32c6.menu.FlashMode.dio.build.flash_mode=dio
+dfrobot_beetle_esp32c6.menu.FlashMode.dio.build.boot=dio
+
+dfrobot_beetle_esp32c6.menu.FlashFreq.80=80MHz
+dfrobot_beetle_esp32c6.menu.FlashFreq.80.build.flash_freq=80m
+dfrobot_beetle_esp32c6.menu.FlashFreq.40=40MHz
+dfrobot_beetle_esp32c6.menu.FlashFreq.40.build.flash_freq=40m
+
+dfrobot_beetle_esp32c6.menu.FlashSize.4M=4MB (32Mb)
+dfrobot_beetle_esp32c6.menu.FlashSize.4M.build.flash_size=4MB
+
+dfrobot_beetle_esp32c6.menu.UploadSpeed.921600=921600
+dfrobot_beetle_esp32c6.menu.UploadSpeed.921600.upload.speed=921600
+dfrobot_beetle_esp32c6.menu.UploadSpeed.115200=115200
+dfrobot_beetle_esp32c6.menu.UploadSpeed.115200.upload.speed=115200
+dfrobot_beetle_esp32c6.menu.UploadSpeed.256000.windows=256000
+dfrobot_beetle_esp32c6.menu.UploadSpeed.256000.upload.speed=256000
+dfrobot_beetle_esp32c6.menu.UploadSpeed.230400.windows.upload.speed=256000
+dfrobot_beetle_esp32c6.menu.UploadSpeed.230400=230400
+dfrobot_beetle_esp32c6.menu.UploadSpeed.230400.upload.speed=230400
+dfrobot_beetle_esp32c6.menu.UploadSpeed.460800.linux=460800
+dfrobot_beetle_esp32c6.menu.UploadSpeed.460800.macosx=460800
+dfrobot_beetle_esp32c6.menu.UploadSpeed.460800.upload.speed=460800
+dfrobot_beetle_esp32c6.menu.UploadSpeed.512000.windows=512000
+dfrobot_beetle_esp32c6.menu.UploadSpeed.512000.upload.speed=512000
+
+dfrobot_beetle_esp32c6.menu.DebugLevel.none=None
+dfrobot_beetle_esp32c6.menu.DebugLevel.none.build.code_debug=0
+dfrobot_beetle_esp32c6.menu.DebugLevel.error=Error
+dfrobot_beetle_esp32c6.menu.DebugLevel.error.build.code_debug=1
+dfrobot_beetle_esp32c6.menu.DebugLevel.warn=Warn
+dfrobot_beetle_esp32c6.menu.DebugLevel.warn.build.code_debug=2
+dfrobot_beetle_esp32c6.menu.DebugLevel.info=Info
+dfrobot_beetle_esp32c6.menu.DebugLevel.info.build.code_debug=3
+dfrobot_beetle_esp32c6.menu.DebugLevel.debug=Debug
+dfrobot_beetle_esp32c6.menu.DebugLevel.debug.build.code_debug=4
+dfrobot_beetle_esp32c6.menu.DebugLevel.verbose=Verbose
+dfrobot_beetle_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
+
+dfrobot_beetle_esp32c6.menu.EraseFlash.none=Disabled
+dfrobot_beetle_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
+dfrobot_beetle_esp32c6.menu.EraseFlash.all=Enabled
+dfrobot_beetle_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
@@ -8723,6 +8870,155 @@ dfrobot_firebeetle2_esp32s3.menu.EraseFlash.all=Enabled
 dfrobot_firebeetle2_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+
+dfrobot_firebeetle2_esp32c6.name=DFRobot FireBeetle 2 ESP32-C6
+dfrobot_firebeetle2_esp32c6.vid.0=0x303a
+dfrobot_firebeetle2_esp32c6.pid.0=0x1001
+
+dfrobot_firebeetle2_esp32c6.bootloader.tool=esptool_py
+dfrobot_firebeetle2_esp32c6.bootloader.tool.default=esptool_py
+
+dfrobot_firebeetle2_esp32c6.upload.tool=esptool_py
+dfrobot_firebeetle2_esp32c6.upload.tool.default=esptool_py
+dfrobot_firebeetle2_esp32c6.upload.tool.network=esp_ota
+
+dfrobot_firebeetle2_esp32c6.upload.maximum_size=1310720
+dfrobot_firebeetle2_esp32c6.upload.maximum_data_size=327680
+dfrobot_firebeetle2_esp32c6.upload.flags=
+dfrobot_firebeetle2_esp32c6.upload.extra_flags=
+dfrobot_firebeetle2_esp32c6.upload.use_1200bps_touch=false
+dfrobot_firebeetle2_esp32c6.upload.wait_for_upload_port=false
+
+dfrobot_firebeetle2_esp32c6.serial.disableDTR=false
+dfrobot_firebeetle2_esp32c6.serial.disableRTS=false
+
+dfrobot_firebeetle2_esp32c6.build.tarch=riscv32
+dfrobot_firebeetle2_esp32c6.build.target=esp
+dfrobot_firebeetle2_esp32c6.build.mcu=esp32c6
+dfrobot_firebeetle2_esp32c6.build.core=esp32
+dfrobot_firebeetle2_esp32c6.build.variant=dfrobot_firebeetle2_esp32c6
+dfrobot_firebeetle2_esp32c6.build.board=DFROBOT_FIREBEETLE_2_ESP32C6
+dfrobot_firebeetle2_esp32c6.build.bootloader_addr=0x0
+
+dfrobot_firebeetle2_esp32c6.build.cdc_on_boot=0
+dfrobot_firebeetle2_esp32c6.build.f_cpu=160000000L
+dfrobot_firebeetle2_esp32c6.build.flash_size=4MB
+dfrobot_firebeetle2_esp32c6.build.flash_freq=80m
+dfrobot_firebeetle2_esp32c6.build.flash_mode=qio
+dfrobot_firebeetle2_esp32c6.build.boot=qio
+dfrobot_firebeetle2_esp32c6.build.partitions=default
+dfrobot_firebeetle2_esp32c6.build.defines=
+
+## IDE 2.0 Seems to not update the value
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.default=Disabled
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.default.build.copy_jtag_files=0
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.builtin=Integrated USB JTAG
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.builtin.build.openocdscript=esp32c6-builtin.cfg
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.external=FTDI Adapter
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.external.build.openocdscript=esp32c6-ftdi.cfg
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.external.build.copy_jtag_files=1
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.bridge=ESP USB Bridge
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.bridge.build.openocdscript=esp32c6-bridge.cfg
+dfrobot_firebeetle2_esp32c6.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+dfrobot_firebeetle2_esp32c6.menu.CDCOnBoot.default=Disabled
+dfrobot_firebeetle2_esp32c6.menu.CDCOnBoot.default.build.cdc_on_boot=0
+dfrobot_firebeetle2_esp32c6.menu.CDCOnBoot.cdc=Enabled
+dfrobot_firebeetle2_esp32c6.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.default.build.partitions=default
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.minimal.build.partitions=minimal
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.no_ota.build.partitions=no_ota
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.huge_app.build.partitions=huge_app
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.rainmaker=RainMaker
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.custom=Custom
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.custom.build.partitions=
+dfrobot_firebeetle2_esp32c6.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.160=160MHz (WiFi)
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.160.build.f_cpu=160000000L
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.80=80MHz (WiFi)
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.80.build.f_cpu=80000000L
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.40=40MHz
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.40.build.f_cpu=40000000L
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.20=20MHz
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.20.build.f_cpu=20000000L
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.10=10MHz
+dfrobot_firebeetle2_esp32c6.menu.CPUFreq.10.build.f_cpu=10000000L
+
+dfrobot_firebeetle2_esp32c6.menu.FlashMode.qio=QIO
+dfrobot_firebeetle2_esp32c6.menu.FlashMode.qio.build.flash_mode=dio
+dfrobot_firebeetle2_esp32c6.menu.FlashMode.qio.build.boot=qio
+dfrobot_firebeetle2_esp32c6.menu.FlashMode.dio=DIO
+dfrobot_firebeetle2_esp32c6.menu.FlashMode.dio.build.flash_mode=dio
+dfrobot_firebeetle2_esp32c6.menu.FlashMode.dio.build.boot=dio
+
+dfrobot_firebeetle2_esp32c6.menu.FlashFreq.80=80MHz
+dfrobot_firebeetle2_esp32c6.menu.FlashFreq.80.build.flash_freq=80m
+dfrobot_firebeetle2_esp32c6.menu.FlashFreq.40=40MHz
+dfrobot_firebeetle2_esp32c6.menu.FlashFreq.40.build.flash_freq=40m
+
+dfrobot_firebeetle2_esp32c6.menu.FlashSize.4M=4MB (32Mb)
+dfrobot_firebeetle2_esp32c6.menu.FlashSize.4M.build.flash_size=4MB
+
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.921600=921600
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.921600.upload.speed=921600
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.115200=115200
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.115200.upload.speed=115200
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.256000.windows=256000
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.256000.upload.speed=256000
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.230400.windows.upload.speed=256000
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.230400=230400
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.230400.upload.speed=230400
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.460800.linux=460800
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.460800.macosx=460800
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.460800.upload.speed=460800
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.512000.windows=512000
+dfrobot_firebeetle2_esp32c6.menu.UploadSpeed.512000.upload.speed=512000
+
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.none=None
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.none.build.code_debug=0
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.error=Error
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.error.build.code_debug=1
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.warn=Warn
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.warn.build.code_debug=2
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.info=Info
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.info.build.code_debug=3
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.debug=Debug
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.debug.build.code_debug=4
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.verbose=Verbose
+dfrobot_firebeetle2_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
+
+dfrobot_firebeetle2_esp32c6.menu.EraseFlash.none=Disabled
+dfrobot_firebeetle2_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
+dfrobot_firebeetle2_esp32c6.menu.EraseFlash.all=Enabled
+dfrobot_firebeetle2_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 # dfrobot Romeo ESP32-S3
 dfrobot_romeo_esp32s3.name=DFRobot Romeo ESP32-S3
 dfrobot_romeo_esp32s3.vid.0=0x303a

--- a/variants/dfrobot_beetle_esp32c6/pins_arduino.h
+++ b/variants/dfrobot_beetle_esp32c6/pins_arduino.h
@@ -1,0 +1,24 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+
+static const uint8_t LED_BUILTIN = 15;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 16;
+static const uint8_t RX = 17;
+
+static const uint8_t SDA = 19;
+static const uint8_t SCL = 20;
+
+static const uint8_t SS   = 4;
+static const uint8_t MOSI = 22;
+static const uint8_t MISO = 21;
+static const uint8_t SCK  = 23;
+
+
+#endif /* Pins_Arduino_h */

--- a/variants/dfrobot_firebeetle2_esp32c6/pins_arduino.h
+++ b/variants/dfrobot_firebeetle2_esp32c6/pins_arduino.h
@@ -1,0 +1,57 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+
+static const uint8_t LED_BUILTIN = 15;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 16;
+static const uint8_t RX = 17;
+
+static const uint8_t SDA = 19;
+static const uint8_t SCL = 20;
+
+static const uint8_t SS   = 5;
+static const uint8_t MOSI = 22;
+static const uint8_t MISO = 21;
+static const uint8_t SCK  = 23;
+
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+
+static const uint8_t D2  = 8;
+static const uint8_t D3  = 14;
+static const uint8_t D6  = 1;
+static const uint8_t D7  = 18;
+static const uint8_t D9  = 9;
+static const uint8_t D11 = 7;
+static const uint8_t D12 = 6;
+static const uint8_t D13 = 15;
+
+#define GDI_DISPLAY_FPC_INTERFACE
+#ifdef  GDI_DISPLAY_FPC_INTERFACE
+
+#define GDI_BLK       D13
+#define GDI_SPI_SCLK  SCK
+#define GDI_SPI_MOSI  MOSI
+#define GDI_SPI_MISO  MISO
+#define GDI_DC        D2
+#define GDI_RES       D3
+#define GDI_CS        D6 //LCD_CS
+#define GDI_SDCS      D7
+#define GDI_FCS       -1
+#define GDI_TCS       D12
+#define GDI_SCL       SCL
+#define GDI_SDA       SDA
+#define GDI_INT       D11
+#define GDI_BUSY_TE   -1
+
+#endif
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
-----------
## Description of Change
Add the DFRobot Beetle ESP32C6 and the DFRobot FireBeetle2 ESP32C6 as two development boards.

## Tests scenarios
Compiles and can build projects.


## Related links
The product link has not been released yet.

