### PR TITLE
Add new UM TinyC6 board and re-ordered UM boards in boards.txt file.

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2315,1284 +2315,1412 @@ aventen_s3_sync.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-tinypico.name=UM TinyPICO
+um_feathers2.name=UM FeatherS2
+um_feathers2.vid.0=0x239A
+um_feathers2.pid.0=0x80AB
 
-tinypico.bootloader.tool=esptool_py
-tinypico.bootloader.tool.default=esptool_py
+um_feathers2.bootloader.tool=esptool_py
+um_feathers2.bootloader.tool.default=esptool_py
 
-tinypico.upload.tool=esptool_py
-tinypico.upload.tool.default=esptool_py
-tinypico.upload.tool.network=esp_ota
+um_feathers2.upload.tool=esptool_py
+um_feathers2.upload.tool.default=esptool_py
+um_feathers2.upload.tool.network=esp_ota
 
-tinypico.upload.maximum_size=1310720
-tinypico.upload.maximum_data_size=327680
-tinypico.upload.flags=
-tinypico.upload.extra_flags=
+um_feathers2.upload.maximum_size=1310720
+um_feathers2.upload.maximum_data_size=327680
+um_feathers2.upload.flags=
+um_feathers2.upload.extra_flags=
+um_feathers2.upload.use_1200bps_touch=true
+um_feathers2.upload.wait_for_upload_port=true
 
-tinypico.serial.disableDTR=true
-tinypico.serial.disableRTS=true
+um_feathers2.serial.disableDTR=false
+um_feathers2.serial.disableRTS=false
 
-tinypico.build.tarch=xtensa
-tinypico.build.bootloader_addr=0x1000
-tinypico.build.target=esp32
-tinypico.build.mcu=esp32
-tinypico.build.core=esp32
-tinypico.build.variant=um_tinypico
-tinypico.build.board=TINYPICO
+um_feathers2.build.tarch=xtensa
+um_feathers2.build.bootloader_addr=0x1000
+um_feathers2.build.target=esp32s2
+um_feathers2.build.mcu=esp32s2
+um_feathers2.build.core=esp32
+um_feathers2.build.variant=um_feathers2
+um_feathers2.build.board=FEATHERS2
 
-tinypico.build.f_cpu=240000000L
-tinypico.build.flash_size=4MB
-tinypico.build.flash_freq=80m
-tinypico.build.flash_mode=dio
-tinypico.build.boot=dio
-tinypico.build.partitions=default
-tinypico.build.defines=
+um_feathers2.build.cdc_on_boot=1
+um_feathers2.build.msc_on_boot=0
+um_feathers2.build.dfu_on_boot=0
+um_feathers2.build.f_cpu=240000000L
+um_feathers2.build.flash_size=16MB
+um_feathers2.build.flash_freq=80m
+um_feathers2.build.flash_mode=dio
+um_feathers2.build.boot=qio
+um_feathers2.build.partitions=fatflash
+um_feathers2.build.defines=
 
-tinypico.menu.PartitionScheme.default=Default
-tinypico.menu.PartitionScheme.default.build.partitions=default
-tinypico.menu.PartitionScheme.no_ota=No OTA (Large APP)
-tinypico.menu.PartitionScheme.no_ota.build.partitions=no_ota
-tinypico.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-tinypico.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
-tinypico.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-tinypico.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+um_feathers2.menu.CDCOnBoot.cdc=Enabled
+um_feathers2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_feathers2.menu.CDCOnBoot.default=Disabled
+um_feathers2.menu.CDCOnBoot.default.build.cdc_on_boot=0
 
-tinypico.menu.UploadSpeed.921600=921600
-tinypico.menu.UploadSpeed.921600.upload.speed=921600
-tinypico.menu.UploadSpeed.115200=115200
-tinypico.menu.UploadSpeed.115200.upload.speed=115200
-tinypico.menu.UploadSpeed.256000.windows=256000
-tinypico.menu.UploadSpeed.256000.upload.speed=256000
-tinypico.menu.UploadSpeed.230400.windows.upload.speed=256000
-tinypico.menu.UploadSpeed.230400=230400
-tinypico.menu.UploadSpeed.230400.upload.speed=230400
-tinypico.menu.UploadSpeed.460800.linux=460800
-tinypico.menu.UploadSpeed.460800.macosx=460800
-tinypico.menu.UploadSpeed.460800.upload.speed=460800
-tinypico.menu.UploadSpeed.512000.windows=512000
-tinypico.menu.UploadSpeed.512000.upload.speed=512000
+um_feathers2.menu.MSCOnBoot.default=Disabled
+um_feathers2.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_feathers2.menu.MSCOnBoot.msc=Enabled
+um_feathers2.menu.MSCOnBoot.msc.build.msc_on_boot=1
 
-tinypico.menu.FlashMode.qio=QIO
-tinypico.menu.FlashMode.qio.build.flash_mode=dio
-tinypico.menu.FlashMode.qio.build.boot=qio
-tinypico.menu.FlashMode.dio=DIO
-tinypico.menu.FlashMode.dio.build.flash_mode=dio
-tinypico.menu.FlashMode.dio.build.boot=dio
+um_feathers2.menu.DFUOnBoot.default=Disabled
+um_feathers2.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_feathers2.menu.DFUOnBoot.dfu=Enabled
+um_feathers2.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
-tinypico.menu.FlashFreq.80=80MHz
-tinypico.menu.FlashFreq.80.build.flash_freq=80m
-tinypico.menu.FlashFreq.40=40MHz
-tinypico.menu.FlashFreq.40.build.flash_freq=40m
+um_feathers2.menu.PSRAM.enabled=Enabled
+um_feathers2.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_feathers2.menu.PSRAM.disabled=Disabled
+um_feathers2.menu.PSRAM.disabled.build.defines=
 
-tinypico.menu.PSRAM.enabled=Enabled
-tinypico.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
-tinypico.menu.PSRAM.enabled.build.extra_libs=
-tinypico.menu.PSRAM.disabled=Disabled
-tinypico.menu.PSRAM.disabled.build.defines=
-tinypico.menu.PSRAM.disabled.build.extra_libs=
+um_feathers2.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+um_feathers2.menu.PartitionScheme.fatflash.build.partitions=ffat
+um_feathers2.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+um_feathers2.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+um_feathers2.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+um_feathers2.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+um_feathers2.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+um_feathers2.menu.PartitionScheme.default.build.partitions=default
+um_feathers2.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+um_feathers2.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+um_feathers2.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+um_feathers2.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+um_feathers2.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+um_feathers2.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+um_feathers2.menu.PartitionScheme.minimal.build.partitions=minimal
+um_feathers2.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+um_feathers2.menu.PartitionScheme.no_ota.build.partitions=no_ota
+um_feathers2.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+um_feathers2.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+um_feathers2.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+um_feathers2.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+um_feathers2.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+um_feathers2.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+um_feathers2.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+um_feathers2.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+um_feathers2.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+um_feathers2.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+um_feathers2.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+um_feathers2.menu.PartitionScheme.huge_app.build.partitions=huge_app
+um_feathers2.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+um_feathers2.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+um_feathers2.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+um_feathers2.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
-tinypico.menu.DebugLevel.none=None
-tinypico.menu.DebugLevel.none.build.code_debug=0
-tinypico.menu.DebugLevel.error=Error
-tinypico.menu.DebugLevel.error.build.code_debug=1
-tinypico.menu.DebugLevel.warn=Warn
-tinypico.menu.DebugLevel.warn.build.code_debug=2
-tinypico.menu.DebugLevel.info=Info
-tinypico.menu.DebugLevel.info.build.code_debug=3
-tinypico.menu.DebugLevel.debug=Debug
-tinypico.menu.DebugLevel.debug.build.code_debug=4
-tinypico.menu.DebugLevel.verbose=Verbose
-tinypico.menu.DebugLevel.verbose.build.code_debug=5
+um_feathers2.menu.CPUFreq.240=240MHz (WiFi)
+um_feathers2.menu.CPUFreq.240.build.f_cpu=240000000L
+um_feathers2.menu.CPUFreq.160=160MHz (WiFi)
+um_feathers2.menu.CPUFreq.160.build.f_cpu=160000000L
+um_feathers2.menu.CPUFreq.80=80MHz (WiFi)
+um_feathers2.menu.CPUFreq.80.build.f_cpu=80000000L
+um_feathers2.menu.CPUFreq.40=40MHz
+um_feathers2.menu.CPUFreq.40.build.f_cpu=40000000L
+um_feathers2.menu.CPUFreq.20=20MHz
+um_feathers2.menu.CPUFreq.20.build.f_cpu=20000000L
+um_feathers2.menu.CPUFreq.10=10MHz
+um_feathers2.menu.CPUFreq.10.build.f_cpu=10000000L
 
-tinypico.menu.EraseFlash.none=Disabled
-tinypico.menu.EraseFlash.none.upload.erase_cmd=
-tinypico.menu.EraseFlash.all=Enabled
-tinypico.menu.EraseFlash.all.upload.erase_cmd=-e
+um_feathers2.menu.FlashSize.16M=16MB (128Mb)
+um_feathers2.menu.FlashSize.16M.build.flash_size=16MB
+um_feathers2.menu.FlashSize.4M=4MB (32Mb)
+um_feathers2.menu.FlashSize.4M.build.flash_size=4MB
+um_feathers2.menu.FlashSize.8M=8MB (64Mb)
+um_feathers2.menu.FlashSize.8M.build.flash_size=8MB
+um_feathers2.menu.FlashSize.8M.build.partitions=default_8MB
+um_feathers2.menu.FlashSize.2M=2MB (16Mb)
+um_feathers2.menu.FlashSize.2M.build.flash_size=2MB
+um_feathers2.menu.FlashSize.2M.build.partitions=minimal
 
-##############################################################
+um_feathers2.menu.UploadSpeed.921600=921600
+um_feathers2.menu.UploadSpeed.921600.upload.speed=921600
+um_feathers2.menu.UploadSpeed.115200=115200
+um_feathers2.menu.UploadSpeed.115200.upload.speed=115200
+um_feathers2.menu.UploadSpeed.256000.windows=256000
+um_feathers2.menu.UploadSpeed.256000.upload.speed=256000
+um_feathers2.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_feathers2.menu.UploadSpeed.230400=230400
+um_feathers2.menu.UploadSpeed.230400.upload.speed=230400
+um_feathers2.menu.UploadSpeed.460800.linux=460800
+um_feathers2.menu.UploadSpeed.460800.macosx=460800
+um_feathers2.menu.UploadSpeed.460800.upload.speed=460800
 
-feathers2.name=UM FeatherS2
-feathers2.vid.0=0x239A
-feathers2.pid.0=0x80AB
+um_feathers2.menu.DebugLevel.none=None
+um_feathers2.menu.DebugLevel.none.build.code_debug=0
+um_feathers2.menu.DebugLevel.error=Error
+um_feathers2.menu.DebugLevel.error.build.code_debug=1
+um_feathers2.menu.DebugLevel.warn=Warn
+um_feathers2.menu.DebugLevel.warn.build.code_debug=2
+um_feathers2.menu.DebugLevel.info=Info
+um_feathers2.menu.DebugLevel.info.build.code_debug=3
+um_feathers2.menu.DebugLevel.debug=Debug
+um_feathers2.menu.DebugLevel.debug.build.code_debug=4
+um_feathers2.menu.DebugLevel.verbose=Verbose
+um_feathers2.menu.DebugLevel.verbose.build.code_debug=5
 
-feathers2.bootloader.tool=esptool_py
-feathers2.bootloader.tool.default=esptool_py
-
-feathers2.upload.tool=esptool_py
-feathers2.upload.tool.default=esptool_py
-feathers2.upload.tool.network=esp_ota
-
-feathers2.upload.maximum_size=1310720
-feathers2.upload.maximum_data_size=327680
-feathers2.upload.flags=
-feathers2.upload.extra_flags=
-feathers2.upload.use_1200bps_touch=true
-feathers2.upload.wait_for_upload_port=true
-
-feathers2.serial.disableDTR=false
-feathers2.serial.disableRTS=false
-
-feathers2.build.tarch=xtensa
-feathers2.build.bootloader_addr=0x1000
-feathers2.build.target=esp32s2
-feathers2.build.mcu=esp32s2
-feathers2.build.core=esp32
-feathers2.build.variant=um_feathers2
-feathers2.build.board=FEATHERS2
-
-feathers2.build.cdc_on_boot=1
-feathers2.build.msc_on_boot=0
-feathers2.build.dfu_on_boot=0
-feathers2.build.f_cpu=240000000L
-feathers2.build.flash_size=16MB
-feathers2.build.flash_freq=80m
-feathers2.build.flash_mode=dio
-feathers2.build.boot=qio
-feathers2.build.partitions=fatflash
-feathers2.build.defines=
-
-feathers2.menu.CDCOnBoot.cdc=Enabled
-feathers2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-feathers2.menu.CDCOnBoot.default=Disabled
-feathers2.menu.CDCOnBoot.default.build.cdc_on_boot=0
-
-feathers2.menu.MSCOnBoot.default=Disabled
-feathers2.menu.MSCOnBoot.default.build.msc_on_boot=0
-feathers2.menu.MSCOnBoot.msc=Enabled
-feathers2.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-feathers2.menu.DFUOnBoot.default=Disabled
-feathers2.menu.DFUOnBoot.default.build.dfu_on_boot=0
-feathers2.menu.DFUOnBoot.dfu=Enabled
-feathers2.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-feathers2.menu.PSRAM.enabled=Enabled
-feathers2.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-feathers2.menu.PSRAM.disabled=Disabled
-feathers2.menu.PSRAM.disabled.build.defines=
-
-feathers2.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
-feathers2.menu.PartitionScheme.fatflash.build.partitions=ffat
-feathers2.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
-feathers2.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
-feathers2.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-feathers2.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
-feathers2.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-feathers2.menu.PartitionScheme.default.build.partitions=default
-feathers2.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-feathers2.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-feathers2.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
-feathers2.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
-feathers2.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
-feathers2.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-feathers2.menu.PartitionScheme.minimal.build.partitions=minimal
-feathers2.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-feathers2.menu.PartitionScheme.no_ota.build.partitions=no_ota
-feathers2.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-feathers2.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-feathers2.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-feathers2.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-feathers2.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-feathers2.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-feathers2.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-feathers2.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-feathers2.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-feathers2.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-feathers2.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-feathers2.menu.PartitionScheme.huge_app.build.partitions=huge_app
-feathers2.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-feathers2.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-feathers2.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-feathers2.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-
-feathers2.menu.CPUFreq.240=240MHz (WiFi)
-feathers2.menu.CPUFreq.240.build.f_cpu=240000000L
-feathers2.menu.CPUFreq.160=160MHz (WiFi)
-feathers2.menu.CPUFreq.160.build.f_cpu=160000000L
-feathers2.menu.CPUFreq.80=80MHz (WiFi)
-feathers2.menu.CPUFreq.80.build.f_cpu=80000000L
-feathers2.menu.CPUFreq.40=40MHz
-feathers2.menu.CPUFreq.40.build.f_cpu=40000000L
-feathers2.menu.CPUFreq.20=20MHz
-feathers2.menu.CPUFreq.20.build.f_cpu=20000000L
-feathers2.menu.CPUFreq.10=10MHz
-feathers2.menu.CPUFreq.10.build.f_cpu=10000000L
-
-feathers2.menu.FlashSize.16M=16MB (128Mb)
-feathers2.menu.FlashSize.16M.build.flash_size=16MB
-feathers2.menu.FlashSize.4M=4MB (32Mb)
-feathers2.menu.FlashSize.4M.build.flash_size=4MB
-feathers2.menu.FlashSize.8M=8MB (64Mb)
-feathers2.menu.FlashSize.8M.build.flash_size=8MB
-feathers2.menu.FlashSize.8M.build.partitions=default_8MB
-feathers2.menu.FlashSize.2M=2MB (16Mb)
-feathers2.menu.FlashSize.2M.build.flash_size=2MB
-feathers2.menu.FlashSize.2M.build.partitions=minimal
-
-feathers2.menu.UploadSpeed.921600=921600
-feathers2.menu.UploadSpeed.921600.upload.speed=921600
-feathers2.menu.UploadSpeed.115200=115200
-feathers2.menu.UploadSpeed.115200.upload.speed=115200
-feathers2.menu.UploadSpeed.256000.windows=256000
-feathers2.menu.UploadSpeed.256000.upload.speed=256000
-feathers2.menu.UploadSpeed.230400.windows.upload.speed=256000
-feathers2.menu.UploadSpeed.230400=230400
-feathers2.menu.UploadSpeed.230400.upload.speed=230400
-feathers2.menu.UploadSpeed.460800.linux=460800
-feathers2.menu.UploadSpeed.460800.macosx=460800
-feathers2.menu.UploadSpeed.460800.upload.speed=460800
-
-feathers2.menu.DebugLevel.none=None
-feathers2.menu.DebugLevel.none.build.code_debug=0
-feathers2.menu.DebugLevel.error=Error
-feathers2.menu.DebugLevel.error.build.code_debug=1
-feathers2.menu.DebugLevel.warn=Warn
-feathers2.menu.DebugLevel.warn.build.code_debug=2
-feathers2.menu.DebugLevel.info=Info
-feathers2.menu.DebugLevel.info.build.code_debug=3
-feathers2.menu.DebugLevel.debug=Debug
-feathers2.menu.DebugLevel.debug.build.code_debug=4
-feathers2.menu.DebugLevel.verbose=Verbose
-feathers2.menu.DebugLevel.verbose.build.code_debug=5
-
-feathers2.menu.EraseFlash.none=Disabled
-feathers2.menu.EraseFlash.none.upload.erase_cmd=
-feathers2.menu.EraseFlash.all=Enabled
-feathers2.menu.EraseFlash.all.upload.erase_cmd=-e
+um_feathers2.menu.EraseFlash.none=Disabled
+um_feathers2.menu.EraseFlash.none.upload.erase_cmd=
+um_feathers2.menu.EraseFlash.all=Enabled
+um_feathers2.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-feathers2neo.name=UM FeatherS2 Neo
-feathers2neo.vid.0=0x303a
-feathers2neo.pid.0=0x80B4
+um_feathers2neo.name=UM FeatherS2 Neo
+um_feathers2neo.vid.0=0x303a
+um_feathers2neo.pid.0=0x80B4
 
