### PR TITLE
Fix NetworkManager compilation warning

### DIFF
--- a/libraries/Network/src/NetworkManager.cpp
+++ b/libraries/Network/src/NetworkManager.cpp
@@ -67,10 +67,11 @@ int NetworkManager::hostByName(const char* aHostname, IPAddress& aResult)
 
     const char *servname = "0";
     struct addrinfo *res;
-    const struct addrinfo hints = {
-        .ai_family = AF_UNSPEC,
-        .ai_socktype = SOCK_STREAM,
-    };
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
     err = lwip_getaddrinfo(aHostname, servname, &hints, &res);
     if (err == ERR_OK)
     {


### PR DESCRIPTION
## Description of Change
Fixes "missing initializer" warnings for the NetworkManager

```
/home/lucassvaz/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkManager.cpp: In member function 'int NetworkManager::hostByName(const char*, IPAddress&)':
/home/lucassvaz/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkManager.cpp:73:5: warning: missing initializer for member 'addrinfo::ai_flags' [-Wmissing-field-initializers]
   73 |     };
      |     ^
/home/lucassvaz/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkManager.cpp:73:5: warning: missing initializer for member 'addrinfo::ai_protocol' [-Wmissing-field-initializers]
/home/lucassvaz/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkManager.cpp:73:5: warning: missing initializer for member 'addrinfo::ai_addrlen' [-Wmissing-field-initializers]
/home/lucassvaz/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkManager.cpp:73:5: warning: missing initializer for member 'addrinfo::ai_addr' [-Wmissing-field-initializers]
/home/lucassvaz/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkManager.cpp:73:5: warning: missing initializer for member 'addrinfo::ai_canonname' [-Wmissing-field-initializers]
/home/lucassvaz/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkManager.cpp:73:5: warning: missing initializer for member 'addrinfo::ai_next' [-Wmissing-field-initializers]
```