### PR TITLE
Add missing include for SemaphoreHandle_t to LEDC header file

### DIFF
--- a/cores/esp32/esp32-hal-ledc.h
+++ b/cores/esp32/esp32-hal-ledc.h
@@ -24,6 +24,8 @@ extern "C" {
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 typedef enum {
     NOTE_C, NOTE_Cs, NOTE_D, NOTE_Eb, NOTE_E, NOTE_F, NOTE_Fs, NOTE_G, NOTE_Gs, NOTE_A, NOTE_Bb, NOTE_B, NOTE_MAX


### PR DESCRIPTION
## Description of Change

Add missing include references to `esp32-hal-ledc.h` for type `SemaphoreHandle_t`

This header is used by the M5Unified library, via M5GFX, in the Light_PWM.cpp file and in that context does not have the required FreeRTOS semaphore type, so the build/compile fails. Files should generally include the references they use and not rely on other files having included necessary headers prior to them (in case they are loaded in a different order).

This is a minor change.

## Tests scenarios

Tested on M5Stack Core2 (ESP32). Note that this is a compilation error, so can be reproduced without board (although after fixing I did test the sample ran). Sample code is in the bug report.

## Related links

Fixes #9133

-------------
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [X] Please **update relevant Documentation** if applicable - no relevant documentation
4. [X] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [X] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