-feathers2neo.bootloader.tool=esptool_py
-feathers2neo.bootloader.tool.default=esptool_py
+um_feathers2neo.bootloader.tool=esptool_py
+um_feathers2neo.bootloader.tool.default=esptool_py
 
-feathers2neo.upload.tool=esptool_py
-feathers2neo.upload.tool.default=esptool_py
-feathers2neo.upload.tool.network=esp_ota
+um_feathers2neo.upload.tool=esptool_py
+um_feathers2neo.upload.tool.default=esptool_py
+um_feathers2neo.upload.tool.network=esp_ota
 
-feathers2neo.upload.maximum_size=1310720
-feathers2neo.upload.maximum_data_size=327680
-feathers2neo.upload.flags=
-feathers2neo.upload.extra_flags=
-feathers2neo.upload.use_1200bps_touch=true
-feathers2neo.upload.wait_for_upload_port=true
+um_feathers2neo.upload.maximum_size=1310720
+um_feathers2neo.upload.maximum_data_size=327680
+um_feathers2neo.upload.flags=
+um_feathers2neo.upload.extra_flags=
+um_feathers2neo.upload.use_1200bps_touch=true
+um_feathers2neo.upload.wait_for_upload_port=true
 
-feathers2neo.serial.disableDTR=false
-feathers2neo.serial.disableRTS=false
+um_feathers2neo.serial.disableDTR=false
+um_feathers2neo.serial.disableRTS=false
 
-feathers2neo.build.tarch=xtensa
-feathers2neo.build.bootloader_addr=0x1000
-feathers2neo.build.target=esp32s2
-feathers2neo.build.mcu=esp32s2
-feathers2neo.build.core=esp32
-feathers2neo.build.variant=um_feathers2neo
-feathers2neo.build.board=FEATHERS2NEO
+um_feathers2neo.build.tarch=xtensa
+um_feathers2neo.build.bootloader_addr=0x1000
+um_feathers2neo.build.target=esp32s2
+um_feathers2neo.build.mcu=esp32s2
+um_feathers2neo.build.core=esp32
+um_feathers2neo.build.variant=um_feathers2neo
+um_feathers2neo.build.board=FEATHERS2NEO
 
-feathers2neo.build.cdc_on_boot=1
-feathers2neo.build.msc_on_boot=0
-feathers2neo.build.dfu_on_boot=0
-feathers2neo.build.f_cpu=240000000L
-feathers2neo.build.flash_size=4MB
-feathers2neo.build.flash_freq=80m
-feathers2neo.build.flash_mode=dio
-feathers2neo.build.boot=qio
-feathers2neo.build.partitions=default
-feathers2neo.build.defines=
+um_feathers2neo.build.cdc_on_boot=1
+um_feathers2neo.build.msc_on_boot=0
+um_feathers2neo.build.dfu_on_boot=0
+um_feathers2neo.build.f_cpu=240000000L
+um_feathers2neo.build.flash_size=4MB
+um_feathers2neo.build.flash_freq=80m
+um_feathers2neo.build.flash_mode=dio
+um_feathers2neo.build.boot=qio
+um_feathers2neo.build.partitions=default
+um_feathers2neo.build.defines=
 
-feathers2neo.menu.CDCOnBoot.cdc=Enabled
-feathers2neo.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-feathers2neo.menu.CDCOnBoot.default=Disabled
-feathers2neo.menu.CDCOnBoot.default.build.cdc_on_boot=0
+um_feathers2neo.menu.CDCOnBoot.cdc=Enabled
+um_feathers2neo.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_feathers2neo.menu.CDCOnBoot.default=Disabled
+um_feathers2neo.menu.CDCOnBoot.default.build.cdc_on_boot=0
 
-feathers2neo.menu.MSCOnBoot.default=Disabled
-feathers2neo.menu.MSCOnBoot.default.build.msc_on_boot=0
-feathers2neo.menu.MSCOnBoot.msc=Enabled
-feathers2neo.menu.MSCOnBoot.msc.build.msc_on_boot=1
+um_feathers2neo.menu.MSCOnBoot.default=Disabled
+um_feathers2neo.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_feathers2neo.menu.MSCOnBoot.msc=Enabled
+um_feathers2neo.menu.MSCOnBoot.msc.build.msc_on_boot=1
 
-feathers2neo.menu.DFUOnBoot.default=Disabled
-feathers2neo.menu.DFUOnBoot.default.build.dfu_on_boot=0
-feathers2neo.menu.DFUOnBoot.dfu=Enabled
-feathers2neo.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+um_feathers2neo.menu.DFUOnBoot.default=Disabled
+um_feathers2neo.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_feathers2neo.menu.DFUOnBoot.dfu=Enabled
+um_feathers2neo.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
-feathers2neo.menu.PSRAM.enabled=Enabled
-feathers2neo.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-feathers2neo.menu.PSRAM.disabled=Disabled
-feathers2neo.menu.PSRAM.disabled.build.defines=
+um_feathers2neo.menu.PSRAM.enabled=Enabled
+um_feathers2neo.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_feathers2neo.menu.PSRAM.disabled=Disabled
+um_feathers2neo.menu.PSRAM.disabled.build.defines=
 
-feathers2neo.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-feathers2neo.menu.PartitionScheme.default.build.partitions=default
-feathers2neo.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-feathers2neo.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-feathers2neo.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-feathers2neo.menu.PartitionScheme.minimal.build.partitions=minimal
-feathers2neo.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-feathers2neo.menu.PartitionScheme.no_ota.build.partitions=no_ota
-feathers2neo.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-feathers2neo.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-feathers2neo.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-feathers2neo.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-feathers2neo.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-feathers2neo.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-feathers2neo.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-feathers2neo.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-feathers2neo.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-feathers2neo.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-feathers2neo.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-feathers2neo.menu.PartitionScheme.huge_app.build.partitions=huge_app
-feathers2neo.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-feathers2neo.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-feathers2neo.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-feathers2neo.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+um_feathers2neo.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+um_feathers2neo.menu.PartitionScheme.default.build.partitions=default
+um_feathers2neo.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+um_feathers2neo.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+um_feathers2neo.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+um_feathers2neo.menu.PartitionScheme.minimal.build.partitions=minimal
+um_feathers2neo.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+um_feathers2neo.menu.PartitionScheme.no_ota.build.partitions=no_ota
+um_feathers2neo.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+um_feathers2neo.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+um_feathers2neo.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+um_feathers2neo.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+um_feathers2neo.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+um_feathers2neo.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+um_feathers2neo.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+um_feathers2neo.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+um_feathers2neo.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+um_feathers2neo.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+um_feathers2neo.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+um_feathers2neo.menu.PartitionScheme.huge_app.build.partitions=huge_app
+um_feathers2neo.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+um_feathers2neo.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+um_feathers2neo.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+um_feathers2neo.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
-feathers2neo.menu.CPUFreq.240=240MHz (WiFi)
-feathers2neo.menu.CPUFreq.240.build.f_cpu=240000000L
-feathers2neo.menu.CPUFreq.160=160MHz (WiFi)
-feathers2neo.menu.CPUFreq.160.build.f_cpu=160000000L
-feathers2neo.menu.CPUFreq.80=80MHz (WiFi)
-feathers2neo.menu.CPUFreq.80.build.f_cpu=80000000L
-feathers2neo.menu.CPUFreq.40=40MHz
-feathers2neo.menu.CPUFreq.40.build.f_cpu=40000000L
-feathers2neo.menu.CPUFreq.20=20MHz
-feathers2neo.menu.CPUFreq.20.build.f_cpu=20000000L
-feathers2neo.menu.CPUFreq.10=10MHz
-feathers2neo.menu.CPUFreq.10.build.f_cpu=10000000L
+um_feathers2neo.menu.CPUFreq.240=240MHz (WiFi)
+um_feathers2neo.menu.CPUFreq.240.build.f_cpu=240000000L
+um_feathers2neo.menu.CPUFreq.160=160MHz (WiFi)
+um_feathers2neo.menu.CPUFreq.160.build.f_cpu=160000000L
+um_feathers2neo.menu.CPUFreq.80=80MHz (WiFi)
+um_feathers2neo.menu.CPUFreq.80.build.f_cpu=80000000L
+um_feathers2neo.menu.CPUFreq.40=40MHz
+um_feathers2neo.menu.CPUFreq.40.build.f_cpu=40000000L
+um_feathers2neo.menu.CPUFreq.20=20MHz
+um_feathers2neo.menu.CPUFreq.20.build.f_cpu=20000000L
+um_feathers2neo.menu.CPUFreq.10=10MHz
+um_feathers2neo.menu.CPUFreq.10.build.f_cpu=10000000L
 
-feathers2neo.menu.FlashSize.4M=4MB (32Mb)
-feathers2neo.menu.FlashSize.4M.build.flash_size=4MB
-feathers2neo.menu.FlashSize.2M=2MB (16Mb)
-feathers2neo.menu.FlashSize.2M.build.flash_size=2MB
-feathers2neo.menu.FlashSize.2M.build.partitions=minimal
+um_feathers2neo.menu.FlashSize.4M=4MB (32Mb)
+um_feathers2neo.menu.FlashSize.4M.build.flash_size=4MB
+um_feathers2neo.menu.FlashSize.2M=2MB (16Mb)
+um_feathers2neo.menu.FlashSize.2M.build.flash_size=2MB
+um_feathers2neo.menu.FlashSize.2M.build.partitions=minimal
 
-feathers2neo.menu.UploadSpeed.921600=921600
-feathers2neo.menu.UploadSpeed.921600.upload.speed=921600
-feathers2neo.menu.UploadSpeed.115200=115200
-feathers2neo.menu.UploadSpeed.115200.upload.speed=115200
-feathers2neo.menu.UploadSpeed.256000.windows=256000
-feathers2neo.menu.UploadSpeed.256000.upload.speed=256000
-feathers2neo.menu.UploadSpeed.230400.windows.upload.speed=256000
-feathers2neo.menu.UploadSpeed.230400=230400
-feathers2neo.menu.UploadSpeed.230400.upload.speed=230400
-feathers2neo.menu.UploadSpeed.460800.linux=460800
-feathers2neo.menu.UploadSpeed.460800.macosx=460800
-feathers2neo.menu.UploadSpeed.460800.upload.speed=460800
+um_feathers2neo.menu.UploadSpeed.921600=921600
+um_feathers2neo.menu.UploadSpeed.921600.upload.speed=921600
+um_feathers2neo.menu.UploadSpeed.115200=115200
+um_feathers2neo.menu.UploadSpeed.115200.upload.speed=115200
+um_feathers2neo.menu.UploadSpeed.256000.windows=256000
+um_feathers2neo.menu.UploadSpeed.256000.upload.speed=256000
+um_feathers2neo.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_feathers2neo.menu.UploadSpeed.230400=230400
+um_feathers2neo.menu.UploadSpeed.230400.upload.speed=230400
+um_feathers2neo.menu.UploadSpeed.460800.linux=460800
+um_feathers2neo.menu.UploadSpeed.460800.macosx=460800
+um_feathers2neo.menu.UploadSpeed.460800.upload.speed=460800
 
-feathers2neo.menu.DebugLevel.none=None
-feathers2neo.menu.DebugLevel.none.build.code_debug=0
-feathers2neo.menu.DebugLevel.error=Error
-feathers2neo.menu.DebugLevel.error.build.code_debug=1
-feathers2neo.menu.DebugLevel.warn=Warn
-feathers2neo.menu.DebugLevel.warn.build.code_debug=2
-feathers2neo.menu.DebugLevel.info=Info
-feathers2neo.menu.DebugLevel.info.build.code_debug=3
-feathers2neo.menu.DebugLevel.debug=Debug
-feathers2neo.menu.DebugLevel.debug.build.code_debug=4
-feathers2neo.menu.DebugLevel.verbose=Verbose
-feathers2neo.menu.DebugLevel.verbose.build.code_debug=5
+um_feathers2neo.menu.DebugLevel.none=None
+um_feathers2neo.menu.DebugLevel.none.build.code_debug=0
+um_feathers2neo.menu.DebugLevel.error=Error
+um_feathers2neo.menu.DebugLevel.error.build.code_debug=1
+um_feathers2neo.menu.DebugLevel.warn=Warn
+um_feathers2neo.menu.DebugLevel.warn.build.code_debug=2
+um_feathers2neo.menu.DebugLevel.info=Info
+um_feathers2neo.menu.DebugLevel.info.build.code_debug=3
+um_feathers2neo.menu.DebugLevel.debug=Debug
+um_feathers2neo.menu.DebugLevel.debug.build.code_debug=4
+um_feathers2neo.menu.DebugLevel.verbose=Verbose
+um_feathers2neo.menu.DebugLevel.verbose.build.code_debug=5
 
