### PR TITLE
Update of LED_ROBOHEART in RoboHeart Hercules pins_arduino.h

### DIFF
--- a/variants/roboheart_hercules/pins_arduino.h
+++ b/variants/roboheart_hercules/pins_arduino.h
@@ -15,7 +15,7 @@
 
 #define SLEEP_MOTOR_ABC 2  //  nSLEEP 
 
-#define LED_ROBOHEART 14  // Built in LED
+#define LED_ROBOHEART 13  // Built in LED
 #define BUILTIN_LED LED_ROBOHEART // backward compatibility
 #define LED_BUILTIN LED_ROBOHEART
 


### PR DESCRIPTION
The built-in "Blink" LED on the new version of the RoboHeart development board is connected to IO13 instead of IO14.

I am one of the founders of Augmented Robotics who oversees design and production of RoboHeart Hercules, see website: https://augmented-robotics.com/index.php/roboheart-hercules/

I am also the maintainer of the original RoboHeart Hercules Arduino library repository on github: https://github.com/Augmented-Robotics/roboheart-arduino-library

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.
It changes the pin definition of the built-in LED on the RoboHeart Hercules board. In the new version the built-in LED is connected to IO13 instead of IO14. This change only impacts the RoboHeart Hercules board by Augmented Robotics. 

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.
I have tested my Pull Request on Arduino-esp32 core v2.0.15 with the RoboHeart Hercules Board v0.6L, which uses ESP32-WROOM-32E as its main microcontroller.

