### PR TITLE
Adding a note to allow access to PR secrets into PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@
 2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
 3. [ ] Please **update relevant Documentation** if applicable
 4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
+5. [ ] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request
 
 *This entire section above can be deleted if all items are checked.*
 


### PR DESCRIPTION
## Description of Change
Adding a note to the Pull Request Template.

**Reason:**
Sometimes maintainers need to take over of opened Pull Requests and they are blocked by not provided permissions.

## Tests scenarios
N/A

## Related links
N/A
