### PR TITLE
Revert "undeprecate available() (#9027)"

### DIFF
--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -44,7 +44,7 @@ class WiFiServer : public Server {
       log_v("WiFiServer::WiFiServer(addr=%s, port=%d, ...)", addr.toString().c_str(), port);
     }
     ~WiFiServer(){ end();}
-    WiFiClient available();
+    WiFiClient available() __attribute__((deprecated("Renamed to accept().")));
     WiFiClient accept();
     void begin(uint16_t port=0);
     void begin(uint16_t port, int reuse_enable);


### PR DESCRIPTION
This reverts commit 5d97e02ad777100430dd443ac3e3458e5d5f72df.

As a result of discussion on PR https://github.com/espressif/arduino-esp32/pull/9028 "WiFiServer - implementation aligned with Arduino.cc" this is a PR to mark `server.available` as deprecated.

I also recommend the  PR https://github.com/espressif/arduino-esp32/pull/8930 "WiFiServer - don't inherit from Print and Server" 