### PR TITLE
Fix External libs test to not upload PR number if not labeled

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -125,7 +125,7 @@ jobs:
   #Upload PR number as artifact
   upload-pr-number:
     name: Upload PR number
-    if: github.event_name == 'pull_request'
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'lib_test'))
     runs-on: ubuntu-latest
     steps:
       - name: Save the PR number in an artifact


### PR DESCRIPTION
## Description of Change
Skip uploading PR number if PR is not labeled to run lib testing

## Tests scenarios

## Related links
