### PR TITLE
Deep Sleep Example Fix

### DIFF
--- a/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
+++ b/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
@@ -23,8 +23,8 @@
 #include "driver/rtc_io.h"
 
 #define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
-#define USE_EXT0_WAKEUP 1  // 1 = EXT0 wakeup, 0 = EXT1 wakeup
-#define WAKEUP_GPIO GPIO_NUM_33 // Only RTC IO are allowed - ESP32 Pin example
+#define USE_EXT0_WAKEUP          1               // 1 = EXT0 wakeup, 0 = EXT1 wakeup
+#define WAKEUP_GPIO              GPIO_NUM_33     // Only RTC IO are allowed - ESP32 Pin example
 RTC_DATA_ATTR int bootCount = 0;
 
 /*
@@ -74,8 +74,8 @@ void setup() {
   // No need to keep that power domain explicitly, unlike EXT1.
   rtc_gpio_pullup_dis(WAKEUP_GPIO);
   rtc_gpio_pulldown_en(WAKEUP_GPIO);
-  
-#else // EXT1 WAKEUP
+
+#else  // EXT1 WAKEUP
   //If you were to use ext1, you would use it like
   esp_sleep_enable_ext1_wakeup_io(BUTTON_PIN_BITMASK(WAKEUP_GPIO), ESP_EXT1_WAKEUP_ANY_HIGH);
   /*

--- a/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
+++ b/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
@@ -24,6 +24,7 @@
 
 #define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
 #define USE_EXT0_WAKEUP 1  // 1 = EXT0 wakeup, 0 = EXT1 wakeup
+#define WAKEUP_GPIO GPIO_NUM_33 // Only RTC GPIO are allowed - this is a ESP32 example
 RTC_DATA_ATTR int bootCount = 0;
 
 /*
@@ -67,24 +68,24 @@ void setup() {
     RTC peripherals to be turned on.
   */
 #if USE_EXT0_WAKEUP
-  esp_sleep_enable_ext0_wakeup(GPIO_NUM_33, 1);  //1 = High, 0 = Low
+  esp_sleep_enable_ext0_wakeup(WAKEUP_GPIO, 1);  //1 = High, 0 = Low
   // Configure pullup/downs via RTCIO to tie wakeup pins to inactive level during deepsleep.
   // EXT0 resides in the same power domain (RTC_PERIPH) as the RTC IO pullup/downs.
   // No need to keep that power domain explicitly, unlike EXT1.
-  rtc_gpio_pullup_dis(GPIO_NUM_33);
-  rtc_gpio_pulldown_en(GPIO_NUM_33);
+  rtc_gpio_pullup_dis(WAKEUP_GPIO);
+  rtc_gpio_pulldown_en(WAKEUP_GPIO);
   
 #else // EXT1 WAKEUP
   //If you were to use ext1, you would use it like
-  esp_sleep_enable_ext1_wakeup_io(BUTTON_PIN_BITMASK(GPIO_NUM_33), ESP_EXT1_WAKEUP_ANY_HIGH);
+  esp_sleep_enable_ext1_wakeup_io(BUTTON_PIN_BITMASK(WAKEUP_GPIO), ESP_EXT1_WAKEUP_ANY_HIGH);
   /*
     If there are no external pull-up/downs, tie wakeup pins to inactive level with internal pull-up/downs via RTC IO
          during deepsleep. However, RTC IO relies on the RTC_PERIPH power domain. Keeping this power domain on will
          increase some power comsumption. However, if we turn off the RTC_PERIPH domain or if certain chips lack the RTC_PERIPH
          domain, we will use the HOLD feature to maintain the pull-up and pull-down on the pins during sleep.
   */
-  rtc_gpio_pulldown_en(GPIO_NUM_33);  // GPIO33 is tie to GND in order to wake up in HIGH
-  rtc_gpio_pullup_dis(GPIO_NUM_33);   // Disable PULL_UP in order to allow it to wakeup on HIGH
+  rtc_gpio_pulldown_en(WAKEUP_GPIO);  // GPIO33 is tie to GND in order to wake up in HIGH
+  rtc_gpio_pullup_dis(WAKEUP_GPIO);   // Disable PULL_UP in order to allow it to wakeup on HIGH
 #endif
   //Go to sleep now
   Serial.println("Going to sleep now");

--- a/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
+++ b/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
@@ -24,7 +24,7 @@
 
 #define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
 #define USE_EXT0_WAKEUP 1  // 1 = EXT0 wakeup, 0 = EXT1 wakeup
-#define WAKEUP_GPIO GPIO_NUM_33 // Only RTC GPIO are allowed - this is a ESP32 example
+#define WAKEUP_GPIO GPIO_NUM_33 // Only RTC IO are allowed - ESP32 Pin example
 RTC_DATA_ATTR int bootCount = 0;
 
 /*


### PR DESCRIPTION
## Description of Change
IDF 5.1 has changed the way how RTC IO shall be configured in order to make it work as Wakeup source.
This PR fixes the example to work within Arduino Core 3.0.x that uses IDF 5.1.

## Tests scenarios
Using ESP32  + the example provided. Tested using EXT0 and EXT1.

## Related links
Closes #9809 