### PR TITLE
Add: make digitalRead() for RGB_BUILTIN work

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -104,14 +104,14 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
 #endif
 
     if (pin >= SOC_GPIO_PIN_COUNT) {
-        log_e("Invalid pin selected");
+        log_e("Invalid IO %i selected", pin);
         return;
     }
 
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
         perimanSetBusDeinit(ESP32_BUS_TYPE_GPIO, gpioDetachBus);
         if(!perimanClearPinBus(pin)){
-            log_e("Deinit of previous bus failed");
+            log_e("Deinit of previous bus from IO %i failed", pin);
             return;
         }
     }
@@ -140,7 +140,7 @@ extern void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode)
     }
     if(gpio_config(&conf) != ESP_OK)
     {
-        log_e("GPIO config failed");
+        log_e("IO %i config failed", pin);
         return;
     }
     if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL){
@@ -169,7 +169,7 @@ extern void ARDUINO_ISR_ATTR __digitalWrite(uint8_t pin, uint8_t val)
         if(perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) != NULL){
             gpio_set_level((gpio_num_t)pin, val);
         } else {
-            log_e("Pin is not set as GPIO.");
+            log_e("IO %i is not set as GPIO.", pin);
         }
 }
 
@@ -185,7 +185,7 @@ extern int ARDUINO_ISR_ATTR __digitalRead(uint8_t pin)
         return gpio_get_level((gpio_num_t)pin);
     }
     else {
-        log_e("Pin is not set as GPIO.");
+        log_e("IO %i is not set as GPIO.", pin);
         return 0;
     }
 }
@@ -215,7 +215,7 @@ extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc,
     	interrupt_initialized = (err == ESP_OK) || (err == ESP_ERR_INVALID_STATE);
     }
     if(!interrupt_initialized) {
-    	log_e("GPIO ISR Service Failed To Start");
+    	log_e("IO %i ISR Service Failed To Start", pin);
     	return;
     }
 
@@ -265,6 +265,14 @@ extern void __detachInterrupt(uint8_t pin)
     __pinInterruptHandlers[pin].functional = false;
 
     gpio_set_intr_type((gpio_num_t)pin, GPIO_INTR_DISABLE);
+}
+
+extern void enableInterrupt(uint8_t pin) {
+    gpio_intr_enable((gpio_num_t)pin);
+}
+
+extern void disableInterrupt(uint8_t pin) {
+    gpio_intr_disable((gpio_num_t)pin);
 }
 
 


### PR DESCRIPTION
Standard Arduino-Way of blinking a LED can be the shortest with:

void loop() {
  static uint32_t ledticker = 0;
  if (millis() - ledticker > 1000) {
    ledticker = millis();
    digitalWrite(RGB_BUILTIN, !digitalRead(RGB_BUILTIN));
  }
}

Worked with the old LED_BUILTIN on Pin 2, now even works with Pin 48/neopixel.