### PR TITLE
Handle large octet-stream (master branch)

### DIFF
--- a/libraries/WebServer/examples/UploadHugeFile/README.md
+++ b/libraries/WebServer/examples/UploadHugeFile/README.md
@@ -1,0 +1,13 @@
+# Upload Huge File To SD Over Http
+
+This project is an example of an HTTP server designed to facilitate the transfer of large files using the PUT method, in accordance with RFC specifications.
+
+### Example cURL Command
+
+```bash
+curl -X PUT -H "Content-Type: application/octet-stream" -T ./my-file.mp3 http://esp-ip/upload/my-file.mp3
+```
+
+## Resources
+
+- RFC HTTP/1.0 - Additional Request Methods - PUT : [Link](https://datatracker.ietf.org/doc/html/rfc1945#appendix-D.1.1)

--- a/libraries/WebServer/examples/UploadHugeFile/README.md
+++ b/libraries/WebServer/examples/UploadHugeFile/README.md
@@ -5,7 +5,7 @@ This project is an example of an HTTP server designed to facilitate the transfer
 ### Example cURL Command
 
 ```bash
-curl -X PUT -H "Content-Type: application/octet-stream" -T ./my-file.mp3 http://esp-ip/upload/my-file.mp3
+curl -X PUT -T ./my-file.mp3 http://esp-ip/upload/my-file.mp3
 ```
 
 ## Resources

--- a/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
+++ b/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
@@ -1,0 +1,132 @@
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <WebServer.h>
+#include <uri/UriRegex.h>
+#include <SD.h>
+
+const char* ssid = "**********";
+const char* password = "**********";
+
+WebServer server(80);
+
+File rawFile;
+void handleCreate() {
+  server.send(200, "text/plain", "");
+}
+void handleCreateProcess() {
+  String path = server.pathArg(0);
+  HTTPRaw& raw = server.raw();
+  if (raw.status == RAW_START) {
+    if (SD.exists((char *)path.c_str())) {
+      SD.remove((char *)path.c_str());
+    }
+    rawFile = SD.open(path.c_str(), FILE_WRITE);
+    Serial.print("Upload: START, filename: "); 
+    Serial.println(path);
+  } else if (raw.status == RAW_WRITE) {
+    if (rawFile) {
+      rawFile.write(raw.buf, raw.currentSize);
+    }
+    Serial.print("Upload: WRITE, Bytes: "); 
+    Serial.println(raw.currentSize);
+  } else if (raw.status == RAW_END) {
+    if (rawFile) {
+      rawFile.close();
+    }
+    Serial.print("Upload: END, Size: "); 
+    Serial.println(raw.totalSize);
+  }
+}
+
+void returnFail(String msg) {
+  server.send(500, "text/plain", msg + "\r\n");
+}
+
+void printDirectory() {
+  if (!server.hasArg("dir")) {
+    return returnFail("BAD ARGS");
+  }
+  String path = server.arg("dir");
+  if (path != "/" && !SD.exists((char *)path.c_str())) {
+    return returnFail("BAD PATH");
+  }
+  File dir = SD.open((char *)path.c_str());
+  path = String();
+  if (!dir.isDirectory()) {
+    dir.close();
+    return returnFail("NOT DIR");
+  }
+  dir.rewindDirectory();
+  server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+  server.send(200, "text/json", "");
+  WiFiClient client = server.client();
+
+  server.sendContent("[");
+  for (int cnt = 0; true; ++cnt) {
+    File entry = dir.openNextFile();
+    if (!entry) {
+      break;
+    }
+
+    String output;
+    if (cnt > 0) {
+      output = ',';
+    }
+
+    output += "{\"type\":\"";
+    output += (entry.isDirectory()) ? "dir" : "file";
+    output += "\",\"name\":\"";
+    output += entry.path();
+    output += "\"";
+    output += "}";
+    server.sendContent(output);
+    entry.close();
+  }
+  server.sendContent("]");
+  dir.close();
+}
+
+void handleNotFound() {
+  String message = "File Not Found\n\n";
+  message += "URI: ";
+  message += server.uri();
+  message += "\nMethod: ";
+  message += (server.method() == HTTP_GET) ? "GET" : "POST";
+  message += "\nArguments: ";
+  message += server.args();
+  message += "\n";
+  for (uint8_t i = 0; i < server.args(); i++) {
+    message += " " + server.argName(i) + ": " + server.arg(i) + "\n";
+  }
+  server.send(404, "text/plain", message);
+}
+
+void setup(void) {
+  Serial.begin(115200);
+
+  while (!SD.begin()) delay(1);
+  Serial.println("SD Card initialized.");
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  server.on(UriRegex("/upload/(.*)"), HTTP_PUT, handleCreate, handleCreateProcess);
+  server.onNotFound(handleNotFound);
+  server.begin();
+  Serial.println("HTTP server started");
+
+}
+
+void loop(void) {
+  server.handleClient();
+  delay(2);//allow the cpu to switch to other tasks
+}

--- a/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
+++ b/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
@@ -14,7 +14,7 @@ void handleCreate() {
   server.send(200, "text/plain", "");
 }
 void handleCreateProcess() {
-  String path = server.pathArg(0);
+  String path = "/" + server.pathArg(0);
   HTTPRaw& raw = server.raw();
   if (raw.status == RAW_START) {
     if (SD.exists((char *)path.c_str())) {

--- a/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
+++ b/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
@@ -42,50 +42,6 @@ void returnFail(String msg) {
   server.send(500, "text/plain", msg + "\r\n");
 }
 
-void printDirectory() {
-  if (!server.hasArg("dir")) {
-    return returnFail("BAD ARGS");
-  }
-  String path = server.arg("dir");
-  if (path != "/" && !SD.exists((char *)path.c_str())) {
-    return returnFail("BAD PATH");
-  }
-  File dir = SD.open((char *)path.c_str());
-  path = String();
-  if (!dir.isDirectory()) {
-    dir.close();
-    return returnFail("NOT DIR");
-  }
-  dir.rewindDirectory();
-  server.setContentLength(CONTENT_LENGTH_UNKNOWN);
-  server.send(200, "text/json", "");
-  WiFiClient client = server.client();
-
-  server.sendContent("[");
-  for (int cnt = 0; true; ++cnt) {
-    File entry = dir.openNextFile();
-    if (!entry) {
-      break;
-    }
-
-    String output;
-    if (cnt > 0) {
-      output = ',';
-    }
-
-    output += "{\"type\":\"";
-    output += (entry.isDirectory()) ? "dir" : "file";
-    output += "\",\"name\":\"";
-    output += entry.path();
-    output += "\"";
-    output += "}";
-    server.sendContent(output);
-    entry.close();
-  }
-  server.sendContent("]");
-  dir.close();
-}
-
 void handleNotFound() {
   String message = "File Not Found\n\n";
   message += "URI: ";

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -136,7 +136,6 @@ bool WebServer::_parseRequest(NetworkClient& client) {
     String headerName;
     String headerValue;
     bool isForm = false;
-    bool isRaw = false;
     bool isEncoded = false;
     //parse headers
     while(1){
@@ -159,8 +158,6 @@ bool WebServer::_parseRequest(NetworkClient& client) {
         using namespace mime;
         if (headerValue.startsWith(FPSTR(mimeTable[txt].mimeType))){
           isForm = false;
-        } else if (headerValue.startsWith(FPSTR(mimeTable[none].mimeType))){
-          isRaw = true;
         } else if (headerValue.startsWith(F("application/x-www-form-urlencoded"))){
           isForm = false;
           isEncoded = true;
@@ -176,7 +173,7 @@ bool WebServer::_parseRequest(NetworkClient& client) {
       }
     }
 
-    if (isRaw && _currentHandler && _currentHandler->canRaw(_currentUri)){
+    if (!isForm && _currentHandler && _currentHandler->canRaw(_currentUri)){
       log_v("Parse raw");
       _currentRaw.reset(new HTTPRaw());
       _currentRaw->status = RAW_START;

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -136,6 +136,7 @@ bool WebServer::_parseRequest(NetworkClient& client) {
     String headerName;
     String headerValue;
     bool isForm = false;
+    bool isRaw = false;
     bool isEncoded = false;
     //parse headers
     while(1){
@@ -158,6 +159,8 @@ bool WebServer::_parseRequest(NetworkClient& client) {
         using namespace mime;
         if (headerValue.startsWith(FPSTR(mimeTable[txt].mimeType))){
           isForm = false;
+        } else if (headerValue.startsWith(FPSTR(mimeTable[none].mimeType))){
+          isRaw = true;
         } else if (headerValue.startsWith(F("application/x-www-form-urlencoded"))){
           isForm = false;
           isEncoded = true;
@@ -173,7 +176,30 @@ bool WebServer::_parseRequest(NetworkClient& client) {
       }
     }
 
-    if (!isForm){
+    if (isRaw && _currentHandler && _currentHandler->canRaw(_currentUri)){
+      log_v("Parse raw");
+      _currentRaw.reset(new HTTPRaw());
+      _currentRaw->status = RAW_START;
+      _currentRaw->totalSize = 0;
+      _currentRaw->currentSize = 0;
+      log_v("Start Raw");
+      _currentHandler->raw(*this, _currentUri, *_currentRaw);
+      _currentRaw->status = RAW_WRITE;
+
+      while (_currentRaw->totalSize < _clientContentLength) {
+        _currentRaw->currentSize = client.readBytes(_currentRaw->buf, HTTP_RAW_BUFLEN);
+        _currentRaw->totalSize += _currentRaw->currentSize;
+        if (_currentRaw->currentSize == 0) {
+          _currentRaw->status = RAW_ABORTED;
+          _currentHandler->raw(*this, _currentUri, *_currentRaw);
+          return false;
+        }
+        _currentHandler->raw(*this, _currentUri, *_currentRaw);
+      }
+      _currentRaw->status = RAW_END;
+      _currentHandler->raw(*this, _currentUri, *_currentRaw);
+      log_v("Finish Raw");
+    } else if (!isForm) {
       size_t plainLength;
       char* plainBuf = readBytesWithTimeout(client, _clientContentLength, plainLength, HTTP_MAX_POST_WAIT);
       if (plainLength < _clientContentLength) {

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -438,6 +438,7 @@ void WebServer::handleClient() {
     _currentClient = NetworkClient();
     _currentStatus = HC_NONE;
     _currentUpload.reset();
+    _currentRaw.reset();
   }
 
   if (callYield) {

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -33,6 +33,7 @@
 
 enum HTTPUploadStatus { UPLOAD_FILE_START, UPLOAD_FILE_WRITE, UPLOAD_FILE_END,
                         UPLOAD_FILE_ABORTED };
+enum HTTPRawStatus { RAW_START, RAW_WRITE, RAW_END, RAW_ABORTED };
 enum HTTPClientStatus { HC_NONE, HC_WAIT_READ, HC_WAIT_CLOSE };
 enum HTTPAuthMethod { BASIC_AUTH, DIGEST_AUTH, OTHER_AUTH };
 
@@ -40,6 +41,10 @@ enum HTTPAuthMethod { BASIC_AUTH, DIGEST_AUTH, OTHER_AUTH };
 
 #ifndef HTTP_UPLOAD_BUFLEN
 #define HTTP_UPLOAD_BUFLEN 1436
+#endif
+
+#ifndef HTTP_RAW_BUFLEN
+#define HTTP_RAW_BUFLEN 1436
 #endif
 
 #define HTTP_MAX_DATA_WAIT 5000 //ms to wait for the client to send the request
@@ -62,6 +67,15 @@ typedef struct {
   size_t  currentSize;  // size of data currently in buf
   uint8_t buf[HTTP_UPLOAD_BUFLEN];
 } HTTPUpload;
+
+typedef struct
+{
+  HTTPRawStatus status;
+  size_t  totalSize;   // content size
+  size_t  currentSize; // size of data currently in buf
+  uint8_t buf[HTTP_UPLOAD_BUFLEN];
+  void    *data;       // additional data
+} HTTPRaw;
 
 #include "detail/RequestHandler.h"
 
@@ -128,6 +142,7 @@ public:
   HTTPMethod method() { return _currentMethod; }
   virtual NetworkClient & client() { return _currentClient; }
   HTTPUpload& upload() { return *_currentUpload; }
+  HTTPRaw& raw() { return *_currentRaw; }
 
   String pathArg(unsigned int i); // get request path argument by number
   String arg(String name);        // get request argument value by name
@@ -232,6 +247,7 @@ protected:
   RequestArgument* _postArgs;
 
   std::unique_ptr<HTTPUpload> _currentUpload;
+  std::unique_ptr<HTTPRaw>    _currentRaw;
 
   int              _headerKeysCount;
   RequestArgument* _currentHeaders;

--- a/libraries/WebServer/src/detail/RequestHandler.h
+++ b/libraries/WebServer/src/detail/RequestHandler.h
@@ -9,8 +9,10 @@ public:
     virtual ~RequestHandler() { }
     virtual bool canHandle(HTTPMethod method, String uri) { (void) method; (void) uri; return false; }
     virtual bool canUpload(String uri) { (void) uri; return false; }
+    virtual bool canRaw(String uri) { (void) uri; return false; }
     virtual bool handle(WebServer& server, HTTPMethod requestMethod, String requestUri) { (void) server; (void) requestMethod; (void) requestUri; return false; }
     virtual void upload(WebServer& server, String requestUri, HTTPUpload& upload) { (void) server; (void) requestUri; (void) upload; }
+    virtual void raw(WebServer& server, String requestUri, HTTPRaw& raw) { (void) server; (void) requestUri; (void) raw; }
 
     RequestHandler* next() { return _next; }
     void next(RequestHandler* r) { _next = r; }

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -38,6 +38,12 @@ public:
 
         return true;
     }
+    bool canRaw(String requestUri) override {
+        if (!_ufn || _method == HTTP_GET)
+            return false;
+
+        return true;
+    }
 
     bool handle(WebServer& server, HTTPMethod requestMethod, String requestUri) override {
         (void) server;
@@ -52,6 +58,13 @@ public:
         (void) server;
         (void) upload;
         if (canUpload(requestUri))
+            _ufn();
+    }
+
+    void raw(WebServer& server, String requestUri, HTTPRaw& raw) override {
+        (void)server;
+        (void)raw;
+        if (canRaw(requestUri))
             _ufn();
     }
 


### PR DESCRIPTION
### Issue

In scenarios where the request body size exceeds the available RAM, the ESP fails to allocate sufficient memory to process the request in one go.

### Change

Now, when the "Content-Type" of the request is "application/octet-stream", it will attempt to call the "ufn" function of the handler, similar to how it handles multipart requests.

**Code Example:**

```cpp
server.on(uri, HTTP_PUT, finalCallback, [](){
  HTTPRaw raw = server.raw();
  if (raw.status == RAW_START) {
    ...
  } else if (raw.status == RAW_WRITE) {
    ...
  } else if (raw.status == RAW_END) {
    ...
  }
});
```