### PR TITLE
IDF v5.1 ebe0b3f40c with RTTI

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-442a798083"
+              "version": "idf--ebe0b3f40c"
             },
             {
               "packager": "esp32",
@@ -77,7 +77,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20230921"
+              "version": "v0.12.0-esp32-20240318"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-442a798083",
+          "version": "idf--ebe0b3f40c",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/951ade74d7886e1ce931ea46614c4ac47ae3a6c0",
-              "archiveFileName": "esp32-arduino-libs-951ade74d7886e1ce931ea46614c4ac47ae3a6c0.zip",
-              "checksum": "SHA-256:ac9e200eac443655c5661a4a9251032cb08a7d7a4e32c34ebeb8d340f0030aab",
-              "size": "375249835"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3937d87bd94627eedd5e6aecedfe7057747f3851",
+              "archiveFileName": "esp32-arduino-libs-3937d87bd94627eedd5e6aecedfe7057747f3851.zip",
+              "checksum": "SHA-256:2e87e4ef1312365cee7e0764850255d5c627b8e00e916634de011e8808b82f96",
+              "size": "297575359"
             }
           ]
         },
@@ -539,56 +539,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20230921",
+          "version": "v0.12.0-esp32-20240318",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20230921/openocd-esp32-linux-amd64-0.12.0-esp32-20230921.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20230921.tar.gz",
-              "checksum": "SHA-256:61e38e0a13a5c1664624ec1c397d7f7d6868554b0d345d3fb1f7294cce38cc4b",
-              "size": "2193783"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
+              "checksum": "SHA-256:cf26c5cef4f6b04aa23cd2778675604e5a74a4ce4d8d17b854d05fbcb782d52c",
+              "size": "2252682"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20230921/openocd-esp32-linux-arm64-0.12.0-esp32-20230921.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20230921.tar.gz",
-              "checksum": "SHA-256:6430315dc1b926541c93cef63d2b08982543ad3f9fe6e0d7107c8a518ef20432",
-              "size": "2062058"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
+              "checksum": "SHA-256:9b97a37aa2cab94424a778c25c0b4aa0f90d6ef9cda764a1d9289d061305f4b7",
+              "size": "2132904"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20230921/openocd-esp32-linux-armel-0.12.0-esp32-20230921.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20230921.tar.gz",
-              "checksum": "SHA-256:5df16d8a91f013a547f6b3b914c655a9d267996a3b6503031b335ac04a4f8d15",
-              "size": "2206666"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-armel-0.12.0-esp32-20240318.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20240318.tar.gz",
+              "checksum": "SHA-256:b7e82776ec374983807d3389df09c632ad9bc8341f2075690b6b500319dfeaf4",
+              "size": "2271761"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20230921/openocd-esp32-macos-0.12.0-esp32-20230921.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20230921.tar.gz",
-              "checksum": "SHA-256:0a4f764934f488af18cdac2a0d152dd36b4870f3bec1a2d4e25b6b3b7a5258a0",
-              "size": "2305832"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
+              "checksum": "SHA-256:b16c3082c94df1079367c44d99f7a8605534cd48aabc18898e46e94a2c8c57e7",
+              "size": "2365588"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20230921/openocd-esp32-macos-arm64-0.12.0-esp32-20230921.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20230921.tar.gz",
-              "checksum": "SHA-256:6dce89048f642eb0559a915b6e514f90feb2a95afe21b84f0b0ebf2b27824816",
-              "size": "2341406"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
+              "checksum": "SHA-256:534ec925ae6e35e869e4e4e6e4d2c4a1eb081f97ebcc2dd5efdc52d12f4c2f86",
+              "size": "2406377"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20230921/openocd-esp32-win32-0.12.0-esp32-20230921.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20230921.zip",
-              "checksum": "SHA-256:ac9d522a63b0816f64d921547bd55c031788035ced85c067d8e7c2862cb1bd0d",
-              "size": "2710475"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-win32-0.12.0-esp32-20240318.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240318.zip",
+              "checksum": "SHA-256:d379329eba052435173ab0d69c9b15bc164a6ce489e2a67cd11169d2dabff633",
+              "size": "2783915"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20230921/openocd-esp32-win32-0.12.0-esp32-20230921.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20230921.zip",
-              "checksum": "SHA-256:ac9d522a63b0816f64d921547bd55c031788035ced85c067d8e7c2862cb1bd0d",
-              "size": "2710475"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-win32-0.12.0-esp32-20240318.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240318.zip",
+              "checksum": "SHA-256:d379329eba052435173ab0d69c9b15bc164a6ce489e2a67cd11169d2dabff633",
+              "size": "2783915"
             }
           ]
         },


### PR DESCRIPTION
Fixes: https://github.com/espressif/arduino-esp32/issues/9370

```
lib-builder: feature/rtti 114346a
esp-idf: ebe0b3f40c
arduino: master c16a3254
tinyusb: master d10b65ada
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.0
espressif__esp-zboss-lib: 1.3.2
espressif__esp-zigbee-lib: 1.3.2
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.1.0
espressif__esp_schedule: 1.1.1
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__mdns: 1.3.1
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.5
joltwallet__littlefs: 1.14.4
```
