### PR TITLE
Fixes HW Serial attaching pins, PHY initialization, crash after end()

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -26,11 +26,7 @@
 #include "soc/io_mux_reg.h"
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "hal/usb_serial_jtag_ll.h"
-#if defined __has_include && __has_include ("hal/usb_phy_ll.h")
 #include "hal/usb_phy_ll.h"
-#else
-#include "hal/usb_fsls_phy_ll.h"
-#endif
 #pragma GCC diagnostic warning "-Wvolatile"
 #include "rom/ets_sys.h"
 #include "driver/usb_serial_jtag.h"
@@ -270,11 +266,7 @@ void HWCDC::begin(unsigned long baud)
         }
     }
     // Configure PHY
-    #if defined __has_include && __has_include ("hal/usb_phy_ll.h") 
     usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG); 
-    #else 
-    usb_fsls_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG); 
-    #endif
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY | USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT | USB_SERIAL_JTAG_INTR_BUS_RESET);
     if(!intr_handle && esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, 0, hw_cdc_isr_handler, NULL, &intr_handle) != ESP_OK){

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -87,7 +87,7 @@ static void hw_cdc_isr_handler(void *arg) {
         } else {
             connected = true;
         }
-        if (usb_serial_jtag_ll_txfifo_writable() == 1) {
+        if (tx_ring_buf != NULL && usb_serial_jtag_ll_txfifo_writable() == 1) {
             // We disable the interrupt here so that the interrupt won't be triggered if there is no data to send.
             usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
             size_t queued_size;
@@ -165,6 +165,9 @@ bool HWCDC::isCDC_Connected()
 }
 
 static void ARDUINO_ISR_ATTR cdc0_write_char(char c) {
+    if(tx_ring_buf == NULL) {
+        return;
+    }
     uint32_t tx_timeout_ms = 0;
     if(HWCDC::isConnected()) {
         tx_timeout_ms = requested_tx_timeout_ms;
@@ -292,6 +295,7 @@ void HWCDC::end()
         arduino_hw_cdc_event_loop_handle = NULL;
     }
     HWCDC::deinit(this);
+    setDebugOutput(false);
     connected = false;
 }
 

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -244,7 +244,7 @@ void HWCDC::begin(unsigned long baud)
     }
 
 #if CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2
-// it needs the HW Serial pins to be first deinited in order to allow `if(Serial)` to work :-(
+// the HW Serial pins needs to be first deinited in order to allow `if(Serial)` to work :-(
     deinit(NULL);
     delay(10);
 #endif

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -246,7 +246,7 @@ void HWCDC::begin(unsigned long baud)
         return;
     }
     // Setting USB D+ D- pins
-    uint8_t pin = ESP32_BUS_TYPE_USB_DM;
+    uint8_t pin = USB_DM_GPIO_NUM;
     if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT){
         if(!perimanClearPinBus(pin)){
             goto err;
@@ -255,7 +255,7 @@ void HWCDC::begin(unsigned long baud)
     if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DM, (void *) this, -1, -1)){
         goto err;
     }
-    pin = ESP32_BUS_TYPE_USB_DP;
+    pin = USB_DP_GPIO_NUM;
     if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT){
         if(!perimanClearPinBus(pin)){
             goto err;

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -242,11 +242,7 @@ void HWCDC::begin(unsigned long baud)
             log_e("HW CDC TX Buffer error");
         }    
     }
-<<<<<<< Updated upstream
-    // Setting USB D+ D- pins
-=======
     // Setting USB D+ D- pins || reduces number of debug messages
->>>>>>> Stashed changes
     uint8_t pin = USB_DM_GPIO_NUM;
     if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_USB_DM){
         if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT){
@@ -268,15 +264,6 @@ void HWCDC::begin(unsigned long baud)
         if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DP, (void *) this, -1, -1)){
             goto err;
         }
-    }
-    // Configure PHY
-    usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
-    usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
-    usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY | USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT | USB_SERIAL_JTAG_INTR_BUS_RESET);
-    if(!intr_handle && esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, 0, hw_cdc_isr_handler, NULL, &intr_handle) != ESP_OK){
-        isr_log_e("HW USB CDC failed to init interrupts");
-        end();
-        return;
     }
     // Configure PHY
     usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -24,9 +24,9 @@
 #include "esp_intr_alloc.h"
 #include "soc/periph_defs.h"
 #include "soc/io_mux_reg.h"
+#include "soc/usb_serial_jtag_struct.h"
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "hal/usb_serial_jtag_ll.h"
-#include "hal/usb_phy_ll.h"
 #pragma GCC diagnostic warning "-Wvolatile"
 #include "rom/ets_sys.h"
 #include "driver/usb_serial_jtag.h"