-feathers2neo.menu.EraseFlash.none=Disabled
-feathers2neo.menu.EraseFlash.none.upload.erase_cmd=
-feathers2neo.menu.EraseFlash.all=Enabled
-feathers2neo.menu.EraseFlash.all.upload.erase_cmd=-e
-
-##############################################################
-
-tinys2.name=UM TinyS2
-tinys2.vid.0=0x303a
-tinys2.pid.0=0x8001
-
-tinys2.bootloader.tool=esptool_py
-tinys2.bootloader.tool.default=esptool_py
-
-tinys2.upload.tool=esptool_py
-tinys2.upload.tool.default=esptool_py
-tinys2.upload.tool.network=esp_ota
-
-tinys2.upload.maximum_size=1310720
-tinys2.upload.maximum_data_size=327680
-tinys2.upload.flags=
-tinys2.upload.extra_flags=
-tinys2.upload.use_1200bps_touch=true
-tinys2.upload.wait_for_upload_port=true
-
-tinys2.serial.disableDTR=false
-tinys2.serial.disableRTS=false
-
-tinys2.build.tarch=xtensa
-tinys2.build.bootloader_addr=0x1000
-tinys2.build.target=esp32s2
-tinys2.build.mcu=esp32s2
-tinys2.build.core=esp32
-tinys2.build.variant=um_tinys2
-tinys2.build.board=TINYS2
-
-tinys2.build.cdc_on_boot=1
-tinys2.build.msc_on_boot=0
-tinys2.build.dfu_on_boot=0
-tinys2.build.f_cpu=240000000L
-tinys2.build.flash_size=4MB
-tinys2.build.flash_freq=80m
-tinys2.build.flash_mode=dio
-tinys2.build.boot=qio
-tinys2.build.partitions=default
-tinys2.build.defines=
-
-tinys2.menu.CDCOnBoot.cdc=Enabled
-tinys2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-tinys2.menu.CDCOnBoot.default=Disabled
-tinys2.menu.CDCOnBoot.default.build.cdc_on_boot=0
-
-tinys2.menu.MSCOnBoot.default=Disabled
-tinys2.menu.MSCOnBoot.default.build.msc_on_boot=0
-tinys2.menu.MSCOnBoot.msc=Enabled
-tinys2.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-tinys2.menu.DFUOnBoot.default=Disabled
-tinys2.menu.DFUOnBoot.default.build.dfu_on_boot=0
-tinys2.menu.DFUOnBoot.dfu=Enabled
-tinys2.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-tinys2.menu.PSRAM.enabled=Enabled
-tinys2.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-tinys2.menu.PSRAM.disabled=Disabled
-tinys2.menu.PSRAM.disabled.build.defines=
-
-tinys2.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-tinys2.menu.PartitionScheme.default.build.partitions=default
-tinys2.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-tinys2.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-tinys2.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-tinys2.menu.PartitionScheme.minimal.build.partitions=minimal
-tinys2.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-tinys2.menu.PartitionScheme.no_ota.build.partitions=no_ota
-tinys2.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-tinys2.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-tinys2.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-tinys2.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-tinys2.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-tinys2.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-tinys2.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-tinys2.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-tinys2.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-tinys2.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-tinys2.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-tinys2.menu.PartitionScheme.huge_app.build.partitions=huge_app
-tinys2.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-tinys2.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-tinys2.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-tinys2.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-
-tinys2.menu.CPUFreq.240=240MHz (WiFi)
-tinys2.menu.CPUFreq.240.build.f_cpu=240000000L
-tinys2.menu.CPUFreq.160=160MHz (WiFi)
-tinys2.menu.CPUFreq.160.build.f_cpu=160000000L
-tinys2.menu.CPUFreq.80=80MHz (WiFi)
-tinys2.menu.CPUFreq.80.build.f_cpu=80000000L
-tinys2.menu.CPUFreq.40=40MHz
-tinys2.menu.CPUFreq.40.build.f_cpu=40000000L
-tinys2.menu.CPUFreq.20=20MHz
-tinys2.menu.CPUFreq.20.build.f_cpu=20000000L
-tinys2.menu.CPUFreq.10=10MHz
-tinys2.menu.CPUFreq.10.build.f_cpu=10000000L
-
-tinys2.menu.FlashSize.4M=4MB (32Mb)
-tinys2.menu.FlashSize.4M.build.flash_size=4MB
-tinys2.menu.FlashSize.2M=2MB (16Mb)
-tinys2.menu.FlashSize.2M.build.flash_size=2MB
-tinys2.menu.FlashSize.2M.build.partitions=minimal
-
-tinys2.menu.UploadSpeed.921600=921600
-tinys2.menu.UploadSpeed.921600.upload.speed=921600
-tinys2.menu.UploadSpeed.115200=115200
-tinys2.menu.UploadSpeed.115200.upload.speed=115200
-tinys2.menu.UploadSpeed.256000.windows=256000
-tinys2.menu.UploadSpeed.256000.upload.speed=256000
-tinys2.menu.UploadSpeed.230400.windows.upload.speed=256000
-tinys2.menu.UploadSpeed.230400=230400
-tinys2.menu.UploadSpeed.230400.upload.speed=230400
-tinys2.menu.UploadSpeed.460800.linux=460800
-tinys2.menu.UploadSpeed.460800.macosx=460800
-tinys2.menu.UploadSpeed.460800.upload.speed=460800
-
-tinys2.menu.DebugLevel.none=None
-tinys2.menu.DebugLevel.none.build.code_debug=0
-tinys2.menu.DebugLevel.error=Error
-tinys2.menu.DebugLevel.error.build.code_debug=1
-tinys2.menu.DebugLevel.warn=Warn
-tinys2.menu.DebugLevel.warn.build.code_debug=2
-tinys2.menu.DebugLevel.info=Info
-tinys2.menu.DebugLevel.info.build.code_debug=3
-tinys2.menu.DebugLevel.debug=Debug
-tinys2.menu.DebugLevel.debug.build.code_debug=4
-tinys2.menu.DebugLevel.verbose=Verbose
-tinys2.menu.DebugLevel.verbose.build.code_debug=5
-
-tinys2.menu.EraseFlash.none=Disabled
-tinys2.menu.EraseFlash.none.upload.erase_cmd=
-tinys2.menu.EraseFlash.all=Enabled
-tinys2.menu.EraseFlash.all.upload.erase_cmd=-e
+um_feathers2neo.menu.EraseFlash.none=Disabled
+um_feathers2neo.menu.EraseFlash.none.upload.erase_cmd=
+um_feathers2neo.menu.EraseFlash.all=Enabled
+um_feathers2neo.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-rmp.name=UM RMP
-rmp.vid.0=0x303a
-rmp.pid.0=0x80F6
+um_feathers3.name=UM FeatherS3
+um_feathers3.vid.0=0x303a
+um_feathers3.pid.0=0x80D6
 
-rmp.upload.tool=esptool_py
-rmp.upload.tool.default=esptool_py
-rmp.upload.tool.network=esp_ota
+um_feathers3.bootloader.tool=esptool_py
+um_feathers3.bootloader.tool.default=esptool_py
 
-rmp.upload.maximum_size=1310720
-rmp.upload.maximum_data_size=327680
-rmp.upload.flags=
-rmp.upload.extra_flags=
-rmp.upload.use_1200bps_touch=true
-rmp.upload.wait_for_upload_port=true
+um_feathers3.upload.tool=esptool_py
+um_feathers3.upload.tool.default=esptool_py
+um_feathers3.upload.tool.network=esp_ota
 
-rmp.serial.disableDTR=false
-rmp.serial.disableRTS=false
+um_feathers3.upload.maximum_size=1310720
+um_feathers3.upload.maximum_data_size=327680
+um_feathers3.upload.flags=
+um_feathers3.upload.extra_flags=
+um_feathers3.upload.use_1200bps_touch=false
+um_feathers3.upload.wait_for_upload_port=false
 
-rmp.build.tarch=xtensa
-rmp.build.bootloader_addr=0x1000
-rmp.build.target=esp32s2
-rmp.build.mcu=esp32s2
-rmp.build.core=esp32
-rmp.build.variant=um_rmp
-rmp.build.board=RMP
+um_feathers3.serial.disableDTR=false
+um_feathers3.serial.disableRTS=false
 
-rmp.build.cdc_on_boot=1
-rmp.build.msc_on_boot=0
-rmp.build.dfu_on_boot=0
-rmp.build.f_cpu=240000000L
-rmp.build.flash_size=4MB
-rmp.build.flash_freq=80m
-rmp.build.flash_mode=dio
-rmp.build.boot=qio
-rmp.build.partitions=default
-rmp.build.defines=
+um_feathers3.build.tarch=xtensa
+um_feathers3.build.bootloader_addr=0x0
+um_feathers3.build.target=esp32s3
+um_feathers3.build.mcu=esp32s3
+um_feathers3.build.core=esp32
+um_feathers3.build.variant=um_feathers3
+um_feathers3.build.board=FEATHERS3
 
-rmp.menu.CDCOnBoot.cdc=Enabled
-rmp.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-rmp.menu.CDCOnBoot.default=Disabled
-rmp.menu.CDCOnBoot.default.build.cdc_on_boot=0
+um_feathers3.build.usb_mode=1
+um_feathers3.build.cdc_on_boot=0
+um_feathers3.build.msc_on_boot=0
+um_feathers3.build.dfu_on_boot=0
+um_feathers3.build.f_cpu=240000000L
+um_feathers3.build.flash_size=16MB
+um_feathers3.build.flash_freq=80m
+um_feathers3.build.flash_mode=dio
+um_feathers3.build.boot=qio
+um_feathers3.build.partitions=default
+um_feathers3.build.defines=
+um_feathers3.build.loop_core=
+um_feathers3.build.event_core=
+um_feathers3.build.flash_type=qio
+um_feathers3.build.psram_type=qspi
+um_feathers3.build.memory_type=qio_qspi
 
-rmp.menu.MSCOnBoot.default=Disabled
-rmp.menu.MSCOnBoot.default.build.msc_on_boot=0
-rmp.menu.MSCOnBoot.msc=Enabled
-rmp.menu.MSCOnBoot.msc.build.msc_on_boot=1
+um_feathers3.menu.LoopCore.1=Core 1
+um_feathers3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+um_feathers3.menu.LoopCore.0=Core 0
+um_feathers3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
 
-rmp.menu.DFUOnBoot.default=Disabled
-rmp.menu.DFUOnBoot.default.build.dfu_on_boot=0
-rmp.menu.DFUOnBoot.dfu=Enabled
-rmp.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+um_feathers3.menu.EventsCore.1=Core 1
+um_feathers3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+um_feathers3.menu.EventsCore.0=Core 0
+um_feathers3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
-rmp.menu.PSRAM.enabled=Enabled
-rmp.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-rmp.menu.PSRAM.disabled=Disabled
-rmp.menu.PSRAM.disabled.build.defines=
+um_feathers3.menu.USBMode.default=USB-OTG (TinyUSB)
+um_feathers3.menu.USBMode.default.build.usb_mode=0
+um_feathers3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+um_feathers3.menu.USBMode.hwcdc.build.usb_mode=1
 
-rmp.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-rmp.menu.PartitionScheme.default.build.partitions=default
-rmp.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-rmp.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-rmp.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-rmp.menu.PartitionScheme.minimal.build.partitions=minimal
-rmp.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-rmp.menu.PartitionScheme.no_ota.build.partitions=no_ota
-rmp.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-rmp.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-rmp.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-rmp.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-rmp.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-rmp.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-rmp.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-rmp.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-rmp.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-rmp.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-rmp.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-rmp.menu.PartitionScheme.huge_app.build.partitions=huge_app
-rmp.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-rmp.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-rmp.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-rmp.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+um_feathers3.menu.CDCOnBoot.cdc=Enabled
+um_feathers3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_feathers3.menu.CDCOnBoot.default=Disabled
+um_feathers3.menu.CDCOnBoot.default.build.cdc_on_boot=0
 
-rmp.menu.CPUFreq.240=240MHz (WiFi)
-rmp.menu.CPUFreq.240.build.f_cpu=240000000L
-rmp.menu.CPUFreq.160=160MHz (WiFi)
-rmp.menu.CPUFreq.160.build.f_cpu=160000000L
-rmp.menu.CPUFreq.80=80MHz (WiFi)
-rmp.menu.CPUFreq.80.build.f_cpu=80000000L
-rmp.menu.CPUFreq.40=40MHz
-rmp.menu.CPUFreq.40.build.f_cpu=40000000L
-rmp.menu.CPUFreq.20=20MHz
-rmp.menu.CPUFreq.20.build.f_cpu=20000000L
-rmp.menu.CPUFreq.10=10MHz
-rmp.menu.CPUFreq.10.build.f_cpu=10000000L
+um_feathers3.menu.MSCOnBoot.default=Disabled
+um_feathers3.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_feathers3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+um_feathers3.menu.MSCOnBoot.msc.build.msc_on_boot=1
 
-rmp.menu.FlashSize.4M=4MB (32Mb)
-rmp.menu.FlashSize.4M.build.flash_size=4MB
-rmp.menu.FlashSize.2M=2MB (16Mb)
-rmp.menu.FlashSize.2M.build.flash_size=2MB
-rmp.menu.FlashSize.2M.build.partitions=minimal
+um_feathers3.menu.DFUOnBoot.default=Disabled
+um_feathers3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_feathers3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+um_feathers3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
-rmp.menu.UploadSpeed.921600=921600
-rmp.menu.UploadSpeed.921600.upload.speed=921600
-rmp.menu.UploadSpeed.115200=115200
-rmp.menu.UploadSpeed.115200.upload.speed=115200
-rmp.menu.UploadSpeed.256000.windows=256000
-rmp.menu.UploadSpeed.256000.upload.speed=256000
-rmp.menu.UploadSpeed.230400.windows.upload.speed=256000
-rmp.menu.UploadSpeed.230400=230400
-rmp.menu.UploadSpeed.230400.upload.speed=230400
-rmp.menu.UploadSpeed.460800.linux=460800
-rmp.menu.UploadSpeed.460800.macosx=460800
-rmp.menu.UploadSpeed.460800.upload.speed=460800
+um_feathers3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+um_feathers3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+um_feathers3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+um_feathers3.menu.UploadMode.default=UART0 / Hardware CDC
+um_feathers3.menu.UploadMode.default.upload.use_1200bps_touch=false
+um_feathers3.menu.UploadMode.default.upload.wait_for_upload_port=false
 
-rmp.menu.DebugLevel.none=None
-rmp.menu.DebugLevel.none.build.code_debug=0
-rmp.menu.DebugLevel.error=Error
-rmp.menu.DebugLevel.error.build.code_debug=1
-rmp.menu.DebugLevel.warn=Warn
-rmp.menu.DebugLevel.warn.build.code_debug=2
-rmp.menu.DebugLevel.info=Info
-rmp.menu.DebugLevel.info.build.code_debug=3
-rmp.menu.DebugLevel.debug=Debug
-rmp.menu.DebugLevel.debug.build.code_debug=4
-rmp.menu.DebugLevel.verbose=Verbose
-rmp.menu.DebugLevel.verbose.build.code_debug=5
+um_feathers3.menu.PSRAM.enabled=Enabled
+um_feathers3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_feathers3.menu.PSRAM.disabled=Disabled
+um_feathers3.menu.PSRAM.disabled.build.defines=
 
-rmp.menu.EraseFlash.none=Disabled
-rmp.menu.EraseFlash.none.upload.erase_cmd=
-rmp.menu.EraseFlash.all=Enabled
-rmp.menu.EraseFlash.all.upload.erase_cmd=-e
+um_feathers3.menu.PartitionScheme.default_16MB=Default (6.25MB APP/3.43MB SPIFFS)
+um_feathers3.menu.PartitionScheme.default_16MB.build.partitions=default_16MB
+um_feathers3.menu.PartitionScheme.default_16MB.upload.maximum_size=6553600
+um_feathers3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/12MB FFAT)
+um_feathers3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
+um_feathers3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
+um_feathers3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
+um_feathers3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
+um_feathers3.menu.PartitionScheme.large_spiffs=Large SPIFFS (4.5MB APP/6.93MB SPIFFS)
+um_feathers3.menu.PartitionScheme.large_spiffs.build.partitions=large_spiffs_16MB
+um_feathers3.menu.PartitionScheme.large_spiffs.upload.maximum_size=4718592
+um_feathers3.menu.PartitionScheme.app3M_fat9M_16MB=FFAT (3MB APP/9MB FATFS)
+um_feathers3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+um_feathers3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+um_feathers3.menu.PartitionScheme.fatflash=Large FFAT (2MB APP/12.5MB FATFS)
+um_feathers3.menu.PartitionScheme.fatflash.build.partitions=ffat
+um_feathers3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
 
