### PR TITLE
feat(board): add Waveshare ESP32-S3-Matrix

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -37362,6 +37362,201 @@ Geekble_ESP32C3.menu.EraseFlash.none.upload.erase_cmd=
 Geekble_ESP32C3.menu.EraseFlash.all=Enabled
 Geekble_ESP32C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
+######################################################
+
+ws_esp32_s3_matrix.name=Waveshare ESP32-S3-Matrix
+ws_esp32_s3_matrix.vid.0=0x303a
+ws_esp32_s3_matrix.pid.0=0x81FB
+ws_esp32_s3_matrix.upload_port.0.vid=0x303a
+ws_esp32_s3_matrix.upload_port.0.pid=0x81FB
+
+ws_esp32_s3_matrix.bootloader.tool=esptool_py
+ws_esp32_s3_matrix.bootloader.tool.default=esptool_py
+
+ws_esp32_s3_matrix.upload.tool=esptool_py
+ws_esp32_s3_matrix.upload.tool.default=esptool_py
+ws_esp32_s3_matrix.upload.tool.network=esp_ota
+
+ws_esp32_s3_matrix.upload.maximum_size=1310720
+
+ws_esp32_s3_matrix.upload.maximum_data_size=327680
+ws_esp32_s3_matrix.upload.flags=
+ws_esp32_s3_matrix.upload.extra_flags=
+ws_esp32_s3_matrix.upload.use_1200bps_touch=false
+ws_esp32_s3_matrix.upload.wait_for_upload_port=false
+
+ws_esp32_s3_matrix.serial.disableDTR=false
+ws_esp32_s3_matrix.serial.disableRTS=false
+
+ws_esp32_s3_matrix.build.tarch=xtensa
+ws_esp32_s3_matrix.build.bootloader_addr=0x0
+ws_esp32_s3_matrix.build.target=esp32s3
+ws_esp32_s3_matrix.build.mcu=esp32s3
+ws_esp32_s3_matrix.build.core=esp32
+ws_esp32_s3_matrix.build.variant=ws_esp32_s3_matrix
+ws_esp32_s3_matrix.build.board=WS_ESP32_S3_MATRIX
+
+ws_esp32_s3_matrix.build.usb_mode=1
+ws_esp32_s3_matrix.build.cdc_on_boot=0
+ws_esp32_s3_matrix.build.msc_on_boot=0
+ws_esp32_s3_matrix.build.dfu_on_boot=0
+ws_esp32_s3_matrix.build.f_cpu=240000000L
+ws_esp32_s3_matrix.build.flash_size=4MB
+ws_esp32_s3_matrix.build.flash_freq=80m
+ws_esp32_s3_matrix.build.flash_mode=dio
+ws_esp32_s3_matrix.build.boot=qio
+ws_esp32_s3_matrix.build.boot_freq=80m
+ws_esp32_s3_matrix.build.partitions=default
+ws_esp32_s3_matrix.build.defines=
+ws_esp32_s3_matrix.build.loop_core=
+ws_esp32_s3_matrix.build.event_core=
+ws_esp32_s3_matrix.build.psram_type=qspi
+ws_esp32_s3_matrix.build.memory_type={build.boot}_{build.psram_type}
+
+ws_esp32_s3_matrix.menu.PSRAM.disabled=Disabled
+ws_esp32_s3_matrix.menu.PSRAM.disabled.build.defines=
+ws_esp32_s3_matrix.menu.PSRAM.disabled.build.psram_type=qspi
+ws_esp32_s3_matrix.menu.PSRAM.enabled=Enabled
+ws_esp32_s3_matrix.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+ws_esp32_s3_matrix.menu.PSRAM.enabled.build.psram_type=qspi
+
+ws_esp32_s3_matrix.menu.FlashMode.qio=QIO 80MHz
+ws_esp32_s3_matrix.menu.FlashMode.qio.build.flash_mode=dio
+ws_esp32_s3_matrix.menu.FlashMode.qio.build.boot=qio
+ws_esp32_s3_matrix.menu.FlashMode.qio.build.boot_freq=80m
+ws_esp32_s3_matrix.menu.FlashMode.qio.build.flash_freq=80m
+ws_esp32_s3_matrix.menu.FlashMode.qio120=QIO 120MHz
+ws_esp32_s3_matrix.menu.FlashMode.qio120.build.flash_mode=dio
+ws_esp32_s3_matrix.menu.FlashMode.qio120.build.boot=qio
+ws_esp32_s3_matrix.menu.FlashMode.qio120.build.boot_freq=120m
+ws_esp32_s3_matrix.menu.FlashMode.qio120.build.flash_freq=80m
+
+ws_esp32_s3_matrix.menu.FlashSize.4M=4MB (32Mb)
+ws_esp32_s3_matrix.menu.FlashSize.4M.build.flash_size=4MB
+
+ws_esp32_s3_matrix.menu.LoopCore.1=Core 1
+ws_esp32_s3_matrix.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+ws_esp32_s3_matrix.menu.LoopCore.0=Core 0
+ws_esp32_s3_matrix.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+ws_esp32_s3_matrix.menu.EventsCore.1=Core 1
+ws_esp32_s3_matrix.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+ws_esp32_s3_matrix.menu.EventsCore.0=Core 0
+ws_esp32_s3_matrix.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+ws_esp32_s3_matrix.menu.USBMode.hwcdc=Hardware CDC and JTAG
+ws_esp32_s3_matrix.menu.USBMode.hwcdc.build.usb_mode=1
+ws_esp32_s3_matrix.menu.USBMode.default=USB-OTG (TinyUSB)
+ws_esp32_s3_matrix.menu.USBMode.default.build.usb_mode=0
+
+ws_esp32_s3_matrix.menu.CDCOnBoot.default=Disabled
+ws_esp32_s3_matrix.menu.CDCOnBoot.default.build.cdc_on_boot=0
+ws_esp32_s3_matrix.menu.CDCOnBoot.cdc=Enabled
+ws_esp32_s3_matrix.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+ws_esp32_s3_matrix.menu.MSCOnBoot.default=Disabled
+ws_esp32_s3_matrix.menu.MSCOnBoot.default.build.msc_on_boot=0
+ws_esp32_s3_matrix.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+ws_esp32_s3_matrix.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+ws_esp32_s3_matrix.menu.DFUOnBoot.default=Disabled
+ws_esp32_s3_matrix.menu.DFUOnBoot.default.build.dfu_on_boot=0
+ws_esp32_s3_matrix.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+ws_esp32_s3_matrix.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+ws_esp32_s3_matrix.menu.UploadMode.default=UART0 / Hardware CDC
+ws_esp32_s3_matrix.menu.UploadMode.default.upload.use_1200bps_touch=false
+ws_esp32_s3_matrix.menu.UploadMode.default.upload.wait_for_upload_port=false
+ws_esp32_s3_matrix.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+ws_esp32_s3_matrix.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+ws_esp32_s3_matrix.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+ws_esp32_s3_matrix.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.default.build.partitions=default
+ws_esp32_s3_matrix.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+ws_esp32_s3_matrix.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.no_ota.build.partitions=no_ota
+ws_esp32_s3_matrix.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+ws_esp32_s3_matrix.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+ws_esp32_s3_matrix.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.huge_app.build.partitions=huge_app
+ws_esp32_s3_matrix.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+ws_esp32_s3_matrix.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+ws_esp32_s3_matrix.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+ws_esp32_s3_matrix.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+ws_esp32_s3_matrix.menu.PartitionScheme.rainmaker=RainMaker 4MB
+ws_esp32_s3_matrix.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+ws_esp32_s3_matrix.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+ws_esp32_s3_matrix.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+ws_esp32_s3_matrix.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+ws_esp32_s3_matrix.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+
+ws_esp32_s3_matrix.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+ws_esp32_s3_matrix.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+ws_esp32_s3_matrix.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+ws_esp32_s3_matrix.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+ws_esp32_s3_matrix.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+ws_esp32_s3_matrix.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+ws_esp32_s3_matrix.menu.PartitionScheme.custom=Custom
+ws_esp32_s3_matrix.menu.PartitionScheme.custom.build.partitions=
+ws_esp32_s3_matrix.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+ws_esp32_s3_matrix.menu.CPUFreq.240=240MHz (WiFi)
+ws_esp32_s3_matrix.menu.CPUFreq.240.build.f_cpu=240000000L
+ws_esp32_s3_matrix.menu.CPUFreq.160=160MHz (WiFi)
+ws_esp32_s3_matrix.menu.CPUFreq.160.build.f_cpu=160000000L
+ws_esp32_s3_matrix.menu.CPUFreq.80=80MHz (WiFi)
+ws_esp32_s3_matrix.menu.CPUFreq.80.build.f_cpu=80000000L
+ws_esp32_s3_matrix.menu.CPUFreq.40=40MHz
+ws_esp32_s3_matrix.menu.CPUFreq.40.build.f_cpu=40000000L
+ws_esp32_s3_matrix.menu.CPUFreq.20=20MHz
+ws_esp32_s3_matrix.menu.CPUFreq.20.build.f_cpu=20000000L
+ws_esp32_s3_matrix.menu.CPUFreq.10=10MHz
+ws_esp32_s3_matrix.menu.CPUFreq.10.build.f_cpu=10000000L
+
+ws_esp32_s3_matrix.menu.UploadSpeed.921600=921600
+ws_esp32_s3_matrix.menu.UploadSpeed.921600.upload.speed=921600
+ws_esp32_s3_matrix.menu.UploadSpeed.115200=115200
+ws_esp32_s3_matrix.menu.UploadSpeed.115200.upload.speed=115200
+ws_esp32_s3_matrix.menu.UploadSpeed.256000.windows=256000
+ws_esp32_s3_matrix.menu.UploadSpeed.256000.upload.speed=256000
+ws_esp32_s3_matrix.menu.UploadSpeed.230400.windows.upload.speed=256000
+ws_esp32_s3_matrix.menu.UploadSpeed.230400=230400
+ws_esp32_s3_matrix.menu.UploadSpeed.230400.upload.speed=230400
+ws_esp32_s3_matrix.menu.UploadSpeed.460800.linux=460800
+ws_esp32_s3_matrix.menu.UploadSpeed.460800.macosx=460800
+ws_esp32_s3_matrix.menu.UploadSpeed.460800.upload.speed=460800
+ws_esp32_s3_matrix.menu.UploadSpeed.512000.windows=512000
+ws_esp32_s3_matrix.menu.UploadSpeed.512000.upload.speed=512000
+
+ws_esp32_s3_matrix.menu.DebugLevel.none=None
+ws_esp32_s3_matrix.menu.DebugLevel.none.build.code_debug=0
+ws_esp32_s3_matrix.menu.DebugLevel.error=Error
+ws_esp32_s3_matrix.menu.DebugLevel.error.build.code_debug=1
+ws_esp32_s3_matrix.menu.DebugLevel.warn=Warn
+ws_esp32_s3_matrix.menu.DebugLevel.warn.build.code_debug=2
+ws_esp32_s3_matrix.menu.DebugLevel.info=Info
+ws_esp32_s3_matrix.menu.DebugLevel.info.build.code_debug=3
+ws_esp32_s3_matrix.menu.DebugLevel.debug=Debug
+ws_esp32_s3_matrix.menu.DebugLevel.debug.build.code_debug=4
+ws_esp32_s3_matrix.menu.DebugLevel.verbose=Verbose
+ws_esp32_s3_matrix.menu.DebugLevel.verbose.build.code_debug=5
+
+ws_esp32_s3_matrix.menu.EraseFlash.none=Disabled
+ws_esp32_s3_matrix.menu.EraseFlash.none.upload.erase_cmd=
+ws_esp32_s3_matrix.menu.EraseFlash.all=Enabled
+ws_esp32_s3_matrix.menu.EraseFlash.all.upload.erase_cmd=-e
+
 ##############################################################
 
 waveshare_esp32s3_touch_lcd_128.name=Waveshare ESP32S3 Touch LCD 128

