### PR TITLE
add(board): Add LOLIN S3 Mini Pro

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -8749,6 +8749,174 @@ lolin_s3_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+lolin_s3_mini_pro.name=LOLIN S3 Mini Pro
+lolin_s3_mini_pro.vid.0=0x303a
+lolin_s3_mini_pro.pid.0=0x8216
+
+lolin_s3_mini_pro.bootloader.tool=esptool_py
+lolin_s3_mini_pro.bootloader.tool.default=esptool_py
+
+lolin_s3_mini_pro.upload.tool=esptool_py
+lolin_s3_mini_pro.upload.tool.default=esptool_py
+lolin_s3_mini_pro.upload.tool.network=esp_ota
+
+lolin_s3_mini_pro.upload.maximum_size=1310720
+lolin_s3_mini_pro.upload.maximum_data_size=327680
+lolin_s3_mini_pro.upload.flags=
+lolin_s3_mini_pro.upload.extra_flags=
+lolin_s3_mini_pro.upload.use_1200bps_touch=false
+lolin_s3_mini_pro.upload.wait_for_upload_port=false
+
+lolin_s3_mini_pro.serial.disableDTR=false
+lolin_s3_mini_pro.serial.disableRTS=false
+
+lolin_s3_mini_pro.build.tarch=xtensa
+lolin_s3_mini_pro.build.bootloader_addr=0x0
+lolin_s3_mini_pro.build.target=esp32s3
+lolin_s3_mini_pro.build.mcu=esp32s3
+lolin_s3_mini_pro.build.core=esp32
+lolin_s3_mini_pro.build.variant=lolin_s3_mini_pro
+lolin_s3_mini_pro.build.board=LOLIN_S3_MINI_PRO
+
+lolin_s3_mini_pro.build.usb_mode=1
+lolin_s3_mini_pro.build.cdc_on_boot=0
+lolin_s3_mini_pro.build.msc_on_boot=0
+lolin_s3_mini_pro.build.dfu_on_boot=0
+lolin_s3_mini_pro.build.f_cpu=240000000L
+lolin_s3_mini_pro.build.flash_size=4MB
+lolin_s3_mini_pro.build.flash_freq=80m
+lolin_s3_mini_pro.build.flash_mode=dio
+lolin_s3_mini_pro.build.boot=qio
+lolin_s3_mini_pro.build.boot_freq=80m
+lolin_s3_mini_pro.build.partitions=default
+lolin_s3_mini_pro.build.defines=-DBOARD_HAS_PSRAM
+lolin_s3_mini_pro.build.loop_core=
+lolin_s3_mini_pro.build.event_core=
+lolin_s3_mini_pro.build.psram_type=qspi
+lolin_s3_mini_pro.build.memory_type={build.boot}_{build.psram_type}
+
+lolin_s3_mini_pro.menu.FlashMode.qio=QIO 80MHz
+lolin_s3_mini_pro.menu.FlashMode.qio.build.flash_mode=dio
+lolin_s3_mini_pro.menu.FlashMode.qio.build.boot=qio
+lolin_s3_mini_pro.menu.FlashMode.qio.build.boot_freq=80m
+lolin_s3_mini_pro.menu.FlashMode.qio.build.flash_freq=80m
+lolin_s3_mini_pro.menu.FlashMode.qio120=QIO 120MHz
+lolin_s3_mini_pro.menu.FlashMode.qio120.build.flash_mode=dio
+lolin_s3_mini_pro.menu.FlashMode.qio120.build.boot=qio
+lolin_s3_mini_pro.menu.FlashMode.qio120.build.boot_freq=120m
+lolin_s3_mini_pro.menu.FlashMode.qio120.build.flash_freq=80m
+
+lolin_s3_mini_pro.menu.LoopCore.1=Core 1
+lolin_s3_mini_pro.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+lolin_s3_mini_pro.menu.LoopCore.0=Core 0
+lolin_s3_mini_pro.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+lolin_s3_mini_pro.menu.EventsCore.1=Core 1
+lolin_s3_mini_pro.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+lolin_s3_mini_pro.menu.EventsCore.0=Core 0
+lolin_s3_mini_pro.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+lolin_s3_mini_pro.menu.USBMode.hwcdc=Hardware CDC and JTAG
+lolin_s3_mini_pro.menu.USBMode.hwcdc.build.usb_mode=1
+lolin_s3_mini_pro.menu.USBMode.default=USB-OTG (TinyUSB)
+lolin_s3_mini_pro.menu.USBMode.default.build.usb_mode=0
+
+lolin_s3_mini_pro.menu.CDCOnBoot.default=Disabled
+lolin_s3_mini_pro.menu.CDCOnBoot.default.build.cdc_on_boot=0
+lolin_s3_mini_pro.menu.CDCOnBoot.cdc=Enabled
+lolin_s3_mini_pro.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+lolin_s3_mini_pro.menu.MSCOnBoot.default=Disabled
+lolin_s3_mini_pro.menu.MSCOnBoot.default.build.msc_on_boot=0
+lolin_s3_mini_pro.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+lolin_s3_mini_pro.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+lolin_s3_mini_pro.menu.DFUOnBoot.default=Disabled
+lolin_s3_mini_pro.menu.DFUOnBoot.default.build.dfu_on_boot=0
+lolin_s3_mini_pro.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+lolin_s3_mini_pro.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+lolin_s3_mini_pro.menu.UploadMode.default=UART0 / Hardware CDC
+lolin_s3_mini_pro.menu.UploadMode.default.upload.use_1200bps_touch=false
+lolin_s3_mini_pro.menu.UploadMode.default.upload.wait_for_upload_port=false
+lolin_s3_mini_pro.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+lolin_s3_mini_pro.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+lolin_s3_mini_pro.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+lolin_s3_mini_pro.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+lolin_s3_mini_pro.menu.PartitionScheme.default.build.partitions=default
+lolin_s3_mini_pro.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+lolin_s3_mini_pro.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+lolin_s3_mini_pro.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+lolin_s3_mini_pro.menu.PartitionScheme.no_ota.build.partitions=no_ota
+lolin_s3_mini_pro.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+lolin_s3_mini_pro.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+lolin_s3_mini_pro.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+lolin_s3_mini_pro.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+lolin_s3_mini_pro.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+lolin_s3_mini_pro.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+lolin_s3_mini_pro.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+lolin_s3_mini_pro.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+lolin_s3_mini_pro.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+lolin_s3_mini_pro.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+lolin_s3_mini_pro.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+lolin_s3_mini_pro.menu.PartitionScheme.huge_app.build.partitions=huge_app
+lolin_s3_mini_pro.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+lolin_s3_mini_pro.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+lolin_s3_mini_pro.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+lolin_s3_mini_pro.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+lolin_s3_mini_pro.menu.PartitionScheme.rainmaker=RainMaker
+lolin_s3_mini_pro.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+lolin_s3_mini_pro.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
+
+lolin_s3_mini_pro.menu.CPUFreq.240=240MHz (WiFi)
+lolin_s3_mini_pro.menu.CPUFreq.240.build.f_cpu=240000000L
+lolin_s3_mini_pro.menu.CPUFreq.160=160MHz (WiFi)
+lolin_s3_mini_pro.menu.CPUFreq.160.build.f_cpu=160000000L
+lolin_s3_mini_pro.menu.CPUFreq.80=80MHz (WiFi)
+lolin_s3_mini_pro.menu.CPUFreq.80.build.f_cpu=80000000L
+lolin_s3_mini_pro.menu.CPUFreq.40=40MHz
+lolin_s3_mini_pro.menu.CPUFreq.40.build.f_cpu=40000000L
+lolin_s3_mini_pro.menu.CPUFreq.20=20MHz
+lolin_s3_mini_pro.menu.CPUFreq.20.build.f_cpu=20000000L
+lolin_s3_mini_pro.menu.CPUFreq.10=10MHz
+lolin_s3_mini_pro.menu.CPUFreq.10.build.f_cpu=10000000L
+
+lolin_s3_mini_pro.menu.UploadSpeed.921600=921600
+lolin_s3_mini_pro.menu.UploadSpeed.921600.upload.speed=921600
+lolin_s3_mini_pro.menu.UploadSpeed.115200=115200
+lolin_s3_mini_pro.menu.UploadSpeed.115200.upload.speed=115200
+lolin_s3_mini_pro.menu.UploadSpeed.256000.windows=256000
+lolin_s3_mini_pro.menu.UploadSpeed.256000.upload.speed=256000
+lolin_s3_mini_pro.menu.UploadSpeed.230400.windows.upload.speed=256000
+lolin_s3_mini_pro.menu.UploadSpeed.230400=230400
+lolin_s3_mini_pro.menu.UploadSpeed.230400.upload.speed=230400
+lolin_s3_mini_pro.menu.UploadSpeed.460800.linux=460800
+lolin_s3_mini_pro.menu.UploadSpeed.460800.macosx=460800
+lolin_s3_mini_pro.menu.UploadSpeed.460800.upload.speed=460800
+lolin_s3_mini_pro.menu.UploadSpeed.512000.windows=512000
+lolin_s3_mini_pro.menu.UploadSpeed.512000.upload.speed=512000
+
+lolin_s3_mini_pro.menu.DebugLevel.none=None
+lolin_s3_mini_pro.menu.DebugLevel.none.build.code_debug=0
+lolin_s3_mini_pro.menu.DebugLevel.error=Error
+lolin_s3_mini_pro.menu.DebugLevel.error.build.code_debug=1
+lolin_s3_mini_pro.menu.DebugLevel.warn=Warn
+lolin_s3_mini_pro.menu.DebugLevel.warn.build.code_debug=2
+lolin_s3_mini_pro.menu.DebugLevel.info=Info
+lolin_s3_mini_pro.menu.DebugLevel.info.build.code_debug=3
+lolin_s3_mini_pro.menu.DebugLevel.debug=Debug
+lolin_s3_mini_pro.menu.DebugLevel.debug.build.code_debug=4
+lolin_s3_mini_pro.menu.DebugLevel.verbose=Verbose
+lolin_s3_mini_pro.menu.DebugLevel.verbose.build.code_debug=5
+
+lolin_s3_mini_pro.menu.EraseFlash.none=Disabled
+lolin_s3_mini_pro.menu.EraseFlash.none.upload.erase_cmd=
+lolin_s3_mini_pro.menu.EraseFlash.all=Enabled
+lolin_s3_mini_pro.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 lolin_s3_pro.name=LOLIN S3 Pro
 lolin_s3_pro.vid.0=0x303a
 lolin_s3_pro.pid.0=0x8161

