### PR TITLE
WiFi.BSSID and scan result BSSID with parameter as in WiFi libraries by Arduino

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -716,14 +716,23 @@ String WiFiSTAClass::psk() const
  * Return the current bssid / mac associated with the network if configured
  * @return bssid uint8_t *
  */
-uint8_t* WiFiSTAClass::BSSID(void)
+uint8_t* WiFiSTAClass::BSSID(uint8_t* buff)
 {
     static uint8_t bssid[6];
     wifi_ap_record_t info;
     if(WiFiGenericClass::getMode() == WIFI_MODE_NULL){
         return NULL;
     }
-    if(!esp_wifi_sta_get_ap_info(&info)) {
+    esp_err_t err = esp_wifi_sta_get_ap_info(&info);
+    if (buff != NULL) {
+        if(err) {
+          memset(buff, 0, 6);
+        } else {
+          memcpy(buff, info.bssid, 6);
+        }
+        return  buff;
+    }
+    if(!err) {
         memcpy(bssid, info.bssid, 6);
         return reinterpret_cast<uint8_t*>(bssid);
     }

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -98,7 +98,7 @@ public:
     String SSID() const;
     String psk() const;
 
-    uint8_t * BSSID();
+    uint8_t * BSSID(uint8_t* bssid = NULL);
     String BSSIDstr();
 
     int8_t RSSI();

--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -243,11 +243,20 @@ int32_t WiFiScanClass::RSSI(uint8_t i)
 /**
  * return MAC / BSSID of scanned wifi
  * @param i specify from which network item want to get the information
+ * @param buff optional buffer for the result uint8_t array with length 6
  * @return uint8_t * MAC / BSSID of scanned wifi
  */
-uint8_t * WiFiScanClass::BSSID(uint8_t i)
+uint8_t * WiFiScanClass::BSSID(uint8_t i, uint8_t* buff)
 {
     wifi_ap_record_t* it = reinterpret_cast<wifi_ap_record_t*>(_getScanInfoByIndex(i));
+    if(buff != NULL) {
+        if(!it) {
+            memset(buff, 0, 6);
+        } else {
+            memcpy(buff, it->bssid, 6);
+        }
+        return buff;
+    }
     if(!it) {
         return 0;
     }

--- a/libraries/WiFi/src/WiFiScan.h
+++ b/libraries/WiFi/src/WiFiScan.h
@@ -42,7 +42,7 @@ public:
     String SSID(uint8_t networkItem);
     wifi_auth_mode_t encryptionType(uint8_t networkItem);
     int32_t RSSI(uint8_t networkItem);
-    uint8_t * BSSID(uint8_t networkItem);
+    uint8_t * BSSID(uint8_t networkItem, uint8_t* bssid = NULL);
     String BSSIDstr(uint8_t networkItem);
     int32_t channel(uint8_t networkItem);
     static void * getScanInfoByIndex(int i) { return _getScanInfoByIndex(i); }; 


### PR DESCRIPTION
Arduino doc on BSSID getters: https://www.arduino.cc/reference/en/libraries/wifi/wifi.bssid/

I [compared more than a dozen of Arduino Networking libraries](https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md) to find the common API for Arduino networking. Then I wrote [a test sketch](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/WiFiTest/WiFiTest.ino) which checks how a library complies to this common API.

ESP32 Arduino WiFi library was based on ESP8266 Arduino WiFi library which was based on the first WiFi library by Arduino. Arduino later created more WiFi libraries and the API diverged, but at least with the most recent library they looked at the ESP32 WiFi library for new method names (for example dnsIP(n)).

While doing the research and tests I do PR in Arduino networking libraries repositories with in most cases simple modifications to unify the API where it doesn't break the library (for example I will not ask esp8266 and esp32 maintainers to make WiFi.begin blocking :-) ). 

Similar [PR](https://github.com/esp8266/Arduino/pull/9008) by me was recently merged in esp8266 Arduino repository.