### PR TITLE
Fixes for some boards which are failing CI test.

### DIFF
--- a/.github/scripts/find_all_boards.sh
+++ b/.github/scripts/find_all_boards.sh
@@ -5,6 +5,11 @@ boards_array=()
 
 for line in `grep '.tarch=' boards.txt`; do
     board_name=$(echo "$line" | cut -d '.' -f1 | cut -d '#' -f1)
+    # skip esp32c2 as we dont build libs for it
+    if [ "$board_name" == "esp32c2" ]; then
+        echo "Skipping 'espressif:esp32:$board_name'"
+        continue
+    fi
     boards_array+=("espressif:esp32:$board_name")
     echo "Added 'espressif:esp32:$board_name' to array"
 done

--- a/cores/esp32/io_pin_remap.h
+++ b/cores/esp32/io_pin_remap.h
@@ -100,11 +100,7 @@ int8_t gpioNumberToDigitalPin(int8_t gpioNumber);
 #define spiAttachSCK(spi, sck)          spiAttachSCK(spi, digitalPinToGPIONumber(sck))
 #define spiAttachMISO(spi, miso)        spiAttachMISO(spi, digitalPinToGPIONumber(miso))
 #define spiAttachMOSI(spi, mosi)        spiAttachMOSI(spi, digitalPinToGPIONumber(mosi))
-#define spiDetachSCK(spi, sck)          spiDetachSCK(spi, digitalPinToGPIONumber(sck))
-#define spiDetachMISO(spi, miso)        spiDetachMISO(spi, digitalPinToGPIONumber(miso))
-#define spiDetachMOSI(spi, mosi)        spiDetachMOSI(spi, digitalPinToGPIONumber(mosi))
 #define spiAttachSS(spi, cs_num, ss)    spiAttachSS(spi, cs_num, digitalPinToGPIONumber(ss))
-#define spiDetachSS(spi, ss)            spiDetachSS(spi, digitalPinToGPIONumber(ss))
 
 // cores/esp32/esp32-hal-touch.h
 #define touchInterruptGetLastStatus(pin)                        touchInterruptGetLastStatus(digitalPinToGPIONumber(pin))

--- a/variants/imbrios-logsens-v1p1/pins_arduino.h
+++ b/variants/imbrios-logsens-v1p1/pins_arduino.h
@@ -45,7 +45,7 @@ static const uint8_t MOSI  = 13;
 static const uint8_t MISO  = 12;
 static const uint8_t SCK   = 14;
 
-static const uint8_t SPI_SS1  = 23;		// SPI Chip Select - 1; connected to MicroSD Card on the LogSens V1.1 Board
+static const uint8_t SS1  = 23;		// SPI Chip Select - 1; connected to MicroSD Card on the LogSens V1.1 Board
   
 /* Software Controlled: IO, LEDs and Switches */
 static const uint8_t BUZZER_CTRL = 19;		// Signal connected to MOSFET gate pin to control conenctor (X8)


### PR DESCRIPTION
## Description of Change
This PR contain fixes needed for CI to pass compilation test on all boards.
Test results: https://github.com/P-R-O-C-H-Y/arduino-esp32/actions/runs/8326763069 

Fixing:
- ESP32-C2 removed from all-boards-test
- IO remapping fixed for SPI, as the pin is no longer needed to detach pin
- #3880 collision of `SPI_SS1` with `#define SPI_SS1` in esp32-hal-spi.h. Renamed to `SS1`.
## Tests scenarios

## Related links