--- a/variants/ws_esp32_s3_matrix/partitions_all_app_4MB.csv
+++ b/variants/ws_esp32_s3_matrix/partitions_all_app_4MB.csv
@@ -1,4 +1,3 @@
 # Name,    Type,  SubType,     Offset,      Size,  Flags
 nvs,       data,  nvs,         0x9000,    0x5000,
 factory,   app,   factory,    0x10000,  0x3F0000,
-

--- a/variants/ws_esp32_s3_matrix/partitions_all_app_4MB.csv
+++ b/variants/ws_esp32_s3_matrix/partitions_all_app_4MB.csv
@@ -1,0 +1,4 @@
+# Name,    Type,  SubType,     Offset,      Size,  Flags
+nvs,       data,  nvs,         0x9000,    0x5000,
+factory,   app,   factory,    0x10000,  0x3F0000,
+

--- a/variants/ws_esp32_s3_matrix/partitions_otanofs_4MB.csv
+++ b/variants/ws_esp32_s3_matrix/partitions_otanofs_4MB.csv
@@ -1,0 +1,6 @@
+#   Name, Type,  SubType,   Offset,      Size, Flags
+     nvs, data,      nvs,   0x9000,    0x5000,
+ otadata, data,      ota,   0xE000,    0x2000,
+    app0,  app,    ota_0,  0x10000,  0x1F0000,
+    app1,  app,    ota_1, 0x200000,  0x1F0000,
+coredump, data, coredump, 0x3F0000,   0x10000,

