### PR TITLE
WiFi.config handle Arduino parameters ordering and auto dns,gw,mask

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -169,7 +169,33 @@ bool WiFiSTAClass::eraseAP(void) {
  */
 bool WiFiSTAClass::config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1, IPAddress dns2)
 {
+    // handle Arduino ordering of parameters: ip, dns, gw, subnet
+    if (local_ip.type() == IPv4 && local_ip != INADDR_NONE && subnet[0] != 255) {
+        IPAddress tmp = dns1;
+        dns1 = gateway;
+        gateway = subnet;
+        subnet = (tmp != INADDR_NONE) ? tmp : IPAddress(255, 255, 255, 0);
+    }
+
     return STA.config(local_ip, gateway, subnet, dns1, dns2);
+}
+
+bool WiFiSTAClass::config(IPAddress local_ip, IPAddress dns) {
+
+    if (local_ip == INADDR_NONE) {
+        return config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+    }
+
+    if (local_ip.type() != IPv4) {
+        return false;
+    }
+
+    IPAddress gw(local_ip);
+    gw[3] = 1;
+    if (dns == INADDR_NONE) {
+        dns = gw;
+    }
+    return config(local_ip, gw, IPAddress(255, 255, 255, 0), dns);
 }
 
 /**

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -112,7 +112,11 @@ public:
     }
     wl_status_t begin();
 
+    // also accepts Arduino ordering of parameters: ip, dns, gw, mask
     bool config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1 = (uint32_t)0x00000000, IPAddress dns2 = (uint32_t)0x00000000);
+
+    // two and one parameter version. 2nd parameter is DNS like in Arduino
+    bool config(IPAddress local_ip, IPAddress dns = (uint32_t)0x00000000);
 
     bool setDNS(IPAddress dns1, IPAddress dns2 = (uint32_t)0x00000000);  // sets DNS IP for all network interfaces
 


### PR DESCRIPTION
repeat of https://github.com/espressif/arduino-esp32/pull/8892 rebased after networking refactoring.

In WiFi libraries by Arduino `config` has parameters `ip, dnsIP, gatewayIP, subnet`. only ip is not optional. for unspecified subnet default is 255.255.255.0 and unspecified gateway and dns are based on IP with last number changed to 1.

the ESP8266WiFi library accepts the 'esp\ ordering ip, gw, subnet, dns and Arduino ordering ip, dns, gw, subnet. The detection is based on the position of the subnet mask which has 255 as first number.

This PR adds handling of Arduino ordering of parameters. Parameter subnet is on position of dns1 which is an optional parameter so default value is used if needed.

And this PR adds a second `config` with two parameters local_ip and dns IP. dns IP is optional. gateway IP is calculated, dns IP is calculated if not provided. then the other `config` is invoked.

this allows `config` invocations as in Arduino library
```
config(ip)
config(ip, dns)
config(ip, dns, gw)
config(ip, dns, gw, subnet)
```
it also allows `WiFi.config(INADDR_NONE)` to return to DHCP as in other WiFi libraries.

overview of WiFi object API in significant libraries: 
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#wifi-station-network-interface