### PR TITLE
fix(time): Fix SimpleTime to also use time servers from DHCP

### DIFF
--- a/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
+++ b/libraries/ESP32/examples/Time/SimpleTime/SimpleTime.ino
@@ -33,14 +33,6 @@ void setup() {
   // First step is to configure WiFi STA and connect in order to get the current time and date.
   Serial.printf("Connecting to %s ", ssid);
   WiFi.begin(ssid, password);
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
-    Serial.print(".");
-  }
-  Serial.println(" CONNECTED");
-
-  // set notification call-back function
-  sntp_set_time_sync_notification_cb(timeavailable);
 
   /**
    * NTP server address could be acquired via DHCP,
@@ -51,6 +43,15 @@ void setup() {
    * will OVERRIDE acquired NTP server address
    */
   esp_sntp_servermode_dhcp(1);  // (optional)
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println(" CONNECTED");
+
+  // set notification call-back function
+  sntp_set_time_sync_notification_cb(timeavailable);
 
   /**
    * This will set configured ntp servers and constant TimeZone/daylightOffset


### PR DESCRIPTION
It is said that `esp_sntp_servermode_dhcp(1);` should be called before STA get's IP, yet the call is made after that had already happened. This PR puts it in the right place: after `WiFi.begin();`