### PR TITLE
NetworkClientSecure - copyability improvements and _timeout shadowing fixed

### DIFF
--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.h
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.h
@@ -30,9 +30,6 @@ class NetworkClientSecure : public NetworkClient {
 protected:
   std::shared_ptr<sslclient_context> sslclient;
 
-  int _lastError = 0;
-  int _peek = -1;
-  int _timeout;
   bool _use_insecure;
   bool _stillinPlainStart = false;
   const char *_CA_cert;

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -48,6 +48,7 @@ void ssl_init(sslclient_context *ssl_client) {
   mbedtls_ssl_init(&ssl_client->ssl_ctx);
   mbedtls_ssl_config_init(&ssl_client->ssl_conf);
   mbedtls_ctr_drbg_init(&ssl_client->drbg_ctx);
+  ssl_client->peek_buf = -1;
 }
 
 int start_ssl_client(
@@ -368,12 +369,15 @@ void stop_ssl_socket(sslclient_context *ssl_client) {
   // save only interesting fields
   int handshake_timeout = ssl_client->handshake_timeout;
   int socket_timeout = ssl_client->socket_timeout;
+  int last_err = ssl_client->last_error;
 
   // reset embedded pointers to zero
   memset(ssl_client, 0, sizeof(sslclient_context));
 
   ssl_client->handshake_timeout = handshake_timeout;
   ssl_client->socket_timeout = socket_timeout;
+  ssl_client->last_error = last_err;
+  ssl_client->peek_buf = -1;
 }
 
 int data_to_read(sslclient_context *ssl_client) {

--- a/libraries/NetworkClientSecure/src/ssl_client.h
+++ b/libraries/NetworkClientSecure/src/ssl_client.h
@@ -26,6 +26,10 @@ typedef struct sslclient_context {
 
   unsigned long socket_timeout;
   unsigned long handshake_timeout;
+
+  int last_error;
+  int peek_buf;
+
 } sslclient_context;
 
 void ssl_init(sslclient_context *ssl_client);


### PR DESCRIPTION
The PR has 3 fixes for NetworkClientSecure

1) buffer to store the peeked byte is moved into the shared objects to be shared between NetworkClientSecure copies
2) last error code is moved into the shared objects to be available in all copies
3) NetworkClientSecure::_timeout shadowed NetworkClient::_timeout and then NetworkClient::setConnectionTimeout didn't set the timeout for NetworkClientSecure

test (to test the last error change port to 80)
```
#include <WiFi.h>
#include <WiFiClientSecure.h>

const char *ssid = "yourssid";
const char *password = "yourpasswd";

const char* server = "example.com";

WiFiClientSecure connect() {
  WiFiClientSecure client;
  client.setInsecure();
  Serial.println("Starting connection to server...");
  if (client.connect(server, 443)) {
    Serial.println("connected to server");
    client.println("GET / HTTP/1.1");
    client.print("Host: ");
    client.println(server);
    client.println();
    client.find("\r\n\r\n"); // skip headers
  }
  return client;
}

char peekTest(WiFiClientSecure client) {
  return client.peek();
}

void setup() {
  Serial.begin(115200);
  while (!Serial);

  Serial.println("Waiting for connection to WiFi");
  WiFi.begin(ssid, password);
  while (WiFi.status() != WL_CONNECTED) {
    delay(1000);
    Serial.print('.');
  }
  Serial.println();
  Serial.println("Connected to WiFi network.");

  WiFiClientSecure client = connect();
  if (client) {

  char peek = peekTest(client);
  if (client.peek() != peek) {
      Serial.println("ERROR peek result doesn't match!");
      Serial.print("peek 1: ");
      Serial.println(peek);
      Serial.print("peek 2: ");
      Serial.println((char) client.peek());
      Serial.println();
    }

    while (client.available()) {
      char c = client.read();
      Serial.write(c);
    }
  } else {

    char buff[100];
    int errCode = client.lastError(buff, sizeof(buff));
    Serial.println();
    Serial.print("Connect result code: ");
    Serial.println(errCode);
    if (errCode < 0) {
      Serial.print("\tmessage: ");
      Serial.println(buff);
    }
  }
}

void loop() {
  delay(1);
}
```
