### PR TITLE
Network refactoring - fix some IPv6 DNS issues

### DIFF
--- a/libraries/Network/src/NetworkEvents.cpp
+++ b/libraries/Network/src/NetworkEvents.cpp
@@ -55,7 +55,7 @@ NetworkEvents::~NetworkEvents(){
 	}
 }
 
-static uint32_t _initial_bits = NET_DNS_IDLE_BIT;
+static uint32_t _initial_bits = 0;
 
 bool NetworkEvents::initNetworkEvents(){
     if(!_arduino_event_group){

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -28,9 +28,6 @@ static const int WIFI_SCANNING_BIT = BIT0;
 static const int WIFI_SCAN_DONE_BIT= BIT1;
 #endif
 
-static const int NET_DNS_IDLE_BIT  = BIT2;
-static const int NET_DNS_DONE_BIT  = BIT3;
-
 #define NET_HAS_IP6_GLOBAL_BIT 0
 
 ESP_EVENT_DECLARE_BASE(ARDUINO_EVENTS);

--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -606,6 +606,35 @@ IPAddress NetworkInterface::dnsIP(uint8_t dns_no) const
     if(esp_netif_get_dns_info(_esp_netif, dns_no?ESP_NETIF_DNS_BACKUP:ESP_NETIF_DNS_MAIN, &d) != ESP_OK){
         return IPAddress();
     }
+    if (d.ip.type == ESP_IPADDR_TYPE_V6){
+        // IPv6 from 4x uint32_t; byte order based on IPV62STR() in esp_netif_ip_addr.h
+        log_d("DNS got IPv6: " IPV6STR, IPV62STR(d.ip.u_addr.ip6));
+        uint32_t addr0 esp_netif_htonl(d.ip.u_addr.ip6.addr[0]);
+        uint32_t addr1 esp_netif_htonl(d.ip.u_addr.ip6.addr[1]);
+        uint32_t addr2 esp_netif_htonl(d.ip.u_addr.ip6.addr[2]);
+        uint32_t addr3 esp_netif_htonl(d.ip.u_addr.ip6.addr[3]);
+        return IPAddress(
+            (uint8_t)(addr0 >> 24) & 0xFF,
+            (uint8_t)(addr0 >> 16) & 0xFF,
+            (uint8_t)(addr0 >> 8) & 0xFF,
+            (uint8_t)addr0 & 0xFF,
+            (uint8_t)(addr1 >> 24) & 0xFF,
+            (uint8_t)(addr1 >> 16) & 0xFF,
+            (uint8_t)(addr1 >> 8) & 0xFF,
+            (uint8_t)addr1 & 0xFF,
+            (uint8_t)(addr2 >> 24) & 0xFF,
+            (uint8_t)(addr2 >> 16) & 0xFF,
+            (uint8_t)(addr2 >> 8) & 0xFF,
+            (uint8_t)addr2 & 0xFF,
+            (uint8_t)(addr3 >> 24) & 0xFF,
+            (uint8_t)(addr3 >> 16) & 0xFF,
+            (uint8_t)(addr3 >> 8) & 0xFF,
+            (uint8_t)addr3 & 0xFF,
+            d.ip.u_addr.ip6.zone
+        );
+    }
+    // IPv4 from single uint32_t
+    log_d("DNS IPv4: " IPSTR, IP2STR(&d.ip.u_addr.ip4));
     return IPAddress(d.ip.u_addr.ip4.addr);
 }
 

--- a/libraries/Network/src/NetworkManager.cpp
+++ b/libraries/Network/src/NetworkManager.cpp
@@ -5,11 +5,11 @@
  */
 #include "NetworkManager.h"
 #include "NetworkInterface.h"
+#include "IPAddress.h"
 #include "esp_netif.h"
-#include "lwip/ip_addr.h"
 #include "lwip/dns.h"
-#include "esp32-hal-log.h"
 #include "esp_mac.h"
+#include "netdb.h"
 
 NetworkManager::NetworkManager(){
 
@@ -36,43 +36,6 @@ bool NetworkManager::begin(){
     return initialized;
 }
 
-typedef struct gethostbynameParameters {
-    const char *hostname;
-    ip_addr_t addr;
-    uint8_t addr_type;
-    int result;
-} gethostbynameParameters_t;
-
-/**
- * DNS callback
- * @param name
- * @param ipaddr
- * @param callback_arg
- */
-static void wifi_dns_found_callback(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
-{
-    gethostbynameParameters_t *parameters = static_cast<gethostbynameParameters_t *>(callback_arg);
-    if(ipaddr) {
-        if(parameters->result == 0){
-            memcpy(&(parameters->addr), ipaddr, sizeof(ip_addr_t));
-            parameters->result = 1;
-        }
-    } else {
-        parameters->result = -1;
-    }
-    Network.setStatusBits(NET_DNS_DONE_BIT);
-}
-
-/**
- * Callback to execute dns_gethostbyname in lwIP's TCP/IP context
- * @param param Parameters for dns_gethostbyname call
- */
-static esp_err_t wifi_gethostbyname_tcpip_ctx(void *param)
-{
-    gethostbynameParameters_t *parameters = static_cast<gethostbynameParameters_t *>(param);
-    return dns_gethostbyname_addrtype(parameters->hostname, &parameters->addr, &wifi_dns_found_callback, parameters, parameters->addr_type);
-}
-
 /**
  * Resolve the given hostname to an IP address.
  * @param aHostname     Name to be resolved
@@ -80,10 +43,9 @@ static esp_err_t wifi_gethostbyname_tcpip_ctx(void *param)
  * @return 1 if aIPAddrString was successfully converted to an IP address,
  *          else error code
  */
-int NetworkManager::hostByName(const char* aHostname, IPAddress& aResult, bool preferV6)
+int NetworkManager::hostByName(const char* aHostname, IPAddress& aResult)
 {
     err_t err = ERR_OK;
-    gethostbynameParameters_t params;
 
     // This should generally check if we have a global address assigned to one of the interfaces.
     // If such address is not assigned, there is no point in trying to get V6 from DNS as we will not be able to reach it.
@@ -97,32 +59,41 @@ int NetworkManager::hostByName(const char* aHostname, IPAddress& aResult, bool p
     }
 
     aResult = static_cast<uint32_t>(0);
-    params.hostname = aHostname;
-    params.addr_type = (preferV6 || hasGlobalV6)?LWIP_DNS_ADDRTYPE_IPV6_IPV4:LWIP_DNS_ADDRTYPE_IPV4;
-    params.result = 0;
-    aResult.to_ip_addr_t(&(params.addr));
 
-    if (!aResult.fromString(aHostname)) {
-        Network.waitStatusBits(NET_DNS_IDLE_BIT, 16000);
-        Network.clearStatusBits(NET_DNS_IDLE_BIT | NET_DNS_DONE_BIT);
-
-        err = esp_netif_tcpip_exec(wifi_gethostbyname_tcpip_ctx, &params);
-        if (err == ERR_OK) {
-            aResult.from_ip_addr_t(&(params.addr));
-        } else if (err == ERR_INPROGRESS) {
-            Network.waitStatusBits(NET_DNS_DONE_BIT, 15000);  //real internal timeout in lwip library is 14[s]
-            Network.clearStatusBits(NET_DNS_DONE_BIT);
-            if (params.result == 1) {
-                aResult.from_ip_addr_t(&(params.addr));
-                err = ERR_OK;
-            }
-        }
-        Network.setStatusBits(NET_DNS_IDLE_BIT);
-    }
-    if (err == ERR_OK) {
+    // First check if the host parses as a literal address
+    if (aResult.fromString(aHostname)) {
         return 1;
     }
-    log_e("DNS Failed for '%s' with error '%d' and result '%d'", aHostname, err, params.result);
+
+    const char *servname = "0";
+    struct addrinfo *res;
+    const struct addrinfo hints = {
+        .ai_family = AF_UNSPEC,
+        .ai_socktype = SOCK_STREAM,
+    };
+    err = lwip_getaddrinfo(aHostname, servname, &hints, &res);
+    if (err == ERR_OK)
+    {
+        if (res->ai_family == AF_INET6)
+        {
+            struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)res->ai_addr;
+            // As an array of u8_t
+            aResult = IPAddress(IPv6, ipv6->sin6_addr.s6_addr);
+            log_d("DNS found IPv6 %s", aResult.toString().c_str());
+        }
+        else
+        {
+            struct sockaddr_in *ipv4 = (struct sockaddr_in *)res->ai_addr;
+            // As a single u32_t
+            aResult = IPAddress(ipv4->sin_addr.s_addr);
+            log_d("DNS found IPv4 %s", aResult.toString().c_str());
+        }
+
+        lwip_freeaddrinfo(res);
+        return 1;
+    }
+
+    log_e("DNS Failed for '%s' with error '%d'", aHostname, err);
     return err;
 }
 

--- a/libraries/Network/src/NetworkManager.h
+++ b/libraries/Network/src/NetworkManager.h
@@ -14,7 +14,7 @@ public:
 	NetworkManager();
 
 	bool begin();
-	int hostByName(const char *aHostname, IPAddress &aResult, bool preferV6=false);
+	int hostByName(const char *aHostname, IPAddress &aResult);
 	uint8_t * macAddress(uint8_t * mac);
 	String macAddress();
 

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -794,9 +794,9 @@ set_ant:
 /*
  * Deprecated Methods
 */
-int WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult, bool preferV6)
+int WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult)
 {
-    return Network.hostByName(aHostname, aResult, preferV6);
+    return Network.hostByName(aHostname, aResult);
 }
 
 IPAddress WiFiGenericClass::calculateNetworkID(IPAddress ip, IPAddress subnet) {

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -115,7 +115,7 @@ class WiFiGenericClass
     static void useStaticBuffers(bool bufferMode);
     static bool useStaticBuffers();
 
-    static int hostByName(const char *aHostname, IPAddress &aResult, bool preferV6=false);
+    static int hostByName(const char *aHostname, IPAddress &aResult);
 
     static IPAddress calculateNetworkID(IPAddress ip, IPAddress subnet);
     static IPAddress calculateBroadcast(IPAddress ip, IPAddress subnet);


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [X] Please **update relevant Documentation** if applicable
4. [X] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [X] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change

Allows dual-stack networks to connect to IPv6-only destinations.

Replace hostbyname with getaddrinfo for better IPv6 support. The API is also simpler, as it has no callbacks (they are handled internally). 

Note: Still does not work for IPv6-only networks, as IPv6 DNS is not enabled in the pre-built ESP-IDF libraries.

Also includes an update to `dnsIP()` to correctly return IPv6 addresses (they do work internally, when enabled, just weren't being returned correctly).

## Tests scenarios

Tested on M5Stack Core2 (ESP32), on dual-stack, IPv4-only, and IPv6-only networks (with DNS64/NAT64), for dual-stack. IPv4-only, and IPv6-only destination servers.

The IPv4-only and dual-stack networks work for all destination servers, although due to a limitation in LWIP the dual-stack to dual-stack scenario uses the IPv4 address (instead of IPv6).

I have a patch submitted for ESP-LWIP to fix this issue, and in the meanwhile also have a workaround I can implement for Arduino-ESP32.

| Network | Dual-Stack | IPv6 | IPv4 | TLS Dual-Stack
| -- | -- | -- | --| --
| IPv4 (Shadow) | Yes | Not Possible | Yes | Yes
| Dual-stack+NAT64 (Astral) | IPv4 | Yes | Yes | Yes
| IPv6+NAT64 (Wildspace) | No DNS | No DNS | No DNS | No DNS

Note that IPv6-only networks do not work yet. They are reporting no-DNS, probably because the underlying ESP-IDF libraries do not have IPv6 DNS enabled.

Example outputs:

(These are from my own test app, at https://github.com/sgryphon/iot-demo-build/tree/feature/arduino-esp32-v3-update/m5stack/m5unified_wifi_https -- I will look at making sure a simpler test example in Arduino-ESP32 also works.)

Dual-stack network, to IPv6-only destination:

```
[ 38329][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: Button 3, scenario 2, v0.1.0-156-gaf345f5
[ 38342][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: Global IPv6 2407:8800:bc61:1340:a3a:f2ff:fe65:db28
[ 38357][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: IPv4 192.168.1.159
[ 38365][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: Link-Local IPv6 fe80::a3a:f2ff:fe65:db28%st1
sta: <UP>
      ether 08:3A:F2:65:DB:28
      inet 192.168.1.159 netmask 255.255.255.0 broadcast 192.168.1.255
      gateway 192.168.1.1 dns 192.168.1.1
      inet6 fe80::a3a:f2ff:fe65:db28%st1 type LINK_LOCAL
      inet6 2407:8800:bc61:1340:a3a:f2ff:fe65:db28 type GLOBAL
      inet6 fd7c:e25e:67e8:40:a3a:f2ff:fe65:db28 type UNIQUE_LOCAL
[ 38402][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: DNS0 192.168.1.1
[ 38417][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: DNS1 0.0.0.0
[ 38424][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: URL: http://v4.ipv6-test.com/api/myip.php
[ 38465][D][HTTPClient.cpp:303] beginInternal(): protocol: http, host: v4.ipv6-test.com port: 80 url: /api/myip.php
[ 38476][D][HTTPClient.cpp:598] sendRequest(): request type: 'GET' redirCount: 0

[ 38505][D][NetworkManager.cpp:88] hostByName(): DNS found IPv4 51.75.78.103
[ 38917][D][HTTPClient.cpp:1170] connect():  connected to v4.ipv6-test.com:80
[ 39330][D][HTTPClient.cpp:1321] handleHeaderResponse(): code: 200
[ 39336][D][HTTPClient.cpp:1328] handleHeaderResponse(): Transfer-Encoding: chunked
[ 39344][D][HTTPClient.cpp:642] sendRequest(): sendRequest code=200

[ 39350][D][HTTPClient.cpp:388] disconnect(): still data in buffer (2), clean up.

[ 39358][D][HTTPClient.cpp:393] disconnect(): tcp keep open for reuse
[ 39364][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: response=<220.240.255.134>
[ 39375][I][Core2Logger.cpp:176] success(): [Core2Logger] Success
```

Failure - IPv6 only network, to dual-stack host. No IPv6 DNS available. (LWIP does support IPv6 DNS, but not enabled in library build)

```
[ 18184][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: Button 1, scenario 0, v0.1.0-156-gaf345f5
[ 18196][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: Global IPv6 2407:8800:bc61:1300:a3a:f2ff:fe65:db28
[ 18211][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: IPv4 0.0.0.0
[ 18218][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: Link-Local IPv6 fe80::a3a:f2ff:fe65:db28%st1
sta: <UP>
      ether 08:3A:F2:65:DB:28
      inet 0.0.0.0 netmask 0.0.0.0 broadcast 255.255.255.255
      gateway 0.0.0.0 dns 0.0.0.0
      inet6 fe80::a3a:f2ff:fe65:db28%st1 type LINK_LOCAL
      inet6 2407:8800:bc61:1300:a3a:f2ff:fe65:db28 type GLOBAL
      inet6 fd7c:e25e:67e8:0:a3a:f2ff:fe65:db28 type UNIQUE_LOCAL
[ 18256][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: DNS0 0.0.0.0
[ 18268][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: DNS1 0.0.0.0
[ 18275][I][Core2Logger.cpp:198] log(): [Core2Logger] CORE2: URL: http://v4v6.ipv6-test.com/api/myip.php
[ 18289][D][HTTPClient.cpp:303] beginInternal(): protocol: http, host: v4v6.ipv6-test.com port: 80 url: /api/myip.php
[ 18299][D][HTTPClient.cpp:598] sendRequest(): request type: 'GET' redirCount: 0

[ 18307][E][NetworkManager.cpp:101] hostByName(): DNS Failed for 'v4v6.ipv6-test.com' with error '-54'
[ 18317][E][NetworkClient.cpp:258] connect(): connect on fd 48, errno: 118, "Host is unreachable"
[ 18326][D][HTTPClient.cpp:1163] connect(): failed connect to v4v6.ipv6-test.com:80
[ 18333][W][HTTPClient.cpp:1486] returnError(): error(-1): connection refused
[ 18340][E][Core2Logger.cpp:192] log(): [Core2Logger] CORE2: HTTP GET error -1: connection refused
```

## Related links

Partially addresses the issues in #9143, and in the IPv6 discussion.

