### PR TITLE
Fix i2c compilation when #define CONFIG_DISABLE_HAL_LOCKS=1

### DIFF
--- a/cores/esp32/esp32-hal-i2c.c
+++ b/cores/esp32/esp32-hal-i2c.c
@@ -42,9 +42,10 @@ typedef volatile struct {
     uint32_t frequency;
 #if !CONFIG_DISABLE_HAL_LOCKS
     SemaphoreHandle_t lock;
+#endif
     int8_t scl;
     int8_t sda;
-#endif
+
 } i2c_bus_t;
 
 static i2c_bus_t bus[SOC_I2C_NUM];


### PR DESCRIPTION
## Description of Change
Simple fix of moving I2C pins (SDA and SCL) to of #if !CONFIG_DISABLE_HAL_LOCKS section.

## Tests scenarios

## Related links
Closes #9073 