### PR TITLE
Add support for the MotorGo Mini board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -26632,7 +26632,7 @@ sensebox_mcu_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
 motorgo_mini_1.name=MotorGo Mini 1 (ESP32-S3)
 motorgo_mini_1.vid.0=0x303a
-motorgo_mini_1.pid.0=0x9001
+motorgo_mini_1.pid.0=0x1001
 
 motorgo_mini_1.bootloader.tool=esptool_py
 motorgo_mini_1.bootloader.tool.default=esptool_py

--- a/boards.txt
+++ b/boards.txt
@@ -26629,3 +26629,226 @@ sensebox_mcu_esp32s2.menu.EraseFlash.all=Enabled
 sensebox_mcu_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+
+motorgo_mini_1.name=MotorGo Mini 1 (ESP32-S3)
+motorgo_mini_1.vid.0=0x303a
+motorgo_mini_1.pid.0=0x9001
+
+motorgo_mini_1.bootloader.tool=esptool_py
+motorgo_mini_1.bootloader.tool.default=esptool_py
+
+motorgo_mini_1.upload.tool=esptool_py
+motorgo_mini_1.upload.tool.default=esptool_py
+motorgo_mini_1.upload.tool.network=esp_ota
+
+motorgo_mini_1.upload.maximum_size=1310720
+motorgo_mini_1.upload.maximum_data_size=327680
+motorgo_mini_1.upload.flags=
+motorgo_mini_1.upload.extra_flags=
+motorgo_mini_1.upload.use_1200bps_touch=false
+motorgo_mini_1.upload.wait_for_upload_port=false
+
+motorgo_mini_1.serial.disableDTR=false
+motorgo_mini_1.serial.disableRTS=false
+
+motorgo_mini_1.build.tarch=xtensa
+motorgo_mini_1.build.bootloader_addr=0x0
+motorgo_mini_1.build.target=esp32s3
+motorgo_mini_1.build.mcu=esp32s3
+motorgo_mini_1.build.core=esp32
+motorgo_mini_1.build.variant=motorgo_mini_1
+motorgo_mini_1.build.board=MOTORGO_MINI_1
+
+motorgo_mini_1.build.usb_mode=1
+motorgo_mini_1.build.cdc_on_boot=1
+motorgo_mini_1.build.msc_on_boot=0
+motorgo_mini_1.build.dfu_on_boot=0
+motorgo_mini_1.build.f_cpu=240000000L
+motorgo_mini_1.build.flash_size=4MB
+motorgo_mini_1.build.flash_freq=80m
+motorgo_mini_1.build.flash_mode=dio
+motorgo_mini_1.build.boot=qio
+motorgo_mini_1.build.boot_freq=80m
+motorgo_mini_1.build.partitions=default
+motorgo_mini_1.build.defines=
+motorgo_mini_1.build.loop_core=
+motorgo_mini_1.build.event_core=
+motorgo_mini_1.build.psram_type=qspi
+motorgo_mini_1.build.memory_type={build.boot}_{build.psram_type}
+
+
+## IDE 2.0 Seems to not update the value
+motorgo_mini_1.menu.JTAGAdapter.default=Disabled
+motorgo_mini_1.menu.JTAGAdapter.default.build.copy_jtag_files=0
+motorgo_mini_1.menu.JTAGAdapter.builtin=Integrated USB JTAG
+motorgo_mini_1.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
+motorgo_mini_1.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+motorgo_mini_1.menu.JTAGAdapter.external=FTDI Adapter
+motorgo_mini_1.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+motorgo_mini_1.menu.JTAGAdapter.external.build.copy_jtag_files=1
+motorgo_mini_1.menu.JTAGAdapter.bridge=ESP USB Bridge
+motorgo_mini_1.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+motorgo_mini_1.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+motorgo_mini_1.menu.PSRAM.disabled=Disabled
+motorgo_mini_1.menu.PSRAM.disabled.build.defines=
+motorgo_mini_1.menu.PSRAM.disabled.build.psram_type=qspi
+motorgo_mini_1.menu.PSRAM.enabled=QSPI PSRAM
+motorgo_mini_1.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+motorgo_mini_1.menu.PSRAM.enabled.build.psram_type=qspi
+motorgo_mini_1.menu.PSRAM.opi=OPI PSRAM
+motorgo_mini_1.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+motorgo_mini_1.menu.PSRAM.opi.build.psram_type=opi
+
+motorgo_mini_1.menu.FlashMode.qio=QIO 80MHz
+motorgo_mini_1.menu.FlashMode.qio.build.flash_mode=dio
+motorgo_mini_1.menu.FlashMode.qio.build.boot=qio
+motorgo_mini_1.menu.FlashMode.qio.build.boot_freq=80m
+motorgo_mini_1.menu.FlashMode.qio.build.flash_freq=80m
+motorgo_mini_1.menu.FlashMode.qio120=QIO 120MHz
+motorgo_mini_1.menu.FlashMode.qio120.build.flash_mode=dio
+motorgo_mini_1.menu.FlashMode.qio120.build.boot=qio
+motorgo_mini_1.menu.FlashMode.qio120.build.boot_freq=120m
+motorgo_mini_1.menu.FlashMode.qio120.build.flash_freq=80m
+motorgo_mini_1.menu.FlashMode.dio=DIO 80MHz
+motorgo_mini_1.menu.FlashMode.dio.build.flash_mode=dio
+motorgo_mini_1.menu.FlashMode.dio.build.boot=dio
+motorgo_mini_1.menu.FlashMode.dio.build.boot_freq=80m
+motorgo_mini_1.menu.FlashMode.dio.build.flash_freq=80m
+motorgo_mini_1.menu.FlashMode.opi=OPI 80MHz
+motorgo_mini_1.menu.FlashMode.opi.build.flash_mode=dout
+motorgo_mini_1.menu.FlashMode.opi.build.boot=opi
+motorgo_mini_1.menu.FlashMode.opi.build.boot_freq=80m
+motorgo_mini_1.menu.FlashMode.opi.build.flash_freq=80m
+
+motorgo_mini_1.menu.FlashSize.4M=4MB (32Mb)
+motorgo_mini_1.menu.FlashSize.4M.build.flash_size=4MB
+motorgo_mini_1.menu.FlashSize.8M=8MB (64Mb)
+motorgo_mini_1.menu.FlashSize.8M.build.flash_size=8MB
+motorgo_mini_1.menu.FlashSize.8M.build.partitions=default_8MB
+motorgo_mini_1.menu.FlashSize.16M=16MB (128Mb)
+motorgo_mini_1.menu.FlashSize.16M.build.flash_size=16MB
+#esp32s3.menu.FlashSize.32M=32MB (256Mb)
+#esp32s3.menu.FlashSize.32M.build.flash_size=32MB
+
+motorgo_mini_1.menu.LoopCore.1=Core 1
+motorgo_mini_1.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+motorgo_mini_1.menu.LoopCore.0=Core 0
+motorgo_mini_1.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+motorgo_mini_1.menu.EventsCore.1=Core 1
+motorgo_mini_1.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+motorgo_mini_1.menu.EventsCore.0=Core 0
+motorgo_mini_1.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+motorgo_mini_1.menu.USBMode.hwcdc=Hardware CDC and JTAG
+motorgo_mini_1.menu.USBMode.hwcdc.build.usb_mode=1
+motorgo_mini_1.menu.USBMode.default=USB-OTG (TinyUSB)
+motorgo_mini_1.menu.USBMode.default.build.usb_mode=0
+
+motorgo_mini_1.menu.CDCOnBoot.default=Enabled
+motorgo_mini_1.menu.CDCOnBoot.default.build.cdc_on_boot=1
+motorgo_mini_1.menu.CDCOnBoot.cdc=Disabled
+motorgo_mini_1.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+motorgo_mini_1.menu.MSCOnBoot.default=Disabled
+motorgo_mini_1.menu.MSCOnBoot.default.build.msc_on_boot=0
+motorgo_mini_1.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+motorgo_mini_1.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+motorgo_mini_1.menu.DFUOnBoot.default=Disabled
+motorgo_mini_1.menu.DFUOnBoot.default.build.dfu_on_boot=0
+motorgo_mini_1.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+motorgo_mini_1.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+motorgo_mini_1.menu.UploadMode.default=UART0 / Hardware CDC
+motorgo_mini_1.menu.UploadMode.default.upload.use_1200bps_touch=false
+motorgo_mini_1.menu.UploadMode.default.upload.wait_for_upload_port=false
+motorgo_mini_1.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+motorgo_mini_1.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+motorgo_mini_1.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+motorgo_mini_1.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+motorgo_mini_1.menu.PartitionScheme.default.build.partitions=default
+motorgo_mini_1.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+motorgo_mini_1.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+motorgo_mini_1.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+motorgo_mini_1.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+motorgo_mini_1.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+motorgo_mini_1.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+motorgo_mini_1.menu.PartitionScheme.minimal.build.partitions=minimal
+motorgo_mini_1.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+motorgo_mini_1.menu.PartitionScheme.no_ota.build.partitions=no_ota
+motorgo_mini_1.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+motorgo_mini_1.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+motorgo_mini_1.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+motorgo_mini_1.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+motorgo_mini_1.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+motorgo_mini_1.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+motorgo_mini_1.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+motorgo_mini_1.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+motorgo_mini_1.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+motorgo_mini_1.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+motorgo_mini_1.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+motorgo_mini_1.menu.PartitionScheme.huge_app.build.partitions=huge_app
+motorgo_mini_1.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+motorgo_mini_1.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+motorgo_mini_1.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+motorgo_mini_1.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+motorgo_mini_1.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+motorgo_mini_1.menu.PartitionScheme.fatflash.build.partitions=ffat
+motorgo_mini_1.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+motorgo_mini_1.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+motorgo_mini_1.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+motorgo_mini_1.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+motorgo_mini_1.menu.PartitionScheme.rainmaker=RainMaker
+motorgo_mini_1.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+motorgo_mini_1.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+motorgo_mini_1.menu.CPUFreq.240=240MHz (WiFi)
+motorgo_mini_1.menu.CPUFreq.240.build.f_cpu=240000000L
+motorgo_mini_1.menu.CPUFreq.160=160MHz (WiFi)
+motorgo_mini_1.menu.CPUFreq.160.build.f_cpu=160000000L
+motorgo_mini_1.menu.CPUFreq.80=80MHz (WiFi)
+motorgo_mini_1.menu.CPUFreq.80.build.f_cpu=80000000L
+motorgo_mini_1.menu.CPUFreq.40=40MHz
+motorgo_mini_1.menu.CPUFreq.40.build.f_cpu=40000000L
+motorgo_mini_1.menu.CPUFreq.20=20MHz
+motorgo_mini_1.menu.CPUFreq.20.build.f_cpu=20000000L
+motorgo_mini_1.menu.CPUFreq.10=10MHz
+motorgo_mini_1.menu.CPUFreq.10.build.f_cpu=10000000L
+
+motorgo_mini_1.menu.UploadSpeed.921600=921600
+motorgo_mini_1.menu.UploadSpeed.921600.upload.speed=921600
+motorgo_mini_1.menu.UploadSpeed.115200=115200
+motorgo_mini_1.menu.UploadSpeed.115200.upload.speed=115200
+motorgo_mini_1.menu.UploadSpeed.256000.windows=256000
+motorgo_mini_1.menu.UploadSpeed.256000.upload.speed=256000
+motorgo_mini_1.menu.UploadSpeed.230400.windows.upload.speed=256000
+motorgo_mini_1.menu.UploadSpeed.230400=230400
+motorgo_mini_1.menu.UploadSpeed.230400.upload.speed=230400
+motorgo_mini_1.menu.UploadSpeed.460800.linux=460800
+motorgo_mini_1.menu.UploadSpeed.460800.macosx=460800
+motorgo_mini_1.menu.UploadSpeed.460800.upload.speed=460800
+motorgo_mini_1.menu.UploadSpeed.512000.windows=512000
+motorgo_mini_1.menu.UploadSpeed.512000.upload.speed=512000
+
+motorgo_mini_1.menu.DebugLevel.none=None
+motorgo_mini_1.menu.DebugLevel.none.build.code_debug=0
+motorgo_mini_1.menu.DebugLevel.error=Error
+motorgo_mini_1.menu.DebugLevel.error.build.code_debug=1
+motorgo_mini_1.menu.DebugLevel.warn=Warn
+motorgo_mini_1.menu.DebugLevel.warn.build.code_debug=2
+motorgo_mini_1.menu.DebugLevel.info=Info
+motorgo_mini_1.menu.DebugLevel.info.build.code_debug=3
+motorgo_mini_1.menu.DebugLevel.debug=Debug
+motorgo_mini_1.menu.DebugLevel.debug.build.code_debug=4
+motorgo_mini_1.menu.DebugLevel.verbose=Verbose
+motorgo_mini_1.menu.DebugLevel.verbose.build.code_debug=5
+
+motorgo_mini_1.menu.EraseFlash.none=Disabled
+motorgo_mini_1.menu.EraseFlash.none.upload.erase_cmd=
+motorgo_mini_1.menu.EraseFlash.all=Enabled
+motorgo_mini_1.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -26728,8 +26728,8 @@ motorgo_mini_1.menu.FlashSize.8M.build.flash_size=8MB
 motorgo_mini_1.menu.FlashSize.8M.build.partitions=default_8MB
 motorgo_mini_1.menu.FlashSize.16M=16MB (128Mb)
 motorgo_mini_1.menu.FlashSize.16M.build.flash_size=16MB
