### PR TITLE
Arduino core for the esp32 - Add new function "bool isDirty()" to EEPROM.h and EEPROM.cpp

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -133,6 +133,10 @@ void EEPROMClass::end() {
   _handle = 0;
 }
 
+bool EEPROMClass::isDirty() {
+  return _dirty;
+}
+
 uint8_t EEPROMClass::read(int address) {
   if (address < 0 || (size_t)address >= _size) {
     return 0;

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -45,6 +45,7 @@ public:
   uint16_t length();
   bool commit();
   void end();
+  bool isDirty();
 
   uint8_t *getDataPtr();
   uint16_t convert(bool clear, const char *EEPROMname = "eeprom", const char *nvsname = "eeprom");


### PR DESCRIPTION

-----------
## Description of Change

Added new function "bool isDirty()" to EEPROM.h and EEPROM.cpp

In Deep-Sleep sensor EUTs where data is initially stored in rtc-memory, before being intermittently transferred to EEPROM, it is very useful to know if the EEPROM is dirty [function “EEPROM.isDirty()”], so that if so you can transfer the rtc-memory-data into the EEPROM before doing an “EEPROM.commit()”.

See https://github.com/espressif/arduino-esp32/issues/9589


## Tests scenarios
I have tested my Pull Request on Arduino-esp32 (github as at 10May24) with ESP32 and ModeMCU-32S Board with this scenario.

## Related links
Closes https://github.com/espressif/arduino-esp32/issues/9589
