### PR TITLE
IDF release/v5.1

### DIFF
--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -11,7 +11,6 @@
 #include "lwip/ip_addr.h"
 #include "lwip/err.h"
 #include "lwip/netif.h"
-#include "lwip/dns.h"
 #include "dhcpserver/dhcpserver.h"
 #include "dhcpserver/dhcpserver_options.h"
 #include "esp32-hal-log.h"

--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -35,6 +35,7 @@ NetworkInterface *getNetifByID(Network_Interface_ID id) {
 }
 
 #if CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM
+extern "C" int lwip_hook_ip6_input(struct pbuf *p, struct netif *inp) __attribute__((weak));
 extern "C" int lwip_hook_ip6_input(struct pbuf *p, struct netif *inp) {
   if (ip6_addr_isany_val(inp->ip6_addr[0].u_addr.ip6)) {
     // We don't have an LL address -> eat this packet here, so it won't get accepted on input netif

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -16,8 +16,8 @@
 #include "freertos/semphr.h"
 #include "freertos/queue.h"
 
-#include "esp_netif.h"
-#include "esp_netif_types.h"
+#include "esp_netif_net_stack.h"
+#include "lwip/netif.h"
 
 static TaskHandle_t s_cli_task = NULL;
 static TaskHandle_t s_console_cli_task = NULL;
@@ -27,6 +27,9 @@ static xQueueHandle tx_queue = NULL;
 static esp_openthread_platform_config_t ot_native_config;
 static TaskHandle_t s_ot_task = NULL;
 static esp_netif_t *openthread_netif = NULL;
+#if CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM
+static struct netif *ot_lwip_netif = NULL;
+#endif
 
 #define OT_CLI_MAX_LINE_LENGTH 512
 
@@ -37,6 +40,20 @@ typedef struct {
   OnReceiveCb_t responseCallBack;
 } ot_cli_console_t;
 static ot_cli_console_t otConsole = {NULL, false, (const char *)NULL, NULL};
+
+#if CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM
+extern "C" int lwip_hook_ip6_input(struct pbuf *p, struct netif *inp) {
+  if (ot_lwip_netif && ot_lwip_netif == inp) {
+    return 0;
+  }
+  if (ip6_addr_isany_val(inp->ip6_addr[0].u_addr.ip6)) {
+    // We don't have an LL address -> eat this packet here, so it won't get accepted on input netif
+    pbuf_free(p);
+    return 1;
+  }
+  return 0;
+}
+#endif
 
 // process the CLI commands sent to the OpenThread stack
 static void ot_cli_loop(void *context) {
@@ -258,6 +275,15 @@ static void ot_task_worker(void *aContext) {
     // Initialize the esp_netif bindings
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_OPENTHREAD();
     openthread_netif = esp_netif_new(&cfg);
+#if CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM
+    // Get LwIP Netif
+    if (openthread_netif != NULL) {
+      ot_lwip_netif = (struct netif *)esp_netif_get_netif_impl(openthread_netif);
+      if (ot_lwip_netif == NULL) {
+        log_e("Failed to get OpenThread LwIP netif");
+      }
+    }
+#endif
   }
   if (!err && openthread_netif == NULL) {
     log_e("Failed to create OpenThread esp_netif");
@@ -335,6 +361,9 @@ void OpenThreadCLI::end() {
     // Clean up
     esp_openthread_deinit();
     esp_openthread_netif_glue_deinit();
+#if CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM
+    ot_lwip_netif = NULL;
+#endif
     esp_netif_destroy(openthread_netif);
     esp_vfs_eventfd_unregister();
   }

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-bd2b9390ef"
+              "version": "idf-release_v5.1-dc859c1e67"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-bd2b9390ef",
+          "version": "idf-release_v5.1-dc859c1e67",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/c4ae7a78eafc339c71efcc7a75d5caa525c92f58",
-              "archiveFileName": "esp32-arduino-libs-c4ae7a78eafc339c71efcc7a75d5caa525c92f58.zip",
-              "checksum": "SHA-256:bd9d095d468b517e9836355246cff536223b456aa67ffdb176e167c368ddfd1f",
-              "size": "307841384"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
+              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
+              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
+              "size": "307528289"
             }
           ]
         },


### PR DESCRIPTION
the ESP might accept and act on some IPv6 packets, even though IPv6 is not enabled for the interface in Arduino. [This](https://github.com/espressif/arduino-esp32/pull/10038/commits/98da733f41f08256bfdfaa0c478a2f7c9f6bcff1) change makes the ESP ignore all IPv6 packets if IPv6 address is not available.

Depends on https://github.com/espressif/esp32-arduino-lib-builder/pull/194
Fixes https://github.com/espressif/arduino-esp32/issues/9712

```
lib-builder: master d7f4a33
esp-idf: release/v5.1 dc859c1e67
arduino: master e850afb1
tinyusb: master 1ba88ff3a
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.0
espressif__esp-zigbee-lib: 1.4.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.3.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
```