-##############################################################
+um_feathers3.menu.CPUFreq.240=240MHz (WiFi)
+um_feathers3.menu.CPUFreq.240.build.f_cpu=240000000L
+um_feathers3.menu.CPUFreq.160=160MHz (WiFi)
+um_feathers3.menu.CPUFreq.160.build.f_cpu=160000000L
+um_feathers3.menu.CPUFreq.80=80MHz (WiFi)
+um_feathers3.menu.CPUFreq.80.build.f_cpu=80000000L
+um_feathers3.menu.CPUFreq.40=40MHz
+um_feathers3.menu.CPUFreq.40.build.f_cpu=40000000L
+um_feathers3.menu.CPUFreq.20=20MHz
+um_feathers3.menu.CPUFreq.20.build.f_cpu=20000000L
+um_feathers3.menu.CPUFreq.10=10MHz
+um_feathers3.menu.CPUFreq.10.build.f_cpu=10000000L
 
-nanos3.name=UM NanoS3
-nanos3.vid.0=0x303a
-nanos3.pid.0=0x8179
+um_feathers3.menu.FlashMode.qio=QIO
+um_feathers3.menu.FlashMode.qio.build.flash_mode=dio
+um_feathers3.menu.FlashMode.qio.build.boot=qio
+um_feathers3.menu.FlashMode.dio=DIO
+um_feathers3.menu.FlashMode.dio.build.flash_mode=dio
+um_feathers3.menu.FlashMode.dio.build.boot=dio
 
-nanos3.bootloader.tool=esptool_py
-nanos3.bootloader.tool.default=esptool_py
+um_feathers3.menu.UploadSpeed.921600=921600
+um_feathers3.menu.UploadSpeed.921600.upload.speed=921600
+um_feathers3.menu.UploadSpeed.115200=115200
+um_feathers3.menu.UploadSpeed.115200.upload.speed=115200
+um_feathers3.menu.UploadSpeed.256000.windows=256000
+um_feathers3.menu.UploadSpeed.256000.upload.speed=256000
+um_feathers3.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_feathers3.menu.UploadSpeed.230400=230400
+um_feathers3.menu.UploadSpeed.230400.upload.speed=230400
+um_feathers3.menu.UploadSpeed.460800.linux=460800
+um_feathers3.menu.UploadSpeed.460800.macosx=460800
+um_feathers3.menu.UploadSpeed.460800.upload.speed=460800
+um_feathers3.menu.UploadSpeed.512000.windows=512000
+um_feathers3.menu.UploadSpeed.512000.upload.speed=512000
 
-nanos3.upload.tool=esptool_py
-nanos3.upload.tool.default=esptool_py
-nanos3.upload.tool.network=esp_ota
+um_feathers3.menu.DebugLevel.none=None
+um_feathers3.menu.DebugLevel.none.build.code_debug=0
+um_feathers3.menu.DebugLevel.error=Error
+um_feathers3.menu.DebugLevel.error.build.code_debug=1
+um_feathers3.menu.DebugLevel.warn=Warn
+um_feathers3.menu.DebugLevel.warn.build.code_debug=2
+um_feathers3.menu.DebugLevel.info=Info
+um_feathers3.menu.DebugLevel.info.build.code_debug=3
+um_feathers3.menu.DebugLevel.debug=Debug
+um_feathers3.menu.DebugLevel.debug.build.code_debug=4
+um_feathers3.menu.DebugLevel.verbose=Verbose
+um_feathers3.menu.DebugLevel.verbose.build.code_debug=5
 
-nanos3.upload.maximum_size=1310720
-nanos3.upload.maximum_data_size=327680
-nanos3.upload.flags=
-nanos3.upload.extra_flags=
-nanos3.upload.use_1200bps_touch=false
-nanos3.upload.wait_for_upload_port=false
-
-nanos3.serial.disableDTR=false
-nanos3.serial.disableRTS=false
-
-nanos3.build.tarch=xtensa
-nanos3.build.bootloader_addr=0x0
-nanos3.build.target=esp32s3
-nanos3.build.mcu=esp32s3
-nanos3.build.core=esp32
-nanos3.build.variant=um_nanos3
-nanos3.build.board=NANOS3
-
-nanos3.build.usb_mode=1
-nanos3.build.cdc_on_boot=0
-nanos3.build.msc_on_boot=0
-nanos3.build.dfu_on_boot=0
-nanos3.build.f_cpu=240000000L
-nanos3.build.flash_size=8MB
-nanos3.build.flash_freq=80m
-nanos3.build.flash_mode=dio
-nanos3.build.boot=qio
-nanos3.build.partitions=default
-nanos3.build.defines=
-nanos3.build.loop_core=
-nanos3.build.event_core=
-nanos3.build.flash_type=qio
-nanos3.build.psram_type=qspi
-nanos3.build.memory_type=qio_qspi
-
-nanos3.menu.LoopCore.1=Core 1
-nanos3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-nanos3.menu.LoopCore.0=Core 0
-nanos3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-nanos3.menu.EventsCore.1=Core 1
-nanos3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-nanos3.menu.EventsCore.0=Core 0
-nanos3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-nanos3.menu.USBMode.default=USB-OTG (TinyUSB)
-nanos3.menu.USBMode.default.build.usb_mode=0
-nanos3.menu.USBMode.hwcdc=Hardware CDC and JTAG
-nanos3.menu.USBMode.hwcdc.build.usb_mode=1
-
-nanos3.menu.CDCOnBoot.cdc=Enabled
-nanos3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-nanos3.menu.CDCOnBoot.default=Disabled
-nanos3.menu.CDCOnBoot.default.build.cdc_on_boot=0
-
-nanos3.menu.MSCOnBoot.default=Disabled
-nanos3.menu.MSCOnBoot.default.build.msc_on_boot=0
-nanos3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-nanos3.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-nanos3.menu.DFUOnBoot.default=Disabled
-nanos3.menu.DFUOnBoot.default.build.dfu_on_boot=0
-nanos3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-nanos3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-nanos3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-nanos3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-nanos3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-nanos3.menu.UploadMode.default=UART0 / Hardware CDC
-nanos3.menu.UploadMode.default.upload.use_1200bps_touch=false
-nanos3.menu.UploadMode.default.upload.wait_for_upload_port=false
-
-nanos3.menu.PSRAM.enabled=Enabled
-nanos3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-nanos3.menu.PSRAM.disabled=Disabled
-nanos3.menu.PSRAM.disabled.build.defines=
-
-nanos3.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
-nanos3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
-nanos3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
-nanos3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/3.7MB FFAT)
-nanos3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
-nanos3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
-nanos3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
-nanos3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
-
-nanos3.menu.CPUFreq.240=240MHz (WiFi)
-nanos3.menu.CPUFreq.240.build.f_cpu=240000000L
-nanos3.menu.CPUFreq.160=160MHz (WiFi)
-nanos3.menu.CPUFreq.160.build.f_cpu=160000000L
-nanos3.menu.CPUFreq.80=80MHz (WiFi)
-nanos3.menu.CPUFreq.80.build.f_cpu=80000000L
-nanos3.menu.CPUFreq.40=40MHz
-nanos3.menu.CPUFreq.40.build.f_cpu=40000000L
-nanos3.menu.CPUFreq.20=20MHz
-nanos3.menu.CPUFreq.20.build.f_cpu=20000000L
-nanos3.menu.CPUFreq.10=10MHz
-nanos3.menu.CPUFreq.10.build.f_cpu=10000000L
-
-nanos3.menu.FlashMode.qio=QIO
-nanos3.menu.FlashMode.qio.build.flash_mode=dio
-nanos3.menu.FlashMode.qio.build.boot=qio
-nanos3.menu.FlashMode.dio=DIO
-nanos3.menu.FlashMode.dio.build.flash_mode=dio
-nanos3.menu.FlashMode.dio.build.boot=dio
-
-nanos3.menu.UploadSpeed.921600=921600
-nanos3.menu.UploadSpeed.921600.upload.speed=921600
-nanos3.menu.UploadSpeed.115200=115200
-nanos3.menu.UploadSpeed.115200.upload.speed=115200
-nanos3.menu.UploadSpeed.256000.windows=256000
-nanos3.menu.UploadSpeed.256000.upload.speed=256000
-nanos3.menu.UploadSpeed.230400.windows.upload.speed=256000
-nanos3.menu.UploadSpeed.230400=230400
-nanos3.menu.UploadSpeed.230400.upload.speed=230400
-nanos3.menu.UploadSpeed.460800.linux=460800
-nanos3.menu.UploadSpeed.460800.macosx=460800
-nanos3.menu.UploadSpeed.460800.upload.speed=460800
-nanos3.menu.UploadSpeed.512000.windows=512000
-nanos3.menu.UploadSpeed.512000.upload.speed=512000
-
-nanos3.menu.DebugLevel.none=None
-nanos3.menu.DebugLevel.none.build.code_debug=0
-nanos3.menu.DebugLevel.error=Error
-nanos3.menu.DebugLevel.error.build.code_debug=1
-nanos3.menu.DebugLevel.warn=Warn
-nanos3.menu.DebugLevel.warn.build.code_debug=2
-nanos3.menu.DebugLevel.info=Info
-nanos3.menu.DebugLevel.info.build.code_debug=3
-nanos3.menu.DebugLevel.debug=Debug
-nanos3.menu.DebugLevel.debug.build.code_debug=4
-nanos3.menu.DebugLevel.verbose=Verbose
-nanos3.menu.DebugLevel.verbose.build.code_debug=5
-
-nanos3.menu.EraseFlash.none=Disabled
-nanos3.menu.EraseFlash.none.upload.erase_cmd=
-nanos3.menu.EraseFlash.all=Enabled
-nanos3.menu.EraseFlash.all.upload.erase_cmd=-e
+um_feathers3.menu.EraseFlash.none=Disabled
+um_feathers3.menu.EraseFlash.none.upload.erase_cmd=
+um_feathers3.menu.EraseFlash.all=Enabled
+um_feathers3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-tinys3.name=UM TinyS3
-tinys3.vid.0=0x303a
-tinys3.pid.0=0x80D0
+um_nanos3.name=UM NanoS3
+um_nanos3.vid.0=0x303a
+um_nanos3.pid.0=0x8179
 
-tinys3.bootloader.tool=esptool_py
-tinys3.bootloader.tool.default=esptool_py
+um_nanos3.bootloader.tool=esptool_py
+um_nanos3.bootloader.tool.default=esptool_py
 
-tinys3.upload.tool=esptool_py
-tinys3.upload.tool.default=esptool_py
-tinys3.upload.tool.network=esp_ota
+um_nanos3.upload.tool=esptool_py
+um_nanos3.upload.tool.default=esptool_py
+um_nanos3.upload.tool.network=esp_ota
 
-tinys3.upload.maximum_size=1310720
-tinys3.upload.maximum_data_size=327680
-tinys3.upload.flags=
-tinys3.upload.extra_flags=
-tinys3.upload.use_1200bps_touch=false
-tinys3.upload.wait_for_upload_port=false
+um_nanos3.upload.maximum_size=1310720
+um_nanos3.upload.maximum_data_size=327680
+um_nanos3.upload.flags=
+um_nanos3.upload.extra_flags=
+um_nanos3.upload.use_1200bps_touch=false
+um_nanos3.upload.wait_for_upload_port=false
 
-tinys3.serial.disableDTR=false
-tinys3.serial.disableRTS=false
+um_nanos3.serial.disableDTR=false
+um_nanos3.serial.disableRTS=false
 
-tinys3.build.tarch=xtensa
-tinys3.build.bootloader_addr=0x0
-tinys3.build.target=esp32s3
-tinys3.build.mcu=esp32s3
-tinys3.build.core=esp32
-tinys3.build.variant=um_tinys3
-tinys3.build.board=TINYS3
+um_nanos3.build.tarch=xtensa
+um_nanos3.build.bootloader_addr=0x0
+um_nanos3.build.target=esp32s3
+um_nanos3.build.mcu=esp32s3
+um_nanos3.build.core=esp32
+um_nanos3.build.variant=um_nanos3
+um_nanos3.build.board=NANOS3
 
-tinys3.build.usb_mode=1
-tinys3.build.cdc_on_boot=0
-tinys3.build.msc_on_boot=0
-tinys3.build.dfu_on_boot=0
-tinys3.build.f_cpu=240000000L
-tinys3.build.flash_size=8MB
-tinys3.build.flash_freq=80m
-tinys3.build.flash_mode=dio
-tinys3.build.boot=qio
-tinys3.build.partitions=default
-tinys3.build.defines=
-tinys3.build.loop_core=
-tinys3.build.event_core=
-tinys3.build.flash_type=qio
-tinys3.build.psram_type=qspi
-tinys3.build.memory_type=qio_qspi
+um_nanos3.build.usb_mode=1
+um_nanos3.build.cdc_on_boot=0
+um_nanos3.build.msc_on_boot=0
+um_nanos3.build.dfu_on_boot=0
+um_nanos3.build.f_cpu=240000000L
+um_nanos3.build.flash_size=8MB
+um_nanos3.build.flash_freq=80m
+um_nanos3.build.flash_mode=dio
+um_nanos3.build.boot=qio
+um_nanos3.build.partitions=default
+um_nanos3.build.defines=
+um_nanos3.build.loop_core=
+um_nanos3.build.event_core=
+um_nanos3.build.flash_type=qio
+um_nanos3.build.psram_type=qspi
+um_nanos3.build.memory_type=qio_qspi
 
-tinys3.menu.LoopCore.1=Core 1
-tinys3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-tinys3.menu.LoopCore.0=Core 0
-tinys3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+um_nanos3.menu.LoopCore.1=Core 1
+um_nanos3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+um_nanos3.menu.LoopCore.0=Core 0
+um_nanos3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
 
-tinys3.menu.EventsCore.1=Core 1
-tinys3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-tinys3.menu.EventsCore.0=Core 0
-tinys3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+um_nanos3.menu.EventsCore.1=Core 1
+um_nanos3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+um_nanos3.menu.EventsCore.0=Core 0
+um_nanos3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
-tinys3.menu.USBMode.default=USB-OTG (TinyUSB)
-tinys3.menu.USBMode.default.build.usb_mode=0
-tinys3.menu.USBMode.hwcdc=Hardware CDC and JTAG
-tinys3.menu.USBMode.hwcdc.build.usb_mode=1
+um_nanos3.menu.USBMode.default=USB-OTG (TinyUSB)
+um_nanos3.menu.USBMode.default.build.usb_mode=0
+um_nanos3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+um_nanos3.menu.USBMode.hwcdc.build.usb_mode=1
 
-tinys3.menu.CDCOnBoot.cdc=Enabled
-tinys3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-tinys3.menu.CDCOnBoot.default=Disabled
-tinys3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+um_nanos3.menu.CDCOnBoot.cdc=Enabled
+um_nanos3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_nanos3.menu.CDCOnBoot.default=Disabled
+um_nanos3.menu.CDCOnBoot.default.build.cdc_on_boot=0
 
