### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-e60b0235ad"
+              "version": "idf-release_v5.1-8a6d244a21"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-e60b0235ad",
+          "version": "idf-release_v5.1-8a6d244a21",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
-              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
-              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
-              "size": "352532053"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
+              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
+              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
+              "size": "352534299"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-4fe15460ab"
+              "version": "idf-release_v5.1-bcf1645e44"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-4fe15460ab",
+          "version": "idf-release_v5.1-bcf1645e44",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
-              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
-              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
-              "size": "352502200"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
+              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
+              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
+              "size": "352519413"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-c57b352725"
+              "version": "idf-release_v5.1-bbd8d13f93"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-c57b352725",
+          "version": "idf-release_v5.1-bbd8d13f93",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
-              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
-              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
-              "size": "352620488"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
+              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
+              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
+              "size": "352673644"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-8a6d244a21"
+              "version": "idf-release_v5.1-36ca229332"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-8a6d244a21",
+          "version": "idf-release_v5.1-36ca229332",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/8f182e189045367e6a3397273af2e2f322ff4dc0",
-              "archiveFileName": "esp32-arduino-libs-8f182e189045367e6a3397273af2e2f322ff4dc0.zip",
-              "checksum": "SHA-256:e008f9169702d30e375ab17270b27b2ac4b2005a9bc37ab0a643c25c25582eee",
-              "size": "352534299"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
+              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
+              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
+              "size": "352534325"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-3662303f31"
+              "version": "idf-release_v5.1-4fe15460ab"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-3662303f31",
+          "version": "idf-release_v5.1-4fe15460ab",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7504ef548d7280003452c84f15450eeb8027e6c3",
+              "archiveFileName": "esp32-arduino-libs-7504ef548d7280003452c84f15450eeb8027e6c3.zip",
+              "checksum": "SHA-256:d8bc55d6ecb038bc09516370b696b5bb024b9ad89421ce25ef40ec30b4656ef1",
+              "size": "352502200"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-fa7383162f"
+              "version": "idf-release_v5.1-b38ee33b6d"
             },
             {
               "packager": "esp32",
@@ -62,7 +62,7 @@
             {
               "packager": "esp32",
               "name": "xtensa-esp-elf-gdb",
-              "version": "12.1_20221002"
+              "version": "12.1_20231023"
             },
             {
               "packager": "esp32",
@@ -72,7 +72,7 @@
             {
               "packager": "esp32",
               "name": "riscv32-esp-elf-gdb",
-              "version": "12.1_20221002"
+              "version": "12.1_20231023"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-fa7383162f",
+          "version": "idf-release_v5.1-b38ee33b6d",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
-              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
-              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
-              "size": "352534246"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
+              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
+              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
+              "size": "352600793"
             }
           ]
         },
@@ -353,63 +353,63 @@
         },
         {
           "name": "xtensa-esp-elf-gdb",
-          "version": "12.1_20221002",
+          "version": "12.1_20231023",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:d056f2435ef05cccadac5d8fcefa3efd8f8c456c3d853f5eba1edb501acfe4f7",
-              "size": "32006939"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:d0743ec43cd92c35452a9097f7863281de4e72f04120d63cfbcf9d591a373529",
+              "size": "36942094"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:7fc9674cc4f4c5e7bc94ca05bc5deaaa4c4bbcc972a9caee6fcd6a872c804c02",
-              "size": "32227425"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:bc1fac0366c6a08e26c45896ca21c8c90efc2cdd431b8ba084e8772e15502d0e",
+              "size": "37134601"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:68118ff36e9dd2284d92a7a529d0e2a8d20f6426036a0736fa1147935614ece2",
-              "size": "29960020"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:25efc51d52b71f097ccec763c5c885c8f5026b432fec4b5badd6a5f36fe34d04",
+              "size": "34579556"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:cf6cac8ed70726d390d30713d537754544872715e1b70a8a4a28b5dc616193b9",
-              "size": "30877187"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:e0af0b3b4a6b29a843cd5f47e331a966d9258f7d825b4656c6251490f71b05b2",
+              "size": "35676578"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "checksum": "SHA-256:417fcf8d1b596b9481603d6987def1d6cfcebdb9739f53940887334a7de855fa",
-              "size": "45941853"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "checksum": "SHA-256:bd146fd99a52b2d71c7ce0f62b9e18f3423d6cae7b2b2c954046b0dd7a23142f",
+              "size": "52863941"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "checksum": "SHA-256:95d6ed2311d6a72bf349e152d096aeeb151f9c5989bfa3120facb1c99e879196",
-              "size": "27596410"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:5edc76565bf9d2fadf24e443ddf3df7567354f336a65d4af5b2ee805cdfcec24",
+              "size": "33504923"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:642b6a135c38ff1d5e54ad2c29469b769f8e1b101dab363d06101b02284bb979",
-              "size": "27387730"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:ea4f3ee6b95ad1ad2e07108a21a50037a3e64a420cdeb34b2ba95d612faed898",
+              "size": "31068749"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:2d958570ff6aa69ed32cbb076cbaf303349a26b3301a7c4628be8d7ad39cf9f1",
-              "size": "29561472"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:13bb97f39173948d1cfb6e651d9b335ea9d52f1fdd0dda1eda3a2d23d8c63644",
+              "size": "33514906"
             }
           ]
         },
