### PR TITLE
Fixed duplicated getType documentation.

### DIFF
--- a/docs/en/api/preferences.rst
+++ b/docs/en/api/preferences.rst
@@ -198,24 +198,6 @@ Arduino-esp32 Preferences API
    
    **Note** 
       * Attempting to check a key without a namespace being open will return false.
-  
-  
-``getType``
-*************
-
-   Returns the type of a key-value pair from the currently open namespace.
-   
-   .. code-block:: arduino
-   
-       PreferenceType getType(const char * key)
-   ..
-
-   **Parameters**
-      * ``key`` (Required)
-         -  the name of the key to be checked. 
-   
-   **Returns**
-      * PreferenceType element contaning the type of the key-value pair or PT_INVALID on error.
 
 
 ``putChar, putUChar``


### PR DESCRIPTION
This PR to fix a mistake I made while adding documentation for the preference library.
This removes the duplicated getType reference.

See https://github.com/espressif/arduino-esp32/pull/9111 for more details.