### PR TITLE
fix sdcard_unmount crashing when sd missing

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -774,7 +774,7 @@ uint8_t sdcard_unmount(uint8_t pdrv)
     card->type = CARD_NONE;
 
     char drv[3] = {(char)('0' + pdrv), ':', 0};
-    f_mount(NULL, drv, 0);
+    // f_mount(NULL, drv, 0);
     return 0;
 }
 


### PR DESCRIPTION
## Description of Change
When SDCARD is not present and we try to mount it, it calls "sdcard_unmount()" which in turns call f_mount(NULL, drv, 0); This crashes the ESP32 instead of returning an error. simply commenting out f_mount(NULL, drv, 0); fixed the crash.
```c++
f_mount(NULL, drv, 0);
```
I highly suggest investigating with other SPI ports to see if it may be related.

## Tests scenarios

#define SD_CARD_SCK 14     // USING VSPI
#define SD_CARD_MISO 12    // USING VSPI
#define SD_CARD_MOSI 13    // USING VSPI
#define SD_CARD_CS 15      // USING VSPI

Board with sd soldered. sd works fine

## code used
```c++
#app/lib/filesystem/FileSystem_ESP32.cpp
#if defined(PLATFORM_ESP32)

#include "FileSystem.h"
#include "LogManager.h" // Include LogManager header

#include <SD.h>
#include <SPI.h>
#include <string>
#include <vector>

// SD card pin definitions
#define SD_CARD_SCK 14     // USING VSPI
#define SD_CARD_MISO 12    // USING VSPI
#define SD_CARD_MOSI 13    // USING VSPI
#define SD_CARD_CS 15      // USING VSPI

class FileSystem_ESP32 : public FileSystem {
public:
    bool init(LogManager& logManager) override {
        // Initialize SPI with the correct pins
        SPI.begin(SD_CARD_SCK, SD_CARD_MISO, SD_CARD_MOSI, SD_CARD_CS);

        // Initialize SD card with the correct CS pin
        if (!SD.begin(SD_CARD_CS, SPI)) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to initialize SD card");
            return false;
        }

        uint8_t cardType = SD.cardType();
        if (cardType == CARD_NONE) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "No SD card attached");
            return false;
        }

        logManager.log(LOG_INFO, "FileSystem", LOG_TARGET_SERIAL, "SD Card initialized");
        return true;
    }

    bool write(LogManager& logManager, const char* path, const char* data, bool create_file = true) override {
        File file = SD.open(path, create_file ? FILE_WRITE : FILE_WRITE);
        if (!file) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to open file for writing: %s", path);
            return false;
        }
        file.seek(currentPosition);
        file.print(data);
        currentPosition = file.position();
        file.close();
        logManager.log(LOG_INFO, "FileSystem", LOG_TARGET_SERIAL, "Data written to file: %s", path);
        return true;
    }

    std::string read(LogManager& logManager, const char* path, std::size_t bytes, bool create_file = true) override {
        File file = SD.open(path);
        if (!file) {
            if (create_file) {
                file = SD.open(path, FILE_WRITE);
                if (!file) {
                    logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to create file: %s", path);
                    return "";
                }
                file.close();
            } else {
                logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to open file for reading: %s", path);
                return "";
            }
        }
        file.seek(currentPosition);
        std::string result;
        result.reserve(bytes);
        char buffer[128];
        while (bytes > 0 && file.available()) {
            size_t toRead = std::min(bytes, sizeof(buffer) - 1);
            size_t bytesRead = file.readBytes(buffer, toRead);
            buffer[bytesRead] = '\0';
            result.append(buffer, bytesRead);
            bytes -= bytesRead;
        }
        currentPosition = file.position();
        file.close();
        return result;
    }

    std::string readLine(LogManager& logManager, const char* path, std::size_t& position, bool create_file = true) override {
        File file = SD.open(path);
        if (!file) {
            if (create_file) {
                file = SD.open(path, FILE_WRITE);
                if (!file) {
                    logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to create file: %s", path);
                    return "";
                }
                file.close();
            } else {
                logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to open file for reading: %s", path);
                return "";
            }
        }
        file.seek(position);
        std::string result;
        result.reserve(128);
        char buffer[128];
        size_t totalRead = 0;
        while (file.available() && totalRead < 4096) {
            size_t bytesRead = file.readBytesUntil('\n', buffer, sizeof(buffer) - 1);
            buffer[bytesRead] = '\0';
            result.append(buffer, bytesRead);
            totalRead += bytesRead;
            if (result.find('\r') != std::string::npos || result.find('\n') != std::string::npos) {
                break;
            }
        }
        if (totalRead >= 4096) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to find newline within 4096 bytes");
            return "";
        }
        position = file.position();
        file.close();

        // Remove any trailing \r or \n characters
        result.erase(result.find_last_not_of("\r\n") + 1);
        return result;
    }

    bool append(LogManager& logManager, const char* path, const char* data) override {
        File file = SD.open(path, FILE_APPEND);
        if (!file) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to open file for appending: %s", path);
            return false;
        }
        file.print(data);
        file.print("\r\n"); // Append data with \r\n
        file.close();
        logManager.log(LOG_INFO, "FileSystem", LOG_TARGET_SERIAL, "Data appended to file: %s", path);
        return true;
    }

    bool seek(LogManager& logManager, const char* path, std::size_t position) override {
        File file = SD.open(path);
        if (!file) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to open file for seeking: %s", path);
            return false;
        }
        if (!file.seek(position)) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to seek to position %zu in file: %s", position, path);
            return false;
        }
        currentPosition = position;
        file.close();
        logManager.log(LOG_INFO, "FileSystem", LOG_TARGET_SERIAL, "Seeked to position %zu in file: %s", position, path);
        return true;
    }

    void logCurrentWorkingDirectory(LogManager& logManager) override {
        // ESP32 does not have a concept of working directory, so we log the SD card root
        logManager.log(LOG_INFO, "FileSystem", LOG_TARGET_SERIAL, "Current working directory: / (SD card root)");
    }

    bool deleteFile(LogManager& logManager, const char* path) override {
        if (SD.remove(path)) {
            logManager.log(LOG_INFO, "FileSystem", LOG_TARGET_SERIAL, "File deleted: %s", path);
            return true;
        } else {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to delete file: %s", path);
            return false;
        }
    }

    std::vector<std::string> listFiles(LogManager& logManager, const char* directory) override {
        std::vector<std::string> fileList;
        File dir = SD.open(directory);
        if (!dir) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to open directory: %s", directory);
            return fileList;
        }
        if (!dir.isDirectory()) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Not a directory: %s", directory);
            return fileList;
        }
        File file = dir.openNextFile();
        while (file) {
            fileList.push_back(file.name());
            file = dir.openNextFile();
        }
        return fileList;
    }

    std::size_t fileSize(LogManager& logManager, const char* path) override {
        File file = SD.open(path);
        if (!file) {
            logManager.log(LOG_ERROR, "FileSystem", LOG_TARGET_SERIAL, "Failed to open file: %s", path);
            return 0;
        }
        std::size_t size = file.size();
        file.close();
        return size;
    }

private:
    std::streampos currentPosition = 0;
};

#endif // PLATFORM_ESP32
``` 

