### PR TITLE
Boards: Update LED_BUILTIN with the correct value for esp32c3

### DIFF
--- a/variants/esp32c3/pins_arduino.h
+++ b/variants/esp32c3/pins_arduino.h
@@ -6,7 +6,7 @@
 
 #define PIN_NEOPIXEL 8
 // BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_NEOPIXEL;
+static const uint8_t LED_BUILTIN = PIN_NEOPIXEL;
 #define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API neopixelWrite()


### PR DESCRIPTION
### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
The led pin for esp32-c3 should be pin 8.

## Tests scenarios
I was upload blink example and checked it myself on my esp32c3.

## Related links
According to this manual and esp32-c3 schema:
https://wiki.icbbuy.com/doku.php?id=developmentboard:esp32-c3mini
One more example:
https://github.com/MoonFox2006/ESP32C3_Wake_Demo/blob/main/src/main.cpp#L6