### PR TITLE
HardwareSerial:begin() changes RTS and CTS pins preventing detaching those pins 

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -509,8 +509,6 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
         uart->_rxfifo_full_thrhd = rxfifo_full_thrhd;
         uart->_rx_buffer_size = rx_buffer_size;
         uart->_tx_buffer_size = tx_buffer_size;
-        uart->_ctsPin = -1;
-        uart->_rtsPin = -1;
         uart->has_peek = false;
         uart->peek_byte = 0;
     }


### PR DESCRIPTION
## Description of Change

Begin() may "undo" a setpins() that has set RTS and/or CTS pin.
As consequence, RTS and CTS won't be detached with end(). 
This pins are only changed by using setPins() passing RTS and CTS.

setpins() can be called after or before begin()
when called before, begin() shall not change those pins.

This PR fixes it.

## Tests scenarios
Tested with ESP32 just checking logs.

``` cpp
void setup() {
  Serial.setPins(3, 1, 25, 26); // ESP32 RX, TX, CTS, RTS
  Serial.begin(115200);
  Serial.end();  // only detaches RX and TX. CTS and RTS will be -1 after begin() and won't be detached!
}
void loop() {}
```

## Related links

This changes has been backported to 2.0.15 by #9176 
