### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-9069767c9e"
+              "version": "idf-release_v5.1-ecdd485305"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-9069767c9e",
+          "version": "idf-release_v5.1-ecdd485305",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
-              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
-              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
-              "size": "307568522"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
+              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
+              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
+              "size": "307666578"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-dc859c1e67"
+              "version": "idf-release_v5.1-cd4714dd01"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-dc859c1e67",
+          "version": "idf-release_v5.1-cd4714dd01",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
+              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
+              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
+              "size": "307524827"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-cd4714dd01"
+              "version": "idf-release_v5.1-9069767c9e"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-cd4714dd01",
+          "version": "idf-release_v5.1-9069767c9e",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ced5069ee639c92f3bbe3305d398715965d55868",
-              "archiveFileName": "esp32-arduino-libs-ced5069ee639c92f3bbe3305d398715965d55868.zip",
-              "checksum": "SHA-256:1af20116f6703142de16b2254d6e634f14a67691dbbc1a216c4cbb080303c84f",
-              "size": "307524827"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/a79c4a00d7add26cd552cd548d342ba852a78c2f",
+              "archiveFileName": "esp32-arduino-libs-a79c4a00d7add26cd552cd548d342ba852a78c2f.zip",
+              "checksum": "SHA-256:37e5fbae3d3c99e5ab9bd28f36b58907a8d525b758f9b98e3e95330ac2a855a4",
+              "size": "307568522"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-ecdd485305"
+              "version": "idf-release_v5.1-5a26d8ae8e"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-ecdd485305",
+          "version": "idf-release_v5.1-5a26d8ae8e",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e3e61232bf5626dbbab4f42ceebec7c74779147b",
-              "archiveFileName": "esp32-arduino-libs-e3e61232bf5626dbbab4f42ceebec7c74779147b.zip",
-              "checksum": "SHA-256:30581fd17ad39c0a005ff29c17f8d12f2decd49654367907759ba55672012c53",
-              "size": "307666578"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/e780659aa23ecb571cc56403c4577c80c7d61405",
+              "archiveFileName": "esp32-arduino-libs-e780659aa23ecb571cc56403c4577c80c7d61405.zip",
+              "checksum": "SHA-256:5d0b89dbfed5aa00b0b8618ccbe37f4860301e5e72389fb34cf7b16f58f40647",
+              "size": "307824525"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master d7f4a33
esp-idf: release/v5.1 cd4714dd01
arduino: master 690bdb51
tinyusb: master 7706e6f5d
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.0
espressif__esp-zigbee-lib: 1.4.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.1.0
espressif__esp_insights: 1.1.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.3.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
```