-tinys3.menu.MSCOnBoot.default=Disabled
-tinys3.menu.MSCOnBoot.default.build.msc_on_boot=0
-tinys3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-tinys3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+um_nanos3.menu.MSCOnBoot.default=Disabled
+um_nanos3.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_nanos3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+um_nanos3.menu.MSCOnBoot.msc.build.msc_on_boot=1
 
-tinys3.menu.DFUOnBoot.default=Disabled
-tinys3.menu.DFUOnBoot.default.build.dfu_on_boot=0
-tinys3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-tinys3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+um_nanos3.menu.DFUOnBoot.default=Disabled
+um_nanos3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_nanos3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+um_nanos3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
-tinys3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-tinys3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-tinys3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-tinys3.menu.UploadMode.default=UART0 / Hardware CDC
-tinys3.menu.UploadMode.default.upload.use_1200bps_touch=false
-tinys3.menu.UploadMode.default.upload.wait_for_upload_port=false
+um_nanos3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+um_nanos3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+um_nanos3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+um_nanos3.menu.UploadMode.default=UART0 / Hardware CDC
+um_nanos3.menu.UploadMode.default.upload.use_1200bps_touch=false
+um_nanos3.menu.UploadMode.default.upload.wait_for_upload_port=false
 
-tinys3.menu.PSRAM.enabled=Enabled
-tinys3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-tinys3.menu.PSRAM.disabled=Disabled
-tinys3.menu.PSRAM.disabled.build.defines=
+um_nanos3.menu.PSRAM.enabled=Enabled
+um_nanos3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_nanos3.menu.PSRAM.disabled=Disabled
+um_nanos3.menu.PSRAM.disabled.build.defines=
 
-tinys3.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
-tinys3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
-tinys3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
-tinys3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/3.7MB FFAT)
-tinys3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
-tinys3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
-tinys3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
-tinys3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
+um_nanos3.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
+um_nanos3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+um_nanos3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+um_nanos3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/3.7MB FFAT)
+um_nanos3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
+um_nanos3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
+um_nanos3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
+um_nanos3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
 
-tinys3.menu.CPUFreq.240=240MHz (WiFi)
-tinys3.menu.CPUFreq.240.build.f_cpu=240000000L
-tinys3.menu.CPUFreq.160=160MHz (WiFi)
-tinys3.menu.CPUFreq.160.build.f_cpu=160000000L
-tinys3.menu.CPUFreq.80=80MHz (WiFi)
-tinys3.menu.CPUFreq.80.build.f_cpu=80000000L
-tinys3.menu.CPUFreq.40=40MHz
-tinys3.menu.CPUFreq.40.build.f_cpu=40000000L
-tinys3.menu.CPUFreq.20=20MHz
-tinys3.menu.CPUFreq.20.build.f_cpu=20000000L
-tinys3.menu.CPUFreq.10=10MHz
-tinys3.menu.CPUFreq.10.build.f_cpu=10000000L
+um_nanos3.menu.CPUFreq.240=240MHz (WiFi)
+um_nanos3.menu.CPUFreq.240.build.f_cpu=240000000L
+um_nanos3.menu.CPUFreq.160=160MHz (WiFi)
+um_nanos3.menu.CPUFreq.160.build.f_cpu=160000000L
+um_nanos3.menu.CPUFreq.80=80MHz (WiFi)
+um_nanos3.menu.CPUFreq.80.build.f_cpu=80000000L
+um_nanos3.menu.CPUFreq.40=40MHz
+um_nanos3.menu.CPUFreq.40.build.f_cpu=40000000L
+um_nanos3.menu.CPUFreq.20=20MHz
+um_nanos3.menu.CPUFreq.20.build.f_cpu=20000000L
+um_nanos3.menu.CPUFreq.10=10MHz
+um_nanos3.menu.CPUFreq.10.build.f_cpu=10000000L
 
-tinys3.menu.FlashMode.qio=QIO
-tinys3.menu.FlashMode.qio.build.flash_mode=dio
-tinys3.menu.FlashMode.qio.build.boot=qio
-tinys3.menu.FlashMode.dio=DIO
-tinys3.menu.FlashMode.dio.build.flash_mode=dio
-tinys3.menu.FlashMode.dio.build.boot=dio
+um_nanos3.menu.FlashMode.qio=QIO
+um_nanos3.menu.FlashMode.qio.build.flash_mode=dio
+um_nanos3.menu.FlashMode.qio.build.boot=qio
+um_nanos3.menu.FlashMode.dio=DIO
+um_nanos3.menu.FlashMode.dio.build.flash_mode=dio
+um_nanos3.menu.FlashMode.dio.build.boot=dio
 
-tinys3.menu.UploadSpeed.921600=921600
-tinys3.menu.UploadSpeed.921600.upload.speed=921600
-tinys3.menu.UploadSpeed.115200=115200
-tinys3.menu.UploadSpeed.115200.upload.speed=115200
-tinys3.menu.UploadSpeed.256000.windows=256000
-tinys3.menu.UploadSpeed.256000.upload.speed=256000
-tinys3.menu.UploadSpeed.230400.windows.upload.speed=256000
-tinys3.menu.UploadSpeed.230400=230400
-tinys3.menu.UploadSpeed.230400.upload.speed=230400
-tinys3.menu.UploadSpeed.460800.linux=460800
-tinys3.menu.UploadSpeed.460800.macosx=460800
-tinys3.menu.UploadSpeed.460800.upload.speed=460800
-tinys3.menu.UploadSpeed.512000.windows=512000
-tinys3.menu.UploadSpeed.512000.upload.speed=512000
+um_nanos3.menu.UploadSpeed.921600=921600
+um_nanos3.menu.UploadSpeed.921600.upload.speed=921600
+um_nanos3.menu.UploadSpeed.115200=115200
+um_nanos3.menu.UploadSpeed.115200.upload.speed=115200
+um_nanos3.menu.UploadSpeed.256000.windows=256000
+um_nanos3.menu.UploadSpeed.256000.upload.speed=256000
+um_nanos3.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_nanos3.menu.UploadSpeed.230400=230400
+um_nanos3.menu.UploadSpeed.230400.upload.speed=230400
+um_nanos3.menu.UploadSpeed.460800.linux=460800
+um_nanos3.menu.UploadSpeed.460800.macosx=460800
+um_nanos3.menu.UploadSpeed.460800.upload.speed=460800
+um_nanos3.menu.UploadSpeed.512000.windows=512000
+um_nanos3.menu.UploadSpeed.512000.upload.speed=512000
 
-tinys3.menu.DebugLevel.none=None
-tinys3.menu.DebugLevel.none.build.code_debug=0
-tinys3.menu.DebugLevel.error=Error
-tinys3.menu.DebugLevel.error.build.code_debug=1
-tinys3.menu.DebugLevel.warn=Warn
-tinys3.menu.DebugLevel.warn.build.code_debug=2
-tinys3.menu.DebugLevel.info=Info
-tinys3.menu.DebugLevel.info.build.code_debug=3
-tinys3.menu.DebugLevel.debug=Debug
-tinys3.menu.DebugLevel.debug.build.code_debug=4
-tinys3.menu.DebugLevel.verbose=Verbose
-tinys3.menu.DebugLevel.verbose.build.code_debug=5
+um_nanos3.menu.DebugLevel.none=None
+um_nanos3.menu.DebugLevel.none.build.code_debug=0
+um_nanos3.menu.DebugLevel.error=Error
+um_nanos3.menu.DebugLevel.error.build.code_debug=1
+um_nanos3.menu.DebugLevel.warn=Warn
+um_nanos3.menu.DebugLevel.warn.build.code_debug=2
+um_nanos3.menu.DebugLevel.info=Info
+um_nanos3.menu.DebugLevel.info.build.code_debug=3
+um_nanos3.menu.DebugLevel.debug=Debug
+um_nanos3.menu.DebugLevel.debug.build.code_debug=4
+um_nanos3.menu.DebugLevel.verbose=Verbose
+um_nanos3.menu.DebugLevel.verbose.build.code_debug=5
 
-tinys3.menu.EraseFlash.none=Disabled
-tinys3.menu.EraseFlash.none.upload.erase_cmd=
-tinys3.menu.EraseFlash.all=Enabled
-tinys3.menu.EraseFlash.all.upload.erase_cmd=-e
-
-##############################################################
-
-pros3.name=UM PROS3
-pros3.vid.0=0x303a
-pros3.pid.0=0x80D3
-
-pros3.bootloader.tool=esptool_py
-pros3.bootloader.tool.default=esptool_py
-
-pros3.upload.tool=esptool_py
-pros3.upload.tool.default=esptool_py
-pros3.upload.tool.network=esp_ota
-
-pros3.upload.maximum_size=1310720
-pros3.upload.maximum_data_size=327680
-pros3.upload.flags=
-pros3.upload.extra_flags=
-pros3.upload.use_1200bps_touch=false
-pros3.upload.wait_for_upload_port=false
-
-pros3.serial.disableDTR=false
-pros3.serial.disableRTS=false
-
-pros3.build.tarch=xtensa
-pros3.build.bootloader_addr=0x0
-pros3.build.target=esp32s3
-pros3.build.mcu=esp32s3
-pros3.build.core=esp32
-pros3.build.variant=um_pros3
-pros3.build.board=PROS3
-
-pros3.build.usb_mode=1
-pros3.build.cdc_on_boot=0
-pros3.build.msc_on_boot=0
-pros3.build.dfu_on_boot=0
-pros3.build.f_cpu=240000000L
-pros3.build.flash_size=16MB
-pros3.build.flash_freq=80m
-pros3.build.flash_mode=dio
-pros3.build.boot=qio
-pros3.build.partitions=default
-pros3.build.defines=
-pros3.build.loop_core=
-pros3.build.event_core=
-pros3.build.flash_type=qio
-pros3.build.psram_type=qspi
-pros3.build.memory_type=qio_qspi
-
-pros3.menu.LoopCore.1=Core 1
-pros3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-pros3.menu.LoopCore.0=Core 0
-pros3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-pros3.menu.EventsCore.1=Core 1
-pros3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-pros3.menu.EventsCore.0=Core 0
-pros3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-pros3.menu.USBMode.default=USB-OTG (TinyUSB)
-pros3.menu.USBMode.default.build.usb_mode=0
-pros3.menu.USBMode.hwcdc=Hardware CDC and JTAG
-pros3.menu.USBMode.hwcdc.build.usb_mode=1
-
-pros3.menu.CDCOnBoot.cdc=Enabled
-pros3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-pros3.menu.CDCOnBoot.default=Disabled
-pros3.menu.CDCOnBoot.default.build.cdc_on_boot=0
-
-pros3.menu.MSCOnBoot.default=Disabled
-pros3.menu.MSCOnBoot.default.build.msc_on_boot=0
-pros3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-pros3.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-pros3.menu.DFUOnBoot.default=Disabled
-pros3.menu.DFUOnBoot.default.build.dfu_on_boot=0
-pros3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-pros3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-pros3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-pros3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-pros3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-pros3.menu.UploadMode.default=UART0 / Hardware CDC
-pros3.menu.UploadMode.default.upload.use_1200bps_touch=false
-pros3.menu.UploadMode.default.upload.wait_for_upload_port=false
-
-pros3.menu.PSRAM.enabled=Enabled
-pros3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-pros3.menu.PSRAM.disabled=Disabled
-pros3.menu.PSRAM.disabled.build.defines=
-
-pros3.menu.PartitionScheme.default_16MB=Default (6.25MB APP/3.43MB SPIFFS)
-pros3.menu.PartitionScheme.default_16MB.build.partitions=default_16MB
-pros3.menu.PartitionScheme.default_16MB.upload.maximum_size=6553600
-pros3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/12MB FFAT)
-pros3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
-pros3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
-pros3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
-pros3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
-pros3.menu.PartitionScheme.large_spiffs=Large SPIFFS (4.5MB APP/6.93MB SPIFFS)
-pros3.menu.PartitionScheme.large_spiffs.build.partitions=large_spiffs_16MB
-pros3.menu.PartitionScheme.large_spiffs.upload.maximum_size=4718592
-pros3.menu.PartitionScheme.app3M_fat9M_16MB=FFAT (3MB APP/9MB FATFS)
-pros3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-pros3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
-pros3.menu.PartitionScheme.fatflash=Large FFAT (2MB APP/12.5MB FATFS)
-pros3.menu.PartitionScheme.fatflash.build.partitions=ffat
-pros3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
-
-pros3.menu.CPUFreq.240=240MHz (WiFi)
-pros3.menu.CPUFreq.240.build.f_cpu=240000000L
-pros3.menu.CPUFreq.160=160MHz (WiFi)
-pros3.menu.CPUFreq.160.build.f_cpu=160000000L
-pros3.menu.CPUFreq.80=80MHz (WiFi)
-pros3.menu.CPUFreq.80.build.f_cpu=80000000L
-pros3.menu.CPUFreq.40=40MHz
-pros3.menu.CPUFreq.40.build.f_cpu=40000000L
-pros3.menu.CPUFreq.20=20MHz
-pros3.menu.CPUFreq.20.build.f_cpu=20000000L
-pros3.menu.CPUFreq.10=10MHz
-pros3.menu.CPUFreq.10.build.f_cpu=10000000L
-
-pros3.menu.FlashMode.qio=QIO
-pros3.menu.FlashMode.qio.build.flash_mode=dio
-pros3.menu.FlashMode.qio.build.boot=qio
-pros3.menu.FlashMode.dio=DIO
-pros3.menu.FlashMode.dio.build.flash_mode=dio
-pros3.menu.FlashMode.dio.build.boot=dio
-
-pros3.menu.UploadSpeed.921600=921600
-pros3.menu.UploadSpeed.921600.upload.speed=921600
-pros3.menu.UploadSpeed.115200=115200
-pros3.menu.UploadSpeed.115200.upload.speed=115200
-pros3.menu.UploadSpeed.256000.windows=256000
-pros3.menu.UploadSpeed.256000.upload.speed=256000
-pros3.menu.UploadSpeed.230400.windows.upload.speed=256000
-pros3.menu.UploadSpeed.230400=230400
-pros3.menu.UploadSpeed.230400.upload.speed=230400
-pros3.menu.UploadSpeed.460800.linux=460800
-pros3.menu.UploadSpeed.460800.macosx=460800
-pros3.menu.UploadSpeed.460800.upload.speed=460800
-pros3.menu.UploadSpeed.512000.windows=512000
-pros3.menu.UploadSpeed.512000.upload.speed=512000
-
-pros3.menu.DebugLevel.none=None
-pros3.menu.DebugLevel.none.build.code_debug=0
-pros3.menu.DebugLevel.error=Error
-pros3.menu.DebugLevel.error.build.code_debug=1
-pros3.menu.DebugLevel.warn=Warn
-pros3.menu.DebugLevel.warn.build.code_debug=2
-pros3.menu.DebugLevel.info=Info
-pros3.menu.DebugLevel.info.build.code_debug=3
-pros3.menu.DebugLevel.debug=Debug
-pros3.menu.DebugLevel.debug.build.code_debug=4
-pros3.menu.DebugLevel.verbose=Verbose
-pros3.menu.DebugLevel.verbose.build.code_debug=5
-
-pros3.menu.EraseFlash.none=Disabled
-pros3.menu.EraseFlash.none.upload.erase_cmd=
-pros3.menu.EraseFlash.all=Enabled
-pros3.menu.EraseFlash.all.upload.erase_cmd=-e
+um_nanos3.menu.EraseFlash.none=Disabled
+um_nanos3.menu.EraseFlash.none.upload.erase_cmd=
+um_nanos3.menu.EraseFlash.all=Enabled
+um_nanos3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-feathers3.name=UM FeatherS3
-feathers3.vid.0=0x303a
-feathers3.pid.0=0x80D6
+um_pros3.name=UM PROS3
+um_pros3.vid.0=0x303a
+um_pros3.pid.0=0x80D3
 
