### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-c00dad83c1"
+              "version": "idf-release_v5.1-bd2b9390ef"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-c00dad83c1",
+          "version": "idf-release_v5.1-bd2b9390ef",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/946521b2ad18b0b22c19133c00bfa53105e9832d",
-              "archiveFileName": "esp32-arduino-libs-946521b2ad18b0b22c19133c00bfa53105e9832d.zip",
-              "checksum": "SHA-256:4c7b3b21ccc375e10e69fb6ef344067799d44f250214125d43e129fbe00e5937",
-              "size": "307795199"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
+              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
+              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
+              "size": "307841384"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 6683a0d
esp-idf: release/v5.1 bd2b9390ef
arduino: master 9e55ccd9
tinyusb: master 044f4d180
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.3.2
espressif__esp-zigbee-lib: 1.3.2
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.5
joltwallet__littlefs: 1.14.6
```
