### PR TITLE
ci(optimization): Run workflows only when related files change

### DIFF
--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -1,8 +1,11 @@
 name: Boards Test
 
-# The workflow will run on schedule and labeled pull requests
 on:
   pull_request:
+    paths:
+      - 'boards.txt'
+      - 'libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino'
+      - '.github/workflows/boards.yml'
 
 env:
   # It's convenient to set variables for values used multiple times in the workflow
@@ -24,7 +27,7 @@ jobs:
         uses: dcarbone/install-jq-action@v1.0.1
 
       - name: Get board name
-        run: 
+        run:
           bash .github/scripts/find_new_boards.sh ${{ github.repository }} ${{github.event.number}}
 
   test-boards:

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -3,6 +3,16 @@ name: Run tests
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
+    paths:
+      - 'tests/**'
+      - 'cores/**'
+      - 'libraries/**'
+      - 'package/**'
+      - '.github/workflows/hil.yml'
+      - '.github/workflows/wokwi.yml'
+      - '.github/scripts/install-*.sh'
+      - '.github/scripts/tests_*.sh'
+      - '.github/scripts/sketch_utils.sh'
 
   schedule:
     - cron: '0 2 * * *'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,20 @@ on:
     - master
     - release/*
   pull_request:
+    paths:
+      - 'cores/**'
+      - 'libraries/**'
+      - 'package/**'
+      - 'tools/**.py'
+      - 'platform.txt'
+      - 'programmers.txt'
+      - 'package.json'
+      - '.github/workflows/push.yml'
+      - '.github/scripts/**'
+      - '!.github/scripts/find_*'
+      - '!.github/scripts/on-release.sh'
+      - '!.github/scripts/tests_*'
+      - '!.github/scripts/upload_*'
 
 concurrency:
   group: build-${{github.event.pull_request.number || github.ref}}
@@ -127,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Check out repository
-      - name: Checkout repository    
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -143,7 +157,7 @@ jobs:
           pattern: pr_cli_compile_*
           merge-multiple: true
           path: master_cli_compile
-        
+
       - name: List files in the directory
         run: ls -R
 
@@ -155,7 +169,7 @@ jobs:
           git add --all
           git commit -m "Updated cli compile json files"
           git push origin HEAD:gh-pages
-  
+
   #Upload PR number as artifact
   upload-pr-number:
     name: Upload PR number


### PR DESCRIPTION
## Description of Change
Speed up the CI in some cases by making it run only the workflows related to the change.
This is the first step towards improving CI speed. Later the workflows will only compile the files that were changed.

## Tests scenarios
CI