-feathers3.bootloader.tool=esptool_py
-feathers3.bootloader.tool.default=esptool_py
+um_pros3.bootloader.tool=esptool_py
+um_pros3.bootloader.tool.default=esptool_py
 
-feathers3.upload.tool=esptool_py
-feathers3.upload.tool.default=esptool_py
-feathers3.upload.tool.network=esp_ota
+um_pros3.upload.tool=esptool_py
+um_pros3.upload.tool.default=esptool_py
+um_pros3.upload.tool.network=esp_ota
 
-feathers3.upload.maximum_size=1310720
-feathers3.upload.maximum_data_size=327680
-feathers3.upload.flags=
-feathers3.upload.extra_flags=
-feathers3.upload.use_1200bps_touch=false
-feathers3.upload.wait_for_upload_port=false
+um_pros3.upload.maximum_size=1310720
+um_pros3.upload.maximum_data_size=327680
+um_pros3.upload.flags=
+um_pros3.upload.extra_flags=
+um_pros3.upload.use_1200bps_touch=false
+um_pros3.upload.wait_for_upload_port=false
 
-feathers3.serial.disableDTR=false
-feathers3.serial.disableRTS=false
+um_pros3.serial.disableDTR=false
+um_pros3.serial.disableRTS=false
 
-feathers3.build.tarch=xtensa
-feathers3.build.bootloader_addr=0x0
-feathers3.build.target=esp32s3
-feathers3.build.mcu=esp32s3
-feathers3.build.core=esp32
-feathers3.build.variant=um_feathers3
-feathers3.build.board=FEATHERS3
+um_pros3.build.tarch=xtensa
+um_pros3.build.bootloader_addr=0x0
+um_pros3.build.target=esp32s3
+um_pros3.build.mcu=esp32s3
+um_pros3.build.core=esp32
+um_pros3.build.variant=um_pros3
+um_pros3.build.board=PROS3
 
-feathers3.build.usb_mode=1
-feathers3.build.cdc_on_boot=0
-feathers3.build.msc_on_boot=0
-feathers3.build.dfu_on_boot=0
-feathers3.build.f_cpu=240000000L
-feathers3.build.flash_size=16MB
-feathers3.build.flash_freq=80m
-feathers3.build.flash_mode=dio
-feathers3.build.boot=qio
-feathers3.build.partitions=default
-feathers3.build.defines=
-feathers3.build.loop_core=
-feathers3.build.event_core=
-feathers3.build.flash_type=qio
-feathers3.build.psram_type=qspi
-feathers3.build.memory_type=qio_qspi
+um_pros3.build.usb_mode=1
+um_pros3.build.cdc_on_boot=0
+um_pros3.build.msc_on_boot=0
+um_pros3.build.dfu_on_boot=0
+um_pros3.build.f_cpu=240000000L
+um_pros3.build.flash_size=16MB
+um_pros3.build.flash_freq=80m
+um_pros3.build.flash_mode=dio
+um_pros3.build.boot=qio
+um_pros3.build.partitions=default
+um_pros3.build.defines=
+um_pros3.build.loop_core=
+um_pros3.build.event_core=
+um_pros3.build.flash_type=qio
+um_pros3.build.psram_type=qspi
+um_pros3.build.memory_type=qio_qspi
 
-feathers3.menu.LoopCore.1=Core 1
-feathers3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-feathers3.menu.LoopCore.0=Core 0
-feathers3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+um_pros3.menu.LoopCore.1=Core 1
+um_pros3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+um_pros3.menu.LoopCore.0=Core 0
+um_pros3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
 
-feathers3.menu.EventsCore.1=Core 1
-feathers3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-feathers3.menu.EventsCore.0=Core 0
-feathers3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+um_pros3.menu.EventsCore.1=Core 1
+um_pros3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+um_pros3.menu.EventsCore.0=Core 0
+um_pros3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
-feathers3.menu.USBMode.default=USB-OTG (TinyUSB)
-feathers3.menu.USBMode.default.build.usb_mode=0
-feathers3.menu.USBMode.hwcdc=Hardware CDC and JTAG
-feathers3.menu.USBMode.hwcdc.build.usb_mode=1
+um_pros3.menu.USBMode.default=USB-OTG (TinyUSB)
+um_pros3.menu.USBMode.default.build.usb_mode=0
+um_pros3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+um_pros3.menu.USBMode.hwcdc.build.usb_mode=1
 
-feathers3.menu.CDCOnBoot.cdc=Enabled
-feathers3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-feathers3.menu.CDCOnBoot.default=Disabled
-feathers3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+um_pros3.menu.CDCOnBoot.cdc=Enabled
+um_pros3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_pros3.menu.CDCOnBoot.default=Disabled
+um_pros3.menu.CDCOnBoot.default.build.cdc_on_boot=0
 
-feathers3.menu.MSCOnBoot.default=Disabled
-feathers3.menu.MSCOnBoot.default.build.msc_on_boot=0
-feathers3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-feathers3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+um_pros3.menu.MSCOnBoot.default=Disabled
+um_pros3.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_pros3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+um_pros3.menu.MSCOnBoot.msc.build.msc_on_boot=1
 
-feathers3.menu.DFUOnBoot.default=Disabled
-feathers3.menu.DFUOnBoot.default.build.dfu_on_boot=0
-feathers3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-feathers3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+um_pros3.menu.DFUOnBoot.default=Disabled
+um_pros3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_pros3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+um_pros3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
-feathers3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-feathers3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-feathers3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-feathers3.menu.UploadMode.default=UART0 / Hardware CDC
-feathers3.menu.UploadMode.default.upload.use_1200bps_touch=false
-feathers3.menu.UploadMode.default.upload.wait_for_upload_port=false
+um_pros3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+um_pros3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+um_pros3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+um_pros3.menu.UploadMode.default=UART0 / Hardware CDC
+um_pros3.menu.UploadMode.default.upload.use_1200bps_touch=false
+um_pros3.menu.UploadMode.default.upload.wait_for_upload_port=false
 
-feathers3.menu.PSRAM.enabled=Enabled
-feathers3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-feathers3.menu.PSRAM.disabled=Disabled
-feathers3.menu.PSRAM.disabled.build.defines=
+um_pros3.menu.PSRAM.enabled=Enabled
+um_pros3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_pros3.menu.PSRAM.disabled=Disabled
+um_pros3.menu.PSRAM.disabled.build.defines=
 
-feathers3.menu.PartitionScheme.default_16MB=Default (6.25MB APP/3.43MB SPIFFS)
-feathers3.menu.PartitionScheme.default_16MB.build.partitions=default_16MB
-feathers3.menu.PartitionScheme.default_16MB.upload.maximum_size=6553600
-feathers3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/12MB FFAT)
-feathers3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
-feathers3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
-feathers3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
-feathers3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
-feathers3.menu.PartitionScheme.large_spiffs=Large SPIFFS (4.5MB APP/6.93MB SPIFFS)
-feathers3.menu.PartitionScheme.large_spiffs.build.partitions=large_spiffs_16MB
-feathers3.menu.PartitionScheme.large_spiffs.upload.maximum_size=4718592
-feathers3.menu.PartitionScheme.app3M_fat9M_16MB=FFAT (3MB APP/9MB FATFS)
-feathers3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-feathers3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
-feathers3.menu.PartitionScheme.fatflash=Large FFAT (2MB APP/12.5MB FATFS)
-feathers3.menu.PartitionScheme.fatflash.build.partitions=ffat
-feathers3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+um_pros3.menu.PartitionScheme.default_16MB=Default (6.25MB APP/3.43MB SPIFFS)
+um_pros3.menu.PartitionScheme.default_16MB.build.partitions=default_16MB
+um_pros3.menu.PartitionScheme.default_16MB.upload.maximum_size=6553600
+um_pros3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/12MB FFAT)
+um_pros3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
+um_pros3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
+um_pros3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
+um_pros3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
+um_pros3.menu.PartitionScheme.large_spiffs=Large SPIFFS (4.5MB APP/6.93MB SPIFFS)
+um_pros3.menu.PartitionScheme.large_spiffs.build.partitions=large_spiffs_16MB
+um_pros3.menu.PartitionScheme.large_spiffs.upload.maximum_size=4718592
+um_pros3.menu.PartitionScheme.app3M_fat9M_16MB=FFAT (3MB APP/9MB FATFS)
+um_pros3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+um_pros3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+um_pros3.menu.PartitionScheme.fatflash=Large FFAT (2MB APP/12.5MB FATFS)
+um_pros3.menu.PartitionScheme.fatflash.build.partitions=ffat
+um_pros3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
 
-feathers3.menu.CPUFreq.240=240MHz (WiFi)
-feathers3.menu.CPUFreq.240.build.f_cpu=240000000L
-feathers3.menu.CPUFreq.160=160MHz (WiFi)
-feathers3.menu.CPUFreq.160.build.f_cpu=160000000L
-feathers3.menu.CPUFreq.80=80MHz (WiFi)
-feathers3.menu.CPUFreq.80.build.f_cpu=80000000L
-feathers3.menu.CPUFreq.40=40MHz
-feathers3.menu.CPUFreq.40.build.f_cpu=40000000L
-feathers3.menu.CPUFreq.20=20MHz
-feathers3.menu.CPUFreq.20.build.f_cpu=20000000L
-feathers3.menu.CPUFreq.10=10MHz
-feathers3.menu.CPUFreq.10.build.f_cpu=10000000L
+um_pros3.menu.CPUFreq.240=240MHz (WiFi)
+um_pros3.menu.CPUFreq.240.build.f_cpu=240000000L
+um_pros3.menu.CPUFreq.160=160MHz (WiFi)
+um_pros3.menu.CPUFreq.160.build.f_cpu=160000000L
+um_pros3.menu.CPUFreq.80=80MHz (WiFi)
+um_pros3.menu.CPUFreq.80.build.f_cpu=80000000L
+um_pros3.menu.CPUFreq.40=40MHz
+um_pros3.menu.CPUFreq.40.build.f_cpu=40000000L
+um_pros3.menu.CPUFreq.20=20MHz
+um_pros3.menu.CPUFreq.20.build.f_cpu=20000000L
+um_pros3.menu.CPUFreq.10=10MHz
+um_pros3.menu.CPUFreq.10.build.f_cpu=10000000L
 
-feathers3.menu.FlashMode.qio=QIO
-feathers3.menu.FlashMode.qio.build.flash_mode=dio
-feathers3.menu.FlashMode.qio.build.boot=qio
-feathers3.menu.FlashMode.dio=DIO
-feathers3.menu.FlashMode.dio.build.flash_mode=dio
-feathers3.menu.FlashMode.dio.build.boot=dio
+um_pros3.menu.FlashMode.qio=QIO
+um_pros3.menu.FlashMode.qio.build.flash_mode=dio
+um_pros3.menu.FlashMode.qio.build.boot=qio
+um_pros3.menu.FlashMode.dio=DIO
+um_pros3.menu.FlashMode.dio.build.flash_mode=dio
+um_pros3.menu.FlashMode.dio.build.boot=dio
 
-feathers3.menu.UploadSpeed.921600=921600
-feathers3.menu.UploadSpeed.921600.upload.speed=921600
-feathers3.menu.UploadSpeed.115200=115200
-feathers3.menu.UploadSpeed.115200.upload.speed=115200
-feathers3.menu.UploadSpeed.256000.windows=256000
-feathers3.menu.UploadSpeed.256000.upload.speed=256000
-feathers3.menu.UploadSpeed.230400.windows.upload.speed=256000
-feathers3.menu.UploadSpeed.230400=230400
-feathers3.menu.UploadSpeed.230400.upload.speed=230400
-feathers3.menu.UploadSpeed.460800.linux=460800
-feathers3.menu.UploadSpeed.460800.macosx=460800
-feathers3.menu.UploadSpeed.460800.upload.speed=460800
-feathers3.menu.UploadSpeed.512000.windows=512000
-feathers3.menu.UploadSpeed.512000.upload.speed=512000
+um_pros3.menu.UploadSpeed.921600=921600
+um_pros3.menu.UploadSpeed.921600.upload.speed=921600
+um_pros3.menu.UploadSpeed.115200=115200
+um_pros3.menu.UploadSpeed.115200.upload.speed=115200
+um_pros3.menu.UploadSpeed.256000.windows=256000
+um_pros3.menu.UploadSpeed.256000.upload.speed=256000
+um_pros3.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_pros3.menu.UploadSpeed.230400=230400
+um_pros3.menu.UploadSpeed.230400.upload.speed=230400
+um_pros3.menu.UploadSpeed.460800.linux=460800
+um_pros3.menu.UploadSpeed.460800.macosx=460800
+um_pros3.menu.UploadSpeed.460800.upload.speed=460800
+um_pros3.menu.UploadSpeed.512000.windows=512000
+um_pros3.menu.UploadSpeed.512000.upload.speed=512000
 
-feathers3.menu.DebugLevel.none=None
-feathers3.menu.DebugLevel.none.build.code_debug=0
-feathers3.menu.DebugLevel.error=Error
-feathers3.menu.DebugLevel.error.build.code_debug=1
-feathers3.menu.DebugLevel.warn=Warn
-feathers3.menu.DebugLevel.warn.build.code_debug=2
-feathers3.menu.DebugLevel.info=Info
-feathers3.menu.DebugLevel.info.build.code_debug=3
-feathers3.menu.DebugLevel.debug=Debug
-feathers3.menu.DebugLevel.debug.build.code_debug=4
-feathers3.menu.DebugLevel.verbose=Verbose
-feathers3.menu.DebugLevel.verbose.build.code_debug=5
+um_pros3.menu.DebugLevel.none=None
+um_pros3.menu.DebugLevel.none.build.code_debug=0
+um_pros3.menu.DebugLevel.error=Error
+um_pros3.menu.DebugLevel.error.build.code_debug=1
+um_pros3.menu.DebugLevel.warn=Warn
+um_pros3.menu.DebugLevel.warn.build.code_debug=2
+um_pros3.menu.DebugLevel.info=Info
+um_pros3.menu.DebugLevel.info.build.code_debug=3
+um_pros3.menu.DebugLevel.debug=Debug
+um_pros3.menu.DebugLevel.debug.build.code_debug=4
+um_pros3.menu.DebugLevel.verbose=Verbose
+um_pros3.menu.DebugLevel.verbose.build.code_debug=5
 
