### PR TITLE
Auto re-connect feature

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino
@@ -39,6 +39,8 @@
 const char *ssid = "**********";
 const char *password = "**********";
 
+bool tryingToConnectWifi = true;
+
 void startCameraServer();
 void setupLedFlash(int pin);
 
@@ -151,6 +153,24 @@ void setup() {
 }
 
 void loop() {
-  // Do nothing. Everything is done in another task by the web server
-  delay(10000);
+  if (WiFi.status() != WL_CONNECTED) {
+    if (!tryingToConnectWifi) {
+      WiFi.begin(ssid, password);
+      WiFi.setSleep(false);
+      tryingToConnectWifi = true;
+    }
+
+    Serial.println("Wifi not connected, trying to re-connect");
+    delay(500);
+  } else if (WiFi.status() == WL_CONNECTED) {
+    if (tryingToConnectWifi) {
+      startCameraServer();
+      Serial.print("Camera Ready! Use 'http://");
+      Serial.print(WiFi.localIP());
+      Serial.println("' to connect");
+      tryingToConnectWifi = false;
+    }
+  }
+
+  delay(2000);
 }


### PR DESCRIPTION
## Description of Change
Updated the loop function of CameraWebServer example. Currently this software will not try to re-connect to the network if it lost once. There may be a lot of reasons - wifi router lost electricity, some noise in the radio space and much more. Now, the loop function will check for the connection, it is lost - will try to re-connect. Once re-conencted, will run the web server again.

## Tests scenarios
I have 6 ESP32 AI Thinker cameras and tested on all of them. 

##### How to test this code
1. Connect the camer to wifi by filling the credentials and uploading to camera
2. Wait until its connected
3. Power off your wifi device
4. Check the serial monitor if camera said that it's trying to reconnect
5. Power on the wifi device
6. Check if camera could reconnect
