### PR TITLE
BLEAdvertising.h: Fix spelling mistake in setScanFilter parameter

### DIFF
--- a/libraries/BLE/src/BLEAdvertising.h
+++ b/libraries/BLE/src/BLEAdvertising.h
@@ -62,7 +62,7 @@ public:
   void setMaxInterval(uint16_t maxinterval);
   void setMinInterval(uint16_t mininterval);
   void setAdvertisementData(BLEAdvertisementData &advertisementData);
-  void setScanFilter(bool scanRequertWhitelistOnly, bool connectWhitelistOnly);
+  void setScanFilter(bool scanRequestWhitelistOnly, bool connectWhitelistOnly);
   void setScanResponseData(BLEAdvertisementData &advertisementData);
   void setPrivateAddress(esp_ble_addr_type_t type = BLE_ADDR_TYPE_RANDOM);
   void setDeviceAddress(esp_bd_addr_t addr, esp_ble_addr_type_t type = BLE_ADDR_TYPE_RANDOM);


### PR DESCRIPTION
-----------
## Description of Change
Fix minor spelling mistake in setScanFilter Parameter. 
Issue is only in .h file, not .cpp file

## Tests scenarios
No tests changed

## Related links
no links relevant
