### PR TITLE
ci(install): Change "arch" to distro-agnostic "uname -m"

### DIFF
--- a/.github/scripts/install-arduino-cli.sh
+++ b/.github/scripts/install-arduino-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OSBITS=`arch`
+OSBITS=`uname -m`
 if [[ "$OSTYPE" == "linux"* ]]; then
     export OS_IS_LINUX="1"
     if [[ "$OSBITS" == "i686" ]]; then

--- a/.github/scripts/install-arduino-ide.sh
+++ b/.github/scripts/install-arduino-ide.sh
@@ -4,7 +4,7 @@
 #OSTYPE: 'msys', ARCH: 'x86_64' => win32
 #OSTYPE: 'darwin18', ARCH: 'i386' => macos
 
-OSBITS=`arch`
+OSBITS=`uname -m`
 if [[ "$OSTYPE" == "linux"* ]]; then
     export OS_IS_LINUX="1"
     ARCHIVE_FORMAT="tar.xz"


### PR DESCRIPTION
## Description of Change
Change the `arch` command to `uname -m` in the install scripts.
This will make debugging the CI scripts easier when running in a distro that doesn't contain the `arch` command.

## Tests scenarios
Tested locally and CI

