### PR TITLE
fix(variant): Arduino Nano ESP32 variant fix for core 3

### DIFF
--- a/variants/arduino_nano_nora/dfu_callbacks.cpp
+++ b/variants/arduino_nano_nora/dfu_callbacks.cpp
@@ -10,6 +10,7 @@ namespace {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #include "../../libraries/Update/src/Updater.cpp"
+#include "../../cores/esp32/HEXBuilder.cpp"
 #include "../../cores/esp32/MD5Builder.cpp"
 #pragma GCC diagnostic pop
 }  // namespace


### PR DESCRIPTION
I don't know what hack that is including cpp files, but without this PR every build for this board fails with core 3. linker can't find `bytes2hex` from HEXBuilder.

I just unpacked my new Nano ESP32. I wonder why nobody cares about this board with core 3. 