### PR TITLE
Update Kconfig.projbuild to fix LittleFS selective compilation

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -311,8 +311,8 @@ config ARDUINO_SELECTIVE_FFat
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_FS
     default y
 
-config ARDUINO_SELECTIVE_LITTLEFS
-    bool "Enable LITTLEFS"
+config ARDUINO_SELECTIVE_LittleFS
+    bool "Enable LittleFS"
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_FS
     default y
 


### PR DESCRIPTION
Fix selective compilation to include LittleFS library when checked in menu.

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Updating Kconfig.projbuild to fix LittleFS inclusion during selective compilation. There is a mismatch in names in Kconfig.projbuild and CMakeLists.txt. The latter is using correct notation ``LittleFS`` as the library folder is named, but in Kconfig the option is using allcaps notation ``LITTLEFS``. This results in LittleFS library not being included even when it is selected in ``Include only specific Arduino libraries `` menu. By default CMake includes all libraries not checking for their respective menu options, thus this bug was missed.

## Tests scenarios
Tested on 3.0.0RC3 with ESP32-C3. Checked in menuconfig ``Arduino Configuration > Include only specific Arduino libraries > Enable FS > Enable LittleFS``
