### PR TITLE
v2.x: Fix RMT mutex unlock using incorrect channel number in rmtDeinit

### DIFF
--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -325,22 +325,23 @@ bool rmtDeinit(rmt_obj_t *rmt)
         return false;
     }
 
-    RMT_MUTEX_LOCK(rmt->channel);
+    int channel = rmt->channel;
+    RMT_MUTEX_LOCK(channel);
     // force stopping rmt processing
     if (rmt->tx_not_rx) {
-        rmt_tx_stop(rmt->channel);
+        rmt_tx_stop(channel);
     } else {
-        rmt_rx_stop(rmt->channel);
+        rmt_rx_stop(channel);
         if(rmt->rxTaskHandle){
             vTaskDelete(rmt->rxTaskHandle);
             rmt->rxTaskHandle = NULL;
         }       
     }
 
-    rmt_driver_uninstall(rmt->channel);
+    rmt_driver_uninstall(channel);
 
-    size_t from = rmt->channel;
-    size_t to = rmt->buffers + rmt->channel;
+    size_t from = channel;
+    size_t to = rmt->buffers + channel;
     size_t i;
 
     for (i = from; i < to; i++) {
@@ -349,7 +350,7 @@ bool rmtDeinit(rmt_obj_t *rmt)
 
     g_rmt_objects[from].channel = 0;
     g_rmt_objects[from].buffers = 0;
-    RMT_MUTEX_UNLOCK(rmt->channel);
+    RMT_MUTEX_UNLOCK(channel);
 
 #if !CONFIG_DISABLE_HAL_LOCKS
     if(g_rmt_objlocks[from] != NULL) {


### PR DESCRIPTION
## Description of Change
This pull request fixes crashes caused by `rmtDeinit` function by improving how the RMT channel is handled.
- Added `int channel = rmt->channel;` at the beginning of `rmtDeinit`.
- Used `channel` consistently throughout the function, including for mutex operations.

This change mirrors the approach used in the other RMT hal functions such as `rmtLoop`, `rmtWrite`, `rmtWriteBlocking` and others, ensuring consistency across the codebase.

Previously, the line `g_rmt_objects[from].channel = 0;` would set `rmt->channel` to 0 before `RMT_MUTEX_UNLOCK(rmt->channel)` was called. This caused the mutex to always be unlocked with an incorrect 0 as channel number, leading to crashes for channels > 0.

## Tests scenarios
Tested on Lolin32 with Arduino-esp32 core v2.0.16, PlatformIO, VS Code, on Linux.
By calling:
```cpp
rmt1 = rmtInit(21, RMT_TX_MODE, RMT_MEM_64);
rmt2 = rmtInit(22, RMT_TX_MODE, RMT_MEM_64);
rmtDeinit(rmt1); // no crash (channel 0)
rmtDeinit(rmt2); // crash (channel 1), caused by RMT_MUTEX_UNLOCK(0)
```
This crashed the ESP32 before the pull request (even with proper error checking), and no longer crashes after the changes of the pull request

## Related links
There doesn't seem to be any issues discussing this problem
