### PR TITLE
Fix hal-uart truncated tx/rx buffer size (uint16_t -> uint32_t)

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -375,7 +375,7 @@ bool uartSetHwFlowCtrlMode(uart_t *uart, uart_hw_flowcontrol_t mode, uint8_t thr
 
 // This helper function will return true if a new IDF UART driver needs to be restarted and false if the current one can continue its execution
 bool _testUartBegin(
-  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted,
+  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted,
   uint8_t rxfifo_full_thrhd
 ) {
   if (uart_nr >= SOC_UART_NUM) {
@@ -397,7 +397,7 @@ bool _testUartBegin(
 }
 
 uart_t *uartBegin(
-  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted,
+  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted,
   uint8_t rxfifo_full_thrhd
 ) {
   if (uart_nr >= SOC_UART_NUM) {

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -33,11 +33,11 @@ struct uart_struct_t;
 typedef struct uart_struct_t uart_t;
 
 bool _testUartBegin(
-  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted,
+  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted,
   uint8_t rxfifo_full_thrhd
 );
 uart_t *uartBegin(
-  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted,
+  uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted,
   uint8_t rxfifo_full_thrhd
 );
 void uartEnd(uint8_t uart_num);


### PR DESCRIPTION
## Description of Change

Changed the parameter types of `rx_buffer_size` and `tx_buffer_size` in the incoming parameters of the `uartBegin` function from `uint16_t` to `uint32_t`, which solved 2 issues:
- When setting a tx / rx buffer larger than 65535 bytes, the function returns normally without warning, but the actual buffer is not the same as the one set by the user.
- Be able to use tx / rx buffer which larger than 65535 bytes.

## Tests scenarios

- Arduino IDE 2.3.2 Linux_64
- ESP32S3

## Related links

The `uart_driver_install` function accepts incoming tx / rx buffer size parameters of type `int`: https://github.com/espressif/esp-idf/blob/636ff35b52f10e1a804a3760a5bd94e68f4b1b71/components/esp_driver_uart/include/driver/uart.h#L113
