### PR TITLE
undeprecate WiFiServer::available()

### DIFF
--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -45,7 +45,7 @@ class WiFiServer : public Server {
       log_v("WiFiServer::WiFiServer(addr=%s, port=%d, ...)", addr.toString().c_str(), port);
     }
     ~WiFiServer(){ end();}
-    WiFiClient available() __attribute__((deprecated("Renamed to accept().")));
+    WiFiClient available();
     WiFiClient accept();
     void begin(uint16_t port=0);
     void begin(uint16_t port, int reuse_enable);


### PR DESCRIPTION
## Description of Change
Removes depricated message for WiFiServer::available() to follow Arduino upstream API.

## Tests scenarios
None

## Related links
None