--- a/variants/lolin_s3_mini_pro/pins_arduino.h
+++ b/variants/lolin_s3_mini_pro/pins_arduino.h
@@ -1,0 +1,76 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x8216
+
+static const uint8_t LED_BUILTIN = 8 + SOC_GPIO_PIN_COUNT;;
+#define BUILTIN_LED    LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN    LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 5
+#define RGB_POWER     7  //RGB LED POWER PIN
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 12;
+static const uint8_t SCL = 11;
+
+static const uint8_t SS = 37;
+static const uint8_t MOSI = 38;
+static const uint8_t MISO = 39;
+static const uint8_t SCK = 40;
+
+//TFT
+static const uint8_t TFT_BL = 33;
+static const uint8_t TFT_DC = 36;
+static const uint8_t TFT_CS = 35;
+static const uint8_t TFT_RST = 34;
+
+//IR
+static const uint8_t PIN_IR = 9;
+
+//BUTTON
+static const uint8_t BUTTON_LEFT = 0;
+static const uint8_t BUTTON_OK = 47;
+static const uint8_t BUTTON_RIGHT = 48;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/lolin_s3_mini_pro/pins_arduino.h
+++ b/variants/lolin_s3_mini_pro/pins_arduino.h
@@ -7,12 +7,13 @@
 #define USB_VID 0x303a
 #define USB_PID 0x8216
 
