### PR TITLE
fix(esp-hal-log):Provide a default TAG name for USE_ESP_IDF_LOG logging macro

### DIFF
--- a/cores/esp32/esp32-hal-log.h
+++ b/cores/esp32/esp32-hal-log.h
@@ -108,16 +108,16 @@ void log_print_buf(const uint8_t *b, size_t len);
     ARDUHAL_LOG_COLOR_PRINT_END; \
   } while (0)
 #else
-#define log_v(format, ...)                                            \
-  do {                                                                \
+#define log_v(format, ...)                                                            \
+  do {                                                                                \
     ESP_LOG_LEVEL_LOCAL(ESP_LOG_VERBOSE, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
-#define isr_log_v(format, ...)                                                  \
-  do {                                                                          \
+#define isr_log_v(format, ...)                                                                  \
+  do {                                                                                          \
     ets_printf(LOG_FORMAT(V, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
-#define log_buf_v(b, l)                                 \
-  do {                                                  \
+#define log_buf_v(b, l)                                                 \
+  do {                                                                  \
     ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_VERBOSE); \
   } while (0)
 #endif
@@ -144,16 +144,16 @@ void log_print_buf(const uint8_t *b, size_t len);
     ARDUHAL_LOG_COLOR_PRINT_END; \
   } while (0)
 #else
-#define log_d(format, ...)                                          \
-  do {                                                              \
+#define log_d(format, ...)                                                          \
+  do {                                                                              \
     ESP_LOG_LEVEL_LOCAL(ESP_LOG_DEBUG, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
-#define isr_log_d(format, ...)                                                  \
-  do {                                                                          \
+#define isr_log_d(format, ...)                                                                  \
+  do {                                                                                          \
     ets_printf(LOG_FORMAT(D, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
-#define log_buf_d(b, l)                               \
-  do {                                                \
+#define log_buf_d(b, l)                                               \
+  do {                                                                \
     ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_DEBUG); \
   } while (0)
 #endif
@@ -180,16 +180,16 @@ void log_print_buf(const uint8_t *b, size_t len);
     ARDUHAL_LOG_COLOR_PRINT_END; \
   } while (0)
 #else
-#define log_i(format, ...)                                         \
-  do {                                                             \
+#define log_i(format, ...)                                                         \
+  do {                                                                             \
     ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
-#define isr_log_i(format, ...)                                                  \
-  do {                                                                          \
+#define isr_log_i(format, ...)                                                                  \
+  do {                                                                                          \
     ets_printf(LOG_FORMAT(I, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
-#define log_buf_i(b, l)                              \
-  do {                                               \
+#define log_buf_i(b, l)                                              \
+  do {                                                               \
     ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_INFO); \
   } while (0)
 #endif
@@ -216,16 +216,16 @@ void log_print_buf(const uint8_t *b, size_t len);
     ARDUHAL_LOG_COLOR_PRINT_END; \
   } while (0)
 #else
-#define log_w(format, ...)                                         \
-  do {                                                             \
+#define log_w(format, ...)                                                         \
+  do {                                                                             \
     ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
-#define isr_log_w(format, ...)                                                  \
-  do {                                                                          \
+#define isr_log_w(format, ...)                                                                  \
+  do {                                                                                          \
     ets_printf(LOG_FORMAT(W, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
-#define log_buf_w(b, l)                              \
-  do {                                               \
+#define log_buf_w(b, l)                                              \
+  do {                                                               \
     ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_WARN); \
   } while (0)
 #endif
@@ -252,16 +252,16 @@ void log_print_buf(const uint8_t *b, size_t len);
     ARDUHAL_LOG_COLOR_PRINT_END; \
   } while (0)
 #else
-#define log_e(format, ...)                                          \
-  do {                                                              \
+#define log_e(format, ...)                                                          \
+  do {                                                                              \
     ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
-#define isr_log_e(format, ...)                                                  \
-  do {                                                                          \
+#define isr_log_e(format, ...)                                                                  \
+  do {                                                                                          \
     ets_printf(LOG_FORMAT(E, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
-#define log_buf_e(b, l)                               \
-  do {                                                \
+#define log_buf_e(b, l)                                               \
+  do {                                                                \
     ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_ERROR); \
   } while (0)
 #endif
@@ -288,16 +288,16 @@ void log_print_buf(const uint8_t *b, size_t len);
     ARDUHAL_LOG_COLOR_PRINT_END; \
   } while (0)
 #else
-#define log_n(format, ...)                                          \
-  do {                                                              \
+#define log_n(format, ...)                                                          \
+  do {                                                                              \
     ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
-#define isr_log_n(format, ...)                                                  \
-  do {                                                                          \
+#define isr_log_n(format, ...)                                                                  \
+  do {                                                                                          \
     ets_printf(LOG_FORMAT(E, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
-#define log_buf_n(b, l)                               \
-  do {                                                \
+#define log_buf_n(b, l)                                               \
+  do {                                                                \
     ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_ERROR); \
   } while (0)
 #endif

--- a/cores/esp32/esp32-hal-log.h
+++ b/cores/esp32/esp32-hal-log.h
@@ -80,6 +80,12 @@ extern "C" {
 #define ARDUHAL_LOG_COLOR_PRINT_END
 #endif
 
+#ifdef USE_ESP_IDF_LOG
+#ifndef ARDUHAL_ESP_LOG_TAG
+#define ARDUHAL_ESP_LOG_TAG "ARDUINO"
+#endif
+#endif
+
 const char *pathToFileName(const char *path);
 int log_printf(const char *fmt, ...);
 void log_print_buf(const uint8_t *b, size_t len);
@@ -104,15 +110,15 @@ void log_print_buf(const uint8_t *b, size_t len);
 #else
 #define log_v(format, ...)                                            \
   do {                                                                \
-    ESP_LOG_LEVEL_LOCAL(ESP_LOG_VERBOSE, TAG, format, ##__VA_ARGS__); \
+    ESP_LOG_LEVEL_LOCAL(ESP_LOG_VERBOSE, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
 #define isr_log_v(format, ...)                                                  \
   do {                                                                          \
-    ets_printf(LOG_FORMAT(V, format), esp_log_timestamp(), TAG, ##__VA_ARGS__); \
+    ets_printf(LOG_FORMAT(V, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
 #define log_buf_v(b, l)                                 \
   do {                                                  \
-    ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_VERBOSE); \
+    ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_VERBOSE); \
   } while (0)
 #endif
 #else
@@ -140,15 +146,15 @@ void log_print_buf(const uint8_t *b, size_t len);
 #else
 #define log_d(format, ...)                                          \
   do {                                                              \
-    ESP_LOG_LEVEL_LOCAL(ESP_LOG_DEBUG, TAG, format, ##__VA_ARGS__); \
+    ESP_LOG_LEVEL_LOCAL(ESP_LOG_DEBUG, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
 #define isr_log_d(format, ...)                                                  \
   do {                                                                          \
-    ets_printf(LOG_FORMAT(D, format), esp_log_timestamp(), TAG, ##__VA_ARGS__); \
+    ets_printf(LOG_FORMAT(D, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
 #define log_buf_d(b, l)                               \
   do {                                                \
-    ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_DEBUG); \
+    ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_DEBUG); \
   } while (0)
 #endif
 #else
@@ -176,15 +182,15 @@ void log_print_buf(const uint8_t *b, size_t len);
 #else
 #define log_i(format, ...)                                         \
   do {                                                             \
-    ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO, TAG, format, ##__VA_ARGS__); \
+    ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
 #define isr_log_i(format, ...)                                                  \
   do {                                                                          \
-    ets_printf(LOG_FORMAT(I, format), esp_log_timestamp(), TAG, ##__VA_ARGS__); \
+    ets_printf(LOG_FORMAT(I, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
 #define log_buf_i(b, l)                              \
   do {                                               \
-    ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_INFO); \
+    ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_INFO); \
   } while (0)
 #endif
 #else
@@ -212,15 +218,15 @@ void log_print_buf(const uint8_t *b, size_t len);
 #else
 #define log_w(format, ...)                                         \
   do {                                                             \
-    ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN, TAG, format, ##__VA_ARGS__); \
+    ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
 #define isr_log_w(format, ...)                                                  \
   do {                                                                          \
-    ets_printf(LOG_FORMAT(W, format), esp_log_timestamp(), TAG, ##__VA_ARGS__); \
+    ets_printf(LOG_FORMAT(W, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
 #define log_buf_w(b, l)                              \
   do {                                               \
-    ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_WARN); \
+    ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_WARN); \
   } while (0)
 #endif
 #else
@@ -248,15 +254,15 @@ void log_print_buf(const uint8_t *b, size_t len);
 #else
 #define log_e(format, ...)                                          \
   do {                                                              \
-    ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, TAG, format, ##__VA_ARGS__); \
+    ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
 #define isr_log_e(format, ...)                                                  \
   do {                                                                          \
-    ets_printf(LOG_FORMAT(E, format), esp_log_timestamp(), TAG, ##__VA_ARGS__); \
+    ets_printf(LOG_FORMAT(E, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
 #define log_buf_e(b, l)                               \
   do {                                                \
-    ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_ERROR); \
+    ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_ERROR); \
   } while (0)
 #endif
 #else
@@ -284,15 +290,15 @@ void log_print_buf(const uint8_t *b, size_t len);
 #else
 #define log_n(format, ...)                                          \
   do {                                                              \
-    ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, TAG, format, ##__VA_ARGS__); \
+    ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR, ARDUHAL_ESP_LOG_TAG, format, ##__VA_ARGS__); \
   } while (0)
 #define isr_log_n(format, ...)                                                  \
   do {                                                                          \
-    ets_printf(LOG_FORMAT(E, format), esp_log_timestamp(), TAG, ##__VA_ARGS__); \
+    ets_printf(LOG_FORMAT(E, format), esp_log_timestamp(), ARDUHAL_ESP_LOG_TAG, ##__VA_ARGS__); \
   } while (0)
 #define log_buf_n(b, l)                               \
   do {                                                \
-    ESP_LOG_BUFFER_HEXDUMP(TAG, b, l, ESP_LOG_ERROR); \
+    ESP_LOG_BUFFER_HEXDUMP(ARDUHAL_ESP_LOG_TAG, b, l, ESP_LOG_ERROR); \
   } while (0)
 #endif
 #else
@@ -309,12 +315,7 @@ void log_print_buf(const uint8_t *b, size_t len);
 
 #include "esp_log.h"
 
-#ifdef USE_ESP_IDF_LOG
-//#ifndef TAG
-//#define TAG "ARDUINO"
-//#endif
-//#define log_n(format, ...) myLog(ESP_LOG_NONE, format, ##__VA_ARGS__)
-#else
+#ifndef USE_ESP_IDF_LOG
 #ifdef CONFIG_ARDUHAL_ESP_LOG
 #undef ESP_LOGE
 #undef ESP_LOGW


### PR DESCRIPTION
## Description of Change

The ESP-IDF logging library has some nice features such as log forwarding. esp32-hal-log.h has long supported the `USE_ESP_IDF_LOG` macro, but due to subsequent changes, it requires a global `TAG` preprocessor macro to be defined. The macro name is too generic and just having a sane default would be preferable.

This PR changes the default tag macro name to `ARDUHAL_ESP_LOG_TAG` and, if it's not defined, sets it to `"ARDUINO"`.

## Tests scenarios

I wasn't able to build arduino-esp32 master. Instead, I copied the file to Arduino-ESP32 Core v2.0.16 as provided by PlatformIO's `framework-arduinoespressif32` framework package. Test hardware was SH-ESP32 and HALMET (compatible with esp32 devkit devices).

With the change applied, logging works as expected both when `USE_IDF_LOG` is set and when it isn't.

## Related links
Please provide links to related issue, PRs etc.

Closes #6893.
