### PR TITLE
Update LittleFS Platformio example

### DIFF
--- a/libraries/LittleFS/examples/LITTLEFS_PlatformIO/littlefsbuilder.py
+++ b/libraries/LittleFS/examples/LITTLEFS_PlatformIO/littlefsbuilder.py
@@ -1,2 +1,0 @@
-Import("env")
-env.Replace( MKFSTOOL=env.get("PROJECT_DIR") + '/mklittlefs' )  # PlatformIO now believes it has actually created a SPIFFS

--- a/libraries/LittleFS/examples/LITTLEFS_PlatformIO/platformio.ini
+++ b/libraries/LittleFS/examples/LITTLEFS_PlatformIO/platformio.ini
@@ -17,8 +17,6 @@ framework = arduino
 [env:esp32]
 platform = espressif32
 board = esp32dev
-;board_build.partitions = partitions_custom.csv
+board_build.partitions = partitions_custom.csv
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
-
-extra_scripts = ./littlefsbuilder.py


### PR DESCRIPTION
Actual Platformio Platform espressif32 do not need anymore the Python script to build the LittleFS image. 
Use custom partition scheme to guarantee to have a SPIFFS partition which works with the example code.