### PR TITLE
[release/2.x] Set Default Parameter for `edge` in timerAttachInterupt(...) Function

### DIFF
--- a/cores/esp32/esp32-hal-timer.h
+++ b/cores/esp32/esp32-hal-timer.h
@@ -37,7 +37,7 @@ void timerSetConfig(hw_timer_t *timer, uint32_t config);
 uint32_t timerGetConfig(hw_timer_t *timer);
 
 void timerAttachInterruptFlag(hw_timer_t *timer, void (*fn)(void), bool edge, int intr_alloc_flags);
-void timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge);
+void timerAttachInterrupt(hw_timer_t *timer, void (*fn)(void), bool edge = false);
 void timerDetachInterrupt(hw_timer_t *timer);
 
 void timerStart(hw_timer_t *timer);


### PR DESCRIPTION
# Set Default Parameter for edge in timerAttachInterupt
The actual Documentation for the funtion ` timerAttachInterupt(...)` looks like:

![image](https://github.com/espressif/arduino-esp32/assets/26808969/925673fc-0674-4bc9-badd-279c7cc76976)

But the actual code look like:
![image](https://github.com/espressif/arduino-esp32/assets/26808969/8978da71-fb1f-42da-a778-76f61158b929)

To be consistent with the documentation, and `edge`is not supportet:
see:
```
void timerAttachInterruptFlag(hw_timer_t *timer, void (*fn)(void), bool edge, int intr_alloc_flags){
    if(edge){
        log_w("EDGE timer interrupt is not supported! Setting to LEVEL...");
    }
    timer_isr_callback_add(timer->group, timer->num, timerFnWrapper, fn, intr_alloc_flags);
}
```
A default parameter for `edge = false ` would be a good change to be consistent with the documentation.