### PR TITLE
Neopixel fix

### DIFF
--- a/cores/esp32/esp32-hal-rgb-led.c
+++ b/cores/esp32/esp32-hal-rgb-led.c
@@ -3,34 +3,22 @@
 
 void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue_val){
   rmt_data_t led_data[24];
-  static bool initialized = false;
-
-  uint8_t _pin = pin;
-#ifdef RGB_BUILTIN
-  if(pin == RGB_BUILTIN){
-    _pin = RGB_BUILTIN - SOC_GPIO_PIN_COUNT;
-  }
-#endif
-
-  if(!initialized){
-    if (!rmtInit(_pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)){
-        log_e("RGB LED driver initialization failed!");
-        return;
-    }
-    initialized = true;
+  if (!rmtInit(pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) {
+    log_e("RGB LED driver initialization failed!");
+    return;
   }
 
   int color[] = {green_val, red_val, blue_val};  // Color coding is in order GREEN, RED, BLUE
   int i = 0;
-  for(int col=0; col<3; col++ ){
-    for(int bit=0; bit<8; bit++){
-      if((color[col] & (1<<(7-bit)))){
+  for (int col = 0; col < 3; col++ ) {
+    for (int bit = 0; bit < 8; bit++) {
+      if ((color[col] & (1 << (7 - bit)))) {
         // HIGH bit
         led_data[i].level0 = 1; // T1H
         led_data[i].duration0 = 8; // 0.8us
         led_data[i].level1 = 0; // T1L
         led_data[i].duration1 = 4; // 0.4us
-      }else{
+      } else {
         // LOW bit
         led_data[i].level0 = 1; // T0H
         led_data[i].duration0 = 4; // 0.4us
@@ -40,5 +28,5 @@ void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue
       i++;
     }
   }
-  rmtWrite(_pin, led_data, RMT_SYMBOLS_OF(led_data), RMT_WAIT_FOR_EVER);
+  rmtWrite(pin, led_data, RMT_SYMBOLS_OF(led_data), RMT_WAIT_FOR_EVER);
 }

--- a/cores/esp32/esp32-hal-rgb-led.c
+++ b/cores/esp32/esp32-hal-rgb-led.c
@@ -4,7 +4,7 @@
 void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue_val){
   rmt_data_t led_data[24];
   if (!rmtInit(pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) {
-    log_e("RGB LED driver initialization failed!");
+    log_e("RGB LED driver initialization failed for GPIO%d!", pin);
     return;
   }
 

--- a/cores/esp32/esp32-hal-rgb-led.c
+++ b/cores/esp32/esp32-hal-rgb-led.c
@@ -3,6 +3,9 @@
 
 void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue_val){
   rmt_data_t led_data[24];
+
+  // Verify if the pin used is RGB_BUILTIN and fix GPIO number
+  pin = pin == RGB_BUILTIN ? pin - SOC_GPIO_PIN_COUNT : pin;
   if (!rmtInit(pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) {
     log_e("RGB LED driver initialization failed for GPIO%d!", pin);
     return;

--- a/cores/esp32/esp32-hal-rgb-led.c
+++ b/cores/esp32/esp32-hal-rgb-led.c
@@ -5,7 +5,9 @@ void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue
   rmt_data_t led_data[24];
 
   // Verify if the pin used is RGB_BUILTIN and fix GPIO number
+#ifdef RGB_BUILTIN
   pin = pin == RGB_BUILTIN ? pin - SOC_GPIO_PIN_COUNT : pin;
+#endif
   if (!rmtInit(pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) {
     log_e("RGB LED driver initialization failed for GPIO%d!", pin);
     return;

--- a/libraries/ESP32/examples/RMT/RMTWriteNeoPixel/RMTWriteNeoPixel.ino
+++ b/libraries/ESP32/examples/RMT/RMTWriteNeoPixel/RMTWriteNeoPixel.ino
@@ -19,15 +19,11 @@
  * Parameters can be changed by the user. In a single LED circuit, it will just blink.
  */
 
-// The effect seen in ESP32C3, ESP32S2 and ESP32S3 is like a Blink of RGB LED
-#if CONFIG_IDF_TARGET_ESP32S2
-#define BUILTIN_RGBLED_PIN   18
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define BUILTIN_RGBLED_PIN   48  // 48 or 38
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define BUILTIN_RGBLED_PIN   8
+// The effect seen in (Espressif devkits) ESP32C6, ESP32H2, ESP32C3, ESP32S2 and ESP32S3 is like a Blink of RGB LED
+#ifdef PIN_NEOPIXEL
+#define BUILTIN_RGBLED_PIN   PIN_NEOPIXEL
 #else
-#define BUILTIN_RGBLED_PIN   21   // ESP32 has no builtin RGB LED
+#define BUILTIN_RGBLED_PIN   21   // ESP32 has no builtin RGB LED (PIN_NEOPIXEL)
 #endif
 
 #define NR_OF_LEDS   8*4

--- a/libraries/ESP32/examples/RMT/RMT_CPUFreq_Test/RMT_CPUFreq_Test.ino
+++ b/libraries/ESP32/examples/RMT/RMT_CPUFreq_Test/RMT_CPUFreq_Test.ino
@@ -26,14 +26,11 @@
 
 
 // Default DevKit RGB LED GPIOs:
-#if CONFIG_IDF_TARGET_ESP32S2
-#define MY_LED_GPIO   18
-#elif CONFIG_IDF_TARGET_ESP32S3
-#define MY_LED_GPIO   48  // 48 or 38
-#elif CONFIG_IDF_TARGET_ESP32C3
-#define MY_LED_GPIO   8
+// The effect seen in (Espressif devkits) ESP32C6, ESP32H2, ESP32C3, ESP32S2 and ESP32S3 is like a Blink of RGB LED
+#ifdef PIN_NEOPIXEL
+#define MY_LED_GPIO   PIN_NEOPIXEL
 #else
-#define MY_LED_GPIO   21   // Any, ESP32 has no RGB LED - depends on circuit setup
+#define MY_LED_GPIO   21   // ESP32 has no builtin RGB LED (PIN_NEOPIXEL)
 #endif
 
 // Set the correct GPIO to any necessary by changing RGB_LED_GPIO value


### PR DESCRIPTION
## Description of Change
Based on issue #8841, it was clear that some improvements could be done to the `neopixelWrite()` function.
Changes:
1- All RMT examples use the `PIN_NEOPIXEL` defined in `pins_arduino.h` for the Espressif devkits
2- `neopixelWrite()` can be used with many GPIOs in the same sketch. Before this changes, the sketch could only use one GPIO with `neopixelWrite()`.


## Tests scenarios
Tested with ESP32-C6:

``` cpp
void blinkRGBLED(uint32_t count, uint32_t time_ms) {
  const uint8_t LED_Pin = 23;  // change it to any other valid GPIO
  for ( ; count; count--) {
    neopixelWrite(LED_Pin, 255, 255, 255);  // RGB = White (on)
    Serial.println("HIGH");
    delay(time_ms);
    neopixelWrite(LED_Pin, 0, 0, 0); // RGB = Black (off)
    Serial.println("LOW");
    delay(time_ms);
  }
}

void setup() {
  // No need to initialize the RGB LED
  blinkRGBLED(5, 500);
}

// the loop function runs over and over again forever
void loop() {
#ifdef RGB_BUILTIN
  digitalWrite(RGB_BUILTIN, HIGH);   // Turn the RGB LED white
  delay(1000);
  digitalWrite(RGB_BUILTIN, LOW);    // Turn the RGB LED off
  delay(1000);

  neopixelWrite(PIN_NEOPIXEL, RGB_BRIGHTNESS, 0, 0); // Red
  delay(1000);
  neopixelWrite(PIN_NEOPIXEL, 0, RGB_BRIGHTNESS, 0); // Green
  delay(1000);
  neopixelWrite(PIN_NEOPIXEL, 0, 0, RGB_BRIGHTNESS); // Blue
  delay(1000);
  neopixelWrite(PIN_NEOPIXEL, 0, 0, 0); // Off / black
  delay(1000);
#endif
}
```

## Related links
Fix #8841 
