### PR TITLE
fix(IDF): Define max IDF version for the component

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -42,7 +42,7 @@ files:
     - "platform.txt"
     - "programmers.txt"
 dependencies:
-  idf: ">=5.1"
+  idf: ">=5.1,<5.2"
   # mdns 1.2.1 is necessary to build H2 with no WiFi
   mdns: "^1.2.3"
   espressif/esp_modem: "^1.1.0"


### PR DESCRIPTION
Fixes the issue, where the component is shown as compatible with ESP-IDF 5.2, while in fact isn't.

cc: @igrr
