### PR TITLE
fix(SimpleTime): fixes example for SimpleTime.ino

### DIFF
--- a/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
+++ b/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
@@ -50,7 +50,7 @@ void setup() {
    * NOTE: configTime() function call if made AFTER DHCP-client run
    * will OVERRIDE acquired NTP server address
    */
-  esp_sntp_servermode_dhcp(1);  // (optional)
+  //esp_sntp_servermode_dhcp(1);  // (optional) -- Not used within Arduino Core 3.0.0+
 
   /**
    * This will set configured ntp servers and constant TimeZone/daylightOffset


### PR DESCRIPTION
## Description of Change
Fixes the SimpleTime.ino example in order to make it work within Arduino core 3.0.0.
There is a DHCP option that shall not be used anymore.

## Tests scenarios
Using the ESP32 and the SimpleTime.ino example.

## Related links
Fixes #9879 