### PR TITLE
Set Apache license to Update Library

### DIFF
--- a/libraries/Update/src/HttpsOTAUpdate.cpp
+++ b/libraries/Update/src/HttpsOTAUpdate.cpp
@@ -1,6 +1,5 @@
-/* OTA task
-
-   This example code is in the Public Domain (or CC0 licensed, at your option.)
+/* 
+   This code is in the Public Domain (or CC0 licensed, at your option.)
 
    Unless required by applicable law or agreed to in writing, this
    software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/libraries/Update/src/HttpsOTAUpdate.cpp
+++ b/libraries/Update/src/HttpsOTAUpdate.cpp
@@ -1,10 +1,9 @@
-/* 
-   This code is in the Public Domain (or CC0 licensed, at your option.)
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-   Unless required by applicable law or agreed to in writing, this
-   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied.
-*/
 #include <stdio.h>
 #include <string.h>
 

--- a/libraries/Update/src/HttpsOTAUpdate.h
+++ b/libraries/Update/src/HttpsOTAUpdate.h
@@ -1,3 +1,11 @@
+/* 
+   This code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
 #ifndef HTTPSOTAUPDATE_H
 #define HTTPSOTAUPDATE_H
 #include "esp_http_client.h"

--- a/libraries/Update/src/HttpsOTAUpdate.h
+++ b/libraries/Update/src/HttpsOTAUpdate.h
@@ -1,10 +1,8 @@
-/* 
-   This code is in the Public Domain (or CC0 licensed, at your option.)
-
-   Unless required by applicable law or agreed to in writing, this
-   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied.
-*/
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #ifndef HTTPSOTAUPDATE_H
 #define HTTPSOTAUPDATE_H

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -1,10 +1,8 @@
-/* 
-   This code is in the Public Domain (or CC0 licensed, at your option.)
-
-   Unless required by applicable law or agreed to in writing, this
-   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied.
-*/
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #ifndef ESP32UPDATER_H
 #define ESP32UPDATER_H

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -1,3 +1,11 @@
+/* 
+   This code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
 #ifndef ESP32UPDATER_H
 #define ESP32UPDATER_H
 

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -1,10 +1,8 @@
-/* 
-   This code is in the Public Domain (or CC0 licensed, at your option.)
-
-   Unless required by applicable law or agreed to in writing, this
-   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied.
-*/
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "Update.h"
 #include "Arduino.h"

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -1,3 +1,11 @@
+/* 
+   This code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
 #include "Update.h"
 #include "Arduino.h"
 #include "spi_flash_mmap.h"


### PR DESCRIPTION
## Description of Change
Changes the Update Library license to Apache, fillowing all the other Espressif source code.

## Tests scenarios
N/A

## Related links
Internal.