### PR TITLE
[Enhancement] Support no-IRQ for SPI Ethernet W5500

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -351,8 +351,13 @@ bool ETHClass::beginSPI(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, 
         log_w("ETH Already Started");
         return true;
     }
+#if ETH_SPI_SUPPORTS_NO_IRQ
     if(cs < 0){
         log_e("CS pin must be defined!");
+#else
+    if(cs < 0 || irq < 0){
+        log_e("CS and IRQ pins must be defined!");
+#endif
         return false;
     }
 
@@ -447,9 +452,11 @@ bool ETHClass::beginSPI(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, 
     if(type == ETH_PHY_W5500){
         eth_w5500_config_t mac_config = ETH_W5500_DEFAULT_CONFIG(spi_host, &spi_devcfg);
         mac_config.int_gpio_num = _pin_irq;
+#if ETH_SPI_SUPPORTS_NO_IRQ
         if (_pin_irq < 0) {
             mac_config.poll_period_ms = 10;
         }
+#endif
 #if ETH_SPI_SUPPORTS_CUSTOM
         if(_spi != NULL){
             mac_config.custom_spi_driver.config = this;
@@ -589,9 +596,13 @@ bool ETHClass::beginSPI(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, 
 #if ETH_SPI_SUPPORTS_CUSTOM
     }
 #endif
+#if ETH_SPI_SUPPORTS_NO_IRQ
     if(_pin_irq != -1){
+#endif
         if(!perimanSetPinBus(_pin_irq, ESP32_BUS_TYPE_ETHERNET_SPI, (void *)(this), -1, -1)){ goto err; }
+#if ETH_SPI_SUPPORTS_NO_IRQ
     }
+#endif
     if(_pin_sck != -1){
         if(!perimanSetPinBus(_pin_sck, ESP32_BUS_TYPE_ETHERNET_SPI, (void *)(this), -1, -1)){ goto err; }
     }

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -351,8 +351,8 @@ bool ETHClass::beginSPI(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, 
         log_w("ETH Already Started");
         return true;
     }
-    if(cs < 0 /*|| irq < 0*/){
-        log_e("CS and IRQ pins must be defined!");
+    if(cs < 0){
+        log_e("CS pin must be defined!");
         return false;
     }
 

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -149,9 +149,6 @@ bool ETHClass::begin(eth_phy_type_t type, uint8_t phy_addr, int mdc, int mdio, i
         case ETH_PHY_DP83848:
             phy = esp_eth_phy_new_dp83848(&phy_config);
             break;
-	case ETH_PHY_JL1101:
-            phy = esp_eth_phy_new_jl1101(&phy_config);
-            break;
         case ETH_PHY_KSZ8041:
             phy = esp_eth_phy_new_ksz80xx(&phy_config);
             break;


### PR DESCRIPTION
Requires this commit from ESP-IDF to be cherry picked: https://github.com/espressif/esp-idf/commit/fd0a1dc53c4cff99f04dfe658047f7c2e3e6d8ad

Related discussion: https://github.com/espressif/esp-idf/issues/12682#issuecomment-1914807052

Fixes: https://github.com/espressif/arduino-esp32/issues/9246
