### PR TITLE
Add variant for Waveshare ESP32-S3-Touch-LCD-1.28

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -34815,7 +34815,7 @@ waveshare_esp32s3_touch_lcd_128.serial.disableDTR=true
 waveshare_esp32s3_touch_lcd_128.serial.disableRTS=true
 
 waveshare_esp32s3_touch_lcd_128.build.tarch=xtensa
-waveshare_esp32s3_touch_lcd_128.build.bootloader_addr=0x1000
+waveshare_esp32s3_touch_lcd_128.build.bootloader_addr=0x0
 waveshare_esp32s3_touch_lcd_128.build.mcu=esp32s3
 waveshare_esp32s3_touch_lcd_128.build.core=esp32
 waveshare_esp32s3_touch_lcd_128.build.target=esp32s3
@@ -34832,7 +34832,7 @@ waveshare_esp32s3_touch_lcd_128.build.partitions=default
 waveshare_esp32s3_touch_lcd_128.menu.PSRAM.disabled=Disabled
 waveshare_esp32s3_touch_lcd_128.menu.PSRAM.disabled.build.defines=
 waveshare_esp32s3_touch_lcd_128.menu.PSRAM.enabled=Enabled
-waveshare_esp32s3_touch_lcd_128.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+waveshare_esp32s3_touch_lcd_128.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 waveshare_esp32s3_touch_lcd_128.menu.PSRAM.enabled.build.extra_libs=
 
 waveshare_esp32s3_touch_lcd_128.menu.LoopCore.1=Core 1

--- a/boards.txt
+++ b/boards.txt
@@ -34793,3 +34793,154 @@ Geekble_ESP32C3.menu.EraseFlash.all=Enabled
 Geekble_ESP32C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+
