### PR TITLE
WiFi.disconnect() "aligned with Aduino.cc". waiting for status change.

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -367,7 +367,7 @@ bool WiFiSTAClass::reconnect()
  * @param eraseap `true` to erase the AP configuration from the NVS memory.
  * @return `true` when successful.
  */
-bool WiFiSTAClass::disconnect(bool wifioff, bool eraseap)
+bool WiFiSTAClass::disconnectAsync(bool wifioff, bool eraseap)
 {
     wifi_config_t conf;
     wifi_sta_config(&conf);
@@ -389,6 +389,31 @@ bool WiFiSTAClass::disconnect(bool wifioff, bool eraseap)
     }
 
     return false;
+}
+
+/**
+ * Disconnect from the network.
+ * @param wifioff `true` to turn the Wi-Fi radio off.
+ * @param eraseap `true` to erase the AP configuration from the NVS memory.
+ * @param timeoutLength timeout to wait for status change
+ * @return `true` when successful.
+ */
+bool WiFiSTAClass::disconnect(bool wifioff, bool eraseap, unsigned long timeoutLength)
+{
+    if (!disconnectAsync(wifioff, eraseap)) {
+        return false;
+    }
+    if (!timeoutLength) {
+        return true;
+    }
+    const unsigned long start = millis();
+    while ((WiFiGenericClass::getStatusBits() & STA_CONNECTED_BIT) != 0) {
+        if((millis() - start) >= timeoutLength){
+            return false;
+        }
+        delay(2);
+    }
+    return true;
 }
 
 /**

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -61,7 +61,8 @@ public:
     bool bandwidth(wifi_bandwidth_t bandwidth);
 
     bool reconnect();
-    bool disconnect(bool wifioff = false, bool eraseap = false);
+    bool disconnectAsync(bool wifioff = false, bool eraseap = false);
+    bool disconnect(bool wifioff = false, bool eraseap = false, unsigned long timeoutLength = 100);
     bool eraseAP(void);
 
     bool isConnected();


### PR DESCRIPTION
WiFi.disconnect() "aligned with Aduino.cc". 
`WiFi.disconnect` renamed to `disconnectAsync`
new `WiFi.disconnect` waits for `status` change

the WiFi library with async disconnect behaves very strange. after disconnect() and immediate WiFi.begin it can't connect. I had to add a wait for status change after disconnect in my [test sketch](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/WiFiTest/WiFiTest.ino).
So I think the blocking version of disconnect() is a better option for everybody. It is quick.
