### PR TITLE
Fixed "Invalid mbox" error in SimpleTime example

### DIFF
--- a/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
+++ b/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
@@ -33,8 +33,8 @@ void setup()
 {
   Serial.begin(115200);
 
-  // configure WiFi
-  WiFi.mode(WIFI_STA);
+  // configure WiFi STA and connect in order to get the current time and date.
+  WiFi.begin(ssid, password);
 
   // set notification call-back function
   sntp_set_time_sync_notification_cb( timeavailable );

--- a/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
+++ b/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
@@ -33,8 +33,14 @@ void setup()
 {
   Serial.begin(115200);
 
-  // configure WiFi STA and connect in order to get the current time and date.
+  // First step is to configure WiFi STA and connect in order to get the current time and date.
+  Serial.printf("Connecting to %s ", ssid);
   WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+      delay(500);
+      Serial.print(".");
+  }
+  Serial.println(" CONNECTED");
 
   // set notification call-back function
   sntp_set_time_sync_notification_cb( timeavailable );
@@ -62,16 +68,6 @@ void setup()
    * A list of rules for your zone could be obtained from https://github.com/esp8266/Arduino/blob/master/cores/esp8266/TZ.h
    */
   //configTzTime(time_zone, ntpServer1, ntpServer2);
-
-  //connect to WiFi
-  Serial.printf("Connecting to %s ", ssid);
-  WiFi.begin(ssid, password);
-  while (WiFi.status() != WL_CONNECTED) {
-      delay(500);
-      Serial.print(".");
-  }
-  Serial.println(" CONNECTED");
-
 }
 
 void loop()

--- a/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
+++ b/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
@@ -33,6 +33,9 @@ void setup()
 {
   Serial.begin(115200);
 
+  // configure WiFi
+  WiFi.mode(WIFI_STA);
+
   // set notification call-back function
   sntp_set_time_sync_notification_cb( timeavailable );
 


### PR DESCRIPTION
## Description of Change

As stated in https://github.com/espressif/arduino-esp32/issues/8661, we have to call `WiFi.mode` before networking.

## Tests scenarios

I've tested my Pull Request on arduino-esp32 v2.0.14 with ESP32-DevKitC-32E Board.

## Related links

- https://github.com/espressif/arduino-esp32/issues/8661