+waveshare_esp32s3_touch_lcd_128.name=Waveshare ESP32S3 Touch LCD 128
+waveshare_esp32s3_touch_lcd_128.vid.0=0x1a86
+waveshare_esp32s3_touch_lcd_128.pid.0=0x55d3
+
+waveshare_esp32s3_touch_lcd_128.upload.tool=esptool_py
+waveshare_esp32s3_touch_lcd_128.upload.tool.default=esptool_py
+waveshare_esp32s3_touch_lcd_128.upload.tool.network=esp_ota
+waveshare_esp32s3_touch_lcd_128.upload.maximum_size=16777216
+waveshare_esp32s3_touch_lcd_128.upload.maximum_data_size=327680
+waveshare_esp32s3_touch_lcd_128.upload.wait_for_upload_port=true
+waveshare_esp32s3_touch_lcd_128.upload.speed=460800
+waveshare_esp32s3_touch_lcd_128.upload.flags=
+waveshare_esp32s3_touch_lcd_128.upload.extra_flags=
+
+waveshare_esp32s3_touch_lcd_128.bootloader.tool=esptool_py
+waveshare_esp32s3_touch_lcd_128.bootloader.tool.default=esptool_py
+
+waveshare_esp32s3_touch_lcd_128.serial.disableDTR=true
+waveshare_esp32s3_touch_lcd_128.serial.disableRTS=true
+
+waveshare_esp32s3_touch_lcd_128.build.tarch=xtensa
+waveshare_esp32s3_touch_lcd_128.build.bootloader_addr=0x1000
+waveshare_esp32s3_touch_lcd_128.build.mcu=esp32s3
+waveshare_esp32s3_touch_lcd_128.build.core=esp32
+waveshare_esp32s3_touch_lcd_128.build.target=esp32s3
+waveshare_esp32s3_touch_lcd_128.build.variant=waveshare_esp32s3_touch_lcd_128
+waveshare_esp32s3_touch_lcd_128.build.board=WAVESHARE_ESP32S3_TOUCH_LCD_128
+
+waveshare_esp32s3_touch_lcd_128.build.f_cpu=240000000L
+waveshare_esp32s3_touch_lcd_128.build.flash_size=16MB
+waveshare_esp32s3_touch_lcd_128.build.flash_freq=80m
+waveshare_esp32s3_touch_lcd_128.build.flash_mode=dio
+waveshare_esp32s3_touch_lcd_128.build.boot=dio
+waveshare_esp32s3_touch_lcd_128.build.partitions=default
+
+waveshare_esp32s3_touch_lcd_128.menu.PSRAM.disabled=Disabled
+waveshare_esp32s3_touch_lcd_128.menu.PSRAM.disabled.build.defines=
+waveshare_esp32s3_touch_lcd_128.menu.PSRAM.enabled=Enabled
+waveshare_esp32s3_touch_lcd_128.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+waveshare_esp32s3_touch_lcd_128.menu.PSRAM.enabled.build.extra_libs=
+
+waveshare_esp32s3_touch_lcd_128.menu.LoopCore.1=Core 1
+waveshare_esp32s3_touch_lcd_128.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32s3_touch_lcd_128.menu.LoopCore.0=Core 0
+waveshare_esp32s3_touch_lcd_128.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32s3_touch_lcd_128.menu.EventsCore.1=Core 1
+waveshare_esp32s3_touch_lcd_128.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32s3_touch_lcd_128.menu.EventsCore.0=Core 0
+waveshare_esp32s3_touch_lcd_128.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.minimal.build.partitions=minimal
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FAT)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32s3_touch_lcd_128.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.240=240MHz (WiFi/BT)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.160=160MHz (WiFi/BT)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.80=80MHz (WiFi/BT)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.40=40MHz (40MHz XTAL)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.26=26MHz (26MHz XTAL)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.26.build.f_cpu=26000000L
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.20=20MHz (40MHz XTAL)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.13=13MHz (26MHz XTAL)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.13.build.f_cpu=13000000L
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.10=10MHz (40MHz XTAL)
+waveshare_esp32s3_touch_lcd_128.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32s3_touch_lcd_128.menu.FlashMode.qio=QIO
+waveshare_esp32s3_touch_lcd_128.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32s3_touch_lcd_128.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32s3_touch_lcd_128.menu.FlashMode.dio=DIO
+waveshare_esp32s3_touch_lcd_128.menu.FlashMode.dio.build.flash_mode=dio
+waveshare_esp32s3_touch_lcd_128.menu.FlashMode.dio.build.boot=dio
+
+waveshare_esp32s3_touch_lcd_128.menu.FlashFreq.80=80MHz
+waveshare_esp32s3_touch_lcd_128.menu.FlashFreq.80.build.flash_freq=80m
+waveshare_esp32s3_touch_lcd_128.menu.FlashFreq.40=40MHz
+waveshare_esp32s3_touch_lcd_128.menu.FlashFreq.40.build.flash_freq=40m
+
+waveshare_esp32s3_touch_lcd_128.menu.FlashSize.4M=4MB (32Mb)
+waveshare_esp32s3_touch_lcd_128.menu.FlashSize.4M.build.flash_size=4MB
+waveshare_esp32s3_touch_lcd_128.menu.FlashSize.16M=16MB (128Mb)
+waveshare_esp32s3_touch_lcd_128.menu.FlashSize.16M.build.flash_size=16MB
+
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.921600=921600
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.115200=115200
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.230400=230400
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32s3_touch_lcd_128.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.none=None
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.error=Error
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.warn=Warn
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.info=Info
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.debug=Debug
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.verbose=Verbose
+waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.none=Disabled
+waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.all=Enabled
+waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -35839,7 +35839,7 @@ waveshare_esp32s3_touch_lcd_128.upload.tool.default=esptool_py
 waveshare_esp32s3_touch_lcd_128.upload.tool.network=esp_ota
 waveshare_esp32s3_touch_lcd_128.upload.maximum_size=16777216
 waveshare_esp32s3_touch_lcd_128.upload.maximum_data_size=327680
-waveshare_esp32s3_touch_lcd_128.upload.wait_for_upload_port=true
+waveshare_esp32s3_touch_lcd_128.upload.wait_for_upload_port=false
 waveshare_esp32s3_touch_lcd_128.upload.speed=460800
 waveshare_esp32s3_touch_lcd_128.upload.flags=
 waveshare_esp32s3_touch_lcd_128.upload.extra_flags=
