### PR TITLE
Added KEY_SPACE definition to USBHIDKeyboard.h

### DIFF
--- a/libraries/USB/src/USBHIDKeyboard.h
+++ b/libraries/USB/src/USBHIDKeyboard.h
@@ -58,6 +58,7 @@ typedef union {
 #define KEY_RIGHT_SHIFT 0x85
 #define KEY_RIGHT_ALT   0x86
 #define KEY_RIGHT_GUI   0x87
+#define KEY_SPACE       0x20
 
 #define KEY_UP_ARROW    0xDA
 #define KEY_DOWN_ARROW  0xD9


### PR DESCRIPTION
This commit introduces a new key definition for the space key in the USBHIDKeyboard.h file. Previously, there was no direct way to refer to the space key in the HID keyboard interface. Users had to use the ASCII value '0x20', which was not intuitive and inconsistent with how other keys are handled.

By defining `KEY_SPACE` as `0x20`, this commit aligns the handling of the space key with other special keys in the library, making the code more readable and user-friendly. This change simplifies the process of programming keyboard interactions, especially for beginners, by allowing them to use `Keyboard.press(KEY_SPACE);` in a manner consistent with other keys.

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
