### PR TITLE
ETH: Support physical address auto detection

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -82,7 +82,7 @@ bool ETHClass::ethDetachBus(void * bus_pointer){
 }
 
 #if CONFIG_ETH_USE_ESP32_EMAC
-bool ETHClass::begin(eth_phy_type_t type, uint8_t phy_addr, int mdc, int mdio, int power, eth_clock_mode_t clock_mode)
+bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int mdc, int mdio, int power, eth_clock_mode_t clock_mode)
 {
     esp_err_t ret = ESP_OK;
     if(_esp_netif != NULL){
@@ -168,7 +168,7 @@ bool ETHClass::begin(eth_phy_type_t type, uint8_t phy_addr, int mdc, int mdio, i
     esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, phy);
     ret = esp_eth_driver_install(&eth_config, &_eth_handle);
     if(ret != ESP_OK){
-        log_e("SPI Ethernet driver install failed: %d", ret);
+        log_e("Ethernet driver install failed: %d", ret);
         return false;
     }
     if(_eth_handle == NULL){
@@ -340,7 +340,7 @@ esp_err_t ETHClass::eth_spi_write(uint32_t cmd, uint32_t addr, const void *data,
 }
 #endif
 
-bool ETHClass::beginSPI(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, int rst, 
+bool ETHClass::beginSPI(eth_phy_type_t type, int32_t phy_addr, int cs, int irq, int rst, 
 #if ETH_SPI_SUPPORTS_CUSTOM
     SPIClass *spi, 
 #endif
@@ -625,13 +625,13 @@ err:
 }
 
 #if ETH_SPI_SUPPORTS_CUSTOM
-bool ETHClass::begin(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, int rst, SPIClass &spi, uint8_t spi_freq_mhz){
+bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int cs, int irq, int rst, SPIClass &spi, uint8_t spi_freq_mhz){
 
     return beginSPI(type, phy_addr, cs, irq, rst, &spi, -1, -1, -1, SPI2_HOST, spi_freq_mhz);
 }
 #endif
 
-bool ETHClass::begin(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, int rst, spi_host_device_t spi_host, int sck, int miso, int mosi, uint8_t spi_freq_mhz){
+bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int cs, int irq, int rst, spi_host_device_t spi_host, int sck, int miso, int mosi, uint8_t spi_freq_mhz){
 
     return beginSPI(type, phy_addr, cs, irq, rst,
 #if ETH_SPI_SUPPORTS_CUSTOM 

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -88,6 +88,10 @@ bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int mdc, int mdio, i
     if(_esp_netif != NULL){
         return true;
     }
+    if(phy_addr < ETH_PHY_ADDR_AUTO){
+        log_e("Invalid PHY address: %d, set to ETH_PHY_ADDR_AUTO for auto detection", phy_addr);
+        return false;
+    }
     perimanSetBusDeinit(ESP32_BUS_TYPE_ETHERNET_RMII, ETHClass::ethDetachBus);
     perimanSetBusDeinit(ESP32_BUS_TYPE_ETHERNET_CLK, ETHClass::ethDetachBus);
     perimanSetBusDeinit(ESP32_BUS_TYPE_ETHERNET_MCD, ETHClass::ethDetachBus);
@@ -358,6 +362,10 @@ bool ETHClass::beginSPI(eth_phy_type_t type, int32_t phy_addr, int cs, int irq, 
     if(cs < 0 || irq < 0){
         log_e("CS and IRQ pins must be defined!");
 #endif
+        return false;
+    }
+    if(phy_addr < ETH_PHY_ADDR_AUTO){
+        log_e("Invalid PHY address: %d, set to ETH_PHY_ADDR_AUTO for auto detection", phy_addr);
         return false;
     }
 

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -87,6 +87,8 @@ typedef enum { ETH_CLOCK_GPIO0_IN, ETH_CLOCK_GPIO0_OUT, ETH_CLOCK_GPIO16_OUT, ET
 #define ETH_PHY_SPI_FREQ_MHZ 20
 #endif /* ETH_PHY_SPI_FREQ_MHZ */
 
+#define ETH_PHY_ADDR_AUTO ESP_ETH_PHY_ADDR_AUTO
+
 typedef enum { 
 #if CONFIG_ETH_USE_ESP32_EMAC
     ETH_PHY_LAN8720, ETH_PHY_TLK110, ETH_PHY_RTL8201, ETH_PHY_DP83848, ETH_PHY_KSZ8041, ETH_PHY_KSZ8081, 
@@ -109,12 +111,12 @@ class ETHClass {
         ~ETHClass();
 
 #if CONFIG_ETH_USE_ESP32_EMAC
-        bool begin(eth_phy_type_t type, uint8_t phy_addr, int mdc, int mdio, int power, eth_clock_mode_t clk_mode);
+        bool begin(eth_phy_type_t type, int32_t phy_addr, int mdc, int mdio, int power, eth_clock_mode_t clk_mode);
 #endif /* CONFIG_ETH_USE_ESP32_EMAC */
 #if ETH_SPI_SUPPORTS_CUSTOM
-        bool begin(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, int rst, SPIClass &spi, uint8_t spi_freq_mhz=ETH_PHY_SPI_FREQ_MHZ);
+        bool begin(eth_phy_type_t type, int32_t phy_addr, int cs, int irq, int rst, SPIClass &spi, uint8_t spi_freq_mhz=ETH_PHY_SPI_FREQ_MHZ);
 #endif
-        bool begin(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, int rst, spi_host_device_t spi_host, int sck=-1, int miso=-1, int mosi=-1, uint8_t spi_freq_mhz=ETH_PHY_SPI_FREQ_MHZ);
+        bool begin(eth_phy_type_t type, int32_t phy_addr, int cs, int irq, int rst, spi_host_device_t spi_host, int sck=-1, int miso=-1, int mosi=-1, uint8_t spi_freq_mhz=ETH_PHY_SPI_FREQ_MHZ);
 
         bool begin(){
 #if defined(ETH_PHY_TYPE) && defined(ETH_PHY_ADDR)
@@ -208,7 +210,7 @@ class ETHClass {
 #endif /* CONFIG_ETH_USE_ESP32_EMAC */
 
         static bool ethDetachBus(void * bus_pointer);
-        bool beginSPI(eth_phy_type_t type, uint8_t phy_addr, int cs, int irq, int rst, 
+        bool beginSPI(eth_phy_type_t type, int32_t phy_addr, int cs, int irq, int rst, 
 #if ETH_SPI_SUPPORTS_CUSTOM
             SPIClass * spi, 
 #endif


### PR DESCRIPTION
## Description of Change
This PR changes ETH.begin's parameter `phy_addr` from `uint8_t` to `int32_t` to match the `eth_phy_config_t`.
This also enables using `ETH_PHY_ADDR_AUTO` as `phy_addr` in `ETH.begin()` to automatically get the phy address from the chip.

## Tests scenarios
Tested only with SPI Ethernet for now. Will test next week with RMII Ethernet.

## Related links

Closes #9311 
