### PR TITLE
fix(gpio): add missing include for digitalPinCanOutput()

### DIFF
--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -27,6 +27,7 @@ extern "C" {
 #include "esp32-hal.h"
 #include "soc/soc_caps.h"
 #include "pins_arduino.h"
+#include "driver/gpio.h"
 
 #if (CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3)
 #define NUM_OUPUT_PINS 46


### PR DESCRIPTION
## Description of Change
Fixing digitalPinCanOutput() by adding the missing include.

## Tests scenarios
Locally

## Related links
Closes #10049 
