### PR TITLE
Added clearing of queue with unTone()

### DIFF
--- a/cores/esp32/Tone.cpp
+++ b/cores/esp32/Tone.cpp
@@ -95,6 +95,7 @@ void noTone(uint8_t pin){
         .frequency = 0, // Ignored
         .duration = 0, // Ignored
       };
+      xQueueReset(_tone_queue); // clear queue
       xQueueSend(_tone_queue, &tone_msg, portMAX_DELAY);
     }
   }


### PR DESCRIPTION
unTone() does not stop until the queue is exhausted. Therefore, we added clearing the queue.

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

-----------
## Description of Change
unTone() does not stop until the queue is exhausted. Therefore, we added clearing the queue.

## Tests scenarios
```c
void setup(void) {
    for (int i = 0; i < 4; i++) {
      int frequency = 523.251 * pow(2, i);
      tone(GPIO_NUM_2, frequency, 500);

      frequency = 587.330 * pow(2, i);
      tone(GPIO_NUM_2, frequency, 500);

      frequency = 659.255 * pow(2, i);
      tone(GPIO_NUM_2, frequency, 500);
    }

    // It stops after all tones are finished
    // tone() is a non-blocking function, so I want to stop the sound immediately.
    unTone(GPIO_NUM_2);
 }

void loop(void) {
}
```
## Related links

