### PR TITLE
fix: restores UART1/2 pins as in 2.0.14

### DIFF
--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -138,9 +138,9 @@ typedef enum {
 #if SOC_UART_NUM > 1
 #ifndef RX1
     #if CONFIG_IDF_TARGET_ESP32
-      #define RX1 (gpio_num_t)26
+      #define RX1 (gpio_num_t)9
     #elif CONFIG_IDF_TARGET_ESP32S2
-      #define RX1 (gpio_num_t)4
+      #define RX1 (gpio_num_t)18
     #elif CONFIG_IDF_TARGET_ESP32C3
       #define RX1 (gpio_num_t)18
     #elif CONFIG_IDF_TARGET_ESP32S3
@@ -150,9 +150,9 @@ typedef enum {
 
   #ifndef TX1
     #if CONFIG_IDF_TARGET_ESP32
-      #define TX1 (gpio_num_t)27
+      #define TX1 (gpio_num_t)10
     #elif CONFIG_IDF_TARGET_ESP32S2
-      #define TX1 (gpio_num_t)5
+      #define TX1 (gpio_num_t)17
     #elif CONFIG_IDF_TARGET_ESP32C3
       #define TX1 (gpio_num_t)19
     #elif CONFIG_IDF_TARGET_ESP32S3
@@ -166,7 +166,7 @@ typedef enum {
 #if SOC_UART_NUM > 2
   #ifndef RX2
     #if CONFIG_IDF_TARGET_ESP32
-      #define RX2 (gpio_num_t)4
+      #define RX2 (gpio_num_t)16
     #elif CONFIG_IDF_TARGET_ESP32S3
       #define RX2 (gpio_num_t)19
     #endif
@@ -174,7 +174,7 @@ typedef enum {
 
   #ifndef TX2
     #if CONFIG_IDF_TARGET_ESP32
-      #define TX2 (gpio_num_t)25
+      #define TX2 (gpio_num_t)17
     #elif CONFIG_IDF_TARGET_ESP32S3
       #define TX2 (gpio_num_t)20
     #endif


### PR DESCRIPTION
## Description of Change
As pointed out by a user, ESP32 and ESP32S2 had their defalut pins changed to avoid issue with PSRAM and Flash (DIO/QIO) pins.

That was done in #8800 for 3.0.0. 
But it was also imported as part of #9176 to 2.0.15, by mistake.

This PR fixes and rolls back those Pin chenges.

|          |   Name  | ESP32 | S2 | S3 | C3 |
|:--------:|:-------:|:-----:|:--:|:--:|:--:|
| UART0 RX | SOC_RX0 |   3   | 44 | 44 | 20 |
| UART0 TX | SOC_TX0 |   1   | 43 | 43 | 21 |
| UART1 RX |   RX1   |   ~26~ -> 9  | ~4~ -> 18 | 15 | 18 | 
| UART1 TX |   TX1   |   ~27~ -> 10  | ~5~ -> 17 | 16 | 19 |
| UART2 RX |   RX2   |  ~4~ -> 16   | -- | 19 | -- |
| UART2 TX |   TX2   |   ~25~ -> 17  | -- | 20 | -- |

## Tests scenarios
Just CI.

## Related links
Fixes #9500 