### PR TITLE
[CI] Update workflows actions to latest versions with Node.js 20

### DIFF
--- a/.github/workflows/allboards.yml
+++ b/.github/workflows/allboards.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.branch }}
 
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.branch }}
 
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.branch }}
 

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # This step makes the contents of the repository available to the workflow
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup jq
         uses: dcarbone/install-jq-action@v1.0.1
@@ -43,7 +43,7 @@ jobs:
     steps:
       # This step makes the contents of the repository available to the workflow
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check if build.board is uppercase
         run: |

--- a/.github/workflows/build_py_tools.yml
+++ b/.github/workflows/build_py_tools.yml
@@ -17,7 +17,7 @@ jobs:
       all_changed_files: ${{ steps.verify-changed-files.outputs.all_changed_files }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.ref }}
@@ -87,7 +87,7 @@ jobs:
             echo "tool $tool was changed"
           done
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up Python 3.8

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -22,10 +22,10 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Build

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -20,10 +20,10 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Deploy Documentation

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build GitHub Pages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Copy Files
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -25,7 +25,7 @@ jobs:
       chunks: ${{ steps.gen-chunks.outputs.chunks }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate Chunks matrix
         id: gen-chunks
@@ -51,7 +51,7 @@ jobs:
         chunks: ${{fromJson(needs.gen_chunks.outputs.chunks)}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build sketches
         run: |
           bash .github/scripts/tests_build.sh -c -t ${{matrix.chip}} -i ${{matrix.chunks}} -m ${{env.MAX_CHUNKS}}
@@ -78,7 +78,7 @@ jobs:
 
     steps:
        - name: Checkout repository
-         uses: actions/checkout@v3
+         uses: actions/checkout@v4
 
        - name: Download ${{matrix.chip}}-${{matrix.chunks}} artifacts
          uses: actions/download-artifact@v3

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       # This step makes the contents of the repository available to the workflow
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Compile sketch
         uses: P-R-O-C-H-Y/compile-sketches@main
@@ -87,7 +87,7 @@ jobs:
     steps:
       # Check out repository
       - name: Checkout repository    
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ env.GITHUB_TOKEN }}
           fetch-depth: '0'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check cmake file
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: bash ./.github/scripts/check-cmakelists.sh
 
   # Ubuntu
@@ -31,13 +31,13 @@ jobs:
         chunk: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Cache tools
       id: cache-linux
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ./tools/dist
@@ -58,8 +58,8 @@ jobs:
         os: [windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Build Sketches
@@ -75,8 +75,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Build Sketches
@@ -97,7 +97,7 @@ jobs:
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
       - name: Check out arduino-esp32 as a component
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           path: components/arduino-esp32

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Build Release

--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -7,7 +7,7 @@ jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 


### PR DESCRIPTION
## Description of Change
Node.js 16 actions are deprecated. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Following actions were updated:
- checkout@v3 -> v4
- cache@v3 -> v4
- setup-python@v4 -> v5

## Tests scenarios

## Related links
