### PR TITLE
HTTPClient lib - add HTTPCLIENT_NOSECURE build flag

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -142,7 +142,9 @@ bool HTTPClient::begin(NetworkClient &client, String url) {
   _secure = (protocol == "https");
 
 #ifdef HTTPCLIENT_NOSECURE
-  if (_secure) return false;
+  if (_secure) {
+    return false;
+  }
 #endif  // HTTPCLIENT_NOSECURE
   return beginInternal(url, protocol.c_str());
 }

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -142,10 +142,9 @@ bool HTTPClient::begin(NetworkClient &client, String url) {
   _secure = (protocol == "https");
 
 #ifdef HTTPCLIENT_NOSECURE
-  return _secure ? false : beginInternal(url, protocol.c_str());
-#else
-  return beginInternal(url, protocol.c_str());
+  if (_secure) return false;
 #endif  // HTTPCLIENT_NOSECURE
+  return beginInternal(url, protocol.c_str());
 }
 
 /**

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -28,15 +28,8 @@
 
 #include <Arduino.h>
 #include <esp32-hal-log.h>
-
-#ifdef HTTPCLIENT_1_1_COMPATIBLE
-#include <NetworkClient.h>
-#include <NetworkClientSecure.h>
-#endif
-
 #include <StreamString.h>
 #include <base64.h>
-
 #include "HTTPClient.h"
 
 /// Cookie jar support
@@ -56,6 +49,7 @@ public:
   }
 };
 
+#ifndef HTTPCLIENT_NOSECURE
 class TLSTraits : public TransportTraits {
 public:
   TLSTraits(const char *CAcert, const char *clicert = nullptr, const char *clikey = nullptr) : _cacert(CAcert), _clicert(clicert), _clikey(clikey) {}
@@ -81,6 +75,7 @@ protected:
   const char *_clicert;
   const char *_clikey;
 };
+#endif  // HTTPCLIENT_NOSECURE
 #endif  // HTTPCLIENT_1_1_COMPATIBLE
 
 /**
@@ -145,7 +140,12 @@ bool HTTPClient::begin(NetworkClient &client, String url) {
 
   _port = (protocol == "https" ? 443 : 80);
   _secure = (protocol == "https");
+
+#ifdef HTTPCLIENT_NOSECURE
+  return _secure ? false : beginInternal(url, protocol.c_str());
+#else
   return beginInternal(url, protocol.c_str());
+#endif  // HTTPCLIENT_NOSECURE
 }
 
 /**
@@ -174,10 +174,16 @@ bool HTTPClient::begin(NetworkClient &client, String host, uint16_t port, String
   _uri = uri;
   _protocol = (https ? "https" : "http");
   _secure = https;
+
+#ifdef HTTPCLIENT_NOSECURE
+  return _secure ? false : true;
+#else
   return true;
+#endif  // HTTPCLIENT_NOSECURE
 }
 
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
+#ifndef HTTPCLIENT_NOSECURE
 bool HTTPClient::begin(String url, const char *CAcert) {
   if (_client && !_tcpDeprecated) {
     log_d("mix up of new and deprecated api");
@@ -199,6 +205,7 @@ bool HTTPClient::begin(String url, const char *CAcert) {
 
   return true;
 }
+#endif  // HTTPCLIENT_NOSECURE
 
 /**
  * parsing the url for all needed parameters
@@ -214,7 +221,11 @@ bool HTTPClient::begin(String url) {
   clear();
   _port = 80;
   if (!beginInternal(url, "http")) {
+#ifdef HTTPCLIENT_NOSECURE
+    return false;
+#else
     return begin(url, (const char *)NULL);
+#endif  // HTTPCLIENT_NOSECURE
   }
   _transportTraits = TransportTraitsPtr(new TransportTraits());
   if (!_transportTraits) {
@@ -299,6 +310,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri) {
   return true;
 }
 
+#ifndef HTTPCLIENT_NOSECURE
 bool HTTPClient::begin(String host, uint16_t port, String uri, const char *CAcert) {
   if (_client && !_tcpDeprecated) {
     log_d("mix up of new and deprecated api");
@@ -338,6 +350,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, const char *CAcer
   _transportTraits = TransportTraitsPtr(new TLSTraits(CAcert, cli_cert, cli_key));
   return true;
 }
+#endif  // HTTPCLIENT_NOSECURE
 #endif  // HTTPCLIENT_1_1_COMPATIBLE
 
 /**

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -34,7 +34,9 @@
 #include <memory>
 #include <Arduino.h>
 #include <NetworkClient.h>
+#ifndef HTTPCLIENT_NOSECURE
 #include <NetworkClientSecure.h>
+#endif  // HTTPCLIENT_NOSECURE
 
 /// Cookie jar support
 #include <vector>
@@ -182,10 +184,17 @@ public:
 
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
   bool begin(String url);
-  bool begin(String url, const char *CAcert);
   bool begin(String host, uint16_t port, String uri = "/");
+#ifndef HTTPCLIENT_NOSECURE
+  bool begin(String url, const char *CAcert);
   bool begin(String host, uint16_t port, String uri, const char *CAcert);
   bool begin(String host, uint16_t port, String uri, const char *CAcert, const char *cli_cert, const char *cli_key);
+#else
+  bool begin(String url, const char *CAcert){ return false; };
+  bool begin(String host, uint16_t port, String uri, const char *CAcert){ return false; };
+  bool begin(String host, uint16_t port, String uri, const char *CAcert, const char *cli_cert, const char *cli_key){ return false; };
+#endif  // HTTPCLIENT_NOSECURE
+
 #endif
 
   void end(void);

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -190,9 +190,15 @@ public:
   bool begin(String host, uint16_t port, String uri, const char *CAcert);
   bool begin(String host, uint16_t port, String uri, const char *CAcert, const char *cli_cert, const char *cli_key);
 #else
-  bool begin(String url, const char *CAcert){ return false; };
-  bool begin(String host, uint16_t port, String uri, const char *CAcert){ return false; };
-  bool begin(String host, uint16_t port, String uri, const char *CAcert, const char *cli_cert, const char *cli_key){ return false; };
+  bool begin(String url, const char *CAcert) {
+    return false;
+  };
+  bool begin(String host, uint16_t port, String uri, const char *CAcert) {
+    return false;
+  };
+  bool begin(String host, uint16_t port, String uri, const char *CAcert, const char *cli_cert, const char *cli_key) {
+    return false;
+  };
 #endif  // HTTPCLIENT_NOSECURE
 
 #endif


### PR DESCRIPTION
Now it is impossible to use HTTPClient lib without bringing all mbedTLS stuff along, even when no https connections requred.

`HTTPCLIENT_NOSECURE` build flag disables TLS support in HTTPClient library by excluding `NetworkClientSecure.h` header.
This allows linker to strip down mbedTLS lib and certificates bundle, which in turn reduces firmware image for about ~80kib.

Could be handy for the cases when no encrypted http connections required for the sake of saving firmware size.

Tested on all HTTPClient lib examples, firmware image size reduction is about 80kib, RAM reduction is about 600 bytes.

origin:
```
Per-archive contributions to ELF file:
    Archive File     DRAM .data & 0.bss IRAM0 .text & 0.vectors ram_st_total Flash .text & .rodata  & flash_total
    libmbedcrypto.a         144      85          30           0          259       83098     52516         135788
    libmbedtls_2.a           72     488           0           0          560       32160      7339          39571

RAM:   [=         ]  13.3% (used 43712 bytes from 327680 bytes)
Flash: [========  ]  78.5% (used 1029069 bytes from 1310720 bytes)
```

this PR:
```
Per-archive contributions to ELF file:
    Archive File     DRAM .data & 0.bss IRAM0 .text & 0.vectors ram_st_total Flash .text & .rodata    flash_total
    libmbedcrypto.a         144      85          30           0          259       67325     41566         109065

RAM:   [=         ]  13.2% (used 43144 bytes from 327680 bytes)
Flash: [=======   ]  72.0% (used 943213 bytes from 1310720 bytes)
```

