### PR TITLE
Added support for 2 new Olimex boards and updated 3 existing ones

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -16261,6 +16261,371 @@ esp32c6-evb.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+esp32h2-devkitlipo.name=OLIMEX ESP32-H2-DevKit-LiPo
+esp32h2-devkitlipo.vid.0=0x303a
+esp32h2-devkitlipo.pid.0=0x1001
+
+esp32h2-devkitlipo.bootloader.tool=esptool_py
+esp32h2-devkitlipo.bootloader.tool.default=esptool_py
+
+esp32h2-devkitlipo.upload.tool=esptool_py
+esp32h2-devkitlipo.upload.tool.default=esptool_py
+esp32h2-devkitlipo.upload.tool.network=esp_ota
+
+esp32h2-devkitlipo.upload.maximum_size=1310720
+esp32h2-devkitlipo.upload.maximum_data_size=327680
+esp32h2-devkitlipo.upload.flags=
+esp32h2-devkitlipo.upload.extra_flags=
+esp32h2-devkitlipo.upload.use_1200bps_touch=false
+esp32h2-devkitlipo.upload.wait_for_upload_port=false
+
+esp32h2-devkitlipo.serial.disableDTR=false
+esp32h2-devkitlipo.serial.disableRTS=false
+
+esp32h2-devkitlipo.build.tarch=riscv32
+esp32h2-devkitlipo.build.target=esp
+esp32h2-devkitlipo.build.mcu=esp32h2
+esp32h2-devkitlipo.build.core=esp32
+esp32h2-devkitlipo.build.variant=esp32h2-devkit-lipo
+esp32h2-devkitlipo.build.board=ESP32H2_DEVKIT_LIPO
+esp32h2-devkitlipo.build.bootloader_addr=0x0
+
+esp32h2-devkitlipo.build.cdc_on_boot=0
+esp32h2-devkitlipo.build.f_cpu=96000000L
+esp32h2-devkitlipo.build.flash_size=4MB
+esp32h2-devkitlipo.build.flash_freq=64m
+esp32h2-devkitlipo.build.img_freq=48m
+esp32h2-devkitlipo.build.flash_mode=qio
+esp32h2-devkitlipo.build.boot=qio
+esp32h2-devkitlipo.build.partitions=default
+esp32h2-devkitlipo.build.defines=
+
+esp32h2-devkitlipo.menu.JTAGAdapter.default=Disabled
+esp32h2-devkitlipo.menu.JTAGAdapter.default.build.copy_jtag_files=0
+esp32h2-devkitlipo.menu.JTAGAdapter.builtin=Integrated USB JTAG
+esp32h2-devkitlipo.menu.JTAGAdapter.builtin.build.openocdscript=esp32h2-builtin.cfg
+esp32h2-devkitlipo.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+esp32h2-devkitlipo.menu.JTAGAdapter.external=FTDI Adapter
+esp32h2-devkitlipo.menu.JTAGAdapter.external.build.openocdscript=esp32h2-ftdi.cfg
+esp32h2-devkitlipo.menu.JTAGAdapter.external.build.copy_jtag_files=1
+esp32h2-devkitlipo.menu.JTAGAdapter.bridge=ESP USB Bridge
+esp32h2-devkitlipo.menu.JTAGAdapter.bridge.build.openocdscript=esp32h2-bridge.cfg
+esp32h2-devkitlipo.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+esp32h2-devkitlipo.menu.CDCOnBoot.default=Disabled
+esp32h2-devkitlipo.menu.CDCOnBoot.default.build.cdc_on_boot=0
+esp32h2-devkitlipo.menu.CDCOnBoot.cdc=Enabled
+esp32h2-devkitlipo.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+esp32h2-devkitlipo.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+esp32h2-devkitlipo.menu.PartitionScheme.default.build.partitions=default
+esp32h2-devkitlipo.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+esp32h2-devkitlipo.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+esp32h2-devkitlipo.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+esp32h2-devkitlipo.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32h2-devkitlipo.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32h2-devkitlipo.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+esp32h2-devkitlipo.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32h2-devkitlipo.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+esp32h2-devkitlipo.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32h2-devkitlipo.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32h2-devkitlipo.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+esp32h2-devkitlipo.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+esp32h2-devkitlipo.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+esp32h2-devkitlipo.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+esp32h2-devkitlipo.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+esp32h2-devkitlipo.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+esp32h2-devkitlipo.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+esp32h2-devkitlipo.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+esp32h2-devkitlipo.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+esp32h2-devkitlipo.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+esp32h2-devkitlipo.menu.PartitionScheme.huge_app.build.partitions=huge_app
+esp32h2-devkitlipo.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+esp32h2-devkitlipo.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+esp32h2-devkitlipo.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32h2-devkitlipo.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32h2-devkitlipo.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+esp32h2-devkitlipo.menu.PartitionScheme.fatflash.build.partitions=ffat
+esp32h2-devkitlipo.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+esp32h2-devkitlipo.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+esp32h2-devkitlipo.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+esp32h2-devkitlipo.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32h2-devkitlipo.menu.PartitionScheme.rainmaker=RainMaker
+esp32h2-devkitlipo.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32h2-devkitlipo.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+esp32h2-devkitlipo.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
+esp32h2-devkitlipo.menu.PartitionScheme.zigbee.build.partitions=zigbee
+esp32h2-devkitlipo.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
+esp32h2-devkitlipo.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+esp32h2-devkitlipo.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+esp32h2-devkitlipo.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+esp32h2-devkitlipo.menu.PartitionScheme.custom=Custom
+esp32h2-devkitlipo.menu.PartitionScheme.custom.build.partitions=
+esp32h2-devkitlipo.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+esp32h2-devkitlipo.menu.FlashMode.qio=QIO
+esp32h2-devkitlipo.menu.FlashMode.qio.build.flash_mode=dio
+esp32h2-devkitlipo.menu.FlashMode.qio.build.boot=qio
+esp32h2-devkitlipo.menu.FlashMode.dio=DIO
+esp32h2-devkitlipo.menu.FlashMode.dio.build.flash_mode=dio
+esp32h2-devkitlipo.menu.FlashMode.dio.build.boot=dio
+
+esp32h2-devkitlipo.menu.FlashFreq.64=64MHz
+esp32h2-devkitlipo.menu.FlashFreq.64.build.flash_freq=64m
+esp32h2-devkitlipo.menu.FlashFreq.64.build.img_freq=48m
+#esp32h-devkitlipo2.menu.FlashFreq.32=32MHz
+#esp32h-devkitlipo2.menu.FlashFreq.32.build.flash_freq=32m
+#esp32h-devkitlipo2.menu.FlashFreq.32.build.img_freq=24m
+esp32h2-devkitlipo.menu.FlashFreq.16=16MHz
+esp32h2-devkitlipo.menu.FlashFreq.16.build.flash_freq=16m
+esp32h2-devkitlipo.menu.FlashFreq.16.build.img_freq=12m
+
+esp32h2-devkitlipo.menu.FlashSize.4M=4MB (32Mb)
+esp32h2-devkitlipo.menu.FlashSize.4M.build.flash_size=4MB
+esp32h2-devkitlipo.menu.FlashSize.8M=8MB (64Mb)
+esp32h2-devkitlipo.menu.FlashSize.8M.build.flash_size=8MB
+esp32h2-devkitlipo.menu.FlashSize.8M.build.partitions=default_8MB
+esp32h2-devkitlipo.menu.FlashSize.2M=2MB (16Mb)
+esp32h2-devkitlipo.menu.FlashSize.2M.build.flash_size=2MB
+esp32h2-devkitlipo.menu.FlashSize.2M.build.partitions=minimal
+esp32h2-devkitlipo.menu.FlashSize.16M=16MB (128Mb)
+esp32h2-devkitlipo.menu.FlashSize.16M.build.flash_size=16MB
+
+esp32h2-devkitlipo.menu.UploadSpeed.921600=921600
+esp32h2-devkitlipo.menu.UploadSpeed.921600.upload.speed=921600
+esp32h2-devkitlipo.menu.UploadSpeed.115200=115200
+esp32h2-devkitlipo.menu.UploadSpeed.115200.upload.speed=115200
+esp32h2-devkitlipo.menu.UploadSpeed.256000.windows=256000
+esp32h2-devkitlipo.menu.UploadSpeed.256000.upload.speed=256000
+esp32h2-devkitlipo.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32h2-devkitlipo.menu.UploadSpeed.230400=230400
+esp32h2-devkitlipo.menu.UploadSpeed.230400.upload.speed=230400
+esp32h2-devkitlipo.menu.UploadSpeed.460800.linux=460800
+esp32h2-devkitlipo.menu.UploadSpeed.460800.macosx=460800
+esp32h2-devkitlipo.menu.UploadSpeed.460800.upload.speed=460800
+esp32h2-devkitlipo.menu.UploadSpeed.512000.windows=512000
+esp32h2-devkitlipo.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32h2-devkitlipo.menu.DebugLevel.none=None
+esp32h2-devkitlipo.menu.DebugLevel.none.build.code_debug=0
+esp32h2-devkitlipo.menu.DebugLevel.error=Error
+esp32h2-devkitlipo.menu.DebugLevel.error.build.code_debug=1
+esp32h2-devkitlipo.menu.DebugLevel.warn=Warn
+esp32h2-devkitlipo.menu.DebugLevel.warn.build.code_debug=2
+esp32h2-devkitlipo.menu.DebugLevel.info=Info
+esp32h2-devkitlipo.menu.DebugLevel.info.build.code_debug=3
+esp32h2-devkitlipo.menu.DebugLevel.debug=Debug
+esp32h2-devkitlipo.menu.DebugLevel.debug.build.code_debug=4
+esp32h2-devkitlipo.menu.DebugLevel.verbose=Verbose
+esp32h2-devkitlipo.menu.DebugLevel.verbose.build.code_debug=5
+
+esp32h2-devkitlipo.menu.EraseFlash.none=Disabled
+esp32h2-devkitlipo.menu.EraseFlash.none.upload.erase_cmd=
+esp32h2-devkitlipo.menu.EraseFlash.all=Enabled
+esp32h2-devkitlipo.menu.EraseFlash.all.upload.erase_cmd=-e
+
+esp32h2-devkitlipo.menu.ZigbeeMode.default=Disabled
+esp32h2-devkitlipo.menu.ZigbeeMode.default.build.zigbee_mode=
+esp32h2-devkitlipo.menu.ZigbeeMode.default.build.zigbee_libs=
+esp32h2-devkitlipo.menu.ZigbeeMode.ed=Zigbee ED (end device)
+esp32h2-devkitlipo.menu.ZigbeeMode.ed.build.zigbee_mode=-DZIGBEE_MODE_ED
+esp32h2-devkitlipo.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api_ed -lesp_zb_cli_command -lzboss_stack.ed.trace -lzboss_stack.ed -lzboss_port
+esp32h2-devkitlipo.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator)
+esp32h2-devkitlipo.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+esp32h2-devkitlipo.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api_zczr -lesp_zb_cli_command -lzboss_stack.zczr.trace -lzboss_stack.zczr -lzboss_port
+esp32h2-devkitlipo.menu.ZigbeeMode.rcp=Zigbee RCP (radio co-processor)
+esp32h2-devkitlipo.menu.ZigbeeMode.rcp.build.zigbee_mode=-DZIGBEE_MODE_RCP
+esp32h2-devkitlipo.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api_rcp -lesp_zb_cli_command -lzboss_stack.rcp -lzboss_port
+
+##############################################################
+
+esp32-sbc-fabgl.name=OLIMEX ESP32-SBC-FABGL
+
+esp32-sbc-fabgl.bootloader.tool=esptool_py
+esp32-sbc-fabgl.bootloader.tool.default=esptool_py
+
+esp32-sbc-fabgl.upload.tool=esptool_py
+esp32-sbc-fabgl.upload.tool.default=esptool_py
+esp32-sbc-fabgl.upload.tool.network=esp_ota
+
+esp32-sbc-fabgl.upload.maximum_size=1310720
+esp32-sbc-fabgl.upload.maximum_data_size=327680
+esp32-sbc-fabgl.upload.flags=
+esp32-sbc-fabgl.upload.extra_flags=
+
+esp32-sbc-fabgl.serial.disableDTR=true
+esp32-sbc-fabgl.serial.disableRTS=true
+
+esp32-sbc-fabgl.build.tarch=xtensa
+esp32-sbc-fabgl.build.bootloader_addr=0x1000
+esp32-sbc-fabgl.build.target=esp32
+esp32-sbc-fabgl.build.mcu=esp32
+esp32-sbc-fabgl.build.core=esp32
+esp32-sbc-fabgl.build.variant=esp32-sbc-fabgl
+esp32-sbc-fabgl.build.board=ESP32_SBC_FABGL
+
+esp32-sbc-fabgl.build.f_cpu=240000000L
+esp32-sbc-fabgl.build.flash_size=4MB
+esp32-sbc-fabgl.build.flash_freq=40m
+esp32-sbc-fabgl.build.flash_mode=dio
+esp32-sbc-fabgl.build.boot=dio
+esp32-sbc-fabgl.build.partitions=default
+esp32-sbc-fabgl.build.defines=
+esp32-sbc-fabgl.build.loop_core=
+esp32-sbc-fabgl.build.event_core=
+
+## IDE 2.0 Seems to not update the value
+esp32-sbc-fabgl.menu.JTAGAdapter.default=Disabled
+esp32-sbc-fabgl.menu.JTAGAdapter.default.build.copy_jtag_files=0
+esp32-sbc-fabgl.menu.JTAGAdapter.external=FTDI Adapter
+esp32-sbc-fabgl.menu.JTAGAdapter.external.build.openocdscript=esp32-wrover-kit-3.3v.cfg
+esp32-sbc-fabgl.menu.JTAGAdapter.external.build.copy_jtag_files=1
+esp32-sbc-fabgl.menu.JTAGAdapter.bridge=ESP USB Bridge
+esp32-sbc-fabgl.menu.JTAGAdapter.bridge.build.openocdscript=esp32-bridge.cfg
+esp32-sbc-fabgl.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+esp32-sbc-fabgl.menu.PSRAM.disabled=Disabled
+esp32-sbc-fabgl.menu.PSRAM.disabled.build.defines=
+esp32-sbc-fabgl.menu.PSRAM.disabled.build.extra_libs=
+esp32-sbc-fabgl.menu.PSRAM.enabled=Enabled
+esp32-sbc-fabgl.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+esp32-sbc-fabgl.menu.PSRAM.enabled.build.extra_libs=
+
+esp32-sbc-fabgl.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+esp32-sbc-fabgl.menu.PartitionScheme.default.build.partitions=default
+esp32-sbc-fabgl.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+esp32-sbc-fabgl.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+esp32-sbc-fabgl.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+esp32-sbc-fabgl.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32-sbc-fabgl.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32-sbc-fabgl.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+esp32-sbc-fabgl.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32-sbc-fabgl.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+esp32-sbc-fabgl.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32-sbc-fabgl.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32-sbc-fabgl.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+esp32-sbc-fabgl.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+esp32-sbc-fabgl.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+esp32-sbc-fabgl.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+esp32-sbc-fabgl.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+esp32-sbc-fabgl.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+esp32-sbc-fabgl.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+esp32-sbc-fabgl.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+esp32-sbc-fabgl.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+esp32-sbc-fabgl.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+esp32-sbc-fabgl.menu.PartitionScheme.huge_app.build.partitions=huge_app
+esp32-sbc-fabgl.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+esp32-sbc-fabgl.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+esp32-sbc-fabgl.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32-sbc-fabgl.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32-sbc-fabgl.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+esp32-sbc-fabgl.menu.PartitionScheme.fatflash.build.partitions=ffat
+esp32-sbc-fabgl.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+esp32-sbc-fabgl.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+esp32-sbc-fabgl.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+esp32-sbc-fabgl.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32-sbc-fabgl.menu.PartitionScheme.rainmaker=RainMaker
+esp32-sbc-fabgl.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32-sbc-fabgl.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+esp32-sbc-fabgl.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+esp32-sbc-fabgl.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+esp32-sbc-fabgl.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+esp32-sbc-fabgl.menu.PartitionScheme.custom=Custom
+esp32-sbc-fabgl.menu.PartitionScheme.custom.build.partitions=
+esp32-sbc-fabgl.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+esp32-sbc-fabgl.menu.CPUFreq.240=240MHz (WiFi/BT)
+esp32-sbc-fabgl.menu.CPUFreq.240.build.f_cpu=240000000L
+esp32-sbc-fabgl.menu.CPUFreq.160=160MHz (WiFi/BT)
+esp32-sbc-fabgl.menu.CPUFreq.160.build.f_cpu=160000000L
+esp32-sbc-fabgl.menu.CPUFreq.80=80MHz (WiFi/BT)
+esp32-sbc-fabgl.menu.CPUFreq.80.build.f_cpu=80000000L
+esp32-sbc-fabgl.menu.CPUFreq.40=40MHz (40MHz XTAL)
+esp32-sbc-fabgl.menu.CPUFreq.40.build.f_cpu=40000000L
+esp32-sbc-fabgl.menu.CPUFreq.26=26MHz (26MHz XTAL)
+esp32-sbc-fabgl.menu.CPUFreq.26.build.f_cpu=26000000L
+esp32-sbc-fabgl.menu.CPUFreq.20=20MHz (40MHz XTAL)
+esp32-sbc-fabgl.menu.CPUFreq.20.build.f_cpu=20000000L
+esp32-sbc-fabgl.menu.CPUFreq.13=13MHz (26MHz XTAL)
+esp32-sbc-fabgl.menu.CPUFreq.13.build.f_cpu=13000000L
+esp32-sbc-fabgl.menu.CPUFreq.10=10MHz (40MHz XTAL)
+esp32-sbc-fabgl.menu.CPUFreq.10.build.f_cpu=10000000L
+
+esp32-sbc-fabgl.menu.FlashMode.qio=QIO
+esp32-sbc-fabgl.menu.FlashMode.qio.build.flash_mode=dio
+esp32-sbc-fabgl.menu.FlashMode.qio.build.boot=qio
+esp32-sbc-fabgl.menu.FlashMode.dio=DIO
+esp32-sbc-fabgl.menu.FlashMode.dio.build.flash_mode=dio
+esp32-sbc-fabgl.menu.FlashMode.dio.build.boot=dio
+
+esp32-sbc-fabgl.menu.FlashFreq.80=80MHz
+esp32-sbc-fabgl.menu.FlashFreq.80.build.flash_freq=80m
+esp32-sbc-fabgl.menu.FlashFreq.40=40MHz
+esp32-sbc-fabgl.menu.FlashFreq.40.build.flash_freq=40m
+
+esp32-sbc-fabgl.menu.FlashSize.4M=4MB (32Mb)
+esp32-sbc-fabgl.menu.FlashSize.4M.build.flash_size=4MB
+esp32-sbc-fabgl.menu.FlashSize.8M=8MB (64Mb)
+esp32-sbc-fabgl.menu.FlashSize.8M.build.flash_size=8MB
+esp32-sbc-fabgl.menu.FlashSize.8M.build.partitions=default_8MB
+esp32-sbc-fabgl.menu.FlashSize.2M=2MB (16Mb)
+esp32-sbc-fabgl.menu.FlashSize.2M.build.flash_size=2MB
+esp32-sbc-fabgl.menu.FlashSize.2M.build.partitions=minimal
+esp32-sbc-fabgl.menu.FlashSize.16M=16MB (128Mb)
+esp32-sbc-fabgl.menu.FlashSize.16M.build.flash_size=16MB
+
+esp32-sbc-fabgl.menu.UploadSpeed.921600=921600
+esp32-sbc-fabgl.menu.UploadSpeed.921600.upload.speed=921600
+esp32-sbc-fabgl.menu.UploadSpeed.115200=115200
+esp32-sbc-fabgl.menu.UploadSpeed.115200.upload.speed=115200
+esp32-sbc-fabgl.menu.UploadSpeed.256000.windows=256000
+esp32-sbc-fabgl.menu.UploadSpeed.256000.upload.speed=256000
+esp32-sbc-fabgl.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32-sbc-fabgl.menu.UploadSpeed.230400=230400
+esp32-sbc-fabgl.menu.UploadSpeed.230400.upload.speed=230400
+esp32-sbc-fabgl.menu.UploadSpeed.460800.linux=460800
+esp32-sbc-fabgl.menu.UploadSpeed.460800.macosx=460800
+esp32-sbc-fabgl.menu.UploadSpeed.460800.upload.speed=460800
+esp32-sbc-fabgl.menu.UploadSpeed.512000.windows=512000
+esp32-sbc-fabgl.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32-sbc-fabgl.menu.LoopCore.1=Core 1
+esp32-sbc-fabgl.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+esp32-sbc-fabgl.menu.LoopCore.0=Core 0
+esp32-sbc-fabgl.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+esp32-sbc-fabgl.menu.EventsCore.1=Core 1
+esp32-sbc-fabgl.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+esp32-sbc-fabgl.menu.EventsCore.0=Core 0
+esp32-sbc-fabgl.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+esp32-sbc-fabgl.menu.DebugLevel.none=None
+esp32-sbc-fabgl.menu.DebugLevel.none.build.code_debug=0
+esp32-sbc-fabgl.menu.DebugLevel.error=Error
+esp32-sbc-fabgl.menu.DebugLevel.error.build.code_debug=1
+esp32-sbc-fabgl.menu.DebugLevel.warn=Warn
+esp32-sbc-fabgl.menu.DebugLevel.warn.build.code_debug=2
+esp32-sbc-fabgl.menu.DebugLevel.info=Info
+esp32-sbc-fabgl.menu.DebugLevel.info.build.code_debug=3
+esp32-sbc-fabgl.menu.DebugLevel.debug=Debug
+esp32-sbc-fabgl.menu.DebugLevel.debug.build.code_debug=4
+esp32-sbc-fabgl.menu.DebugLevel.verbose=Verbose
+esp32-sbc-fabgl.menu.DebugLevel.verbose.build.code_debug=5
+
+esp32-sbc-fabgl.menu.EraseFlash.none=Disabled
+esp32-sbc-fabgl.menu.EraseFlash.none.upload.erase_cmd=
+esp32-sbc-fabgl.menu.EraseFlash.all=Enabled
+esp32-sbc-fabgl.menu.EraseFlash.all.upload.erase_cmd=-e
+
+esp32-sbc-fabgl.menu.ZigbeeMode.default=Disabled
+esp32-sbc-fabgl.menu.ZigbeeMode.default.build.zigbee_mode=
+esp32-sbc-fabgl.menu.ZigbeeMode.default.build.zigbee_libs=
+esp32-sbc-fabgl.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator)
+esp32-sbc-fabgl.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+esp32-sbc-fabgl.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api_zczr -lesp_zb_cli_command -lzboss_stack.zczr.trace -lzboss_stack.zczr -lzboss_port
+
+##############################################################
+
 espino32.name=ThaiEasyElec's ESPino32
 
 espino32.bootloader.tool=esptool_py