-#esp32s3.menu.FlashSize.32M=32MB (256Mb)
-#esp32s3.menu.FlashSize.32M.build.flash_size=32MB
+motorgo_mini_1.menu.FlashSize.32M=32MB (256Mb)
+motorgo_mini_1.menu.FlashSize.32M.build.flash_size=32MB
 
 motorgo_mini_1.menu.LoopCore.1=Core 1
 motorgo_mini_1.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1

--- a/variants/motorgo_mini_1/pins_arduino.h
+++ b/variants/motorgo_mini_1/pins_arduino.h
@@ -1,0 +1,88 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303A
+#define USB_PID 0x9001
+#define USB_MANUFACTURER "MotorGo"
+#define USB_PRODUCT "MotorGo Mini 1 (ESP32-S3)"
+#define USB_SERIAL ""  // Empty string for MAC adddress
+
+// Default USB FirmwareMSC Settings
+#define USB_FW_MSC_VENDOR_ID "MotorGo"                     // max 8 chars
+#define USB_FW_MSC_PRODUCT_ID "MotorGo Mini 1 (ESP32-S3)"  // max 16 chars
+#define USB_FW_MSC_PRODUCT_REVISION "3.00"                 // max 4 chars
+#define USB_FW_MSC_VOLUME_NAME "MotorGo"                   // max 11 chars
+
+#define NUM_DIGITAL_PINS 6
+#define NUM_ANALOG_INPUTS 1
+
+#define analogInputToDigitalPin(p) \
+  (((p) < 20) ? (analogChannelToDigitalPin(p)) : -1)
+#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
+#define digitalPinHasPWM(p) (p < 46)
+
+// A flag to indicate a GPIO pin is not set
+#define MOTORGO_GPIO_NOT_SET 0xFF
+
+// Built-in LED available to user
+static const uint8_t LED_BUILTIN = 38;
+
+// Status LED
+static const uint8_t LED_STATUS = 8;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 38;
+static const uint8_t SCL = 39;
+static const uint8_t QWIIC_SDA = SDA;
+static const uint8_t QWIIC_SCL = SCL;
+
+static const uint8_t ENC_SDA = 35;
+static const uint8_t ENC_SCL = 36;
+// Encoder uses SSI, but we still need to define MOSI
+// Pin 45 is not connected to anything, so we can use it
+static const uint8_t ENC_MOSI = 45;
+
+// ch0 Motor and Encoder pins
+static const uint8_t CH0_ENC_CS = 37;
+static const uint8_t CH0_UH = 18;
+static const uint8_t CH0_UL = 15;
+static const uint8_t CH0_VH = 17;
+static const uint8_t CH0_VL = 5;
+static const uint8_t CH0_WH = 16;
+static const uint8_t CH0_WL = 6;
+static const uint8_t CH0_CURRENT_U = 7;
+static const uint8_t CH0_CURRENT_V = MOTORGO_GPIO_NOT_SET;
+static const uint8_t CH0_CURRENT_W = 4;
+
+// ch1 Motor and Encoder pins
+static const uint8_t CH1_ENC_CS = 48;
+static const uint8_t CH1_UH = 9;
+static const uint8_t CH1_UL = 13;
+static const uint8_t CH1_VH = 10;
+static const uint8_t CH1_VL = 21;
+static const uint8_t CH1_WH = 11;
+static const uint8_t CH1_WL = 14;
+static const uint8_t CH1_CURRENT_U = 8;
+static const uint8_t CH1_CURRENT_V = MOTORGO_GPIO_NOT_SET;
+static const uint8_t CH1_CURRENT_W = 12;
+
+static const uint8_t CURRENT_SENSE_AMP_GAIN = 200;
+static const uint8_t CURRENT_SENSE_RESISTANCE_mOHM = 3;
+
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 13;
+static const uint8_t SCK = 12;
+
+// The MotorGo Mini 1 exposes 1 GPIO pin connected to an ADC
+static const uint8_t A8 = 8;
+
+#endif /* Pins_Arduino_h */

