### PR TITLE
BluetoothSerial - Reduce bluetooth serial flush delay

### DIFF
--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -878,7 +878,7 @@ size_t BluetoothSerial::write(const uint8_t *buffer, size_t size) {
 void BluetoothSerial::flush() {
   if (_spp_tx_queue != NULL) {
     while (uxQueueMessagesWaiting(_spp_tx_queue) > 0) {
-      delay(100);
+      delay(2);
     }
   }
 }


### PR DESCRIPTION
<!--
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [ ] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
-->
## Description of Change
Changed https://github.com/espressif/arduino-esp32/blob/b77b38e40ef3c0f47b4e35c88636f68f56e09004/libraries/BluetoothSerial/src/BluetoothSerial.cpp#L881 to use `delay(2)` instead to reduce the flush time.

## Tests scenarios
Tested the change on Windows. Found the affected file in `C:\Users\<local_machine_name>\AppData\Local\Arduino15\packages\esp32\hardware\esp32\2.0.3\libraries\BluetoothSerial\src`

I used this for testing:
```
#include "BluetoothSerial.h"

#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
#error Bluetooth is not enabled! Please run `make menuconfig` to and enable it
#endif

#if !defined(CONFIG_BT_SPP_ENABLED)
#error Serial Bluetooth not available or not enabled. It is only available for the ESP32 chip.
#endif

BluetoothSerial SerialBT;
unsigned long takenTime;

void setup() {
  // put your setup code here, to run once:
  Serial.begin(115200);
  SerialBT.begin("ESP32-Slave");
}

void loop() {
  // put your main code here, to run repeatedly:
  if (!SerialBT.connected(1000)) {
    return;
  }
  
  SerialBT.println("Lorem ipsum dolor sit amet, consectetur adipiscing elit."
  " Fusce in felis vel nunc finibus maximus ut ut mi. In hac habitasse platea dictumst. Etiam ac tincidunt nulla. Curabitur vel dictum enim."
  " Interdum et malesuada fames ac ante ipsum primis in faucibus. Fusce viverra neque sit amet erat ultrices, sed dictum sem auctor. Sed eget ultrices justo. Etiam non posuere odio."
  " In dignissim enim sed magna porta cursus. Nulla semper tortor vel sapien pellentesque, quis dapibus diam posuere. Nulla dapibus enim in lacus dictum, vitae blandit purus semper."
  " Proin augue elit, euismod sit amet sem eget, iaculis cursus neque. Proin in placerat diam. Nam hendrerit interdum accumsan. Aliquam et eros sit amet felis varius hendrerit."
  " Sed vel massa fermentum, elementum orci eleifend, consequat arcu. Curabitur viverra mollis tortor ut lobortis. Proin at lobortis tortor. Praesent non est enim."
  " Nullam mattis ultrices dapibus. Integer hendrerit, lacus sed pellentesque pharetra, mauris dui gravida odio, in tempus nisl dolor non nunc. Nullam nec magna a elit molestie blandit."
  " Pellentesque dignissim, arcu id sollicitudin auctor, urna nisl sollicitudin metus, at lobortis arcu enim nec leo. Quisque cursus euismod dolor. Donec id velit et lacus commodo accumsan."
  " Duis cursus bibendum massa, ac viverra risus tempus in."
  " Aenean porta pharetra libero et placerat. Phasellus et lobortis ipsum. Morbi aliquam aliquam accumsan. Praesent sit amet scelerisque nulla."
  " Nam dictum, erat sit amet pulvinar vestibulum, justo turpis lobortis dui, id malesuada magna augue et leo. Donec sit amet elit est."
  " Pellentesque purus ligula, auctor eget ligula at, pharetra congue sapien. Nulla scelerisque eros a semper eleifend."
  " Quisque euismod, justo id ultricies pellentesque, risus urna gravida ante, ut pulvinar nibh est nec mauris.");

  takenTime = millis();

  SerialBT.flush();
  Serial.print("Time spent flushing (in ms): ");
  Serial.println(millis() - takenTime);

  delay(250);
}
``` 

### Result without the change (100 ms of delay)
```
21:19:10.328 -> Time spent flushing (in ms): 100
21:19:10.688 -> Time spent flushing (in ms): 100
21:19:11.048 -> Time spent flushing (in ms): 100
21:19:11.409 -> Time spent flushing (in ms): 100
21:19:11.729 -> Time spent flushing (in ms): 100
21:19:12.089 -> Time spent flushing (in ms): 100
21:19:12.450 -> Time spent flushing (in ms): 100
21:19:12.810 -> Time spent flushing (in ms): 100
21:19:13.130 -> Time spent flushing (in ms): 100
21:19:13.490 -> Time spent flushing (in ms): 100
21:19:13.851 -> Time spent flushing (in ms): 100
21:19:14.210 -> Time spent flushing (in ms): 100
21:19:14.530 -> Time spent flushing (in ms): 100
21:19:14.891 -> Time spent flushing (in ms): 100
21:19:15.250 -> Time spent flushing (in ms): 100
21:19:15.610 -> Time spent flushing (in ms): 100
21:19:15.930 -> Time spent flushing (in ms): 100
21:19:16.291 -> Time spent flushing (in ms): 100
21:19:16.652 -> Time spent flushing (in ms): 100
21:19:17.012 -> Time spent flushing (in ms): 100
21:19:17.333 -> Time spent flushing (in ms): 100
21:19:17.693 -> Time spent flushing (in ms): 100
21:19:18.053 -> Time spent flushing (in ms): 100
21:19:18.413 -> Time spent flushing (in ms): 100
21:19:18.733 -> Time spent flushing (in ms): 100
21:19:19.093 -> Time spent flushing (in ms): 100
21:19:19.453 -> Time spent flushing (in ms): 100
21:19:19.813 -> Time spent flushing (in ms): 100
21:19:20.133 -> Time spent flushing (in ms): 100
21:19:20.493 -> Time spent flushing (in ms): 100
21:19:20.853 -> Time spent flushing (in ms): 100
21:19:21.213 -> Time spent flushing (in ms): 100
21:19:21.534 -> Time spent flushing (in ms): 100
21:19:21.894 -> Time spent flushing (in ms): 100
21:19:22.256 -> Time spent flushing (in ms): 100
21:19:22.616 -> Time spent flushing (in ms): 100
21:19:22.936 -> Time spent flushing (in ms): 100
21:19:23.296 -> Time spent flushing (in ms): 100
21:19:23.655 -> Time spent flushing (in ms): 100
21:19:24.016 -> Time spent flushing (in ms): 100
```

### Result with the change (2 ms of delay)
```
21:17:16.994 -> Time spent flushing (in ms): 8
21:17:17.234 -> Time spent flushing (in ms): 8
21:17:17.514 -> Time spent flushing (in ms): 8
21:17:17.754 -> Time spent flushing (in ms): 8
21:17:18.035 -> Time spent flushing (in ms): 8
21:17:18.275 -> Time spent flushing (in ms): 8
21:17:18.555 -> Time spent flushing (in ms): 8
21:17:18.795 -> Time spent flushing (in ms): 8
21:17:19.035 -> Time spent flushing (in ms): 8
21:17:19.315 -> Time spent flushing (in ms): 8
21:17:19.555 -> Time spent flushing (in ms): 8
21:17:19.836 -> Time spent flushing (in ms): 8
21:17:20.076 -> Time spent flushing (in ms): 8
21:17:20.356 -> Time spent flushing (in ms): 8
21:17:20.596 -> Time spent flushing (in ms): 8
21:17:20.876 -> Time spent flushing (in ms): 8
21:17:21.116 -> Time spent flushing (in ms): 8
21:17:21.397 -> Time spent flushing (in ms): 10
21:17:21.637 -> Time spent flushing (in ms): 8
21:17:21.877 -> Time spent flushing (in ms): 8
21:17:22.157 -> Time spent flushing (in ms): 8
21:17:22.397 -> Time spent flushing (in ms): 8
21:17:22.677 -> Time spent flushing (in ms): 8
21:17:22.917 -> Time spent flushing (in ms): 10
21:17:23.199 -> Time spent flushing (in ms): 8
21:17:23.439 -> Time spent flushing (in ms): 8
21:17:23.719 -> Time spent flushing (in ms): 8
21:17:23.959 -> Time spent flushing (in ms): 8
21:17:24.239 -> Time spent flushing (in ms): 8
21:17:24.479 -> Time spent flushing (in ms): 10
21:17:24.719 -> Time spent flushing (in ms): 8
21:17:24.999 -> Time spent flushing (in ms): 8
21:17:25.239 -> Time spent flushing (in ms): 8
21:17:25.519 -> Time spent flushing (in ms): 8
21:17:25.759 -> Time spent flushing (in ms): 8
21:17:26.039 -> Time spent flushing (in ms): 10
21:17:26.280 -> Time spent flushing (in ms): 8
```

## Related links
Closes https://github.com/espressif/arduino-esp32/issues/9868