### PR TITLE
fix(sd): AquireSPI lock in sdcard_uninit

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -718,6 +718,7 @@ uint8_t sdcard_uninit(uint8_t pdrv)
     if (pdrv >= FF_VOLUMES || card == NULL) {
         return 1;
     }
+    AcquireSPI lock(card);
     sdTransaction(pdrv, GO_IDLE_STATE, 0, NULL);
     ff_diskio_register(pdrv, NULL);
     s_cards[pdrv] = NULL;


### PR DESCRIPTION
## Description of Change
This PR fixes SPI SD card thread-safe issue.

## Tests scenarios
Tested with SPI TFT and SD card on ESP32.

## Related links
Closes #9438 