### PR TITLE
ClientSecure.available() fix for connection closed by remote socket

### DIFF
--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
@@ -305,9 +305,11 @@ int NetworkClientSecure::available() {
   res = data_to_read(sslclient.get());
 
   if (res < 0 && !_stillinPlainStart) {
-    log_e("Closing connection on failed available check");
+    if (res != MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+      log_e("Closing connection on failed available check");
+    }
     stop();
-    return peeked ? peeked : res;
+    return peeked;
   }
   return res + peeked;
 }

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -27,7 +27,7 @@
 const char *pers = "esp32-tls";
 
 static int _handle_error(int err, const char *function, int line) {
-  if (err == -30848) {
+  if (err == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
     return err;
   }
 #ifdef MBEDTLS_ERROR_C


### PR DESCRIPTION
for connection closed by remote socket the `NetworkClientSecure.available()` method:
1) logged an error. 
2) returned a negative value (the error code)

The error logging is skipped for error code returned in this case. This error code is skipped in ssl_client.cpp `_handle_error` too.

I tested it with modified WiFiClientInsecure example
```
#include <NetworkClientSecure.h>
#include <WiFi.h>

const char *ssid = "your-ssid";          // your network SSID (name of wifi network)
const char *password = "your-password";  // your network password

const char *server = "arduino.tips";  // Server URL

NetworkClientSecure client;

void setup() {
  Serial.begin(115200);
  delay(500);

  Serial.print("Attempting to connect to SSID: ");
  Serial.println(ssid);
  WiFi.begin(ssid, password);
  while (WiFi.status() != WL_CONNECTED) {
    Serial.print(".");
    delay(1000);
  }
  Serial.print("Connected to ");
  Serial.println(ssid);

  Serial.println("\nStarting connection to server...");
  client.setInsecure();  //skip verification
  if (!client.connect(server, 443)) {
    Serial.println("Connection failed!");
  } else {
    Serial.println("Connected to server!");
    client.println("GET /asciilogo.txt HTTP/1.1");
    client.print("Host: ");
    client.println(server);
    client.println("Connection: close");
    client.println();

    while (client.connected()) {
      String line = client.readStringUntil('\n');
      if (line == "\r") {
        Serial.println("headers received");
        break;
      }
    }
    while (client.available()) {
      char c = client.read();
      Serial.write(c);
    }
    client.stop();
  }
}

void loop() {
  delay(1);
}
```
without the fix it logged
```
[  2572][E][NetworkClientSecure.cpp:308] available(): Closing connection on failed available check
[  2587][E][NetworkClient.cpp:315] setSocketOption(): fail on 0, errno: 9, "Bad file number"
�
```
the setSocketOption error and the strange character were the result of `read` which was executed because available() didn't return a 0 but a negative value.