### PR TITLE
Serial as a #define

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -436,12 +436,9 @@ void HWCDC::setDebugOutput(bool en)
     }
 }
 
-#if ARDUINO_USB_MODE
-#if ARDUINO_USB_CDC_ON_BOOT//Serial used for USB CDC
-HWCDC Serial;
-#else
+#if ARDUINO_USB_MODE         // Hardware JTAG CDC selected
+// USBSerial is always available to used
 HWCDC USBSerial;
-#endif
 #endif
 
 #endif /* SOC_USB_SERIAL_JTAG_SUPPORTED */

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -436,9 +436,9 @@ void HWCDC::setDebugOutput(bool en)
     }
 }
 
-#if ARDUINO_USB_MODE         // Hardware JTAG CDC selected
+#if ARDUINO_USB_MODE  // Hardware JTAG CDC selected
 // USBSerial is always available to be used
-HWCDC USBSerial;
+HWCDC HWCDCSerial;
 #endif
 
 #endif /* SOC_USB_SERIAL_JTAG_SUPPORTED */

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -437,7 +437,7 @@ void HWCDC::setDebugOutput(bool en)
 }
 
 #if ARDUINO_USB_MODE         // Hardware JTAG CDC selected
-// USBSerial is always available to used
+// USBSerial is always available to be used
 HWCDC USBSerial;
 #endif
 

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -103,12 +103,13 @@ public:
 
 };
 
-#if ARDUINO_USB_MODE
-#if ARDUINO_USB_CDC_ON_BOOT//Serial used for USB CDC
-extern HWCDC Serial;
-#else
+#if ARDUINO_USB_MODE         // Hardware JTAG CDC selected
+#if ARDUINO_USB_CDC_ON_BOOT  //Serial used for USB CDC
+// When using CDC on Boot, Arduino Serial is the USB device
+#define Serial USBSerial
+#endif
+// USBSerial is always available to used
 extern HWCDC USBSerial;
 #endif
-#endif
 
-#endif /* CONFIG_IDF_TARGET_ESP32C3 */
+#endif /* SOC_USB_SERIAL_JTAG_SUPPORTED */

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -102,14 +102,12 @@ public:
     uint32_t baudRate(){return 115200;}
 
 };
-
-#if ARDUINO_USB_MODE         // Hardware JTAG CDC selected
-#if ARDUINO_USB_CDC_ON_BOOT  //Serial used for USB CDC
-// When using CDC on Boot, Arduino Serial is the USB device
-#define Serial USBSerial
+#if ARDUINO_USB_MODE  // Hardware JTAG CDC selected
+#ifndef HWCDC_SERIAL_IS_DEFINED
+#define HWCDC_SERIAL_IS_DEFINED 1
 #endif
-// USBSerial is always available to be used
-extern HWCDC USBSerial;
+// HWCDCSerial is always available to be used
+extern HWCDC HWCDCSerial;
 #endif
 
 #endif /* SOC_USB_SERIAL_JTAG_SUPPORTED */

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -108,7 +108,7 @@ public:
 // When using CDC on Boot, Arduino Serial is the USB device
 #define Serial USBSerial
 #endif
-// USBSerial is always available to used
+// USBSerial is always available to be used
 extern HWCDC USBSerial;
 #endif
 

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -122,10 +122,27 @@ HardwareSerial Serial1(1);
 HardwareSerial Serial2(2);
 #endif
 
