### PR TITLE
feat(net): Switch to typedefs for WiFiClient, WiFiServer, WiFiUdp and WiFiClientSecure

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -355,7 +355,7 @@ config ARDUINO_SELECTIVE_ESPmDNS
 config ARDUINO_SELECTIVE_HTTPClient
     bool "Enable HTTPClient"
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
-    select ARDUINO_SELECTIVE_WiFiClientSecure
+    select ARDUINO_SELECTIVE_NetworkClientSecure
     default y
 
 config ARDUINO_SELECTIVE_NetBIOS
@@ -375,7 +375,7 @@ config ARDUINO_SELECTIVE_WiFi
     default y
 
 config ARDUINO_SELECTIVE_NetworkClientSecure
-    bool "Enable WiFiClientSecure"
+    bool "Enable NetworkClientSecure"
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
     default y
 

--- a/libraries/NetworkClientSecure/src/WiFiClientSecure.h
+++ b/libraries/NetworkClientSecure/src/WiFiClientSecure.h
@@ -1,3 +1,4 @@
 #pragma once
+#warning WiFiClientSecure has been deprecated, please use NetworkClientSecure instead.
 #include "NetworkClientSecure.h"
 #define WiFiClientSecure NetworkClientSecure

--- a/libraries/NetworkClientSecure/src/WiFiClientSecure.h
+++ b/libraries/NetworkClientSecure/src/WiFiClientSecure.h
@@ -1,4 +1,3 @@
 #pragma once
-#warning WiFiClientSecure has been deprecated, please use NetworkClientSecure instead.
 #include "NetworkClientSecure.h"
-#define WiFiClientSecure NetworkClientSecure
+typedef NetworkClientSecure WiFiClientSecure;

--- a/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
+++ b/libraries/WebServer/examples/UploadHugeFile/UploadHugeFile.ino
@@ -1,5 +1,4 @@
 #include <WiFi.h>
-#include <WiFiClient.h>
 #include <WebServer.h>
 #include <uri/UriRegex.h>
 #include <SD.h>

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -35,9 +35,9 @@
 #include "WiFiScan.h"
 #include "WiFiGeneric.h"
 
-#include "WiFiClient.h"
-#include "WiFiServer.h"
-#include "WiFiUdp.h"
+#include "NetworkClient.h"
+#include "NetworkServer.h"
+#include "NetworkUdp.h"
 
 class WiFiClass : public WiFiGenericClass, public WiFiSTAClass, public WiFiScanClass, public WiFiAPClass {
 private:

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -38,6 +38,11 @@
 #include "NetworkClient.h"
 #include "NetworkServer.h"
 #include "NetworkUdp.h"
+//defines are added here not to cause warnings
+//to be removed in the future
+#define WiFiClient NetworkClient
+#define WiFiServer NetworkServer
+#define WiFiUDP NetworkUDP
 
 class WiFiClass : public WiFiGenericClass, public WiFiSTAClass, public WiFiScanClass, public WiFiAPClass {
 private:

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -35,14 +35,9 @@
 #include "WiFiScan.h"
 #include "WiFiGeneric.h"
 
-#include "NetworkClient.h"
-#include "NetworkServer.h"
-#include "NetworkUdp.h"
-//defines are added here not to cause warnings
-//to be removed in the future
-#define WiFiClient NetworkClient
-#define WiFiServer NetworkServer
-#define WiFiUDP NetworkUDP
+#include "WiFiClient.h"
+#include "WiFiServer.h"
+#include "WiFiUdp.h"
 
 class WiFiClass : public WiFiGenericClass, public WiFiSTAClass, public WiFiScanClass, public WiFiAPClass {
 private:

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -1,3 +1,4 @@
 #pragma once
+#warning WiFiClient has been deprecated, please use NetworkClient instead.
 #include "NetworkClient.h"
 #define WiFiClient NetworkClient

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -1,4 +1,3 @@
 #pragma once
-#warning WiFiClient has been deprecated, please use NetworkClient instead.
 #include "NetworkClient.h"
-#define WiFiClient NetworkClient
+typedef NetworkClient WiFiClient;

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -1,3 +1,4 @@
 #pragma once
+#warning WiFiServer has been deprecated, please use NetworkServer instead.
 #include "NetworkServer.h"
 #define WiFiServer NetworkServer

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -1,4 +1,3 @@
 #pragma once
-#warning WiFiServer has been deprecated, please use NetworkServer instead.
 #include "NetworkServer.h"
-#define WiFiServer NetworkServer
+typedef NetworkServer WiFiServer;

--- a/libraries/WiFi/src/WiFiUdp.h
+++ b/libraries/WiFi/src/WiFiUdp.h
@@ -1,3 +1,4 @@
 #pragma once
+#warning WiFiUDP has been deprecated, please use NetworkUDP instead.
 #include "NetworkUdp.h"
 #define WiFiUDP NetworkUDP

--- a/libraries/WiFi/src/WiFiUdp.h
+++ b/libraries/WiFi/src/WiFiUdp.h
@@ -1,4 +1,3 @@
 #pragma once
-#warning WiFiUDP has been deprecated, please use NetworkUDP instead.
 #include "NetworkUdp.h"
-#define WiFiUDP NetworkUDP
+typedef NetworkUDP WiFiUDP;


### PR DESCRIPTION
Deprecates WiFiClient, WiFiServer, WiFiUdp and WiFiClientSecure

Fixes: #9891