### PR TITLE
Reduced GPIO17 (Ethernet clock GPIO) signal strength to reduce noise. 

### DIFF
--- a/variants/esp32-gateway/variant.cpp
+++ b/variants/esp32-gateway/variant.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2024 Olimex Ltd (support@olimex.com)
@@ -28,9 +28,8 @@
 
 extern "C" {
 // Initialize variant/board, called before setup()
-void initVariant(void)
-{
-// Change the drive strength of the digital output num 17 from the default value 20mA to 5mA
-gpio_set_drive_capability((gpio_num_t)GPIO_NUM_17, GPIO_DRIVE_CAP_0); 
+void initVariant(void) {
+  // Change the drive strength of the digital output num 17 from the default value 20mA to 5mA
+  gpio_set_drive_capability((gpio_num_t)GPIO_NUM_17, GPIO_DRIVE_CAP_0);
 }
 }

--- a/variants/esp32-gateway/variant.cpp
+++ b/variants/esp32-gateway/variant.cpp
@@ -1,0 +1,36 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Olimex Ltd (support@olimex.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+#include "driver/gpio.h"
+
+extern "C" {
+// Initialize variant/board, called before setup()
+void initVariant(void)
+{
+// Change the drive strength of the digital output num 17 from the default value 20mA to 5mA
+gpio_set_drive_capability((gpio_num_t)GPIO_NUM_17, GPIO_DRIVE_CAP_0); 
+}
+}


### PR DESCRIPTION
Hello guys,

Olimex employee here. We received feedback from customers about some noise in Olimex ESP32-GATEWAY design. We did own tests and confirmed there is some noise coming from the GPIO pin we use to feed the clock to the Ethernet. This is GPIO17. It appears all GPIO strength is set to the maximum level 3 - 20mA. Reducing the Ethernet clock GPIO signal strength reduces the noise a lot. There is no benefit for Ethernet clock GPIO to be at max strength for our boards with Ethernet. Reducing the strength of that pin has only benefits for our ESP32-GATEWAY design.

The addition applies only to ESP32-GATEWAY in the folder of its variant we've added a cpp file with GPIO_DRIVE_CAP_0 for GPIO17. Let me know if something is not done properly.

Thanks for your work.