### PR TITLE
fixes default 100ms delay with HWCDC write() is CDC is not connected 

### DIFF
--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2015-2024 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class HWCDC: public Stream
 {
 private:
     static bool deinit(void * busptr);
-    bool isCDC_Connected();
+    static bool isCDC_Connected();
     
 public:
     HWCDC();
@@ -71,12 +71,12 @@ public:
     size_t write(const uint8_t *buffer, size_t size);
     void flush(void);
 
-    inline bool isPlugged(void)
+    inline static bool isPlugged(void)
     {
         return usb_serial_jtag_is_connected();
     }
 
-    inline bool isConnected(void)
+    inline static bool isConnected(void)
     {
         return isCDC_Connected();
     }

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -46,6 +46,7 @@ class HWCDC: public Stream
 {
 private:
     static bool deinit(void * busptr);
+    static bool isCDC_Connected();
     
 public:
     HWCDC();

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -21,6 +21,7 @@
 #include <inttypes.h>
 #include "esp_event.h"
 #include "Stream.h"
+#include "driver/usb_serial_jtag.h"
 
 ESP_EVENT_DECLARE_BASE(ARDUINO_HW_CDC_EVENTS);
 
@@ -46,7 +47,7 @@ class HWCDC: public Stream
 {
 private:
     static bool deinit(void * busptr);
-    static bool isCDC_Connected();
+    bool isCDC_Connected();
     
 public:
     HWCDC();
@@ -69,7 +70,17 @@ public:
     size_t write(uint8_t);
     size_t write(const uint8_t *buffer, size_t size);
     void flush(void);
-    
+
+    inline bool isPlugged(void)
+    {
+        return usb_serial_jtag_is_connected();
+    }
+
+    inline bool isConnected(void)
+    {
+        return isCDC_Connected();
+    }
+
     inline size_t read(char * buffer, size_t size)
     {
         return read((uint8_t*) buffer, size);

--- a/libraries/ESP32/examples/HWSerial_Events/HWSerial_Events.ino
+++ b/libraries/ESP32/examples/HWSerial_Events/HWSerial_Events.ino
@@ -24,8 +24,6 @@ void loop(){}
 HWCDC HWCDCSerial;
 #endif
 
-#include "driver/usb_serial_jtag.h"
-
 // USB Event Callback Function that will log CDC events into UART0
 static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data) {
   if (event_base == ARDUINO_HW_CDC_EVENTS) {
@@ -51,20 +49,16 @@ static void usbEventCallback(void* arg, esp_event_base_t event_base, int32_t eve
   }
 }
 
-bool isPlugged() {
-  return usb_serial_jtag_is_connected();
-}
-
 const char* _hwcdc_status[] = {
-  " USB Plugged but CDC is not connected\r\n",
+  " USB Plugged but CDC is NOT connected\r\n",
   " USB Plugged and CDC is connected\r\n",
-  " USB Unplugged and CDC not connected\r\n",
+  " USB Unplugged and CDC NOT connected\r\n",
   " USB Unplugged BUT CDC is connected :: PROBLEM\r\n",
 };
 
 const char* HWCDC_Status() {
-  int i = isPlugged() ? 0 : 2;
-  if(HWCDCSerial) i += 1;
+  int i = HWCDCSerial.isPlugged() ? 0 : 2;
+  if(HWCDCSerial.isConnected()) i += 1;
   return _hwcdc_status[i];
 }
 


### PR DESCRIPTION
## Description of Change
Improves the functionality of HW CDC (HW Serial) when CDC is not connected to the Host side. At this point it solves the delay issue only when it is not plugged to the USB port. But even when plugged and the host enumerates it, it still delays when CDC is not connected, causing some side effect.

This PR fixes it and also adds 2 new APIs:
- HWCDC::isConnected() will return true when HWCDC has a CDC connection to an application in the host side (like a serial terminal) and false otherwise.
- HWCDC::isPlugged() will return true when USB is plugged to a USB host and it has enumarated the CDC class.

## Tests scenarios
``` cpp
void setup() {
  Serial0.begin(115200);
  HWCDCSerial.begin();

  Serial0.println("\n ==> Connect to the CDC Serial Terminal\n");
  while(!HWCDCSerial) delay(100);

  Serial0.println("CDC is connected. It will write to the CDC and delay 1s.\nCheck the millisecond counter.");
  Serial0.println("After checking that it is steady in 1,000 milliseconds, unplug the USB cable. Check the time.");
  Serial0.println("Latter plug back the USB cable. Check the time. Do not open the CDC terminal.");
}

void loop() {
  Serial0.print("Time (ms): ");
  Serial0.println(millis());
  HWCDCSerial.print("Time (ms): ");
  HWCDCSerial.println(millis());

  // when USB is plugged and CDC terminal is not connected, it loop execution will take 1.1 seconds instead of 1.0 seconds.
  delay(1000);
}
```

### Bad Output (from UART0):

```
ESP-ROM:esp32h2-20221101
Build:Nov  1 2022
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x4083cfd0,len:0xb68
load:0x4083efd0,len:0x2718
load:0x408460e8,len:0x590
entry 0x4083cfd0

 ==> Connect to the CDC Serial Terminal

CDC is connected. It will write to the CDC and delay 1s.
Check the millisecond counter.
After checking that it is steady in 1,000 milliseconds, unplug the USB cable. Check the time.
Latter plug back the USB cable. Check the time. Do not open the CDC terminal.
Time (ms): 12049             <<<<<======== USB plugged and CDC connected
Time (ms): 13049
Time (ms): 14054
Time (ms): 15054 <<<<<< average is + 1,000 ms
Time (ms): 16059
Time (ms): 17059
Time (ms): 18064             <<<<<======== USB NOT plugged and CDC NOT connected
Time (ms): 19064
Time (ms): 20069
Time (ms): 21069  <<<<<< average is + 1,000 ms
Time (ms): 22074
Time (ms): 23074
Time (ms): 24079
Time (ms): 25079             <<<<<======== USB plugged and CDC NOT connected :: PROBLEM
Time (ms): 26184
Time (ms): 27284
Time (ms): 28389
Time (ms): 29489
Time (ms): 30594 <<<<<< average is + 1,100 ms
Time (ms): 31694
Time (ms): 32799
Time (ms): 33899
Time (ms): 35004
```

## Related links
#9043 
