### PR TITLE
define HTTP_METHOD_STR as static const to save RAM

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -32,7 +32,7 @@
 
 #define __STR(a) #a
 #define _STR(a)  __STR(a)
-const char *_http_method_str[] = {
+static const char *_http_method_str[] = {
 #define XX(num, name, string) _STR(name),
   HTTP_METHOD_MAP(XX)
 #undef XX


### PR DESCRIPTION

## Description of Change
defines constant array as to strings as static const so that it moves from RAM to Flash

## Tests scenarios
I have tested this using Arduino-esp32 core v2.0.16 running FluidNC - http://wiki.fluidnc.com/

This should be cherry-picked into the v2.0.x branch
