### PR TITLE
3.0.0-alpha3 escaping fix

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -147,7 +147,7 @@ recipe.hooks.prebuild.6.pattern.windows=cmd /c if not exist "{build.path}\build_
 # Set -DARDUINO_CORE_BUILD only on core file compilation
 file_opts.path={build.path}/file_opts
 recipe.hooks.prebuild.set_core_build_flag.pattern=/usr/bin/env bash -c ": > '{file_opts.path}'"
-recipe.hooks.core.prebuild.set_core_build_flag.pattern=/usr/bin/env bash -c "echo '-DARDUINO_CORE_BUILD' > '{file_opts.path}'"
+recipe.hooks.core.prebuild.set_core_build_flag.pattern=/usr/bin/env bash -c "echo -DARDUINO_CORE_BUILD > '{file_opts.path}'"
 recipe.hooks.core.postbuild.set_core_build_flag.pattern=/usr/bin/env bash -c ": > '{file_opts.path}'"
 
 recipe.hooks.prebuild.set_core_build_flag.pattern.windows=cmd /c type nul > "{file_opts.path}"


### PR DESCRIPTION
## Description of Change

On a Linux host the **alpha3** gives a build error like this:

```
>: -c: line 1: unexpected EOF while looking for matching `''
>: -c: line 2: syntax error: unexpected end of file
```

**alpha2** was fine.

The issue looks very similar to #8424

The idea of this fix was taken from that PR #8433 .

