### PR TITLE
Fix compile branch master as Arduino as component with latest IDF 5.1

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -445,7 +445,11 @@ static void usb_switch_to_cdc_jtag(){
     digitalWrite(USBPHY_DP_NUM, LOW);
 
     // Initialize CDC+JTAG ISR to listen for BUS_RESET
+    #if defined __has_include && __has_include ("hal/usb_phy_ll.h")
     usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
+    #else
+    usb_fsls_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
+    #endif
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_BUS_RESET);

--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -42,8 +42,12 @@
 #include "esp32s2/rom/usb/usb_dc.h"
 #include "esp32s2/rom/usb/chip_usb_dw_wrapper.h"
 #elif CONFIG_IDF_TARGET_ESP32S3
-#include "hal/usb_serial_jtag_ll.h"
+#if defined __has_include && __has_include ("hal/usb_phy_ll.h")
 #include "hal/usb_phy_ll.h"
+#else
+#include "hal/usb_fsls_phy_ll.h"
+#endif
+#include "hal/usb_serial_jtag_ll.h"
 #include "esp32s3/rom/usb/usb_persist.h"
 #include "esp32s3/rom/usb/usb_dc.h"
 #include "esp32s3/rom/usb/chip_usb_dw_wrapper.h"


### PR DESCRIPTION
Since the include file name changed from `hal/usb_phy_ll.h` to `hal/usb_fsls_phy_ll.h` IDF commit https://github.com/espressif/esp-idf/commit/148cc6e75d6f131deb36bd0a4ffdfbaaa2520520

The PR code change checks if the old file is there if yes it is included else the new file is included.

@me-no-dev 