--- a/boards.txt
+++ b/boards.txt
@@ -15045,7 +15045,7 @@ esp32-gateway.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-esp32-poe.name=OLIMEX ESP32-PoE
+esp32-poe.name=OLIMEX ESP32-POE
 
 esp32-poe.bootloader.tool=esptool_py
 esp32-poe.bootloader.tool.default=esptool_py
@@ -15071,16 +15071,81 @@ esp32-poe.build.variant=esp32-poe
 esp32-poe.build.board=ESP32_POE
 
 esp32-poe.build.f_cpu=240000000L
-esp32-poe.build.flash_mode=dio
 esp32-poe.build.flash_size=4MB
+esp32-poe.build.flash_freq=40m
+esp32-poe.build.flash_mode=dio
 esp32-poe.build.boot=dio
 esp32-poe.build.partitions=default
 esp32-poe.build.defines=
+esp32-poe.build.loop_core=
+esp32-poe.build.event_core=
+
+esp32-poe.menu.PSRAM.disabled=Disabled (WROOM)
+esp32-poe.menu.PSRAM.disabled.build.defines=
+esp32-poe.menu.PSRAM.disabled.build.extra_libs=
+esp32-poe.menu.PSRAM.enabled=Enabled (WROVER)
+esp32-poe.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+esp32-poe.menu.PSRAM.enabled.build.extra_libs=
+
+esp32-poe.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+esp32-poe.menu.PartitionScheme.default.build.partitions=default
+esp32-poe.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+esp32-poe.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+esp32-poe.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+esp32-poe.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32-poe.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32-poe.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+esp32-poe.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32-poe.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+esp32-poe.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32-poe.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32-poe.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+esp32-poe.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+esp32-poe.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+esp32-poe.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+esp32-poe.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+esp32-poe.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+esp32-poe.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+esp32-poe.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+esp32-poe.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+esp32-poe.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+esp32-poe.menu.PartitionScheme.huge_app.build.partitions=huge_app
+esp32-poe.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+esp32-poe.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+esp32-poe.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32-poe.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32-poe.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+esp32-poe.menu.PartitionScheme.fatflash.build.partitions=ffat
+esp32-poe.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+esp32-poe.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+esp32-poe.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+esp32-poe.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32-poe.menu.PartitionScheme.rainmaker=RainMaker
+esp32-poe.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32-poe.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+esp32-poe.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+esp32-poe.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+esp32-poe.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+esp32-poe.menu.PartitionScheme.custom=Custom
+esp32-poe.menu.PartitionScheme.custom.build.partitions=
+esp32-poe.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+esp32-poe.menu.FlashMode.qio=QIO
+esp32-poe.menu.FlashMode.qio.build.flash_mode=dio
+esp32-poe.menu.FlashMode.qio.build.boot=qio
+esp32-poe.menu.FlashMode.dio=DIO
+esp32-poe.menu.FlashMode.dio.build.flash_mode=dio
+esp32-poe.menu.FlashMode.dio.build.boot=dio
 
 esp32-poe.menu.FlashFreq.80=80MHz
 esp32-poe.menu.FlashFreq.80.build.flash_freq=80m
 esp32-poe.menu.FlashFreq.40=40MHz
 esp32-poe.menu.FlashFreq.40.build.flash_freq=40m
