### PR TITLE
add LittleFS part ID

### DIFF
--- a/tools/gen_esp32part.py
+++ b/tools/gen_esp32part.py
@@ -71,6 +71,7 @@ SUBTYPES = {
         'esphttpd': 0x80,
         'fat': 0x81,
         'spiffs': 0x82,
+        'littlefs': 0x83,
     },
 }
 


### PR DESCRIPTION
latest IDF 5.1 does support LittleFS and has added its own Partition ID.
This PR updates gen_esp32part.py to latest from commit https://github.com/espressif/esp-idf/commit/2374a0c04eeefc0a6006afe068fdf4542815ec21