### PR TITLE
Add support for ESP32-S3 PowerFeather

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -28352,8 +28352,8 @@ esp32s3_powerfeather.upload.maximum_size=1310720
 esp32s3_powerfeather.upload.maximum_data_size=327680
 esp32s3_powerfeather.upload.flags=
 esp32s3_powerfeather.upload.extra_flags=
-esp32s3_powerfeather.upload.use_1200bps_touch=true
-esp32s3_powerfeather.upload.wait_for_upload_port=true
+esp32s3_powerfeather.upload.use_1200bps_touch=false
+esp32s3_powerfeather.upload.wait_for_upload_port=false
 
 esp32s3_powerfeather.serial.disableDTR=false
 esp32s3_powerfeather.serial.disableRTS=false
@@ -28366,8 +28366,8 @@ esp32s3_powerfeather.build.core=esp32
 esp32s3_powerfeather.build.variant=esp32s3_powerfeather
 esp32s3_powerfeather.build.board=ESP32S3_POWERFEATHER
 
-esp32s3_powerfeather.build.usb_mode=0
-esp32s3_powerfeather.build.cdc_on_boot=1
+esp32s3_powerfeather.build.usb_mode=1
+esp32s3_powerfeather.build.cdc_on_boot=0
 esp32s3_powerfeather.build.msc_on_boot=0
 esp32s3_powerfeather.build.dfu_on_boot=0
 esp32s3_powerfeather.build.f_cpu=240000000L
@@ -28375,13 +28375,36 @@ esp32s3_powerfeather.build.flash_size=8MB
 esp32s3_powerfeather.build.flash_freq=80m
 esp32s3_powerfeather.build.flash_mode=dio
 esp32s3_powerfeather.build.boot=qio
-esp32s3_powerfeather.build.partitions=default
+esp32s3_powerfeather.build.boot_freq=80m
+esp32s3_powerfeather.build.partitions=default_8MB
 esp32s3_powerfeather.build.defines=
 esp32s3_powerfeather.build.loop_core=
 esp32s3_powerfeather.build.event_core=
-esp32s3_powerfeather.build.flash_type=qio
 esp32s3_powerfeather.build.psram_type=qspi
-esp32s3_powerfeather.build.memory_type={build.flash_type}_{build.psram_type}
+esp32s3_powerfeather.build.memory_type={build.boot}_{build.psram_type}
+
+esp32s3_powerfeather.menu.PSRAM.disabled=Disabled
+esp32s3_powerfeather.menu.PSRAM.disabled.build.defines=
+esp32s3_powerfeather.menu.PSRAM.disabled.build.psram_type=qspi
+esp32s3_powerfeather.menu.PSRAM.enabled=QSPI PSRAM
+esp32s3_powerfeather.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+esp32s3_powerfeather.menu.PSRAM.enabled.build.psram_type=qspi
+
+esp32s3_powerfeather.menu.FlashMode.qio=QIO 80MHz
+esp32s3_powerfeather.menu.FlashMode.qio.build.flash_mode=dio
+esp32s3_powerfeather.menu.FlashMode.qio.build.boot=qio
+esp32s3_powerfeather.menu.FlashMode.qio.build.boot_freq=80m
+esp32s3_powerfeather.menu.FlashMode.qio.build.flash_freq=80m
+esp32s3_powerfeather.menu.FlashMode.qio120=QIO 120MHz
+esp32s3_powerfeather.menu.FlashMode.qio120.build.flash_mode=dio
+esp32s3_powerfeather.menu.FlashMode.qio120.build.boot=qio
+esp32s3_powerfeather.menu.FlashMode.qio120.build.boot_freq=120m
+esp32s3_powerfeather.menu.FlashMode.qio120.build.flash_freq=80m
+esp32s3_powerfeather.menu.FlashMode.dio=DIO 80MHz
+esp32s3_powerfeather.menu.FlashMode.dio.build.flash_mode=dio
+esp32s3_powerfeather.menu.FlashMode.dio.build.boot=dio
+esp32s3_powerfeather.menu.FlashMode.dio.build.boot_freq=80m
+esp32s3_powerfeather.menu.FlashMode.dio.build.flash_freq=80m
 
 esp32s3_powerfeather.menu.LoopCore.1=Core 1
 esp32s3_powerfeather.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