-feathers3.menu.EraseFlash.none=Disabled
-feathers3.menu.EraseFlash.none.upload.erase_cmd=
-feathers3.menu.EraseFlash.all=Enabled
-feathers3.menu.EraseFlash.all.upload.erase_cmd=-e
+um_pros3.menu.EraseFlash.none=Disabled
+um_pros3.menu.EraseFlash.none.upload.erase_cmd=
+um_pros3.menu.EraseFlash.all=Enabled
+um_pros3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+um_rmp.name=UM RMP
+um_rmp.vid.0=0x303a
+um_rmp.pid.0=0x80F6
+
+um_rmp.upload.tool=esptool_py
+um_rmp.upload.tool.default=esptool_py
+um_rmp.upload.tool.network=esp_ota
+
+um_rmp.upload.maximum_size=1310720
+um_rmp.upload.maximum_data_size=327680
+um_rmp.upload.flags=
+um_rmp.upload.extra_flags=
+um_rmp.upload.use_1200bps_touch=true
+um_rmp.upload.wait_for_upload_port=true
+
+um_rmp.serial.disableDTR=false
+um_rmp.serial.disableRTS=false
+
+um_rmp.build.tarch=xtensa
+um_rmp.build.bootloader_addr=0x1000
+um_rmp.build.target=esp32s2
+um_rmp.build.mcu=esp32s2
+um_rmp.build.core=esp32
+um_rmp.build.variant=um_rmp
+um_rmp.build.board=RMP
+
+um_rmp.build.cdc_on_boot=1
+um_rmp.build.msc_on_boot=0
+um_rmp.build.dfu_on_boot=0
+um_rmp.build.f_cpu=240000000L
+um_rmp.build.flash_size=4MB
+um_rmp.build.flash_freq=80m
+um_rmp.build.flash_mode=dio
+um_rmp.build.boot=qio
+um_rmp.build.partitions=default
+um_rmp.build.defines=
+
+um_rmp.menu.CDCOnBoot.cdc=Enabled
+um_rmp.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_rmp.menu.CDCOnBoot.default=Disabled
+um_rmp.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+um_rmp.menu.MSCOnBoot.default=Disabled
+um_rmp.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_rmp.menu.MSCOnBoot.msc=Enabled
+um_rmp.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+um_rmp.menu.DFUOnBoot.default=Disabled
+um_rmp.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_rmp.menu.DFUOnBoot.dfu=Enabled
+um_rmp.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+um_rmp.menu.PSRAM.enabled=Enabled
+um_rmp.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_rmp.menu.PSRAM.disabled=Disabled
+um_rmp.menu.PSRAM.disabled.build.defines=
+
+um_rmp.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+um_rmp.menu.PartitionScheme.default.build.partitions=default
+um_rmp.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+um_rmp.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+um_rmp.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+um_rmp.menu.PartitionScheme.minimal.build.partitions=minimal
+um_rmp.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+um_rmp.menu.PartitionScheme.no_ota.build.partitions=no_ota
+um_rmp.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+um_rmp.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+um_rmp.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+um_rmp.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+um_rmp.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+um_rmp.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+um_rmp.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+um_rmp.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+um_rmp.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+um_rmp.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+um_rmp.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+um_rmp.menu.PartitionScheme.huge_app.build.partitions=huge_app
+um_rmp.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+um_rmp.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+um_rmp.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+um_rmp.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+um_rmp.menu.CPUFreq.240=240MHz (WiFi)
+um_rmp.menu.CPUFreq.240.build.f_cpu=240000000L
+um_rmp.menu.CPUFreq.160=160MHz (WiFi)
+um_rmp.menu.CPUFreq.160.build.f_cpu=160000000L
+um_rmp.menu.CPUFreq.80=80MHz (WiFi)
+um_rmp.menu.CPUFreq.80.build.f_cpu=80000000L
+um_rmp.menu.CPUFreq.40=40MHz
+um_rmp.menu.CPUFreq.40.build.f_cpu=40000000L
+um_rmp.menu.CPUFreq.20=20MHz
+um_rmp.menu.CPUFreq.20.build.f_cpu=20000000L
+um_rmp.menu.CPUFreq.10=10MHz
+um_rmp.menu.CPUFreq.10.build.f_cpu=10000000L
+
+um_rmp.menu.FlashSize.4M=4MB (32Mb)
+um_rmp.menu.FlashSize.4M.build.flash_size=4MB
+um_rmp.menu.FlashSize.2M=2MB (16Mb)
+um_rmp.menu.FlashSize.2M.build.flash_size=2MB
+um_rmp.menu.FlashSize.2M.build.partitions=minimal
+
+um_rmp.menu.UploadSpeed.921600=921600
+um_rmp.menu.UploadSpeed.921600.upload.speed=921600
+um_rmp.menu.UploadSpeed.115200=115200
+um_rmp.menu.UploadSpeed.115200.upload.speed=115200
+um_rmp.menu.UploadSpeed.256000.windows=256000
+um_rmp.menu.UploadSpeed.256000.upload.speed=256000
+um_rmp.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_rmp.menu.UploadSpeed.230400=230400
+um_rmp.menu.UploadSpeed.230400.upload.speed=230400
+um_rmp.menu.UploadSpeed.460800.linux=460800
+um_rmp.menu.UploadSpeed.460800.macosx=460800
+um_rmp.menu.UploadSpeed.460800.upload.speed=460800
+
+um_rmp.menu.DebugLevel.none=None
+um_rmp.menu.DebugLevel.none.build.code_debug=0
+um_rmp.menu.DebugLevel.error=Error
+um_rmp.menu.DebugLevel.error.build.code_debug=1
+um_rmp.menu.DebugLevel.warn=Warn
+um_rmp.menu.DebugLevel.warn.build.code_debug=2
+um_rmp.menu.DebugLevel.info=Info
+um_rmp.menu.DebugLevel.info.build.code_debug=3
+um_rmp.menu.DebugLevel.debug=Debug
+um_rmp.menu.DebugLevel.debug.build.code_debug=4
+um_rmp.menu.DebugLevel.verbose=Verbose
+um_rmp.menu.DebugLevel.verbose.build.code_debug=5
+
+um_rmp.menu.EraseFlash.none=Disabled
+um_rmp.menu.EraseFlash.none.upload.erase_cmd=
+um_rmp.menu.EraseFlash.all=Enabled
+um_rmp.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+um_tinypico.name=UM TinyPICO
+
+um_tinypico.bootloader.tool=esptool_py
+um_tinypico.bootloader.tool.default=esptool_py
+
+um_tinypico.upload.tool=esptool_py
+um_tinypico.upload.tool.default=esptool_py
+um_tinypico.upload.tool.network=esp_ota
+
+um_tinypico.upload.maximum_size=1310720
+um_tinypico.upload.maximum_data_size=327680
+um_tinypico.upload.flags=
+um_tinypico.upload.extra_flags=
+
+um_tinypico.serial.disableDTR=true
+um_tinypico.serial.disableRTS=true
+
+um_tinypico.build.tarch=xtensa
+um_tinypico.build.bootloader_addr=0x1000
+um_tinypico.build.target=esp32
+um_tinypico.build.mcu=esp32
+um_tinypico.build.core=esp32
+um_tinypico.build.variant=um_tinypico
+um_tinypico.build.board=TINYPICO
+
+um_tinypico.build.f_cpu=240000000L
+um_tinypico.build.flash_size=4MB
+um_tinypico.build.flash_freq=80m
+um_tinypico.build.flash_mode=dio
+um_tinypico.build.boot=dio
+um_tinypico.build.partitions=default
+um_tinypico.build.defines=
+
+um_tinypico.menu.PartitionScheme.default=Default
+um_tinypico.menu.PartitionScheme.default.build.partitions=default
+um_tinypico.menu.PartitionScheme.no_ota=No OTA (Large APP)
+um_tinypico.menu.PartitionScheme.no_ota.build.partitions=no_ota
+um_tinypico.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+um_tinypico.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
+um_tinypico.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+um_tinypico.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+um_tinypico.menu.UploadSpeed.921600=921600
+um_tinypico.menu.UploadSpeed.921600.upload.speed=921600
+um_tinypico.menu.UploadSpeed.115200=115200
+um_tinypico.menu.UploadSpeed.115200.upload.speed=115200
+um_tinypico.menu.UploadSpeed.256000.windows=256000
+um_tinypico.menu.UploadSpeed.256000.upload.speed=256000
+um_tinypico.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_tinypico.menu.UploadSpeed.230400=230400
+um_tinypico.menu.UploadSpeed.230400.upload.speed=230400
+um_tinypico.menu.UploadSpeed.460800.linux=460800
+um_tinypico.menu.UploadSpeed.460800.macosx=460800
+um_tinypico.menu.UploadSpeed.460800.upload.speed=460800
+um_tinypico.menu.UploadSpeed.512000.windows=512000
+um_tinypico.menu.UploadSpeed.512000.upload.speed=512000
+
+um_tinypico.menu.FlashMode.qio=QIO
+um_tinypico.menu.FlashMode.qio.build.flash_mode=dio
+um_tinypico.menu.FlashMode.qio.build.boot=qio
+um_tinypico.menu.FlashMode.dio=DIO
+um_tinypico.menu.FlashMode.dio.build.flash_mode=dio
+um_tinypico.menu.FlashMode.dio.build.boot=dio
+
+um_tinypico.menu.FlashFreq.80=80MHz
+um_tinypico.menu.FlashFreq.80.build.flash_freq=80m
+um_tinypico.menu.FlashFreq.40=40MHz
+um_tinypico.menu.FlashFreq.40.build.flash_freq=40m
+
+um_tinypico.menu.PSRAM.enabled=Enabled
+um_tinypico.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+um_tinypico.menu.PSRAM.enabled.build.extra_libs=
+um_tinypico.menu.PSRAM.disabled=Disabled
+um_tinypico.menu.PSRAM.disabled.build.defines=
+um_tinypico.menu.PSRAM.disabled.build.extra_libs=
+
+um_tinypico.menu.DebugLevel.none=None
+um_tinypico.menu.DebugLevel.none.build.code_debug=0
+um_tinypico.menu.DebugLevel.error=Error
+um_tinypico.menu.DebugLevel.error.build.code_debug=1
+um_tinypico.menu.DebugLevel.warn=Warn
+um_tinypico.menu.DebugLevel.warn.build.code_debug=2
+um_tinypico.menu.DebugLevel.info=Info
+um_tinypico.menu.DebugLevel.info.build.code_debug=3
+um_tinypico.menu.DebugLevel.debug=Debug
+um_tinypico.menu.DebugLevel.debug.build.code_debug=4
+um_tinypico.menu.DebugLevel.verbose=Verbose
+um_tinypico.menu.DebugLevel.verbose.build.code_debug=5
+
+um_tinypico.menu.EraseFlash.none=Disabled
+um_tinypico.menu.EraseFlash.none.upload.erase_cmd=
+um_tinypico.menu.EraseFlash.all=Enabled
+um_tinypico.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+um_tinyc6.name=UM TinyC6
+um_tinyc6.vid.0=0x303a
+um_tinyc6.pid.0=0x1001
+
+um_tinyc6.bootloader.tool=esptool_py
+um_tinyc6.bootloader.tool.default=esptool_py
+
+um_tinyc6.upload.tool=esptool_py
+um_tinyc6.upload.tool.default=esptool_py
+um_tinyc6.upload.tool.network=esp_ota
+
+um_tinyc6.upload.maximum_size=1310720
+um_tinyc6.upload.maximum_data_size=327680
+um_tinyc6.upload.flags=
+um_tinyc6.upload.extra_flags=
+um_tinyc6.upload.use_1200bps_touch=false
+um_tinyc6.upload.wait_for_upload_port=false
+
+um_tinyc6.serial.disableDTR=false
+um_tinyc6.serial.disableRTS=false
+
+um_tinyc6.build.tarch=riscv32
+um_tinyc6.build.target=esp
+um_tinyc6.build.mcu=esp32c6
+um_tinyc6.build.core=esp32
+um_tinyc6.build.variant=um_tinyc6
+um_tinyc6.build.board=TINYC6
+um_tinyc6.build.bootloader_addr=0x0
+
+um_tinyc6.build.cdc_on_boot=1
+um_tinyc6.build.f_cpu=160000000L
+um_tinyc6.build.flash_size=4MB
+um_tinyc6.build.flash_freq=80m
+um_tinyc6.build.flash_mode=qio
+um_tinyc6.build.boot=qio
+um_tinyc6.build.partitions=default
+um_tinyc6.build.defines=
+
+## IDE 2.0 Seems to not update the value
+um_tinyc6.menu.JTAGAdapter.default=Disabled
+um_tinyc6.menu.JTAGAdapter.default.build.copy_jtag_files=0
+um_tinyc6.menu.JTAGAdapter.builtin=Integrated USB JTAG
+um_tinyc6.menu.JTAGAdapter.builtin.build.openocdscript=esp32c6-builtin.cfg
+um_tinyc6.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+um_tinyc6.menu.JTAGAdapter.external=FTDI Adapter
+um_tinyc6.menu.JTAGAdapter.external.build.openocdscript=esp32c6-ftdi.cfg
+um_tinyc6.menu.JTAGAdapter.external.build.copy_jtag_files=1
+um_tinyc6.menu.JTAGAdapter.bridge=ESP USB Bridge
+um_tinyc6.menu.JTAGAdapter.bridge.build.openocdscript=esp32c6-bridge.cfg
+um_tinyc6.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+um_tinyc6.menu.CDCOnBoot.cdc=Enabled
+um_tinyc6.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_tinyc6.menu.CDCOnBoot.default=Disabled
+um_tinyc6.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+um_tinyc6.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+um_tinyc6.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+um_tinyc6.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+um_tinyc6.menu.PartitionScheme.rainmaker=RainMaker
+um_tinyc6.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+um_tinyc6.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+um_tinyc6.menu.PartitionScheme.custom=Custom
+um_tinyc6.menu.PartitionScheme.custom.build.partitions=
+um_tinyc6.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+um_tinyc6.menu.CPUFreq.160=160MHz (WiFi)
+um_tinyc6.menu.CPUFreq.160.build.f_cpu=160000000L
+um_tinyc6.menu.CPUFreq.80=80MHz (WiFi)
+um_tinyc6.menu.CPUFreq.80.build.f_cpu=80000000L
+um_tinyc6.menu.CPUFreq.40=40MHz
+um_tinyc6.menu.CPUFreq.40.build.f_cpu=40000000L
+um_tinyc6.menu.CPUFreq.20=20MHz
+um_tinyc6.menu.CPUFreq.20.build.f_cpu=20000000L
+um_tinyc6.menu.CPUFreq.10=10MHz
+um_tinyc6.menu.CPUFreq.10.build.f_cpu=10000000L
+
+um_tinyc6.menu.FlashMode.qio=QIO
+um_tinyc6.menu.FlashMode.qio.build.flash_mode=dio
+um_tinyc6.menu.FlashMode.qio.build.boot=qio
+um_tinyc6.menu.FlashMode.dio=DIO
+um_tinyc6.menu.FlashMode.dio.build.flash_mode=dio
+um_tinyc6.menu.FlashMode.dio.build.boot=dio
+
+um_tinyc6.menu.FlashFreq.80=80MHz
+um_tinyc6.menu.FlashFreq.80.build.flash_freq=80m
+um_tinyc6.menu.FlashFreq.40=40MHz
+um_tinyc6.menu.FlashFreq.40.build.flash_freq=40m
+
+um_tinyc6.menu.FlashSize.8M=8MB (64Mb)
+um_tinyc6.menu.FlashSize.8M.build.flash_size=8MB
+um_tinyc6.menu.FlashSize.8M.build.partitions=default_8MB
+
+um_tinyc6.menu.UploadSpeed.921600=921600
+um_tinyc6.menu.UploadSpeed.921600.upload.speed=921600
+um_tinyc6.menu.UploadSpeed.115200=115200
+um_tinyc6.menu.UploadSpeed.115200.upload.speed=115200
+um_tinyc6.menu.UploadSpeed.256000.windows=256000
+um_tinyc6.menu.UploadSpeed.256000.upload.speed=256000
+um_tinyc6.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_tinyc6.menu.UploadSpeed.230400=230400
+um_tinyc6.menu.UploadSpeed.230400.upload.speed=230400
+um_tinyc6.menu.UploadSpeed.460800.linux=460800
+um_tinyc6.menu.UploadSpeed.460800.macosx=460800
+um_tinyc6.menu.UploadSpeed.460800.upload.speed=460800
+um_tinyc6.menu.UploadSpeed.512000.windows=512000
+um_tinyc6.menu.UploadSpeed.512000.upload.speed=512000
+
+um_tinyc6.menu.DebugLevel.none=None
+um_tinyc6.menu.DebugLevel.none.build.code_debug=0
+um_tinyc6.menu.DebugLevel.error=Error
+um_tinyc6.menu.DebugLevel.error.build.code_debug=1
+um_tinyc6.menu.DebugLevel.warn=Warn
+um_tinyc6.menu.DebugLevel.warn.build.code_debug=2
+um_tinyc6.menu.DebugLevel.info=Info
+um_tinyc6.menu.DebugLevel.info.build.code_debug=3
+um_tinyc6.menu.DebugLevel.debug=Debug
+um_tinyc6.menu.DebugLevel.debug.build.code_debug=4
+um_tinyc6.menu.DebugLevel.verbose=Verbose
+um_tinyc6.menu.DebugLevel.verbose.build.code_debug=5
+
+um_tinyc6.menu.EraseFlash.none=Disabled
+um_tinyc6.menu.EraseFlash.none.upload.erase_cmd=
+um_tinyc6.menu.EraseFlash.all=Enabled
+um_tinyc6.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+um_tinys2.name=UM TinyS2
+um_tinys2.vid.0=0x303a
+um_tinys2.pid.0=0x8001
+
+um_tinys2.bootloader.tool=esptool_py
+um_tinys2.bootloader.tool.default=esptool_py
+
+um_tinys2.upload.tool=esptool_py
+um_tinys2.upload.tool.default=esptool_py
+um_tinys2.upload.tool.network=esp_ota
+
+um_tinys2.upload.maximum_size=1310720
+um_tinys2.upload.maximum_data_size=327680
+um_tinys2.upload.flags=
+um_tinys2.upload.extra_flags=
+um_tinys2.upload.use_1200bps_touch=true
+um_tinys2.upload.wait_for_upload_port=true
+
+um_tinys2.serial.disableDTR=false
+um_tinys2.serial.disableRTS=false
+
+um_tinys2.build.tarch=xtensa
+um_tinys2.build.bootloader_addr=0x1000
+um_tinys2.build.target=esp32s2
+um_tinys2.build.mcu=esp32s2
+um_tinys2.build.core=esp32
+um_tinys2.build.variant=um_tinys2
+um_tinys2.build.board=TINYS2
+
+um_tinys2.build.cdc_on_boot=1
+um_tinys2.build.msc_on_boot=0
+um_tinys2.build.dfu_on_boot=0
+um_tinys2.build.f_cpu=240000000L
+um_tinys2.build.flash_size=4MB
+um_tinys2.build.flash_freq=80m
+um_tinys2.build.flash_mode=dio
+um_tinys2.build.boot=qio
+um_tinys2.build.partitions=default
+um_tinys2.build.defines=
+
+um_tinys2.menu.CDCOnBoot.cdc=Enabled
+um_tinys2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_tinys2.menu.CDCOnBoot.default=Disabled
+um_tinys2.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+um_tinys2.menu.MSCOnBoot.default=Disabled
+um_tinys2.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_tinys2.menu.MSCOnBoot.msc=Enabled
+um_tinys2.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+um_tinys2.menu.DFUOnBoot.default=Disabled
+um_tinys2.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_tinys2.menu.DFUOnBoot.dfu=Enabled
+um_tinys2.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+um_tinys2.menu.PSRAM.enabled=Enabled
+um_tinys2.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_tinys2.menu.PSRAM.disabled=Disabled
+um_tinys2.menu.PSRAM.disabled.build.defines=
+
+um_tinys2.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+um_tinys2.menu.PartitionScheme.default.build.partitions=default
+um_tinys2.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+um_tinys2.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+um_tinys2.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+um_tinys2.menu.PartitionScheme.minimal.build.partitions=minimal
+um_tinys2.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+um_tinys2.menu.PartitionScheme.no_ota.build.partitions=no_ota
+um_tinys2.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+um_tinys2.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+um_tinys2.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+um_tinys2.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+um_tinys2.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+um_tinys2.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+um_tinys2.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+um_tinys2.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+um_tinys2.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+um_tinys2.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+um_tinys2.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+um_tinys2.menu.PartitionScheme.huge_app.build.partitions=huge_app
+um_tinys2.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+um_tinys2.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+um_tinys2.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+um_tinys2.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+
+um_tinys2.menu.CPUFreq.240=240MHz (WiFi)
+um_tinys2.menu.CPUFreq.240.build.f_cpu=240000000L
+um_tinys2.menu.CPUFreq.160=160MHz (WiFi)
+um_tinys2.menu.CPUFreq.160.build.f_cpu=160000000L
+um_tinys2.menu.CPUFreq.80=80MHz (WiFi)
+um_tinys2.menu.CPUFreq.80.build.f_cpu=80000000L
+um_tinys2.menu.CPUFreq.40=40MHz
+um_tinys2.menu.CPUFreq.40.build.f_cpu=40000000L
+um_tinys2.menu.CPUFreq.20=20MHz
+um_tinys2.menu.CPUFreq.20.build.f_cpu=20000000L
+um_tinys2.menu.CPUFreq.10=10MHz
+um_tinys2.menu.CPUFreq.10.build.f_cpu=10000000L
+
+um_tinys2.menu.FlashSize.4M=4MB (32Mb)
+um_tinys2.menu.FlashSize.4M.build.flash_size=4MB
+um_tinys2.menu.FlashSize.2M=2MB (16Mb)
+um_tinys2.menu.FlashSize.2M.build.flash_size=2MB
+um_tinys2.menu.FlashSize.2M.build.partitions=minimal
+
+um_tinys2.menu.UploadSpeed.921600=921600
+um_tinys2.menu.UploadSpeed.921600.upload.speed=921600
+um_tinys2.menu.UploadSpeed.115200=115200
+um_tinys2.menu.UploadSpeed.115200.upload.speed=115200
+um_tinys2.menu.UploadSpeed.256000.windows=256000
+um_tinys2.menu.UploadSpeed.256000.upload.speed=256000
+um_tinys2.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_tinys2.menu.UploadSpeed.230400=230400
+um_tinys2.menu.UploadSpeed.230400.upload.speed=230400
+um_tinys2.menu.UploadSpeed.460800.linux=460800
+um_tinys2.menu.UploadSpeed.460800.macosx=460800
+um_tinys2.menu.UploadSpeed.460800.upload.speed=460800
+
+um_tinys2.menu.DebugLevel.none=None
+um_tinys2.menu.DebugLevel.none.build.code_debug=0
+um_tinys2.menu.DebugLevel.error=Error
+um_tinys2.menu.DebugLevel.error.build.code_debug=1
+um_tinys2.menu.DebugLevel.warn=Warn
+um_tinys2.menu.DebugLevel.warn.build.code_debug=2
+um_tinys2.menu.DebugLevel.info=Info
+um_tinys2.menu.DebugLevel.info.build.code_debug=3
+um_tinys2.menu.DebugLevel.debug=Debug
+um_tinys2.menu.DebugLevel.debug.build.code_debug=4
+um_tinys2.menu.DebugLevel.verbose=Verbose
+um_tinys2.menu.DebugLevel.verbose.build.code_debug=5
+
+um_tinys2.menu.EraseFlash.none=Disabled
+um_tinys2.menu.EraseFlash.none.upload.erase_cmd=
+um_tinys2.menu.EraseFlash.all=Enabled
+um_tinys2.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+um_tinys3.name=UM TinyS3
+um_tinys3.vid.0=0x303a
+um_tinys3.pid.0=0x80D0
+
+um_tinys3.bootloader.tool=esptool_py
+um_tinys3.bootloader.tool.default=esptool_py
+
+um_tinys3.upload.tool=esptool_py
+um_tinys3.upload.tool.default=esptool_py
+um_tinys3.upload.tool.network=esp_ota
+
+um_tinys3.upload.maximum_size=1310720
+um_tinys3.upload.maximum_data_size=327680
+um_tinys3.upload.flags=
+um_tinys3.upload.extra_flags=
+um_tinys3.upload.use_1200bps_touch=false
+um_tinys3.upload.wait_for_upload_port=false
+
+um_tinys3.serial.disableDTR=false
+um_tinys3.serial.disableRTS=false
+
+um_tinys3.build.tarch=xtensa
+um_tinys3.build.bootloader_addr=0x0
+um_tinys3.build.target=esp32s3
+um_tinys3.build.mcu=esp32s3
+um_tinys3.build.core=esp32
+um_tinys3.build.variant=um_tinys3
+um_tinys3.build.board=TINYS3
+
+um_tinys3.build.usb_mode=1
+um_tinys3.build.cdc_on_boot=0
+um_tinys3.build.msc_on_boot=0
+um_tinys3.build.dfu_on_boot=0
+um_tinys3.build.f_cpu=240000000L
+um_tinys3.build.flash_size=8MB
+um_tinys3.build.flash_freq=80m
+um_tinys3.build.flash_mode=dio
+um_tinys3.build.boot=qio
+um_tinys3.build.partitions=default
+um_tinys3.build.defines=
+um_tinys3.build.loop_core=
+um_tinys3.build.event_core=
+um_tinys3.build.flash_type=qio
+um_tinys3.build.psram_type=qspi
+um_tinys3.build.memory_type=qio_qspi
+
+um_tinys3.menu.LoopCore.1=Core 1
+um_tinys3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+um_tinys3.menu.LoopCore.0=Core 0
+um_tinys3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+um_tinys3.menu.EventsCore.1=Core 1
+um_tinys3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+um_tinys3.menu.EventsCore.0=Core 0
+um_tinys3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+um_tinys3.menu.USBMode.default=USB-OTG (TinyUSB)
+um_tinys3.menu.USBMode.default.build.usb_mode=0
+um_tinys3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+um_tinys3.menu.USBMode.hwcdc.build.usb_mode=1
+
+um_tinys3.menu.CDCOnBoot.cdc=Enabled
+um_tinys3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+um_tinys3.menu.CDCOnBoot.default=Disabled
+um_tinys3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+um_tinys3.menu.MSCOnBoot.default=Disabled
+um_tinys3.menu.MSCOnBoot.default.build.msc_on_boot=0
+um_tinys3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+um_tinys3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+um_tinys3.menu.DFUOnBoot.default=Disabled
+um_tinys3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+um_tinys3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+um_tinys3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+um_tinys3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+um_tinys3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+um_tinys3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+um_tinys3.menu.UploadMode.default=UART0 / Hardware CDC
+um_tinys3.menu.UploadMode.default.upload.use_1200bps_touch=false
+um_tinys3.menu.UploadMode.default.upload.wait_for_upload_port=false
+
+um_tinys3.menu.PSRAM.enabled=Enabled
+um_tinys3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+um_tinys3.menu.PSRAM.disabled=Disabled
+um_tinys3.menu.PSRAM.disabled.build.defines=
+
+um_tinys3.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
+um_tinys3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+um_tinys3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+um_tinys3.menu.PartitionScheme.tinyuf2=TinyUF2 Compatibility (2MB APP/3.7MB FFAT)
+um_tinys3.menu.PartitionScheme.tinyuf2.build.custom_bootloader=bootloader_tinyuf2
+um_tinys3.menu.PartitionScheme.tinyuf2.build.custom_partitions=partitions_tinyuf2
+um_tinys3.menu.PartitionScheme.tinyuf2.upload.extra_flags=0x410000 "{runtime.platform.path}/variants/{build.variant}/tinyuf2.bin"
+um_tinys3.menu.PartitionScheme.tinyuf2.upload.maximum_size=2097152
+
+um_tinys3.menu.CPUFreq.240=240MHz (WiFi)
+um_tinys3.menu.CPUFreq.240.build.f_cpu=240000000L
+um_tinys3.menu.CPUFreq.160=160MHz (WiFi)
+um_tinys3.menu.CPUFreq.160.build.f_cpu=160000000L
+um_tinys3.menu.CPUFreq.80=80MHz (WiFi)
+um_tinys3.menu.CPUFreq.80.build.f_cpu=80000000L
+um_tinys3.menu.CPUFreq.40=40MHz
+um_tinys3.menu.CPUFreq.40.build.f_cpu=40000000L
+um_tinys3.menu.CPUFreq.20=20MHz
+um_tinys3.menu.CPUFreq.20.build.f_cpu=20000000L
+um_tinys3.menu.CPUFreq.10=10MHz
+um_tinys3.menu.CPUFreq.10.build.f_cpu=10000000L
+
+um_tinys3.menu.FlashMode.qio=QIO
+um_tinys3.menu.FlashMode.qio.build.flash_mode=dio
+um_tinys3.menu.FlashMode.qio.build.boot=qio
+um_tinys3.menu.FlashMode.dio=DIO
+um_tinys3.menu.FlashMode.dio.build.flash_mode=dio
+um_tinys3.menu.FlashMode.dio.build.boot=dio
+
+um_tinys3.menu.UploadSpeed.921600=921600
+um_tinys3.menu.UploadSpeed.921600.upload.speed=921600
+um_tinys3.menu.UploadSpeed.115200=115200
+um_tinys3.menu.UploadSpeed.115200.upload.speed=115200
+um_tinys3.menu.UploadSpeed.256000.windows=256000
+um_tinys3.menu.UploadSpeed.256000.upload.speed=256000
+um_tinys3.menu.UploadSpeed.230400.windows.upload.speed=256000
+um_tinys3.menu.UploadSpeed.230400=230400
+um_tinys3.menu.UploadSpeed.230400.upload.speed=230400
+um_tinys3.menu.UploadSpeed.460800.linux=460800
+um_tinys3.menu.UploadSpeed.460800.macosx=460800
+um_tinys3.menu.UploadSpeed.460800.upload.speed=460800
+um_tinys3.menu.UploadSpeed.512000.windows=512000
+um_tinys3.menu.UploadSpeed.512000.upload.speed=512000
+
+um_tinys3.menu.DebugLevel.none=None
+um_tinys3.menu.DebugLevel.none.build.code_debug=0
+um_tinys3.menu.DebugLevel.error=Error
+um_tinys3.menu.DebugLevel.error.build.code_debug=1
+um_tinys3.menu.DebugLevel.warn=Warn
+um_tinys3.menu.DebugLevel.warn.build.code_debug=2
+um_tinys3.menu.DebugLevel.info=Info
+um_tinys3.menu.DebugLevel.info.build.code_debug=3
+um_tinys3.menu.DebugLevel.debug=Debug
+um_tinys3.menu.DebugLevel.debug.build.code_debug=4
+um_tinys3.menu.DebugLevel.verbose=Verbose
+um_tinys3.menu.DebugLevel.verbose.build.code_debug=5
+
+um_tinys3.menu.EraseFlash.none=Disabled
+um_tinys3.menu.EraseFlash.none.upload.erase_cmd=
+um_tinys3.menu.EraseFlash.all=Enabled
+um_tinys3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 

