### PR TITLE
Fixed typo for adc_continuous_data typedef in esp32-hal-adc.h/.c

### DIFF
--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -360,7 +360,7 @@ static uint8_t __adcContinuousAtten = ADC_11db;
 static uint8_t __adcContinuousWidth = SOC_ADC_DIGI_MAX_BITWIDTH;
 
 static uint8_t used_adc_channels = 0;
-adc_continuos_data_t *adc_result = NULL;
+adc_continuous_data_t *adc_result = NULL;
 
 static bool adcContinuousDetachBus(void *adc_unit_number) {
   adc_unit_t adc_unit = (adc_unit_t)adc_unit_number - 1;
@@ -537,7 +537,7 @@ bool analogContinuous(uint8_t pins[], size_t pins_count, uint32_t conversions_pe
   }
 
   //Allocate and prepare result structure for adc readings
-  adc_result = malloc(pins_count * sizeof(adc_continuos_data_t));
+  adc_result = malloc(pins_count * sizeof(adc_continuous_data_t));
   for (int k = 0; k < pins_count; k++) {
     adc_result[k].pin = pins[k];
     adc_result[k].channel = channel[k];
@@ -578,7 +578,7 @@ bool analogContinuous(uint8_t pins[], size_t pins_count, uint32_t conversions_pe
   return true;
 }
 
-bool analogContinuousRead(adc_continuos_data_t **buffer, uint32_t timeout_ms) {
+bool analogContinuousRead(adc_continuous_data_t **buffer, uint32_t timeout_ms) {
   if (adc_handle[ADC_UNIT_1].adc_continuous_handle != NULL) {
     uint32_t bytes_read = 0;
     uint32_t read_raw[used_adc_channels];

--- a/cores/esp32/esp32-hal-adc.h
+++ b/cores/esp32/esp32-hal-adc.h
@@ -86,7 +86,7 @@ extern "C" {
     uint8_t channel;     /*!<ADC channel */
     int avg_read_raw;    /*!<ADC average raw data */
     int avg_read_mvolts; /*!<ADC average voltage in mV */
-  } adc_continuos_data_t;
+  } adc_continuous_data_t;
 
   /*
  * Setup ADC continuous peripheral
@@ -96,7 +96,7 @@ extern "C" {
   /*
  * Read ADC continuous conversion data
  * */
-  bool analogContinuousRead(adc_continuos_data_t** buffer, uint32_t timeout_ms);
+  bool analogContinuousRead(adc_continuous_data_t** buffer, uint32_t timeout_ms);
 
   /*
  * Start ADC continuous conversions

--- a/docs/en/api/adc.rst
+++ b/docs/en/api/adc.rst
@@ -184,7 +184,7 @@ If ``false`` is returned, error occurs and ADC continuous was not configured.
 analogContinuousRead
 ^^^^^^^^^^^^^^^^^^^^
 
-This function is used to read ADC continuous data to the result buffer. The result buffer is an array of ``adc_continuos_data_t``.
+This function is used to read ADC continuous data to the result buffer. The result buffer is an array of ``adc_continuous_data_t``.
 
 .. code-block:: arduino
 
@@ -193,13 +193,13 @@ This function is used to read ADC continuous data to the result buffer. The resu
         uint8_t channel;       /*!<ADC channel */
         int avg_read_raw;      /*!<ADC average raw data */
         int avg_read_mvolts;   /*!<ADC average voltage in mV */
-    } adc_continuos_data_t;
+    } adc_continuous_data_t;
 
 .. code-block:: arduino
 
-    bool analogContinuousRead(adc_continuos_data_t ** buffer, uint32_t timeout_ms);
+    bool analogContinuousRead(adc_continuous_data_t ** buffer, uint32_t timeout_ms);
 
-* ``buffer`` conversion result buffer to read from ADC in adc_continuos_data_t format.
+* ``buffer`` conversion result buffer to read from ADC in adc_continuous_data_t format.
 * ``timeout_ms`` time to wait for data in milliseconds.
 
 This function will return ``true`` if reading is successful and ``buffer`` is filled with data.

--- a/libraries/ESP32/examples/AnalogReadContinuous/AnalogReadContinuous.ino
+++ b/libraries/ESP32/examples/AnalogReadContinuous/AnalogReadContinuous.ino
@@ -16,7 +16,7 @@ uint8_t adc_pins_count = sizeof(adc_pins) / sizeof(uint8_t);
 volatile bool adc_coversion_done = false;
 
 // Result structure for ADC Continuous reading
-adc_continuos_data_t* result = NULL;
+adc_continuous_data_t* result = NULL;
 
 // ISR Function that will be triggered when ADC conversion is done
 void ARDUINO_ISR_ATTR adcComplete() {

--- a/tests/periman/periman.ino
+++ b/tests/periman/periman.ino
@@ -158,7 +158,7 @@ void adc_continuous_test(void) {
   test_executed = true;
   uint8_t adc_pins[] = { ADC1_DEFAULT, ADC2_DEFAULT };
   uint8_t adc_pins_count = 2;
-  adc_continuos_data_t* result = NULL;
+  adc_continuous_data_t* result = NULL;
 
   analogContinuousSetWidth(12);
   analogContinuousSetAtten(ADC_11db);


### PR DESCRIPTION
Fixed typo in adc_continuous_data typedef

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

## Description of Change
Please describe your proposed Pull Request and it's impact.

A simple typo adjustment. It's impact is more clarity when developing. Less distraction.


## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)
Tested on ESP32-S3 while using ADC Continuous Mode to read off 4 pins at a time continuously while utilizing ISR after each conversion. Very close scenario to the example scenario.

## Related links
Please provide links to related issue, PRs etc.
It's just a typo. 