### PR TITLE
fix(httpc): Fix data read was less than expected

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1362,7 +1362,7 @@ int HTTPClient::writeToStreamDataBlock(Stream *stream, int size) {
           // some time for the stream
           delay(1);
 
-          int leftBytes = (readBytes - bytesWrite);
+          int leftBytes = (bytesRead - bytesWrite);
 
           // retry to send the missed bytes
           bytesWrite = stream->write((buff + bytesWrite), leftBytes);
@@ -1385,7 +1385,7 @@ int HTTPClient::writeToStreamDataBlock(Stream *stream, int size) {
 
         // count bytes to read left
         if (len > 0) {
-          len -= readBytes;
+          len -= bytesRead;
         }
 
         delay(0);


### PR DESCRIPTION
Data read from the client might actually be less than what we requested. Use the proper count when calculating data lengths.

Fixes: https://github.com/espressif/arduino-esp32/issues/9997