### PR TITLE
UpdateClass::setMD5 store expected md5 in lowercase

### DIFF
--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -277,7 +277,7 @@ bool UpdateClass::setMD5(const char * expected_md5){
     {
         return false;
     }
-    _target_md5 = expected_md5;
+    _target_md5 = expected_md5.toLowerCase();
     return true;
 }
 

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -277,7 +277,8 @@ bool UpdateClass::setMD5(const char * expected_md5){
     {
         return false;
     }
-    _target_md5 = expected_md5.toLowerCase();
+    _target_md5 = expected_md5;
+    _target_md5.toLowerCase();
     return true;
 }
 


### PR DESCRIPTION
## Description of Change
As calculated MD5 checksum is always lowercase, force `UpdateClass::setMD5` to store the expected MD5 in lowercase as some servers may return the MD5 in uppercase.

## Tests scenarios
Tested forcing Arduino OTA to receive Uppercase MD5 by espota.py. Working as expected with MD5 lowercase or uppercase.

## Related links
Closes #8945 