### PR TITLE
Makes MP3 header files public for I2S code

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -25,7 +25,7 @@ files:
     - "**/*"
 dependencies:
   idf: ">=5.1"
-  mdns: "^1.1.0"
+  mdns: "1.2.1"
   chmorgan/esp-libhelix-mp3:
     version: "1.0.3"
     require: public

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -25,6 +25,7 @@ files:
     - "**/*"
 dependencies:
   idf: ">=5.1"
+  # mdns 1.2.1 is necessary to build H2 with no WiFi
   mdns: "1.2.1"
   chmorgan/esp-libhelix-mp3:
     version: "1.0.3"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -26,7 +26,9 @@ files:
 dependencies:
   idf: ">=5.1"
   mdns: "^1.1.0"
-  chmorgan/esp-libhelix-mp3: "1.0.3"
+  chmorgan/esp-libhelix-mp3:
+    version: "1.0.3"
+    require: public
   espressif/esp-zboss-lib: "^1.0.1"
   espressif/esp-zigbee-lib: "^1.0.1"
   esp-dsp: "^1.3.4"


### PR DESCRIPTION
## Description of Change
Arduino I2S uses MP3 header file and it fails when Arduino is built as IDF component.
This fixes it by making it public and exporting its header files to the I2S code and examples. 

project/main/idf_component.yml:
```
dependencies:
  # Required IDF version
  idf: ">=5.1"
  espressif/arduino-esp32:
    version: "*"
    git: https://github.com/espressif/arduino-esp32.git
    require: public
```

## Tests scenarios
Build any sketch using Arduino as IDF component and with Arduino as Managed Component in the `idf_component.yml` file.

## Related links
None