### PR TITLE
Added pin check in ETH examples to avoid redefinition

### DIFF
--- a/libraries/Ethernet/examples/ETH_LAN8720/ETH_LAN8720.ino
+++ b/libraries/Ethernet/examples/ETH_LAN8720/ETH_LAN8720.ino
@@ -5,12 +5,14 @@
 
 // Important to be defined BEFORE including ETH.h for ETH.begin() to work.
 // Example RMII LAN8720 (Olimex, etc.)
+#ifndef ETH_PHY_TYPE
 #define ETH_PHY_TYPE        ETH_PHY_LAN8720
 #define ETH_PHY_ADDR         0
 #define ETH_PHY_MDC         23
 #define ETH_PHY_MDIO        18
 #define ETH_PHY_POWER       -1
 #define ETH_CLK_MODE        ETH_CLOCK_GPIO0_IN
+#endif
 
 #include <ETH.h>
 

--- a/libraries/Ethernet/examples/ETH_TLK110/ETH_TLK110.ino
+++ b/libraries/Ethernet/examples/ETH_TLK110/ETH_TLK110.ino
@@ -5,12 +5,14 @@
 
 #include <ETH.h>
 
-#define ETH_TYPE            ETH_PHY_TLK110
-#define ETH_ADDR            31
-#define ETH_MDC_PIN         23
-#define ETH_MDIO_PIN        18
-#define ETH_POWER_PIN       17
+#ifndef ETH_PHY_TYPE
+#define ETH_PHY_TYPE        ETH_PHY_TLK110
+#define ETH_PHY_ADDR        31
+#define ETH_PHY_MDC         23
+#define ETH_PHY_MDIO        18
+#define ETH_PHY_POWER       17
 #define ETH_CLK_MODE        ETH_CLOCK_GPIO0_IN
+#endif
 
 static bool eth_connected = false;
 
@@ -73,7 +75,7 @@ void setup()
 {
   Serial.begin(115200);
   WiFi.onEvent(WiFiEvent);  // Will call WiFiEvent() from another thread.
-  ETH.begin(ETH_TYPE, ETH_ADDR, ETH_MDC_PIN, ETH_MDIO_PIN, ETH_POWER_PIN, ETH_CLK_MODE);
+  ETH.begin(ETH_PHY_TYPE, ETH_PHY_ADDR, ETH_PHY_MDC, ETH_PHY_MDIO, ETH_PHY_POWER, ETH_CLK_MODE);
 }
 
 

--- a/libraries/Ethernet/examples/ETH_W5500_Arduino_SPI/ETH_W5500_Arduino_SPI.ino
+++ b/libraries/Ethernet/examples/ETH_W5500_Arduino_SPI/ETH_W5500_Arduino_SPI.ino
@@ -9,24 +9,28 @@
 // Set this to 1 to enable dual Ethernet support
 #define USE_TWO_ETH_PORTS 0
 
-#define ETH_TYPE        ETH_PHY_W5500
-#define ETH_ADDR         1
-#define ETH_CS          15
-#define ETH_IRQ          4
-#define ETH_RST          5
+#ifndef ETH_PHY_TYPE
+#define ETH_PHY_TYPE        ETH_PHY_W5500
+#define ETH_PHY_ADDR         1
+#define ETH_PHY_CS          15
+#define ETH_PHY_IRQ          4
+#define ETH_PHY_RST          5
+#endif
 
 // SPI pins
-#define ETH_SPI_SCK     14
-#define ETH_SPI_MISO    12
-#define ETH_SPI_MOSI    13
+#define ETH_SPI_SCK         14
+#define ETH_SPI_MISO        12
+#define ETH_SPI_MOSI        13
 
 #if USE_TWO_ETH_PORTS
 // Second port on shared SPI bus
-#define ETH1_TYPE        ETH_PHY_W5500
-#define ETH1_ADDR         1
-#define ETH1_CS          32
-#define ETH1_IRQ         33
-#define ETH1_RST         18
+#ifndef ETH1_PHY_TYPE
+#define ETH1_PHY_TYPE        ETH_PHY_W5500
+#define ETH1_PHY_ADDR         1
+#define ETH1_PHY_CS          32
+#define ETH1_PHY_IRQ         33
+#define ETH1_PHY_RST         18
+#endif
 ETHClass ETH1(1);
 #endif
 
@@ -94,9 +98,9 @@ void setup()
   WiFi.onEvent(onEvent);
 
   SPI.begin(ETH_SPI_SCK, ETH_SPI_MISO, ETH_SPI_MOSI);
