### PR TITLE
feat (uart): uses the same IDF 32bits size for TX/RX buffers

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -236,27 +236,27 @@ void HardwareSerial::_uartEventTask(void *args)
                                 uart->_onReceiveCB();
                         break;
                     case UART_FIFO_OVF:
-                        log_w("UART%d FIFO Overflow. Consider adding Hardware Flow Control to your Application.", uart->_uart_nr);
+                        log_v("UART%d FIFO Overflow. Consider adding Hardware Flow Control to your Application.", uart->_uart_nr);
                         currentErr = UART_FIFO_OVF_ERROR;
                         break;
                     case UART_BUFFER_FULL:
-                        log_w("UART%d Buffer Full. Consider increasing your buffer size of your Application.", uart->_uart_nr);
+                        log_v("UART%d Buffer Full. Consider increasing your buffer size of your Application.", uart->_uart_nr);
                         currentErr = UART_BUFFER_FULL_ERROR;
                         break;
                     case UART_BREAK:
-                        log_w("UART%d RX break.", uart->_uart_nr);
+                        log_v("UART%d RX break.", uart->_uart_nr);
                         currentErr = UART_BREAK_ERROR;
                         break;
                     case UART_PARITY_ERR:
-                        log_w("UART%d parity error.", uart->_uart_nr);
+                        log_v("UART%d parity error.", uart->_uart_nr);
                         currentErr = UART_PARITY_ERROR;
                         break;
                     case UART_FRAME_ERR:
-                        log_w("UART%d frame error.", uart->_uart_nr);
+                        log_v("UART%d frame error.", uart->_uart_nr);
                         currentErr = UART_FRAME_ERROR;
                         break;
                     default:
-                        log_w("UART%d unknown event type %d.", uart->_uart_nr, event.type);
+                        log_v("UART%d unknown event type %d.", uart->_uart_nr, event.type);
                         break;
                 }
                 if (currentErr != UART_NO_ERROR) {

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -301,7 +301,7 @@ bool uartSetHwFlowCtrlMode(uart_t *uart, uart_hw_flowcontrol_t mode, uint8_t thr
 }
 
 // This helper function will return true if a new IDF UART driver needs to be restarted and false if the current one can continue its execution
-bool _testUartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd)
+bool _testUartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd)
 {
     if(uart_nr >= SOC_UART_NUM) {
         return false;  // no new driver has to be installed
@@ -320,7 +320,7 @@ bool _testUartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t 
     }
 }
 
-uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd)
+uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd)
 {
     if(uart_nr >= SOC_UART_NUM) {
         log_e("UART number is invalid, please use number from 0 to %u", SOC_UART_NUM - 1);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -29,8 +29,8 @@ extern "C" {
 struct uart_struct_t;
 typedef struct uart_struct_t uart_t;
 
-bool _testUartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd);
-uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint16_t rx_buffer_size, uint16_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd);
+bool _testUartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd);
+uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rxPin, int8_t txPin, uint32_t rx_buffer_size, uint32_t tx_buffer_size, bool inverted, uint8_t rxfifo_full_thrhd);
 void uartEnd(uint8_t uart_num);
 
 // This is used to retrieve the Event Queue pointer from a UART IDF Driver in order to allow user to deal with its events


### PR DESCRIPTION
## Description of Change

Uses the same IDF 32bits size for TX/RX buffers.

Changed header files to use the same IDF buffer limits.
* this is a backport from PR #9554

## Tests scenarios
CI Only.

## Related links
related to #9554 