### PR TITLE
RMT: Fix RMT TX interrupt level

### DIFF
--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -513,6 +513,7 @@ bool rmtInit(int pin, rmt_ch_dir_t channel_direction, rmt_reserve_memsize_t mem_
     tx_cfg.flags.with_dma = 0;
     tx_cfg.flags.io_loop_back = 0;
     tx_cfg.flags.io_od_mode = 0;
+    tx_cfg.intr_priority = 0;
 
     if (rmt_new_tx_channel(&tx_cfg, &bus->rmt_channel_h) != ESP_OK) {
       log_e("GPIO %d - RMT TX Initialization error.", pin);


### PR DESCRIPTION
## Description of Change

This PR aims to fix RMT failing to start due to the uninitialized interrupt value. This would cause the interrupt to be initialized with garbage memory values:

```
E (18193) rmt: rmt_new_tx_channel(210): invalid interrupt priority:-2113922172
```

## Tests scenarios

Tested with ESP32-S3-DevKitC-1 using the BlinkRGB example.
