### PR TITLE
Fixes log with NULL ptr

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -536,9 +536,9 @@ uart_t *uartBegin(
     retCode &= uartSetPins(uart_nr, rxPin, txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
   }
   if (!retCode) {
+    log_e("UART%d initialization error.", uart->num);
     uartEnd(uart_nr);
     uart = NULL;
-    log_e("UART%d initialization error.", uart->num);
   } else {
     uartFlush(uart);
     log_v("UART%d initialization done.", uart->num);


### PR DESCRIPTION
## Description of Change
Fixes a log that uses a NULL pointer.

## Tests scenarios
CI only.

## Related links
Fix #9634