### PR TITLE
fix(libs): Update all libraries to match the core version

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -36,4 +36,11 @@ sed "s/#define ESP_ARDUINO_VERSION_MAJOR.*/#define ESP_ARDUINO_VERSION_MAJOR $ES
 sed "s/#define ESP_ARDUINO_VERSION_MINOR.*/#define ESP_ARDUINO_VERSION_MINOR $ESP_ARDUINO_VERSION_MINOR/g" | \
 sed "s/#define ESP_ARDUINO_VERSION_PATCH.*/#define ESP_ARDUINO_VERSION_PATCH $ESP_ARDUINO_VERSION_PATCH/g" > __esp_arduino_version.h && mv __esp_arduino_version.h cores/esp32/esp_arduino_version.h
 
+for lib in `ls libraries`; do
+	if [ -f "libraries/$lib/library.properties" ]; then
+		echo "Updating Library $lib..."
+		cat "libraries/$lib/library.properties" | sed "s/version=.*/version=$ESP_ARDUINO_VERSION/g" > "libraries/$lib/__library.properties" && mv "libraries/$lib/__library.properties" "libraries/$lib/library.properties"
+	fi
+done
+
 exit 0

--- a/libraries/ArduinoOTA/library.properties
+++ b/libraries/ArduinoOTA/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoOTA
-version=2.0.0
+version=3.0.3
 author=Ivan Grokhotkov and Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Enables Over The Air upgrades, via wifi and espota.py UDP request/TCP download.

--- a/libraries/AsyncUDP/library.properties
+++ b/libraries/AsyncUDP/library.properties
@@ -1,5 +1,5 @@
 name=ESP32 Async UDP
-version=2.0.0
+version=3.0.3
 author=Me-No-Dev
 maintainer=Me-No-Dev
 sentence=Async UDP Library for ESP32

--- a/libraries/BLE/library.properties
+++ b/libraries/BLE/library.properties
@@ -1,5 +1,5 @@
 name=BLE
-version=2.0.0
+version=3.0.3
 author=Neil Kolban <kolban1@kolban.com>
 maintainer=Dariusz Krempa <esp32@esp32.eu.org>
 sentence=BLE functions for ESP32

--- a/libraries/BluetoothSerial/library.properties
+++ b/libraries/BluetoothSerial/library.properties
@@ -1,5 +1,5 @@
 name=BluetoothSerial
-version=2.0.0
+version=3.0.3
 author=Evandro Copercini
 maintainer=Evandro Copercini
 sentence=Simple UART to Classical Bluetooth bridge for ESP32

--- a/libraries/DNSServer/library.properties
+++ b/libraries/DNSServer/library.properties
@@ -1,5 +1,5 @@
 name=DNSServer
-version=2.0.0
+version=3.0.3
 author=Kristijan Novoselić
 maintainer=Kristijan Novoselić, <kristijan.novoselic@gmail.com>
 sentence=A simple DNS server for ESP32.

--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -1,5 +1,5 @@
 name=EEPROM
-version=2.0.0
+version=3.0.3
 author=Ivan Grokhotkov
 maintainer=Paolo Becchi <pbecchi@aerobusiness.it>
 sentence=Enables reading and writing data a sequential, addressable FLASH storage

--- a/libraries/ESP32/library.properties
+++ b/libraries/ESP32/library.properties
@@ -1,5 +1,5 @@
 name=ESP32
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov, Ivan Grokhtkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32 sketches examples

--- a/libraries/ESP_I2S/library.properties
+++ b/libraries/ESP_I2S/library.properties
@@ -1,5 +1,5 @@
 name=ESP_I2S
-version=1.0.0
+version=3.0.3
 author=me-no-dev
 maintainer=me-no-dev
 sentence=Library for ESP I2S communication

--- a/libraries/ESP_NOW/library.properties
+++ b/libraries/ESP_NOW/library.properties
@@ -1,5 +1,5 @@
 name=ESP_NOW
-version=1.0.0
+version=3.0.3
 author=me-no-dev
 maintainer=P-R-O-C-H-Y
 sentence=Library for ESP_NOW