@@ -28393,15 +28416,15 @@ esp32s3_powerfeather.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_
 esp32s3_powerfeather.menu.EventsCore.0=Core 0
 esp32s3_powerfeather.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
-esp32s3_powerfeather.menu.USBMode.default=USB-OTG (TinyUSB)
-esp32s3_powerfeather.menu.USBMode.default.build.usb_mode=0
 esp32s3_powerfeather.menu.USBMode.hwcdc=Hardware CDC and JTAG
 esp32s3_powerfeather.menu.USBMode.hwcdc.build.usb_mode=1
+esp32s3_powerfeather.menu.USBMode.default=USB-OTG (TinyUSB)
+esp32s3_powerfeather.menu.USBMode.default.build.usb_mode=0
 
-esp32s3_powerfeather.menu.CDCOnBoot.cdc=Enabled
-esp32s3_powerfeather.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 esp32s3_powerfeather.menu.CDCOnBoot.default=Disabled
 esp32s3_powerfeather.menu.CDCOnBoot.default.build.cdc_on_boot=0
+esp32s3_powerfeather.menu.CDCOnBoot.cdc=Enabled
+esp32s3_powerfeather.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 
 esp32s3_powerfeather.menu.MSCOnBoot.default=Disabled
 esp32s3_powerfeather.menu.MSCOnBoot.default.build.msc_on_boot=0
@@ -28413,19 +28436,12 @@ esp32s3_powerfeather.menu.DFUOnBoot.default.build.dfu_on_boot=0
 esp32s3_powerfeather.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
 esp32s3_powerfeather.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
-esp32s3_powerfeather.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-esp32s3_powerfeather.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-esp32s3_powerfeather.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 esp32s3_powerfeather.menu.UploadMode.default=UART0 / Hardware CDC
 esp32s3_powerfeather.menu.UploadMode.default.upload.use_1200bps_touch=false
 esp32s3_powerfeather.menu.UploadMode.default.upload.wait_for_upload_port=false
-
-esp32s3_powerfeather.menu.PSRAM.enabled=QSPI PSRAM
-esp32s3_powerfeather.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-esp32s3_powerfeather.menu.PSRAM.enabled.build.psram_type=qspi
-esp32s3_powerfeather.menu.PSRAM.disabled=Disabled
-esp32s3_powerfeather.menu.PSRAM.disabled.build.defines=
-esp32s3_powerfeather.menu.PSRAM.disabled.build.psram_type=qspi
+esp32s3_powerfeather.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+esp32s3_powerfeather.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+esp32s3_powerfeather.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 
 esp32s3_powerfeather.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 esp32s3_powerfeather.menu.PartitionScheme.default.build.partitions=default
@@ -28473,25 +28489,6 @@ esp32s3_powerfeather.menu.CPUFreq.20=20MHz
 esp32s3_powerfeather.menu.CPUFreq.20.build.f_cpu=20000000L
 esp32s3_powerfeather.menu.CPUFreq.10=10MHz
 esp32s3_powerfeather.menu.CPUFreq.10.build.f_cpu=10000000L
