### PR TITLE
fix(idf): Require MDNS as public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ endforeach()
 set(includedirs variants/${CONFIG_ARDUINO_VARIANT}/ cores/esp32/ ${ARDUINO_LIBRARIES_INCLUDEDIRS})
 set(srcs ${CORE_SRCS} ${ARDUINO_LIBRARIES_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash esp_partition mbedtls wifi_provisioning wpa_supplicant esp_adc esp_eth http_parser espressif__mdns)
+set(requires spi_flash esp_partition mbedtls wifi_provisioning wpa_supplicant esp_adc esp_eth http_parser)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid usb ${ARDUINO_LIBRARIES_REQUIRES})
 
 idf_component_register(INCLUDE_DIRS ${includedirs} PRIV_INCLUDE_DIRS ${priv_includes} SRCS ${srcs} REQUIRES ${requires} PRIV_REQUIRES ${priv_requires})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ endforeach()
 set(includedirs variants/${CONFIG_ARDUINO_VARIANT}/ cores/esp32/ ${ARDUINO_LIBRARIES_INCLUDEDIRS})
 set(srcs ${CORE_SRCS} ${ARDUINO_LIBRARIES_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash esp_partition mbedtls wifi_provisioning wpa_supplicant esp_adc esp_eth http_parser)
+set(requires spi_flash esp_partition mbedtls wifi_provisioning wpa_supplicant esp_adc esp_eth http_parser espressif__mdns)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid usb ${ARDUINO_LIBRARIES_REQUIRES})
 
 idf_component_register(INCLUDE_DIRS ${includedirs} PRIV_INCLUDE_DIRS ${priv_includes} SRCS ${srcs} REQUIRES ${requires} PRIV_REQUIRES ${priv_requires})

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -44,11 +44,11 @@ files:
 dependencies:
   idf: ">=5.1,<5.2"
   # mdns 1.2.1 is necessary to build H2 with no WiFi
-  mdns: "^1.2.3"
-  espressif/esp_modem: "^1.1.0"
-  chmorgan/esp-libhelix-mp3:
-    version: "1.0.3"
+  espressif/mdns:
+    version: "^1.2.3"
     require: public
+  espressif/esp_modem:
+    version: "^1.1.0"
   espressif/esp-zboss-lib:
     version: "^1.0.1"
     rules:
@@ -57,7 +57,7 @@ dependencies:
     version: "^1.0.1"
     rules:
       - if: "target != esp32c2"
-  esp-dsp:
+  espressif/esp-dsp:
     version: "^1.3.4"
     rules:
       - if: "target != esp32c2"
@@ -77,10 +77,14 @@ dependencies:
     version: "^0.1.0~1"
     rules:
       - if: "target != esp32c2"
-  joltwallet/littlefs: "^1.10.2"
   espressif/esp-sr:
     version: "^1.4.2"
     rules:
       - if: "target in [esp32s3]"
+  joltwallet/littlefs:
+    version: "^1.10.2"
+  chmorgan/esp-libhelix-mp3:
+    version: "1.0.3"
+    require: public
 examples:
   - path: ./idf_component_examples/Hello_world


### PR DESCRIPTION
Included in Arduino's public headers

Fixes: https://github.com/espressif/esp-idf/issues/13899