### PR TITLE
Fix - no use of led_stripe.h

### DIFF
--- a/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
+++ b/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
@@ -2,7 +2,7 @@
 #include "RMaker.h"
 #include "WiFi.h"
 #include "WiFiProv.h"
-#include "led_strip.h"
+//#include "led_strip.h"
 
 #define DEFAULT_POWER_MODE true
 #define DEFAULT_SWING false


### PR DESCRIPTION
## Description of Change
RainMaker fix - based on CI message https://github.com/espressif/arduino-esp32/actions/runs/6825648311/job/18563939589#step:5:461

There is no use for `#include "led_strip.h"` that is the cause of the CI error.

## Tests scenarios
Tested on CI 

## Related links
None