### PR TITLE
NetworkClient - don't stop() in destroy

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -178,7 +178,6 @@ NetworkClient::NetworkClient(int fd) : _connected(true), _timeout(WIFI_CLIENT_DE
 }
 
 NetworkClient::~NetworkClient() {
-  stop();
 }
 
 void NetworkClient::stop() {


### PR DESCRIPTION
Destroy of a NetworkClient instance should not close the TCP connection unless it is the last copy handling that connection. Thanks to shared_ptr NetworkClientSocketHandle instance closes the connection as it is destroyed when the last copy of NetworkClient for that connection is destroyed. 