### PR TITLE
Adds RMT End of Transmission Level API 

### DIFF
--- a/cores/esp32/esp32-hal-rmt.h
+++ b/cores/esp32/esp32-hal-rmt.h
@@ -77,6 +77,18 @@ typedef union {
 bool rmtInit(int pin, rmt_ch_dir_t channel_direction, rmt_reserve_memsize_t memsize, uint32_t frequency_Hz);
 
 /**
+     Sets the End of Transmission level to be set the <pin> when the RMT transmission ends.
+     This function affects how rmtWrite(), rmtWriteAsync() or rmtWriteLooping() will set the pin after writing the data.
+     The default EOT level is LOW, in case this function isn't used before RMT Writing.
+     This level can be set for each RMT pin and can change between writings to the same pin.
+
+     <EOT_Level> shall be Zero (LOW) or non-zero (HIGH) value.
+     It only affects the transmission process, therefore, it doesn't affect any IDLE LEVEL before starting the RMT transmission. 
+     The pre-transmission idle level can be set manually calling, for instance, digitalWrite(pin, Level).
+*/
+void rmtSetEOT(int pin, uint8_t EOT_Level);
+
+/**
      Sending data in Blocking Mode. 
      <rmt_symbol> is a 32 bits structure as defined by rmt_data_t type.
      It is possible to use the macro RMT_SYMBOLS_OF(data), if data is an array of <rmt_data_t>.


### PR DESCRIPTION
## Description of Change
This PR adds a new API to RMT that allows the application to set the End of Transmission Level after writing to a RMT chanel.

## Tests scenarios

Example:
``` cpp
#define BLINK_GPIO 2

// RMT is at 400KHz with a 2.5us tick
// This RMT data sends a 0.5Hz pulse with 1s High and 1s Low signal
rmt_data_t blink_1s_rmt_data[] = {
  // 400,000 x 2.5us = 1 second ON
  {25000, 1, 25000, 1,},
  {25000, 1, 25000, 1,},
  {25000, 1, 25000, 1,},
  {25000, 1, 25000, 1,},
  {25000, 1, 25000, 1,},
  {25000, 1, 25000, 1,},
  {25000, 1, 25000, 1,},
  {25000, 1, 25000, 1,},
  // 400,000 x 2.5us = 1 second OFF
  {25000, 0, 25000, 0,},
  {25000, 0, 25000, 0,},
  {25000, 0, 25000, 0,},
  {25000, 0, 25000, 0,},
  {25000, 0, 25000, 0,},
  {25000, 0, 25000, 0,},
  {25000, 0, 25000, 0,},
  {25000, 0, 25000, 0,},
  // Looping mode needs a Zero ending data to mark the EOF
  {0, 0, 0, 0}
};

void setup() {
  Serial.begin(115200);
  Serial.println("Starting Blink testing...");
  Serial.flush();
  
  // 1 RMT Block has 64 RMT_SYMBOLS (ESP32|ESP32S2) or 48 RMT_SYMBOLS (ESP32C3|ESP32S3)
  if (!rmtInit(BLINK_GPIO, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 400000)) { //2.5us tick
    Serial.println("===> rmtInit Error!");
  }
  delay(1000); // initial state of the LED is LOW by default.
  
  // sets the End of Transmission Level to HIGH, after writing to the pin. DEFAULT is LOW.
  rmtSetEOT(MY_RMT_PIN, HIGH);
    
  // Send the data and wait until it is done - set EOT level to HIGH
  if (!rmtWrite(BLINK_GPIO, blink_1s_rmt_data, RMT_SYMBOLS_OF(blink_1s_rmt_data) - 2, RMT_WAIT_FOR_EVER)) {
    Serial.println("===> rmtWrite Blink 1s Error!");
  }
    
  // LED shall stay 1 seconds OFF (initial state), BLINK: 1 second ON, 1 second OFF and then stay in HIGH level at the end.
}
```

## Related links
Closes #9235 