### PR TITLE
Fixes uart attach/detach

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -107,10 +107,6 @@ _eventTask(NULL)
         }
     }
 #endif
-    // sets UART0 (default console) RX/TX pins as already configured in boot
-    if (uart_nr == 0) {
-        setPins(SOC_RX0, SOC_TX0);
-    }
     // set deinit function in the Peripheral Manager
     uart_init_PeriMan();
 }

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -184,6 +184,8 @@ static bool _uartAttachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
 
     bool retCode = true;
     if (rxPin >= 0) {
+        // forces a clean detaching from a previous peripheral
+        if (perimanGetPinBusType(rxPin) != ESP32_BUS_TYPE_INIT) perimanSetPinBus(rxPin, ESP32_BUS_TYPE_INIT, NULL);
         // connect RX Pad
         bool ret = ESP_OK == uart_set_pin(uart->num, UART_PIN_NO_CHANGE, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
         if (ret) {
@@ -196,6 +198,8 @@ static bool _uartAttachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
         retCode &= ret;
     }
     if (txPin >= 0) {
+        // forces a clean detaching from a previous peripheral
+        if (perimanGetPinBusType(txPin) != ESP32_BUS_TYPE_INIT) perimanSetPinBus(txPin, ESP32_BUS_TYPE_INIT, NULL);
         // connect TX Pad
         bool ret = ESP_OK == uart_set_pin(uart->num, txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
         if (ret) {
@@ -208,6 +212,8 @@ static bool _uartAttachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
         retCode &= ret;
     }
     if (ctsPin >= 0) {
+        // forces a clean detaching from a previous peripheral
+        if (perimanGetPinBusType(ctsPin) != ESP32_BUS_TYPE_INIT) perimanSetPinBus(ctsPin, ESP32_BUS_TYPE_INIT, NULL);
         // connect CTS Pad
         bool ret = ESP_OK == uart_set_pin(uart->num, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, ctsPin);
         if (ret) {
@@ -220,6 +226,8 @@ static bool _uartAttachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
         retCode &= ret;
     }
     if (rtsPin >= 0) {
+        // forces a clean detaching from a previous peripheral
+        if (perimanGetPinBusType(rtsPin) != ESP32_BUS_TYPE_INIT) perimanSetPinBus(rtsPin, ESP32_BUS_TYPE_INIT, NULL);
         // connect RTS Pad
         bool ret = ESP_OK == uart_set_pin(uart->num, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, rtsPin, UART_PIN_NO_CHANGE);
         if (ret) {

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -45,6 +45,8 @@ __attribute__((weak)) bool shouldPrintChipDebugReport(void) {
 
 void loopTask(void *pvParameters)
 {
+    // sets UART0 (default console) RX/TX pins as already configured in boot or as defined in variants/pins_arduino.h
+    Serial0.setPins(SOC_RX0, SOC_TX0);
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
     printBeforeSetupInfo();
 #else


### PR DESCRIPTION
## Description of Change
Fixes the order that a UART pin attaching shall work when a previous peripheral has been already attached.

## Tests scenarios

Using Serial as UART0, independently of using `USB CDC On Boot: "Enabled` + any Logging Level (None | Verbose)
``` cpp
#include <SPI.h>

#ifndef LED_BUILTIN
#define LED_BUILTIN 2
#endif

void setup() {
  Serial0.begin(115200);
  //Serial0.setDebugOutput(true);
  Serial0.println("TESTING... 1 - UART0");
  Serial0.flush();
  log_v("12345567890");  // just testing logging
  // initialize digital pin LED_BUILTIN as an output.
  pinMode(LED_BUILTIN, OUTPUT);

  const uint8_t testedPin = SOC_TX0; // works for any any SoC

  //First testing is using TX0 as RMT channel
  rmtInit(testedPin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000);
  Serial0.println("RMT tick set to: 100ns");  // not printed -- TX UART0 attached to RMT
  // works for any any SoC
  Serial0.setPins(SOC_RX0, SOC_TX0);
  Serial0.println("TESTING... 2 - RMT");  // Must be printed fine
  Serial0.flush();

  // Second testing is using TX0 as SPI Clock
  SPI.begin(testedPin, MISO, MOSI, SS); //CLK,MISO,MOSI,CS
  //delay(1000);
  //SPI.end();
  // works for any any SoC
  Serial0.setPins(SOC_RX0, SOC_TX0);
  Serial0.println("TESTING... 3 - SPI");  // Must be printed fine
  Serial0.flush();
}

void loop() {
  Serial0.println("Looping ...");    // Must be printed fine
  digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
  delay(3500);                       // wait for a second
  digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
  delay(1500);                       // wait for a second
}
```
#### Console ouput using ESP32-C6:
```
ESP-ROM:esp32c6-20220919
Build:Sep 19 2022
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x4086c410,len:0xc24
load:0x4086e610,len:0x26f8
load:0x40875728,len:0x594
entry 0x4086c410
=========== Before Setup Start ===========
Chip Info:
------------------------------------------
  Model             : ESP32-C6
  Package           : 1
  Revision          : 1
  Cores             : 1
  Frequency         : 160 MHz
  Embedded Flash    : No
  Embedded PSRAM    : No
  2.4GHz WiFi       : Yes
  Classic BT        : No
  BT Low Energy     : Yes
  IEEE 802.15.4     : Yes
------------------------------------------
INTERNAL Memory Info:
------------------------------------------
  Total Size        :   482044 B ( 470.7 KB)
  Free Bytes        :   448888 B ( 438.4 KB)
  Allocated Bytes   :    26956 B (  26.3 KB)
  Minimum Free Bytes:   448844 B ( 438.3 KB)
  Largest Free Block:   425972 B ( 416.0 KB)
------------------------------------------
Flash Info:
------------------------------------------
  Chip Size         :  4194304 B (4 MB)
  Block Size        :    65536 B (  64.0 KB)
  Sector Size       :     4096 B (   4.0 KB)
  Page Size         :      256 B (   0.2 KB)
  Bus Speed         : 40 MHz
  Bus Mode          : QIO
------------------------------------------
Partitions Info:
------------------------------------------
                nvs : addr: 0x00009000, size:    20.0 KB, type: DATA, subtype: NVS
            otadata : addr: 0x0000E000, size:     8.0 KB, type: DATA, subtype: OTA
               app0 : addr: 0x00010000, size:  1280.0 KB, type:  APP, subtype: OTA_0
               app1 : addr: 0x00150000, size:  1280.0 KB, type:  APP, subtype: OTA_1
             spiffs : addr: 0x00290000, size:  1408.0 KB, type: DATA, subtype: SPIFFS
           coredump : addr: 0x003F0000, size:    64.0 KB, type: DATA, subtype: COREDUMP
------------------------------------------
Software Info:
------------------------------------------
  Compile Date/Time : Oct 31 2023 08:02:28
  Compile Host OS   : windows
  ESP-IDF Version   : v5.1.1-577-g6b1f40b9bf-dirty
  Arduino Version   : 3.0.0
------------------------------------------
Board Info:
------------------------------------------
  Arduino Board     : ESP32C6_DEV
  Arduino Variant   : esp32c6
  Arduino FQBN      : espressif:esp32-SuGlider:esp32c6:JTAGAdapter=default,CDCOnBoot=default,PartitionScheme=default,CPUFreq=160,FlashMode=qio,FlashFreq=80,FlashSize=4M,UploadSpeed=921600,DebugLevel=verbose,EraseFlash=none
============ Before Setup End ============
[   395][V][esp32-hal-uart.c:409] uartBegin(): UART0 baud(115200) Mode(800001c) rxPin(17) txPin(16)
TESTING... 1 - UART0
[   406][V][issue_8809_Serial_UART0_TX_reuse_attaching_error.ino:12] setup(): 12345567890
[   414][V][esp32-hal-rmt.c:442] rmtInit(): GPIO 16 - TX MODE - MemSize[48] - Freq=10000000Hz
TESTING... 2 - RMT
TESTING... 3 - SPI
=========== After Setup Start ============
NTERNAL Memory Info:
------------------------------------------
  Total Size        :   482044 B ( 470.7 KB)
  Free Bytes        :   451368 B ( 440.8 KB)
  Allocated Bytes   :    24132 B (  23.6 KB)
  Minimum Free Bytes:   448300 B ( 437.8 KB)
  Largest Free Block:   425972 B ( 416.0 KB)
------------------------------------------
GPIO Info:
------------------------------------------
                  8 : GPIO
                 16 : UART_TX
                 17 : UART_RX
============ After Setup End =============
Looping ...
[   557][V][esp32-hal-rmt.c:442] rmtInit(): GPIO 8 - TX MODE - MemSize[48] - Freq=10000000Hz
[   566][V][esp32-hal-rmt.c:298] _rmtWrite(): GPIO: 8 - Request: 24 RMT Symbols - Blocking - Timeout: -1
[   576][V][esp32-hal-rmt.c:299] _rmtWrite(): GPIO: 8 - Currently in Loop Mode: [NO] | Asked to Loop: NO, LoopCancel: NO
[  4086][V][esp32-hal-rmt.c:298] _rmtWrite(): GPIO: 8 - Request: 24 RMT Symbols - Blocking - Timeout: -1
[  4096][V][esp32-hal-rmt.c:299] _rmtWrite(): GPIO: 8 - Currently in Loop Mode: [NO] | Asked to Loop: NO, LoopCancel: NO
Looping ...

```


## Related links
Closes #8809