### PR TITLE
Add 120Mhz cpu frequency option to setCpuFrequencyMhz() 

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -430,6 +430,8 @@ esp32c6.menu.PartitionScheme.custom.upload.maximum_size=16777216
 
 esp32c6.menu.CPUFreq.160=160MHz (WiFi)
 esp32c6.menu.CPUFreq.160.build.f_cpu=160000000L
+esp32c6.menu.CPUFreq.120=120MHz (WiFi)
+esp32c6.menu.CPUFreq.120.build.f_cpu=120000000L
 esp32c6.menu.CPUFreq.80=80MHz (WiFi)
 esp32c6.menu.CPUFreq.80.build.f_cpu=80000000L
 esp32c6.menu.CPUFreq.40=40MHz

--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -188,11 +188,11 @@ bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz){
     }
 #endif
 #ifndef CONFIG_IDF_TARGET_ESP32H2
-    if(cpu_freq_mhz > xtal && cpu_freq_mhz != 240 && cpu_freq_mhz != 160 && cpu_freq_mhz != 80){
+    if(cpu_freq_mhz > xtal && cpu_freq_mhz != 240 && cpu_freq_mhz != 160 && cpu_freq_mhz != 120 && cpu_freq_mhz != 80){
         if(xtal >= RTC_XTAL_FREQ_40M){
-            log_e("Bad frequency: %u MHz! Options are: 240, 160, 80, %u, %u and %u MHz", cpu_freq_mhz, xtal, xtal/2, xtal/4);
+            log_e("Bad frequency: %u MHz! Options are: 240, 160, 120, 80, %u, %u and %u MHz", cpu_freq_mhz, xtal, xtal/2, xtal/4);
         } else {
-            log_e("Bad frequency: %u MHz! Options are: 240, 160, 80, %u and %u MHz", cpu_freq_mhz, xtal, xtal/2);
+            log_e("Bad frequency: %u MHz! Options are: 240, 160, 120, 80, %u and %u MHz", cpu_freq_mhz, xtal, xtal/2);
         }
         return false;
     }


### PR DESCRIPTION
## Description of Change
Added 120 MHz option to `setCpuFrequencyMhz()` as ESP32-C6 and ESP32-C2 supports this frequency.
Also added 120 MHz option for ESP32-C6 in the tools menu.

## Tests scenarios
Tested locally on ESP32-C6.

## Related links
Closes #8955