### PR TITLE
Add LED pin aliases to Arduino Nano ESP32 for portability

### DIFF
--- a/variants/arduino_nano_nora/pins_arduino.h
+++ b/variants/arduino_nano_nora/pins_arduino.h
@@ -76,6 +76,12 @@ static constexpr uint8_t A7         = 14;
 
 #endif
 
+// Aliases
+
+static constexpr uint8_t LEDR = LED_RED;
+static constexpr uint8_t LEDG = LED_GREEN;
+static constexpr uint8_t LEDB = LED_BLUE;
+
 // alternate pin functions
 
 static constexpr uint8_t LED_BUILTIN = D13;


### PR DESCRIPTION
## Description of Change
This PR adds aliases to control the RGB led on the Arduino Nano ESP32 board. On other Arduino boards those pins are named LEDR, LEDG, LEDB. To improve portability amoung the Arduino boards the Arduino Nano ESP32 should support those names.

## Tests scenarios
Tested on Arduino Nano ESP32