@@ -35858,12 +35858,34 @@ waveshare_esp32s3_touch_lcd_128.build.target=esp32s3
 waveshare_esp32s3_touch_lcd_128.build.variant=waveshare_esp32s3_touch_lcd_128
 waveshare_esp32s3_touch_lcd_128.build.board=WAVESHARE_ESP32S3_TOUCH_LCD_128
 
+waveshare_esp32s3_touch_lcd_128.build.usb_mode=1
+waveshare_esp32s3_touch_lcd_128.build.cdc_on_boot=1
+waveshare_esp32s3_touch_lcd_128.build.msc_on_boot=0
+waveshare_esp32s3_touch_lcd_128.build.dfu_on_boot=0
+
 waveshare_esp32s3_touch_lcd_128.build.f_cpu=240000000L
 waveshare_esp32s3_touch_lcd_128.build.flash_size=16MB
 waveshare_esp32s3_touch_lcd_128.build.flash_freq=80m
 waveshare_esp32s3_touch_lcd_128.build.flash_mode=dio
 waveshare_esp32s3_touch_lcd_128.build.boot=dio
 waveshare_esp32s3_touch_lcd_128.build.partitions=default
+
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.hwcdc.upload.use_1200bps_touch=false
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.hwcdc.upload.wait_for_upload_port=false
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.default=USB-OTG
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.default.build.usb_mode=0
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.default.upload.use_1200bps_touch=true
+waveshare_esp32s3_touch_lcd_128.menu.USBMode.default.upload.wait_for_upload_port=true
+waveshare_esp32s3_touch_lcd_128.menu.MSCOnBoot.default=Disabled
+waveshare_esp32s3_touch_lcd_128.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32s3_touch_lcd_128.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32s3_touch_lcd_128.menu.MSCOnBoot.msc.build.msc_on_boot=1
+waveshare_esp32s3_touch_lcd_128.menu.DFUOnBoot.default=Disabled
+waveshare_esp32s3_touch_lcd_128.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32s3_touch_lcd_128.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32s3_touch_lcd_128.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
 waveshare_esp32s3_touch_lcd_128.menu.PSRAM.disabled=Disabled
 waveshare_esp32s3_touch_lcd_128.menu.PSRAM.disabled.build.defines=
@@ -35941,8 +35963,6 @@ waveshare_esp32s3_touch_lcd_128.menu.FlashFreq.80.build.flash_freq=80m
 waveshare_esp32s3_touch_lcd_128.menu.FlashFreq.40=40MHz
 waveshare_esp32s3_touch_lcd_128.menu.FlashFreq.40.build.flash_freq=40m
 
-waveshare_esp32s3_touch_lcd_128.menu.FlashSize.4M=4MB (32Mb)
-waveshare_esp32s3_touch_lcd_128.menu.FlashSize.4M.build.flash_size=4MB
 waveshare_esp32s3_touch_lcd_128.menu.FlashSize.16M=16MB (128Mb)
 waveshare_esp32s3_touch_lcd_128.menu.FlashSize.16M.build.flash_size=16MB
 

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -24,6 +24,7 @@
 #include "esp_intr_alloc.h"
 #include "soc/periph_defs.h"
 #include "soc/io_mux_reg.h"
+#include "soc/usb_serial_jtag_struct.h"
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "hal/usb_serial_jtag_ll.h"
 #pragma GCC diagnostic warning "-Wvolatile"
@@ -86,7 +87,7 @@ static void hw_cdc_isr_handler(void *arg) {
         } else {
             connected = true;
         }
