### PR TITLE
feat: Rename Firebeetle ESP32 board definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -9996,7 +9996,7 @@ firebeetle32.build.target=esp32
 firebeetle32.build.mcu=esp32
 firebeetle32.build.core=esp32
 firebeetle32.build.variant=firebeetle32
-firebeetle32.build.board=ESP32_DEV
+firebeetle32.build.board=DFROBOT_FIREBEETLE_ESP32
 
 firebeetle32.build.f_cpu=240000000L
 firebeetle32.build.flash_mode=dio


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [X] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [X] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
The previous board definition `ESP32_DEV` is used for several boards, i.e. it is not specific to the DFRobot FireBeetle ESP32 board. The proposed name has been chosen according to other DFRobot boards.

The change allows to compile code specific for the selected board. In my target application, a specific "FireBeetle Cover" (similar to a "HAT" or Adafruit's "Feather" concept) is assumed to be installed if this board is selected.

## Tests scenarios
-

## Related links
* https://wiki.dfrobot.com/FireBeetle_ESP32_IOT_Microcontroller(V3.0)__Supports_Wi-Fi_&_Bluetooth__SKU__DFR0478
