### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-3f9ab2d6a6"
+              "version": "idf-release_v5.1-b9707a371c"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-3f9ab2d6a6",
+          "version": "idf-release_v5.1-b9707a371c",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a6dac936bfcfa4c11468e003f550b41c76efeae6",
-              "archiveFileName": "esp32-arduino-libs-a6dac936bfcfa4c11468e003f550b41c76efeae6.zip",
-              "checksum": "SHA-256:b9173333fca2c6caa265dab050c62f1bb71e52dcb7cf21bd91b7fe1c37b3b444",
-              "size": "297521768"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9f889b1dadfb54c37f017b21f70c35828941a3fd",
+              "archiveFileName": "esp32-arduino-libs-9f889b1dadfb54c37f017b21f70c35828941a3fd.zip",
+              "checksum": "SHA-256:cb902ac1dd666f7ec72cac040b88c6c52d09f13c55b0bdecb1bdb2663c8dbeda",
+              "size": "304865373"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 4b47beb
esp-idf: release/v5.1 b9707a371c
arduino: master 849ec57c
tinyusb: master ba2f2299c
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.3.2
espressif__esp-zigbee-lib: 1.3.2
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.1.0
espressif__esp_schedule: 1.1.1
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.5
joltwallet__littlefs: 1.14.5
```
