### PR TITLE
fixes RX1/TX1 + RX2/TX2 pins in HardwareSerial.h

### DIFF
--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -135,7 +135,7 @@ typedef enum {
 #endif
 
 // Default pins for UART1 are arbitrary, and defined here for convenience.
-
+#if SOC_UART_NUM > 1
 #ifndef RX1
     #if CONFIG_IDF_TARGET_ESP32
       #define RX1 (gpio_num_t)9


### PR DESCRIPTION
## Description of Change
As pointed out by a user, ESP32 and ESP32S2 had their defaut pins changed to avoid issue with PSRAM and Flash (DIO/QIO) pins.
That was done in #8800 for 3.0.0.
But it was also imported as part of #9176 to 2.0.15.

This PR fixes and rolls back those Pin chenges.

|          |   Name  | ESP32 | S2 | S3 | C3 |
|:--------:|:-------:|:-----:|:--:|:--:|:--:|
| UART0 RX | SOC_RX0 |   3   | 44 | 44 | 20 |
| UART0 TX | SOC_TX0 |   1   | 43 | 43 | 21 |
| UART1 RX |   RX1   |   ~26~ -> 9  | ~4~ -> 18 | 15 | 18 | 
| UART1 TX |   TX1   |   ~27~ -> 10  | ~5~ -> 17 | 16 | 19 |
| UART2 RX |   RX2   |  ~4~ -> 16   | -- | 19 | -- |
| UART2 TX |   TX2   |   ~25~ -> 17  | -- | 20 | -- |

@VojtechBartoska @me-no-dev - As HardwareSerial maintainer, I was not included in the Reviewer list in #8800.
This lead me to don't pay attention to the existance of such change. We must follow a clearer review standard.

## Tests scenarios
Just CI.

## Related links
Fixes #9500 