### PR TITLE
IDF release/v5.1

### DIFF
--- a/libraries/BLE/examples/BLE5_extended_scan/BLE5_extended_scan.ino
+++ b/libraries/BLE/examples/BLE5_extended_scan/BLE5_extended_scan.ino
@@ -20,7 +20,7 @@ uint32_t scanTime = 100; //In 10ms (1000ms)
 BLEScan* pBLEScan;
 
 class MyBLEExtAdvertisingCallbacks: public BLEExtAdvertisingCallbacks {
-    void onResult(esp_ble_gap_ext_adv_reprot_t report) {
+    void onResult(esp_ble_gap_ext_adv_report_t report) {
       if(report.event_type & ESP_BLE_GAP_SET_EXT_ADV_PROP_LEGACY){
         // here we can receive regular advertising data from BLE4.x devices
         Serial.println("BLE4.2");

--- a/libraries/BLE/examples/BLE5_periodic_sync/BLE5_periodic_sync.ino
+++ b/libraries/BLE/examples/BLE5_periodic_sync/BLE5_periodic_sync.ino
@@ -28,7 +28,7 @@ static esp_ble_gap_periodic_adv_sync_params_t periodic_adv_sync_params = {
 
 class MyBLEExtAdvertisingCallbacks : public BLEExtAdvertisingCallbacks
 {
-  void onResult(esp_ble_gap_ext_adv_reprot_t params)
+  void onResult(esp_ble_gap_ext_adv_report_t params)
   {
     uint8_t *adv_name = NULL;
     uint8_t adv_name_len = 0;

--- a/libraries/BLE/src/BLEAdvertisedDevice.h
+++ b/libraries/BLE/src/BLEAdvertisedDevice.h
@@ -145,7 +145,7 @@ public:
 	 * As we are scanning, we will find new devices.  When found, this call back is invoked with a reference to the
 	 * device that was found.  During any individual scan, a device will only be detected one time.
 	 */
-	virtual void onResult(esp_ble_gap_ext_adv_reprot_t report) = 0;
+	virtual void onResult(esp_ble_gap_ext_adv_report_t report) = 0;
 };
 #endif // SOC_BLE_50_SUPPORTED
 

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-3662303f31"
+              "version": "idf-release_v5.1-d23b7a0361"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-3662303f31",
+          "version": "idf-release_v5.1-d23b7a0361",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2c6907b9e2b6ff8d7d47c93d622827575190b806",
-              "archiveFileName": "esp32-arduino-libs-2c6907b9e2b6ff8d7d47c93d622827575190b806.zip",
-              "checksum": "SHA-256:33998f3ba0cf1080ef6a3c70d477b9d535944191a045f9078d427ee5e79afbe1",
-              "size": "352415499"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ca0a9395adebef4558b86d3f472e6054edcbec5e",
+              "archiveFileName": "esp32-arduino-libs-ca0a9395adebef4558b86d3f472e6054edcbec5e.zip",
+              "checksum": "SHA-256:5f147a253fc79b99fed10f03661e8665def76363c775b71e8d209e9770e523bb",
+              "size": "359217801"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 4ab9e16
esp-idf: release/v5.1 d23b7a0361
arduino: idf-release/v5.1 16dbcee9
tinyusb: master 42decf28f
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.0
espressif__esp-tflite-micro: 1.2.0
espressif__esp-zboss-lib: 1.2.2
espressif__esp-zigbee-lib: 1.2.2
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_rainmaker: 1.1.0
espressif__esp_schedule: 1.1.1
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__mdns: 1.2.5
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.5
joltwallet__littlefs: 1.14.2
```
