### PR TITLE
Fixes Pointer and Call using Serial BT callback

### DIFF
--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -55,7 +55,7 @@ static TaskHandle_t _spp_task_handle = NULL;
 static EventGroupHandle_t _spp_event_group = NULL;
 static EventGroupHandle_t _bt_event_group = NULL;
 static boolean secondConnectionAttempt;
-static esp_spp_cb_t * custom_spp_callback = NULL;
+static esp_spp_cb_t custom_spp_callback = NULL;
 static BluetoothSerialDataCb custom_data_callback = NULL;
 static esp_bd_addr_t current_bd_addr;
 static ConfirmRequestCb confirm_request_callback = NULL;
@@ -945,7 +945,7 @@ void BluetoothSerial::confirmReply(boolean confirm)
 }
 
 
-esp_err_t BluetoothSerial::register_callback(esp_spp_cb_t * callback)
+esp_err_t BluetoothSerial::register_callback(esp_spp_cb_t callback)
 {
     custom_spp_callback = callback;
     return ESP_OK;

--- a/libraries/BluetoothSerial/src/BluetoothSerial.h
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.h
@@ -57,7 +57,7 @@ class BluetoothSerial: public Stream
         void memrelease();
         void setTimeout(int timeoutMS);
         void onData(BluetoothSerialDataCb cb);
-        esp_err_t register_callback(esp_spp_cb_t * callback);
+        esp_err_t register_callback(esp_spp_cb_t callback);
         
 #ifdef CONFIG_BT_SSP_ENABLED
         void onConfirmRequest(ConfirmRequestCb cb);

--- a/libraries/BluetoothSerial/src/BluetoothSerial.h
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.h
@@ -28,7 +28,6 @@
 #include "BTScan.h"
 #include "BTAdvertisedDevice.h"
 
-
 typedef std::function<void(const uint8_t *buffer, size_t size)> BluetoothSerialDataCb;
 typedef std::function<void(uint32_t num_val)> ConfirmRequestCb;
 typedef std::function<void()> KeyRequestCb;


### PR DESCRIPTION
## Description of Change
IDF has changed Serial BT Callback type definition. This PR fixes the Arduino SerialBT API to match new type and function signature.


## Tests scenarios
ESP32 - CI

``` cpp
#include "BluetoothSerial.h"
 
BluetoothSerial SerialBT;
 
void callback(esp_spp_cb_event_t event, esp_spp_cb_param_t *param){
  if(event == ESP_SPP_SRV_OPEN_EVT){
    Serial.println("Client Connected");
  }
 
  if(event == ESP_SPP_CLOSE_EVT ){
    Serial.println("Client disconnected");
  }
}
 
void setup() {
  Serial.begin(115200);
 
  SerialBT.register_callback(callback);
 
  if(!SerialBT.begin("ESP32")){
    Serial.println("An error occurred initializing Bluetooth");
  }else{
    Serial.println("Bluetooth initialized");
  }
}
 
void loop() {}
```

## Related links
Closes #9244 