### PR TITLE
feat(tools):Use Windows native path separator in ESP_SR model copy command pattern

### DIFF
--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -221,6 +221,7 @@ RVTC_NEW_NAME="esp-rv32"
 echo "Generating platform.txt..."
 cat "$GITHUB_WORKSPACE/platform.txt" | \
 sed "s/version=.*/version=$RELEASE_TAG/g" | \
+sed 's/tools\.esp32-arduino-libs\.path\.windows=.*//g' | \
 sed 's/{runtime\.platform\.path}.tools.esp32-arduino-libs/\{runtime.tools.esp32-arduino-libs.path\}/g' | \
 sed 's/{runtime\.platform\.path}.tools.xtensa-esp-elf-gdb/\{runtime.tools.xtensa-esp-elf-gdb.path\}/g' | \
 sed 's/{runtime\.platform\.path}.tools.xtensa-esp32-elf/\{runtime.tools.xtensa-esp32-elf-gcc.path\}/g' | \

--- a/platform.txt
+++ b/platform.txt
@@ -2,6 +2,7 @@ name=ESP32 Arduino
 version=3.0.0
 
 tools.esp32-arduino-libs.path={runtime.platform.path}/tools/esp32-arduino-libs
+tools.esp32-arduino-libs.path.windows={runtime.platform.path}\tools\esp32-arduino-libs
 tools.xtensa-esp32-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32-elf
 tools.xtensa-esp32s2-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32s2-elf
 tools.xtensa-esp32s3-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32s3-elf
@@ -30,6 +31,7 @@ compiler.path={tools.{build.tarch}-{build.target}-elf-gcc.path}/bin/
 compiler.prefix={build.tarch}-{build.target}-elf-
 
 compiler.sdk.path={tools.esp32-arduino-libs.path}/{build.mcu}
+compiler.sdk.path.windows={tools.esp32-arduino-libs.path}\{build.mcu}
 
 # EXPERIMENTAL feature: optimization flags
 #  - this is alpha and may be subject to change without notice


### PR DESCRIPTION
Although Windows generally supports the use of the POSIX compliant slash (`/`) path separator in addition to the Windows native backslash (`\`) separator, in the specific use case where a path is present in a native command executed via an argument to `cmd /c` in a platform command pattern, it is mandatory to use backslash path separators.

Previously, a slash path separator was used in the `tools.esp32-arduino-libs.path` (non-release value) and `compiler.sdk.path` platform properties, which were referenced in a `copy` command in the `cmd /c` argument part of the platform's `recipe.hooks.objcopy.postobjcopy.2.pattern.windows` command pattern. This caused compilation to fail with a "`The syntax of the command is incorrect.`" error under the following conditions:

- The compilation is performed on a Windows machine
- The compiled sketch uses the [ESP_SR library](https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP_SR)

## Description of Change

Fix the compilation failure by adding [Windows override variants](https://arduino.github.io/arduino-cli/dev/platform-specification/#automatic-property-override-for-specific-os) of the properties, with backslash path separators.

## Tests scenarios

I have tested my pull request by compiling the following minimal sketch on a Windows machine:

```cpp
#include "ESP_SR.h"
void setup(){}
void loop(){}
```

Prior (50ef6f4369fb85139f000f7bbc5a9f9d5bc02b9f) to the change proposed by this PR, compilation of this sketch failed:

```text
cmd /c if exist "C:\\Users\\per\\AppData\\Local\\Temp\\arduino\\sketches\\34BD93C254D6DD95CD18E3C0730A1199\\libraries\\ESP_SR" if exist "C:\\Users\\per\\AppData\\Local\\Arduino15\\packages\\esp32\\tools\\esp32-arduino-libs\\idf-release_v5.1-442a798083/esp32s3\\esp_sr\\srmodels.bin" COPY /y "C:\\Users\\per\\AppData\\Local\\Arduino15\\packages\\esp32\\tools\\esp32-arduino-libs\\idf-release_v5.1-442a798083/esp32s3\\esp_sr\\srmodels.bin" "C:\\Users\\per\\AppData\\Local\\Temp\\arduino\\sketches\\34BD93C254D6DD95CD18E3C0730A1199\\srmodels.bin"
The syntax of the command is incorrect.
```

(note the `/` in `"C:\\Users\\per\\AppData\\Local\\Arduino15\\packages\\esp32\\tools\\esp32-arduino-libs\\idf-release_v5.1-442a798083/esp32s3\\esp_sr\\srmodels.bin"`)

After the change proposed by this PR, the compilation is successful, with the `recipe.hooks.objcopy.postobjcopy.2.pattern.windows` command pattern now generating a command with this format:

```text
cmd /c if exist "C:\\Users\\per\\AppData\\Local\\Temp\\arduino\\sketches\\34BD93C254D6DD95CD18E3C0730A1199\\libraries\\ESP_SR" if exist "C:\\Users\\per\\AppData\\Local\\Arduino15\\packages\\esp32\\tools\\esp32-arduino-libs\\idf-release_v5.1-442a798083\\esp32s3\\esp_sr\\srmodels.bin" COPY /y "C:\\Users\\per\\AppData\\Local\\Arduino15\\packages\\esp32\\tools\\esp32-arduino-libs\\idf-release_v5.1-442a798083\\esp32s3\\esp_sr\\srmodels.bin" "C:\\Users\\per\\AppData\\Local\\Temp\\arduino\\sketches\\34BD93C254D6DD95CD18E3C0730A1199\\srmodels.bin"
```

(note the path is now `"C:\\Users\\per\\AppData\\Local\\Arduino15\\packages\\esp32\\tools\\esp32-arduino-libs\\idf-release_v5.1-442a798083\\esp32s3\\esp_sr\\srmodels.bin"`, with exclusively `\` path separators)

I verified the results with Arduino IDE 2.3.2 and 1.8.19, with both a manual installation of the platform as well as the Boards Manager installation (with the `sed` processing of `platform.txt` processing that is applied by `.github/scripts/on-release.sh`).

## Related links

Originally reported at https://forum.arduino.cc/t/esp32-exit-status-1-when-building-esp-sr-basic-example/1260494