### PR TITLE
Improve Log Messages in GPIO HAL

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -104,14 +104,14 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 #endif
 
     if (pin >= SOC_GPIO_PIN_COUNT) {
-        log_e("Invalid pin (%i) selected", pin);
+        log_e("Invalid IO %i selected", pin);
         return;
     }
 
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
         perimanSetBusDeinit(ESP32_BUS_TYPE_GPIO, gpioDetachBus);
         if(!perimanClearPinBus(pin)){
-            log_e("Deinit of previous bus from pin %i failed", pin);
+            log_e("Deinit of previous bus from IO %i failed", pin);
             return;
         }
     }
@@ -140,7 +140,7 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
     }
     if(gpio_config(&conf) != ESP_OK)
     {
-        log_e("Pin %i config failed", pin);
+        log_e("IO %i config failed", pin);
         return;
     }
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
@@ -164,7 +164,7 @@ extern void ARDUINO_ISR_ATTR __digitalWrite(uint8_t pin, uint8_t val)
         if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) != NULL){
             gpio_set_level((gpio_num_t)pin, val);
         } else {
-            log_e("Pin %i is not set as GPIO.", pin);
+            log_e("IO %i is not set as GPIO.", pin);
         }
 }
 
@@ -174,7 +174,7 @@ extern int ARDUINO_ISR_ATTR __digitalRead(uint8_t pin)
         return gpio_get_level((gpio_num_t)pin);
     }
     else {
-        log_e("Pin %i is not set as GPIO.", pin);
+        log_e("IO %i is not set as GPIO.", pin);
         return 0;
     }
 }

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -104,14 +104,14 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 #endif
 
     if (pin >= SOC_GPIO_PIN_COUNT) {
-        log_e("Invalid pin selected");
+        log_e("Invalid pin (%i) selected", pin);
         return;
     }
 
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
         perimanSetBusDeinit(ESP32_BUS_TYPE_GPIO, gpioDetachBus);
         if(!perimanClearPinBus(pin)){
-            log_e("Deinit of previous bus failed");
+            log_e("Deinit of previous bus from GPIO %i failed", pin);
             return;
         }
     }
@@ -140,7 +140,7 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
     }
     if(gpio_config(&conf) != ESP_OK)
     {
-        log_e("GPIO config failed");
+        log_e("GPIO %i config failed", pin);
         return;
     }
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
@@ -164,7 +164,7 @@ extern void ARDUINO_ISR_ATTR __digitalWrite(uint8_t pin, uint8_t val)
         if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) != NULL){
             gpio_set_level((gpio_num_t)pin, val);
         } else {
-            log_e("Pin is not set as GPIO.");
+            log_e("Pin %i is not set as GPIO.", pin);
         }
 }
 
@@ -174,7 +174,7 @@ extern int ARDUINO_ISR_ATTR __digitalRead(uint8_t pin)
         return gpio_get_level((gpio_num_t)pin);
     }
     else {
-        log_e("Pin is not set as GPIO.");
+        log_e("Pin %i is not set as GPIO.", pin);
         return 0;
     }
 }
@@ -204,7 +204,7 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
     	interrupt_initialized = (err == ESP_OK) || (err == ESP_ERR_INVALID_STATE);
     }
     if(!interrupt_initialized) {
-    	log_e("GPIO ISR Service Failed To Start");
+    	log_e("GPIO %i ISR Service Failed To Start", pin);
     	return;
     }
 

--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -111,7 +111,7 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
         perimanSetBusDeinit(ESP32_BUS_TYPE_GPIO, gpioDetachBus);
         if(!perimanClearPinBus(pin)){
-            log_e("Deinit of previous bus from GPIO %i failed", pin);
+            log_e("Deinit of previous bus from pin %i failed", pin);
             return;
         }
     }
@@ -140,7 +140,7 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
     }
     if(gpio_config(&conf) != ESP_OK)
     {
-        log_e("GPIO %i config failed", pin);
+        log_e("Pin %i config failed", pin);
         return;
     }
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
@@ -204,7 +204,7 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
     	interrupt_initialized = (err == ESP_OK) || (err == ESP_ERR_INVALID_STATE);
     }
     if(!interrupt_initialized) {
-    	log_e("GPIO %i ISR Service Failed To Start", pin);
+    	log_e("IO %i ISR Service Failed To Start", pin);
     	return;
     }
 


### PR DESCRIPTION
## Description of Change
Improves the log messages by adding the GPIO number that has triggered the error message for better debugging.

## Tests scenarios
Tested with ESP32-C3.


## Related links
Fixes #9008 