### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -39,7 +39,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-b6a66b7d8c"
+              "version": "idf-release_v5.1-3662303f31"
             },
             {
               "packager": "esp32",
@@ -97,63 +97,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-b6a66b7d8c",
+          "version": "idf-release_v5.1-3662303f31",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a",
-              "archiveFileName": "esp32-arduino-libs-9ceb4a6f9bf33c9b72c95b647ad67d45f25fd01a.zip",
-              "checksum": "SHA-256:a7ba8799757ab5c59501895f936ce77cdb0b2599c3a63b437f9a2ca686207abe",
-              "size": "367803590"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6",
+              "archiveFileName": "esp32-arduino-libs-e0b2e0dfdda2bff877b9498dcf4c1ac372d8e8a6.zip",
+              "checksum": "SHA-256:c0bcfb5b40db846969e3427c6313f3563256fc3e4e51bb2ce914f332aa129317",
+              "size": "352357755"
             }
           ]
         },


### PR DESCRIPTION
lib-builder: master e86b30aesp-idf: release/v5.1 3662303f31arduino: master bb72b02etinyusb: master d6b8b3515chmorgan__esp-libhelix-mp3: 1.0.3espressif__cbor: 0.6.0~1espressif__esp-dl:espressif__esp-dsp: 1.4.9espressif__esp-nn: 1.0.2espressif__esp-sr: 1.5.1espressif__esp-tflite-micro: 1.2.0espressif__esp-zboss-lib: 1.0.3espressif__esp-zigbee-lib: 1.0.4espressif__esp32-camera:espressif__esp_diag_data_store: 1.0.1espressif__esp_diagnostics: 1.0.1espressif__esp_insights: 1.0.1espressif__esp_rainmaker: 1.0.0espressif__esp_schedule: 1.0.1espressif__esp_secure_cert_mgr: 2.4.1espressif__jsmn: 1.1.0espressif__json_generator: 1.1.1espressif__json_parser: 1.0.3espressif__mdns: 1.2.1espressif__qrcode: 0.1.0~1espressif__rmaker_common: 1.4.3joltwallet__littlefs: 1.10.2
