### PR TITLE
fix: UART0 boot pin setup

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -99,6 +99,8 @@ _eventTask(NULL)
         }
     }
 #endif
+    // do the same as boot time, that will set default UART0 pins RX, TX. 
+    if(uart_nr == 0) uartSetPins(0, SOC_RX0, SOC_TX0, -1, -1);
 }
 
 HardwareSerial::~HardwareSerial()


### PR DESCRIPTION
## Description of Change

UART0 pins are set by ROM Boot to default values. 
This must be reflected into Arduino HardwareSerial in order to allow it to correctly detach it and then attach it to something else.

Summary:
UART0 constructor sets default RX/TX pins as done in boot time.

## Tests scenarios
Tested with DevKits ESP32, ESP32-S3, ESP32-S2.

``` cpp
// necessary to crossconnect 
// TX0(4) <--> Original TX pin, in order to see the output in the Serial Monitor - testing TX0 pin
// RX0(2) <--> TX1(17) for testing RX0 pin
void setup() {
  Serial.begin(115200, SERIAL_8N1, 2, 4); // rx0, tx0
  Serial1.begin(115200, SERIAL_8N1, 16, 17); // rx1, tx1
}

void loop() {
  Serial.println("Loop from UART0...");
  delay(1000);
  Serial1.println("Loop from UART1...");
  delay(1000);
  while(Serial.available()) Serial.write(Serial.read());
  delay(1000);
}
```

## Related links

Fixes #9363 