-
-esp32s3_powerfeather.menu.FlashMode.qio=QIO 80MHz
-esp32s3_powerfeather.menu.FlashMode.qio.build.flash_mode=dio
-esp32s3_powerfeather.menu.FlashMode.qio.build.boot=qio
-esp32s3_powerfeather.menu.FlashMode.qio.build.boot_freq=80m
-esp32s3_powerfeather.menu.FlashMode.qio.build.flash_freq=80m
-esp32s3_powerfeather.menu.FlashMode.qio120=QIO 120MHz
-esp32s3_powerfeather.menu.FlashMode.qio120.build.flash_mode=dio
-esp32s3_powerfeather.menu.FlashMode.qio120.build.boot=qio
-esp32s3_powerfeather.menu.FlashMode.qio120.build.boot_freq=120m
-esp32s3_powerfeather.menu.FlashMode.qio120.build.flash_freq=80m
-esp32s3_powerfeather.menu.FlashMode.dio=DIO 80MHz
-esp32s3_powerfeather.menu.FlashMode.dio.build.flash_mode=dio
-esp32s3_powerfeather.menu.FlashMode.dio.build.boot=dio
-esp32s3_powerfeather.menu.FlashMode.dio.build.boot_freq=80m
-esp32s3_powerfeather.menu.FlashMode.dio.build.flash_freq=80m
-
-esp32s3_powerfeather.menu.FlashSize.8M=8MB (64Mb)
-esp32s3_powerfeather.menu.FlashSize.8M.build.flash_size=8MB
 
 esp32s3_powerfeather.menu.UploadSpeed.921600=921600
 esp32s3_powerfeather.menu.UploadSpeed.921600.upload.speed=921600

--- a/boards.txt
+++ b/boards.txt
@@ -28335,3 +28335,195 @@ atd147_s3.menu.EraseFlash.all=Enabled
 atd147_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+# ESP32-S3 PowerFeather
