### PR TITLE
Add board support for Nologo ESP32S3 Pico

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -14272,6 +14272,247 @@ nologo_esp32c3_super_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+nologo_esp32s3_pico.name=Nologo ESP32S3 Pico
+nologo_esp32s3_pico.vid.0=0x303a
+nologo_esp32s3_pico.pid.0=0x1001
+
+nologo_esp32s3_pico.bootloader.tool=esptool_py
+nologo_esp32s3_pico.bootloader.tool.default=esptool_py
+
+nologo_esp32s3_pico.upload.tool=esptool_py
+nologo_esp32s3_pico.upload.tool.default=esptool_py
+nologo_esp32s3_pico.upload.tool.network=esp_ota
+
+nologo_esp32s3_pico.upload.maximum_size=1310720
+nologo_esp32s3_pico.upload.maximum_data_size=327680
+nologo_esp32s3_pico.upload.flags=
+nologo_esp32s3_pico.upload.extra_flags=
+nologo_esp32s3_pico.upload.use_1200bps_touch=false
+nologo_esp32s3_pico.upload.wait_for_upload_port=false
+
+nologo_esp32s3_pico.serial.disableDTR=false
+nologo_esp32s3_pico.serial.disableRTS=false
+
+nologo_esp32s3_pico.build.tarch=xtensa
+nologo_esp32s3_pico.build.bootloader_addr=0x0
+nologo_esp32s3_pico.build.target=esp32s3
+nologo_esp32s3_pico.build.mcu=esp32s3
+nologo_esp32s3_pico.build.core=esp32
+nologo_esp32s3_pico.build.variant=nologo_esp32s3_pico
+nologo_esp32s3_pico.build.board=NOLOGO_ESP32S3_PICO
+
+nologo_esp32s3_pico.build.usb_mode=1
+nologo_esp32s3_pico.build.cdc_on_boot=1
+nologo_esp32s3_pico.build.msc_on_boot=0
+nologo_esp32s3_pico.build.dfu_on_boot=0
+nologo_esp32s3_pico.build.f_cpu=240000000L
+nologo_esp32s3_pico.build.flash_size=8MB
+nologo_esp32s3_pico.build.flash_freq=80m
+nologo_esp32s3_pico.build.flash_mode=dio
+nologo_esp32s3_pico.build.boot=qio
+nologo_esp32s3_pico.build.boot_freq=80m
+nologo_esp32s3_pico.build.partitions=default
+nologo_esp32s3_pico.build.defines=
+nologo_esp32s3_pico.build.loop_core=
+nologo_esp32s3_pico.build.event_core=
+nologo_esp32s3_pico.build.psram_type=qspi
+nologo_esp32s3_pico.build.memory_type={build.boot}_{build.psram_type}
+
+## IDE 2.0 Seems to not update the value
+nologo_esp32s3_pico.menu.JTAGAdapter.default=Disabled
+nologo_esp32s3_pico.menu.JTAGAdapter.default.build.copy_jtag_files=0
+nologo_esp32s3_pico.menu.JTAGAdapter.builtin=Integrated USB JTAG
+nologo_esp32s3_pico.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
+nologo_esp32s3_pico.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+nologo_esp32s3_pico.menu.JTAGAdapter.external=FTDI Adapter
+nologo_esp32s3_pico.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+nologo_esp32s3_pico.menu.JTAGAdapter.external.build.copy_jtag_files=1
+nologo_esp32s3_pico.menu.JTAGAdapter.bridge=ESP USB Bridge
+nologo_esp32s3_pico.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+nologo_esp32s3_pico.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+nologo_esp32s3_pico.menu.PSRAM.disabled=Disabled
+nologo_esp32s3_pico.menu.PSRAM.disabled.build.defines=
+nologo_esp32s3_pico.menu.PSRAM.disabled.build.psram_type=qspi
+nologo_esp32s3_pico.menu.PSRAM.enabled=QSPI PSRAM
+nologo_esp32s3_pico.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+nologo_esp32s3_pico.menu.PSRAM.enabled.build.psram_type=qspi
+nologo_esp32s3_pico.menu.PSRAM.opi=OPI PSRAM
+nologo_esp32s3_pico.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+nologo_esp32s3_pico.menu.PSRAM.opi.build.psram_type=opi
+
+nologo_esp32s3_pico.menu.FlashMode.qio=QIO 80MHz
+nologo_esp32s3_pico.menu.FlashMode.qio.build.flash_mode=dio
+nologo_esp32s3_pico.menu.FlashMode.qio.build.boot=qio
+nologo_esp32s3_pico.menu.FlashMode.qio.build.boot_freq=80m
+nologo_esp32s3_pico.menu.FlashMode.qio.build.flash_freq=80m
+nologo_esp32s3_pico.menu.FlashMode.qio120=QIO 120MHz
+nologo_esp32s3_pico.menu.FlashMode.qio120.build.flash_mode=dio
+nologo_esp32s3_pico.menu.FlashMode.qio120.build.boot=qio
+nologo_esp32s3_pico.menu.FlashMode.qio120.build.boot_freq=120m
+nologo_esp32s3_pico.menu.FlashMode.qio120.build.flash_freq=80m
+nologo_esp32s3_pico.menu.FlashMode.dio=DIO 80MHz
+nologo_esp32s3_pico.menu.FlashMode.dio.build.flash_mode=dio
+nologo_esp32s3_pico.menu.FlashMode.dio.build.boot=dio
+nologo_esp32s3_pico.menu.FlashMode.dio.build.boot_freq=80m
+nologo_esp32s3_pico.menu.FlashMode.dio.build.flash_freq=80m
+nologo_esp32s3_pico.menu.FlashMode.opi=OPI 80MHz
+nologo_esp32s3_pico.menu.FlashMode.opi.build.flash_mode=dout
+nologo_esp32s3_pico.menu.FlashMode.opi.build.boot=opi
+nologo_esp32s3_pico.menu.FlashMode.opi.build.boot_freq=80m
+nologo_esp32s3_pico.menu.FlashMode.opi.build.flash_freq=80m
+
+nologo_esp32s3_pico.menu.FlashSize.8M=8MB (64Mb)
+nologo_esp32s3_pico.menu.FlashSize.8M.build.flash_size=8MB
+nologo_esp32s3_pico.menu.FlashSize.8M.build.partitions=default_8MB
+nologo_esp32s3_pico.menu.FlashSize.16M=16MB (128Mb)
+nologo_esp32s3_pico.menu.FlashSize.16M.build.flash_size=16MB
+
+nologo_esp32s3_pico.menu.LoopCore.1=Core 1
+nologo_esp32s3_pico.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+nologo_esp32s3_pico.menu.LoopCore.0=Core 0
+nologo_esp32s3_pico.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+nologo_esp32s3_pico.menu.EventsCore.1=Core 1
+nologo_esp32s3_pico.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+nologo_esp32s3_pico.menu.EventsCore.0=Core 0
+nologo_esp32s3_pico.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+nologo_esp32s3_pico.menu.USBMode.hwcdc=Hardware CDC and JTAG
+nologo_esp32s3_pico.menu.USBMode.hwcdc.build.usb_mode=1
+nologo_esp32s3_pico.menu.USBMode.default=USB-OTG (TinyUSB)
+nologo_esp32s3_pico.menu.USBMode.default.build.usb_mode=0
+
+nologo_esp32s3_pico.menu.CDCOnBoot.default=Enabled
+nologo_esp32s3_pico.menu.CDCOnBoot.default.build.cdc_on_boot=1
+nologo_esp32s3_pico.menu.CDCOnBoot.cdc=Enabled
+nologo_esp32s3_pico.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+nologo_esp32s3_pico.menu.MSCOnBoot.default=Disabled
+nologo_esp32s3_pico.menu.MSCOnBoot.default.build.msc_on_boot=0
+nologo_esp32s3_pico.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+nologo_esp32s3_pico.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+nologo_esp32s3_pico.menu.DFUOnBoot.default=Disabled
+nologo_esp32s3_pico.menu.DFUOnBoot.default.build.dfu_on_boot=0
+nologo_esp32s3_pico.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+nologo_esp32s3_pico.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+nologo_esp32s3_pico.menu.UploadMode.default=UART0 / Hardware CDC
+nologo_esp32s3_pico.menu.UploadMode.default.upload.use_1200bps_touch=false
+nologo_esp32s3_pico.menu.UploadMode.default.upload.wait_for_upload_port=false
+nologo_esp32s3_pico.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+nologo_esp32s3_pico.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+nologo_esp32s3_pico.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+nologo_esp32s3_pico.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+nologo_esp32s3_pico.menu.PartitionScheme.default.build.partitions=default
+nologo_esp32s3_pico.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+nologo_esp32s3_pico.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+nologo_esp32s3_pico.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+nologo_esp32s3_pico.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+nologo_esp32s3_pico.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+nologo_esp32s3_pico.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+nologo_esp32s3_pico.menu.PartitionScheme.minimal.build.partitions=minimal
+nologo_esp32s3_pico.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+nologo_esp32s3_pico.menu.PartitionScheme.no_ota.build.partitions=no_ota
+nologo_esp32s3_pico.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+nologo_esp32s3_pico.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+nologo_esp32s3_pico.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+nologo_esp32s3_pico.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+nologo_esp32s3_pico.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+nologo_esp32s3_pico.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+nologo_esp32s3_pico.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+nologo_esp32s3_pico.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+nologo_esp32s3_pico.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+nologo_esp32s3_pico.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+nologo_esp32s3_pico.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+nologo_esp32s3_pico.menu.PartitionScheme.huge_app.build.partitions=huge_app
+nologo_esp32s3_pico.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+nologo_esp32s3_pico.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+nologo_esp32s3_pico.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+nologo_esp32s3_pico.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+nologo_esp32s3_pico.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+nologo_esp32s3_pico.menu.PartitionScheme.fatflash.build.partitions=ffat
+nologo_esp32s3_pico.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+nologo_esp32s3_pico.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+nologo_esp32s3_pico.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+nologo_esp32s3_pico.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+nologo_esp32s3_pico.menu.PartitionScheme.rainmaker=RainMaker
+nologo_esp32s3_pico.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+nologo_esp32s3_pico.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+nologo_esp32s3_pico.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
+nologo_esp32s3_pico.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
+nologo_esp32s3_pico.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
+nologo_esp32s3_pico.menu.PartitionScheme.app5M_little24M_32MB=32M Flash (4.8MB APP/22MB LittleFS)
+nologo_esp32s3_pico.menu.PartitionScheme.app5M_little24M_32MB.build.partitions=large_littlefs_32MB
+nologo_esp32s3_pico.menu.PartitionScheme.app5M_little24M_32MB.upload.maximum_size=4718592
+nologo_esp32s3_pico.menu.PartitionScheme.esp_sr_16=ESP SR 16M (3MB APP/7MB SPIFFS/2.9MB MODEL)
+nologo_esp32s3_pico.menu.PartitionScheme.esp_sr_16.upload.maximum_size=3145728
+nologo_esp32s3_pico.menu.PartitionScheme.esp_sr_16.upload.extra_flags=0xD10000 {build.path}/srmodels.bin
+nologo_esp32s3_pico.menu.PartitionScheme.esp_sr_16.build.partitions=esp_sr_16
+nologo_esp32s3_pico.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+nologo_esp32s3_pico.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+nologo_esp32s3_pico.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+nologo_esp32s3_pico.menu.PartitionScheme.custom=Custom
+nologo_esp32s3_pico.menu.PartitionScheme.custom.build.partitions=
+nologo_esp32s3_pico.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+nologo_esp32s3_pico.menu.CPUFreq.240=240MHz (WiFi)
+nologo_esp32s3_pico.menu.CPUFreq.240.build.f_cpu=240000000L
+nologo_esp32s3_pico.menu.CPUFreq.160=160MHz (WiFi)
+nologo_esp32s3_pico.menu.CPUFreq.160.build.f_cpu=160000000L
+nologo_esp32s3_pico.menu.CPUFreq.80=80MHz (WiFi)
+nologo_esp32s3_pico.menu.CPUFreq.80.build.f_cpu=80000000L
+nologo_esp32s3_pico.menu.CPUFreq.40=40MHz
+nologo_esp32s3_pico.menu.CPUFreq.40.build.f_cpu=40000000L
+nologo_esp32s3_pico.menu.CPUFreq.20=20MHz
+nologo_esp32s3_pico.menu.CPUFreq.20.build.f_cpu=20000000L
+nologo_esp32s3_pico.menu.CPUFreq.10=10MHz
+nologo_esp32s3_pico.menu.CPUFreq.10.build.f_cpu=10000000L
+
+nologo_esp32s3_pico.menu.UploadSpeed.921600=921600
+nologo_esp32s3_pico.menu.UploadSpeed.921600.upload.speed=921600
+nologo_esp32s3_pico.menu.UploadSpeed.115200=115200
+nologo_esp32s3_pico.menu.UploadSpeed.115200.upload.speed=115200
+nologo_esp32s3_pico.menu.UploadSpeed.256000.windows=256000
+nologo_esp32s3_pico.menu.UploadSpeed.256000.upload.speed=256000
+nologo_esp32s3_pico.menu.UploadSpeed.230400.windows.upload.speed=256000
+nologo_esp32s3_pico.menu.UploadSpeed.230400=230400
+nologo_esp32s3_pico.menu.UploadSpeed.230400.upload.speed=230400
+nologo_esp32s3_pico.menu.UploadSpeed.460800.linux=460800
+nologo_esp32s3_pico.menu.UploadSpeed.460800.macosx=460800
+nologo_esp32s3_pico.menu.UploadSpeed.460800.upload.speed=460800
+nologo_esp32s3_pico.menu.UploadSpeed.512000.windows=512000
+nologo_esp32s3_pico.menu.UploadSpeed.512000.upload.speed=512000
+
+nologo_esp32s3_pico.menu.DebugLevel.none=None
+nologo_esp32s3_pico.menu.DebugLevel.none.build.code_debug=0
+nologo_esp32s3_pico.menu.DebugLevel.error=Error
+nologo_esp32s3_pico.menu.DebugLevel.error.build.code_debug=1
+nologo_esp32s3_pico.menu.DebugLevel.warn=Warn
+nologo_esp32s3_pico.menu.DebugLevel.warn.build.code_debug=2
+nologo_esp32s3_pico.menu.DebugLevel.info=Info
+nologo_esp32s3_pico.menu.DebugLevel.info.build.code_debug=3
+nologo_esp32s3_pico.menu.DebugLevel.debug=Debug
+nologo_esp32s3_pico.menu.DebugLevel.debug.build.code_debug=4
+nologo_esp32s3_pico.menu.DebugLevel.verbose=Verbose
+nologo_esp32s3_pico.menu.DebugLevel.verbose.build.code_debug=5
+
+nologo_esp32s3_pico.menu.EraseFlash.none=Disabled
+nologo_esp32s3_pico.menu.EraseFlash.none.upload.erase_cmd=
+nologo_esp32s3_pico.menu.EraseFlash.all=Enabled
+nologo_esp32s3_pico.menu.EraseFlash.all.upload.erase_cmd=-e
+
+nologo_esp32s3_pico.menu.ZigbeeMode.default=Disabled
+nologo_esp32s3_pico.menu.ZigbeeMode.default.build.zigbee_mode=
+nologo_esp32s3_pico.menu.ZigbeeMode.default.build.zigbee_libs=
+nologo_esp32s3_pico.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator)
+nologo_esp32s3_pico.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+nologo_esp32s3_pico.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api_zczr -lesp_zb_cli_command -lzboss_stack.zczr.trace -lzboss_stack.zczr -lzboss_port
+
+##############################################################
+
 mhetesp32devkit.name=MH ET LIVE ESP32DevKIT
 
 mhetesp32devkit.bootloader.tool=esptool_py

--- a/variants/nologo_esp32s3_pico/pins_arduino.h
+++ b/variants/nologo_esp32s3_pico/pins_arduino.h
@@ -1,0 +1,37 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+static const uint8_t LED_BUILTIN = 21;
+#define BUILTIN_LED  LED_BUILTIN
+#define LED_BUILTIN LED_BUILTIN
+#define RGB_BUILTIN SOC_GPIO_PIN_COUNT + LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
+// SPI - unused but you can create your own definition in your sketch
+static const int8_t SCK = -1;
+static const int8_t MISO = -1;
+static const int8_t MOSI = -1;
+static const int8_t SS = -1;
+
+// I2C - unused but you can create your own definition in your sketch
+static const uint8_t SDA = -1;
+static const uint8_t SCL = -1;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change

Add board support for [Nologo ESP32S3 Pico](https://www.nologo.tech/product/esp32/esp32s3Pico/esp32S3Pico.html)

## Tests scenarios

I have tested my pr on this board. Verified by compiling and uploading using PlatformIO, cherry-picking the changes onto the v2.0.11 branch.

## Related links

- https://www.nologo.tech/product/esp32/esp32s3Pico/esp32S3Pico.html
