### PR TITLE
docs(ledc.rst):Fixed outdated function signature (ledcWrite)

### DIFF
--- a/docs/en/api/ledc.rst
+++ b/docs/en/api/ledc.rst
@@ -68,7 +68,7 @@ This function is used to set duty for the LEDC pin.
 
 .. code-block:: arduino
 
-    void ledcWrite(uint8_t pin, uint32_t duty);
+    bool ledcWrite(uint8_t pin, uint32_t duty);
 
 * ``pin`` select LEDC pin.
 * ``duty`` select duty to be set for selected LEDC pin.


### PR DESCRIPTION
## Description of Change
Small fix in the API documentation. The function `ledcWrite` returns a boolean, not void. 

The documentation already states that:

"This function will return true if setting duty is successful. If false is returned, error occurs and duty was not set." 

I've double checked that in the header file (cores/esp32/esp32-hal-ledc.h). The return value is indeed a boolean.

However, the function signature was inconsistent with this behavior:

`void ledcWrite(uint8_t pin, uint32_t duty);`

The signature was corrected in this patch:

`bool ledcWrite(uint8_t pin, uint32_t duty);`