### PR TITLE
Remove TwoWire::begin(int) overload

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -588,48 +588,48 @@ void TwoWire::flush(void)
     //i2cFlush(num); // cleanup
 }
 
-size_t TwoWire::requestFrom(uint8_t address, size_t len, bool sendStop)
-{
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop));
-}
-  
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len, uint8_t sendStop)
-{
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop));
-}
-
-uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, uint8_t sendStop)
-{
-    return requestFrom(address, static_cast<size_t>(len), static_cast<bool>(sendStop));
-}
-
-/* Added to match the Arduino function definition: https://github.com/arduino/ArduinoCore-API/blob/173e8eadced2ad32eeb93bcbd5c49f8d6a055ea6/api/HardwareI2C.h#L39
- * See: https://github.com/arduino-libraries/ArduinoECCX08/issues/25
-*/
-uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, bool stopBit)
-{
-    return requestFrom((uint16_t)address, (size_t)len, stopBit);
-}
-
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len)
-{
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), true);
-}
-
-uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len)
-{
-    return requestFrom(address, static_cast<size_t>(len), true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int len)
-{
-    return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int len, int sendStop)
-{
-    return static_cast<uint8_t>(requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop)));
-}
+// size_t TwoWire::requestFrom(uint8_t address, size_t len, bool sendStop)
+// {
+//     return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop));
+// }
+//   
+// uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len, uint8_t sendStop)
+// {
+//     return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop));
+// }
+//
+// uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, uint8_t sendStop)
+// {
+//     return requestFrom(address, static_cast<size_t>(len), static_cast<bool>(sendStop));
+// }
+//
+// /* Added to match the Arduino function definition: https://github.com/arduino/ArduinoCore-API/blob/173e8eadced2ad32eeb93bcbd5c49f8d6a055ea6/api/HardwareI2C.h#L39
+//  * See: https://github.com/arduino-libraries/ArduinoECCX08/issues/25
+// */
+// uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len, bool stopBit)
+// {
+//     return requestFrom((uint16_t)address, (size_t)len, stopBit);
+// }
+//
+// uint8_t TwoWire::requestFrom(uint8_t address, uint8_t len)
+// {
+//     return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), true);
+// }
+//
+// uint8_t TwoWire::requestFrom(uint16_t address, uint8_t len)
+// {
+//     return requestFrom(address, static_cast<size_t>(len), true);
+// }
+//
+// uint8_t TwoWire::requestFrom(int address, int len)
+// {
+//     return requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), true);
+// }
+//
+// uint8_t TwoWire::requestFrom(int address, int len, int sendStop)
+// {
+//     return static_cast<uint8_t>(requestFrom(static_cast<uint16_t>(address), static_cast<size_t>(len), static_cast<bool>(sendStop)));
+// }
 
 void TwoWire::beginTransmission(int address)
 {

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -121,15 +121,15 @@ public:
     uint8_t endTransmission(bool sendStop);
     uint8_t endTransmission(void);
 
-    size_t requestFrom(uint16_t address, size_t size, bool sendStop);
-    uint8_t requestFrom(uint16_t address, uint8_t size, bool sendStop);
-    uint8_t requestFrom(uint16_t address, uint8_t size, uint8_t sendStop);
-    size_t requestFrom(uint8_t address, size_t len, bool stopBit);
-    uint8_t requestFrom(uint16_t address, uint8_t size);
-    uint8_t requestFrom(uint8_t address, uint8_t size, uint8_t sendStop);
-    uint8_t requestFrom(uint8_t address, uint8_t size);
-    uint8_t requestFrom(int address, int size, int sendStop);
-    uint8_t requestFrom(int address, int size);
+    size_t requestFrom(uint16_t address, size_t size, bool sendStop = true);
+    // uint8_t requestFrom(uint16_t address, uint8_t size, bool sendStop);
+    // uint8_t requestFrom(uint16_t address, uint8_t size, uint8_t sendStop);
+    // size_t requestFrom(uint8_t address, size_t len, bool stopBit);
+    // uint8_t requestFrom(uint16_t address, uint8_t size);
+    // uint8_t requestFrom(uint8_t address, uint8_t size, uint8_t sendStop);
+    // uint8_t requestFrom(uint8_t address, uint8_t size);
+    // uint8_t requestFrom(int address, int size, int sendStop);
+    // uint8_t requestFrom(int address, int size);
 
     size_t write(uint8_t);
     size_t write(const uint8_t *, size_t);

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -100,11 +100,7 @@ public:
     {
         return begin(addr, -1, -1, 0);
     }
-    inline bool begin(int addr)
-    {
-        return begin(static_cast<uint8_t>(addr), -1, -1, 0);
-    }
-    bool end();
+	bool end();
 
     size_t setBufferSize(size_t bSize);
 


### PR DESCRIPTION
## Description of Change
Remove `TwoWire:: inline bool begin(int addr)` overload.
Inside the function, this overload truncated the data type to a shorter one. This could break some users' hopes.