+
+esp32-poe.menu.FlashSize.4M=4MB (32Mb)
+esp32-poe.menu.FlashSize.4M.build.flash_size=4MB
+esp32-poe.menu.FlashSize.16M=16MB (128Mb)
+esp32-poe.menu.FlashSize.16M.build.flash_size=16MB
 
 esp32-poe.menu.UploadSpeed.921600=921600
 esp32-poe.menu.UploadSpeed.921600.upload.speed=921600
@@ -15096,15 +15161,6 @@ esp32-poe.menu.UploadSpeed.460800.macosx=460800
 esp32-poe.menu.UploadSpeed.460800.upload.speed=460800
 esp32-poe.menu.UploadSpeed.512000.windows=512000
 esp32-poe.menu.UploadSpeed.512000.upload.speed=512000
-
-esp32-poe.menu.PartitionScheme.default=Default
-esp32-poe.menu.PartitionScheme.default.build.partitions=default
-esp32-poe.menu.PartitionScheme.no_ota=No OTA (Large APP)
-esp32-poe.menu.PartitionScheme.no_ota.build.partitions=no_ota
-esp32-poe.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-esp32-poe.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
-esp32-poe.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-esp32-poe.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
 esp32-poe.menu.DebugLevel.none=None
 esp32-poe.menu.DebugLevel.none.build.code_debug=0
