### PR TITLE
fix(ledc): Fix freeing channel if not used anymore

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -52,8 +52,8 @@ static bool ledcDetachBus(void *bus) {
   bool channel_found = false;
   // Check if more pins are attached to the same ledc channel
   for (uint8_t i = 0; i < SOC_GPIO_PIN_COUNT; i++) {
-    if (!perimanPinIsValid(i)) {
-      continue;  //invalid pin, skip
+    if (!perimanPinIsValid(i) || i == handle->pin) {
+      continue;  //invalid pin or same pin
     }
     peripheral_bus_type_t type = perimanGetPinBusType(i);
     if (type == ESP32_BUS_TYPE_LEDC) {


### PR DESCRIPTION
## Description of Change
This PR fixes LEDC channels being not cleared in used_channels on detach, as the bus was still set in the Peripheral Manager causing to always found a pin using the channel. Bus is cleared after successful return from the DetachBus function.

Thanks @nuclearcat for reporting the issue.

## Tests scenarios
Locally

## Related links
Related #10089 