-static const uint8_t LED_BUILTIN = 8 + SOC_GPIO_PIN_COUNT;;
+static const uint8_t LED_BUILTIN = 8 + SOC_GPIO_PIN_COUNT;
+;
 #define BUILTIN_LED    LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN    LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 #define RGB_BUILTIN    LED_BUILTIN
 #define RGB_BRIGHTNESS 5
-#define RGB_POWER     7  //RGB LED POWER PIN
+#define RGB_POWER      7  //RGB LED POWER PIN
 
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;

--- a/variants/lolin_s3_mini_pro/variant.cpp
+++ b/variants/lolin_s3_mini_pro/variant.cpp
@@ -1,0 +1,31 @@
+/*
+ */
+
+#include "esp32-hal-gpio.h"
+#include "pins_arduino.h"
+
+extern "C" {
+
+// Initialize variant/board, called before setup()
+void initVariant(void) {
+  // IR
+  pinMode(PIN_IR, OUTPUT);
+  digitalWrite(PIN_IR, LOW);
+  // RGB
+  pinMode(RGB_POWER, OUTPUT);
+  digitalWrite(RGB_POWER, LOW);
+  // BUTTON
+  pinMode(BUTTON_LEFT, INPUT_PULLUP);
+  pinMode(BUTTON_OK, INPUT_PULLUP);
+  pinMode(BUTTON_RIGHT, INPUT_PULLUP);
+  // TFT
+  pinMode(TFT_BL, OUTPUT);
+  digitalWrite(TFT_BL, LOW);
+  pinMode(TFT_CS, OUTPUT);
+  digitalWrite(TFT_CS, HIGH);
+  pinMode(TFT_RST, OUTPUT);
+  digitalWrite(TFT_RST, LOW);
+  delay(1);
+  digitalWrite(TFT_RST, HIGH);
+}
+}


### PR DESCRIPTION
Add board support for Add LOLIN S3 Mini Pro based ESP32-S3FH4R2 with 0.85 inch TFT Screen and IMU.

https://www.wemos.cc/en/latest/s3/s3_mini_pro.html