## (without change) Error when SD is not present
``` cpp
--- Terminal on /dev/ttyUSB0 | 115200 8-N-1
--- Available filters and text transformations: colorize, debug, default, direct, esp32_exception_decoder, hexlify, log2file, nocontrol, printable, send_on_enter, time
--- More details at https://bit.ly/pio-monitor-filters
--- Quit: Ctrl+C | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H
��initialize continues
[   576][W][sd_diskio.cpp:516] ff_sd_initialize(): GO_IDLE_STATE failed
[   584][E][sd_diskio.cpp:806] sdcard_mount(): f_mount failed: (3) The physical drive cannot work
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x4008d839  PS      : 0x00060030  A0      : 0x800d9ad8  A1      : 0x3ffb2150  
A2      : 0xfefefefe  A3      : 0x3ffb21df  A4      : 0x3ffb21df  A5      : 0x00000001  
A6      : 0x3ffb21df  A7      : 0x3ffb21ac  A8      : 0x800840fa  A9      : 0x3ffb2130  
A10     : 0x3ffc65dc  A11     : 0x3ffb2158  A12     : 0x00060620  A13     : 0x00060423  
A14     : 0x00060423  A15     : 0x3ffb2130  SAR     : 0x00000017  EXCCAUSE: 0x0000001c  
EXCVADDR: 0xfefeff44  LBEG    : 0x400876e6  LEND    : 0x400876f1  LCOUNT  : 0x00000000  


Backtrace: 0x4008d836:0x3ffb2150 0x400d9ad5:0x3ffb2170 0x400d8082:0x3ffb2190 0x400d6012:0x3ffb21d0 0x400d4daf:0x3ffb2200 0x400d217b:0x3ffb2230 0x400d2314:0x3ffb2260 0x400d2378:0x3ffb2280 0x400de0a7:0x3ffb22a0
  #0  0x4008d836 in vQueueDelete at /home/italo/.platformio/packages/framework-espidf/components/freertos/queue.c:2128
  #1  0x400d9ad5 in ff_del_syncobj at /home/italo/.platformio/packages/framework-espidf/components/fatfs/port/freertos/ffsystem.c:75
  #2  0x400d8082 in f_mount at /home/italo/.platformio/packages/framework-espidf/components/fatfs/src/ff.c:3521
  #3  0x400d6012 in sdcard_unmount(unsigned char) at /home/italo/.platformio/packages/framework-arduinoespressif32/libraries/SD/src/sd_diskio.cpp:777
  #4  0x400d4daf in fs::SDFS::begin(unsigned char, SPIClass&, unsigned int, char const*, unsigned char, bool) at /home/italo/.platformio/packages/framework-arduinoespressif32/libraries/SD/src/SD.cpp:39
  #5  0x400d217b in FileSystem_ESP32::init(LogManager&) at lib/filesystem/FileSystem_ESP32.cpp:24
  #6  0x400d2314 in init_file_system() at src/main.cpp:30
  #7  0x400d2378 in setup() at src/main.cpp:43
  #8  0x400de0a7 in loopTask(void*) at /home/italo/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:42

ELF file SHA256: 05b71a0d7e07b385
``` 

##  (without change)  Ok when SD is present
``` cpp
rst:0xc (SW_CPU_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3fff0030,len:1344
load:0x40078000,len:13964
load:0x40080400,len:3600
entry 0x400805f0
HAL_ESP32 initialized
System details for HAL_ESP32:
System uptime: 57 milliseconds
[   560][W][sd_diskio.cpp:104] sdWait(): Wait Failed
[   566][W][sd_diskio.cpp:512] ff_sd_initialize(): sdWait fail ignored, card initialize continues
[684][INFO][FileSystem] SD Card initialized
[684][INFO][FileSystem] Current working directory: / (SD card root)
[1110][INFO][FileSystem] Data written to file: /test.txt
[1111][INFO][Setup] Wrote test data to /test.txt
[1111][INFO][Setup] System setup completed
[2121][INFO][Loop] Using HAL Loop iteration 1 at 2121 ms
[3121][INFO][Loop] Using HAL Loop iteration 2 at 3121 ms
```


Despite the following warning, the files are being written and read.
```cpp
[   560][W][sd_diskio.cpp:104] sdWait(): Wait Failed
[   566][W][sd_diskio.cpp:512] ff_sd_initialize(): sdWait fail ignored, card initialize continues
```