@@ -15126,7 +15182,7 @@ esp32-poe.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-esp32-poe-iso.name=OLIMEX ESP32-PoE-ISO
+esp32-poe-iso.name=OLIMEX ESP32-POE-ISO
 
 esp32-poe-iso.bootloader.tool=esptool_py
 esp32-poe-iso.bootloader.tool.default=esptool_py
@@ -15152,16 +15208,81 @@ esp32-poe-iso.build.variant=esp32-poe-iso
 esp32-poe-iso.build.board=ESP32_POE_ISO
 
 esp32-poe-iso.build.f_cpu=240000000L
-esp32-poe-iso.build.flash_mode=dio
 esp32-poe-iso.build.flash_size=4MB
+esp32-poe-iso.build.flash_freq=40m
+esp32-poe-iso.build.flash_mode=dio
 esp32-poe-iso.build.boot=dio
 esp32-poe-iso.build.partitions=default
 esp32-poe-iso.build.defines=
+esp32-poe-iso.build.loop_core=
+esp32-poe-iso.build.event_core=
+
+esp32-poe-iso.menu.PSRAM.disabled=Disabled (WROOM)
+esp32-poe-iso.menu.PSRAM.disabled.build.defines=
+esp32-poe-iso.menu.PSRAM.disabled.build.extra_libs=
+esp32-poe-iso.menu.PSRAM.enabled=Enabled (WROVER)
+esp32-poe-iso.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+esp32-poe-iso.menu.PSRAM.enabled.build.extra_libs=
+
+esp32-poe-iso.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+esp32-poe-iso.menu.PartitionScheme.default.build.partitions=default
+esp32-poe-iso.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+esp32-poe-iso.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+esp32-poe-iso.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+esp32-poe-iso.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32-poe-iso.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32-poe-iso.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+esp32-poe-iso.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32-poe-iso.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+esp32-poe-iso.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32-poe-iso.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32-poe-iso.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+esp32-poe-iso.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+esp32-poe-iso.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+esp32-poe-iso.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+esp32-poe-iso.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+esp32-poe-iso.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+esp32-poe-iso.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+esp32-poe-iso.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+esp32-poe-iso.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+esp32-poe-iso.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+esp32-poe-iso.menu.PartitionScheme.huge_app.build.partitions=huge_app
+esp32-poe-iso.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+esp32-poe-iso.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+esp32-poe-iso.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32-poe-iso.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32-poe-iso.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+esp32-poe-iso.menu.PartitionScheme.fatflash.build.partitions=ffat
+esp32-poe-iso.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+esp32-poe-iso.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+esp32-poe-iso.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+esp32-poe-iso.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32-poe-iso.menu.PartitionScheme.rainmaker=RainMaker
+esp32-poe-iso.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32-poe-iso.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+esp32-poe-iso.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+esp32-poe-iso.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+esp32-poe-iso.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+esp32-poe-iso.menu.PartitionScheme.custom=Custom
+esp32-poe-iso.menu.PartitionScheme.custom.build.partitions=
+esp32-poe-iso.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+esp32-poe-iso.menu.FlashMode.qio=QIO
+esp32-poe-iso.menu.FlashMode.qio.build.flash_mode=dio
+esp32-poe-iso.menu.FlashMode.qio.build.boot=qio
+esp32-poe-iso.menu.FlashMode.dio=DIO
+esp32-poe-iso.menu.FlashMode.dio.build.flash_mode=dio
+esp32-poe-iso.menu.FlashMode.dio.build.boot=dio
 
 esp32-poe-iso.menu.FlashFreq.80=80MHz
 esp32-poe-iso.menu.FlashFreq.80.build.flash_freq=80m
 esp32-poe-iso.menu.FlashFreq.40=40MHz
 esp32-poe-iso.menu.FlashFreq.40.build.flash_freq=40m