--- a/variants/motorgo_mini_1/pins_arduino.h
+++ b/variants/motorgo_mini_1/pins_arduino.h
@@ -6,16 +6,7 @@
 #include "soc/soc_caps.h"
 
 #define USB_VID 0x303A
-#define USB_PID 0x9001
-#define USB_MANUFACTURER "MotorGo"
-#define USB_PRODUCT "MotorGo Mini 1 (ESP32-S3)"
-#define USB_SERIAL ""  // Empty string for MAC adddress
-
-// Default USB FirmwareMSC Settings
-#define USB_FW_MSC_VENDOR_ID "MotorGo"                     // max 8 chars
-#define USB_FW_MSC_PRODUCT_ID "MotorGo Mini 1 (ESP32-S3)"  // max 16 chars
-#define USB_FW_MSC_PRODUCT_REVISION "3.00"                 // max 4 chars
-#define USB_FW_MSC_VOLUME_NAME "MotorGo"                   // max 11 chars
+#define USB_PID 0x1001
 
 #define NUM_DIGITAL_PINS 6
 #define NUM_ANALOG_INPUTS 1


### PR DESCRIPTION
Add support for MotorGo Mini 1 motor controller with ESP32-S3.

-----------
## Description of Change
Adds a new variant for the MotorGo Mini with an onboard ESP32-S3. Updated boards.txt and created a new variants directory.

## Tests scenarios
Tested the new variant with the Arduino-ESP32Core 2.0.14 running on the MotorGo Mini 1 board. 

## Related links
[MotorGo Website](https://motorgo.net/)