### PR TITLE
Add and init new LittleFS options

### DIFF
--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -81,8 +81,11 @@ bool LittleFSFS::begin(bool formatOnFail, const char * basePath, uint8_t maxOpen
     esp_vfs_littlefs_conf_t conf = {
       .base_path = basePath,
       .partition_label = partitionLabel_,
+      .partition = NULL,
       .format_if_mount_failed = false,
-      .dont_mount = false
+      .read_only = false,
+      .dont_mount = false,
+      .grow_on_mount = true
     };
 
     esp_err_t err = esp_vfs_littlefs_register(&conf);


### PR DESCRIPTION
when IDF LittleFS is built with Arduino Lib Builder latest LittleFS will be used.
This PR adds the new LittleFS options and inits them, so no warnings will be generated.
Backport from branch master