### PR TITLE
fix(lwip): Filter out V6 packets if V6 is not enabled

### DIFF
--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -11,7 +11,6 @@
 #include "lwip/ip_addr.h"
 #include "lwip/err.h"
 #include "lwip/netif.h"
-#include "lwip/dns.h"
 #include "dhcpserver/dhcpserver.h"
 #include "dhcpserver/dhcpserver_options.h"
 #include "esp32-hal-log.h"


### PR DESCRIPTION
the ESP might accept and act on some IPv6 packets, even though IPv6 is not enabled for the interface in Arduino. This change makes the ESP ignore all IPv6 packets if IPv6 address is not available.

Depends on https://github.com/espressif/esp32-arduino-lib-builder/pull/194
Fixes https://github.com/espressif/arduino-esp32/issues/9712