### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-a06c6877fa"
+              "version": "idf-release_v5.1-bae9a3a29f"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-a06c6877fa",
+          "version": "idf-release_v5.1-bae9a3a29f",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
-              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
-              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
-              "size": "307883363"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0",
+              "archiveFileName": "esp32-arduino-libs-3aafb6b5f1bd39cef958a50a5cd3dfbf908ef2c0.zip",
+              "checksum": "SHA-256:e91f443c2276dd4f30ef400565fd84e0a189c06c0405bb6cb7243d1cb701bb95",
+              "size": "307477522"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-bd2b9390ef"
+              "version": "idf-release_v5.1-c98f32ecb9"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-bd2b9390ef",
+          "version": "idf-release_v5.1-c98f32ecb9",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
+              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
+              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
+              "size": "307833697"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-c98f32ecb9"
+              "version": "idf-release_v5.1-a06c6877fa"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-c98f32ecb9",
+          "version": "idf-release_v5.1-a06c6877fa",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/aec4e0dcab14c272af08891ff293fe55de693270",
-              "archiveFileName": "esp32-arduino-libs-aec4e0dcab14c272af08891ff293fe55de693270.zip",
-              "checksum": "SHA-256:8124cd83c16aecc75a48e9ba6fcfd60729c4ea353446188466646590aa149c59",
-              "size": "307833697"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/2f6b18be4447993f623f06466749cf9f6b2a8a49",
+              "archiveFileName": "esp32-arduino-libs-2f6b18be4447993f623f06466749cf9f6b2a8a49.zip",
+              "checksum": "SHA-256:3c159fa7005ca178eff1a3fc2a25ca4643e0b66c9c658e281145c8d3c71b85fd",
+              "size": "307883363"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master b662e2d
esp-idf: release/v5.1 c98f32ecb9
arduino: master 5f663e70
tinyusb: master 236aa9622
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.3.2
espressif__esp-zigbee-lib: 1.3.2
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.6
```
