### PR TITLE
core Server class back to Arduino Core API version

### DIFF
--- a/cores/esp32/Server.h
+++ b/cores/esp32/Server.h
@@ -25,7 +25,7 @@
 class Server: public Print
 {
 public:
-    virtual void begin(uint16_t port=0) =0;
+    virtual void begin() =0;
 };
 
 #endif


### PR DESCRIPTION
the Server class is now not used in NetworkServer. it is in the core only for external libraries like the Arduino Ethernet library, so it should be compatible with them. (optionality of the parameter doesn't apply when matching implementation of virtual function )

https://github.com/arduino-libraries/Ethernet/issues/88

https://github.com/arduino/ArduinoCore-API/blob/master/api/Server.h

