### PR TITLE
fix(net): Add back the friend classes required for Ethernet.h to work

### DIFF
--- a/cores/esp32/IPAddress.h
+++ b/cores/esp32/IPAddress.h
@@ -124,6 +124,9 @@ public:
   friend class UDP;
   friend class Client;
   friend class Server;
+  friend class EthernetClass;
+  friend class DhcpClass;
+  friend class DNSClient;
 
 protected:
   bool fromString4(const char *address);


### PR DESCRIPTION
Fixes: https://github.com/espressif/arduino-esp32/issues/9630
