### PR TITLE
fix(lwip): Add early out in `NetworkUDP::parsePacket()` when socket has no data

### DIFF
--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -297,6 +297,13 @@ int NetworkUDP::parsePacket() {
   struct sockaddr_storage si_other_storage;  // enough storage for v4 and v6
   socklen_t slen = sizeof(sockaddr_storage);
   int len;
+  if (ioctl(udp_server, FIONREAD, &len) == -1) {
+    log_e("could not check for data in buffer length: %d", errno);
+    return 0;
+  }
+  if (!len) {
+    return 0;
+  }
   char *buf = (char *)malloc(1460);
   if (!buf) {
     return 0;

--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -296,7 +296,7 @@ int NetworkUDP::parsePacket() {
   }
   struct sockaddr_storage si_other_storage;  // enough storage for v4 and v6
   socklen_t slen = sizeof(sockaddr_storage);
-  int len;
+  int len = 0;
   if (ioctl(udp_server, FIONREAD, &len) == -1) {
     log_e("could not check for data in buffer length: %d", errno);
     return 0;


### PR DESCRIPTION
## Description of Change
Previously, `NetworkUDP::parsePacket()` would take the time to allocate a 1460 byte buffer to call `recvfrom()` with, immediately freeing it if there was no data read. This is an waste of cycles and provides no benefit.

This change has `parsePacket()` check if there is available data via `ioctl()` with `FIONREAD` first, saving the allocation and thus significantly increasing performance in no data situations.

## Tests scenarios

Tested on Arduino-esp32 core v2.0.3 on an ESP32-C3 dev board (XAIO_ESP32C3) by sending UDP messages from my development machine.

In a near-empty sketch, invoking `parsePacket()` every `loop()` call, I was executing about 20,000 calls per second. After the change, the performance was closer to 35,000 calls/second.

## Related links
I did not find any related issues. However, as I was making this change, I did note the `parsePacket()`'s allocation behavior overall. It seems excessive to allocate 1460 bytes every single call to it, here:

https://github.com/espressif/arduino-esp32/blob/0fa4aa632c6dcb7736a291a33fb9f0a25614d6d0/libraries/Network/src/NetworkUdp.cpp#L300

Even with the change in this PR, that buffer is allocated, and then written into a *second* buffer, `rx_buffer`, which is allocated at the end of the function, here: https://github.com/espressif/arduino-esp32/blob/0fa4aa632c6dcb7736a291a33fb9f0a25614d6d0/libraries/Network/src/NetworkUdp.cpp#L335-L340

It seems like it would be a better option to at least attempt to only allocate a single time; or to consider moving the temporary buffer allocation to be static (or potentially stack allocated.)
