### PR TITLE
FS library position() to return (size_t) -1 on error

### DIFF
--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -105,7 +105,7 @@ bool File::seek(uint32_t pos, SeekMode mode) {
 
 size_t File::position() const {
   if (!*this) {
-    return 0;
+    return (size_t)-1;
   }
 
   return _p->position();

--- a/libraries/FS/src/FS.h
+++ b/libraries/FS/src/FS.h
@@ -64,7 +64,7 @@ public:
   bool seek(uint32_t pos) {
     return seek(pos, SeekSet);
   }
-  size_t position() const; // returns (size_t)-1 on error
+  size_t position() const;  // returns (size_t)-1 on error
   size_t size() const;
   bool setBufferSize(size_t size);
   void close();

--- a/libraries/FS/src/FS.h
+++ b/libraries/FS/src/FS.h
@@ -64,7 +64,7 @@ public:
   bool seek(uint32_t pos) {
     return seek(pos, SeekSet);
   }
-  size_t position() const;
+  size_t position() const; // returns (size_t)-1 on error
   size_t size() const;
   bool setBufferSize(size_t size);
   void close();


### PR DESCRIPTION
Fix for error return from position()
PR Issue #9992

## Description of Change
Currently FS::position() returns 0 if file is invalid,  this change return (size_t) -1 instead, which is a very large number, to indicate an error 

## Tests scenarios
none

## Related links
Closes #9992 