### PR TITLE
fix(esp32): Set the maximum value of AnalogRead to 4095

### DIFF
--- a/libraries/ESP32/examples/AnalogRead/AnalogRead.ino
+++ b/libraries/ESP32/examples/AnalogRead/AnalogRead.ino
@@ -2,7 +2,7 @@ void setup() {
   // initialize serial communication at 115200 bits per second:
   Serial.begin(115200);
   
-  //set the resolution to 12 bits (0-4096)
+  //set the resolution to 12 bits (0-4095)
   analogReadResolution(12);
 }
 


### PR DESCRIPTION
The 12-bit MAX is 4095, not 4096.

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

-----------
## Description of Change
Fixed an incorrect comment.

## Tests scenarios
Confirm that values from 0 to 4095 can be obtained.
