### PR TITLE
Added support for removing routes in WebServer library

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -363,7 +363,7 @@ void WebServer::_addRequestHandler(RequestHandler *handler) {
 bool WebServer::_removeRequestHandler(RequestHandler *handler) {
   RequestHandler *current = _firstHandler;
   RequestHandler *previous = nullptr;
-  
+
   while (current != nullptr) {
     if (current == handler) {
       if (previous == nullptr) {
@@ -371,11 +371,11 @@ bool WebServer::_removeRequestHandler(RequestHandler *handler) {
       } else {
         previous->next(current->next());
       }
-            
+
       if (current == _lastHandler) {
         _lastHandler = previous;
       }
-      
+
       // Delete 'matching' handler
       delete current;
       return true;

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -147,7 +147,12 @@ public:
   void on(const Uri &uri, THandlerFunction fn);
   void on(const Uri &uri, HTTPMethod method, THandlerFunction fn);
   void on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);  //ufn handles file uploads
+  bool removeRoute(const char *uri);
+  bool removeRoute(const char *uri, HTTPMethod method);
+  bool removeRoute(const String &uri);
+  bool removeRoute(const String &uri, HTTPMethod method);
   void addHandler(RequestHandler *handler);
+  bool removeHandler(RequestHandler *handler);
   void serveStatic(const char *uri, fs::FS &fs, const char *path, const char *cache_header = NULL);
   void onNotFound(THandlerFunction fn);     //called when handler is not assigned
   void onFileUpload(THandlerFunction ufn);  //handle file uploads
@@ -230,6 +235,7 @@ protected:
     return _currentClient.write_P(b, l);
   }
   void _addRequestHandler(RequestHandler *handler);
+  bool _removeRequestHandler(RequestHandler *handler);
   void _handleRequest();
   void _finalizeResponse();
   bool _parseRequest(NetworkClient &client);


### PR DESCRIPTION
## Description of Change
Added support for removing routes in WebServer library. This PR implements `removeRoute` and `removeHandler` methods to remove any specific route which was added earlier using `on` function of WebServer library. 

## Tests scenarios
I have tested this PR on arduino-esp32 core v2.0.17 with ESP32 (Wemos D1 Mini ESP32 Board)

Update (12-06-2024): Tested with arduino-esp32 core v3.0.1 too. Works well and good.

## Related links
--