### PR TITLE
fix(boards): boards.txt error

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -31087,7 +31087,7 @@ XIAO_ESP32C6.build.target=esp
 XIAO_ESP32C6.build.mcu=esp32c6
 XIAO_ESP32C6.build.core=esp32
 XIAO_ESP32C6.build.variant=XIAO_ESP32C6
-XIAO_ESP32C6.build.board=XIAO_ESP32C3
+XIAO_ESP32C6.build.board=XIAO_ESP32C6
 XIAO_ESP32C6.build.bootloader_addr=0x0
 
 XIAO_ESP32C6.build.cdc_on_boot=1


### PR DESCRIPTION
## Description of Change
Fixes XIAO C6 board name in boards.txt file

## Tests scenarios
IDE View

## Related links
Fix #9929 