### PR TITLE
Add methods to enable/disable GPIOs interrupt

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -256,6 +256,14 @@ extern void __detachInterrupt(uint8_t pin)
     gpio_set_intr_type((gpio_num_t)pin, GPIO_INTR_DISABLE);
 }
 
+extern void enableInterrupt(uint8_t pin) {
+    gpio_intr_enable((gpio_num_t)pin);
+}
+
+extern void disableInterrupt(uint8_t pin) {
+    gpio_intr_disable((gpio_num_t)pin);
+}
+
 
 extern void pinMode(uint8_t pin, uint8_t mode) __attribute__ ((weak, alias("__pinMode")));
 extern void digitalWrite(uint8_t pin, uint8_t val) __attribute__ ((weak, alias("__digitalWrite")));

--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -78,6 +78,8 @@ int digitalRead(uint8_t pin);
 void attachInterrupt(uint8_t pin, void (*)(void), int mode);
 void attachInterruptArg(uint8_t pin, void (*)(void*), void * arg, int mode);
 void detachInterrupt(uint8_t pin);
+void enableInterrupt(uint8_t pin);
+void disableInterrupt(uint8_t pin);
 
 int8_t digitalPinToTouchChannel(uint8_t pin);
 int8_t digitalPinToAnalogChannel(uint8_t pin);


### PR DESCRIPTION
## Description of Change
This PR adds 2 simple methods to enable/disable GPIOs interrupt.

## Tests scenarios
Tested on C6 and H2 using the Zigbee examples.

## Related links

