### PR TITLE
Use WiFi.mode to enable/disable the Network Interfaces

### DIFF
--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -671,7 +671,10 @@ IPAddress NetworkInterface::globalIPv6() const
 
 size_t NetworkInterface::printTo(Print & out) const {
     size_t bytes = 0;
-    bytes += out.print(esp_netif_get_desc(_esp_netif));
+    const char * dscr = esp_netif_get_desc(_esp_netif);
+    if(dscr != NULL){
+        bytes += out.print(dscr);
+    }
     bytes += out.print(":");
     if(esp_netif_is_netif_up(_esp_netif)){
         bytes += out.print(" <UP");

--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -55,6 +55,10 @@ class APClass: public NetworkInterface {
 
     protected:
         size_t printDriverInfo(Print & out) const;
+        
+        friend class WiFiGenericClass;
+        bool onEnable();
+        bool onDisable();
 };
 
 // ----------------------------------------------------------------------------------------------

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -471,17 +471,36 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
             return false;
         }
         Network.onSysEvent(_eventCallback);
-    } else if(cm && !m){
+    }
+
+    if(((m & WIFI_MODE_STA) != 0) && ((cm & WIFI_MODE_STA) == 0)){
+        // we are enabling STA interface
+        WiFi.STA.onEnable();
+    }
+    if(((m & WIFI_MODE_AP) != 0) && ((cm & WIFI_MODE_AP) == 0)){
+        // we are enabling AP interface
+        WiFi.AP.onEnable();
+    }
+
+    if(cm && !m){
         // Turn OFF WiFi
         if(!espWiFiStop()){
             return false;
+        }
+        if((cm & WIFI_MODE_STA) != 0){
+            // we are disabling STA interface
+            WiFi.STA.onDisable();
+        }
+        if((cm & WIFI_MODE_AP) != 0){
+            // we are disabling AP interface
+            WiFi.AP.onDisable();
         }
         Network.removeEvent(_eventCallback);
         return true;
     }
 
     esp_err_t err;
-    if(m & WIFI_MODE_STA){
+    if(((m & WIFI_MODE_STA) != 0) && ((cm & WIFI_MODE_STA) == 0)){
     	err = esp_netif_set_hostname(esp_netifs[ESP_IF_WIFI_STA], NetworkManager::getHostname());
         if(err){
             log_e("Could not set hostname! %d", err);
@@ -493,6 +512,16 @@ bool WiFiGenericClass::mode(wifi_mode_t m)
         log_e("Could not set mode! %d", err);
         return false;
     }
+
+    if(((m & WIFI_MODE_STA) == 0) && ((cm & WIFI_MODE_STA) != 0)){
+        // we are disabling STA interface (but AP is ON)
+        WiFi.STA.onDisable();
+    }
+    if(((m & WIFI_MODE_AP) == 0) && ((cm & WIFI_MODE_AP) != 0)){
+        // we are disabling AP interface (but STA is ON)
+        WiFi.AP.onDisable();
+    }
+
     if(_long_range){
         if(m & WIFI_MODE_STA){
             err = esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_LR);

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -91,6 +91,10 @@ class STAClass: public NetworkInterface {
         wl_status_t _status;
 
         size_t printDriverInfo(Print & out) const;
+
+        friend class WiFiGenericClass;
+        bool onEnable();
+        bool onDisable();
 };
 
 // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
After the network refactoring, WiFi.mode would not properly init the interfaces and events would be lost.

cc @Jason2866 @s-hadinger 