+
+esp32-poe-iso.menu.FlashSize.4M=4MB (32Mb)
+esp32-poe-iso.menu.FlashSize.4M.build.flash_size=4MB
+esp32-poe-iso.menu.FlashSize.16M=16MB (128Mb)
+esp32-poe-iso.menu.FlashSize.16M.build.flash_size=16MB
 
 esp32-poe-iso.menu.UploadSpeed.921600=921600
 esp32-poe-iso.menu.UploadSpeed.921600.upload.speed=921600
@@ -15177,15 +15298,6 @@ esp32-poe-iso.menu.UploadSpeed.460800.macosx=460800
 esp32-poe-iso.menu.UploadSpeed.460800.upload.speed=460800
 esp32-poe-iso.menu.UploadSpeed.512000.windows=512000
 esp32-poe-iso.menu.UploadSpeed.512000.upload.speed=512000
-
-esp32-poe-iso.menu.PartitionScheme.default=Default
-esp32-poe-iso.menu.PartitionScheme.default.build.partitions=default
-esp32-poe-iso.menu.PartitionScheme.no_ota=No OTA (Large APP)
-esp32-poe-iso.menu.PartitionScheme.no_ota.build.partitions=no_ota
-esp32-poe-iso.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-esp32-poe-iso.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (Large APPS with OTA)
-esp32-poe-iso.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-esp32-poe-iso.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
 esp32-poe-iso.menu.DebugLevel.none=None
 esp32-poe-iso.menu.DebugLevel.none.build.code_debug=0

