### PR TITLE
Adds BLE Characteristic User Description 0x2901 Descriptor

### DIFF
--- a/libraries/BLE/examples/Notify/Notify.ino
+++ b/libraries/BLE/examples/Notify/Notify.ino
@@ -23,9 +23,12 @@
 #include <BLEServer.h>
 #include <BLEUtils.h>
 #include <BLE2902.h>
+#include <BLE2901.h>
 
 BLEServer *pServer = NULL;
 BLECharacteristic *pCharacteristic = NULL;
+BLE2901 *descriptor_2901 = NULL;
+
 bool deviceConnected = false;
 bool oldDeviceConnected = false;
 uint32_t value = 0;
@@ -33,8 +36,8 @@ uint32_t value = 0;
 // See the following for generating UUIDs:
 // https://www.uuidgenerator.net/
 
-#define SERVICE_UUID        "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
-#define CHARACTERISTIC_UUID "beb5483e-36e1-4688-b7f5-ea07361b26a8"
+#define SERVICE_UUID        "0000ff00-0000-1000-8000-00805f9b34fb"
+#define CHARACTERISTIC_UUID "0000ff01-0000-1000-8000-00805f9b34fb"
 
 class MyServerCallbacks : public BLEServerCallbacks {
   void onConnect(BLEServer *pServer) {
@@ -65,9 +68,13 @@ void setup() {
     BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_WRITE | BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_INDICATE
   );
 
-  // https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml
-  // Create a BLE Descriptor
+  // Creates BLE Descriptor 0x2902: Client Characteristic Configuration Descriptor (CCCD) 
   pCharacteristic->addDescriptor(new BLE2902());
+  // Adds also the Characteristic User Description - 0x2901 descriptor
+  descriptor_2901 = new BLE2901();
+  descriptor_2901->setDescription("My own description for this characteristic.");
+  descriptor_2901->setAccessPermissions(ESP_GATT_PERM_READ); // enforce read only - default is Read|Write 
+  pCharacteristic->addDescriptor(descriptor_2901);
 
   // Start the service
   pService->start();
@@ -87,7 +94,7 @@ void loop() {
     pCharacteristic->setValue((uint8_t *)&value, 4);
     pCharacteristic->notify();
     value++;
-    delay(3);  // bluetooth stack will go into congestion, if too many packets are sent, in 6 hours test i was able to go as low as 3ms
+    delay(500);
   }
   // disconnecting
   if (!deviceConnected && oldDeviceConnected) {

--- a/libraries/BLE/src/BLE2901.cpp
+++ b/libraries/BLE/src/BLE2901.cpp
@@ -1,0 +1,41 @@
+/*
+   BLE2901.h
+ 
+     GATT Descriptor 0x2901 Characteristic User Description
+
+     The value of this description is a user-readable string
+     describing the characteristic.
+
+     The Characteristic User Description descriptor
+     provides a textual user description for a characteristic
+     value.
+     If the Writable Auxiliary bit of the Characteristics
+     Properties is set then this descriptor is written. Only one
+     User Description descriptor exists in a characteristic
+     definition.
+*/
+
+#include "soc/soc_caps.h"
+#if SOC_BLE_SUPPORTED
+
+#include "sdkconfig.h"
+#if defined(CONFIG_BLUEDROID_ENABLED)
+
+#include "BLE2901.h"
+
+BLE2901::BLE2901() : BLEDescriptor(BLEUUID((uint16_t)0x2901)) {
+}  // BLE2901
+
+/**
+ * @brief Set the Characteristic User Description
+ */
+void BLE2901::setDescription(String userDesc) {
+  if (userDesc.length() > ESP_GATT_MAX_ATTR_LEN) {
+    log_e("Size %d too large, must be no bigger than %d", userDesc.length(), ESP_GATT_MAX_ATTR_LEN);
+    return;    
+  }
+  setValue(userDesc);
+}
+
+#endif
+#endif /* SOC_BLE_SUPPORTED */

--- a/libraries/BLE/src/BLE2901.h
+++ b/libraries/BLE/src/BLE2901.h
@@ -1,0 +1,37 @@
+/*
+   BLE2901.h
+
+     GATT Descriptor 0x2901 Characteristic User Description
+
+     The value of this description is a user-readable string
+     describing the characteristic.
+
+     The Characteristic User Description descriptor
+     provides a textual user description for a characteristic
+     value.
+     If the Writable Auxiliary bit of the Characteristics
+     Properties is set then this descriptor is written. Only one
+     User Description descriptor exists in a characteristic
+     definition.
+
+*/
+
+#ifndef COMPONENTS_CPP_UTILS_BLE2901_H_
+#define COMPONENTS_CPP_UTILS_BLE2901_H_
+#include "soc/soc_caps.h"
+#if SOC_BLE_SUPPORTED
+
+#include "sdkconfig.h"
+#if defined(CONFIG_BLUEDROID_ENABLED)
+
+#include "BLEDescriptor.h"
+
+class BLE2901 : public BLEDescriptor {
+  public:
+    BLE2901();
+    void setDescription(String desc);
+};  // BLE2901
+
+#endif /* CONFIG_BLUEDROID_ENABLED */
+#endif /* SOC_BLE_SUPPORTED */
+#endif /* COMPONENTS_CPP_UTILS_BLE2901_H_ */


### PR DESCRIPTION
## Description of Change
This PR adds a new BLE Descriptor Class 0x2901: characteristic user description.

The value of this description is a user-readable string describing the characteristic.
The Characteristic User Description descriptor provides a textual user description for a characteristic value.
If the Writable Auxiliary bit of the Characteristics Properties is set then this descriptor is written.
Only one User Description descriptor exists in a characteristic definition.

## Tests scenarios
Tested with ESP32 and ESP32-C6.

``` cpp
#include <BLEDevice.h>
#include <BLEServer.h>
#include <BLEUtils.h>
#include <BLE2902.h>
#include <BLE2901.h>

BLEServer *pServer = NULL;
BLECharacteristic *pCharacteristic = NULL;
BLE2901 *descriptor_2901 = NULL;

bool deviceConnected = false;
bool oldDeviceConnected = false;
uint32_t value = 0;

// See the following for generating UUIDs:
// https://www.uuidgenerator.net/

#define SERVICE_UUID        "0000ff00-0000-1000-8000-00805f9b34fb"
#define CHARACTERISTIC_UUID "0000ff01-0000-1000-8000-00805f9b34fb"

class MyServerCallbacks : public BLEServerCallbacks {
  void onConnect(BLEServer *pServer) {
    deviceConnected = true;
  };

  void onDisconnect(BLEServer *pServer) {
    deviceConnected = false;
  }
};

void setup() {
  Serial.begin(115200);

  // Create the BLE Device
  BLEDevice::init("ESP32");

  // Create the BLE Server
  pServer = BLEDevice::createServer();
  pServer->setCallbacks(new MyServerCallbacks());

  // Create the BLE Service
  BLEService *pService = pServer->createService(SERVICE_UUID);

  // Create a BLE Characteristic
  pCharacteristic = pService->createCharacteristic(
    CHARACTERISTIC_UUID,
    BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_WRITE | BLECharacteristic::PROPERTY_NOTIFY | BLECharacteristic::PROPERTY_INDICATE
  );

  // Create a BLE Descriptor: Client Characteristic Configuration" Descriptor (CCCD) 
  pCharacteristic->addDescriptor(new BLE2902());
  // Add also the Characteristic User Description - 0x2901 descriptor
  descriptor_2901 = new BLE2901();
  descriptor_2901->setDescription("My own description for this characteristic.");
  descriptor_2901->setAccessPermissions(ESP_GATT_PERM_READ); // enforce read only - default is Read|Write 
  pCharacteristic->addDescriptor(descriptor_2901);

  // Start the service
  pService->start();

  // Start advertising
  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
  pAdvertising->addServiceUUID(SERVICE_UUID);
  pAdvertising->setScanResponse(false);
  pAdvertising->setMinPreferred(0x0);  // set value to 0x00 to not advertise this parameter
  BLEDevice::startAdvertising();
  Serial.println("Waiting a client connection to notify...");
}

void loop() {
  // notify changed value
  if (deviceConnected) {
    pCharacteristic->setValue((uint8_t *)&value, 4);
    pCharacteristic->notify();
    value++;
    delay(300);
  }
  // disconnecting
  if (!deviceConnected && oldDeviceConnected) {
    delay(500);                   // give the bluetooth stack the chance to get things ready
    pServer->startAdvertising();  // restart advertising
    Serial.println("start advertising");
    oldDeviceConnected = deviceConnected;
  }
  // connecting
  if (deviceConnected && !oldDeviceConnected) {
    // do stuff here on connecting
    oldDeviceConnected = deviceConnected;
  }
}
```


## Related links
Used to simulate the issue described in #9768 
