### PR TITLE
fix: pin_remap: make periman APIs private and non-remapped

### DIFF
--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -86,7 +86,6 @@ void yield(void);
 #include "esp32-hal-psram.h"
 #include "esp32-hal-rgb-led.h"
 #include "esp32-hal-cpu.h"
-#include "esp32-hal-periman.h"
 
 void analogWrite(uint8_t pin, int value);
 void analogWriteFrequency(uint8_t pin, uint32_t freq);

--- a/cores/esp32/io_pin_remap.h
+++ b/cores/esp32/io_pin_remap.h
@@ -71,16 +71,6 @@ int8_t gpioNumberToDigitalPin(int8_t gpioNumber);
 #define pinMatrixOutAttach(pin, function, invertOut, invertEnable)  pinMatrixOutAttach(digitalPinToGPIONumber(pin), function, invertOut, invertEnable)
 #define pinMatrixOutDetach(pin, invertOut, invertEnable)            pinMatrixOutDetach(digitalPinToGPIONumber(pin), invertOut, invertEnable)
 
-// cores/esp32/esp32-hal-periman.h
-#define perimanSetPinBus(pin, type, bus, bus_num, bus_channel)      perimanSetPinBus(digitalPinToGPIONumber(pin), type, bus, bus_num, bus_channel)
-#define perimanGetPinBus(pin, type)                                 perimanGetPinBus(digitalPinToGPIONumber(pin), type)
-#define perimanGetPinBusType(pin)                                   perimanGetPinBusType(digitalPinToGPIONumber(pin))
-#define perimanGetPinBusNum(pin)                                    perimanGetPinBusNum(digitalPinToGPIONumber(pin))
-#define perimanGetPinBusChannel(pin)                                perimanGetPinBusChannel(digitalPinToGPIONumber(pin))
-#define perimanPinIsValid(pin)                                      perimanPinIsValid(digitalPinToGPIONumber(pin))
-#define perimanSetPinBusExtraType(pin, extra_type)                  perimanSetPinBusExtraType(digitalPinToGPIONumber(pin), extra_type)
-#define perimanGetPinBusExtraType(pin)                              perimanGetPinBusExtraType(digitalPinToGPIONumber(pin))
-
 // cores/esp32/esp32-hal-rgb-led.h
 #define neopixelWrite(pin, red_val, green_val, blue_val)    neopixelWrite(digitalPinToGPIONumber(pin), red_val, green_val, blue_val)
 

--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -11,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Disable the automatic pin remapping of the API calls in this file
+#define ARDUINO_CORE_BUILD
+
 #include "sd_diskio.h"
 #include "esp_system.h"
 #include "esp32-hal-periman.h"
@@ -742,7 +746,7 @@ uint8_t sdcard_init(uint8_t cs, SPIClass * spi, int hz)
     card->base_path = NULL;
     card->frequency = hz;
     card->spi = spi;
-    card->ssPin = cs;
+    card->ssPin = digitalPinToGPIONumber(cs);
 
     card->supports_crc = true;
     card->type = CARD_NONE;


### PR DESCRIPTION
Disabling the periman APIs from remap has a negligible effect on the source: the core is already excluded from remapping, as are most of the libraries. It's also expected to be somewhat private, not exposed by default via `Arduino.h`.

This patch removes references to those APIs from both `esp32-hal.h` and `io_pin_remap.h`, adjusting the relevant libraries.