### PR TITLE
feat(eth): Enable the possibility to use SPI ETH with only 4 wires

### DIFF
--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -62,6 +62,7 @@
 
 // This will be uncommented once custom SPI support is available in ESP-IDF
 #define ETH_SPI_SUPPORTS_CUSTOM 1
+#define ETH_SPI_SUPPORTS_NO_IRQ 1
 
 #include "Network.h"
 


### PR DESCRIPTION
This PR enables ETH_SPI_SUPPORTS_NO_IRQ to support connection by only 4 wires (SCK, MISO, MOSI and SS) with IRQ and RESET being set as -1