+#if HWCDC_SERIAL_IS_DEFINED == 1        // Hardware JTAG CDC Event
+extern void HWCDCSerialEvent (void)__attribute__((weak));
+void HWCDCSerialEvent(void) {} 
+#endif 
+
+#if USB_SERIAL_IS_DEFINED == 1          // Native USB CDC Event
+// Used by Hardware Serial for USB CDC events
+extern void USBSerialEvent (void)__attribute__((weak));
+void USBSerialEvent(void) {} 
+#endif 
+
 void serialEventRun(void)
 {
-    // Serial is always defined as something (UART0 or USBSerial)
-    if(Serial.available()) serialEvent();
+#if HWCDC_SERIAL_IS_DEFINED == 1        // Hardware JTAG CDC Event
+    if(HWCDCSerial.available()) HWCDCSerialEvent();
+#endif    
+#if USB_SERIAL_IS_DEFINED == 1          // Native USB CDC Event
+    if(USBSerial.available()) USBSerialEvent();
+#endif    
+    // UART0 is default serialEvent()
+    if(Serial0.available()) serialEvent();
 #if SOC_UART_NUM > 1
     if(Serial1.available()) serialEvent1();
 #endif

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -113,11 +113,8 @@ void serialEvent2(void) {}
 #endif /* SOC_UART_NUM > 2 */
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
-#if ARDUINO_USB_CDC_ON_BOOT //Serial used for USB CDC
+// There is always Seria0 for UART0
 HardwareSerial Serial0(0);
-#else
-HardwareSerial Serial(0);
-#endif
 #if SOC_UART_NUM > 1
 HardwareSerial Serial1(1);
 #endif
@@ -127,11 +124,8 @@ HardwareSerial Serial2(2);
 
 void serialEventRun(void)
 {
-#if ARDUINO_USB_CDC_ON_BOOT //Serial used for USB CDC
-    if(Serial0.available()) serialEvent();
-#else
+    // Serial is always defined as something (UART0 or USBSerial)
     if(Serial.available()) serialEvent();
-#endif
 #if SOC_UART_NUM > 1
     if(Serial1.available()) serialEvent1();
 #endif

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -51,6 +51,7 @@
 #include "esp32-hal.h"
 #include "soc/soc_caps.h"
 #include "HWCDC.h"
+#include "USBCDC.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -240,15 +241,14 @@ extern void serialEventRun(void) __attribute__((weak));
 #ifndef ARDUINO_USB_CDC_ON_BOOT
 #define ARDUINO_USB_CDC_ON_BOOT 0
 #endif
-#if ARDUINO_USB_CDC_ON_BOOT //Serial used for USB CDC
-#if !ARDUINO_USB_MODE
-#include "USB.h"
-#include "USBCDC.h"
+#if !ARDUINO_USB_CDC_ON_BOOT //Serial used for USB CDC
+// if not using CDC on Boot, Arduino Serial is the UART0 device
+#define Serial Serial0 
 #endif
+
+// There is always Seria0 for UART0
 extern HardwareSerial Serial0;
-#else
-extern HardwareSerial Serial;
-#endif
+
 #if SOC_UART_NUM > 1
 extern HardwareSerial Serial1;
 #endif

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -241,20 +241,26 @@ extern void serialEventRun(void) __attribute__((weak));
 #ifndef ARDUINO_USB_CDC_ON_BOOT
 #define ARDUINO_USB_CDC_ON_BOOT 0
 #endif
-#if !ARDUINO_USB_CDC_ON_BOOT //Serial used for USB CDC
+#if ARDUINO_USB_CDC_ON_BOOT //Serial used from Native_USB_CDC | HW_CDC_JTAG
+#if ARDUINO_USB_MODE // Hardware CDC mode
+// Arduino Serial is the HW JTAG CDC device
+#define Serial HWCDCSerial
+#else // !ARDUINO_USB_MODE -- Native USB Mode
+// Arduino Serial is the Native USB CDC device
+#define Serial USBSerial
+#endif  // ARDUINO_USB_MODE
+#else   // !ARDUINO_USB_CDC_ON_BOOT -- Serial is used from UART0
 // if not using CDC on Boot, Arduino Serial is the UART0 device
 #define Serial Serial0 
-#endif
-
+#endif  // ARDUINO_USB_CDC_ON_BOOT
 // There is always Seria0 for UART0
 extern HardwareSerial Serial0;
-
 #if SOC_UART_NUM > 1
 extern HardwareSerial Serial1;
 #endif
 #if SOC_UART_NUM > 2
 extern HardwareSerial Serial2;
 #endif
-#endif
+#endif //!defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
 
 #endif // HardwareSerial_h

--- a/cores/esp32/USBCDC.cpp
+++ b/cores/esp32/USBCDC.cpp
@@ -457,7 +457,7 @@ USBCDC::operator bool() const
 
 #if !ARDUINO_USB_MODE         // Native USB CDC selected
 // USBSerial is always available to be used
-USBCDC USBSerial;
+USBCDC USBSerial(0);
 #endif
 
 #endif /* CONFIG_TINYUSB_CDC_ENABLED */

--- a/cores/esp32/USBCDC.cpp
+++ b/cores/esp32/USBCDC.cpp
@@ -456,7 +456,7 @@ USBCDC::operator bool() const
 }
 
 #if !ARDUINO_USB_MODE         // Native USB CDC selected
-// USBSerial is always available to used
+// USBSerial is always available to be used
 USBCDC USBSerial;
 #endif
 

--- a/cores/esp32/USBCDC.cpp
+++ b/cores/esp32/USBCDC.cpp
@@ -455,8 +455,9 @@ USBCDC::operator bool() const
     return connected;
 }
 
-#if ARDUINO_USB_CDC_ON_BOOT && !ARDUINO_USB_MODE //Serial used for USB CDC
-USBCDC Serial(0);
+#if !ARDUINO_USB_MODE         // Native USB CDC selected
+// USBSerial is always available to used
+USBCDC USBSerial;
 #endif
 
 #endif /* CONFIG_TINYUSB_CDC_ENABLED */

--- a/cores/esp32/USBCDC.h
+++ b/cores/esp32/USBCDC.h
@@ -142,13 +142,13 @@ protected:
 };
 
 #if !ARDUINO_USB_MODE        // Native USB CDC selected
-#if ARDUINO_USB_CDC_ON_BOOT  //Serial used for USB CDC
-// When using CDC on Boot, Arduino Serial is the USB device
-#define Serial USBSerial
-#endif
+#ifndef USB_SERIAL_IS_DEFINED
+#define USB_SERIAL_IS_DEFINED 1
+#endif 
 // USBSerial is always available to be used
 extern USBCDC USBSerial;
 #endif
+
 
 #endif /* CONFIG_TINYUSB_CDC_ENABLED */
 #endif /* SOC_USB_OTG_SUPPORTED */

--- a/cores/esp32/USBCDC.h
+++ b/cores/esp32/USBCDC.h
@@ -141,8 +141,13 @@ protected:
     
 };
 
-#if ARDUINO_USB_CDC_ON_BOOT && !ARDUINO_USB_MODE //Serial used for USB CDC
-extern USBCDC Serial;
+#if !ARDUINO_USB_MODE        // Native USB CDC selected
+#if ARDUINO_USB_CDC_ON_BOOT  //Serial used for USB CDC
+// When using CDC on Boot, Arduino Serial is the USB device
+#define Serial USBSerial
+#endif
+// USBSerial is always available to used
+extern USBCDC USBSerial;
 #endif
 
 #endif /* CONFIG_TINYUSB_CDC_ENABLED */

--- a/cores/esp32/USBCDC.h
+++ b/cores/esp32/USBCDC.h
@@ -146,8 +146,8 @@ protected:
 // When using CDC on Boot, Arduino Serial is the USB device
 #define Serial USBSerial
 #endif