--- a/boards.txt
+++ b/boards.txt
@@ -15084,7 +15084,7 @@ esp32-poe.menu.PSRAM.disabled=Disabled (WROOM)
 esp32-poe.menu.PSRAM.disabled.build.defines=
 esp32-poe.menu.PSRAM.disabled.build.extra_libs=
 esp32-poe.menu.PSRAM.enabled=Enabled (WROVER)
-esp32-poe.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+esp32-poe.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 esp32-poe.menu.PSRAM.enabled.build.extra_libs=
 
 esp32-poe.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
@@ -15221,7 +15221,7 @@ esp32-poe-iso.menu.PSRAM.disabled=Disabled (WROOM)
 esp32-poe-iso.menu.PSRAM.disabled.build.defines=
 esp32-poe-iso.menu.PSRAM.disabled.build.extra_libs=
 esp32-poe-iso.menu.PSRAM.enabled=Enabled (WROVER)
-esp32-poe-iso.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+esp32-poe-iso.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 esp32-poe-iso.menu.PSRAM.enabled.build.extra_libs=
 
 esp32-poe-iso.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
@@ -16600,7 +16600,7 @@ esp32-sbc-fabgl.menu.PSRAM.disabled=Disabled
 esp32-sbc-fabgl.menu.PSRAM.disabled.build.defines=
 esp32-sbc-fabgl.menu.PSRAM.disabled.build.extra_libs=
 esp32-sbc-fabgl.menu.PSRAM.enabled=Enabled
