### PR TITLE
fix: I2C pin are relocated for arduino nano compatability

### DIFF
--- a/variants/Geekble_ESP32C3/pins_arduino.h
+++ b/variants/Geekble_ESP32C3/pins_arduino.h
@@ -14,8 +14,8 @@ static const uint8_t SW_BUILTIN = 9;
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
 
-static const uint8_t SDA = 8;
-static const uint8_t SCL = 9;
+static const uint8_t SDA = 4;
+static const uint8_t SCL = 5;
 
 static const uint8_t SS = 7;
 static const uint8_t MOSI = 6;


### PR DESCRIPTION
## Description of Change
I2C pin are relocated for arduino nano compatability

## Tests scenarios
Tested with I2C ADC Modules.

## Related links
https://github.com/SooDragon/GeekbleMini-ESP32C3