--- a/libraries/ESP_SR/library.properties
+++ b/libraries/ESP_SR/library.properties
@@ -1,5 +1,5 @@
 name=ESP_SR
-version=1.0.0
+version=3.0.3
 author=me-no-dev
 maintainer=me-no-dev
 sentence=Library for ESP Sound Recognition

--- a/libraries/ESPmDNS/library.properties
+++ b/libraries/ESPmDNS/library.properties
@@ -1,5 +1,5 @@
 name=ESPmDNS
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov, Ivan Grokhtkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32 mDNS Library

--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -1,5 +1,5 @@
 name=Ethernet
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Enables network connection (local and Internet) using the ESP32 Ethernet.

--- a/libraries/FFat/library.properties
+++ b/libraries/FFat/library.properties
@@ -1,5 +1,5 @@
 name=FFat
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov, Ivan Grokhtkov, Larry Bernstone
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32 FAT on Flash File System

--- a/libraries/FS/library.properties
+++ b/libraries/FS/library.properties
@@ -1,5 +1,5 @@
 name=FS
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov, Ivan Grokhtkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32 File System

--- a/libraries/HTTPClient/library.properties
+++ b/libraries/HTTPClient/library.properties
@@ -1,5 +1,5 @@
 name=HTTPClient
-version=2.0.0
+version=3.0.3
 author=Markus Sattler
 maintainer=Markus Sattler
 sentence=HTTP Client for ESP32

--- a/libraries/HTTPUpdate/library.properties
+++ b/libraries/HTTPUpdate/library.properties
@@ -1,5 +1,5 @@
 name=HTTPUpdate
-version=2.0.0
+version=3.0.3
 author=Markus Sattler
 maintainer=Markus Sattler
 sentence=Http Update for ESP32

--- a/libraries/HTTPUpdateServer/library.properties
+++ b/libraries/HTTPUpdateServer/library.properties
@@ -1,5 +1,5 @@
 name=HTTPUpdateServer
-version=2.0.0
+version=3.0.3
 author=Hristo Kapanakov
 maintainer=
 sentence=Simple HTTP Update server based on the WebServer

--- a/libraries/Insights/library.properties
+++ b/libraries/Insights/library.properties
@@ -1,5 +1,5 @@
 name=ESP Insights
-version=1.0.0
+version=3.0.3
 author=Sanket Wadekar <sanket.wadekar@espressif.com>
 maintainer=Sanket Wadekar <sanket.wadekar@espressif.com>
 sentence=ESP Insights

--- a/libraries/LittleFS/library.properties
+++ b/libraries/LittleFS/library.properties
@@ -1,5 +1,5 @@
 name=LittleFS
-version=2.0.0
+version=3.0.3
 author=
 maintainer=
 sentence=LittleFS for esp32

--- a/libraries/NetBIOS/library.properties
+++ b/libraries/NetBIOS/library.properties
@@ -1,5 +1,5 @@
 name=NetBIOS
-version=2.0.0
+version=3.0.3
 author=Pablo@xpablo.cz
 maintainer=Hristo Gochkov<hristo@espressif.com>
 sentence=Enables NBNS (NetBIOS) name resolution.

--- a/libraries/Network/library.properties
+++ b/libraries/Network/library.properties
@@ -1,5 +1,5 @@
 name=Networking
-version=1.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=General network management library.

--- a/libraries/NetworkClientSecure/library.properties
+++ b/libraries/NetworkClientSecure/library.properties
@@ -1,5 +1,5 @@
 name=NetworkClientSecure
-version=2.0.0
+version=3.0.3
 author=Evandro Luis Copercini
 maintainer=Github Community
 sentence=Enables secure network connection (local and Internet) using the ESP32 built-in WiFi.

--- a/libraries/OpenThread/library.properties
+++ b/libraries/OpenThread/library.properties
@@ -1,5 +1,5 @@
 name=OpenThread
-version=1.0.0
+version=3.0.3
 author=Rodrigo Garcia | GitHub @SuGlider
 maintainer=Rodrigo Garcia <Rodrigo.Garcia@espressif.com>
 sentence=Library for OpenThread Network on ESP32.

