### PR TITLE
Update upload and download artifact action to v4

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -38,7 +38,7 @@ jobs:
         PATH=/home/runner/.local/bin:$PATH pip3 install -r requirements.txt --prefer-binary
         PATH=/home/runner/.local/bin:$PATH SPHINXOPTS="-W" build-docs -l en
     - name: Archive Docs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: docs
         path: docs

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           bash .github/scripts/tests_build.sh -c -t ${{matrix.chip}} -i ${{matrix.chunks}} -m ${{env.MAX_CHUNKS}}
       - name: Upload ${{matrix.chip}}-${{matrix.chunks}} artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.chip}}-${{matrix.chunks}}.artifacts
           path: |
@@ -97,7 +97,7 @@ jobs:
            bash .github/scripts/tests_run.sh -c -t ${{matrix.chip}} -i ${{matrix.chunks}} -m ${{env.MAX_CHUNKS}} -e
 
        - name: Upload test result artifacts
-         uses: actions/upload-artifact@v3
+         uses: actions/upload-artifact@v4
          if: always()
          with:
            name: test_results-${{matrix.chip}}-${{matrix.chunks}}
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - name: Upload
-         uses: actions/upload-artifact@v3
+         uses: actions/upload-artifact@v4
          with:
            name: Event File
            path: ${{github.event_path}}

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -81,7 +81,7 @@ jobs:
          uses: actions/checkout@v4
 
        - name: Download ${{matrix.chip}}-${{matrix.chunks}} artifacts
-         uses: actions/download-artifact@v3
+         uses: actions/download-artifact@v4
          with:
            name: ${{matrix.chip}}-${{matrix.chunks}}.artifacts
            path: ~/.arduino/tests/

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
+          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}-${{ matrix.target }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}
 
   report-to-file:
@@ -100,7 +100,8 @@ jobs:
       - name: Download sketches reports artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
+          pattern: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}-*
+          merge-multiple: true
           path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Report results

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -98,7 +98,7 @@ jobs:
 
       # This step is needed to get the size data produced by the compile jobs
       - name: Download sketches reports artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -75,7 +75,7 @@ jobs:
             - --warnings="all"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
        - name: Upload
-         uses: actions/upload-artifact@v2
+         uses: actions/upload-artifact@v4
          with:
            name: Event File
            path: ${{github.event_path}}


### PR DESCRIPTION
V4 uses node 20 and solves the deprecation warning