### PR TITLE
ci(tests): Fix workflow errors

### DIFF
--- a/.github/scripts/install-arduino-cli.sh
+++ b/.github/scripts/install-arduino-cli.sh
@@ -41,6 +41,12 @@ fi
 if [ ! -d "$ARDUINO_IDE_PATH" ] || [ ! -f "$ARDUINO_IDE_PATH/arduino-cli" ]; then
     echo "Installing Arduino CLI on $OS_NAME ..."
     mkdir -p "$ARDUINO_IDE_PATH"
-    curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR="$ARDUINO_IDE_PATH" sh
+    if [ "$OS_IS_WINDOWS" == "1" ]; then
+        curl -fsSL https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Windows_64bit.zip -o arduino-cli.zip
+        unzip -q arduino-cli.zip -d "$ARDUINO_IDE_PATH"
+        rm arduino-cli.zip
+    else
+        curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR="$ARDUINO_IDE_PATH" sh
+    fi
 fi
 

--- a/.github/workflows/tests_hw.yml
+++ b/.github/workflows/tests_hw.yml
@@ -12,6 +12,13 @@ on:
         description: 'Chip to run tests for'
         required: true
 
+env:
+  DEBIAN_FRONTEND: noninteractive
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   hardware-test:
     name: Hardware ${{ inputs.chip }} ${{ inputs.type }} tests
@@ -48,6 +55,13 @@ jobs:
       - name: Checkout user repository
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            *
+
+      - name: List files
+        if: ${{ steps.check-tests.outputs.enabled == 'true' }}
+        run: ls -la
 
       # setup-python currently only works on ubuntu images
       # - uses: actions/setup-python@v5


### PR DESCRIPTION
## Description of Change

Fix current CI errors by:
- Installing windows arduino-cli using the zip file
- Doing sparse checkout in HW tests (For some reason it cant find some folders without it)

## Tests scenarios

CI
