### PR TITLE
WiFi.begin "aligned with Arduino.cc". blocking (breaking change)

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -305,6 +305,9 @@ wl_status_t WiFiSTAClass::begin(const char* ssid, const char *passphrase, int32_
 		}
     }
 
+    if (beginTimeout) {
+        return (wl_status_t) waitForConnectResult(beginTimeout);
+    }
     return status();
 }
 
@@ -344,6 +347,9 @@ wl_status_t WiFiSTAClass::begin()
     	}
     }
 
+    if (beginTimeout) {
+        return (wl_status_t) waitForConnectResult(beginTimeout);
+    }
     return status();
 }
 

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -108,12 +108,20 @@ public:
 
     static void _setStatus(wl_status_t status);
     
+    void setBeginTimeout(unsigned long timeout) {
+        beginTimeout = timeout;
+    }
+    void setBeginAsync() {
+        beginTimeout = 0;
+    }
+
 protected:
     static bool _useStaticIp;
     static bool _autoReconnect;
     static wifi_auth_mode_t _minSecurity;
     static wifi_scan_method_t _scanMethod;
     static wifi_sort_method_t _sortMethod;
+    unsigned long beginTimeout = 60000;
 
 public: 
     bool beginSmartConfig(smartconfig_type_t type = SC_TYPE_ESPTOUCH, char* crypt_key = NULL);


### PR DESCRIPTION
change `WiFi.begin` to blocking to be "aligned with Arduino.cc". 

PR adds `beginTimeout` property used in `begin` with `waitForConnectResult`

with `beginTimeout` 0 `begin` is async. 
default `beginTimeout` is a minute as in `waitForConnectResult`

