### PR TITLE
Rewrite IPAddress without union

### DIFF
--- a/cores/esp32/IPAddress.h
+++ b/cores/esp32/IPAddress.h
@@ -23,16 +23,14 @@
 #include <stdint.h>
 #include <WString.h>
 #include <Printable.h>
+#include <array>
 
 // A class to make it easier to handle and pass around IP addresses
 
 class IPAddress: public Printable
 {
 private:
-    union {
-        uint8_t bytes[4];  // IPv4 address
-        uint32_t dword;
-    } _address;
+	alignas(alignof(uint32_t)) std::array<uint8_t,4> _address{}; // IPv4 address
 
     // Access the raw byte array containing the address.  Because this returns a pointer
     // to the internal structure rather than a copy of the address this function should only
@@ -40,12 +38,12 @@ private:
     // stored.
     uint8_t* raw_address()
     {
-        return _address.bytes;
+        return _address.data();
     }
 
 public:
     // Constructors
-    IPAddress();
+    IPAddress() = default;
     IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet);
     IPAddress(uint32_t address);
     IPAddress(const uint8_t *address);
@@ -54,26 +52,27 @@ public:
     bool fromString(const char *address);
     bool fromString(const String &address) { return fromString(address.c_str()); }
 
+
     // Overloaded cast operator to allow IPAddress objects to be used where a pointer
     // to a four-byte uint8_t array is expected
     operator uint32_t() const
     {
-        return _address.dword;
+        return reinterpret_cast<const uint32_t&>(_address.front());
     }
     bool operator==(const IPAddress& addr) const
     {
-        return _address.dword == addr._address.dword;
+        return _address == addr._address;
     }
     bool operator==(const uint8_t* addr) const;
 
     // Overloaded index operator to allow getting and setting individual octets of the address
     uint8_t operator[](int index) const
     {
-        return _address.bytes[index];
+        return _address[index];
     }
     uint8_t& operator[](int index)
     {
-        return _address.bytes[index];
+        return _address[index];
     }
 
     // Overloaded copy operators to allow initialisation of IPAddress objects from other types


### PR DESCRIPTION
## Rewrite IPAddress without union
Using a union allowed undefined behavior for array-like INPUT and OUTPUT arguments through a 32-bit integer (and vice versa).

  C++ standard says (https://timsong-cpp.github.io/cppwp/n4659/class.union#1):
  "At most one of the non-static data members of an object of union type
  can be active at any time, that is, the value of at most one of the
  non-static data members can be stored in a union at any time. [ Note:
  One special guarantee is made in order to simplify the use of unions:
  If a standard-layout union contains several standard-layout structs
  that share a common initial sequence, and if a non-static data member
  of an object of this standard-layout union type is active and is one
  of the standard-layout structs, it is permitted to inspect the common
  initial sequence of any of the standard-layout struct members; see
  [class.mem].  — end note ]"

  and (https://timsong-cpp.github.io/cppwp/n4659/class.mem#22):
  "Two standard-layout unions are layout-compatible if they have the same number of non-static data members and corresponding non-static data members (in any order) have layout-compatible types."

you can't hope that compilers don't seem to do undefined behavior at the moment

note: this PR is recreated https://github.com/espressif/arduino-esp32/pull/8819 PR -- to fix https://github.com/espressif/arduino-esp32/pull/8819#issuecomment-1792010809