### PR TITLE
(feat)usbmsc: Add is_writable function to the USBMSC class.

### DIFF
--- a/cores/esp32/USBMSC.h
+++ b/cores/esp32/USBMSC.h
@@ -44,6 +44,7 @@ public:
   void productID(const char *pid);        //max 16 chars
   void productRevision(const char *ver);  //max 4 chars
   void mediaPresent(bool media_present);
+  void isWritable(bool is_writable);
   void onStartStop(msc_start_stop_cb cb);
   void onRead(msc_read_cb cb);
   void onWrite(msc_write_cb cb);

--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -390,6 +390,10 @@ __attribute__((weak)) int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint
 __attribute__((weak)) int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void *buffer, uint16_t bufsize) {
   return -1;
 }
+__attribute__ ((weak)) bool tud_msc_is_writable_cb (uint8_t lun){
+  return false;
+}
+
 #endif
 
 /*


### PR DESCRIPTION
## Description of Change
Add is_writable function to the USBMSC class.
Expose the tinyusb tud_msc_is_writable_cb callback function to the USBMSC class.
Allows to mount an MSC in read-only mode.

eg : 
`MSC.mediaPresent(true);
`
 `MSC.isWritable(false); // make it read-only
`
 `MSC.begin(DISK_SECTOR_COUNT, DISK_SECTOR_SIZE);
`

## Tests scenarios
tested on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S3 Board with this scenario

