### PR TITLE
feat(hwcdc): Fixes HWCDC fw uploading

### DIFF
--- a/cores/esp32/USBCDC.cpp
+++ b/cores/esp32/USBCDC.cpp
@@ -432,9 +432,9 @@ void USBCDC::setDebugOutput(bool en)
 {
     if(en) {
         uartSetDebug(NULL);
-        ets_install_putc1((void (*)(char)) &cdc0_write_char);
+        ets_install_putc2((void (*)(char)) &cdc0_write_char);
     } else {
-        ets_install_putc1(NULL);
+        ets_install_putc2(NULL);
     }
 }
 

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -778,6 +778,7 @@ void uart_install_putc()
         ets_install_putc1(NULL);
         break;
     }
+    ets_install_putc2(NULL);
 }
 
 // Routines that take care of UART mode in the HardwareSerial Class code

--- a/libraries/ESP32/examples/HWCDC_Events/HWCDC_Events.ino
+++ b/libraries/ESP32/examples/HWCDC_Events/HWCDC_Events.ino
@@ -85,7 +85,7 @@ void loop() {
   Serial0.print(HWCDC_Status());
 
   if (USBSerial) {
-    USBSerial.printf("  [%ld] connected\n\r", counter);
+    USBSerial.printf("  [%d] connected\n\r", counter);
   }
   // sends all bytes read from UART0 to USB Hardware Serial
   while (Serial0.available()) USBSerial.write(Serial0.read());


### PR DESCRIPTION
## Description of Change

This PR is a backport of #9628

- Fixes HW CDC uploading issue using the HWSerial/JTAG port.
- Changes SOF detection from ISR to Timer routine instead 
- Uses correct logging functions in order to separate UART from USB CDC, always closing one or the other whenever one of them is selected using `setDebugOutput(bool)` method.
- Fixes a warning about `%ld` versus `%d` in the `HWCDC_Events.ino` example. 

## Tests scenarios
Tested for ESP32-S3 and ESP32-C3 using the `HWCDC_Events.ino` example.
Tested also for ESP32-S3, ESP32-C3 and ESP32-S2 for chekcing that the `log_XX()` functions work correctly.

## Related links
Fix #9646 
Fix #9580