### PR TITLE
[Docs] Add ESP32C6 + ESP32H2

### DIFF
--- a/docs/source/common/datasheet.inc
+++ b/docs/source/common/datasheet.inc
@@ -5,9 +5,13 @@ Datasheet
 * `ESP32-S2`_ (Datasheet)
 * `ESP32-C3`_ (Datasheet)
 * `ESP32-S3`_ (Datasheet)
+* `ESP32-C6`_ (Datasheet)
+* `ESP32-H2`_ (Datasheet)
 
 .. _Espressif Product Selector: https://products.espressif.com/
 .. _ESP32: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
 .. _ESP32-S2: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
 .. _ESP32-C3: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
 .. _ESP32-S3: https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf
+.. _ESP32-C6: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
+.. _ESP32-H2: https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -41,6 +41,8 @@ ESP32    Yes    Yes         `ESP32`_
 ESP32-S2 Yes    Yes         `ESP32-S2`_
 ESP32-C3 Yes    Yes         `ESP32-C3`_
 ESP32-S3 Yes    Yes         `ESP32-S3`_
+ESP32-C6 No     Yes         `ESP32-C6`_
+ESP32-H2 No     Yes         `ESP32-H2`_
 ======== ====== =========== ===================================
 
 See `Boards <boards/boards.html>`_ for more details about ESP32 development boards.


### PR DESCRIPTION
## Description of Change
Added ESP32C6 and ESP32H2 to the getting started page of our docs, as they are now supported in the development releases.

## Tests scenarios

## Related links

