### PR TITLE
Set TFT_BACKLIGHT pin for adafruit_camera_esp32s3 variant

### DIFF
--- a/variants/adafruit_camera_esp32s3/pins_arduino.h
+++ b/variants/adafruit_camera_esp32s3/pins_arduino.h
@@ -24,7 +24,7 @@ static const uint8_t LED_BUILTIN = PIN_NEOPIXEL+SOC_GPIO_PIN_COUNT;
 #define RGB_BRIGHTNESS 64
 
 
-//static const uint8_t TFT_BACKLIGHT = 41;
+static const uint8_t TFT_BACKLIGHT = 45;
 static const uint8_t TFT_DC        = 40;
 static const uint8_t TFT_CS        = 39;
 static const uint8_t TFT_RESET     = 38;


### PR DESCRIPTION
Just updating since pin is known now for this board.