### PR TITLE
Fixes Malloc call in WebServer code

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -135,7 +135,7 @@ bool WebServer::authenticate(const char * username, const char * password){
       authReq = authReq.substring(6);
       authReq.trim();
       char toencodeLen = strlen(username)+strlen(password)+1;
-      char *toencode = (char *)malloc[toencodeLen + 1];
+      char *toencode = (char *)malloc(toencodeLen + 1);
       if(toencode == NULL){
         authReq = "";
         return false;


### PR DESCRIPTION
## Description of Change
This fixes a wrong (but "valid") call for `malloc()`.

C:/Users/user/.platformio/packages/framework-arduinoespressif32/libraries/WebServer/src/WebServer.cpp:138:54: warning: pointer to a function used in arithmetic [-Wpointer-arith]
  138 |       char *toencode = (char *)malloc[toencodeLen + 1];
      |                                                      ^
cc1plus.exe: warning: pointer to a function used in arithmetic [-Wpointer-arith]

## Tests scenarios
Just CI

## Related links
Fixes #9007