### PR TITLE
fix(client): Implement readBytes in NetworkClient for faster downloads

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -483,7 +483,7 @@ size_t NetworkClient::readBytes(char *buffer, size_t length) {
   size_t left = length, sofar = 0;
   int r = 0, to = millis() + getTimeout();
   while (left) {
-    r = read((uint8_t*)buffer+sofar, left);
+    r = read((uint8_t *)buffer + sofar, left);
     if (r < 0) {
       // Error has occurred
       break;

--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -481,7 +481,7 @@ int NetworkClient::read(uint8_t *buf, size_t size) {
 
 size_t NetworkClient::readBytes(char *buffer, size_t length) {
   size_t left = length, sofar = 0;
-  int r = 0, to = millis() + _timeout;
+  int r = 0, to = millis() + getTimeout();
   while (left) {
     r = read((uint8_t*)buffer+sofar, left);
     if (r < 0) {
@@ -492,7 +492,7 @@ size_t NetworkClient::readBytes(char *buffer, size_t length) {
       // We got some data
       left -= r;
       sofar += r;
-      to = millis() + _timeout;
+      to = millis() + getTimeout();
     } else {
       // We got no data
       if (millis() >= to) {

--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -479,6 +479,14 @@ int NetworkClient::read(uint8_t *buf, size_t size) {
   return res;
 }
 
+size_t NetworkClient::readBytes(char *buffer, size_t length) {
+  int r = read((uint8_t*)buffer, length);
+  if (r < 0) {
+    return 0;
+  }
+  return (size_t)r;
+}
+
 int NetworkClient::peek() {
   int res = -1;
   if (fd() >= 0 && _rxBuffer) {

--- a/libraries/Network/src/NetworkClient.h
+++ b/libraries/Network/src/NetworkClient.h
@@ -60,6 +60,10 @@ public:
   int available();
   int read();
   int read(uint8_t *buf, size_t size);
+  size_t readBytes(char *buffer, size_t length);
+  size_t readBytes(uint8_t *buffer, size_t length) {
+    return readBytes((char *)buffer, length);
+  }
   int peek();
   void clear();  // clear rx
   void stop();


### PR DESCRIPTION
Fixes: https://github.com/espressif/arduino-esp32/issues/9822

## Test downloading 22MB zip and using `readBytes` with ESP32-S3

Test results are relative and actual speeds will vary based on the environment. 

### Download from HTTP server (no SSL):
```cpp
// python3 -m http.server 8080 -d .
const char *fileDownloadUrl = "http://192.168.254.91:8080/esp32-3.0.1.zip";
```

New Method:
```
Download completed!
Total download time: 40.714000 s
Average download speed: 573.149578 Kb/s
```

Old Method:
```
Download completed!
Total download time: 63.890000 s
Average download speed: 365.240443 Kb/s
```

### Download from HTTPS server (with SSL):
```cpp
const char *fileDownloadUrl = "https://github.com/espressif/arduino-esp32/releases/download/3.0.1/esp32-3.0.1.zip";
```

New Method:
```
Download completed!
Total download time: 80.371000 s
Average download speed: 290.343680 Kb/s
```

Old Method:
```
Download completed!
Total download time: 162.368000 s
Average download speed: 143.718047 Kb/s
```