### PR TITLE
SDMMC: Fix example code

### DIFF
--- a/libraries/SD_MMC/examples/SDMMC_Test/SDMMC_Test.ino
+++ b/libraries/SD_MMC/examples/SDMMC_Test/SDMMC_Test.ino
@@ -214,8 +214,8 @@ void setup() {
     // If you want to change the pin assignment on ESP32-S3 uncomment this block and the appropriate
     // line depending if you want to use 1-bit or 4-bit line.
     // Please note that ESP32 does not allow pin change and will always fail.
-    //if(! setPins(clk, cmd, d0)){
-    //if(! setPins(clk, cmd, d0, d1, d2, d3)){
+    //if(! SD_MMC.setPins(clk, cmd, d0)){
+    //if(! SD_MMC.setPins(clk, cmd, d0, d1, d2, d3)){
         Serial.println("Pin change failed!");
         return;
     }


### PR DESCRIPTION

## Description of Change
The setPins() function obviously comes from the SD_MMC lib. Not prepending that lib, this code won't compile.

## Tests scenarios
Uncomment code section and compile code.

I have tested my Pull Request on Arduino-esp32 core v2.0.16 with ESP32-S3-devkitc1 Board.

## Related links
None. I found that recently by using the example.