+
+esp32s3_powerfeather.name=ESP32-S3 PowerFeather
+esp32s3_powerfeather.vid.0=0x303a
+esp32s3_powerfeather.pid.0=0x81BB
+
+esp32s3_powerfeather.bootloader.tool=esptool_py
+esp32s3_powerfeather.bootloader.tool.default=esptool_py
+
+esp32s3_powerfeather.upload.tool=esptool_py
+esp32s3_powerfeather.upload.tool.default=esptool_py
+esp32s3_powerfeather.upload.tool.network=esp_ota
+
+esp32s3_powerfeather.upload.maximum_size=1310720
+esp32s3_powerfeather.upload.maximum_data_size=327680
+esp32s3_powerfeather.upload.flags=
+esp32s3_powerfeather.upload.extra_flags=
+esp32s3_powerfeather.upload.use_1200bps_touch=true
+esp32s3_powerfeather.upload.wait_for_upload_port=true
+
+esp32s3_powerfeather.serial.disableDTR=false
+esp32s3_powerfeather.serial.disableRTS=false
+
+esp32s3_powerfeather.build.tarch=xtensa
+esp32s3_powerfeather.build.bootloader_addr=0x0
+esp32s3_powerfeather.build.target=esp32s3
+esp32s3_powerfeather.build.mcu=esp32s3
+esp32s3_powerfeather.build.core=esp32
+esp32s3_powerfeather.build.variant=esp32s3_powerfeather
+esp32s3_powerfeather.build.board=ESP32S3_POWERFEATHER
+
+esp32s3_powerfeather.build.usb_mode=0
+esp32s3_powerfeather.build.cdc_on_boot=1
+esp32s3_powerfeather.build.msc_on_boot=0
+esp32s3_powerfeather.build.dfu_on_boot=0
+esp32s3_powerfeather.build.f_cpu=240000000L
+esp32s3_powerfeather.build.flash_size=8MB
+esp32s3_powerfeather.build.flash_freq=80m
+esp32s3_powerfeather.build.flash_mode=dio
+esp32s3_powerfeather.build.boot=qio
+esp32s3_powerfeather.build.partitions=default
+esp32s3_powerfeather.build.defines=
+esp32s3_powerfeather.build.loop_core=
+esp32s3_powerfeather.build.event_core=
+esp32s3_powerfeather.build.flash_type=qio
+esp32s3_powerfeather.build.psram_type=qspi
+esp32s3_powerfeather.build.memory_type={build.flash_type}_{build.psram_type}
+
+esp32s3_powerfeather.menu.LoopCore.1=Core 1
+esp32s3_powerfeather.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+esp32s3_powerfeather.menu.LoopCore.0=Core 0
+esp32s3_powerfeather.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+esp32s3_powerfeather.menu.EventsCore.1=Core 1
+esp32s3_powerfeather.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+esp32s3_powerfeather.menu.EventsCore.0=Core 0
+esp32s3_powerfeather.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+esp32s3_powerfeather.menu.USBMode.default=USB-OTG (TinyUSB)
+esp32s3_powerfeather.menu.USBMode.default.build.usb_mode=0
+esp32s3_powerfeather.menu.USBMode.hwcdc=Hardware CDC and JTAG
+esp32s3_powerfeather.menu.USBMode.hwcdc.build.usb_mode=1
+
+esp32s3_powerfeather.menu.CDCOnBoot.cdc=Enabled
+esp32s3_powerfeather.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+esp32s3_powerfeather.menu.CDCOnBoot.default=Disabled
+esp32s3_powerfeather.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+esp32s3_powerfeather.menu.MSCOnBoot.default=Disabled
+esp32s3_powerfeather.menu.MSCOnBoot.default.build.msc_on_boot=0
+esp32s3_powerfeather.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+esp32s3_powerfeather.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+esp32s3_powerfeather.menu.DFUOnBoot.default=Disabled
+esp32s3_powerfeather.menu.DFUOnBoot.default.build.dfu_on_boot=0
+esp32s3_powerfeather.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+esp32s3_powerfeather.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+esp32s3_powerfeather.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+esp32s3_powerfeather.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+esp32s3_powerfeather.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+esp32s3_powerfeather.menu.UploadMode.default=UART0 / Hardware CDC
+esp32s3_powerfeather.menu.UploadMode.default.upload.use_1200bps_touch=false
+esp32s3_powerfeather.menu.UploadMode.default.upload.wait_for_upload_port=false
+
+esp32s3_powerfeather.menu.PSRAM.enabled=QSPI PSRAM
+esp32s3_powerfeather.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+esp32s3_powerfeather.menu.PSRAM.enabled.build.psram_type=qspi
+esp32s3_powerfeather.menu.PSRAM.disabled=Disabled
+esp32s3_powerfeather.menu.PSRAM.disabled.build.defines=
+esp32s3_powerfeather.menu.PSRAM.disabled.build.psram_type=qspi
+
+esp32s3_powerfeather.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+esp32s3_powerfeather.menu.PartitionScheme.default.build.partitions=default
+esp32s3_powerfeather.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+esp32s3_powerfeather.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+esp32s3_powerfeather.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+esp32s3_powerfeather.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32s3_powerfeather.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32s3_powerfeather.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+esp32s3_powerfeather.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32s3_powerfeather.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+esp32s3_powerfeather.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32s3_powerfeather.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32s3_powerfeather.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+esp32s3_powerfeather.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+esp32s3_powerfeather.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+esp32s3_powerfeather.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+esp32s3_powerfeather.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+esp32s3_powerfeather.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+esp32s3_powerfeather.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+esp32s3_powerfeather.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+esp32s3_powerfeather.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+esp32s3_powerfeather.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+esp32s3_powerfeather.menu.PartitionScheme.huge_app.build.partitions=huge_app
+esp32s3_powerfeather.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+esp32s3_powerfeather.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+esp32s3_powerfeather.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32s3_powerfeather.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32s3_powerfeather.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
+esp32s3_powerfeather.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
+esp32s3_powerfeather.menu.PartitionScheme.max_app_8MB.upload.maximum_size=8257536
+esp32s3_powerfeather.menu.PartitionScheme.rainmaker=RainMaker
+esp32s3_powerfeather.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32s3_powerfeather.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+esp32s3_powerfeather.menu.CPUFreq.240=240MHz (WiFi)
+esp32s3_powerfeather.menu.CPUFreq.240.build.f_cpu=240000000L
+esp32s3_powerfeather.menu.CPUFreq.160=160MHz (WiFi)
+esp32s3_powerfeather.menu.CPUFreq.160.build.f_cpu=160000000L
+esp32s3_powerfeather.menu.CPUFreq.80=80MHz (WiFi)
+esp32s3_powerfeather.menu.CPUFreq.80.build.f_cpu=80000000L
+esp32s3_powerfeather.menu.CPUFreq.40=40MHz
+esp32s3_powerfeather.menu.CPUFreq.40.build.f_cpu=40000000L
+esp32s3_powerfeather.menu.CPUFreq.20=20MHz
+esp32s3_powerfeather.menu.CPUFreq.20.build.f_cpu=20000000L
+esp32s3_powerfeather.menu.CPUFreq.10=10MHz
+esp32s3_powerfeather.menu.CPUFreq.10.build.f_cpu=10000000L
+
+esp32s3_powerfeather.menu.FlashMode.qio=QIO 80MHz
+esp32s3_powerfeather.menu.FlashMode.qio.build.flash_mode=dio
+esp32s3_powerfeather.menu.FlashMode.qio.build.boot=qio
+esp32s3_powerfeather.menu.FlashMode.qio.build.boot_freq=80m
+esp32s3_powerfeather.menu.FlashMode.qio.build.flash_freq=80m
+esp32s3_powerfeather.menu.FlashMode.qio120=QIO 120MHz
+esp32s3_powerfeather.menu.FlashMode.qio120.build.flash_mode=dio
+esp32s3_powerfeather.menu.FlashMode.qio120.build.boot=qio
+esp32s3_powerfeather.menu.FlashMode.qio120.build.boot_freq=120m
+esp32s3_powerfeather.menu.FlashMode.qio120.build.flash_freq=80m
+esp32s3_powerfeather.menu.FlashMode.dio=DIO 80MHz
+esp32s3_powerfeather.menu.FlashMode.dio.build.flash_mode=dio
+esp32s3_powerfeather.menu.FlashMode.dio.build.boot=dio
+esp32s3_powerfeather.menu.FlashMode.dio.build.boot_freq=80m
+esp32s3_powerfeather.menu.FlashMode.dio.build.flash_freq=80m
+
+esp32s3_powerfeather.menu.FlashSize.8M=8MB (64Mb)
+esp32s3_powerfeather.menu.FlashSize.8M.build.flash_size=8MB
+
+esp32s3_powerfeather.menu.UploadSpeed.921600=921600
+esp32s3_powerfeather.menu.UploadSpeed.921600.upload.speed=921600
+esp32s3_powerfeather.menu.UploadSpeed.115200=115200
+esp32s3_powerfeather.menu.UploadSpeed.115200.upload.speed=115200
+esp32s3_powerfeather.menu.UploadSpeed.256000.windows=256000
+esp32s3_powerfeather.menu.UploadSpeed.256000.upload.speed=256000
+esp32s3_powerfeather.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32s3_powerfeather.menu.UploadSpeed.230400=230400
+esp32s3_powerfeather.menu.UploadSpeed.230400.upload.speed=230400
+esp32s3_powerfeather.menu.UploadSpeed.460800.linux=460800
+esp32s3_powerfeather.menu.UploadSpeed.460800.macosx=460800
+esp32s3_powerfeather.menu.UploadSpeed.460800.upload.speed=460800
+esp32s3_powerfeather.menu.UploadSpeed.512000.windows=512000
+esp32s3_powerfeather.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32s3_powerfeather.menu.DebugLevel.none=None
+esp32s3_powerfeather.menu.DebugLevel.none.build.code_debug=0
+esp32s3_powerfeather.menu.DebugLevel.error=Error
+esp32s3_powerfeather.menu.DebugLevel.error.build.code_debug=1
+esp32s3_powerfeather.menu.DebugLevel.warn=Warn
+esp32s3_powerfeather.menu.DebugLevel.warn.build.code_debug=2
+esp32s3_powerfeather.menu.DebugLevel.info=Info
+esp32s3_powerfeather.menu.DebugLevel.info.build.code_debug=3
+esp32s3_powerfeather.menu.DebugLevel.debug=Debug
+esp32s3_powerfeather.menu.DebugLevel.debug.build.code_debug=4
+esp32s3_powerfeather.menu.DebugLevel.verbose=Verbose
+esp32s3_powerfeather.menu.DebugLevel.verbose.build.code_debug=5
+
+esp32s3_powerfeather.menu.EraseFlash.none=Disabled
+esp32s3_powerfeather.menu.EraseFlash.none.upload.erase_cmd=
+esp32s3_powerfeather.menu.EraseFlash.all=Enabled
+esp32s3_powerfeather.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/variants/esp32s3_powerfeather/pins_arduino.h
+++ b/variants/esp32s3_powerfeather/pins_arduino.h
@@ -1,0 +1,53 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID            0x303A
+#define USB_PID            0x81BB
+#define USB_MANUFACTURER   "PowerFeather"
+#define USB_PRODUCT        "ESP32-S3 PowerFeather"
+#define USB_SERIAL         ""
+
+#define EXTERNAL_NUM_INTERRUPTS 46
+#define NUM_DIGITAL_PINS        23
+#define NUM_ANALOG_INPUTS       13
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
+#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 46)
+
+static const uint8_t ALARM = GPIO_NUM_7;
+static const uint8_t INT =   GPIO_NUM_5;
+
+static const uint8_t LED =   GPIO_NUM_46;
+static const uint8_t BTN =   GPIO_NUM_0;
+static const uint8_t EN =    GPIO_NUM_13;
+
+static const uint8_t TX =    GPIO_NUM_44;
+static const uint8_t RX =    GPIO_NUM_42;
+static const uint8_t TX0 =   GPIO_NUM_43;
+
+static const uint8_t MISO =  GPIO_NUM_41;
+static const uint8_t MOSI =  GPIO_NUM_40;
+static const uint8_t SCK =   GPIO_NUM_39;
+
+static const uint8_t SCL =   GPIO_NUM_36;
+static const uint8_t SDA =   GPIO_NUM_35;
+
+static const uint8_t A0 =    GPIO_NUM_10;
+static const uint8_t A1 =    GPIO_NUM_9;
+static const uint8_t A2 =    GPIO_NUM_8;
+static const uint8_t A3 =    GPIO_NUM_3;
+static const uint8_t A4 =    GPIO_NUM_2;
+static const uint8_t A5 =    GPIO_NUM_1;
+
+static const uint8_t D5 =    GPIO_NUM_15;
+static const uint8_t D6 =    GPIO_NUM_16;
+static const uint8_t D9 =    GPIO_NUM_17;
+static const uint8_t D10 =   GPIO_NUM_18;
+static const uint8_t D11 =   GPIO_NUM_45;
+static const uint8_t D12 =   GPIO_NUM_12;
+static const uint8_t D13 =   GPIO_NUM_11;
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32s3_powerfeather/pins_arduino.h
+++ b/variants/esp32s3_powerfeather/pins_arduino.h
@@ -9,14 +9,6 @@
 #define USB_PRODUCT        "ESP32-S3 PowerFeather"
 #define USB_SERIAL         ""
 
