### PR TITLE
CI: Adding Shared GitHub DangerJS

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -1,0 +1,22 @@
+name: DangerJS Pull Request linter
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  pull-request-style-linter:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out PR head
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: DangerJS pull request linter
+      uses: espressif/shared-github-dangerjs@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of Change
Adding shared GitHub DangerJS to this repository. Keeping the default settings.

**Purpose:**
- improve PR naming → will improve Release notes
- development checks

To-Do:
- check Pull Request template and possibly update it to correspond to DangerJS checks

## Related links
- DangerJS repository: https://github.com/espressif/shared-github-dangerjs

