### PR TITLE
fix(uart): Set back Pin signal polarity

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -514,11 +514,16 @@ uart_t *uartBegin(
   }
 
   // Is it right or the idea is to swap rx and tx pins?
-  if (retCode && inverted) {
-    // invert signal for both Rx and Tx
-    retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);
+  if (retCode) {
+    if (inverted) {
+      // invert signal for both Rx and Tx
+      retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);
+    } else {
+      // invert signal for both Rx and Tx
+      retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_INV_DISABLE);
+    }
   }
-
+  // if all fine, set internal parameters
   if (retCode) {
     uart->_baudrate = baudrate;
     uart->_config = config;


### PR DESCRIPTION
## Description of Change
Fixes a problem related to inverting signal polarity back to normal after a previous inversion.
This shall set the correct polarity in Serial.begin().


## Tests scenarios

``` cpp
#include <Arduino.h>
#include <HardwareSerial.h>

HardwareSerial serial(0);   // use serial(1) for comparison

void setup() {}

void loop() {
  serial.begin(115200, SERIAL_8N1, 3, 1, false);
  serial.write("hello");
  serial.flush();
  serial.end();

  serial.begin(115200, SERIAL_8N1, 3, 1, true);
  serial.write("hello");
  serial.flush();
  serial.end();
}
```


## Related links
Fix #9896