### PR TITLE
change(MD5Builder): Const-correctness.

### DIFF
--- a/cores/esp32/HashBuilder.h
+++ b/cores/esp32/HashBuilder.h
@@ -26,10 +26,10 @@ public:
     virtual ~HashBuilder() {}
     virtual void begin() = 0;
 
-    virtual void add(uint8_t* data, size_t len) = 0;
+    virtual void add(const uint8_t* data, size_t len) = 0;
     virtual void add(const char* data)
     {
-        add((uint8_t*)data, strlen(data));
+        add((const uint8_t*)data, strlen(data));
     }
     virtual void add(char* data)
     {

--- a/cores/esp32/HashBuilder.h
+++ b/cores/esp32/HashBuilder.h
@@ -31,20 +31,12 @@ public:
     {
         add((const uint8_t*)data, strlen(data));
     }
-    virtual void add(char* data)
-    {
-        add((const char*)data);
-    }
     virtual void add(String data)
     {
         add(data.c_str());
     }
 
     virtual void addHexString(const char* data) = 0;
-    virtual void addHexString(char* data)
-    {
-        addHexString((const char*)data);
-    }
     virtual void addHexString(String data)
     {
         addHexString(data.c_str());

--- a/cores/esp32/MD5Builder.cpp
+++ b/cores/esp32/MD5Builder.cpp
@@ -27,7 +27,7 @@ void MD5Builder::begin(void)
     esp_rom_md5_init(&_ctx);
 }
 
-void MD5Builder::add(uint8_t * data, size_t len)
+void MD5Builder::add(const uint8_t * data, size_t len)
 {
     esp_rom_md5_update(&_ctx, data, len);
 }

--- a/cores/esp32/MD5Builder.h
+++ b/cores/esp32/MD5Builder.h
@@ -38,7 +38,7 @@ public:
     void begin(void) override;
 
     using HashBuilder::add;
-    void add(uint8_t * data, size_t len) override;
+    void add(const uint8_t * data, size_t len) override;
 
     using HashBuilder::addHexString;
     void addHexString(const char * data) override;

--- a/cores/esp32/SHA1Builder.cpp
+++ b/cores/esp32/SHA1Builder.cpp
@@ -230,7 +230,7 @@ void SHA1Builder::begin(void)
     memset(hash, 0x00, sizeof(hash));
 }
 
-void SHA1Builder::add(uint8_t* data, size_t len)
+void SHA1Builder::add(const uint8_t* data, size_t len)
 {
     size_t fill;
     uint32_t left;

--- a/cores/esp32/SHA1Builder.h
+++ b/cores/esp32/SHA1Builder.h
@@ -36,7 +36,7 @@ public:
     void begin() override;
 
     using HashBuilder::add;
-    void add(uint8_t* data, size_t len) override;
+    void add(const uint8_t* data, size_t len) override;
 
     using HashBuilder::addHexString;
     void addHexString(const char* data) override;


### PR DESCRIPTION
Propagate 'const' of underlying esp_rom_md5_update() to MD5Builder::add().
Remove some unneeded methods.