-esp32-sbc-fabgl.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+esp32-sbc-fabgl.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 esp32-sbc-fabgl.menu.PSRAM.enabled.build.extra_libs=
 
 esp32-sbc-fabgl.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)

--- a/boards.txt
+++ b/boards.txt
@@ -15084,7 +15084,7 @@ esp32-poe.menu.PSRAM.disabled=Disabled (WROOM)
 esp32-poe.menu.PSRAM.disabled.build.defines=
 esp32-poe.menu.PSRAM.disabled.build.extra_libs=
 esp32-poe.menu.PSRAM.enabled=Enabled (WROVER)
-esp32-poe.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+esp32-poe.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
 esp32-poe.menu.PSRAM.enabled.build.extra_libs=
 
 esp32-poe.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
@@ -15221,7 +15221,7 @@ esp32-poe-iso.menu.PSRAM.disabled=Disabled (WROOM)
 esp32-poe-iso.menu.PSRAM.disabled.build.defines=
 esp32-poe-iso.menu.PSRAM.disabled.build.extra_libs=
 esp32-poe-iso.menu.PSRAM.enabled=Enabled (WROVER)
-esp32-poe-iso.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+esp32-poe-iso.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
 esp32-poe-iso.menu.PSRAM.enabled.build.extra_libs=
 
 esp32-poe-iso.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)

--- a/boards.txt
+++ b/boards.txt
@@ -16596,12 +16596,12 @@ esp32-sbc-fabgl.menu.JTAGAdapter.bridge=ESP USB Bridge
 esp32-sbc-fabgl.menu.JTAGAdapter.bridge.build.openocdscript=esp32-bridge.cfg
 esp32-sbc-fabgl.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
 
-esp32-sbc-fabgl.menu.PSRAM.disabled=Disabled
-esp32-sbc-fabgl.menu.PSRAM.disabled.build.defines=
-esp32-sbc-fabgl.menu.PSRAM.disabled.build.extra_libs=
 esp32-sbc-fabgl.menu.PSRAM.enabled=Enabled
 esp32-sbc-fabgl.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 esp32-sbc-fabgl.menu.PSRAM.enabled.build.extra_libs=
+esp32-sbc-fabgl.menu.PSRAM.disabled=Disabled
+esp32-sbc-fabgl.menu.PSRAM.disabled.build.defines=
+esp32-sbc-fabgl.menu.PSRAM.disabled.build.extra_libs=
 
 esp32-sbc-fabgl.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 esp32-sbc-fabgl.menu.PartitionScheme.default.build.partitions=default

--- a/variants/esp32-gateway/pins_arduino.h
+++ b/variants/esp32-gateway/pins_arduino.h
@@ -4,8 +4,12 @@
 #include <stdint.h>
 
 #if	defined (ARDUINO_ESP32_GATEWAY_E) || defined (ARDUINO_ESP32_GATEWAY_F)
