### PR TITLE
fix(release): Temporary halt JSON uploads on release, until generator is fixed

### DIFF
--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -399,17 +399,17 @@ if [ "$RELEASE_PRE" == "false" ]; then
     fi
 fi
 
-# Upload package JSONs
-echo "Uploading $PACKAGE_JSON_DEV ..."
-echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV"`
-echo "Pages URL: "`git_safe_upload_to_pages "$PACKAGE_JSON_DEV" "$OUTPUT_DIR/$PACKAGE_JSON_DEV"`
-echo
-if [ "$RELEASE_PRE" == "false" ]; then
-    echo "Uploading $PACKAGE_JSON_REL ..."
-    echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
-    echo "Pages URL: "`git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
-    echo
-fi
+# Upload package JSONs (temporary halted to fix json generation)
+# echo "Uploading $PACKAGE_JSON_DEV ..."
+# echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV"`
+# echo "Pages URL: "`git_safe_upload_to_pages "$PACKAGE_JSON_DEV" "$OUTPUT_DIR/$PACKAGE_JSON_DEV"`
+# echo
+# if [ "$RELEASE_PRE" == "false" ]; then
+#     echo "Uploading $PACKAGE_JSON_REL ..."
+#     echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
+#     echo "Pages URL: "`git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
+#     echo
+# fi
 
 set +e
 

--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -400,16 +400,16 @@ if [ "$RELEASE_PRE" == "false" ]; then
 fi
 
 # Upload package JSONs (temporary halted to fix json generation)
-# echo "Uploading $PACKAGE_JSON_DEV ..."
-# echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV"`
+echo "Uploading $PACKAGE_JSON_DEV ..."
+echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV"`
 # echo "Pages URL: "`git_safe_upload_to_pages "$PACKAGE_JSON_DEV" "$OUTPUT_DIR/$PACKAGE_JSON_DEV"`
-# echo
-# if [ "$RELEASE_PRE" == "false" ]; then
-#     echo "Uploading $PACKAGE_JSON_REL ..."
-#     echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
-#     echo "Pages URL: "`git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
-#     echo
-# fi
+echo
+if [ "$RELEASE_PRE" == "false" ]; then
+    echo "Uploading $PACKAGE_JSON_REL ..."
+    echo "Download URL: "`git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
+    # echo "Pages URL: "`git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL"`
+    echo
+fi
 
 set +e
 


### PR DESCRIPTION
Last few release JSONs were broken. We are halting their auto-upload until the issues are fixed. JSONs will be manually vetted and uploaded to gh-pages
