### PR TITLE
Fix class used for web client in WiFiClientEnterprise.ino

### DIFF
--- a/libraries/WiFi/examples/WiFiClientEnterprise/WiFiClientEnterprise.ino
+++ b/libraries/WiFi/examples/WiFiClientEnterprise/WiFiClientEnterprise.ino
@@ -65,7 +65,7 @@ void loop() {
   }
   Serial.print("Connecting to website: ");
   Serial.println(host);
-  NetworkClient client;
+  WiFiClient client;
   if (client.connect(host, 80)) {
     String url = "/rele/rele1.txt";
     client.print(String("GET ") + url + " HTTP/1.1\r\n" + "Host: " + host + "\r\n" + "User-Agent: ESP32\r\n" + "Connection: close\r\n\r\n");


### PR DESCRIPTION
Fix error as NetworkClient class is not found in the context. Used WiFiClient class instead.

## Description of Change
Replaced NetworkClient class with WiFiClient one as NetworkClient was not declared.

## Tests scenarios
Successfully compiled after change on Arduino IDE 2.3.2, platform 2.0.16, and PlatformIO in VSCode, platform 6.1.0, in both cases ESP32 Dev Module selected. Uploaded to an ESP32 Mini D1 by AZ-Delivery.

## Related links
No related issue found.
