### PR TITLE
ci(tools): Fix tools workflows

### DIFF
--- a/.github/scripts/install-arduino-core-esp32.sh
+++ b/.github/scripts/install-arduino-core-esp32.sh
@@ -28,7 +28,11 @@ if [ ! -d "$ARDUINO_ESP32_PATH" ]; then
     #git submodule update --init --recursive > /dev/null 2>&1
 
     echo "Installing Platform Tools ..."
-    cd tools && python get.py
+    if [ "$OS_IS_WINDOWS" == "1" ]; then
+      cd tools && ./get.exe
+    else
+      cd tools && python get.py
+    fi
     cd $script_init_path
 
     echo "ESP32 Arduino has been installed in '$ARDUINO_ESP32_PATH'"

--- a/.github/workflows/build_py_tools.yml
+++ b/.github/workflows/build_py_tools.yml
@@ -3,10 +3,11 @@ name: Build Python Tools
 on:
   pull_request:
     paths:
-    - 'tools/get.py'
-    - 'tools/espota.py'
-    - 'tools/gen_esp32part.py'
-    - 'tools/gen_insights_package.py'
+      - '.github/workflows/build_py_tools.yml'
+      - 'tools/get.py'
+      - 'tools/espota.py'
+      - 'tools/gen_esp32part.py'
+      - 'tools/gen_insights_package.py'
 
 jobs:
   find-changed-tools:
@@ -21,6 +22,13 @@ jobs:
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Check if checkout failed
+        if: failure()
+        run: |
+          echo "Checkout failed."
+          echo "Make sure you are using a branch inside the repository and not a fork."
+
       - name: Verify Python Tools Changed
         uses: tj-actions/changed-files@v41
         id: verify-changed-files
@@ -47,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-20.04, ARM, ARM64]
+        os: [windows-latest, macos-latest, ubuntu-20.04, ARM]
         include:
         - os: windows-latest
           TARGET: win64
@@ -62,10 +70,6 @@ jobs:
         - os: ARM
           CONTAINER: python:3.8-bullseye
           TARGET: arm
-          SEPARATOR: ':'
-        - os: ARM64
-          CONTAINER: python:3.8-bullseye
-          TARGET: arm64
           SEPARATOR: ':'
     container: ${{ matrix.CONTAINER }} # use python container on ARM
     env:
@@ -93,7 +97,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up Python 3.8
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
-        if: matrix.os != 'ARM' && matrix.os != 'ARM64'
+        if: matrix.os != 'ARM'
         uses: actions/setup-python@master
         with:
           python-version: 3.8
@@ -108,7 +112,7 @@ jobs:
             pyinstaller --distpath ./${{ env.DISTPATH }} -F --icon=.github/pytools/espressif.ico tools/$tool.py
           done
       - name: Sign binaries
-        if: matrix.os == 'windows-latest' && env.CERTIFICATE != '' && env.CERTIFICATE_PASSWORD != ''
+        if: matrix.os == 'windows-latest'
         env:
           CERTIFICATE: ${{ secrets.CERTIFICATE }}
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
## Description of Change

- Fix the tools compilation workflows by removing the deprecated ARM64 runner
- Add error message when failing to checkout
- Use `get.exe` for windows compilation test
- Optimize `get.py` and make output easier to read   

## Tests scenarios
Locally and CI