@@ -266,7 +266,14 @@ void HWCDC::begin(unsigned long baud)
         }
     }
     // Configure PHY
-    usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG); 
+    // USB_Serial_JTAG use internal PHY
+    USB_SERIAL_JTAG.conf0.phy_sel = 0;
+    // Disable software control USB D+ D- pullup pulldown (Device FS: dp_pullup = 1)
+    USB_SERIAL_JTAG.conf0.pad_pull_override = 0;
+    // Enable USB D+ pullup
+    USB_SERIAL_JTAG.conf0.dp_pullup = 1;
+    // Enable USB pad function
+    USB_SERIAL_JTAG.conf0.usb_pad_enable = 1;
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY | USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT | USB_SERIAL_JTAG_INTR_BUS_RESET);
     if(!intr_handle && esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, 0, hw_cdc_isr_handler, NULL, &intr_handle) != ESP_OK){

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -243,34 +243,16 @@ void HWCDC::begin(unsigned long baud)
         }    
     }
 
-#if CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2
-// the HW Serial pins needs to be first deinited in order to allow `if(Serial)` to work :-(
+    // the HW Serial pins needs to be first deinited in order to allow `if(Serial)` to work :-(
     deinit(NULL);
-    delay(10);
-#endif
-    // Setting USB D+ D- pins || reduces number of debug messages
+    delay(10);     // USB Host has to enumerate it again
+
+    // Peripheral Manager setting for USB D+ D- pins
     uint8_t pin = USB_DM_GPIO_NUM;
-    if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_USB_DM){
-        if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT){
-            if(!perimanClearPinBus(pin)){
-                goto err;
-            }
-        }
-        if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DM, (void *) this, -1, -1)){
-            goto err;
-        }
-    }
+    if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DM, (void *) this, -1, -1)) goto err;
     pin = USB_DP_GPIO_NUM;
-    if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_USB_DP){
-        if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT){
-            if(!perimanClearPinBus(pin)){
-                goto err;
-            }
-        }
-        if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DP, (void *) this, -1, -1)){
-            goto err;
-        }
-    }
+    if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DP, (void *) this, -1, -1)) goto err;
+
     // Configure PHY
     // USB_Serial_JTAG use internal PHY
     USB_SERIAL_JTAG.conf0.phy_sel = 0;

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -26,7 +26,11 @@
 #include "soc/io_mux_reg.h"
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "hal/usb_serial_jtag_ll.h"
+#if defined __has_include && __has_include ("hal/usb_phy_ll.h")
 #include "hal/usb_phy_ll.h"
+#else
+#include "hal/usb_fsls_phy_ll.h"
+#endif
 #pragma GCC diagnostic warning "-Wvolatile"
 #include "rom/ets_sys.h"
 #include "driver/usb_serial_jtag.h"
@@ -266,7 +270,11 @@ void HWCDC::begin(unsigned long baud)
         }
     }
     // Configure PHY
-    usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
+    #if defined __has_include && __has_include ("hal/usb_phy_ll.h") 
+    usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG); 
+    #else 
+    usb_fsls_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG); 
+    #endif
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY | USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT | USB_SERIAL_JTAG_INTR_BUS_RESET);
     if(!intr_handle && esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, 0, hw_cdc_isr_handler, NULL, &intr_handle) != ESP_OK){

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -242,6 +242,12 @@ void HWCDC::begin(unsigned long baud)
             log_e("HW CDC TX Buffer error");
         }    
     }
+
+#if CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2
+// it needs the HW Serial pins to be first deinited in order to allow `if(Serial)` to work :-(
+    deinit(NULL);
+    delay(10);
+#endif
     // Setting USB D+ D- pins || reduces number of debug messages
     uint8_t pin = USB_DM_GPIO_NUM;
     if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_USB_DM){


### PR DESCRIPTION
## Description of Change
Fixes:
- pin number error
- PHY initialization that prevented HW Serial to start correctly and get enumerated after end() or detaching pins
- crash after executing end() 
- force USB Host enumeration in order to set the right state to detect first time sending data to the HOST (CDC Connection) 

## Tests scenarios
Tested with ESP32-C3, ESP32-S3, ESP32-C6, ESP32-H2

``` cpp
// HW Serial CDC mode with CDC on boot enabled

void setup() {
  Serial.begin();
  Serial.end();
  Serial.begin();
  // waits until Serial Monitor is open
  while (!Serial) delay(100);
  Serial.println();
  Serial.println("Started!");
  Serial.println("");
}

void loop() {
  Serial.println("loop...");
  delay(1000);
}
```


## Related links

Fixes #9360 