### PR TITLE
feat: added support for filters in WebServer library

### DIFF
--- a/libraries/WebServer/examples/Filters/Filters.ino
+++ b/libraries/WebServer/examples/Filters/Filters.ino
@@ -71,14 +71,14 @@ void setup(void) {
   }
 
   // This route will be accessible by STA clients only
-  server.on("/sta", [&]() {
+  server.on("/", [&]() {
     digitalWrite(led, 1);
     server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
     digitalWrite(led, 0);
   }).setFilter(ON_STA_FILTER);
 
   // This route will be accessible by AP clients only
-  server.on("/ap", [&]() {
+  server.on("/", [&]() {
     digitalWrite(led, 1);
     server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
     digitalWrite(led, 0);

--- a/libraries/WebServer/examples/Filters/Filters.ino
+++ b/libraries/WebServer/examples/Filters/Filters.ino
@@ -17,12 +17,12 @@ WebServer server(80);
 
 const int led = 13;
 
-// ON_STA_FILTER - Accept requests coming only from the STA interface
+// ON_STA_FILTER - Only accept requests coming from STA interface
 bool ON_STA_FILTER(WebServer &server) {
   return WiFi.STA.hasIP() && WiFi.STA.localIP() == server.client().localIP();
 }
 
-// ON_AP_FILTER - Accept requests coming only from the AP interface
+// ON_AP_FILTER - Only accept requests coming from AP interface
 bool ON_AP_FILTER(WebServer &server) {
   return WiFi.AP.hasIP() && WiFi.AP.localIP() == server.client().localIP();
 }

--- a/libraries/WebServer/examples/Filters/Filters.ino
+++ b/libraries/WebServer/examples/Filters/Filters.ino
@@ -71,18 +71,28 @@ void setup(void) {
   }
 
   // This route will be accessible by STA clients only
-  server.on("/", [&]() {
-    digitalWrite(led, 1);
-    server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
-    digitalWrite(led, 0);
-  }).setFilter(ON_STA_FILTER);
+  server
+    .on(
+      "/",
+      [&]() {
+        digitalWrite(led, 1);
+        server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
+        digitalWrite(led, 0);
+      }
+    )
+    .setFilter(ON_STA_FILTER);
 
   // This route will be accessible by AP clients only
-  server.on("/", [&]() {
-    digitalWrite(led, 1);
-    server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
-    digitalWrite(led, 0);
-  }).setFilter(ON_AP_FILTER);
+  server
+    .on(
+      "/",
+      [&]() {
+        digitalWrite(led, 1);
+        server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
+        digitalWrite(led, 0);
+      }
+    )
+    .setFilter(ON_AP_FILTER);
 
   server.on("/inline", []() {
     server.send(200, "text/plain", "this works as well");

--- a/libraries/WebServer/examples/Filters/Filters.ino
+++ b/libraries/WebServer/examples/Filters/Filters.ino
@@ -1,0 +1,100 @@
+#include <WiFi.h>
+#include <NetworkClient.h>
+#include <WebServer.h>
+#include <ESPmDNS.h>
+
+// Your STA WiFi Credentials
+// ( This is the AP your ESP will connect to )
+const char *ssid = "........";
+const char *password = "........";
+
+// Your AP WiFi Credentials
+// ( This is the AP your ESP will broadcast )
+const char *ap_ssid = "ESP32_Demo";
+const char *ap_password = "";
+
+WebServer server(80);
+
+const int led = 13;
+
+// ON_STA_FILTER - Accept requests coming only from the STA interface
+bool ON_STA_FILTER(WebServer &server) {
+  return WiFi.STA.hasIP() && WiFi.STA.localIP() == server.client().localIP();
+}
+
+// ON_AP_FILTER - Accept requests coming only from the AP interface
+bool ON_AP_FILTER(WebServer &server) {
+  return WiFi.AP.hasIP() && WiFi.AP.localIP() == server.client().localIP();
+}
+
+void handleNotFound() {
+  digitalWrite(led, 1);
+  String message = "File Not Found\n\n";
+  message += "URI: ";
+  message += server.uri();
+  message += "\nMethod: ";
+  message += (server.method() == HTTP_GET) ? "GET" : "POST";
+  message += "\nArguments: ";
+  message += server.args();
+  message += "\n";
+  for (uint8_t i = 0; i < server.args(); i++) {
+    message += " " + server.argName(i) + ": " + server.arg(i) + "\n";
+  }
+  server.send(404, "text/plain", message);
+  digitalWrite(led, 0);
+}
+
+void setup(void) {
+  pinMode(led, OUTPUT);
+  digitalWrite(led, 0);
+  Serial.begin(115200);
+  WiFi.mode(WIFI_AP_STA);
+  // Connect to STA
+  WiFi.begin(ssid, password);
+  // Start AP
+  WiFi.softAP(ap_ssid, ap_password);
+  Serial.println("");
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  if (MDNS.begin("esp32")) {
+    Serial.println("MDNS responder started");
+  }
+
+  // This route will be accessible by STA clients only
+  server.on("/sta", [&]() {
+    digitalWrite(led, 1);
+    server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
+    digitalWrite(led, 0);
+  }).setFilter(ON_STA_FILTER);
+
+  // This route will be accessible by AP clients only
+  server.on("/ap", [&]() {
+    digitalWrite(led, 1);
+    server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
+    digitalWrite(led, 0);
+  }).setFilter(ON_AP_FILTER);
+
+  server.on("/inline", []() {
+    server.send(200, "text/plain", "this works as well");
+  });
+
+  server.onNotFound(handleNotFound);
+
+  server.begin();
+  Serial.println("HTTP server started");
+}
+
+void loop(void) {
+  server.handleClient();
+  delay(2);  //allow the cpu to switch to other tasks
+}

--- a/libraries/WebServer/examples/Filters/ci.json
+++ b/libraries/WebServer/examples/Filters/ci.json
@@ -1,0 +1,5 @@
+{
+  "targets": {
+    "esp32h2": false
+  }
+}

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -124,7 +124,7 @@ bool WebServer::_parseRequest(NetworkClient &client) {
   //attach handler
   RequestHandler *handler;
   for (handler = _firstHandler; handler; handler = handler->next()) {
-    if (handler->canHandle(_currentMethod, _currentUri)) {
+    if (handler->canHandle(*this, _currentMethod, _currentUri)) {
       break;
     }
   }
@@ -176,7 +176,7 @@ bool WebServer::_parseRequest(NetworkClient &client) {
       }
     }
 
-    if (!isForm && _currentHandler && _currentHandler->canRaw(_currentUri)) {
+    if (!isForm && _currentHandler && _currentHandler->canRaw(*this, _currentUri)) {
       log_v("Parse raw");
       _currentRaw.reset(new HTTPRaw());
       _currentRaw->status = RAW_START;
@@ -334,7 +334,7 @@ void WebServer::_parseArguments(String data) {
 
 void WebServer::_uploadWriteByte(uint8_t b) {
   if (_currentUpload->currentSize == HTTP_UPLOAD_BUFLEN) {
-    if (_currentHandler && _currentHandler->canUpload(_currentUri)) {
+    if (_currentHandler && _currentHandler->canUpload(*this, _currentUri)) {
       _currentHandler->upload(*this, _currentUri, *_currentUpload);
     }
     _currentUpload->totalSize += _currentUpload->currentSize;
@@ -449,7 +449,7 @@ bool WebServer::_parseForm(NetworkClient &client, String boundary, uint32_t len)
             _currentUpload->totalSize = 0;
             _currentUpload->currentSize = 0;
             log_v("Start File: %s Type: %s", _currentUpload->filename.c_str(), _currentUpload->type.c_str());
-            if (_currentHandler && _currentHandler->canUpload(_currentUri)) {
+            if (_currentHandler && _currentHandler->canUpload(*this, _currentUri)) {
               _currentHandler->upload(*this, _currentUri, *_currentUpload);
             }
             _currentUpload->status = UPLOAD_FILE_WRITE;
@@ -488,12 +488,12 @@ bool WebServer::_parseForm(NetworkClient &client, String boundary, uint32_t len)
               }
             }
             // Found the boundary string, finish processing this file upload
-            if (_currentHandler && _currentHandler->canUpload(_currentUri)) {
+            if (_currentHandler && _currentHandler->canUpload(*this, _currentUri)) {
               _currentHandler->upload(*this, _currentUri, *_currentUpload);
             }
             _currentUpload->totalSize += _currentUpload->currentSize;
             _currentUpload->status = UPLOAD_FILE_END;
-            if (_currentHandler && _currentHandler->canUpload(_currentUri)) {
+            if (_currentHandler && _currentHandler->canUpload(*this, _currentUri)) {
               _currentHandler->upload(*this, _currentUri, *_currentUpload);
             }
             log_v("End File: %s Type: %s Size: %d", _currentUpload->filename.c_str(), _currentUpload->type.c_str(), (int)_currentUpload->totalSize);
@@ -567,7 +567,7 @@ String WebServer::urlDecode(const String &text) {
 
 bool WebServer::_parseFormUploadAborted() {
   _currentUpload->status = UPLOAD_FILE_ABORTED;
-  if (_currentHandler && _currentHandler->canUpload(_currentUri)) {
+  if (_currentHandler && _currentHandler->canUpload(*this, _currentUri)) {
     _currentHandler->upload(*this, _currentUri, *_currentUpload);
   }
   return false;

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -21,11 +21,6 @@
 */
 
 #include <Arduino.h>
-
-#if SOC_WIFI_SUPPORTED
-  #include "WiFi.h"
-#endif
-
 #include <esp32-hal-log.h>
 #include <libb64/cdecode.h>
 #include <libb64/cencode.h>
@@ -803,13 +798,3 @@ String WebServer::_responseCodeToString(int code) {
     default:  return F("");
   }
 }
-
-#if SOC_WIFI_SUPPORTED
-  bool ON_STA_FILTER(WebServer &server) {
-    return WiFi.STA.hasIP() && WiFi.STA.localIP() == server.client().localIP();
-  }
-
-  bool ON_AP_FILTER(WebServer &server) {
-    return WiFi.AP.hasIP() && WiFi.AP.localIP() == server.client().localIP();
-  }
-#endif

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -21,6 +21,11 @@
 */
 
 #include <Arduino.h>
+
+#if SOC_WIFI_SUPPORTED
+  #include "WiFi.h"
+#endif
+
 #include <esp32-hal-log.h>
 #include <libb64/cdecode.h>
 #include <libb64/cencode.h>
@@ -799,13 +804,12 @@ String WebServer::_responseCodeToString(int code) {
   }
 }
 
-bool ON_STA_FILTER(WebServer &server) {
-  return (
-    (WiFi.localIP() != IPAddress(0, 0, 0, 0) && server.client().localIP() != IPAddress(0, 0, 0, 0))
-    && WiFi.localIP() == server.client().localIP()
-  );
-}
+#if SOC_WIFI_SUPPORTED
+  bool ON_STA_FILTER(WebServer &server) {
+    return WiFi.STA.localIP() == server.client().localIP();
+  }
 
-bool ON_AP_FILTER(WebServer &server) {
-  return WiFi.localIP() == server.client().localIP();
-}
+  bool ON_AP_FILTER(WebServer &server) {
+    return WiFi.AP.localIP() == server.client().localIP();
+  }
+#endif

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -306,15 +306,15 @@ void WebServer::requestAuthentication(HTTPAuthMethod mode, const char *realm, co
   send(401, String(FPSTR(mimeTable[html].mimeType)), authFailMsg);
 }
 
-RequestHandler& WebServer::on(const Uri &uri, WebServer::THandlerFunction handler) {
+RequestHandler &WebServer::on(const Uri &uri, WebServer::THandlerFunction handler) {
   return on(uri, HTTP_ANY, handler);
 }
 
-RequestHandler& WebServer::on(const Uri &uri, HTTPMethod method, WebServer::THandlerFunction fn) {
+RequestHandler &WebServer::on(const Uri &uri, HTTPMethod method, WebServer::THandlerFunction fn) {
   return on(uri, method, fn, _fileUploadHandler);
 }
 
-RequestHandler& WebServer::on(const Uri &uri, HTTPMethod method, WebServer::THandlerFunction fn, WebServer::THandlerFunction ufn) {
+RequestHandler &WebServer::on(const Uri &uri, HTTPMethod method, WebServer::THandlerFunction fn, WebServer::THandlerFunction ufn) {
   FunctionRequestHandler *handler = new FunctionRequestHandler(fn, ufn, uri, method);
   _addRequestHandler(handler);
   return *handler;

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -806,10 +806,10 @@ String WebServer::_responseCodeToString(int code) {
 
 #if SOC_WIFI_SUPPORTED
   bool ON_STA_FILTER(WebServer &server) {
-    return WiFi.STA.localIP() == server.client().localIP();
+    return WiFi.STA.hasIP() && WiFi.STA.localIP() == server.client().localIP();
   }
 
   bool ON_AP_FILTER(WebServer &server) {
-    return WiFi.AP.localIP() == server.client().localIP();
+    return WiFi.AP.hasIP() && WiFi.AP.localIP() == server.client().localIP();
   }
 #endif

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <memory>
 #include "FS.h"
+#include "WiFi.h"
 #include "Network.h"
 #include "HTTP_Method.h"
 #include "Uri.h"
@@ -144,9 +145,10 @@ public:
   void requestAuthentication(HTTPAuthMethod mode = BASIC_AUTH, const char *realm = NULL, const String &authFailMsg = String(""));
 
   typedef std::function<void(void)> THandlerFunction;
-  void on(const Uri &uri, THandlerFunction fn);
-  void on(const Uri &uri, HTTPMethod method, THandlerFunction fn);
-  void on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);  //ufn handles file uploads
+  typedef std::function<bool(WebServer &server)> FilterFunction;
+  RequestHandler& on(const Uri &uri, THandlerFunction fn);
+  RequestHandler& on(const Uri &uri, HTTPMethod method, THandlerFunction fn);
+  RequestHandler& on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);  //ufn handles file uploads
   void addHandler(RequestHandler *handler);
   void serveStatic(const char *uri, fs::FS &fs, const char *path, const char *cache_header = NULL);
   void onNotFound(THandlerFunction fn);     //called when handler is not assigned
@@ -291,5 +293,13 @@ protected:
   String _sopaque;
   String _srealm;  // Store the Auth realm between Calls
 };
+
+/*
+  Request Filters
+*/
+
+bool ON_STA_FILTER(WebServer &server);
+
+bool ON_AP_FILTER(WebServer &server);
 
 #endif  //ESP8266WEBSERVER_H

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -293,12 +293,4 @@ protected:
   String _srealm;  // Store the Auth realm between Calls
 };
 
-/*
-  Request Filters
-*/
-
-bool ON_STA_FILTER(WebServer &server);
-
-bool ON_AP_FILTER(WebServer &server);
-
 #endif  //ESP8266WEBSERVER_H

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -26,7 +26,6 @@
 #include <functional>
 #include <memory>
 #include "FS.h"
-#include "WiFi.h"
 #include "Network.h"
 #include "HTTP_Method.h"
 #include "Uri.h"

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -145,9 +145,9 @@ public:
 
   typedef std::function<void(void)> THandlerFunction;
   typedef std::function<bool(WebServer &server)> FilterFunction;
-  RequestHandler& on(const Uri &uri, THandlerFunction fn);
-  RequestHandler& on(const Uri &uri, HTTPMethod method, THandlerFunction fn);
-  RequestHandler& on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);  //ufn handles file uploads
+  RequestHandler &on(const Uri &uri, THandlerFunction fn);
+  RequestHandler &on(const Uri &uri, HTTPMethod method, THandlerFunction fn);
+  RequestHandler &on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);  //ufn handles file uploads
   bool removeRoute(const char *uri);
   bool removeRoute(const char *uri, HTTPMethod method);
   bool removeRoute(const String &uri);

--- a/libraries/WebServer/src/detail/RequestHandler.h
+++ b/libraries/WebServer/src/detail/RequestHandler.h
@@ -63,7 +63,7 @@ public:
     (void)raw;
   }
 
-  virtual RequestHandler& setFilter(std::function<bool(WebServer&)> filter) {
+  virtual RequestHandler &setFilter(std::function<bool(WebServer &)> filter) {
     (void)filter;
     return *this;
   }

--- a/libraries/WebServer/src/detail/RequestHandler.h
+++ b/libraries/WebServer/src/detail/RequestHandler.h
@@ -7,16 +7,19 @@
 class RequestHandler {
 public:
   virtual ~RequestHandler() {}
-  virtual bool canHandle(HTTPMethod method, String uri) {
+  virtual bool canHandle(WebServer &server, HTTPMethod method, String uri) {
+    (void)server;
     (void)method;
     (void)uri;
     return false;
   }
-  virtual bool canUpload(String uri) {
+  virtual bool canUpload(WebServer &server, String uri) {
+    (void)server;
     (void)uri;
     return false;
   }
-  virtual bool canRaw(String uri) {
+  virtual bool canRaw(WebServer &server, String uri) {
+    (void)server;
     (void)uri;
     return false;
   }
@@ -35,6 +38,11 @@ public:
     (void)server;
     (void)requestUri;
     (void)raw;
+  }
+
+  virtual RequestHandler& setFilter(std::function<bool(WebServer&)> filter) {
+    (void)filter;
+    return *this;
   }
 
   RequestHandler *next() {

--- a/libraries/WebServer/src/detail/RequestHandler.h
+++ b/libraries/WebServer/src/detail/RequestHandler.h
@@ -7,6 +7,29 @@
 class RequestHandler {
 public:
   virtual ~RequestHandler() {}
+
+  /*
+    note: old handler API for backward compatibility
+  */
+
+  virtual bool canHandle(HTTPMethod method, String uri) {
+    (void)method;
+    (void)uri;
+    return false;
+  }
+  virtual bool canUpload(String uri) {
+    (void)uri;
+    return false;
+  }
+  virtual bool canRaw(String uri) {
+    (void)uri;
+    return false;
+  }
+
+  /*
+    note: new handler API with support for filters etc.
+  */
+
   virtual bool canHandle(WebServer &server, HTTPMethod method, String uri) {
     (void)server;
     (void)method;

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -21,6 +21,30 @@ public:
     delete _uri;
   }
 
+  bool canHandle(HTTPMethod requestMethod, String requestUri) override {
+    if (_method != HTTP_ANY && _method != requestMethod) {
+      return false;
+    }
+
+    return _uri->canHandle(requestUri, pathArgs);
+  }
+
+  bool canUpload(String requestUri) override {
+    if (!_ufn || !canHandle(HTTP_POST, requestUri)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  bool canRaw(String requestUri) override {
+    if (!_ufn || _method == HTTP_GET) {
+      return false;
+    }
+
+    return true;
+  }
+
   bool canHandle(WebServer &server, HTTPMethod requestMethod, String requestUri) override {
     if (_method != HTTP_ANY && _method != requestMethod) {
       return false;
@@ -92,6 +116,18 @@ public:
       "StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header ? cache_header : ""
     );  // issue 5506 - cache_header can be nullptr
     _baseUriLength = _uri.length();
+  }
+
+  bool canHandle(HTTPMethod requestMethod, String requestUri) override {
+    if (requestMethod != HTTP_GET) {
+      return false;
+    }
+
+    if ((_isFile && requestUri != _uri) || !requestUri.startsWith(_uri)) {
+      return false;
+    }
+
+    return true;
   }
 
   bool canHandle(WebServer &server, HTTPMethod requestMethod, String requestUri) override {

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -207,7 +207,14 @@ public:
     return (result);
   }  // calcETag
 
+  StaticRequestHandler& setFilter(WebServer::FilterFunction filter) {
+    _filter = filter;
+    return *this;
+  }
+
 protected:
+  // _filter should return 'true' when the request should be handled
+  // and 'false' when the request should be ignored
   WebServer::FilterFunction _filter;
   FS _fs;
   String _uri;

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -92,7 +92,7 @@ public:
     }
   }
 
-  FunctionRequestHandler& setFilter(WebServer::FilterFunction filter) {
+  FunctionRequestHandler &setFilter(WebServer::FilterFunction filter) {
     _filter = filter;
     return *this;
   }
@@ -243,7 +243,7 @@ public:
     return (result);
   }  // calcETag
 
-  StaticRequestHandler& setFilter(WebServer::FilterFunction filter) {
+  StaticRequestHandler &setFilter(WebServer::FilterFunction filter) {
     _filter = filter;
     return *this;
   }


### PR DESCRIPTION
## Description of Change
This PR implements support for `setFilter` in WebServer library, particularly useful for conditional processing of routes based on filter functions set by user.

- `on` methods now return `RequestHandler` which also provides another way for users to remove routes. ( Ref: #9832 )
- Updated `RequestHandler` & `FunctionRequestHandler` class to add `setFilter` function.
- Added 2 default filters: `ON_STA_FILTER` & `ON_AP_FILTER`

## Tests scenarios
I've tested this on arduino-esp32 core v3.0.1 - ESP32 ( Wemos D1 Mini ESP32 board ).

> [!IMPORTANT]
> ~~Potential Bug: @me-no-dev , NetworkClient's `localIP()` method always returns `IPAddress(0,0,0,0)` no matter through which interface the client's request came. This breaks the `ON_STA_FILTER` & `ON_AP_FILTER` filters as we can't detect the right interface correctly.~~
> 
> ~~Eg. In all scenarios (`WIFI_STA` / `WIFI_AP` / `WIFI_AP_STA`), the `client.localIP()` method return `0.0.0.0`).~~ 
> ~~Issue: #9843~~

~~This PR is ready to be merged once the above bug is fixed.~~

Above issue is fixed and PR is ready to be merged.

## Related links
--
