### PR TITLE
Add method to set the WiFi radio channel

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1274,7 +1274,7 @@ int32_t WiFiGenericClass::channel(void)
  * @param primaryChan primary channel. Depending on the region, not all channels may be available.
  * @param secondChan secondary channel (WIFI_SECOND_CHAN_NONE, WIFI_SECOND_CHAN_ABOVE, WIFI_SECOND_CHAN_BELOW)
  */
-void WiFiGenericClass::channel(uint8_t primary, wifi_second_chan_t secondary)
+void WiFiGenericClass::setChannel(uint8_t primary, wifi_second_chan_t secondary)
 {
     wifi_country_t country;
 

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1277,7 +1277,11 @@ int32_t WiFiGenericClass::channel(void)
 void WiFiGenericClass::channel(uint8_t primary, wifi_second_chan_t secondary)
 {
     wifi_country_t country;
-    esp_wifi_get_country(&country);
+
+    if (esp_wifi_get_country(&country) != ESP_OK) {
+        log_e("Failed to get country info");
+        return;
+    }
 
     uint8_t min_chan = country.schan;
     uint8_t max_chan = min_chan + country.nchan - 1;

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1271,8 +1271,8 @@ int32_t WiFiGenericClass::channel(void)
 
 /**
  * Set the WiFi channel configuration
- * @param primaryChan primary channel. Depending on the region, not all channels may be available.
- * @param secondChan secondary channel (WIFI_SECOND_CHAN_NONE, WIFI_SECOND_CHAN_ABOVE, WIFI_SECOND_CHAN_BELOW)
+ * @param primary primary channel. Depending on the region, not all channels may be available.
+ * @param secondary secondary channel (WIFI_SECOND_CHAN_NONE, WIFI_SECOND_CHAN_ABOVE, WIFI_SECOND_CHAN_BELOW)
  */
 void WiFiGenericClass::setChannel(uint8_t primary, wifi_second_chan_t secondary)
 {

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1291,7 +1291,9 @@ void WiFiGenericClass::setChannel(uint8_t primary, wifi_second_chan_t secondary)
         return;
     }
 
-    esp_wifi_set_channel(primary, secondary);
+    if (esp_wifi_set_channel(primary, secondary)) {
+        log_e("Failed to set channel");
+    }
 }
 
 /**

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1290,7 +1290,7 @@ int WiFiGenericClass::setChannel(uint8_t primary, wifi_second_chan_t secondary)
     uint8_t max_chan = min_chan + country.nchan - 1;
 
     if(primary < min_chan || primary > max_chan){
-        log_e("Invalid primary channel: %d", primary);
+        log_e("Invalid primary channel: %d. Valid range is %d-%d for country %s", primary, min_chan, max_chan, country.cc);
         return ESP_ERR_INVALID_ARG;
     }
 

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1273,14 +1273,17 @@ int32_t WiFiGenericClass::channel(void)
  * Set the WiFi channel configuration
  * @param primary primary channel. Depending on the region, not all channels may be available.
  * @param secondary secondary channel (WIFI_SECOND_CHAN_NONE, WIFI_SECOND_CHAN_ABOVE, WIFI_SECOND_CHAN_BELOW)
+ * @return 0 on success, otherwise error
  */
-void WiFiGenericClass::setChannel(uint8_t primary, wifi_second_chan_t secondary)
+int WiFiGenericClass::setChannel(uint8_t primary, wifi_second_chan_t secondary)
 {
     wifi_country_t country;
+    esp_err_t ret;
 
-    if (esp_wifi_get_country(&country) != ESP_OK) {
+    ret = esp_wifi_get_country(&country);
+    if (ret != ESP_OK) {
         log_e("Failed to get country info");
-        return;
+        return ret;
     }
 
     uint8_t min_chan = country.schan;
@@ -1288,12 +1291,16 @@ void WiFiGenericClass::setChannel(uint8_t primary, wifi_second_chan_t secondary)
 
     if(primary < min_chan || primary > max_chan){
         log_e("Invalid primary channel: %d", primary);
-        return;
+        return ESP_ERR_INVALID_ARG;
     }
 
-    if (esp_wifi_set_channel(primary, secondary)) {
+    ret = esp_wifi_set_channel(primary, secondary);
+    if (ret != ESP_OK) {
         log_e("Failed to set channel");
+        return ret;
     }
+
+    return ESP_OK;
 }
 
 /**

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1270,6 +1270,27 @@ int32_t WiFiGenericClass::channel(void)
 }
 
 /**
+ * Set the WiFi channel configuration
+ * @param primaryChan primary channel. Depending on the region, not all channels may be available.
+ * @param secondChan secondary channel (WIFI_SECOND_CHAN_NONE, WIFI_SECOND_CHAN_ABOVE, WIFI_SECOND_CHAN_BELOW)
+ */
+void WiFiGenericClass::channel(uint8_t primary, wifi_second_chan_t secondary)
+{
+    wifi_country_t country;
+    esp_wifi_get_country(&country);
+
+    uint8_t min_chan = country.schan;
+    uint8_t max_chan = min_chan + country.nchan - 1;
+
+    if(primary < min_chan || primary > max_chan){
+        log_e("Invalid primary channel: %d", primary);
+        return;
+    }
+
+    esp_wifi_set_channel(primary, secondary);
+}
+
+/**
  * store WiFi config in SDK flash area
  * @param persistent
  */

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -183,7 +183,7 @@ class WiFiGenericClass
     static int waitStatusBits(int bits, uint32_t timeout_ms);
 
     int32_t channel(void);
-	void channel(uint8_t primary, wifi_second_chan_t secondary=WIFI_SECOND_CHAN_NONE);
+    void channel(uint8_t primary, wifi_second_chan_t secondary=WIFI_SECOND_CHAN_NONE);
 
     void persistent(bool persistent);
     void enableLongRange(bool enable);

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -183,7 +183,7 @@ class WiFiGenericClass
     static int waitStatusBits(int bits, uint32_t timeout_ms);
 
     int32_t channel(void);
-    void setChannel(uint8_t primary, wifi_second_chan_t secondary=WIFI_SECOND_CHAN_NONE);
+    int setChannel(uint8_t primary, wifi_second_chan_t secondary=WIFI_SECOND_CHAN_NONE);
 
     void persistent(bool persistent);
     void enableLongRange(bool enable);

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -183,7 +183,7 @@ class WiFiGenericClass
     static int waitStatusBits(int bits, uint32_t timeout_ms);
 
     int32_t channel(void);
-    void channel(uint8_t primary, wifi_second_chan_t secondary=WIFI_SECOND_CHAN_NONE);
+    void setChannel(uint8_t primary, wifi_second_chan_t secondary=WIFI_SECOND_CHAN_NONE);
 
     void persistent(bool persistent);
     void enableLongRange(bool enable);

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -183,6 +183,7 @@ class WiFiGenericClass
     static int waitStatusBits(int bits, uint32_t timeout_ms);
 
     int32_t channel(void);
+	void channel(uint8_t primary, wifi_second_chan_t secondary=WIFI_SECOND_CHAN_NONE);
 
     void persistent(bool persistent);
     void enableLongRange(bool enable);


### PR DESCRIPTION
## Description of Change
Adds method to set the WiFi radio channel. This will be useful for applications that need to set the wifi channel without connecting to anything, like ESP-NOW.