### PR TITLE
Allow setting scan timeout in milliseconds

### DIFF
--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -44,9 +44,13 @@ extern "C" {
 
 bool WiFiScanClass::_scanAsync = false;
 uint32_t WiFiScanClass::_scanStarted = 0;
-uint32_t WiFiScanClass::_scanTimeout = 10000;
+uint32_t WiFiScanClass::_scanTimeout = 60000;
 uint16_t WiFiScanClass::_scanCount = 0;
 void *WiFiScanClass::_scanResult = 0;
+
+void WiFiScanClass::setScanTimeout(uint32_t ms) {
+  WiFiScanClass::_scanTimeout = ms;
+}
 
 /**
  * Start scan WiFi networks available
@@ -60,7 +64,6 @@ int16_t
     return WIFI_SCAN_RUNNING;
   }
 
-  WiFiScanClass::_scanTimeout = max_ms_per_chan * 20;
   WiFiScanClass::_scanAsync = async;
 
   WiFi.enableSTA(true);
@@ -92,7 +95,7 @@ int16_t
     if (WiFiScanClass::_scanAsync) {
       return WIFI_SCAN_RUNNING;
     }
-    if (WiFiGenericClass::waitStatusBits(WIFI_SCAN_DONE_BIT, 10000)) {
+    if (WiFiGenericClass::waitStatusBits(WIFI_SCAN_DONE_BIT, _scanTimeout)) {
       return (int16_t)WiFiScanClass::_scanCount;
     }
   }

--- a/libraries/WiFi/src/WiFiScan.h
+++ b/libraries/WiFi/src/WiFiScan.h
@@ -31,6 +31,8 @@
 class WiFiScanClass {
 
 public:
+  void setScanTimeout(uint32_t ms);
+
   int16_t scanNetworks(
     bool async = false, bool show_hidden = false, bool passive = false, uint32_t max_ms_per_chan = 300, uint8_t channel = 0, const char *ssid = nullptr,
     const uint8_t *bssid = nullptr


### PR DESCRIPTION
Also increases the default timeout for the cases where BT and WiFi are both on.

Fixes: https://github.com/espressif/arduino-esp32/issues/9736