### PR TITLE
fix(docs): Correct i2s.srt api example

### DIFF
--- a/docs/en/api/i2s.rst
+++ b/docs/en/api/i2s.rst
@@ -546,9 +546,9 @@ Sample code
     I2S.read();
     available_bytes = I2S.available();
     if(available_bytes < buff_size) {
-      read_bytes = I2S.read(buffer, available_bytes);
+      read_bytes = I2S.readBytes(buffer, available_bytes);
     } else {
-      read_bytes = I2S.read(buffer, buff_size);
+      read_bytes = I2S.readBytes(buffer, buff_size);
     }
     I2S.write(buffer, read_bytes);
     I2S.end();


### PR DESCRIPTION
## Description of Change
Fix of i2s api documentation - example used incorrect method which is not declared.

## Tests scenarios
I have tested example on arduino-esp32 core v3.0.2 with ESP32-S3 Board.
