### PR TITLE
Nano ESP32: delete `programmer.default` entry (on 2.0.x)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -26048,7 +26048,6 @@ nano_nora.debug.additional_config=debug_config.nano_nora
 nano_nora.tools.esptool_py.program.pattern_args=--chip {build.mcu} --port "{serial.port}" --before default_reset --after hard_reset write_flash -z --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} {build.bootloader_addr} "{build.path}/{build.project_name}.bootloader.bin" 0x8000 "{build.path}/{build.project_name}.partitions.bin" 0xe000 "{runtime.platform.path}/tools/partitions/boot_app0.bin" 0xf70000 "{build.variant.path}/extra/nora_recovery/nora_recovery.ino.bin" 0x10000 "{build.path}/{build.project_name}.bin"
 nano_nora.tools.esptool_py.erase.pattern_args=--chip {build.mcu} --port "{serial.port}" --before default_reset --after hard_reset erase_flash
 
-nano_nora.programmer.default=esptool
 nano_nora.debug.executable=
 
 nano_nora.menu.PartitionScheme.default=With FAT partition (default)


### PR DESCRIPTION
## Description of Change
Recent debug support commits added the `programmer.default` entry for the Nano ESP32 on 2.0.x releases.

Setting that parameter has unfortunately multiple effects:
  - sets the tick by default in the Tools->Programmer menu in the IDE (which was the reason for the added line), but also...
  - forces the CLI to use the specified programmer _every time an upload is attempted_ (which is confusing users, since they don't get the DFU upload they expect).
    
For this reason, it is better to remove the `programmer.default` setting from the board definition and let the user choose the programmer in the IDE menus, as it was before.

## Tests scenarios
Behavior observed on latest Arduino IDE and CLI.

## Related links
Arduino forum thread: https://forum.arduino.cc/t/arduino-cli-and-nano-esp32-cant-upload/
Same PR for main branch: #9666

