### PR TITLE
fix(adc): Remove masking for ADC channel number

### DIFF
--- a/cores/esp32/esp32-hal-adc.c
+++ b/cores/esp32/esp32-hal-adc.c
@@ -440,7 +440,7 @@ esp_err_t __analogContinuousInit(adc_channel_t *channel, uint8_t channel_num, ad
   dig_cfg.pattern_num = channel_num;
   for (int i = 0; i < channel_num; i++) {
     adc_pattern[i].atten = __adcContinuousAtten;
-    adc_pattern[i].channel = channel[i] & 0x7;
+    adc_pattern[i].channel = channel[i];
     adc_pattern[i].unit = ADC_UNIT_1;
     adc_pattern[i].bit_width = __adcContinuousWidth;
   }


### PR DESCRIPTION
## Description of Change
This PR fixes ADC Continuous channel number limit for S2/S3, where there are 10 channels per ADC peripheral.
Credits to @victorfleischauer

## Tests scenarios
Tested on esp32-s3

## Related links
Closes #9676 