### PR TITLE
MotorGo Mini 1 - Update LED_STATUS to match latest board revision

### DIFF
--- a/variants/motorgo_mini_1/pins_arduino.h
+++ b/variants/motorgo_mini_1/pins_arduino.h
@@ -23,7 +23,7 @@
 static const uint8_t LED_BUILTIN = 38;
 
 // Status LED
-static const uint8_t LED_STATUS = 8;
+static const uint8_t LED_STATUS = 47;
 #define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN
 


### PR DESCRIPTION
## Description of Change
Changed LED_STATUS pin number to match the latest MotorGo Mini 1 board revision. Due to a communication mistake between me and a teammate, the last PR adding support for the board targeted the wrong board revision. I apologize for the back-to-back PRs :(

## Tests scenarios
Tested this pin definition with Arduino-ESP32Core 2.0.14 running on the MotorGo Mini 1 board (revision 3 - this is the one shipping to consumers). All LEDs turn on as expected.


## Related links
[MotorGo Website](https://motorgo.net/)
Original PR for MotorGo Mini 1: #9269 