-        if (usb_serial_jtag_ll_txfifo_writable() == 1) {
+        if (tx_ring_buf != NULL && usb_serial_jtag_ll_txfifo_writable() == 1) {
             // We disable the interrupt here so that the interrupt won't be triggered if there is no data to send.
             usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
             size_t queued_size;
@@ -164,6 +165,9 @@ bool HWCDC::isCDC_Connected()
 }
 
 static void ARDUINO_ISR_ATTR cdc0_write_char(char c) {
+    if(tx_ring_buf == NULL) {
+        return;
+    }
     uint32_t tx_timeout_ms = 0;
     if(HWCDC::isConnected()) {
         tx_timeout_ms = requested_tx_timeout_ms;
@@ -238,31 +242,32 @@ void HWCDC::begin(unsigned long baud)
             log_e("HW CDC TX Buffer error");
         }    
     }
+
+    // the HW Serial pins needs to be first deinited in order to allow `if(Serial)` to work :-(
+    deinit(NULL);
+    delay(10);     // USB Host has to enumerate it again
+
+    // Peripheral Manager setting for USB D+ D- pins
+    uint8_t pin = USB_DM_GPIO_NUM;
+    if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DM, (void *) this, -1, -1)) goto err;
+    pin = USB_DP_GPIO_NUM;
+    if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DP, (void *) this, -1, -1)) goto err;
+
+    // Configure PHY
+    // USB_Serial_JTAG use internal PHY
+    USB_SERIAL_JTAG.conf0.phy_sel = 0;
+    // Disable software control USB D+ D- pullup pulldown (Device FS: dp_pullup = 1)
+    USB_SERIAL_JTAG.conf0.pad_pull_override = 0;
+    // Enable USB D+ pullup
+    USB_SERIAL_JTAG.conf0.dp_pullup = 1;
+    // Enable USB pad function
+    USB_SERIAL_JTAG.conf0.usb_pad_enable = 1;
     usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
     usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY | USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT | USB_SERIAL_JTAG_INTR_BUS_RESET);
     if(!intr_handle && esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, 0, hw_cdc_isr_handler, NULL, &intr_handle) != ESP_OK){
         isr_log_e("HW USB CDC failed to init interrupts");
         end();
         return;
-    }
-    // Setting USB D+ D- pins
-    uint8_t pin = ESP32_BUS_TYPE_USB_DM;
-    if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT){
-        if(!perimanClearPinBus(pin)){
-            goto err;
-        }
-    }
-    if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DM, (void *) this, -1, -1)){
-        goto err;
-    }
-    pin = ESP32_BUS_TYPE_USB_DP;
-    if(perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT){
-        if(!perimanClearPinBus(pin)){
-            goto err;
-        }
-    }
-    if(!perimanSetPinBus(pin, ESP32_BUS_TYPE_USB_DP, (void *) this, -1, -1)){
-        goto err;
     }
     return;
     
@@ -289,6 +294,7 @@ void HWCDC::end()
         arduino_hw_cdc_event_loop_handle = NULL;
     }
     HWCDC::deinit(this);
+    setDebugOutput(false);
     connected = false;
 }
 

--- a/variants/waveshare_esp32s3_touch_lcd_128/pins_arduino.h
+++ b/variants/waveshare_esp32s3_touch_lcd_128/pins_arduino.h
@@ -1,0 +1,37 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID            0x1A86
+#define USB_PID            0x55D3
+#define USB_MANUFACTURER   "Waveshare"
+#define USB_PRODUCT        "ESP32-S3 Touch LCD 1.28"
+#define USB_SERIAL         "" // Empty string for MAC adddress
+
+#define LCD_BACKLIGHT  2
+#define LCD_DC         8
+#define LCD_RST        14
+
+#define TP_INT 5
+#define TP_RST 13
+
+#define IMU_INT1 4
+#define IMU_INT2 3
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+#define TX1 TX
+#define RX1 RX
+
+static const uint8_t SCL = 7;
+static const uint8_t SDA = 6;
+
+static const uint8_t SS    = 9;
+static const uint8_t MOSI  = 11;
+static const uint8_t MISO  = 12;
+static const uint8_t SCK   = 10;
+
+static const uint8_t A0 = 1; // Connected through voltage divider to battery pin
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Adding variant for Waveshare ESP32-S3-Touch-LCD-1.28 board containing MCU, LCD, and IMU.

## Tests scenarios
Untested, pin definition is based on information in Waveshare wiki.

## Related links
Link to board wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.28
