### PR TITLE
fix(3rd party board): Changed Board name to describe board more clearly

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -35921,7 +35921,7 @@ epulse_feather_c6.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api_rcp -lesp_z
 
 ##############################################################
 
-Geekble_ESP32C3.name=Geekble ESP32-C3
+Geekble_ESP32C3.name=Geekble Mini ESP32-C3
 
 Geekble_ESP32C3.bootloader.tool=esptool_py
 Geekble_ESP32C3.bootloader.tool.default=esptool_py


### PR DESCRIPTION
## Description of Change
fix: Changed Board name to describe board more clearly

## Tests scenarios
Checked under Arduino IDE 2.3.2
board name appears correctly in board list 

## Related links
https://github.com/SooDragon/GeekbleMini-ESP32C3
