### PR TITLE
Remove -Werror=all from build flags, but enable it in CI

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -161,6 +161,7 @@ function build_sketch(){ # build_sketch <ide_path> <user_path> <path-to-ino> [ex
                 --fqbn "$currfqbn" \
                 --board-options "$curroptions" \
                 --warnings "all" \
+                --build-property "compiler.warning_flags.all=-Wall -Werror=all -Wextra" \
                 --build-cache-path "$ARDUINO_CACHE_DIR" \
                 --build-path "$build_dir" \
                 $xtra_opts "${sketchdir}"

--- a/platform.txt
+++ b/platform.txt
@@ -41,8 +41,8 @@ compiler.optimization_flags.debug=-Og -g3
 compiler.warning_flags=-w
 compiler.warning_flags.none=-w
 compiler.warning_flags.default=
-compiler.warning_flags.more=-Wall -Werror=all
-compiler.warning_flags.all=-Wall -Werror=all -Wextra
+compiler.warning_flags.more=-Wall
+compiler.warning_flags.all=-Wall -Wextra
 
 # Compile Flags
 compiler.cpreprocessor.flags="@{compiler.sdk.path}/flags/defines" "-I{build.source.path}" -iprefix "{compiler.sdk.path}/include/" "@{compiler.sdk.path}/flags/includes" "-I{compiler.sdk.path}/{build.memory_type}/include"


### PR DESCRIPTION
Fixes: https://github.com/espressif/arduino-esp32/issues/7024
