### PR TITLE
Fixes sigmaDeltaAttach() when another peripheral is already attached using the same pin

### DIFF
--- a/cores/esp32/esp32-hal-sigmadelta.c
+++ b/cores/esp32/esp32-hal-sigmadelta.c
@@ -27,11 +27,13 @@ static bool sigmaDeltaDetachBus(void * bus){
 bool sigmaDeltaAttach(uint8_t pin, uint32_t freq) //freq 1220-312500
 {
     perimanSetBusDeinit(ESP32_BUS_TYPE_SIGMADELTA, sigmaDeltaDetachBus);
-    sdm_channel_handle_t bus = (sdm_channel_handle_t)perimanGetPinBus(pin, ESP32_BUS_TYPE_SIGMADELTA);
-    if(bus != NULL && !perimanClearPinBus(pin)){
+    sdm_channel_handle_t bus = NULL;
+    // pin may be previously attached to other peripheral -> detach it.
+    // if attached to sigmaDelta, detach it and set the new frequency
+    if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT && !perimanClearPinBus(pin)){
+        log_e("Pin %u could not be detached.", pin);
         return false;
     }
-    bus = NULL;
     sdm_config_t config = {
         .gpio_num = (int)pin,
         .clk_src = SDM_CLK_SRC_DEFAULT,


### PR DESCRIPTION
## Description of Change
If a pin is attached to another peripheral and it is latter attached to SigmaDelta, it won't correctly detach the previous peripheral.
This PR fixes it, including when the DeltaSigma frequency is changed.

## Tests scenarios
ESP32

``` cpp
#define PIN 2
void setup() {
  // Peripheral Manager will attach pin 2 UART (RX) - TX is the UART0 default pin.
  Serial.begin(115200, SERIAL_8N1, PIN);
  Serial.println("Serial pins - RX (pin 2) and TX (default) are attached");
  delay(1000);

  //Peripheral manage will detach pin 2 from UART (TX) and attach it to LEDC
  analogWrite(PIN, 100); // by default it will use 1KHz, 8 bits resolution
  Serial.println("Pin 2 is attached to LEDC");
  delay(5000);

  // Peripheral manager will detach pin 2 from LEDC and attach it to SigmaDelta
  sigmaDeltaAttach(PIN, 312500);
  sigmaDeltaWrite(PIN, 10);     // Start SigmaDelta
  Serial.println("Pin 2 is attached to SigmaDelta");
  delay(5000);
}

void loop() {}
```

## Related links
https://github.com/espressif/arduino-esp32/pull/9257#issuecomment-1955038791