### PR TITLE
fix: USB HID Keyboard raw report

### DIFF
--- a/libraries/USB/src/USBHIDKeyboard.cpp
+++ b/libraries/USB/src/USBHIDKeyboard.cpp
@@ -222,7 +222,7 @@ size_t USBHIDKeyboard::pressRaw(uint8_t k)
     uint8_t i;
     if (k >= 0xE0 && k < 0xE8) {
         // it's a modifier key
-        _keyReport.modifiers |= (1<<(k-0x80));
+        _keyReport.modifiers |= (1<<(k-0xE0));
     } else if (k && k < 0xA5) {
         // Add k to the key report only if it's not already present
         // and if there is an empty slot.
@@ -253,7 +253,7 @@ size_t USBHIDKeyboard::releaseRaw(uint8_t k)
     uint8_t i;
     if (k >= 0xE0 && k < 0xE8) {
         // it's a modifier key
-        _keyReport.modifiers &= ~(1<<(k-0x80));
+        _keyReport.modifiers &= ~(1<<(k-0xE0));
     } else if (k && k < 0xA5) {
         // Test the key report to see if k is present.  Clear it if it exists.
         // Check all positions in case the key is present more than once (which it shouldn't be)


### PR DESCRIPTION
## Description of Change
Fixes key modifier bitmap when using `USBHIDKeyboard::pressRaw(uint8_t k)` and `USBHIDKeyboard::releaseRaw(uint8_t k)`.

The modifiers are marked in a bitmap in the HID Report Descriptor. 
```
Bit:        7   6   5   4   3   2   1   0
          +---+---+---+---+---+---+---+---+
Byte 0    | RG| RA| RS| RC| LG| LA| LS| LC|  Modifier bits (LC=Left Control, LS= Left Shift, etc)
          +---+---+---+---+---+---+---+---+
Byte 1    |        Reserved byte          |
          +---+---+---+---+---+---+---+---+
Byte 2    |        Key 1                  |
          +---+---+---+---+---+---+---+---+
Byte 3    |        Key 2                  |
          +---+---+---+---+---+---+---+---+
Byte 4    |        Key 3                  |
          +---+---+---+---+---+---+---+---+
Byte 5    |        Key 4                  |
          +---+---+---+---+---+---+---+---+
Byte 6    |        Key 5                  |
          +---+---+---+---+---+---+---+---+
Byte 7    |        Key 6                  |
          +---+---+---+---+---+---+---+---+
```

## Tests scenarios
ESP32-S2

## Related links
Fix #9377 