### PR TITLE
UART: Change default Serial1/2 pins and move definition to header

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -22,92 +22,15 @@
 #define ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE -1
 #endif
 
-#ifndef SOC_RX0
-#if CONFIG_IDF_TARGET_ESP32
-#define SOC_RX0 3
-#elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
-#define SOC_RX0 44
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define SOC_RX0 20
-#elif CONFIG_IDF_TARGET_ESP32C6
-#define SOC_RX0 17
-#elif CONFIG_IDF_TARGET_ESP32H2
-#define SOC_RX0 23
-#endif
-#endif
-
-#ifndef SOC_TX0
-#if CONFIG_IDF_TARGET_ESP32
-#define SOC_TX0 1
-#elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
-#define SOC_TX0 43
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define SOC_TX0 21
-#elif CONFIG_IDF_TARGET_ESP32C6
-#define SOC_TX0 16
-#elif CONFIG_IDF_TARGET_ESP32H2
-#define SOC_TX0 24
-#endif
-#endif
-
 void serialEvent(void) __attribute__((weak));
 void serialEvent(void) {}
 
 #if SOC_UART_NUM > 1
-
-#ifndef RX1
-#if CONFIG_IDF_TARGET_ESP32
-#define RX1 9
-#elif CONFIG_IDF_TARGET_ESP32S2
-#define RX1 18
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define RX1 18
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define RX1 15
-#elif CONFIG_IDF_TARGET_ESP32C6
-#define RX1 4
-#elif CONFIG_IDF_TARGET_ESP32H2
-#define RX1 0
-#endif
-#endif
-
-#ifndef TX1
-#if CONFIG_IDF_TARGET_ESP32
-#define TX1 10
-#elif CONFIG_IDF_TARGET_ESP32S2
-#define TX1 17
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define TX1 19
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define TX1 16
-#elif CONFIG_IDF_TARGET_ESP32C6
-#define TX1 5
-#elif CONFIG_IDF_TARGET_ESP32H2
-#define TX1 1
-#endif
-#endif
-
 void serialEvent1(void) __attribute__((weak));
 void serialEvent1(void) {}
 #endif /* SOC_UART_NUM > 1 */
 
 #if SOC_UART_NUM > 2
-#ifndef RX2
-#if CONFIG_IDF_TARGET_ESP32
-#define RX2 16
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define RX2 19
-#endif
-#endif
-
-#ifndef TX2
-#if CONFIG_IDF_TARGET_ESP32
-#define TX2 17
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define TX2 20
-#endif
-#endif
-
 void serialEvent2(void) __attribute__((weak));
 void serialEvent2(void) {}
 #endif /* SOC_UART_NUM > 2 */
@@ -370,16 +293,16 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
             case UART_NUM_0:
                 if (rxPin < 0 && txPin < 0) {
                     // do not change RX0/TX0 if it has already been set before
-                    rxPin = _rxPin < 0 ? SOC_RX0 : _rxPin;
-                    txPin = _txPin < 0 ? SOC_TX0 : _txPin;
+                    rxPin = _rxPin < 0 ? (int8_t)SOC_RX0 : _rxPin;
+                    txPin = _txPin < 0 ? (int8_t)SOC_TX0 : _txPin;
                 }
             break;
 #if SOC_UART_NUM > 1                   // may save some flash bytes...
             case UART_NUM_1:
                if (rxPin < 0 && txPin < 0) {
                     // do not change RX1/TX1 if it has already been set before
-                    rxPin = _rxPin < 0 ? RX1 : _rxPin;
-                    txPin = _txPin < 0 ? TX1 : _txPin;
+                    rxPin = _rxPin < 0 ? (int8_t)RX1 : _rxPin;
+                    txPin = _txPin < 0 ? (int8_t)TX1 : _txPin;
                 }
             break;
 #endif
@@ -387,8 +310,8 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
             case UART_NUM_2:
                if (rxPin < 0 && txPin < 0) {
                     // do not change RX2/TX2 if it has already been set before
-                    rxPin = _rxPin < 0 ? RX2 : _rxPin;
-                    txPin = _txPin < 0 ? TX2 : _txPin;
+                    rxPin = _rxPin < 0 ? (int8_t)RX2 : _rxPin;
+                    txPin = _txPin < 0 ? (int8_t)TX2 : _txPin;
                 }
             break;
 #endif

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -95,6 +95,107 @@ typedef enum {
     UART_PARITY_ERROR
 } hardwareSerial_error_t;
 
