### PR TITLE
fix(misc): Improve micros() int size

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -203,7 +203,7 @@ void delay(uint32_t ms) {
   vTaskDelay(ms / portTICK_PERIOD_MS);
 }
 
-void ARDUINO_ISR_ATTR delayMicroseconds(uint32_t us) {
+void ARDUINO_ISR_ATTR delayMicroseconds(uint64_t us) {
   uint64_t m = (uint64_t)esp_timer_get_time();
   if (us) {
     uint64_t e = (m + us);

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -191,8 +191,8 @@ BaseType_t xTaskCreateUniversal(
 #endif
 }
 
-unsigned long ARDUINO_ISR_ATTR micros() {
-  return (unsigned long)(esp_timer_get_time());
+unsigned long long ARDUINO_ISR_ATTR micros() {
+  return (unsigned long long)(esp_timer_get_time());
 }
 
 unsigned long ARDUINO_ISR_ATTR millis() {

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -124,7 +124,7 @@ BaseType_t xTaskCreateUniversal(
 unsigned long long micros();
 unsigned long millis();
 void delay(uint32_t);
-void delayMicroseconds(uint32_t us);
+void delayMicroseconds(uint64_t us);
 
 #if !CONFIG_ESP32_PHY_AUTO_INIT
 void arduino_phy_init();

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -121,7 +121,7 @@ BaseType_t xTaskCreateUniversal(
   TaskHandle_t *const pxCreatedTask, const BaseType_t xCoreID
 );
 
-unsigned long micros();
+unsigned long long micros();
 unsigned long millis();
 void delay(uint32_t);
 void delayMicroseconds(uint32_t us);


### PR DESCRIPTION
## Description of Change

The `micros()` function on AVR-based Arduino boards is known to overflow after about 70 minutes, and that's because of the integer size of the return value. The ESP32 implementation, however, uses the `esp_timer_get_time()` internally, which currently returns an int64_t (why is it a signed integer?). Inspecting its implementation on the esp-idf repository, I think its type should be uint64_t, since it is just an alias for `esp_timer_impl_get_time()`, which in turn calls the `ticks_to_us`. The latter seems to be an unsigned 64-bit wide integer:

`typedef uint64_t (*ticks_to_us_func_t)(uint64_t ticks);` 
(from esp-idf components/hal/include/hal/systimer_hal.h)

So, I think there's really no need to stick with 32 bits (unsigned long is 32 bits in ESP32 architecture/compiler), since in the end of the chain we have the 64-bit `ticks_to_us()` function. Apparently, we are just truncating the upper 32 bits with no good reason (being intentionally identical to AVR Arduinos in this case doesn't seem correct). I propose changing the `micros()` return type to unsigned long long, in this repository. I would create another pull request to change `int64_t` to `uint64_t` when applicable in the esp_timer_get_time() chain of aliases/function calls (so there would be 2 pull requests, one for this repository and other for the esp-idf repository).

If someone is intentionally relying on the 70 minutes overflow, which seems a very strange use case in my opinion, the code would only be affected if the `auto` keyword is used: if an unsigned long long value is used on an unsigned long variable, we would still have the 32 bits truncated.

Future (and more ordinary) code, however, would be grateful not to have this 70 minutes limitation.

And if I understood it incorrectly, I am sorry to spend your time analyzing this pull-request.

## Tests scenarios
I have tested the new micros() function on two types of ESP32 DevKit modules (ESPduino and ESP32 DevKit V1), althouh I haven't wait 70 minutes to confirm that micros() will no longer overflow.