### PR TITLE
SD library: Fix format

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -818,7 +818,7 @@ bool sdcard_mount(uint8_t pdrv, const char* path, uint8_t max_files, bool format
             }
             //FRESULT f_mkfs (const TCHAR* path, const MKFS_PARM* opt, void* work, UINT len);
             const MKFS_PARM opt = {(BYTE)FM_ANY, 0, 0, 0, 0};
-            res = f_mkfs(drv, &opt, work, sizeof(work));
+            res = f_mkfs(drv, &opt, work, sizeof(BYTE) * FF_MAX_SS);
             free(work);
             if (res != FR_OK) {
                 log_e("f_mkfs failed: %s", fferr2str[res]);


### PR DESCRIPTION
## Description of Change
SD card formatting in the SD library was broken by #6745. The work buffer for `f_mkfs` was moved from the stack to the heap, but the length argument was not updated, instead it currently passes the size of a pointer (32 bits).

## Tests scenarios
Before my change, `SD.begin` with `format_if_empty` set to true and an erased SD card will always fail with the error `[sd_diskio.cpp:824] sdcard_mount(): f_mkfs failed: (17) LFN working buffer could not be allocated`.
After my change `SD.begin` succeeds and creates a FAT filesystem on the card.
