### PR TITLE
Fix AdvancedWebServer.ino uptime conversion

### DIFF
--- a/libraries/WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
+++ b/libraries/WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
@@ -44,8 +44,9 @@ void handleRoot() {
   digitalWrite(led, 1);
   char temp[400];
   int sec = millis() / 1000;
-  int min = sec / 60;
-  int hr = min / 60;
+  int hr = sec / 3600;
+  int min = (sec / 60) % 60;
+  sec = sec % 60
 
   snprintf(temp, 400,
 

--- a/libraries/WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
+++ b/libraries/WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
@@ -46,7 +46,7 @@ void handleRoot() {
   int sec = millis() / 1000;
   int hr = sec / 3600;
   int min = (sec / 60) % 60;
-  sec = sec % 60
+  sec = sec % 60;
 
   snprintf(temp, 400,
 
@@ -65,7 +65,7 @@ void handleRoot() {
   </body>\
 </html>",
 
-           hr, min % 60, sec % 60
+           hr, min, sec
           );
   server.send(200, "text/html", temp);
   digitalWrite(led, 0);


### PR DESCRIPTION
## Description of Change
This PR resolves an insignificant bug in the `AdvancedWebServer.ino` example, where the uptime is converted from seconds to hours, minutes, seconds format.  
The changes do not affect the overall sketch nor its intended usage.  

Prior to the changes, the reported uptime would be incorrectly going over 60 seconds a minute, and minutes would increase incorrectly.  
For examples:  
```text
0:0:59
0:1:0

0:1:60
0:1:61

0:1:118
0:1:119
0:2:120
0:2:121
```

After these changes, minutes and seconds update as expected.



## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core `v2.0.14` with ESP32 on an `ESP32-Ethernet-Kit_A_V1.2` development board.


Thank you for your time,
Cyril :slightly_smiling_face: 
