### PR TITLE
Fix ADC detach bus calibration handle error when not existing.

### DIFF
--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -69,17 +69,19 @@ static bool adcDetachBus(void * pin){
             return false;
         }
         adc_handle[adc_unit].adc_oneshot_handle = NULL;
+        if(adc_handle[adc_unit].adc_cali_handle != NULL){
     #if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED        
-        err = adc_cali_delete_scheme_curve_fitting(adc_handle[adc_unit].adc_cali_handle);
-        if(err != ESP_OK){
-            return false;
-        }
+            err = adc_cali_delete_scheme_curve_fitting(adc_handle[adc_unit].adc_cali_handle);
+            if(err != ESP_OK){
+                return false;
+            }
     #elif !defined(CONFIG_IDF_TARGET_ESP32H2)
-        err = adc_cali_delete_scheme_line_fitting(adc_handle[adc_unit].adc_cali_handle);
-        if(err != ESP_OK){
-            return false;
-        }
+            err = adc_cali_delete_scheme_line_fitting(adc_handle[adc_unit].adc_cali_handle);
+            if(err != ESP_OK){
+                return false;
+            }
     #endif
+        }
         adc_handle[adc_unit].adc_cali_handle = NULL;
     }
     return true;
@@ -220,6 +222,7 @@ esp_err_t __analogInit(uint8_t pin, adc_channel_t channel, adc_unit_t adc_unit){
             return err;
         }
     }
+    perimanSetBusDeinit(ESP32_BUS_TYPE_ADC_ONESHOT, adcDetachBus);
 
     if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_ADC_ONESHOT, (void *)(pin+1), adc_unit, channel)){
         adcDetachBus((void *)(pin+1));
@@ -236,7 +239,6 @@ esp_err_t __analogInit(uint8_t pin, adc_channel_t channel, adc_unit_t adc_unit){
         log_e("adc_oneshot_config_channel failed with error: %d", err);
         return err;
     }
-    perimanSetBusDeinit(ESP32_BUS_TYPE_ADC_ONESHOT, adcDetachBus);
     return ESP_OK;
 }
 


### PR DESCRIPTION
## Description of Change
Added a check if calibration handle of ADC unit exists before deleting it.
Fixes error when reusing analog pin for different peripheral and no there analog pins are used.

## Tests scenarios
Tested on ESP32C3.

## Related links