-#define EXTERNAL_NUM_INTERRUPTS 46
-#define NUM_DIGITAL_PINS        23
-#define NUM_ANALOG_INPUTS       13
-
-#define analogInputToDigitalPin(p)  (((p)<20)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
-#define digitalPinHasPWM(p)         (p < 46)
-
 static const uint8_t ALARM = 7;
 static const uint8_t INT =   5;
 
@@ -28,6 +20,7 @@ static const uint8_t TX =    44;
 static const uint8_t RX =    42;
 static const uint8_t TX0 =   43;
 
+static const uint8_t SS =    -1;
 static const uint8_t MISO =  41;
 static const uint8_t MOSI =  40;
 static const uint8_t SCK =   39;
@@ -49,5 +42,8 @@ static const uint8_t D10 =   18;
 static const uint8_t D11 =   45;
 static const uint8_t D12 =   12;
 static const uint8_t D13 =   11;
+
+#define LED_BUILTIN 46
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 #endif /* Pins_Arduino_h */

--- a/variants/esp32s3_powerfeather/pins_arduino.h
+++ b/variants/esp32s3_powerfeather/pins_arduino.h
@@ -17,37 +17,37 @@
 #define digitalPinToInterrupt(p)    (((p)<48)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 46)
 
-static const uint8_t ALARM = GPIO_NUM_7;
-static const uint8_t INT =   GPIO_NUM_5;
+static const uint8_t ALARM = 7;
+static const uint8_t INT =   5;
 
