### PR TITLE
add tinyuf2 partitions csv

### DIFF
--- a/tools/partitions/tinyuf2-partitions-16MB-noota.csv
+++ b/tools/partitions/tinyuf2-partitions-16MB-noota.csv
@@ -1,0 +1,9 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,,         0x8000, 4K
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,  ota_0,   0x10000,  4096K,
+uf2,      app,  factory,0x410000,  256K,
+ffat,     data, fat,    0x450000,  11968K,

--- a/tools/partitions/tinyuf2-partitions-16MB.csv
+++ b/tools/partitions/tinyuf2-partitions-16MB.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,,         0x8000, 4K
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,  ota_0,   0x10000,  2048K,
+ota_1,    app,  ota_1,  0x210000,  2048K,
+uf2,      app,  factory,0x410000,  256K,
+ffat,     data, fat,    0x450000,  11968K,

--- a/tools/partitions/tinyuf2-partitions-4MB-noota.csv
+++ b/tools/partitions/tinyuf2-partitions-4MB-noota.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,          0x8000, 4K
+
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,  ota_0,   0x10000,  2816K,
+uf2,      app,  factory,0x2d0000,  256K,
+ffat,     data, fat,    0x310000,  960K,

--- a/tools/partitions/tinyuf2-partitions-4MB.csv
+++ b/tools/partitions/tinyuf2-partitions-4MB.csv
@@ -1,0 +1,11 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,          0x8000, 4K
+
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,  ota_0,   0x10000,  1408K,
+ota_1,    app,  ota_1,  0x170000,  1408K,
+uf2,      app,  factory,0x2d0000,  256K,
+ffat,     data, fat,    0x310000,  960K,

--- a/tools/partitions/tinyuf2-partitions-8MB-noota.csv
+++ b/tools/partitions/tinyuf2-partitions-8MB-noota.csv
@@ -1,0 +1,9 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,,         0x8000, 4K
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,    ota_0,   0x10000,  4096K,
+uf2,      app,  factory,0x410000,  256K,
+ffat,     data, fat,    0x450000,  3776K,

--- a/tools/partitions/tinyuf2-partitions-8MB.csv
+++ b/tools/partitions/tinyuf2-partitions-8MB.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,,         0x8000, 4K
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,    ota_0,   0x10000,  2048K,
+ota_1,    app,    ota_1,  0x210000,  2048K,
+uf2,      app,  factory,0x410000,  256K,
+ffat,     data, fat,    0x450000,  3776K,


### PR DESCRIPTION
## Description of Change
TinyUF2 is gettting a bit more popular with ESP32 S2/S3, however, tinyuf2 partition is currently treated as custom paritions and stored in `variants/{board}` folder. All Adafruit S2/S3 boards make use of tinyuf2, this causes quite a bit of csv file duplication within the repo.

This PR adding commonly used tinyuf2 partitions will help to reduce csv duplication and make it easier to add new tinyuf2-enabled boards. 

## Tests scenarios
Nothing to test, will update Adafruit to use these and removed all duplicated csv in adafruit boards as follow-up later on.

@ladyada 