### PR TITLE
Fixed the String::lastIndexOf bug

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -677,7 +677,10 @@ int String::lastIndexOf(char ch, unsigned int fromIndex) const {
     wbuffer()[fromIndex + 1] = tempchar;
     if(temp == NULL)
         return -1;
-    return temp - buffer();
+    const int rv = temp - buffer();
+    if(rv >= len())
+        return -1;
+    return rv;
 }
 
 int String::lastIndexOf(const String &s2) const {


### PR DESCRIPTION
The `String::lastIndexOf` incorrectly finds character `\0` behind the string size, so extra check was added.

## Description of Change
This pull request fixes the bug in `int String::lastIndexOf(char ch, unsigned int fromIndex) const` function. The bug itself 
is that if the character we are searching is `\0` this function returns an index behind bounds of the string itself.
For example the following code prints that it found it at 4th position (points after the end of the actual string):
```cpp
String test = "test";
int p = test.lastIndexOf('\0');
USBSerial.printf("lastIndexOf: %d\n", p);
```
output:
```
lastIndexOf: 4
```
but it must be `-1` because there is no `\0` character inside the string itself.

## Tests scenarios
I've tested the code on M5Stack-CoreS3 hardware, Arduino-esp32 core v `3.20011.230801` (framework-arduinoespressif32)

Test case when it is fixed:
```cpp
String test = "test";
int p = test.lastIndexOf('\0');
assert(p == -1);
```