### PR TITLE
Fix C2 compilation for Updater.cpp

### DIFF
--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -5,7 +5,6 @@
 #include <MD5Builder.h>
 #include <functional>
 #include "esp_partition.h"
-#include "aes/esp_aes.h"
 
 #define UPDATE_ERROR_OK                 (0)
 #define UPDATE_ERROR_WRITE              (1)


### PR DESCRIPTION
Fixes issue reported in https://github.com/espressif/arduino-esp32/pull/5807#issuecomment-1935770156

This will work exactly the same for all chips except C2, where it will use the mbedtls functions. In the future we will need to replace mbedtls with something simpler.
