### PR TITLE
[CI] Add Sizes Results workflow + fix of External lib results

### DIFF
--- a/.github/workflows/publishlib.yml
+++ b/.github/workflows/publishlib.yml
@@ -11,7 +11,7 @@ env:
   # It's convenient to set variables for values used multiple times in the workflow
   SKETCHES_REPORTS_PATH: artifacts/libraries-report
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  PR_EVENT_PATH: artifacts/Event File/event.json
+  PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
 
 jobs:
   lib-test-results:
@@ -25,17 +25,22 @@ jobs:
       - name: Download and Extract Artifacts
         run: |
           mkdir -p artifacts && cd artifacts
+          mkdir -p libraries-report
           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
           do
             IFS=$'\t' read name url <<< "$artifact"
             gh api $url > "$name.zip"
-            unzip -d "$name" "$name.zip"
+            unzip -j "$name.zip" -d "temp_$name"
+            mv "temp_$name"/* libraries-report
+            rm -r "temp_$name"
           done
+          echo "Contents of parent directory:"
+          ls -R ..
     
       - name: Report results
-        uses: P-R-O-C-H-Y/report-size-deltas@main
+        uses: P-R-O-C-H-Y/report-size-deltas@libs
         with:
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
           github-token: ${{ env.GITHUB_TOKEN }}
-          pr-event-path: ${{ env.PR_EVENT_PATH }}
+          pr-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/publishsizes.yml
+++ b/.github/workflows/publishsizes.yml
@@ -1,0 +1,54 @@
+name: Sizes Results
+
+on:
+  workflow_run:
+    workflows: [ESP32 Arduino CI]
+    types:
+      - completed
+
+  workflow_dispatch:
+env:
+  # It's convenient to set variables for values used multiple times in the workflow
+  SKETCHES_REPORTS_PATH: artifacts/sizes-report
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+
+jobs:
+  sizes-test-results:
+    name: Sizes Comparsion Results
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download and Extract Artifacts
+        run: |
+          mkdir -p artifacts && cd artifacts
+          mkdir -p sizes-report
+          mkdir -p sizes-report/master
+          mkdir -p sizes-report/pr
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -j "$name.zip" -d "temp_$name"
+            if [[ "$name" == *"master"* ]]; then
+              mv "temp_$name"/* sizes-report/master
+            elif [[ "$name" == *"pr"* ]]; then
+              mv "temp_$name"/* sizes-report/pr
+            else
+              mv "temp_$name"/* sizes-report
+            fi
+            rm -r "temp_$name"
+          done
+          echo "Contents of parent directory:"
+          ls -R ..
+    
+      - name: Report results
+        uses: P-R-O-C-H-Y/report-size-deltas@sizes_v2
+        with:
+          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
+          github-token: ${{ env.GITHUB_TOKEN }}
+          pr-number: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
## Description of Change
This PR adds a new workflow `Sizes Results`, which is used for printing the results to the PR as a GitHub-bot.
Also fixes External libs Results workflow to not need the event-file, which is causing issues. 

## Tests scenarios
Tested on my fork.

## Related links
