### PR TITLE
IDF c432c692fa

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf--d23b7a0361"
+              "version": "idf--c432c692fa"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf--d23b7a0361",
+          "version": "idf--c432c692fa",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/5daaf1a26c12b495975a367cf2c73b86ddee5d31",
-              "archiveFileName": "esp32-arduino-libs-5daaf1a26c12b495975a367cf2c73b86ddee5d31.zip",
-              "checksum": "SHA-256:6fe9a5643057449bbbe850cd0e7217f3f6753adc8d5da2807f0c071a1ccb44f1",
-              "size": "372257794"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/fbc464148f35fbcc0e93b17a7a21e25b035efedb",
+              "archiveFileName": "esp32-arduino-libs-fbc464148f35fbcc0e93b17a7a21e25b035efedb.zip",
+              "checksum": "SHA-256:bbf2d324c310e8a80e0a4c0c6b2464a7d0ffb2509ae2cc2d06e65a260f3d8bae",
+              "size": "371625301"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: feature/ppp_modem_support 3e386d3
esp-idf: c432c692fa
arduino: feature/ppp_after_linter eed6c578
tinyusb: master e54023d76
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.0
espressif__esp-tflite-micro: 1.2.0
espressif__esp-zboss-lib: 1.2.3
espressif__esp-zigbee-lib: 1.2.3
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.1.0
espressif__esp_schedule: 1.1.1
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__mdns: 1.3.0
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.5
joltwallet__littlefs: 1.14.4
```
