### PR TITLE
esp32-hal-ledc.c: Clear bit in used_channels bitmap

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -271,6 +271,13 @@ uint32_t ledcWriteNote(uint8_t pin, note_t note, uint8_t octave) {
 bool ledcDetach(uint8_t pin) {
   ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(pin, ESP32_BUS_TYPE_LEDC);
   if (bus != NULL) {
+    /* ledc_handle.used_channels use bitmap to indicate if channel is used
+      bit is set if channel is used, in ledcAttachChannel/ledcAttach
+      bit is cleared if channel is detached here
+    */
+    if (ledc_handle.used_channels & (1UL << bus->channel)) {
+      ledc_handle.used_channels &= ~(1UL << bus->channel);
+    }
     // will call ledcDetachBus
     return perimanClearPinBus(pin);
   } else {


### PR DESCRIPTION
When we attach pin to LEDC channel we set bit in used_channels bitmap variable. But used_channels bit was not cleared on detach,
as result simply repeating attach/detach around 16 times will falsely use all available channels and
emit error that channel is not available.

This happen for example in IRSenderESP32.cpp.
This patch fixes this bug.

Sorry for not providing issue, as it require filling big amount of irrelevant form fields for just 2 lines of code.
To reproduce issue enable verbose debug and run in loop:
ledcAttach(13, 12000, 8);
ledcDetach(13);
It will fail, as i recall after 15 or 16th loop cycle.
