### PR TITLE
fix(ota): Magic byte check fails with encrypted firmware

### DIFF
--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -524,9 +524,11 @@ size_t UpdateClass::writeStream(Stream &data) {
     return 0;
   }
 
-  if (!_verifyHeader(data.peek())) {
-    _reset();
-    return 0;
+  if (_command == U_FLASH && !_cryptMode) {
+    if (!_verifyHeader(data.peek())) {
+      _reset();
+      return 0;
+    }
   }
 
   if (_ledPin != -1) {


### PR DESCRIPTION
The check was running before firmware was decrypted, so it fails.
Changes run the check only when unencrypted firmware is being uploaded.

Fixes: https://github.com/espressif/arduino-esp32/issues/9850 