### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-7380f96017"
+              "version": "idf-release_v5.1-931eaf7320"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-7380f96017",
+          "version": "idf-release_v5.1-931eaf7320",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
-              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
-              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
-              "size": "355634251"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
+              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
+              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
+              "size": "355693418"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-931eaf7320"
+              "version": "idf-release_v5.1-d922d4178f"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-931eaf7320",
+          "version": "idf-release_v5.1-d922d4178f",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1e2d85899b736f4bd5920c9702c34b8e049e5377",
-              "archiveFileName": "esp32-arduino-libs-1e2d85899b736f4bd5920c9702c34b8e049e5377.zip",
-              "checksum": "SHA-256:33ee0ff44bc919555a880e0965f7d3dd76a5a0d3c944c348b06de0bd6224b625",
-              "size": "355693418"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/86e4fbbff4374330585949f17603fa0bba7e5a3c",
+              "archiveFileName": "esp32-arduino-libs-86e4fbbff4374330585949f17603fa0bba7e5a3c.zip",
+              "checksum": "SHA-256:0559f27050fc618f264c9781aaee16962fa573ea640bb753b014b0ab5d0dd4a9",
+              "size": "355692397"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-3662303f31"
+              "version": "idf-release_v5.1-7cbee80fb9"
             },
             {
               "packager": "esp32",
@@ -62,7 +62,7 @@
             {
               "packager": "esp32",
               "name": "xtensa-esp-elf-gdb",
-              "version": "12.1_20221002"
+              "version": "12.1_20231023"
             },
             {
               "packager": "esp32",
@@ -72,7 +72,7 @@
             {
               "packager": "esp32",
               "name": "riscv32-esp-elf-gdb",
-              "version": "12.1_20221002"
+              "version": "12.1_20231023"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-3662303f31",
+          "version": "idf-release_v5.1-7cbee80fb9",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
+              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
+              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
+              "size": "355580187"
             }
           ]
         },
@@ -353,63 +353,63 @@
         },
         {
           "name": "xtensa-esp-elf-gdb",
-          "version": "12.1_20221002",
+          "version": "12.1_20231023",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:d056f2435ef05cccadac5d8fcefa3efd8f8c456c3d853f5eba1edb501acfe4f7",
-              "size": "32006939"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:d0743ec43cd92c35452a9097f7863281de4e72f04120d63cfbcf9d591a373529",
+              "size": "36942094"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:7fc9674cc4f4c5e7bc94ca05bc5deaaa4c4bbcc972a9caee6fcd6a872c804c02",
-              "size": "32227425"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:bc1fac0366c6a08e26c45896ca21c8c90efc2cdd431b8ba084e8772e15502d0e",
+              "size": "37134601"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:68118ff36e9dd2284d92a7a529d0e2a8d20f6426036a0736fa1147935614ece2",
-              "size": "29960020"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:25efc51d52b71f097ccec763c5c885c8f5026b432fec4b5badd6a5f36fe34d04",
+              "size": "34579556"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:cf6cac8ed70726d390d30713d537754544872715e1b70a8a4a28b5dc616193b9",
-              "size": "30877187"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:e0af0b3b4a6b29a843cd5f47e331a966d9258f7d825b4656c6251490f71b05b2",
+              "size": "35676578"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "checksum": "SHA-256:417fcf8d1b596b9481603d6987def1d6cfcebdb9739f53940887334a7de855fa",
-              "size": "45941853"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "checksum": "SHA-256:bd146fd99a52b2d71c7ce0f62b9e18f3423d6cae7b2b2c954046b0dd7a23142f",
+              "size": "52863941"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "checksum": "SHA-256:95d6ed2311d6a72bf349e152d096aeeb151f9c5989bfa3120facb1c99e879196",
-              "size": "27596410"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:5edc76565bf9d2fadf24e443ddf3df7567354f336a65d4af5b2ee805cdfcec24",
+              "size": "33504923"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:642b6a135c38ff1d5e54ad2c29469b769f8e1b101dab363d06101b02284bb979",
-              "size": "27387730"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:ea4f3ee6b95ad1ad2e07108a21a50037a3e64a420cdeb34b2ba95d612faed898",
+              "size": "31068749"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/xtensa-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:2d958570ff6aa69ed32cbb076cbaf303349a26b3301a7c4628be8d7ad39cf9f1",
-              "size": "29561472"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/xtensa-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:13bb97f39173948d1cfb6e651d9b335ea9d52f1fdd0dda1eda3a2d23d8c63644",
+              "size": "33514906"
             }
           ]
         },
