### PR TITLE
HardwareSerial Available For Write

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -537,35 +537,38 @@ bool HardwareSerial::setMode(SerialMode mode)
     return uartSetMode(_uart, mode);
 }
 
+// minimum total RX Buffer size is the UART FIFO space (128 bytes for most SoC) + 1. IDF imposition.
 size_t HardwareSerial::setRxBufferSize(size_t new_size) {
 
     if (_uart) {
-        log_e("RX Buffer can't be resized when Serial is already running.\n");
+        log_e("RX Buffer can't be resized when Serial is already running. Set it before calling begin().");
         return 0;
     }
 
     if (new_size <= SOC_UART_FIFO_LEN) {
-        log_e("RX Buffer must be higher than %d.\n", SOC_UART_FIFO_LEN);  // ESP32, S2, S3 and C3 means higher than 128
-        return 0;
+        log_w("RX Buffer set to minimum value: %d.", SOC_UART_FIFO_LEN + 1);  // ESP32, S2, S3 and C3 means higher than 128
+        new_size = SOC_UART_FIFO_LEN + 1;
     }
 
     _rxBufferSize = new_size;
     return _rxBufferSize;
 }
 
+// minimum total TX Buffer size is the UART FIFO space (128 bytes for most SoC).
 size_t HardwareSerial::setTxBufferSize(size_t new_size) {
 
     if (_uart) {
-        log_e("TX Buffer can't be resized when Serial is already running.\n");
+        log_e("TX Buffer can't be resized when Serial is already running. Set it before calling begin().");
         return 0;
     }
 
-    if (new_size <= SOC_UART_FIFO_LEN) {
-        log_e("TX Buffer must be higher than %d.\n", SOC_UART_FIFO_LEN);  // ESP32, S2, S3 and C3 means higher than 128
-        return 0;
+    if (new_size < SOC_UART_FIFO_LEN) {
+        log_w("TX Buffer set to minimum value: %d.", SOC_UART_FIFO_LEN);  // ESP32, S2, S3 and C3 means higher than 128
+        _txBufferSize = 0; // it will use just UART FIFO with SOC_UART_FIFO_LEN bytes (128 for most SoC)
+        return SOC_UART_FIFO_LEN;
     }
-
-    _txBufferSize = new_size;
-    return _txBufferSize;
+    // if new_size is SOC_UART_FIFO_LEN, _txBufferSize will be zero - just use the UART FIFO space
+    _txBufferSize = new_size - SOC_UART_FIFO_LEN; // for total correct report from "availableForWrite()"  that matches a call to this function
+    return new_size;
 }
 

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -562,13 +562,12 @@ size_t HardwareSerial::setTxBufferSize(size_t new_size) {
         return 0;
     }
 
-    if (new_size < SOC_UART_FIFO_LEN) {
+    if (new_size <= SOC_UART_FIFO_LEN) {
         log_w("TX Buffer set to minimum value: %d.", SOC_UART_FIFO_LEN);  // ESP32, S2, S3 and C3 means higher than 128
         _txBufferSize = 0; // it will use just UART FIFO with SOC_UART_FIFO_LEN bytes (128 for most SoC)
         return SOC_UART_FIFO_LEN;
     }
-    // if new_size is SOC_UART_FIFO_LEN, _txBufferSize will be zero - just use the UART FIFO space
-    _txBufferSize = new_size - SOC_UART_FIFO_LEN; // for total correct report from "availableForWrite()"  that matches a call to this function
+    // if new_size is higher than SOC_UART_FIFO_LEN, TX Ringbuffer will be active and it will be used to report back "availableToWrite()"
+    _txBufferSize = new_size;
     return new_size;
 }
-

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -642,7 +642,7 @@ uint32_t uartAvailableForWrite(uart_t* uart)
     uint32_t available =  uart_ll_get_txfifo_len(UART_LL_GET_HW(uart->num));  
     size_t txRingBufferAvailable = 0;
     if (ESP_OK == uart_get_tx_buffer_free_size(uart->num, &txRingBufferAvailable)) {
-        available += txRingBufferAvailable; 
+        available = txRingBufferAvailable == 0 ? available : txRingBufferAvailable; 
     }
     UART_MUTEX_UNLOCK();
     return available;


### PR DESCRIPTION
## Description of Change
When setting RX buffer, the `setRxBufferSize()` method would fail with values lower than 128 bytes. 
Although it seems what IDF requests, it is not the best way to execute it, because the return value would be zero and the buffer size would be kept the same, by default 256. Now it returns the size it has been set, defining a minimum of 128+1 bytes, as required by IDF UART driver.

By other hand, for TX buffer, the  `setTxBufferSize()` method also fails with less than 128 bytes, returning also 0.
With the change, it will return and set it to 128 (minimum), as requeired by IDF. 
It also changes `availableForWrite()` in order to return a value that matches `setTxBufferSize()` when there is no data to be written, making it possible for applications to better compare and decide when to write to the UART.


## Tests scenarios
Tested with ESP32 and ESP32-S3.

``` cpp
void setup() {
  size_t Ts = Serial.setTxBufferSize(100);
  size_t Rs = Serial.setRxBufferSize(100);
  Serial.begin(115200);
  delay(1000);
  
  Serial.printf("TX Buffer (%d) Size is %d\n", Ts, Serial.availableForWrite());
  Serial.printf("RX Buffer Size is %d\n", Rs);
}

void loop() {
  if (Serial.available()) {
    char c = Serial.read();
    Serial.write(c);
  }
}
```

## Related links
Closes #9317