--- a/variants/ws_esp32_s3_matrix/pins_arduino.h
+++ b/variants/ws_esp32_s3_matrix/pins_arduino.h
@@ -14,14 +14,14 @@
 #define USB_SERIAL       ""
 
 // Onboard 8 x 8 Matrix panel
-#define WS_MATRIX_DIN	14
+#define WS_MATRIX_DIN 14
 
 // Onboard  QMI8658 IMU
-#define WS_IMU_SDA      11
-#define WS_IMU_SCL      12
-#define WS_IMU_ADDRESS	0x6B
-#define WS_IMU_INT1     10
-#define WS_IMU_INT2     13
+#define WS_IMU_SDA     11
+#define WS_IMU_SCL     12
+#define WS_IMU_ADDRESS 0x6B
+#define WS_IMU_INT1    10
+#define WS_IMU_INT2    13
 
 // UART0 pins
 static const uint8_t TX = 43;
@@ -32,10 +32,10 @@ static const uint8_t SDA = 11;
 static const uint8_t SCL = 12;
 
 // Mapping based on the ESP32S3 data sheet - alternate for SPI2
-static const uint8_t   SS = 34;		// FSPICS0
-static const uint8_t MOSI = 35;		// FSPID
-static const uint8_t MISO = 37;		// FSPIQ
-static const uint8_t  SCK = 36;		// FSPICLK
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
 
 // Analog capable pins on the header
 static const uint8_t A0 = 1;

--- a/variants/ws_esp32_s3_matrix/pins_arduino.h
+++ b/variants/ws_esp32_s3_matrix/pins_arduino.h
@@ -1,0 +1,77 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Matrix"
+#define USB_SERIAL       ""
+
+// Onboard 8 x 8 Matrix panel
+#define WS_MATRIX_DIN	14
+
+// Onboard  QMI8658 IMU
+#define WS_IMU_SDA      11
+#define WS_IMU_SCL      12
+#define WS_IMU_ADDRESS	0x6B
+#define WS_IMU_INT1     10
+#define WS_IMU_INT2     13
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 12;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t   SS = 34;		// FSPICS0
+static const uint8_t MOSI = 35;		// FSPID
+static const uint8_t MISO = 37;		// FSPIQ
+static const uint8_t  SCK = 36;		// FSPICLK
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Adds support for the Waveshare ESP32-S3-Matrix board. Includes changes to the Rainmaker partitions as per PR #10046 .

## Tests scenarios:
Tested using:

- Waveshare ESP32-S3-Matrix dev board
- arduino-esp32 core v3.0.3
- Arduino IDE v2.3.2
- Debian GNU/Linux 12

## Related links
PR #10046 
