### PR TITLE
Fixes issue related to writing RGB LED fast in a row

### DIFF
--- a/cores/esp32/esp32-hal-rgb-led.c
+++ b/cores/esp32/esp32-hal-rgb-led.c
@@ -43,5 +43,5 @@ void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue
       i++;
     }
   }
-  rmtWrite(rmt_send, led_data, 24);
+  rmtWriteBlocking(rmt_send, led_data, 24);
 }


### PR DESCRIPTION
## Description of Change

When writing to the same GPIO using RMT, like in a loop, it is necessary to use `rmtWriteBlocking()` instead of `rmtWrite()` to avoid issues with FreeRTOS and IDF 4.4.x.

This PR fixes `neopixelWrite()` (as well as digitalWrite(RGBLED, state)`) in order to avoid such issue.

## Tests scenarios
Tested with ESP32-S3

``` cpp
void setup() 
{
  Serial.begin(115200);
  Serial.println("");
  Serial.println("");
}

void loop() 
{
  Serial.println("blink slow");
  for (auto i = 0; i < 10; i++)
  {
     digitalWrite( LED_BUILTIN, i & 1 );
     //uint8_t color = i & 1 ? 32 : 0;
     //neopixelWrite( 48, color, color, color);  // 47 is Lolin S3 onboard LED
     delay(100);
  }
    
  Serial.println("blink fast");
  for (auto i = 0; i < 10; i++)
  {
     digitalWrite( LED_BUILTIN, i & 1 );
     //uint8_t color = i & 1 ? 32 : 0;
     //neopixelWrite( 48, color, color, color);
  }
}
```
## Related links

Closes #9369 
