### PR TITLE
added EEPROM.update(address, val) method

### DIFF
--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -45,7 +45,9 @@ public:
   uint16_t length();
   bool commit();
   void end();
-
+  void update(int address, uint8_t val) {
+    if (read(address) != val) write(address, val);
+  }
   uint8_t *getDataPtr();
   uint16_t convert(bool clear, const char *EEPROMname = "eeprom", const char *nvsname = "eeprom");
 


### PR DESCRIPTION
EEPROM.update(address, val) is part of the official Arduino API. See https://wiki-content.arduino.cc/en/Tutorial/LibraryExamples/EEPROMUpdate for more information.

-----------
## Description of Change
This change adds a missing function to the EEPROM interface. Without the 'EEPROM.update(address, val)' function the EEPROM API is not complete and breaks compilation of Arduino sketches that depend on it.


## Tests scenarios
I have tested this pull request on Arduino-esp32 core v2.0.11 and ESP32-S2-mini board. The software was tested on Afterburner project, the code which uses EEPROM.update(address, val) function is located here:
https://github.com/ole00/afterburner/blob/master/aftb_vpp.h

## Related links
see issue #6066


