### PR TITLE
Fixes EspClass::deepSleep(64 bits)

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -131,7 +131,7 @@ unsigned long long operator"" _GB(unsigned long long x)
 
 EspClass ESP;
 
-void EspClass::deepSleep(uint32_t time_us)
+void EspClass::deepSleep(uint64_t time_us)
 {
     esp_deep_sleep(time_us);
 }

--- a/cores/esp32/Esp.h
+++ b/cores/esp32/Esp.h
@@ -86,7 +86,7 @@ public:
     const char * getSdkVersion(); //version of ESP-IDF
     const char * getCoreVersion();//version of this core
 
-    void deepSleep(uint32_t time_us);
+    void deepSleep(uint64_t time_us);
 
     uint32_t getFlashChipSize();
     uint32_t getFlashChipSpeed();


### PR DESCRIPTION
## Description of Change
`esp_deep_sleep(uint64_t time_in_us)` takes a 64 bit argument, but `void EspClass::deepSleep(uint32_t time_us)` allows only 32 bit.

This fixes it, for a sleep time over 2,147 seconds (over 36 minutes).

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/sleep_modes.html#_CPPv414esp_deep_sleep8uint64_t

## Tests scenarios
Just CI.

## Related links
Fixes #9074 