@@ -477,63 +477,63 @@
         },
         {
           "name": "riscv32-esp-elf-gdb",
-          "version": "12.1_20221002",
+          "version": "12.1_20231023",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:f0cf0821eaac7e8cf2c63b14f2b69d612f4f8c266b29d02d5547b7d7cbbd0e11",
-              "size": "32035173"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:2c78b806be176b1e449e07ff83429d38dfc39a13f89a127ac1ffa6c1230537a0",
+              "size": "36630145"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:6812344dfb5c50a81d2fd8354463516f0aa5f582e8ab406cbaeca8722b45fa94",
-              "size": "32362642"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:33f80117c8777aaff9179e27953e41764c5c46b3c576dc96a37ecc7a368807ec",
+              "size": "36980143"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:b73042b8e1df5a3fc8008ec3cd000ef579f155d72a66c6ade1d48906d843e738",
-              "size": "30580290"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:292e6ec0a9381c1480bbadf5caae25e86428b68fb5d030c9be7deda5e7f070e0",
+              "size": "34950318"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:3f07a1b8dc87127a1a6bec6fbace4f8daca44755356f0692e9a5d4c8c4bfd81d",
-              "size": "31309798"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:68a25fbcfc6371ec4dbe503ec92211977eb2006f0c29e67dbce6b93c70c6b7ec",
+              "size": "35801607"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "checksum": "SHA-256:bb139229f9a4998cab9cfb617d3ecb05b77cbfa9a3a59c54969035f1b4007487",
-              "size": "46120661"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "checksum": "SHA-256:322c722e6c12225ed8cd97f95a0375105756dc5113d369958ce0858ad1a90257",
+              "size": "52618688"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "checksum": "SHA-256:f6513b57f28245497f9c39a201f3f6444d4180e16b39765c629e01036286c0e6",
-              "size": "27662484"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:c2224b3a8d02451c530cf004c29653292d963a1b4021b4b472b862b6dbe97e0b",
+              "size": "33149392"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:8287fa2891e8d032e8283210048d653705791cda31504369418288d3e4753dd6",
-              "size": "27839143"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:4b42149a99dd87ee7e6dde25c99bad966c7f964253fa8f771593d7cef69f5602",
+              "size": "31635103"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:9debae1135df8f5868a9d945468f0480cdaab25f77ead6a55cc85142c4487abd",
-              "size": "29404989"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:728231546ad5006d34463f972658b2a89e52f660a42abab08a29bedd4a8046ad",
+              "size": "33400816"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-3629f070b6"
+              "version": "idf-release_v5.1-c57b352725"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-3629f070b6",
+          "version": "idf-release_v5.1-c57b352725",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
-              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
-              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
-              "size": "352620450"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5505abd316378a14806cd13e788a971daaf3d080",
+              "archiveFileName": "esp32-arduino-libs-5505abd316378a14806cd13e788a971daaf3d080.zip",
+              "checksum": "SHA-256:42cdad096b0fb2064f9820c1a4909072b43145be9f1ae0ef083fc5d9cfe033ad",
+              "size": "352620488"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-b38ee33b6d"
+              "version": "idf-release_v5.1-3629f070b6"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-b38ee33b6d",
+          "version": "idf-release_v5.1-3629f070b6",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/75606b7e7908bcfa3ec39a5566b1051385a0c46c",
-              "archiveFileName": "esp32-arduino-libs-75606b7e7908bcfa3ec39a5566b1051385a0c46c.zip",
-              "checksum": "SHA-256:e1da421782a85ed73fd57c64d1d2ee015ef2ba6e2744d5294ad5700aa1dc3dd5",
-              "size": "352600793"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/78bdc4a4fff07332df0241640d990eed8f404ec9",
+              "archiveFileName": "esp32-arduino-libs-78bdc4a4fff07332df0241640d990eed8f404ec9.zip",
+              "checksum": "SHA-256:2d9b7c5441057d53186880c57f8246c196e62c7da5fcf4e40e5122dbb8a121f5",
+              "size": "352620450"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-36ca229332"
+              "version": "idf-release_v5.1-fa7383162f"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-36ca229332",
+          "version": "idf-release_v5.1-fa7383162f",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a1db5a085ca35e6ad4af651d5c4797b68f04b27e",
-              "archiveFileName": "esp32-arduino-libs-a1db5a085ca35e6ad4af651d5c4797b68f04b27e.zip",
-              "checksum": "SHA-256:f6d612e0d641cf83fca714e3accf389c0e3efd21016a44300f6d3ad6f36473b5",
-              "size": "352534325"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5028933cece5559010e55d74838bc99813c0c6b0",
+              "archiveFileName": "esp32-arduino-libs-5028933cece5559010e55d74838bc99813c0c6b0.zip",
+              "checksum": "SHA-256:3049bcc47f44e34fab609f647c61f86dcbc85a96ebdaf5ba3cc905ecac894105",
+              "size": "352534246"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-bcf1645e44"
+              "version": "idf-release_v5.1-e60b0235ad"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-bcf1645e44",
+          "version": "idf-release_v5.1-e60b0235ad",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/962bdad05d738f1e583dc59f55cfa3846da731d4",
-              "archiveFileName": "esp32-arduino-libs-962bdad05d738f1e583dc59f55cfa3846da731d4.zip",
-              "checksum": "SHA-256:954a2a941664316d5051f063d82e4de1f48a8fe3d468f40dbb75a577a147183c",
-              "size": "352519413"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/d2ae939f283082eea311c9e7485edd0ccef15dfc",
+              "archiveFileName": "esp32-arduino-libs-d2ae939f283082eea311c9e7485edd0ccef15dfc.zip",
+              "checksum": "SHA-256:8c34781d42965471a6aee3d0de7a155189c6298480c85a3414583d3da2bbfa21",
+              "size": "352532053"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-bbd8d13f93"
+              "version": "idf-release_v5.1-db1e54a0c5"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-bbd8d13f93",
+          "version": "idf-release_v5.1-db1e54a0c5",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1fd511c34cd97dcdf7abbd95e40d20e68ca0f020",
-              "archiveFileName": "esp32-arduino-libs-1fd511c34cd97dcdf7abbd95e40d20e68ca0f020.zip",
-              "checksum": "SHA-256:d78a87f27da6a4c917e97a9e71ae80dba0aca232063120ff2def6ef92413d72e",
-              "size": "352673644"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9d43de2d661e014fea28dd590ed936ac0e06cc59",
+              "archiveFileName": "esp32-arduino-libs-9d43de2d661e014fea28dd590ed936ac0e06cc59.zip",
+              "checksum": "SHA-256:fa61327585c92ffd20d2970940c9a71da269f44f072ca4622473f3d3284ba7d8",
+              "size": "352652327"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 2fcb387
esp-idf: release/v5.1 4fe15460ab
arduino: master 51cb9277
tinyusb: master 338ff2dab
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.10
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.6.0
espressif__esp-tflite-micro: 1.2.0
espressif__esp-zboss-lib: 1.0.5
espressif__esp-zigbee-lib: 1.0.5
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.1
espressif__esp_insights: 1.0.1
espressif__esp_rainmaker: 1.0.0
espressif__esp_schedule: 1.0.1
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__mdns: 1.2.1
espressif__qrcode: 0.1.0~1
espressif__rmaker_common: 1.4.4
joltwallet__littlefs: 1.11.0
```
