### PR TITLE
WiFiClients.setConnectionTimeout added

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -348,6 +348,11 @@ int WiFiClient::getOption(int option, int *value)
     return res;
 }
 
+void WiFiClient::setConnectionTimeout(uint32_t milliseconds)
+{
+    _timeout = milliseconds;
+}
+
 int WiFiClient::setNoDelay(bool nodelay)
 {
     int flag = nodelay;

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -33,6 +33,7 @@ class ESPLwIPClient : public Client
 public:
         virtual int connect(IPAddress ip, uint16_t port, int32_t timeout) = 0;
         virtual int connect(const char *host, uint16_t port, int32_t timeout) = 0;
+        virtual void setConnectionTimeout(uint32_t milliseconds) = 0;
 };
 
 class WiFiClient : public ESPLwIPClient
@@ -92,6 +93,7 @@ public:
     int getSocketOption(int level, int option, const void* value, size_t size);
     int setOption(int option, int *value);
     int getOption(int option, int *value);
+    void setConnectionTimeout(uint32_t milliseconds);
     int setNoDelay(bool nodelay);
     bool getNoDelay();
 


### PR DESCRIPTION
<del>`WiFiClient::setTimeout` now shadows `Stream::setTimeout` which has a different purpose and the unit of the parameter is different. Related [issue](https://github.com/espressif/arduino-esp32/issues/5558).</del>

<del>The solution is to rename `WiFiClient::setTimeout` to [Arduino standard](https://www.arduino.cc/reference/en/libraries/ethernet/client.setconnectiontimeout/) `WiFiClient::setConnectionTimeout`.</del>

EDIT: at the end most of this PR was done in https://github.com/espressif/arduino-esp32/pull/6676 and https://github.com/espressif/arduino-esp32/pull/8998

overview of Client API in Arduino networking libraries:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#client-getters-and-setters