### PR TITLE
feat(net): Add support for selecting the default network interface

### DIFF
--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "NetworkInterface.h"
+#include "NetworkManager.h"
 #include "esp_netif.h"
 #include "esp_netif_defaults.h"
 #include "esp_system.h"
@@ -536,6 +537,43 @@ String NetworkInterface::impl_name(void) const
         return String("");
     }
     return String(netif_name);
+}
+
+int NetworkInterface::impl_index() const
+{
+    if(_esp_netif == NULL){
+        return -1;
+    }
+    return esp_netif_get_netif_impl_index(_esp_netif);
+}
+
+int NetworkInterface::route_prio() const
+{
+    if(_esp_netif == NULL){
+        return -1;
+    }
+    return esp_netif_get_route_prio(_esp_netif);
+}
+
+bool NetworkInterface::setDefault()
+{
+    if(_esp_netif == NULL){
+        return false;
+    }
+    esp_err_t err = esp_netif_set_default_netif(_esp_netif);
+    if(err != ESP_OK){
+        log_e("Failed to set default netif: %d", err);
+        return false;
+    }
+    return true;
+}
+
+bool NetworkInterface::isDefault() const
+{
+    if(_esp_netif == NULL){
+        return false;
+    }
+    return esp_netif_get_default_netif() == _esp_netif;
 }
 
 uint8_t * NetworkInterface::macAddress(uint8_t* mac) const

--- a/libraries/Network/src/NetworkInterface.h
+++ b/libraries/Network/src/NetworkInterface.h
@@ -8,7 +8,6 @@
 #include "esp_netif_types.h"
 #include "esp_event.h"
 #include "Arduino.h"
-#include "NetworkManager.h"
 #include "Printable.h"
 
 typedef enum {
@@ -54,6 +53,10 @@ class NetworkInterface: public Printable {
         const char * ifkey() const;
         const char * desc() const;
         String impl_name() const;
+        int impl_index() const;
+        int route_prio() const;
+        bool setDefault();
+        bool isDefault() const;
 
         uint8_t * macAddress(uint8_t* mac) const;
         String macAddress() const;

--- a/libraries/Network/src/NetworkManager.cpp
+++ b/libraries/Network/src/NetworkManager.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "NetworkManager.h"
-#include "NetworkInterface.h"
 #include "IPAddress.h"
 #include "esp_netif.h"
 #include "lwip/dns.h"
@@ -132,6 +131,23 @@ bool NetworkManager::setHostname(const char * name)
 }
 
 NetworkInterface * getNetifByID(Network_Interface_ID id);
+
+bool NetworkManager::setDefaultInterface(NetworkInterface & ifc)
+{
+    return ifc.setDefault();
+}
+
+NetworkInterface * NetworkManager::getDefaultInterface()
+{
+    esp_netif_t * netif = esp_netif_get_default_netif();
+    for (int i = 0; i < ESP_NETIF_ID_MAX; ++i){
+        NetworkInterface * iface = getNetifByID((Network_Interface_ID)i);
+        if(iface != NULL && iface->netif() == netif){
+            return iface;
+        }
+    }
+    return NULL;
+}
 
 size_t NetworkManager::printTo(Print & out) const {
     size_t bytes = 0;

--- a/libraries/Network/src/NetworkManager.h
+++ b/libraries/Network/src/NetworkManager.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "NetworkEvents.h"
+#include "NetworkInterface.h"
 #include "IPAddress.h"
 #include "WString.h"
 
@@ -17,6 +18,9 @@ public:
 	int hostByName(const char *aHostname, IPAddress &aResult);
 	uint8_t * macAddress(uint8_t * mac);
 	String macAddress();
+
+	bool setDefaultInterface(NetworkInterface & ifc);
+	NetworkInterface * getDefaultInterface();
 
     size_t printTo(Print & out) const;
 


### PR DESCRIPTION
Changes allow for selecting which network interface is the default outgoing interface, get route priority and implementation index (LwIP)