### PR TITLE
Fixes CI error in reset_reason.rst

### DIFF
--- a/docs/source/api/reset_reason.rst
+++ b/docs/source/api/reset_reason.rst
@@ -15,5 +15,5 @@ To get started with Reset Reason, you can try:
 Reset Reason
 ************
 
-.. literalinclude:: ../../../libraries/ESP32/examples/ResetReason/ResetReason.ino
+.. literalinclude:: ../../../libraries/ESP32/examples/ResetReason/ResetReason/ResetReason.ino
     :language: arduino


### PR DESCRIPTION
## Description of Change
CI is failing due to a change in ResetReason.ino folder.

/home/runner/work/arduino-esp32/arduino-esp32/docs/source/api/reset_reason.rst:18:Include file '/home/runner/work/arduino-esp32/arduino-esp32/libraries/ESP32/examples/ResetReason/ResetReason.ino' not found or reading it failed
make: *** [Makefile:28: html] Error 2
Error: Process completed with exit code 2.


## Tests scenarios
CI Testing only.

## Related links
None