### PR TITLE
Update variant unphone9 with digital pin mappings

### DIFF
--- a/variants/unphone9/pins_arduino.h
+++ b/variants/unphone9/pins_arduino.h
@@ -56,4 +56,13 @@ static const uint8_t T12 = 13;
 static const uint8_t T13 = 14;
 static const uint8_t T14 = 15;
 
+static const uint8_t D5 = 14;
+static const uint8_t D6 = 7;
+static const uint8_t D9 = 15;
+static const uint8_t D10 = 16;
+static const uint8_t D11 = 17;
+static const uint8_t D12 = 12;
+static const uint8_t D13 = 13;
+static const uint8_t D21 = 47;
+
 #endif /* Pins_Arduino_h */

--- a/variants/unphone9/pins_arduino.h
+++ b/variants/unphone9/pins_arduino.h
@@ -64,5 +64,6 @@ static const uint8_t D11 = 17;
 static const uint8_t D12 = 12;
 static const uint8_t D13 = 13;
 static const uint8_t D21 = 47;
+#define UNPHONE_D_PINS_MAPPED
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
This change only affects a single board variant, the unPhone. As co-designer of the board I confirm that this change will allow users to work with our hardware using this codebase more easily. No restrictions are imposed on the use of this code.

## Tests scenarios
We have sucessfully tested this change on an unPhone9.

## Related links
unphone description can be found at [unphone.net](https://unphone.net/)