### PR TITLE
fix(BLE): Arduino String shall not be used within std::map<> 

### DIFF
--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -343,7 +343,7 @@ void BLEClient::gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t
       BLEUUID uuid = BLEUUID(evtParam->search_res.srvc_id);
       BLERemoteService *pRemoteService =
         new BLERemoteService(evtParam->search_res.srvc_id, this, evtParam->search_res.start_handle, evtParam->search_res.end_handle);
-      m_servicesMap.insert(std::pair<String, BLERemoteService *>(uuid.toString(), pRemoteService));
+      m_servicesMap.insert(std::pair<std::string, BLERemoteService *>(uuid.toString().c_str(), pRemoteService));
       m_servicesMapByInstID.insert(std::pair<BLERemoteService *, uint16_t>(pRemoteService, evtParam->search_res.srvc_id.inst_id));
       break;
     }  // ESP_GATTC_SEARCH_RES_EVT
@@ -428,7 +428,7 @@ BLERemoteService *BLEClient::getService(BLEUUID uuid) {
   if (!m_haveServices) {
     getServices();
   }
-  String uuidStr = uuid.toString();
+  std::string uuidStr = uuid.toString().c_str();
   for (auto &myPair : m_servicesMap) {
     if (myPair.first == uuidStr) {
       log_v("<< getService: found the service with uuid: %s", uuid.toString().c_str());
@@ -445,7 +445,7 @@ BLERemoteService *BLEClient::getService(BLEUUID uuid) {
  * services and wait until we have received them all.
  * @return N/A
  */
-std::map<String, BLERemoteService *> *BLEClient::getServices() {
+std::map<std::string, BLERemoteService *> *BLEClient::getServices() {
   /*
  * Design
  * ------

--- a/libraries/BLE/src/BLEClient.h
+++ b/libraries/BLE/src/BLEClient.h
@@ -42,7 +42,7 @@ public:
   void disconnect();                                                 // Disconnect from the remote BLE Server
   BLEAddress getPeerAddress();                                       // Get the address of the remote BLE Server
   int getRssi();                                                     // Get the RSSI of the remote BLE Server
-  std::map<std::string, BLERemoteService *> *getServices();               // Get a map of the services offered by the remote BLE Server
+  std::map<std::string, BLERemoteService *> *getServices();          // Get a map of the services offered by the remote BLE Server
   BLERemoteService *getService(const char *uuid);                    // Get a reference to a specified service offered by the remote BLE server.
   BLERemoteService *getService(BLEUUID uuid);                        // Get a reference to a specified service offered by the remote BLE server.
   String getValue(BLEUUID serviceUUID, BLEUUID characteristicUUID);  // Get the value of a given characteristic at a given service.

--- a/libraries/BLE/src/BLEClient.h
+++ b/libraries/BLE/src/BLEClient.h
@@ -42,7 +42,7 @@ public:
   void disconnect();                                                 // Disconnect from the remote BLE Server
   BLEAddress getPeerAddress();                                       // Get the address of the remote BLE Server
   int getRssi();                                                     // Get the RSSI of the remote BLE Server
-  std::map<String, BLERemoteService *> *getServices();               // Get a map of the services offered by the remote BLE Server
+  std::map<std::string, BLERemoteService *> *getServices();               // Get a map of the services offered by the remote BLE Server
   BLERemoteService *getService(const char *uuid);                    // Get a reference to a specified service offered by the remote BLE server.
   BLERemoteService *getService(BLEUUID uuid);                        // Get a reference to a specified service offered by the remote BLE server.
   String getValue(BLEUUID serviceUUID, BLEUUID characteristicUUID);  // Get the value of a given characteristic at a given service.
@@ -82,7 +82,7 @@ private:
   FreeRTOS::Semaphore m_semaphoreOpenEvt = FreeRTOS::Semaphore("OpenEvt");
   FreeRTOS::Semaphore m_semaphoreSearchCmplEvt = FreeRTOS::Semaphore("SearchCmplEvt");
   FreeRTOS::Semaphore m_semaphoreRssiCmplEvt = FreeRTOS::Semaphore("RssiCmplEvt");
-  std::map<String, BLERemoteService *> m_servicesMap;
+  std::map<std::string, BLERemoteService *> m_servicesMap;
   std::map<BLERemoteService *, uint16_t> m_servicesMapByInstID;
   void clearServices();  // Clear any existing services.
   uint16_t m_mtu = 23;

--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -297,7 +297,7 @@ void BLERemoteCharacteristic::retrieveDescriptors() {
     // We now have a new characteristic ... let us add that to our set of known characteristics
     BLERemoteDescriptor *pNewRemoteDescriptor = new BLERemoteDescriptor(result.handle, BLEUUID(result.uuid), this);
 
-    m_descriptorMap.insert(std::pair<String, BLERemoteDescriptor *>(pNewRemoteDescriptor->getUUID().toString(), pNewRemoteDescriptor));
+    m_descriptorMap.insert(std::pair<std::string, BLERemoteDescriptor *>(pNewRemoteDescriptor->getUUID().toString().c_str(), pNewRemoteDescriptor));
 
     offset++;
   }  // while true
@@ -308,7 +308,7 @@ void BLERemoteCharacteristic::retrieveDescriptors() {
 /**
  * @brief Retrieve the map of descriptors keyed by UUID.
  */
-std::map<String, BLERemoteDescriptor *> *BLERemoteCharacteristic::getDescriptors() {
+std::map<std::string, BLERemoteDescriptor *> *BLERemoteCharacteristic::getDescriptors() {
   return &m_descriptorMap;
 }  // getDescriptors
 
@@ -329,7 +329,7 @@ uint16_t BLERemoteCharacteristic::getHandle() {
  */
 BLERemoteDescriptor *BLERemoteCharacteristic::getDescriptor(BLEUUID uuid) {
   log_v(">> getDescriptor: uuid: %s", uuid.toString().c_str());
-  String v = uuid.toString();
+  std::string v = uuid.toString().c_str();
   for (auto &myPair : m_descriptorMap) {
     if (myPair.first == v) {
       log_v("<< getDescriptor: found");

--- a/libraries/BLE/src/BLERemoteCharacteristic.h
+++ b/libraries/BLE/src/BLERemoteCharacteristic.h
@@ -39,7 +39,7 @@ public:
   bool canWrite();
   bool canWriteNoResponse();
   BLERemoteDescriptor *getDescriptor(BLEUUID uuid);
-  std::map<String, BLERemoteDescriptor *> *getDescriptors();
+  std::map<std::string, BLERemoteDescriptor *> *getDescriptors();
   BLERemoteService *getRemoteService();
   uint16_t getHandle();
   BLEUUID getUUID();
@@ -82,7 +82,7 @@ private:
   notify_callback m_notifyCallback;
 
   // We maintain a map of descriptors owned by this characteristic keyed by a string representation of the UUID.
-  std::map<String, BLERemoteDescriptor *> m_descriptorMap;
+  std::map<std::string, BLERemoteDescriptor *> m_descriptorMap;
 };  // BLERemoteCharacteristic
 
 #endif /* CONFIG_BLUEDROID_ENABLED */

--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -179,7 +179,9 @@ void BLERemoteService::retrieveCharacteristics() {
     // We now have a new characteristic ... let us add that to our set of known characteristics
     BLERemoteCharacteristic *pNewRemoteCharacteristic = new BLERemoteCharacteristic(result.char_handle, BLEUUID(result.uuid), result.properties, this);
 
-    m_characteristicMap.insert(std::pair<std::string, BLERemoteCharacteristic *>(pNewRemoteCharacteristic->getUUID().toString().c_str(), pNewRemoteCharacteristic));
+    m_characteristicMap.insert(
+      std::pair<std::string, BLERemoteCharacteristic *>(pNewRemoteCharacteristic->getUUID().toString().c_str(), pNewRemoteCharacteristic)
+    );
     m_characteristicMapByHandle.insert(std::pair<uint16_t, BLERemoteCharacteristic *>(result.char_handle, pNewRemoteCharacteristic));
     offset++;  // Increment our count of number of descriptors found.
   }  // Loop forever (until we break inside the loop).

--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -79,8 +79,8 @@ void BLERemoteService::gattClientEventHandler(esp_gattc_cb_event_t event, esp_ga
 
       // This is an indication that we now have the characteristic details for a characteristic owned
       // by this service so remember it.
-      m_characteristicMap.insert(std::pair<String, BLERemoteCharacteristic*>(
-          BLEUUID(evtParam->get_char.char_id.uuid).toString(),
+      m_characteristicMap.insert(std::pair<std::String, BLERemoteCharacteristic*>(
+          BLEUUID(evtParam->get_char.char_id.uuid).toString().c_str(),
           new BLERemoteCharacteristic(evtParam->get_char.char_id, evtParam->get_char.char_prop, this)  ));
 
 
@@ -134,7 +134,7 @@ BLERemoteCharacteristic *BLERemoteService::getCharacteristic(BLEUUID uuid) {
   if (!m_haveCharacteristics) {
     retrieveCharacteristics();
   }
-  String v = uuid.toString();
+  std::string v = uuid.toString().c_str();
   for (auto &myPair : m_characteristicMap) {
     if (myPair.first == v) {
       return myPair.second;
@@ -179,7 +179,7 @@ void BLERemoteService::retrieveCharacteristics() {
     // We now have a new characteristic ... let us add that to our set of known characteristics
     BLERemoteCharacteristic *pNewRemoteCharacteristic = new BLERemoteCharacteristic(result.char_handle, BLEUUID(result.uuid), result.properties, this);
 
-    m_characteristicMap.insert(std::pair<String, BLERemoteCharacteristic *>(pNewRemoteCharacteristic->getUUID().toString(), pNewRemoteCharacteristic));
+    m_characteristicMap.insert(std::pair<std::string, BLERemoteCharacteristic *>(pNewRemoteCharacteristic->getUUID().toString().c_str(), pNewRemoteCharacteristic));
     m_characteristicMapByHandle.insert(std::pair<uint16_t, BLERemoteCharacteristic *>(result.char_handle, pNewRemoteCharacteristic));
     offset++;  // Increment our count of number of descriptors found.
   }  // Loop forever (until we break inside the loop).
@@ -192,7 +192,7 @@ void BLERemoteService::retrieveCharacteristics() {
  * @brief Retrieve a map of all the characteristics of this service.
  * @return A map of all the characteristics of this service.
  */
-std::map<String, BLERemoteCharacteristic *> *BLERemoteService::getCharacteristics() {
+std::map<std::string, BLERemoteCharacteristic *> *BLERemoteService::getCharacteristics() {
   log_v(">> getCharacteristics() for service: %s", getUUID().toString().c_str());
   // If is possible that we have not read the characteristics associated with the service so do that
   // now.  The request to retrieve the characteristics by calling "retrieveCharacteristics" is a blocking

--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -79,7 +79,7 @@ void BLERemoteService::gattClientEventHandler(esp_gattc_cb_event_t event, esp_ga
 
       // This is an indication that we now have the characteristic details for a characteristic owned
       // by this service so remember it.
-      m_characteristicMap.insert(std::pair<std::String, BLERemoteCharacteristic*>(
+      m_characteristicMap.insert(std::pair<std::string, BLERemoteCharacteristic*>(
           BLEUUID(evtParam->get_char.char_id.uuid).toString().c_str(),
           new BLERemoteCharacteristic(evtParam->get_char.char_id, evtParam->get_char.char_prop, this)  ));
 

--- a/libraries/BLE/src/BLERemoteService.h
+++ b/libraries/BLE/src/BLERemoteService.h
@@ -34,7 +34,7 @@ public:
   BLERemoteCharacteristic *getCharacteristic(const char *uuid);  // Get the specified characteristic reference.
   BLERemoteCharacteristic *getCharacteristic(BLEUUID uuid);      // Get the specified characteristic reference.
   BLERemoteCharacteristic *getCharacteristic(uint16_t uuid);     // Get the specified characteristic reference.
-  std::map<String, BLERemoteCharacteristic *> *getCharacteristics();
+  std::map<std::string, BLERemoteCharacteristic *> *getCharacteristics();
   std::map<uint16_t, BLERemoteCharacteristic *> *getCharacteristicsByHandle();  // Get the characteristics map.
   void getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic *> **pCharacteristicMap);
 
@@ -66,7 +66,7 @@ private:
   // Properties
 
   // We maintain a map of characteristics owned by this service keyed by a string representation of the UUID.
-  std::map<String, BLERemoteCharacteristic *> m_characteristicMap;
+  std::map<std::string, BLERemoteCharacteristic *> m_characteristicMap;
 
   // We maintain a map of characteristics owned by this service keyed by a handle.
   std::map<uint16_t, BLERemoteCharacteristic *> m_characteristicMapByHandle;

--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -99,7 +99,7 @@ void BLEScan::handleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_
           bool shouldDelete = true;
 
           if (!m_wantDuplicates) {
-            if (m_scanResults.m_vectorAdvertisedDevices.count(advertisedAddress.toString()) != 0) {
+            if (m_scanResults.m_vectorAdvertisedDevices.count(advertisedAddress.toString().c_str()) != 0) {
               found = true;
             }
 
@@ -130,7 +130,7 @@ void BLEScan::handleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_
             m_pAdvertisedDeviceCallbacks->onResult(*advertisedDevice);
           }
           if (!m_wantDuplicates && !found) {  // if no callback and not want duplicate, and not already in vector, record it
-            m_scanResults.m_vectorAdvertisedDevices.insert(std::pair<String, BLEAdvertisedDevice *>(advertisedAddress.toString(), advertisedDevice));
+            m_scanResults.m_vectorAdvertisedDevices.insert(std::pair<std::string, BLEAdvertisedDevice *>(advertisedAddress.toString().c_str(), advertisedDevice));
             shouldDelete = false;
           }
           if (shouldDelete) {
@@ -443,8 +443,8 @@ void BLEScan::stop() {
 // delete peer device from cache after disconnecting, it is required in case we are connecting to devices with not public address
 void BLEScan::erase(BLEAddress address) {
   log_i("erase device: %s", address.toString().c_str());
-  BLEAdvertisedDevice *advertisedDevice = m_scanResults.m_vectorAdvertisedDevices.find(address.toString())->second;
-  m_scanResults.m_vectorAdvertisedDevices.erase(address.toString());
+  BLEAdvertisedDevice *advertisedDevice = m_scanResults.m_vectorAdvertisedDevices.find(address.toString().c_str())->second;
+  m_scanResults.m_vectorAdvertisedDevices.erase(address.toString().c_str());
   delete advertisedDevice;
 }
 

--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -130,7 +130,8 @@ void BLEScan::handleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_
             m_pAdvertisedDeviceCallbacks->onResult(*advertisedDevice);
           }
           if (!m_wantDuplicates && !found) {  // if no callback and not want duplicate, and not already in vector, record it
-            m_scanResults.m_vectorAdvertisedDevices.insert(std::pair<std::string, BLEAdvertisedDevice *>(advertisedAddress.toString().c_str(), advertisedDevice));
+            m_scanResults.m_vectorAdvertisedDevices.insert(std::pair<std::string, BLEAdvertisedDevice *>(advertisedAddress.toString().c_str(), advertisedDevice)
+            );
             shouldDelete = false;
           }
           if (shouldDelete) {

--- a/libraries/BLE/src/BLEScan.h
+++ b/libraries/BLE/src/BLEScan.h
@@ -53,7 +53,7 @@ public:
 
 private:
   friend BLEScan;
-  std::map<String, BLEAdvertisedDevice *> m_vectorAdvertisedDevices;
+  std::map<std::string, BLEAdvertisedDevice *> m_vectorAdvertisedDevices;
 };
 
 /**


### PR DESCRIPTION
## Description of Change
This PR partially reverts changes done in PR #8724 related to using Arduino `String`,  as a Key, within `std::map<>`.
It replaces Arduino `String` by `std::string` which is a C++ class compatible with `std::map<>` template, that must implement `std::less` in order to allow necesary comparation when inserting `<Key, T>` into the map.

## Tests scenarios
Tested using ESP32, ESP32-S3 and ESP32-C6.

In order to test it, it is possible to use the BLE Client example running in one ESP32 SoC
https://github.com/espressif/arduino-esp32/blob/master/libraries/BLE/examples/Client/Client.ino

The second ESP32 SoC shall run a modified version of the BLE Server that adds a second characteristic in the same service.
Based on the code of https://github.com/espressif/arduino-esp32/blob/master/libraries/BLE/examples/Server/Server.ino

``` cpp
#include <BLEDevice.h>
#include <BLEUtils.h>
#include <BLEServer.h>

#define SERVICE_UUID        "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
#define CHARACTERISTIC_UUID_1 "beb5483e-36e1-4688-b7f5-ea07361b26a8"
#define CHARACTERISTIC_UUID_2 "beb5483e-36e2-4688-b7f5-ea07361b26a8"

void setup() {
  Serial.begin(115200);
  Serial.println("Starting BLE work!");

  BLEDevice::init("Long name works now");
  BLEServer *pServer = BLEDevice::createServer();
  BLEService *pService = pServer->createService(SERVICE_UUID);
  BLECharacteristic *pCharacteristic1 =
    pService->createCharacteristic(CHARACTERISTIC_UUID_1, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_WRITE);

  pCharacteristic1->setValue("Characteristic 1");

  BLECharacteristic *pCharacteristic2 =
    pService->createCharacteristic(CHARACTERISTIC_UUID_2, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_WRITE);

  pCharacteristic2->setValue("Characteristic 2");

  pService->start();
  // BLEAdvertising *pAdvertising = pServer->getAdvertising();  // this still is working for backward compatibility
  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
  pAdvertising->addServiceUUID(SERVICE_UUID);
  pAdvertising->setScanResponse(true);
  pAdvertising->setMinPreferred(0x06);  // functions that help with iPhone connections issue
  pAdvertising->setMinPreferred(0x12);
  BLEDevice::startAdvertising();
  Serial.println("Characteristic defined! Now you can read it in your phone!");
}

void loop() {
  // put your main code here, to run repeatedly:
  delay(2000);
}
```

## Related links
Fix  #9768 