### PR TITLE
NetworkClientSecure made copyable

### DIFF
--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.h
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.h
@@ -24,10 +24,11 @@
 #include "IPAddress.h"
 #include "Network.h"
 #include "ssl_client.h"
+#include <memory>
 
 class NetworkClientSecure : public NetworkClient {
 protected:
-  sslclient_context *sslclient;
+  std::shared_ptr<sslclient_context> sslclient;
 
   int _lastError = 0;
   int _peek = -1;
@@ -97,14 +98,14 @@ public:
     return mbedtls_ssl_get_peer_cert(&sslclient->ssl_ctx);
   };
   bool getFingerprintSHA256(uint8_t sha256_result[32]) {
-    return get_peer_fingerprint(sslclient, sha256_result);
+    return get_peer_fingerprint(sslclient.get(), sha256_result);
   };
   int fd() const;
 
   operator bool() {
     return connected();
   }
-  NetworkClientSecure &operator=(const NetworkClientSecure &other);
+
   bool operator==(const bool value) {
     return bool() == value;
   }

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -344,7 +344,7 @@ int ssl_starttls_handshake(sslclient_context *ssl_client) {
   return ssl_client->socket;
 }
 
-void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key) {
+void stop_ssl_socket(sslclient_context *ssl_client) {
   log_v("Cleaning SSL connection.");
 
   if (ssl_client->socket >= 0) {

--- a/libraries/NetworkClientSecure/src/ssl_client.h
+++ b/libraries/NetworkClientSecure/src/ssl_client.h
@@ -34,7 +34,7 @@ int start_ssl_client(
   const char *cli_cert, const char *cli_key, const char *pskIdent, const char *psKey, bool insecure, const char **alpn_protos
 );
 int ssl_starttls_handshake(sslclient_context *ssl_client);
-void stop_ssl_socket(sslclient_context *ssl_client, const char *rootCABuff, const char *cli_cert, const char *cli_key);
+void stop_ssl_socket(sslclient_context *ssl_client);
 int data_to_read(sslclient_context *ssl_client);
 int send_ssl_data(sslclient_context *ssl_client, const uint8_t *data, size_t len);
 int get_ssl_receive(sslclient_context *ssl_client, uint8_t *data, int length);


### PR DESCRIPTION
The PR makes NetworkClentSecure copyable as required by Arduino networking API.

I checked with Wireshark that the connection is closed using stop() or when the last copy is destroyed.

A test sketch
```
#include <WiFi.h>
#include <WiFiClientSecure.h>

const char *ssid = "yourssid";
const char *password = "yourpasswd";

const char* server = "example.com";

WiFiClientSecure connect() {
  WiFiClientSecure client;
  client.setInsecure();
  Serial.println("Starting connection to server...");
  if (client.connect(server, 443)) {
    Serial.println("connected to server");
    client.println("GET / HTTP/1.1");
    client.print("Host: ");
    client.println(server);
    client.println();
  }
  return client;
}

void stop(WiFiClientSecure client) {
  client.stop();
}

void setup() {
  Serial.begin(115200);
  while (!Serial);

  Serial.println("Waiting for connection to WiFi");
  WiFi.begin(ssid, password);
  while (WiFi.status() != WL_CONNECTED) {
    delay(1000);
    Serial.print('.');
  }
  Serial.println();
  Serial.println("Connected to WiFi network.");

  WiFiClientSecure client = connect();
  client.find("\r\n\r\n");
  while (client.available()) {
    char c = client.read();
    Serial.write(c);
  }
//  stop(client);
//  delay(3000);
}

void loop() {
  delay(1);
}
```