### PR TITLE
Update new RMT function rmtSetEOT(pin, EOT_Level) in the pin remap macros

### DIFF
--- a/cores/esp32/io_pin_remap.h
+++ b/cores/esp32/io_pin_remap.h
@@ -76,7 +76,7 @@ int8_t gpioNumberToDigitalPin(int8_t gpioNumber);
 
 // cores/esp32/esp32-hal-rmt.h
 #define rmtInit(pin, channel_direction, memsize, frequency_Hz)                      rmtInit(digitalPinToGPIONumber(pin), channel_direction, memsize, frequency_Hz)
-#define rmtSetEOT(int pin, EOT_Level)                                               rmtSetEOT(digitalPinToGPIONumber(pin), EOT_Level) 
+#define rmtSetEOT(pin, EOT_Level)                                                   rmtSetEOT(digitalPinToGPIONumber(pin), EOT_Level) 
 #define rmtWrite(pin, data, num_rmt_symbols, timeout_ms)                            rmtWrite(digitalPinToGPIONumber(pin), data, num_rmt_symbols, timeout_ms)
 #define rmtWriteAsync(pin, data, num_rmt_symbols)                                   rmtWriteAsync(digitalPinToGPIONumber(pin), data, num_rmt_symbols)
 #define rmtWriteLooping(pin, data, num_rmt_symbols)                                 rmtWriteLooping(digitalPinToGPIONumber(pin), data, num_rmt_symbols)

--- a/cores/esp32/io_pin_remap.h
+++ b/cores/esp32/io_pin_remap.h
@@ -76,6 +76,7 @@ int8_t gpioNumberToDigitalPin(int8_t gpioNumber);
 
 // cores/esp32/esp32-hal-rmt.h
 #define rmtInit(pin, channel_direction, memsize, frequency_Hz)                      rmtInit(digitalPinToGPIONumber(pin), channel_direction, memsize, frequency_Hz)
+#define rmtSetEOT(int pin, EOT_Level)                                               rmtSetEOT(digitalPinToGPIONumber(pin), EOT_Level) 
 #define rmtWrite(pin, data, num_rmt_symbols, timeout_ms)                            rmtWrite(digitalPinToGPIONumber(pin), data, num_rmt_symbols, timeout_ms)
 #define rmtWriteAsync(pin, data, num_rmt_symbols)                                   rmtWriteAsync(digitalPinToGPIONumber(pin), data, num_rmt_symbols)
 #define rmtWriteLooping(pin, data, num_rmt_symbols)                                 rmtWriteLooping(digitalPinToGPIONumber(pin), data, num_rmt_symbols)

--- a/docs/en/migration_guides/2.x_to_3.0.rst
+++ b/docs/en/migration_guides/2.x_to_3.0.rst
@@ -90,6 +90,7 @@ Removed APIs
 New APIs
 ********
 
+* ``rmtSetEOT``
 * ``rmtWriteAsync``
 * ``rmtTransmitCompleted``
 * ``rmtSetRxMinThreshold``


### PR DESCRIPTION
## Description of Change
This PR updates and adds the new RMT API `bool rmtSetEOT(int pin, uint8_t EOT_Level);` to the list of MACROS from `io_pin_remap.h`

It also include this new funtion to the Migration Guide documentation.

## Tests scenarios
Just CI.

## Related links
None