### PR TITLE
fix: HWCDC removed clearing USB Serial/JTAG interrupts during begin (#9316)

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -186,7 +186,6 @@ void HWCDC::begin(unsigned long baud)
         }    
     }
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
-    usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY | USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT | USB_SERIAL_JTAG_INTR_BUS_RESET);
     if(!intr_handle && esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, 0, hw_cdc_isr_handler, NULL, &intr_handle) != ESP_OK){
         isr_log_e("HW USB CDC failed to init interrupts");


### PR DESCRIPTION
## Description of Change
Fixes (#9316) where ESP may not respond over the USB Serial/JTAG interface if bytes are sent before `HWCDC::begin(...)` is called. Clearing of the interrupt status has been removed from `HWCDC::begin(...)` so that if the `USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT` is already set, the isr handler can process the interrupt status correctly.

## Tests scenarios
Tested with ESP32-S3:

``` c++
#include <Arduino.h>
#include <HWCDC.h>
#include <hal/usb_serial_jtag_ll.h>
#include <string>


uint32_t prevTime = 0;


void setup() {
  
  delay(5000);

  Serial.begin(115200);
  Serial.println("begin");
}

void loop() {

  if (millis() - prevTime > 500)
  {
    prevTime = millis();
    std::string output;
    output += "rxFifo: " + std::to_string(usb_serial_jtag_ll_rxfifo_data_available());
    output += " Serial avaliable: " + std::to_string(Serial.available());
    Serial.println(output.c_str());

  }

  while (Serial.available())
  {
    uint8_t b = Serial.read();
    Serial.print(Serial.available());
    Serial.print(" - ");
    Serial.write(b);
    Serial.println();
  }
  vTaskDelay(1); // watchdog
}

```


## Related links

Closes (#9316)
