### PR TITLE
Fixes WiFiProv.ino

### DIFF
--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -62,7 +62,7 @@ void setup() {
   // Sample uuid that user can pass during provisioning using BLE
   uint8_t uuid[16] = {0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf, 0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02};
   WiFiProv.beginProvision(
-    WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name, service_key, uuid, reset_provisioned
+    WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BLE, WIFI_PROV_SECURITY_1, pop, service_name, service_key, uuid, reset_provisioned
   );
   log_d("ble qr");
   WiFiProv.printQR(service_name, pop, "ble");

--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -53,7 +53,7 @@ void SysProvEvent(arduino_event_t *sys_event) {
 
 void setup() {
   Serial.begin(115200);
-  WiFi.begin(); // no SSID/PWD - get it from the Provisioning APP or from NVS (last successful connection)
+  WiFi.begin();  // no SSID/PWD - get it from the Provisioning APP or from NVS (last successful connection)
   WiFi.onEvent(SysProvEvent);
 
 // BLE Provisioning using the ESP SoftAP Prov works fine for any BLE SoC, including ESP32, ESP32S3 and ESP32C3.

--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -53,6 +53,7 @@ void SysProvEvent(arduino_event_t *sys_event) {
 
 void setup() {
   Serial.begin(115200);
+  WiFi.begin(); // no SSID/PWD - get it from the Provisioning APP or from NVS (last successful connection)
   WiFi.onEvent(SysProvEvent);
 
 // BLE Provisioning using the ESP SoftAP Prov works fine for any BLE SoC, including ESP32, ESP32S3 and ESP32C3.


### PR DESCRIPTION
## Description of Change
Fixes WiFi Provisioning example to work with the new Network layer.
Adds a `WiFi.begin()` for automatic connection after provisioning or after reading NVS.
Changed the Provisioning mode to BLE in order to avoid a memory releasing problem with ESP32 after provisioning.

## Tests scenarios
Tested with S3 and ESP32 using the example from 
https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino

## Related links
Fix #9943 