### PR TITLE
WiFiServer - implementation aligned with Arduino.cc. With example. (breaking change)

### DIFF
--- a/libraries/WiFi/examples/WiFiPagerServer/WiFiPagerServer.ino
+++ b/libraries/WiFi/examples/WiFiPagerServer/WiFiPagerServer.ino
@@ -1,0 +1,59 @@
+/*
+  WiFi Pager Server - server.available
+  and print-to-all-clients example
+
+  The example is a simple server that echoes any incoming
+  messages to all connected clients. Connect two or more
+  telnet sessions to see how server.available() and
+  server.print() work.
+
+  created in September 2020
+  by Juraj Andrassy
+ */
+
+#include <WiFi.h>
+
+WiFiServer server(2323);
+
+#include "arduino_secrets.h"
+///////please enter your sensitive data in the Secret tab/arduino_secrets.h
+char ssid[] = SECRET_SSID;        // your network SSID (name)
+char pass[] = SECRET_PASS;    // your network password (use for WPA, or use as key for WEP)
+
+void setup() {
+
+  Serial.begin(115200);
+  while (!Serial);
+
+  Serial.print("Attempting to connect to SSID \"");
+  Serial.print(ssid);
+  Serial.println("\" with DHCP ...");
+  WiFi.begin(ssid, pass);
+  while (WiFi.status() != WL_CONNECTED) {
+    Serial.print('.');
+    delay(1000);
+  }
+  Serial.println();
+
+  server.begin();
+
+  IPAddress ip = WiFi.localIP();
+  Serial.println();
+  Serial.println("Connected to WiFi network.");
+  Serial.print("To access the server, connect with Telnet client to ");
+  Serial.print(ip);
+  Serial.println(" 2323");
+}
+
+void loop() {
+
+  WiFiClient client = server.available();     // returns first client which has data to read or a 'false' client
+  if (client) {                               // client is here true only if it is connected and has data to read
+    String s = client.readStringUntil('\n');  // read the message incoming from one of the clients
+    s.trim();                                 // trim eventual \r
+    Serial.println(s);                        // print the message to Serial Monitor
+    client.print("echo: ");                   // this is only for the sending client
+    server.println(s);                        // send the message to all connected clients
+    server.flush();                           // flush the buffers
+  }
+}

--- a/libraries/WiFi/examples/WiFiPagerServer/arduino_secrets.h
+++ b/libraries/WiFi/examples/WiFiPagerServer/arduino_secrets.h
@@ -1,0 +1,2 @@
+#define SECRET_SSID ""
+#define SECRET_PASS ""

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -24,6 +24,10 @@
 #include "WiFiClient.h"
 #include "IPAddress.h"
 
+#ifndef SERVER_MAX_MONITORED_CLIENTS
+#define SERVER_MAX_MONITORED_CLIENTS CONFIG_LWIP_MAX_SOCKETS
+#endif
+
 class WiFiServer : public Server {
   private:
     int sockfd;
@@ -33,17 +37,23 @@ class WiFiServer : public Server {
     uint8_t _max_clients;
     bool _listening;
     bool _noDelay = false;
+    
+    WiFiClient connectedClients[SERVER_MAX_MONITORED_CLIENTS];
+    uint8_t index = 0;
+
+#if !CONFIG_DISABLE_HAL_LOCKS
+    SemaphoreHandle_t _lock;
+#endif
+
+    void acceptClients();
 
   public:
     void listenOnLocalhost(){}
 
-    WiFiServer(uint16_t port=80, uint8_t max_clients=4):sockfd(-1),_accepted_sockfd(-1),_addr(),_port(port),_max_clients(max_clients),_listening(false),_noDelay(false) {
-      log_v("WiFiServer::WiFiServer(port=%d, ...)", port);
-    }
-    WiFiServer(const IPAddress& addr, uint16_t port=80, uint8_t max_clients=4):sockfd(-1),_accepted_sockfd(-1),_addr(addr),_port(port),_max_clients(max_clients),_listening(false),_noDelay(false) {
-      log_v("WiFiServer::WiFiServer(addr=%s, port=%d, ...)", addr.toString().c_str(), port);
-    }
-    ~WiFiServer(){ end();}
+    WiFiServer(uint16_t port=80, uint8_t max_clients=4);
+    WiFiServer(const IPAddress& addr, uint16_t port=80, uint8_t max_clients=4);
+    ~WiFiServer();
+
     WiFiClient available();
     WiFiClient accept();
     void begin(uint16_t port=0);


### PR DESCRIPTION
implements `available()` as documented here https://www.arduino.cc/reference/en/libraries/wifi/server.available/

implements print-to-all-clients as documented here https://www.arduino.cc/reference/en/libraries/wifi/server.print/

adds WiFiPagerServer example to demonstrate how server.available() and  server.print() work. 

Requires #9029