### PR TITLE
feat: adds baudrate detection to S3 and C3 using LL API for all SoC

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -664,49 +664,15 @@ unsigned long uartBaudrateDetect(uart_t *uart, bool flg)
  * detected calling uartBadrateDetect(). The raw baudrate is computed using the UART_CLK_FREQ. The raw baudrate is 
  * rounded to the closed real baudrate.
  * 
- * ESP32-C3 reports wrong baud rate detection as shown below:
- * 
- * This will help in a future recall for the C3.
- * Baud Sent:          Baud Read:
- *  300        -->       19536
- * 2400        -->       19536
- * 4800        -->       19536 
- * 9600        -->       28818 
- * 19200       -->       57678
- * 38400       -->       115440
- * 57600       -->       173535
- * 115200      -->       347826
- * 230400      -->       701754
- * 
- * 
 */
 void uartStartDetectBaudrate(uart_t *uart) {
     if(uart == NULL) {
         return;
     }
 
-#ifdef CONFIG_IDF_TARGET_ESP32C3
-    
-    // ESP32-C3 requires further testing
-    // Baud rate detection returns wrong values 
-   
-    log_e("ESP32-C3 baud rate detection is not supported.");
-    return;
-
-    // Code bellow for C3 kept for future recall
-    //hw->rx_filt.glitch_filt = 0x08;
-    //hw->rx_filt.glitch_filt_en = 1;
-    //hw->conf0.autobaud_en = 0;
-    //hw->conf0.autobaud_en = 1;
-#elif CONFIG_IDF_TARGET_ESP32S3
-    log_e("ESP32-S3 baud rate detection is not supported.");
-    return;
-#else
     uart_dev_t *hw = UART_LL_GET_HW(uart->num);
-    hw->auto_baud.glitch_filt = 0x08;
-    hw->auto_baud.en = 0;
-    hw->auto_baud.en = 1;
-#endif
+    uart_ll_set_autobaud_en(hw, false);
+    uart_ll_set_autobaud_en(hw, true);
 }
  
 unsigned long


### PR DESCRIPTION
## Description of Change
Adds Baud Rate detection into V2.0.15 for the ESP32-C3 and ESP32-S3.
Those 2 SoC have a maximum resolution of 12 bits, while ESP32 and ESP32-S2 have a resolution of 20 bits.
The implication is that ESP32-S3 and ESP32-C3 can not detect any baud rate under 9600 baud.
This is because the calculation of the minimum baud = 40MHz / 4096 =~ 9600

After testing all the 3 possible Clock Source for UART, it is clear that the most precise is when using XTAL as CLK SOURCE.
Using APB or RTC do not produce good results for the C3 or S3.

In case that the calculate baud rate uses the maximum 12 bits resolution (4095), the code will issue a warning message (log_w).
This is because it may be wrong as it can be in the range of 300 to 9600 baud, but the calculation will always be 9600.

This PR shall replace #7782 

## Tests scenarios
Using the Serial example in https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/BaudRateDetect_Demo/BaudRateDetect_Demo.ino

## Related links
Closes #7782 