### PR TITLE
Add option to specify AP auth mode and cipher

### DIFF
--- a/libraries/WiFi/src/AP.cpp
+++ b/libraries/WiFi/src/AP.cpp
@@ -200,7 +200,7 @@ bool APClass::end(){
     return true;
 }
 
-bool APClass::create(const char* ssid, const char* passphrase, int channel, int ssid_hidden, int max_connection, bool ftm_responder){
+bool APClass::create(const char* ssid, const char* passphrase, int channel, int ssid_hidden, int max_connection, bool ftm_responder, wifi_auth_mode_t auth_mode, wifi_cipher_type_t cipher){
     if(!ssid || *ssid == 0) {
         log_e("SSID missing!");
         return false;
@@ -226,8 +226,8 @@ bool APClass::create(const char* ssid, const char* passphrase, int channel, int 
         _wifi_strncpy((char*)conf.ap.ssid, ssid, 32);
         conf.ap.ssid_len = strlen(ssid);
         if(passphrase != NULL && passphrase[0] != 0){
-            conf.ap.authmode = WIFI_AUTH_WPA2_PSK;
-            conf.ap.pairwise_cipher = WIFI_CIPHER_TYPE_CCMP; // Disable by default enabled insecure TKIP and use just CCMP.
+            conf.ap.authmode = auth_mode;
+            conf.ap.pairwise_cipher = cipher;
             _wifi_strncpy((char*)conf.ap.password, passphrase, 64);
         }
     }
@@ -318,15 +318,15 @@ size_t APClass::printDriverInfo(Print & out) const{
 
     if(info.ap.authmode == WIFI_AUTH_OPEN){ bytes += out.print(",OPEN"); }
     else if(info.ap.authmode == WIFI_AUTH_WEP){ bytes += out.print(",WEP"); }
-    else if(info.ap.authmode == WIFI_AUTH_WPA_PSK){ bytes += out.print(",WWPA_PSK"); }
-    else if(info.ap.authmode == WIFI_AUTH_WPA2_PSK){ bytes += out.print(",WWPA2_PSK"); }
-    else if(info.ap.authmode == WIFI_AUTH_WPA_WPA2_PSK){ bytes += out.print(",WWPA_WPA2_PSK"); }
+    else if(info.ap.authmode == WIFI_AUTH_WPA_PSK){ bytes += out.print(",WPA_PSK"); }
+    else if(info.ap.authmode == WIFI_AUTH_WPA2_PSK){ bytes += out.print(",WPA2_PSK"); }
+    else if(info.ap.authmode == WIFI_AUTH_WPA_WPA2_PSK){ bytes += out.print(",WPA_WPA2_PSK"); }
     else if(info.ap.authmode == WIFI_AUTH_ENTERPRISE){ bytes += out.print(",WEAP"); }
-    else if(info.ap.authmode == WIFI_AUTH_WPA3_PSK){ bytes += out.print(",WWPA3_PSK"); }
-    else if(info.ap.authmode == WIFI_AUTH_WPA2_WPA3_PSK){ bytes += out.print(",WWPA2_WPA3_PSK"); }
-    else if(info.ap.authmode == WIFI_AUTH_WAPI_PSK){ bytes += out.print(",WWAPI_PSK"); }
-    else if(info.ap.authmode == WIFI_AUTH_OWE){ bytes += out.print(",WOWE"); }
-    else if(info.ap.authmode == WIFI_AUTH_WPA3_ENT_192){ bytes += out.print(",WWPA3_ENT_SUITE_B_192_BIT"); }
+    else if(info.ap.authmode == WIFI_AUTH_WPA3_PSK){ bytes += out.print(",WPA3_PSK"); }
+    else if(info.ap.authmode == WIFI_AUTH_WPA2_WPA3_PSK){ bytes += out.print(",WPA2_WPA3_PSK"); }
+    else if(info.ap.authmode == WIFI_AUTH_WAPI_PSK){ bytes += out.print(",WAPI_PSK"); }
+    else if(info.ap.authmode == WIFI_AUTH_OWE){ bytes += out.print(",OWE"); }
+    else if(info.ap.authmode == WIFI_AUTH_WPA3_ENT_192){ bytes += out.print(",WPA3_ENT_SUITE_B_192_BIT"); }
 
     if(esp_wifi_ap_get_sta_list(&clients) == ESP_OK) {
         bytes += out.print(",STA:");

--- a/libraries/WiFi/src/WiFiAP.cpp
+++ b/libraries/WiFi/src/WiFiAP.cpp
@@ -47,9 +47,9 @@
  * @param ssid_hidden       Network cloaking (0 = broadcast SSID, 1 = hide SSID)
  * @param max_connection    Max simultaneous connected clients, 1 - 4.
 */
-bool WiFiAPClass::softAP(const char* ssid, const char* passphrase, int channel, int ssid_hidden, int max_connection, bool ftm_responder)
+bool WiFiAPClass::softAP(const char* ssid, const char* passphrase, int channel, int ssid_hidden, int max_connection, bool ftm_responder, wifi_auth_mode_t auth_mode, wifi_cipher_type_t cipher)
 {
-    return AP.begin() && AP.create(ssid, passphrase, channel, ssid_hidden, max_connection, ftm_responder);
+    return AP.begin() && AP.create(ssid, passphrase, channel, ssid_hidden, max_connection, ftm_responder, auth_mode, cipher);
 }
 
 /**

--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -25,11 +25,12 @@
 #include "soc/soc_caps.h"
 #if SOC_WIFI_SUPPORTED
 
-
+#include "esp_wifi_types.h"
 #include "WiFiType.h"
 #include "WiFiGeneric.h"
 
-
+#define WIFI_AP_DEFAULT_AUTH_MODE   WIFI_AUTH_WPA2_PSK
+#define WIFI_AP_DEFAULT_CIPHER      WIFI_CIPHER_TYPE_CCMP // Disable by default enabled insecure TKIP and use just CCMP.
 
 // ----------------------------------------------------------------------------------------------
 // ------------------------------------ NEW AP Implementation  ----------------------------------
@@ -43,7 +44,7 @@ class APClass: public NetworkInterface {
         bool begin();
         bool end();
 
-        bool create(const char* ssid, const char* passphrase = NULL, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false);
+        bool create(const char* ssid, const char* passphrase = NULL, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false, wifi_auth_mode_t auth_mode = WIFI_AP_DEFAULT_AUTH_MODE, wifi_cipher_type_t cipher = WIFI_AP_DEFAULT_CIPHER);
         bool clear();
 
         bool bandwidth(wifi_bandwidth_t bandwidth);
@@ -71,9 +72,9 @@ class WiFiAPClass
 public:
     APClass AP;
 
-    bool softAP(const char* ssid, const char* passphrase = NULL, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false);
-    bool softAP(const String& ssid, const String& passphrase = emptyString, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false) {
-       return softAP(ssid.c_str(), passphrase.c_str(), channel, ssid_hidden, max_connection, ftm_responder);
+    bool softAP(const char* ssid, const char* passphrase = NULL, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false, wifi_auth_mode_t auth_mode = WIFI_AP_DEFAULT_AUTH_MODE, wifi_cipher_type_t cipher = WIFI_AP_DEFAULT_CIPHER);
+    bool softAP(const String& ssid, const String& passphrase = emptyString, int channel = 1, int ssid_hidden = 0, int max_connection = 4, bool ftm_responder = false, wifi_auth_mode_t auth_mode = WIFI_AP_DEFAULT_AUTH_MODE, wifi_cipher_type_t cipher = WIFI_AP_DEFAULT_CIPHER) {
+       return softAP(ssid.c_str(), passphrase.c_str(), channel, ssid_hidden, max_connection, ftm_responder, auth_mode, cipher);
     }
 
     bool softAPConfig(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dhcp_lease_start = (uint32_t) 0);


### PR DESCRIPTION
For example to start the AP with WPA3 auth:
```cpp
WiFi.softAP(WiFi.getHostname(), "password", 1, 0, 4, false, WIFI_AUTH_WPA3_PSK, WIFI_CIPHER_TYPE_CCMP);
```

closes: https://github.com/espressif/arduino-esp32/issues/8451