### PR TITLE
fix(adc): Always use default read resolution in __analogReadMilliVolts

### DIFF
--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -149,7 +149,7 @@ void __analogReadResolution(uint8_t bits)
 #endif
 }
 
-uint16_t __analogRead(uint8_t pin)
+uint16_t __analogReadRaw(uint8_t pin)
 {
     int8_t channel = digitalPinToAnalogChannel(pin);
     int value = 0;
@@ -173,8 +173,14 @@ uint16_t __analogRead(uint8_t pin)
         }
     } else {
         value = adc1_get_raw(channel);
-        return mapResolution(value);
+        return value;
     }
+    return value;
+}
+
+uint16_t __analogRead(uint8_t pin)
+{
+    uint16_t value = __analogReadRaw(pin);
     return mapResolution(value);
 }
 
@@ -201,7 +207,7 @@ uint32_t __analogReadMilliVolts(uint8_t pin){
             if(__analogVRefPin){
                 esp_adc_cal_characteristics_t chars;
                 if(adc_vref_to_gpio(ADC_UNIT_2, __analogVRefPin) == ESP_OK){
-                    __analogVRef = __analogRead(__analogVRefPin);
+                    __analogVRef = __analogReadRaw(__analogVRefPin);
                     esp_adc_cal_characterize(1, __analogAttenuation, __analogWidth, DEFAULT_VREF, &chars);
                     __analogVRef = esp_adc_cal_raw_to_voltage(__analogVRef, &chars);
                     log_d("Vref to GPIO%u: %u", __analogVRefPin, __analogVRef);
@@ -215,7 +221,7 @@ uint32_t __analogReadMilliVolts(uint8_t pin){
         unit = 2;
     }
 
-    uint16_t adc_reading = __analogRead(pin);
+    uint16_t adc_reading = __analogReadRaw(pin);
 
     uint8_t atten = __analogAttenuation;
     if (__pin_attenuation[pin] != ADC_ATTENDB_MAX){
@@ -266,6 +272,7 @@ int __hallRead()    //hall sensor using idf read
 #endif
 
 extern uint16_t analogRead(uint8_t pin) __attribute__ ((weak, alias("__analogRead")));
+extern uint16_t analogReadRaw(uint8_t pin) __attribute__ ((weak, alias("__analogReadRaw")));
 extern uint32_t analogReadMilliVolts(uint8_t pin) __attribute__ ((weak, alias("__analogReadMilliVolts")));
 extern void analogReadResolution(uint8_t bits) __attribute__ ((weak, alias("__analogReadResolution")));
 extern void analogSetClockDiv(uint8_t clockDiv) __attribute__ ((weak, alias("__analogSetClockDiv")));

--- a/cores/esp32/esp32-hal-adc.h
+++ b/cores/esp32/esp32-hal-adc.h
@@ -40,6 +40,11 @@ typedef enum {
 uint16_t analogRead(uint8_t pin);
 
 /*
+ * Get ADC value in default resolution for pin
+ * */
+uint16_t analogReadRaw(uint8_t pin);
+
+/*
  * Get MilliVolts value for pin
  * */
 uint32_t analogReadMilliVolts(uint8_t pin);


### PR DESCRIPTION
## Description of Change
1. Add new __analogReadRaw function and move code from __analogRead without mapResolution part to __analogReadRaw.
2. Refactor __anlogRead to use analogReadRaw (and mapResolution).
3. Refactor __analogReadMilliVolts to always use default read resolution when reading adc value, as expected input by esp_adc_cal_raw_to_voltage is in default resolution (means replacing all calls of __analogRead with __analogReadRaw).

This shall avoid that a change of the resolution of analog readings leads to incorrect values when using the analogReadMilliVolts function, as this function always expects the resolution to be the default one. For more information see description in #8999. 
## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.14 with UM FeatherS2 (ESP32-S2) board with an analog sensor (Truebner  SMT50).

## Related links
Related to #8999. 