-// USBSerial is always available to used
-extern USBCDC USBSerial;
+// USBSerial is always available to be used
+extern USBCDC USBSerial(0);
 #endif
 
 #endif /* CONFIG_TINYUSB_CDC_ENABLED */

--- a/cores/esp32/USBCDC.h
+++ b/cores/esp32/USBCDC.h
@@ -147,7 +147,7 @@ protected:
 #define Serial USBSerial
 #endif
 // USBSerial is always available to be used
-extern USBCDC USBSerial(0);
+extern USBCDC USBSerial;
 #endif
 
 #endif /* CONFIG_TINYUSB_CDC_ENABLED */

--- a/libraries/ESP32/examples/Serial/Serial_STD_Func_OnReceive/Serial_STD_Func_OnReceive.ino
+++ b/libraries/ESP32/examples/Serial/Serial_STD_Func_OnReceive/Serial_STD_Func_OnReceive.ino
@@ -16,16 +16,6 @@
 // This makes the code transparent to what SoC is used.
 #include "soc/soc_caps.h"
 
-// In case that the target has USB CDC and it has being selected to be enable on boot, 
-// the console output will into USB (Serial).
-// Otherwise the output will be sent to UART0 (Serial) and we have to redefine Serial0
-#ifndef ARDUINO_USB_CDC_ON_BOOT
-#define ARDUINO_USB_CDC_ON_BOOT 0
-#endif
-#if ARDUINO_USB_CDC_ON_BOOT == 0 // No USB CDC
-#define Serial0 Serial   // redefine the symbol Serial0 to the default Arduino
-#endif
-
 // This example shall use UART1 or UART2 for testing and UART0 for console messages
 // If UART0 is used for testing, it is necessary to manually send data to it, using the Serial Monitor/Terminal
 // In case that USB CDC is available, it may be used as console for messages.

--- a/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
+++ b/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
@@ -15,13 +15,7 @@ void loop(){}
 #if !ARDUINO_USB_MSC_ON_BOOT
 FirmwareMSC MSC_Update;
 #endif
-#if ARDUINO_USB_CDC_ON_BOOT
 #define HWSerial Serial0
-#define USBSerial Serial
-#else
-#define HWSerial Serial
-USBCDC USBSerial;
-#endif
 
 USBHID HID;
 USBHIDKeyboard Keyboard;

--- a/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
+++ b/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
@@ -15,7 +15,6 @@ void loop(){}
 #if !ARDUINO_USB_MSC_ON_BOOT
 FirmwareMSC MSC_Update;
 #endif
-#define HWSerial Serial0
 
 USBHID HID;
 USBHIDKeyboard Keyboard;
