### PR TITLE
Platformio add `f_boot` to build script

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -88,7 +88,7 @@ def get_bootloader_image(variants_dir):
                 FRAMEWORK_LIBS_DIR,
                 build_mcu,
                 "bin",
-                "bootloader_${__get_board_boot_mode(__env__)}_${__get_board_f_flash(__env__)}.elf",
+                "bootloader_${__get_board_boot_mode(__env__)}_${__get_board_f_boot(__env__)}.elf",
             )
         )
     )


### PR DESCRIPTION
makes speed setting of 120Mhz possible. Needs Platformio PR https://github.com/platformio/platform-espressif32/pull/1331 merged first!
Edit: PR upstream is merged

Fixes https://github.com/espressif/arduino-esp32/issues/9351