### PR TITLE
PPP: Make modem reset delay configurable

### DIFF
--- a/libraries/PPP/examples/PPP_Basic/PPP_Basic.ino
+++ b/libraries/PPP/examples/PPP_Basic/PPP_Basic.ino
@@ -4,15 +4,15 @@
 #define PPP_MODEM_PIN "0000"  // or NULL
 
 // WaveShare SIM7600 HW Flow Control
-#define PPP_MODEM_RST        25
-#define PPP_MODEM_RST_LOW    false  //active HIGH
-#define PPP_MODEM_RST_DELAY  200
-#define PPP_MODEM_TX         21
-#define PPP_MODEM_RX         22
-#define PPP_MODEM_RTS        26
-#define PPP_MODEM_CTS        27
-#define PPP_MODEM_FC         ESP_MODEM_FLOW_CONTROL_HW
-#define PPP_MODEM_MODEL      PPP_MODEM_SIM7600
+#define PPP_MODEM_RST       25
+#define PPP_MODEM_RST_LOW   false  //active HIGH
+#define PPP_MODEM_RST_DELAY 200
+#define PPP_MODEM_TX        21
+#define PPP_MODEM_RX        22
+#define PPP_MODEM_RTS       26
+#define PPP_MODEM_CTS       27
+#define PPP_MODEM_FC        ESP_MODEM_FLOW_CONTROL_HW
+#define PPP_MODEM_MODEL     PPP_MODEM_SIM7600
 
 // SIM800 basic module with just TX,RX and RST
 // #define PPP_MODEM_RST     0

--- a/libraries/PPP/examples/PPP_Basic/PPP_Basic.ino
+++ b/libraries/PPP/examples/PPP_Basic/PPP_Basic.ino
@@ -4,14 +4,15 @@
 #define PPP_MODEM_PIN "0000"  // or NULL
 
 // WaveShare SIM7600 HW Flow Control
-#define PPP_MODEM_RST     25
-#define PPP_MODEM_RST_LOW false  //active HIGH
-#define PPP_MODEM_TX      21
-#define PPP_MODEM_RX      22
-#define PPP_MODEM_RTS     26
-#define PPP_MODEM_CTS     27
-#define PPP_MODEM_FC      ESP_MODEM_FLOW_CONTROL_HW
-#define PPP_MODEM_MODEL   PPP_MODEM_SIM7600
+#define PPP_MODEM_RST        25
+#define PPP_MODEM_RST_LOW    false  //active HIGH
+#define PPP_MODEM_RST_DELAY  200
+#define PPP_MODEM_TX         21
+#define PPP_MODEM_RX         22
+#define PPP_MODEM_RTS        26
+#define PPP_MODEM_CTS        27
+#define PPP_MODEM_FC         ESP_MODEM_FLOW_CONTROL_HW
+#define PPP_MODEM_MODEL      PPP_MODEM_SIM7600
 
 // SIM800 basic module with just TX,RX and RST
 // #define PPP_MODEM_RST     0
@@ -60,7 +61,7 @@ void setup() {
   // Configure the modem
   PPP.setApn(PPP_MODEM_APN);
   PPP.setPin(PPP_MODEM_PIN);
-  PPP.setResetPin(PPP_MODEM_RST, PPP_MODEM_RST_LOW);
+  PPP.setResetPin(PPP_MODEM_RST, PPP_MODEM_RST_LOW, PPP_MODEM_RST_DELAY);
   PPP.setPins(PPP_MODEM_TX, PPP_MODEM_RX, PPP_MODEM_RTS, PPP_MODEM_CTS, PPP_MODEM_FC);
 
   Serial.println("Starting the modem. It might take a while!");

--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -141,8 +141,8 @@ esp_modem_dce_t *PPPClass::handle() const {
 }
 
 PPPClass::PPPClass()
-  : _dce(NULL), _pin_tx(-1), _pin_rx(-1), _pin_rts(-1), _pin_cts(-1), _flow_ctrl(ESP_MODEM_FLOW_CONTROL_NONE), _pin_rst(-1), _pin_rst_act_low(true), _pin(NULL),
-    _apn(NULL), _rx_buffer_size(4096), _tx_buffer_size(512), _mode(ESP_MODEM_MODE_COMMAND), _uart_num(UART_NUM_1) {}
+  : _dce(NULL), _pin_tx(-1), _pin_rx(-1), _pin_rts(-1), _pin_cts(-1), _flow_ctrl(ESP_MODEM_FLOW_CONTROL_NONE), _pin_rst(-1), _pin_rst_act_low(true),
+    _pin_rst_delay(200), _pin(NULL), _apn(NULL), _rx_buffer_size(4096), _tx_buffer_size(512), _mode(ESP_MODEM_MODE_COMMAND), _uart_num(UART_NUM_1) {}
 
 PPPClass::~PPPClass() {}
 
@@ -152,9 +152,10 @@ bool PPPClass::pppDetachBus(void *bus_pointer) {
   return true;
 }
 
-void PPPClass::setResetPin(int8_t rst, bool active_low) {
+void PPPClass::setResetPin(int8_t rst, bool active_low, uint32_t reset_delay) {
   _pin_rst = digitalPinToGPIONumber(rst);
   _pin_rst_act_low = active_low;
+  _pin_rst_delay = reset_delay;
 }
 
 bool PPPClass::setPins(int8_t tx, int8_t rx, int8_t rts, int8_t cts, esp_modem_flow_ctrl_t flow_ctrl) {
@@ -285,7 +286,7 @@ bool PPPClass::begin(ppp_modem_model_t model, uint8_t uart_num, int baud_rate) {
     }
     perimanSetPinBusExtraType(_pin_rst, "PPP_MODEM_RST");
     digitalWrite(_pin_rst, !_pin_rst_act_low);
-    delay(200);
+    delay(_pin_rst_delay);
     digitalWrite(_pin_rst, _pin_rst_act_low);
     delay(100);
   }

--- a/libraries/PPP/src/PPP.h
+++ b/libraries/PPP/src/PPP.h
@@ -36,7 +36,7 @@ public:
   bool setPins(int8_t tx, int8_t rx, int8_t rts = -1, int8_t cts = -1, esp_modem_flow_ctrl_t flow_ctrl = ESP_MODEM_FLOW_CONTROL_NONE);
 
   // Using the reset pin of the module ensures that proper communication can be achieved
-  void setResetPin(int8_t rst, bool active_low = true);
+  void setResetPin(int8_t rst, bool active_low = true, uint32_t reset_delay = 200);
 
   // Modem DCE APIs
   int RSSI() const;
@@ -94,6 +94,7 @@ private:
   esp_modem_flow_ctrl_t _flow_ctrl;
   int8_t _pin_rst;
   bool _pin_rst_act_low;
+  uint32_t _pin_rst_delay;
   const char *_pin;
   const char *_apn;
   int _rx_buffer_size;


### PR DESCRIPTION
The delay required to reset Simcom modem modules varies significantly across different models, even where they have otherwise identical AT command sets.

Make the reset delay configurable to allow customising this for a specific modem.



*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [X] Please **update relevant Documentation** if applicable
4. [X] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [X] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

The delay required to reset Simcom modem modules varies significantly across different models, even where they have otherwise identical AT command sets. Make this configurable, but keep the default at 200ms, which is the correct valaue for the Simcom 7600 model used in the example.
## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

Tested on Simcom A7672G module which requires 2500 ms delay. Modem resets correctly. 

## Related links
Please provide links to related issue, PRs etc.

Fixes: #9907 