@@ -33,16 +32,16 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_event_data_t * data = (arduino_usb_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_STARTED_EVENT:
-        HWSerial.println("USB PLUGGED");
+        Serial.println("USB PLUGGED");
         break;
       case ARDUINO_USB_STOPPED_EVENT:
-        HWSerial.println("USB UNPLUGGED");
+        Serial.println("USB UNPLUGGED");
         break;
       case ARDUINO_USB_SUSPEND_EVENT:
-        HWSerial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
+        Serial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
         break;
       case ARDUINO_USB_RESUME_EVENT:
-        HWSerial.println("USB RESUMED");
+        Serial.println("USB RESUMED");
         break;
       
       default:
@@ -52,28 +51,28 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_cdc_event_data_t * data = (arduino_usb_cdc_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_CDC_CONNECTED_EVENT:
-        HWSerial.println("CDC CONNECTED");
+        Serial.println("CDC CONNECTED");
         break;
       case ARDUINO_USB_CDC_DISCONNECTED_EVENT:
-        HWSerial.println("CDC DISCONNECTED");
+        Serial.println("CDC DISCONNECTED");
         break;
       case ARDUINO_USB_CDC_LINE_STATE_EVENT:
-        HWSerial.printf("CDC LINE STATE: dtr: %u, rts: %u\n", data->line_state.dtr, data->line_state.rts);
+        Serial.printf("CDC LINE STATE: dtr: %u, rts: %u\n", data->line_state.dtr, data->line_state.rts);
         break;
       case ARDUINO_USB_CDC_LINE_CODING_EVENT:
-        HWSerial.printf("CDC LINE CODING: bit_rate: %lu, data_bits: %u, stop_bits: %u, parity: %u\n", data->line_coding.bit_rate, data->line_coding.data_bits, data->line_coding.stop_bits, data->line_coding.parity);
+        Serial.printf("CDC LINE CODING: bit_rate: %lu, data_bits: %u, stop_bits: %u, parity: %u\n", data->line_coding.bit_rate, data->line_coding.data_bits, data->line_coding.stop_bits, data->line_coding.parity);
         break;
       case ARDUINO_USB_CDC_RX_EVENT:
-        HWSerial.printf("CDC RX [%u]:", data->rx.len);
+        Serial.printf("CDC RX [%u]:", data->rx.len);
         {
             uint8_t buf[data->rx.len];
             size_t len = USBSerial.read(buf, data->rx.len);
-            HWSerial.write(buf, len);
+            Serial.write(buf, len);
         }
-        HWSerial.println();
+        Serial.println();
         break;
       case ARDUINO_USB_CDC_RX_OVERFLOW_EVENT:
-        HWSerial.printf("CDC RX Overflow of %d bytes", data->rx_overflow.dropped_bytes);
+        Serial.printf("CDC RX Overflow of %d bytes", data->rx_overflow.dropped_bytes);
         break;
 
       default:
@@ -83,20 +82,20 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_firmware_msc_event_data_t * data = (arduino_firmware_msc_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_FIRMWARE_MSC_START_EVENT:
-        HWSerial.println("MSC Update Start");
+        Serial.println("MSC Update Start");
         break;
       case ARDUINO_FIRMWARE_MSC_WRITE_EVENT:
-        //HWSerial.printf("MSC Update Write %u bytes at offset %u\n", data->write.size, data->write.offset);
-        HWSerial.print(".");
+        //Serial.printf("MSC Update Write %u bytes at offset %u\n", data->write.size, data->write.offset);
+        Serial.print(".");
         break;
       case ARDUINO_FIRMWARE_MSC_END_EVENT:
-        HWSerial.printf("\nMSC Update End: %u bytes\n", data->end.size);
+        Serial.printf("\nMSC Update End: %u bytes\n", data->end.size);
         break;
       case ARDUINO_FIRMWARE_MSC_ERROR_EVENT:
-        HWSerial.printf("MSC Update ERROR! Progress: %u bytes\n", data->error.size);
+        Serial.printf("MSC Update ERROR! Progress: %u bytes\n", data->error.size);
         break;
       case ARDUINO_FIRMWARE_MSC_POWER_EVENT:
-        HWSerial.printf("MSC Update Power: power: %u, start: %u, eject: %u\n", data->power.power_condition, data->power.start, data->power.load_eject);
+        Serial.printf("MSC Update Power: power: %u, start: %u, eject: %u\n", data->power.power_condition, data->power.start, data->power.load_eject);
         break;
       
       default:
@@ -106,10 +105,10 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_hid_event_data_t * data = (arduino_usb_hid_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_HID_SET_PROTOCOL_EVENT:
-        HWSerial.printf("HID SET PROTOCOL: %s\n", data->set_protocol.protocol?"REPORT":"BOOT");
+        Serial.printf("HID SET PROTOCOL: %s\n", data->set_protocol.protocol?"REPORT":"BOOT");
         break;
       case ARDUINO_USB_HID_SET_IDLE_EVENT:
-        HWSerial.printf("HID SET IDLE: %u\n", data->set_idle.idle_rate);
+        Serial.printf("HID SET IDLE: %u\n", data->set_idle.idle_rate);
         break;
       
       default:
@@ -119,7 +118,7 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_hid_keyboard_event_data_t * data = (arduino_usb_hid_keyboard_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_HID_KEYBOARD_LED_EVENT:
-        HWSerial.printf("HID KEYBOARD LED: NumLock:%u, CapsLock:%u, ScrollLock:%u\n", data->numlock, data->capslock, data->scrolllock);
+        Serial.printf("HID KEYBOARD LED: NumLock:%u, CapsLock:%u, ScrollLock:%u\n", data->numlock, data->capslock, data->scrolllock);
         break;
       
       default:
@@ -129,25 +128,25 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_hid_vendor_event_data_t * data = (arduino_usb_hid_vendor_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_HID_VENDOR_GET_FEATURE_EVENT:
-        HWSerial.printf("HID VENDOR GET FEATURE: len:%u\n", data->len);
+        Serial.printf("HID VENDOR GET FEATURE: len:%u\n", data->len);
         for(uint16_t i=0; i<data->len; i++){
-          HWSerial.write(data->buffer[i]?data->buffer[i]:'.');
+          Serial.write(data->buffer[i]?data->buffer[i]:'.');
         }
-        HWSerial.println();
+        Serial.println();
         break;
       case ARDUINO_USB_HID_VENDOR_SET_FEATURE_EVENT:
-        HWSerial.printf("HID VENDOR SET FEATURE: len:%u\n", data->len);
+        Serial.printf("HID VENDOR SET FEATURE: len:%u\n", data->len);
         for(uint16_t i=0; i<data->len; i++){
-          HWSerial.write(data->buffer[i]?data->buffer[i]:'.');
+          Serial.write(data->buffer[i]?data->buffer[i]:'.');
         }
-        HWSerial.println();
+        Serial.println();
         break;
       case ARDUINO_USB_HID_VENDOR_OUTPUT_EVENT:
-        HWSerial.printf("HID VENDOR OUTPUT: len:%u\n", data->len);
+        Serial.printf("HID VENDOR OUTPUT: len:%u\n", data->len);
         for(uint16_t i=0; i<data->len; i++){
-          HWSerial.write(Vendor.read());
+          Serial.write(Vendor.read());
         }
-        HWSerial.println();
+        Serial.println();
         break;
       
       default:
@@ -157,8 +156,8 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
 }
 
 void setup() {
-  HWSerial.begin(115200);
-  HWSerial.setDebugOutput(true);
+  Serial.begin(115200);
+  Serial.setDebugOutput(true);
   
   pinMode(buttonPin, INPUT_PULLUP);
   
@@ -185,7 +184,7 @@ void loop() {
   if (HID.ready() && buttonState != previousButtonState) {
     previousButtonState = buttonState;
     if (buttonState == LOW) {
-      HWSerial.println("Button Pressed");
+      if (Serial != USBSerial) Serial.println("Button Pressed");
       USBSerial.println("Button Pressed");
       Vendor.println("Button Pressed");
       Mouse.move(10,10);
@@ -200,15 +199,15 @@ void loop() {
       //SystemControl.release();
       Vendor.println("Button Released");
       USBSerial.println("Button Released");
-      HWSerial.println("Button Released");
+      if (Serial != USBSerial) Serial.println("Button Released");
     }
     delay(100);
   }
   
-  while(HWSerial.available()){
-    size_t l = HWSerial.available();
+  while(Serial.available()){
+    size_t l = Serial.available();
     uint8_t b[l];
-    l = HWSerial.read(b, l);
+    l = Serial.read(b, l);
     USBSerial.write(b, l);
     if(HID.ready()){
       Vendor.write(b,l);

--- a/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
+++ b/libraries/USB/examples/CompositeDevice/CompositeDevice.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/ConsumerControl/ConsumerControl.ino
+++ b/libraries/USB/examples/ConsumerControl/ConsumerControl.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/CustomHIDDevice/CustomHIDDevice.ino
+++ b/libraries/USB/examples/CustomHIDDevice/CustomHIDDevice.ino
@@ -1,5 +1,7 @@
-#if ARDUINO_USB_MODE
-  #warning This sketch should be used when USB is in OTG mode
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
+#warning This sketch should be used when USB is in OTG mode
   void setup(){}
   void loop(){}
 #else

--- a/libraries/USB/examples/FirmwareMSC/FirmwareMSC.ino
+++ b/libraries/USB/examples/FirmwareMSC/FirmwareMSC.ino
@@ -9,23 +9,22 @@ void loop(){}
 #if !ARDUINO_USB_MSC_ON_BOOT
 FirmwareMSC MSC_Update;
 #endif
-#define HWSerial Serial0
 
 static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data){
   if(event_base == ARDUINO_USB_EVENTS){
     arduino_usb_event_data_t * data = (arduino_usb_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_STARTED_EVENT:
-        HWSerial.println("USB PLUGGED");
+        Serial.println("USB PLUGGED");
         break;
       case ARDUINO_USB_STOPPED_EVENT:
-        HWSerial.println("USB UNPLUGGED");
+        Serial.println("USB UNPLUGGED");
         break;
       case ARDUINO_USB_SUSPEND_EVENT:
-        HWSerial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
+        Serial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
         break;
       case ARDUINO_USB_RESUME_EVENT:
-        HWSerial.println("USB RESUMED");
+        Serial.println("USB RESUMED");
         break;
       
       default:
@@ -35,20 +34,20 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_firmware_msc_event_data_t * data = (arduino_firmware_msc_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_FIRMWARE_MSC_START_EVENT:
-        HWSerial.println("MSC Update Start");
+        Serial.println("MSC Update Start");
         break;
       case ARDUINO_FIRMWARE_MSC_WRITE_EVENT:
-        //HWSerial.printf("MSC Update Write %u bytes at offset %u\n", data->write.size, data->write.offset);
-        HWSerial.print(".");
+        //Serial.printf("MSC Update Write %u bytes at offset %u\n", data->write.size, data->write.offset);
+        Serial.print(".");
         break;
       case ARDUINO_FIRMWARE_MSC_END_EVENT:
-        HWSerial.printf("\nMSC Update End: %u bytes\n", data->end.size);
+        Serial.printf("\nMSC Update End: %u bytes\n", data->end.size);
         break;
       case ARDUINO_FIRMWARE_MSC_ERROR_EVENT:
-        HWSerial.printf("MSC Update ERROR! Progress: %u bytes\n", data->error.size);
+        Serial.printf("MSC Update ERROR! Progress: %u bytes\n", data->error.size);
         break;
       case ARDUINO_FIRMWARE_MSC_POWER_EVENT:
-        HWSerial.printf("MSC Update Power: power: %u, start: %u, eject: %u", data->power.power_condition, data->power.start, data->power.load_eject);
+        Serial.printf("MSC Update Power: power: %u, start: %u, eject: %u", data->power.power_condition, data->power.start, data->power.load_eject);
         break;
       
       default:
@@ -58,8 +57,8 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
 }
 
 void setup() {
-  HWSerial.begin(115200);
-  HWSerial.setDebugOutput(true);
+  Serial.begin(115200);
+  Serial.setDebugOutput(true);
 
   USB.onEvent(usbEventCallback);
   MSC_Update.onEvent(usbEventCallback);

--- a/libraries/USB/examples/FirmwareMSC/FirmwareMSC.ino
+++ b/libraries/USB/examples/FirmwareMSC/FirmwareMSC.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/FirmwareMSC/FirmwareMSC.ino
+++ b/libraries/USB/examples/FirmwareMSC/FirmwareMSC.ino
@@ -9,13 +9,7 @@ void loop(){}
 #if !ARDUINO_USB_MSC_ON_BOOT
 FirmwareMSC MSC_Update;
 #endif
-#if ARDUINO_USB_CDC_ON_BOOT
 #define HWSerial Serial0
-#define USBSerial Serial
-#else
-#define HWSerial Serial
-USBCDC USBSerial;
-#endif
 
 static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data){
   if(event_base == ARDUINO_USB_EVENTS){

--- a/libraries/USB/examples/Gamepad/Gamepad.ino
+++ b/libraries/USB/examples/Gamepad/Gamepad.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/HIDVendor/HIDVendor.ino
+++ b/libraries/USB/examples/HIDVendor/HIDVendor.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/Keyboard/KeyboardLogout/KeyboardLogout.ino
+++ b/libraries/USB/examples/Keyboard/KeyboardLogout/KeyboardLogout.ino
@@ -24,7 +24,9 @@
 
   http://www.arduino.cc/en/Tutorial/KeyboardLogout
 */
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/Keyboard/KeyboardMessage/KeyboardMessage.ino
+++ b/libraries/USB/examples/Keyboard/KeyboardMessage/KeyboardMessage.ino
@@ -19,7 +19,9 @@
 
   http://www.arduino.cc/en/Tutorial/KeyboardMessage
 */
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/Keyboard/KeyboardReprogram/KeyboardReprogram.ino
+++ b/libraries/USB/examples/Keyboard/KeyboardReprogram/KeyboardReprogram.ino
@@ -24,7 +24,9 @@
 
   http://www.arduino.cc/en/Tutorial/KeyboardReprogram
 */
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/Keyboard/KeyboardSerial/KeyboardSerial.ino
+++ b/libraries/USB/examples/Keyboard/KeyboardSerial/KeyboardSerial.ino
@@ -16,7 +16,9 @@
 
   http://www.arduino.cc/en/Tutorial/KeyboardSerial
 */
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/KeyboardAndMouseControl/KeyboardAndMouseControl.ino
+++ b/libraries/USB/examples/KeyboardAndMouseControl/KeyboardAndMouseControl.ino
@@ -18,7 +18,9 @@
 
   http://www.arduino.cc/en/Tutorial/KeyboardAndMouseControl
 */
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/Mouse/ButtonMouseControl/ButtonMouseControl.ino
+++ b/libraries/USB/examples/Mouse/ButtonMouseControl/ButtonMouseControl.ino
@@ -20,7 +20,9 @@
 
   http://www.arduino.cc/en/Tutorial/ButtonMouseControl
 */
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/SystemControl/SystemControl.ino
+++ b/libraries/USB/examples/SystemControl/SystemControl.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/USBMSC/USBMSC.ino
+++ b/libraries/USB/examples/USBMSC/USBMSC.ino
@@ -6,8 +6,6 @@ void loop(){}
 #include "USB.h"
 #include "USBMSC.h"
 
-#define HWSerial Serial0
-
 USBMSC MSC;
 
 #define FAT_U8(v) ((v) & 0xFF)
@@ -130,19 +128,19 @@ static uint8_t msc_disk[DISK_SECTOR_COUNT][DISK_SECTOR_SIZE] =
 };
 
 static int32_t onWrite(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize){
-  HWSerial.printf("MSC WRITE: lba: %lu, offset: %lu, bufsize: %lu\n", lba, offset, bufsize);
+  Serial.printf("MSC WRITE: lba: %lu, offset: %lu, bufsize: %lu\n", lba, offset, bufsize);
   memcpy(msc_disk[lba] + offset, buffer, bufsize);
   return bufsize;
 }
 
 static int32_t onRead(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize){
-  HWSerial.printf("MSC READ: lba: %lu, offset: %lu, bufsize: %lu\n", lba, offset, bufsize);
+  Serial.printf("MSC READ: lba: %lu, offset: %lu, bufsize: %lu\n", lba, offset, bufsize);
   memcpy(buffer, msc_disk[lba] + offset, bufsize);
   return bufsize;
 }
 
 static bool onStartStop(uint8_t power_condition, bool start, bool load_eject){
-  HWSerial.printf("MSC START/STOP: power: %u, start: %u, eject: %u\n", power_condition, start, load_eject);
+  Serial.printf("MSC START/STOP: power: %u, start: %u, eject: %u\n", power_condition, start, load_eject);
   return true;
 }
 
@@ -151,16 +149,16 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_event_data_t * data = (arduino_usb_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_STARTED_EVENT:
-        HWSerial.println("USB PLUGGED");
+        Serial.println("USB PLUGGED");
         break;
       case ARDUINO_USB_STOPPED_EVENT:
-        HWSerial.println("USB UNPLUGGED");
+        Serial.println("USB UNPLUGGED");
         break;
       case ARDUINO_USB_SUSPEND_EVENT:
-        HWSerial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
+        Serial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
         break;
       case ARDUINO_USB_RESUME_EVENT:
-        HWSerial.println("USB RESUMED");
+        Serial.println("USB RESUMED");
         break;
       
       default:
@@ -170,8 +168,8 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
 }
 
 void setup() {
-  HWSerial.begin(115200);
-  HWSerial.setDebugOutput(true);
+  Serial.begin(115200);
+  Serial.setDebugOutput(true);
 
   USB.onEvent(usbEventCallback);
   MSC.vendorID("ESP32");//max 8 chars

--- a/libraries/USB/examples/USBMSC/USBMSC.ino
+++ b/libraries/USB/examples/USBMSC/USBMSC.ino
@@ -6,13 +6,7 @@ void loop(){}
 #include "USB.h"
 #include "USBMSC.h"
 
-#if ARDUINO_USB_CDC_ON_BOOT
 #define HWSerial Serial0
-#define USBSerial Serial
-#else
-#define HWSerial Serial
-USBCDC USBSerial;
-#endif
 
 USBMSC MSC;
 

--- a/libraries/USB/examples/USBMSC/USBMSC.ino
+++ b/libraries/USB/examples/USBMSC/USBMSC.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/USBSerial/USBSerial.ino
+++ b/libraries/USB/examples/USBSerial/USBSerial.ino
@@ -5,23 +5,21 @@ void loop(){}
 #else
 #include "USB.h"
 
-#define HWSerial Serial0
-
 static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data){
   if(event_base == ARDUINO_USB_EVENTS){
     arduino_usb_event_data_t * data = (arduino_usb_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_STARTED_EVENT:
-        HWSerial.println("USB PLUGGED");
+        Serial.println("USB PLUGGED");
         break;
       case ARDUINO_USB_STOPPED_EVENT:
-        HWSerial.println("USB UNPLUGGED");
+        Serial.println("USB UNPLUGGED");
         break;
       case ARDUINO_USB_SUSPEND_EVENT:
-        HWSerial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
+        Serial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
         break;
       case ARDUINO_USB_RESUME_EVENT:
-        HWSerial.println("USB RESUMED");
+        Serial.println("USB RESUMED");
         break;
       
       default:
@@ -31,28 +29,28 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_cdc_event_data_t * data = (arduino_usb_cdc_event_data_t*)event_data;
     switch (event_id){
       case ARDUINO_USB_CDC_CONNECTED_EVENT:
-        HWSerial.println("CDC CONNECTED");
+        Serial.println("CDC CONNECTED");
         break;
       case ARDUINO_USB_CDC_DISCONNECTED_EVENT:
-        HWSerial.println("CDC DISCONNECTED");
+        Serial.println("CDC DISCONNECTED");
         break;
       case ARDUINO_USB_CDC_LINE_STATE_EVENT:
-        HWSerial.printf("CDC LINE STATE: dtr: %u, rts: %u\n", data->line_state.dtr, data->line_state.rts);
+        Serial.printf("CDC LINE STATE: dtr: %u, rts: %u\n", data->line_state.dtr, data->line_state.rts);
         break;
       case ARDUINO_USB_CDC_LINE_CODING_EVENT:
-        HWSerial.printf("CDC LINE CODING: bit_rate: %lu, data_bits: %u, stop_bits: %u, parity: %u\n", data->line_coding.bit_rate, data->line_coding.data_bits, data->line_coding.stop_bits, data->line_coding.parity);
+        Serial.printf("CDC LINE CODING: bit_rate: %lu, data_bits: %u, stop_bits: %u, parity: %u\n", data->line_coding.bit_rate, data->line_coding.data_bits, data->line_coding.stop_bits, data->line_coding.parity);
         break;
       case ARDUINO_USB_CDC_RX_EVENT:
-        HWSerial.printf("CDC RX [%u]:", data->rx.len);
+        Serial.printf("CDC RX [%u]:", data->rx.len);
         {
             uint8_t buf[data->rx.len];
             size_t len = USBSerial.read(buf, data->rx.len);
-            HWSerial.write(buf, len);
+            Serial.write(buf, len);
         }
-        HWSerial.println();
+        Serial.println();
         break;
        case ARDUINO_USB_CDC_RX_OVERFLOW_EVENT:
-        HWSerial.printf("CDC RX Overflow of %d bytes", data->rx_overflow.dropped_bytes);
+        Serial.printf("CDC RX Overflow of %d bytes", data->rx_overflow.dropped_bytes);
         break;
      
       default:
@@ -62,8 +60,8 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
 }
 
 void setup() {
-  HWSerial.begin(115200);
-  HWSerial.setDebugOutput(true);
+  Serial.begin(115200);
+  Serial.setDebugOutput(true);
   
   USB.onEvent(usbEventCallback);
   USBSerial.onEvent(usbEventCallback);
@@ -73,10 +71,10 @@ void setup() {
 }
 
 void loop() {
-  while(HWSerial.available()){
-    size_t l = HWSerial.available();
+  while(Serial.available()){
+    size_t l = Serial.available();
     uint8_t b[l];
-    l = HWSerial.read(b, l);
+    l = Serial.read(b, l);
     USBSerial.write(b, l);
   }
 }

--- a/libraries/USB/examples/USBSerial/USBSerial.ino
+++ b/libraries/USB/examples/USBSerial/USBSerial.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/USBSerial/USBSerial.ino
+++ b/libraries/USB/examples/USBSerial/USBSerial.ino
@@ -5,13 +5,7 @@ void loop(){}
 #else
 #include "USB.h"
 
-#if ARDUINO_USB_CDC_ON_BOOT
 #define HWSerial Serial0
-#define USBSerial Serial
-#else
-#define HWSerial Serial
-USBCDC USBSerial;
-#endif
 
 static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data){
   if(event_base == ARDUINO_USB_EVENTS){

--- a/libraries/USB/examples/USBVendor/USBVendor.ino
+++ b/libraries/USB/examples/USBVendor/USBVendor.ino
@@ -6,11 +6,7 @@ void loop(){}
 #include "USB.h"
 #include "USBVendor.h"
 
-#if ARDUINO_USB_CDC_ON_BOOT
 #define HWSerial Serial0
-#else
-#define HWSerial Serial
-#endif
 
 USBVendor Vendor;
 const int buttonPin = 0;

--- a/libraries/USB/examples/USBVendor/USBVendor.ino
+++ b/libraries/USB/examples/USBVendor/USBVendor.ino
@@ -1,4 +1,6 @@
-#if ARDUINO_USB_MODE
+#ifndef ARDUINO_USB_MODE
+#error This ESP32 SoC has no Native USB interface
+#elif ARDUINO_USB_MODE == 1
 #warning This sketch should be used when USB is in OTG mode
 void setup(){}
 void loop(){}

--- a/libraries/USB/examples/USBVendor/USBVendor.ino
+++ b/libraries/USB/examples/USBVendor/USBVendor.ino
@@ -6,8 +6,6 @@ void loop(){}
 #include "USB.h"
 #include "USBVendor.h"
 
-#define HWSerial Serial0
-
 USBVendor Vendor;
 const int buttonPin = 0;
 
@@ -35,16 +33,16 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_event_data_t * data = (arduino_usb_event_data_t*)event_data;
     switch (event_id) {
       case ARDUINO_USB_STARTED_EVENT:
-        HWSerial.println("USB PLUGGED");
+        Serial.println("USB PLUGGED");
         break;
       case ARDUINO_USB_STOPPED_EVENT:
-        HWSerial.println("USB UNPLUGGED");
+        Serial.println("USB UNPLUGGED");
         break;
       case ARDUINO_USB_SUSPEND_EVENT:
-        HWSerial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
+        Serial.printf("USB SUSPENDED: remote_wakeup_en: %u\n", data->suspend.remote_wakeup_en);
         break;
       case ARDUINO_USB_RESUME_EVENT:
-        HWSerial.println("USB RESUMED");
+        Serial.println("USB RESUMED");
         break;
 
       default:
@@ -54,11 +52,11 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
     arduino_usb_vendor_event_data_t * data = (arduino_usb_vendor_event_data_t*)event_data;
     switch (event_id) {
       case ARDUINO_USB_VENDOR_DATA_EVENT:
-        HWSerial.printf("Vendor RX: len:%u\n", data->data.len);
+        Serial.printf("Vendor RX: len:%u\n", data->data.len);
         for (uint16_t i = 0; i < data->data.len; i++) {
-          HWSerial.write(Vendor.read());
+          Serial.write(Vendor.read());
         }
-        HWSerial.println();
+        Serial.println();
         break;
 
       default:
@@ -74,7 +72,7 @@ static const char * strRequestStages[] = {"SETUP", "DATA", "ACK"};
 
 //Handle USB requests to the vendor interface
 bool vendorRequestCallback(uint8_t rhport, uint8_t requestStage, arduino_usb_control_request_t const * request) {
-  HWSerial.printf("Vendor Request: Stage: %5s, Direction: %3s, Type: %8s, Recipient: %9s, bRequest: 0x%02x, wValue: 0x%04x, wIndex: %u, wLength: %u\n", 
+  Serial.printf("Vendor Request: Stage: %5s, Direction: %3s, Type: %8s, Recipient: %9s, bRequest: 0x%02x, wValue: 0x%04x, wIndex: %u, wLength: %u\n", 
     strRequestStages[requestStage],
     strRequestDirections[request->bmRequestDirection],
     strRequestTypes[request->bmRequestType],
@@ -109,7 +107,7 @@ bool vendorRequestCallback(uint8_t rhport, uint8_t requestStage, arduino_usb_con
             result = Vendor.sendResponse(rhport, request, (void*) &vendor_line_coding, sizeof(request_line_coding_t));
           } else if (requestStage == REQUEST_STAGE_ACK) {
             //In the ACK stage the response is complete
-            HWSerial.printf("Vendor Line Coding: bit_rate: %lu, data_bits: %u, stop_bits: %u, parity: %u\n", vendor_line_coding.bit_rate, vendor_line_coding.data_bits, vendor_line_coding.stop_bits, vendor_line_coding.parity);
+            Serial.printf("Vendor Line Coding: bit_rate: %lu, data_bits: %u, stop_bits: %u, parity: %u\n", vendor_line_coding.bit_rate, vendor_line_coding.data_bits, vendor_line_coding.stop_bits, vendor_line_coding.parity);
           }
           result = true;
           break;
@@ -139,7 +137,7 @@ bool vendorRequestCallback(uint8_t rhport, uint8_t requestStage, arduino_usb_con
             //In the ACK stage the response is complete
             bool dtr = (vendor_line_state & 1) != 0;
             bool rts = (vendor_line_state & 2) != 0;
-            HWSerial.printf("Vendor Line State: dtr: %u, rts: %u\n", dtr, rts);
+            Serial.printf("Vendor Line State: dtr: %u, rts: %u\n", dtr, rts);
           }
           result = true;
           break;
@@ -155,8 +153,8 @@ bool vendorRequestCallback(uint8_t rhport, uint8_t requestStage, arduino_usb_con
 
 void setup() {
   pinMode(buttonPin, INPUT_PULLUP);
-  HWSerial.begin(115200);
-  HWSerial.setDebugOutput(true);
+  Serial.begin(115200);
+  Serial.setDebugOutput(true);
 
   Vendor.onEvent(usbEventCallback);
   Vendor.onRequest(vendorRequestCallback);
@@ -174,19 +172,19 @@ void loop() {
   if (buttonState != previousButtonState) {
     previousButtonState = buttonState;
     if (buttonState == LOW) {
-      HWSerial.println("Button Pressed");
+      Serial.println("Button Pressed");
       Vendor.println("Button Pressed");
     } else {
       Vendor.println("Button Released");
-      HWSerial.println("Button Released");
+      Serial.println("Button Released");
     }
     delay(100);
   }
 
-  while (HWSerial.available()) {
-    size_t l = HWSerial.available();
+  while (Serial.available()) {
+    size_t l = Serial.available();
     uint8_t b[l];
-    l = HWSerial.read(b, l);
+    l = Serial.read(b, l);
     Vendor.write(b, l);
   }
 }


### PR DESCRIPTION
## Description of Change
The PR changes `Serial` to be a pre-processor symbol instead of a HardwareSerial/HWCDC/USBCDC object.
Therefore, UART0 is always the `Serial0` object.

If the sketch doesn't use `CDC on Boot`, `Serial` will defined to be `Serial0` by default.
Whenever the sketch is set to use `CDC on Boot`, `Serial` will defined to be `USBSerial` object, which in turn will point to a HWCDC or USBCDC object depending on how it is configured / which SoC is used.

The PR will make `Serial0`, `Serial1` and `Serial2` (if it exists) always available as UART0/1/2.
`USBSerial` will also always be available whenever the SoC has a CDC interface.

If necessary the sketch can change/force the redefinition of `Serial` symbol to whatever necessary.

The PR also adds a `HWCDCSerialEvent()` callback that is executed after `loop()` whenever there are bytes available in the HW Serial Interface.
The same for `USBSerialEvent()` in Native USB CDC. Those two functions can be defined in the sketch by the user and work in the same way as `SerialEvent()` works.

## Tests scenarios
Used "OnReceive_Demo.ino" to test it using ESP32/ESP32S2/ESP32C3/ESP32S3 with different configurations for USB, whenever possible.

## Related links
None