+
+#ifndef ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE
+  #define ARDUINO_SERIAL_EVENT_TASK_STACK_SIZE 2048
+#endif
+
+#ifndef ARDUINO_SERIAL_EVENT_TASK_PRIORITY
+  #define ARDUINO_SERIAL_EVENT_TASK_PRIORITY (configMAX_PRIORITIES-1)
+#endif
+
+#ifndef ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE
+  #define ARDUINO_SERIAL_EVENT_TASK_RUNNING_CORE -1
+#endif
+
+// UART0 pins are defined by default by the bootloader.
+// The definitions for SOC_* should not be changed unless the bootloader pins
+// have changed and you know what you are doing.
+
+#ifndef SOC_RX0
+  #if CONFIG_IDF_TARGET_ESP32
+    #define SOC_RX0 (gpio_num_t)3
+  #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+    #define SOC_RX0 (gpio_num_t)44
+  #elif CONFIG_IDF_TARGET_ESP32C3
+    #define SOC_RX0 (gpio_num_t)20
+  #elif CONFIG_IDF_TARGET_ESP32C6
+    #define SOC_RX0 (gpio_num_t)17
+  #elif CONFIG_IDF_TARGET_ESP32H2
+    #define SOC_RX0 (gpio_num_t)23
+  #endif
+#endif
+
+#ifndef SOC_TX0
+  #if CONFIG_IDF_TARGET_ESP32
+    #define SOC_TX0 (gpio_num_t)1
+  #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+    #define SOC_TX0 (gpio_num_t)43
+  #elif CONFIG_IDF_TARGET_ESP32C3
+    #define SOC_TX0 (gpio_num_t)21
+  #elif CONFIG_IDF_TARGET_ESP32C6
+    #define SOC_TX0 (gpio_num_t)16
+  #elif CONFIG_IDF_TARGET_ESP32H2
+    #define SOC_TX0 (gpio_num_t)24
+  #endif
+#endif
+
+// Default pins for UART1 are arbitrary, and defined here for convenience.
+
+#if SOC_UART_NUM > 1
+  #ifndef RX1
+    #if CONFIG_IDF_TARGET_ESP32
+      #define RX1 (gpio_num_t)26
+    #elif CONFIG_IDF_TARGET_ESP32S2
+      #define RX1 (gpio_num_t)4
+    #elif CONFIG_IDF_TARGET_ESP32C3
+      #define RX1 (gpio_num_t)18
+    #elif CONFIG_IDF_TARGET_ESP32S3
+      #define RX1 (gpio_num_t)15
+    #elif CONFIG_IDF_TARGET_ESP32C6
+      #define RX1 (gpio_num_t)4
+    #elif CONFIG_IDF_TARGET_ESP32H2
+      #define RX1 (gpio_num_t)0
+    #endif
+  #endif
+
+  #ifndef TX1
+    #if CONFIG_IDF_TARGET_ESP32
+      #define TX1 (gpio_num_t)27
+    #elif CONFIG_IDF_TARGET_ESP32S2
+      #define TX1 (gpio_num_t)5
+    #elif CONFIG_IDF_TARGET_ESP32C3
+      #define TX1 (gpio_num_t)19
+    #elif CONFIG_IDF_TARGET_ESP32S3
+      #define TX1 (gpio_num_t)16
+    #elif CONFIG_IDF_TARGET_ESP32C6
+      #define TX1 (gpio_num_t)5
+    #elif CONFIG_IDF_TARGET_ESP32H2
+      #define TX1 (gpio_num_t)1
+    #endif
+  #endif
+#endif /* SOC_UART_NUM > 1 */
+
+// Default pins for UART2 are arbitrary, and defined here for convenience.
+
+#if SOC_UART_NUM > 2
+  #ifndef RX2
+    #if CONFIG_IDF_TARGET_ESP32
+      #define RX2 (gpio_num_t)4
+    #elif CONFIG_IDF_TARGET_ESP32S3
+      #define RX2 (gpio_num_t)19
+    #endif
+  #endif
+
+  #ifndef TX2
+    #if CONFIG_IDF_TARGET_ESP32
+      #define TX2 (gpio_num_t)25
+    #elif CONFIG_IDF_TARGET_ESP32S3
+      #define TX2 (gpio_num_t)20
+    #endif
+  #endif
+#endif /* SOC_UART_NUM > 2 */
+
 typedef std::function<void(void)> OnReceiveCb;
 typedef std::function<void(hardwareSerial_error_t)> OnReceiveErrorCb;
 
@@ -207,7 +308,7 @@ public:
     // Used to set RS485 modes such as UART_MODE_RS485_HALF_DUPLEX for Auto RTS function on ESP32
     //    UART_MODE_UART                   = 0x00    mode: regular UART mode
     //    UART_MODE_RS485_HALF_DUPLEX      = 0x01    mode: half duplex RS485 UART mode control by RTS pin
-    //    UART_MODE_IRDA                   = 0x02    mode: IRDA  UART mode
+    //    UART_MODE_IRDA                   = 0x02    mode: IRDA UART mode
     //    UART_MODE_RS485_COLLISION_DETECT = 0x03    mode: RS485 collision detection UART mode (used for test purposes)
     //    UART_MODE_RS485_APP_CTRL         = 0x04    mode: application control RS485 UART mode (used for test purposes)
     bool setMode(SerialMode mode);


### PR DESCRIPTION
## Description of Change
This PR aims to change the default UART1 and UART2 pins to avoid conflicts and improve ease of use.
It also moves the pin definitions to the `HardwareSerial.h` file so they can be used in sketches.
The final pin assignments are:

|          |   Name  | ESP32 | S2 | S3 | C3 | C6 | H2 |
|:--------:|:-------:|:-----:|:--:|:--:|:--:|:--:|:--:|
| UART0 RX | SOC_RX0 |   3   | 44 | 44 | 20 | 17 | 23 |
| UART0 TX | SOC_TX0 |   1   | 43 | 43 | 21 | 16 | 24 |
| UART1 RX |   RX1   |   26  |  4 | 15 | 18 |  4 |  0 |
| UART1 TX |   TX1   |   27  |  5 | 16 | 19 |  5 |  1 |
| UART2 RX |   RX2   |   4   | -- | 19 | -- | -- | -- |
| UART2 TX |   TX2   |   25  | -- | 20 | -- | -- | -- |

## Tests scenarios

Tested all chips using the (future) UART CI script.
