### PR TITLE
[release/2.x] fix(uart): Set back Pin signal polarity

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -434,7 +434,6 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
 
     if (retCode) retCode &= ESP_OK == uart_param_config(uart_nr, &uart_config);
 
-    // Is it right or the idea is to swap rx and tx pins? 
     if (retCode) {
       if (inverted) {
         // invert signal for both Rx and Tx

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -435,11 +435,16 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
     if (retCode) retCode &= ESP_OK == uart_param_config(uart_nr, &uart_config);
 
     // Is it right or the idea is to swap rx and tx pins? 
-    if (retCode && inverted) {
+    if (retCode) {
+      if (inverted) {
         // invert signal for both Rx and Tx
-        retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);    
+        retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);
+      } else {
+        // invert signal for both Rx and Tx
+        retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_INV_DISABLE);
+      }
     }
-    
+    // if all fine, set internal parameters
     if (retCode) {
         uart->_baudrate = baudrate;
         uart->_config = config;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -439,7 +439,7 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
         // invert signal for both Rx and Tx
         retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);
       } else {
-        // invert signal for both Rx and Tx
+        // disable invert signal for both Rx and Tx
         retCode &= ESP_OK == uart_set_line_inverse(uart_nr, UART_SIGNAL_INV_DISABLE);
       }
     }


### PR DESCRIPTION
## Description of Change
Backport to `release/v2.x` branch

Fixes a problem related to inverting signal polarity back to normal after a previous inversion.
This shall set the correct polarity in Serial.begin().


## Tests scenarios

``` cpp
#include <Arduino.h>
#include <HardwareSerial.h>

HardwareSerial serial(0);   // use serial(1) for comparison

void setup() {}

void loop() {
  serial.begin(115200, SERIAL_8N1, 3, 1, false);
  serial.write("hello");
  serial.flush();
  serial.end();

  serial.begin(115200, SERIAL_8N1, 3, 1, true);
  serial.write("hello");
  serial.flush();
  serial.end();
}
```


## Related links
Fix #9896