### PR TITLE
docs(component): Update to IDF 5.1 and add component manager instructions

### DIFF
--- a/docs/en/esp-idf_component.rst
+++ b/docs/en/esp-idf_component.rst
@@ -14,14 +14,36 @@ For a simplified method, see `Installing using Boards Manager <https://docs.espr
 If you plan to use these modified settings multiple times, for different projects and targets, you can recompile the Arduino core with the new settings using the Arduino Static Library Builder.
 For more information, see the `Lib Builder documentation <lib_builder.html>`_.
 
+.. note:: Latest Arduino Core ESP32 version (3.0.X) is now compatible with `ESP-IDF v5.1 <https://github.com/espressif/esp-idf/tree/release/v5.1>`_. Please consider this compatibility when using Arduino as a component in ESP-IDF.
+
+For easiest use of Arduino framework as a ESP-IDF component, you can use the `IDF Component Manager <https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/api-guides/tools/idf-component-manager.html>`_ to add the Arduino component to your project. 
+This will automatically clone the repository and its submodules. You can find the Arduino component in the `ESP Registry <https://components.espressif.com/components/espressif/arduino-esp32>`_ together with dependencies list and examples.
+
 Installation
 ------------
-
-.. note:: Latest Arduino Core ESP32 version is now compatible with `ESP-IDF v4.4 <https://github.com/espressif/esp-idf/tree/release/v4.4>`_. Please consider this compatibility when using Arduino as a component in ESP-IDF.
 
 #. Download and install `ESP-IDF <https://github.com/espressif/esp-idf>`_.
 
    * For more information see `Get Started <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step>`_.
+
+Installing using IDF Component Manager
+**************************************
+
+To add the Arduino component to your project using the IDF Component Manager, run the following command in your project directory:
+
+.. code-block:: bash
+
+    idf.py add-dependency "espressif/arduino-esp32^3.0.2"
+
+Or you can start a new project from a template with the Arduino component:
+
+.. code-block:: bash
+
+    idf.py create-project-from-example "espressif/arduino-esp32^3.0.2:hello_world"
+
+Manual installation of Arduino framework
+****************************************
+
 #. Create a blank ESP-IDF project (use sample_project from /examples/get-started) or choose one of the examples.
 #. In the project folder, create a new folder called ``components`` and clone this repository inside the newly created folder.
 

--- a/docs/en/esp-idf_component.rst
+++ b/docs/en/esp-idf_component.rst
@@ -16,7 +16,7 @@ For more information, see the `Lib Builder documentation <lib_builder.html>`_.
 
 .. note:: Latest Arduino Core ESP32 version (3.0.X) is now compatible with `ESP-IDF v5.1 <https://github.com/espressif/esp-idf/tree/release/v5.1>`_. Please consider this compatibility when using Arduino as a component in ESP-IDF.
 
-For easiest use of Arduino framework as a ESP-IDF component, you can use the `IDF Component Manager <https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/api-guides/tools/idf-component-manager.html>`_ to add the Arduino component to your project. 
+For easiest use of Arduino framework as a ESP-IDF component, you can use the `IDF Component Manager <https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/api-guides/tools/idf-component-manager.html>`_ to add the Arduino component to your project.
 This will automatically clone the repository and its submodules. You can find the Arduino component in the `ESP Registry <https://components.espressif.com/components/espressif/arduino-esp32>`_ together with dependencies list and examples.
 
 Installation


### PR DESCRIPTION
## Description of Change
This PR updates the documentation page of using Arduino framework as ESP-IDF component.

## Tests scenarios

## Related links
