### PR TITLE
correct adafruit metro esp32s3 pins for rev B

### DIFF
--- a/variants/adafruit_metro_esp32s3/pins_arduino.h
+++ b/variants/adafruit_metro_esp32s3/pins_arduino.h
@@ -31,10 +31,10 @@ static const uint8_t RX = 41;
 static const uint8_t SDA = 47;
 static const uint8_t SCL = 48;
 
-static const uint8_t SS   = 21;
-static const uint8_t MOSI = 35;
-static const uint8_t SCK  = 36;
-static const uint8_t MISO = 37;
+static const uint8_t SS   = 45;
+static const uint8_t MOSI = 42;
+static const uint8_t SCK  = 39;
+static const uint8_t MISO = 21;
 
 static const uint8_t A0 = 14;
 static const uint8_t A1 = 15;


### PR DESCRIPTION
## Description of Change
This PR correct the SPI pin for Adafruit Metro ESP32S3 revB. https://www.adafruit.com/product/5500

## Tests scenarios
Tested with actual revB hardware

@ladyada 