### PR TITLE
[Docs] Fixed the RTD theme and core version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@
 # pip install --user -r requirements.txt
 #
 # matplotlib is currently required only by the script generate_chart.py
-sphinx-copybutton==0.3.0
+sphinx-rtd-theme
+sphinx-copybutton==0.5.0
 sphinx-tabs==3.2.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,11 @@ import sys
 # -- Project information -----------------------------------------------------
 
 project = 'Arduino-ESP32'
-copyright = '2022, Espressif'
+copyright = '2023, Espressif'
 author = 'Espressif'
 
 # The full version, including alpha/beta/rc tags
-release = '2.0.6'
+release = '2.0.14'
 
 # -- General configuration ---------------------------------------------------
 
@@ -30,6 +30,7 @@ release = '2.0.6'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_rtd_theme',
     'sphinx_copybutton',
     'sphinx_tabs.tabs'
 ]
@@ -56,7 +57,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = "sphinx_rtd_theme"
 html_logo = '_static/logo_espressif.png'
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
## Description of Change

This PR fixes the RTD default theme.
Component `sphinx-copybutton` version update.
Version on the docs footer updated to `2.0.14`.

![Screenshot 2023-10-23 at 09 36 38](https://github.com/espressif/arduino-esp32/assets/274658/b78580db-9bd4-4a5f-bb19-ef78cdc4a6ef)

## Tests scenarios

N/A

## Related links

N/A