### PR TITLE
Fix spiTransaction not updating clock line immediately (#9221)

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -1115,6 +1115,11 @@ void spiTransaction(spi_t * spi, uint32_t clockDiv, uint8_t dataMode, uint8_t bi
         spi->dev->ctrl.wr_bit_order = 1;
         spi->dev->ctrl.rd_bit_order = 1;
     }
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+    // Sync new config with hardware, fixes https://github.com/espressif/arduino-esp32/issues/9221
+    spi->dev->cmd.update = 1;
+    while (spi->dev->cmd.update);
+#endif
 }
 
 void spiSimpleTransaction(spi_t * spi)


### PR DESCRIPTION
## Description of Change
This PR fixes #9221 by forcing SPI clock line to update within `spiTransaction`.
This is especially important when sharing a single SPI bus between devices with different SPI modes.
Notable use case is using SD card (SPI mode 0) and ST7789-based TFT display (mode 3).

## Tests scenarios
Tested with ESP32-C3 SuperMini board.

## Related links
- #9221
- https://github.com/moononournation/Arduino_GFX/issues/433