### PR TITLE
Remove setTimeout from WifiClientSecure

### DIFF
--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.cpp
@@ -401,22 +401,6 @@ void WiFiClientSecure::setAlpnProtocols(const char **alpn_protos)
 {
     _alpn_protos = alpn_protos;
 }
-int WiFiClientSecure::setTimeout(uint32_t seconds)
-{
-    _timeout = seconds * 1000;
-    if (sslclient->socket >= 0) {
-        struct timeval tv;
-        tv.tv_sec = seconds;
-        tv.tv_usec = 0;
-        if(setSocketOption(SO_RCVTIMEO, (char *)&tv, sizeof(struct timeval)) < 0) {
-            return -1;
-        }
-        return setSocketOption(SO_SNDTIMEO, (char *)&tv, sizeof(struct timeval));
-    }
-    else {
-        return 0;
-    }
-}
 
 int WiFiClientSecure::fd() const
 {

--- a/libraries/WiFiClientSecure/src/WiFiClientSecure.h
+++ b/libraries/WiFiClientSecure/src/WiFiClientSecure.h
@@ -80,7 +80,6 @@ public:
     void setAlpnProtocols(const char **alpn_protos);
     const mbedtls_x509_crt* getPeerCertificate() { return mbedtls_ssl_get_peer_cert(&sslclient->ssl_ctx); };
     bool getFingerprintSHA256(uint8_t sha256_result[32]) { return get_peer_fingerprint(sslclient, sha256_result); };
-    int setTimeout(uint32_t seconds);
     int fd() const;
 
     operator bool()


### PR DESCRIPTION
## Description of Change
This PR removes `setTimeout` from WifiClientSecure. This change should be part of #6676, but after rebasing this change was missing.

## Tests scenarios

## Related links