-static const uint8_t LED =   GPIO_NUM_46;
-static const uint8_t BTN =   GPIO_NUM_0;
-static const uint8_t EN =    GPIO_NUM_13;
+static const uint8_t LED =   46;
+static const uint8_t BTN =   0;
+static const uint8_t EN =    13;
 
-static const uint8_t TX =    GPIO_NUM_44;
-static const uint8_t RX =    GPIO_NUM_42;
-static const uint8_t TX0 =   GPIO_NUM_43;
+static const uint8_t TX =    44;
+static const uint8_t RX =    42;
+static const uint8_t TX0 =   43;
 
-static const uint8_t MISO =  GPIO_NUM_41;
-static const uint8_t MOSI =  GPIO_NUM_40;
-static const uint8_t SCK =   GPIO_NUM_39;
+static const uint8_t MISO =  41;
+static const uint8_t MOSI =  40;
+static const uint8_t SCK =   39;
 
-static const uint8_t SCL =   GPIO_NUM_36;
-static const uint8_t SDA =   GPIO_NUM_35;
+static const uint8_t SCL =   36;
+static const uint8_t SDA =   35;
 
-static const uint8_t A0 =    GPIO_NUM_10;
-static const uint8_t A1 =    GPIO_NUM_9;
-static const uint8_t A2 =    GPIO_NUM_8;
-static const uint8_t A3 =    GPIO_NUM_3;
-static const uint8_t A4 =    GPIO_NUM_2;
-static const uint8_t A5 =    GPIO_NUM_1;
+static const uint8_t A0 =    10;
+static const uint8_t A1 =    9;
+static const uint8_t A2 =    8;
+static const uint8_t A3 =    3;
+static const uint8_t A4 =    2;
+static const uint8_t A5 =    1;
 
-static const uint8_t D5 =    GPIO_NUM_15;
-static const uint8_t D6 =    GPIO_NUM_16;
-static const uint8_t D9 =    GPIO_NUM_17;
-static const uint8_t D10 =   GPIO_NUM_18;
-static const uint8_t D11 =   GPIO_NUM_45;
-static const uint8_t D12 =   GPIO_NUM_12;
-static const uint8_t D13 =   GPIO_NUM_11;
+static const uint8_t D5 =    15;
+static const uint8_t D6 =    16;
+static const uint8_t D9 =    17;
+static const uint8_t D10 =   18;
+static const uint8_t D11 =   45;
+static const uint8_t D12 =   12;
+static const uint8_t D13 =   11;
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change

Adds a new `variant` directory for `esp32s3_powerfeather`, under which the `pins_arduino.h` is created.
Entries for `esp32s3_powerfeather` in `boards.txt` are added.

## Tests scenarios


- [x] `pins_arduino.h` is ok
- [x] `boards.txt` entries are ok

## Related links
Website: https://www.powerfeather.dev/
Allocation for PID under Espressif VID used in this PR: https://github.com/espressif/usb-pids/pull/123
