### PR TITLE
Added the Google Analytics ID in the configuration file

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,3 +67,6 @@ html_static_path = ['_static']
 
 # Style
 # pygments_style = "sphinx"
+
+# Tracking ID for Google Analytics
+google_analytics_id = 'G-F58JM78930'


### PR DESCRIPTION
## Description of Change

This PR adds the Google Analytics ID to the `conf.py` file. This will be used for documentation analytics.

## Tests scenarios

N/A

## Related links

N/A