--- a/libraries/PPP/library.properties
+++ b/libraries/PPP/library.properties
@@ -1,5 +1,5 @@
 name=PPP
-version=1.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Enables network connection using GSM Modem.

--- a/libraries/Preferences/library.properties
+++ b/libraries/Preferences/library.properties
@@ -1,5 +1,5 @@
 name=Preferences
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Provides friendly access to ESP32's Non-Volatile Storage

--- a/libraries/RainMaker/library.properties
+++ b/libraries/RainMaker/library.properties
@@ -1,5 +1,5 @@
 name=ESP RainMaker
-version=2.0.0
+version=3.0.3
 author=Sweety Mhaiske <switi.mhaiske@espressif.com>
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP RainMaker Support

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,5 +1,5 @@
 name=SD
-version=2.0.0
+version=3.0.3
 author=Arduino, SparkFun
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables reading and writing on SD cards. For all Arduino boards.

--- a/libraries/SD_MMC/library.properties
+++ b/libraries/SD_MMC/library.properties
@@ -1,5 +1,5 @@
 name=SD_MMC
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov, Ivan Grokhtkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32 SDMMC File System

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -1,5 +1,5 @@
 name=SPI
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Enables the communication with devices that use the Serial Peripheral Interface (SPI) Bus. For all Arduino boards, BUT Arduino DUE.

--- a/libraries/SPIFFS/library.properties
+++ b/libraries/SPIFFS/library.properties
@@ -1,5 +1,5 @@
 name=SPIFFS
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov, Ivan Grokhtkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32 SPIFFS File System

--- a/libraries/SimpleBLE/library.properties
+++ b/libraries/SimpleBLE/library.properties
@@ -1,5 +1,5 @@
 name=SimpleBLE
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Provides really simple BLE advertizer with just on and off

--- a/libraries/TFLiteMicro/library.properties
+++ b/libraries/TFLiteMicro/library.properties
@@ -1,5 +1,5 @@
 name=TFLite Micro
-version=1.0.0
+version=3.0.3
 author=Sanket Wadekar
 maintainer=Sanket Wadekar
 sentence=TensorFlow Lite for Microcontrollers

--- a/libraries/Ticker/library.properties
+++ b/libraries/Ticker/library.properties
@@ -1,5 +1,5 @@
 name=Ticker
-version=2.0.0
+version=3.0.3
 author=Bert Melis
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Allows to call functions with a given interval.

--- a/libraries/USB/library.properties
+++ b/libraries/USB/library.properties
@@ -1,5 +1,5 @@
 name=USB
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32S2 USB Library

--- a/libraries/Update/library.properties
+++ b/libraries/Update/library.properties
@@ -1,5 +1,5 @@
 name=Update
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=ESP32 Sketch Update Library

--- a/libraries/WebServer/library.properties
+++ b/libraries/WebServer/library.properties
@@ -1,5 +1,5 @@
 name=WebServer
-version=2.0.0
+version=3.0.3
 author=Ivan Grokhotkov
 maintainer=Ivan Grokhtkov <ivan@esp8266.com>
 sentence=Simple web server library

--- a/libraries/WiFi/library.properties
+++ b/libraries/WiFi/library.properties
@@ -1,5 +1,5 @@
 name=WiFi
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Enables network connection (local and Internet) using the ESP32 built-in WiFi.

--- a/libraries/WiFiProv/library.properties
+++ b/libraries/WiFiProv/library.properties
@@ -1,5 +1,5 @@
 name=WiFiProv
-version=2.0.0
+version=3.0.3
 author=Switi Mhaiske <sweetymhaiske@gmail.com>
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Enables provisioning.

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -1,5 +1,5 @@
 name=Wire
-version=2.0.0
+version=3.0.3
 author=Hristo Gochkov
 maintainer=Hristo Gochkov <hristo@espressif.com>
 sentence=Allows the communication between devices or sensors connected via Two Wire Interface Bus. For esp8266 boards.


### PR DESCRIPTION
From now on core libraries should have the same version as the core

Closes https://github.com/espressif/arduino-esp32/issues/9947