### PR TITLE
feat(uart): Add esp-modbus to the included components

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -84,6 +84,9 @@ dependencies:
   espressif/libsodium:
     version: "^1.0.20~1"
     require: public
+  espressif/esp-modbus:
+    version: "^1.0.15"
+    require: public
   joltwallet/littlefs:
     version: "^1.10.2"
   chmorgan/esp-libhelix-mp3:


### PR DESCRIPTION
It used to come with IDF 4.x

Fixes: https://github.com/espressif/arduino-esp32/issues/9854