### PR TITLE
fix(xtal): Add a way to change the XTAL frequency for SparkFun ESP32 Thing

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -252,9 +252,6 @@ extern bool btInUse();
 void initArduino() {
   //init proper ref tick value for PLL (uncomment if REF_TICK is different than 1MHz)
   //ESP_REG(APB_CTRL_PLL_TICK_CONF_REG) = APB_CLK_FREQ / REF_CLK_FREQ - 1;
-#ifdef F_CPU
-  setCpuFrequencyMhz(F_CPU / 1000000);
-#endif
 #if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
   psramInit();
 #endif

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -1,6 +1,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_task_wdt.h"
+#include "soc/rtc.h"
 #include "Arduino.h"
 #if (ARDUINO_USB_CDC_ON_BOOT | ARDUINO_USB_MSC_ON_BOOT | ARDUINO_USB_DFU_ON_BOOT) && !ARDUINO_USB_MODE
 #include "USB.h"
@@ -78,6 +79,15 @@ void loopTask(void *pvParameters) {
 }
 
 extern "C" void app_main() {
+#ifdef F_XTAL_MHZ
+#if !CONFIG_IDF_TARGET_ESP32S2 // ESP32-S2 does not support rtc_clk_xtal_freq_update
+  rtc_clk_xtal_freq_update((rtc_xtal_freq_t)F_XTAL_MHZ);
+  rtc_clk_cpu_freq_set_xtal();
+#endif
+#endif
+#ifdef F_CPU
+  setCpuFrequencyMhz(F_CPU / 1000000);
+#endif
 #if ARDUINO_USB_CDC_ON_BOOT && !ARDUINO_USB_MODE
   Serial.begin();
 #endif

--- a/variants/esp32thing/pins_arduino.h
+++ b/variants/esp32thing/pins_arduino.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define F_XTAL_MHZ 26 //SparkFun ESP32 Thing has 26MHz Crystal
+
 static const uint8_t LED_BUILTIN = 5;
 #define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN


### PR DESCRIPTION
Add support for boards like SparkFun ESP32 Thing that use 26MHz XTAL

Fixes: https://github.com/espressif/arduino-esp32/issues/9837
Fixes: https://github.com/espressif/arduino-esp32/issues/9783