@@ -477,63 +477,63 @@
         },
         {
           "name": "riscv32-esp-elf-gdb",
-          "version": "12.1_20221002",
+          "version": "12.1_20231023",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:f0cf0821eaac7e8cf2c63b14f2b69d612f4f8c266b29d02d5547b7d7cbbd0e11",
-              "size": "32035173"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:2c78b806be176b1e449e07ff83429d38dfc39a13f89a127ac1ffa6c1230537a0",
+              "size": "36630145"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:6812344dfb5c50a81d2fd8354463516f0aa5f582e8ab406cbaeca8722b45fa94",
-              "size": "32362642"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:33f80117c8777aaff9179e27953e41764c5c46b3c576dc96a37ecc7a368807ec",
+              "size": "36980143"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:b73042b8e1df5a3fc8008ec3cd000ef579f155d72a66c6ade1d48906d843e738",
-              "size": "30580290"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:292e6ec0a9381c1480bbadf5caae25e86428b68fb5d030c9be7deda5e7f070e0",
+              "size": "34950318"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:3f07a1b8dc87127a1a6bec6fbace4f8daca44755356f0692e9a5d4c8c4bfd81d",
-              "size": "31309798"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:68a25fbcfc6371ec4dbe503ec92211977eb2006f0c29e67dbce6b93c70c6b7ec",
+              "size": "35801607"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-x86_64-apple-darwin14.tar.gz",
-              "checksum": "SHA-256:bb139229f9a4998cab9cfb617d3ecb05b77cbfa9a3a59c54969035f1b4007487",
-              "size": "46120661"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-x86_64-apple-darwin14.tar.gz",
+              "checksum": "SHA-256:322c722e6c12225ed8cd97f95a0375105756dc5113d369958ce0858ad1a90257",
+              "size": "52618688"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-aarch64-apple-darwin21.1.tar.gz",
-              "checksum": "SHA-256:f6513b57f28245497f9c39a201f3f6444d4180e16b39765c629e01036286c0e6",
-              "size": "27662484"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-aarch64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:c2224b3a8d02451c530cf004c29653292d963a1b4021b4b472b862b6dbe97e0b",
+              "size": "33149392"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:8287fa2891e8d032e8283210048d653705791cda31504369418288d3e4753dd6",
-              "size": "27839143"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:4b42149a99dd87ee7e6dde25c99bad966c7f964253fa8f771593d7cef69f5602",
+              "size": "31635103"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20221002/riscv32-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20221002-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:9debae1135df8f5868a9d945468f0480cdaab25f77ead6a55cc85142c4487abd",
-              "size": "29404989"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v12.1_20231023/riscv32-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-12.1_20231023-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:728231546ad5006d34463f972658b2a89e52f660a42abab08a29bedd4a8046ad",
+              "size": "33400816"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-7cbee80fb9"
+              "version": "idf-release_v5.1-7380f96017"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-7cbee80fb9",
+          "version": "idf-release_v5.1-7380f96017",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a373b86ea98023ebebbfb3b23ad8100376ba946",
-              "archiveFileName": "esp32-arduino-libs-1a373b86ea98023ebebbfb3b23ad8100376ba946.zip",
-              "checksum": "SHA-256:3c6926bbf56d2c6a6c13c3c50f7f7b3f0ae77054c7a02ec6694986930df078bd",
-              "size": "355580187"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/bef34d984ad9348f2055653b62998a023273dece",
+              "archiveFileName": "esp32-arduino-libs-bef34d984ad9348f2055653b62998a023273dece.zip",
+              "checksum": "SHA-256:66a03dd67d5ccc9120230d653efff0f4d8f97dc656e0a278bfc6fbd02b9b71bd",
+              "size": "355634251"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master fbf8143
esp-idf: release/v5.1 7cbee80fb9
arduino: master 83e2612f
tinyusb: master 68cc7089b
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.10
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.6.1
espressif__esp-tflite-micro: 1.2.0
espressif__esp-zboss-lib: 1.0.9
espressif__esp-zigbee-lib: 1.0.9
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_rainmaker: 1.1.0
espressif__esp_schedule: 1.1.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__mdns: 1.2.1
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.4
joltwallet__littlefs: 1.14.0
```