--- a/variants/um_tinyc6/pins_arduino.h
+++ b/variants/um_tinyc6/pins_arduino.h
@@ -1,0 +1,60 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303A
+#define USB_PID 0x1001
+#define USB_MANUFACTURER "Unexpected Maker"
+#define USB_PRODUCT "TinyC6"
+#define USB_SERIAL ""
+
+static const uint8_t TX = 16;
+static const uint8_t RX = 17;
+
+static const uint8_t SDA = 6;
+static const uint8_t SCL = 7;
+
+static const uint8_t SS    = 18;
+static const uint8_t MOSI  = 21;
+static const uint8_t MISO  = 20;
+static const uint8_t SDO  = 21;
+static const uint8_t SDI  = 20;
+static const uint8_t SCK   = 19;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+
+static const uint8_t VBAT_SENSE = 4;
+static const uint8_t VBUS_SENSE = 10;
+
+static const uint8_t RGB_DATA = 23;
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN (RGB_DATA + SOC_GPIO_PIN_COUNT)  
+#define RGB_BRIGHTNESS 64
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = RGB_BUILTIN;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t RGB_PWR = 22;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Added Unexpected Maker TinyC6 development board to the boards list.
Renamed and re-ordered all UM boards in boards.txt to make them more identifiable. 

## Tests scenarios
I've tested this on my TinyC6, and it's working as expected.

@me-no-dev Can you please tag this for 3.0.0? I'm not quite sure how this all works when doing a PR for a tag.