### PR TITLE
Increase BT SPP task priority

### DIFF
--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -671,7 +671,7 @@ static bool _init_bt(const char *deviceName)
     }
 
     if(!_spp_task_handle){
-        xTaskCreatePinnedToCore(_spp_tx_task, "spp_tx", 4096, NULL, 10, &_spp_task_handle, 0);
+        xTaskCreatePinnedToCore(_spp_tx_task, "spp_tx", 4096, NULL, configMAX_PRIORITIES-1, &_spp_task_handle, 0);
         if(!_spp_task_handle){
             log_e("Network Event Task Start Failed!");
             return false;


### PR DESCRIPTION
## Description of Change
SerialBT interface uses a task to send and receive data using Bluetooth SPP. When the application wants to reach maximum performance, specially when reading from one peripheral and writing the stream of bytes to the SPP interface, it fails and losses some data.

In order to improve it and make it run in the best performance possible, its task priority shall be the highest possible.

## Tests scenarios
Using ESP32 - example provided in the issue #8808

## Related links
Closes #8808 