-  ETH.begin(ETH_TYPE, ETH_ADDR, ETH_CS, ETH_IRQ, ETH_RST, SPI);
+  ETH.begin(ETH_PHY_TYPE, ETH_PHY_ADDR, ETH_PHY_CS, ETH_PHY_IRQ, ETH_PHY_RST, SPI);
 #if USE_TWO_ETH_PORTS
-  ETH1.begin(ETH1_TYPE, ETH1_ADDR, ETH1_CS, ETH1_IRQ, ETH1_RST, SPI);
+  ETH1.begin(ETH1_PHY_TYPE, ETH1_PHY_ADDR, ETH1_PHY_CS, ETH1_PHY_IRQ, ETH1_PHY_RST, SPI);
 #endif
 }
 

--- a/libraries/Ethernet/examples/ETH_W5500_IDF_SPI/ETH_W5500_IDF_SPI.ino
+++ b/libraries/Ethernet/examples/ETH_W5500_IDF_SPI/ETH_W5500_IDF_SPI.ino
@@ -8,23 +8,27 @@
 // Set this to 1 to enable dual Ethernet support
 #define USE_TWO_ETH_PORTS 0
 
-#define ETH_TYPE        ETH_PHY_W5500
-#define ETH_ADDR         1
-#define ETH_CS          15
-#define ETH_IRQ          4
-#define ETH_RST          5
-#define ETH_SPI_HOST    SPI2_HOST
-#define ETH_SPI_SCK     14
-#define ETH_SPI_MISO    12
-#define ETH_SPI_MOSI    13
+#ifndef ETH_PHY_TYPE
+#define ETH_PHY_TYPE        ETH_PHY_W5500
+#define ETH_PHY_ADDR         1
+#define ETH_PHY_CS          15
+#define ETH_PHY_IRQ          4
+#define ETH_PHY_RST          5
+#define ETH_PHY_SPI_HOST    SPI2_HOST
+#define ETH_PHY_SPI_SCK     14
+#define ETH_PHY_SPI_MISO    12
+#define ETH_PHY_SPI_MOSI    13
+#endif
 
 #if USE_TWO_ETH_PORTS
 // Second port on shared SPI bus
-#define ETH1_TYPE        ETH_PHY_W5500
-#define ETH1_ADDR         1
-#define ETH1_CS          32
-#define ETH1_IRQ         33
-#define ETH1_RST         18
+#ifndef ETH1_PHY_TYPE
+#define ETH1_PHY_TYPE        ETH_PHY_W5500
+#define ETH1_PHY_ADDR         1
+#define ETH1_PHY_CS          32
+#define ETH1_PHY_IRQ         33
+#define ETH1_PHY_RST         18
+#endif
 ETHClass ETH1(1);
 #endif
 
@@ -90,10 +94,10 @@ void setup()
 {
   Serial.begin(115200);
   WiFi.onEvent(onEvent);
-  ETH.begin(ETH_TYPE, ETH_ADDR, ETH_CS, ETH_IRQ, ETH_RST, ETH_SPI_HOST, ETH_SPI_SCK, ETH_SPI_MISO, ETH_SPI_MOSI);
+  ETH.begin(ETH_PHY_TYPE, ETH_PHY_ADDR, ETH_PHY_CS, ETH_PHY_IRQ, ETH_PHY_RST, ETH_PHY_SPI_HOST, ETH_PHY_SPI_SCK, ETH_PHY_SPI_MISO, ETH_PHY_SPI_MOSI);
 #if USE_TWO_ETH_PORTS
   // Since SPI bus is shared, we should skip the SPI pins when calling ETH1.begin()
-  ETH1.begin(ETH1_TYPE, ETH1_ADDR, ETH1_CS, ETH1_IRQ, ETH1_RST, ETH_SPI_HOST);
+  ETH1.begin(ETH1_PHY_TYPE, ETH1_PHY_ADDR, ETH1_PHY_CS, ETH1_PHY_IRQ, ETH1_PHY_RST, ETH_PHY_SPI_HOST);
 #endif
 }
 


### PR DESCRIPTION
## Description of Change
Added check for `ETH_PHY_TYPE` to avoid Ethernet pins redefinition in sketch, if ETH pins are defined in variants `pins_arduino.h`. Also renamed pins defines in examples, to match empales of defines in `ETH.h`.

## Tests scenarios
Compiled all ETH examples + tested variant with ETH pins defined.

## Related links
Closes #9241 