-#define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
-#define ETH_PHY_POWER 5
+#define ETH_PHY_TYPE        ETH_PHY_LAN8720
+#define ETH_PHY_ADDR         0
+#define ETH_PHY_MDC         23
+#define ETH_PHY_MDIO        18
+#define ETH_PHY_POWER        5
+#define ETH_CLK_MODE        ETH_CLOCK_GPIO17_OUT
 #endif
 
 static const uint8_t LED_BUILTIN = 33;

--- a/variants/esp32-poe-iso/pins_arduino.h
+++ b/variants/esp32-poe-iso/pins_arduino.h
@@ -3,8 +3,17 @@
 
 #include <stdint.h>
 
-#define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
-#define ETH_PHY_POWER 12
+#define ETH_PHY_TYPE        ETH_PHY_LAN8720
+#define ETH_PHY_ADDR         0
+#define ETH_PHY_MDC         23
+#define ETH_PHY_MDIO        18
+#define ETH_PHY_POWER       12
+#if defined BOARD_HAS_PSRAM	// when PSRAM is enabled pins 16 and 17 are used for the PSRAM and alternative pins are used for respectively I2C SCL and Ethernet Clock GPIO
+#define ETH_CLK_MODE        ETH_CLOCK_GPIO0_OUT
+#else
+#define ETH_CLK_MODE        ETH_CLOCK_GPIO17_OUT
+#endif
+
 
 static const uint8_t KEY_BUILTIN = 34;
 
@@ -18,7 +27,11 @@ static const uint8_t RX = 3;
 #define RX2 35	// ext2 pin 3
 
 static const uint8_t SDA = 13;
+#if defined BOARD_HAS_PSRAM	// when PSRAM is enabled pins 16 and 17 are used for the PSRAM and alternative pins are used for respectively I2C SCL and Ethernet Clock GPIO
+static const uint8_t SCL = 33;
+#else
 static const uint8_t SCL = 16;
+#endif
 
 static const uint8_t SS    = 5;
 static const uint8_t MOSI  = 2;

--- a/variants/esp32-poe/pins_arduino.h
+++ b/variants/esp32-poe/pins_arduino.h
@@ -3,8 +3,17 @@
 
 #include <stdint.h>
 
-#define ETH_CLK_MODE ETH_CLOCK_GPIO17_OUT
-#define ETH_PHY_POWER 12
+#define ETH_PHY_TYPE        ETH_PHY_LAN8720
+#define ETH_PHY_ADDR         0
+#define ETH_PHY_MDC         23
+#define ETH_PHY_MDIO        18
+#define ETH_PHY_POWER       12
+#if defined BOARD_HAS_PSRAM	// when PSRAM is enabled pins 16 and 17 are used for the PSRAM and alternative pins are used for respectively I2C SCL and Ethernet Clock GPIO
+#define ETH_CLK_MODE        ETH_CLOCK_GPIO0_OUT
+#else
+#define ETH_CLK_MODE        ETH_CLOCK_GPIO17_OUT
+#endif
+
 
 static const uint8_t KEY_BUILTIN = 34;
 
@@ -18,7 +27,11 @@ static const uint8_t RX = 3;
 #define RX2 35	// ext2 pin 3
 
 static const uint8_t SDA = 13;
+#if defined BOARD_HAS_PSRAM	// when PSRAM is enabled pins 16 and 17 are used for the PSRAM and alternative pins are used for respectively I2C SCL and Ethernet Clock GPIO
+static const uint8_t SCL = 33;
+#else
 static const uint8_t SCL = 16;
+#endif
 
 static const uint8_t SS    = 5;
 static const uint8_t MOSI  = 2;

--- a/variants/esp32-sbc-fabgl/pins_arduino.h
+++ b/variants/esp32-sbc-fabgl/pins_arduino.h
@@ -1,0 +1,48 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 5;
+static const uint8_t MOSI  = 23;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 18;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32h2-devkit-lipo/pins_arduino.h
+++ b/variants/esp32h2-devkit-lipo/pins_arduino.h
@@ -1,0 +1,36 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define PIN_NEOPIXEL        8
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT+PIN_NEOPIXEL;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()
+#define RGB_BUILTIN LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
+
+static const uint8_t KEY_BUILTIN = 9;
+
+static const uint8_t TX = 24;
+static const uint8_t RX = 23;
+
+static const uint8_t SDA = 12;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 0;
+static const uint8_t MOSI  = 25;
+static const uint8_t MISO  = 11;
+static const uint8_t SCK   = 10;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Hello!
Olimex employee here.

I have added support for the boards: Olimex ESP32-H2-DevKit-LiPo and ESP32-SBC-FabGL. Added a "pins_arduino.h" files in the "variants" folder and in the board.txt. The boards are open-source hardware and info can be found at our website.

Also for 3 of our existing in your package boards (ESP32-POE, ESP32-POE-ISO, ESP32-Gateway) inside the pins_arduino.h files I added the ethernet macros to match the fix from https://github.com/espressif/arduino-esp32/pull/9242 . 

For ESP32-POE and ESP32-POE-ISO added extra menus and menu options for: PSRAM, Flash Size, Flash mode and Partition scheme.

I tested what I could but let me know if I have missed something and needs further changes.

Thanks espressif and Arduino team.