### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-97de085b35"
+              "version": "idf-release_v5.1-4efd577c19"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-97de085b35",
+          "version": "idf-release_v5.1-4efd577c19",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
-              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
-              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
-              "size": "307841434"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
+              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
+              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
+              "size": "307828133"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-4efd577c19"
+              "version": "idf-release_v5.1-c98f32ecb9"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-4efd577c19",
+          "version": "idf-release_v5.1-c98f32ecb9",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b",
-              "archiveFileName": "esp32-arduino-libs-cedbe3634c77479e8c8ad9c1e9647cf1a38cb07b.zip",
-              "checksum": "SHA-256:f654f988e01fd055c944a3fbd6192dc409ce706a92ce6dbc8a54ad11d3bc3887",
-              "size": "307828133"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/39c75def67077ed6f388f6a2301a94c166695974",
+              "archiveFileName": "esp32-arduino-libs-39c75def67077ed6f388f6a2301a94c166695974.zip",
+              "checksum": "SHA-256:990c65ff630be7ac0133ff619631e2b0956c95d4d5e91cefabe6dd7ad0389a28",
+              "size": "307829831"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-bd2b9390ef"
+              "version": "idf-release_v5.1-97de085b35"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-bd2b9390ef",
+          "version": "idf-release_v5.1-97de085b35",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7a33458f51297e442ec4734b3cacd6e28a1612e0",
+              "archiveFileName": "esp32-arduino-libs-7a33458f51297e442ec4734b3cacd6e28a1612e0.zip",
+              "checksum": "SHA-256:b1223f701d9dd7d585904e9d860354db91b3e56e176a625e5144fee58c5b07bb",
+              "size": "307841434"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 6683a0d
esp-idf: release/v5.1 97de085b35
arduino: master 777d0d70
tinyusb: master 044f4d180
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.3.2
espressif__esp-zigbee-lib: 1.3.2
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.5
joltwallet__littlefs: 1.14.6
```
