### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-dc859c1e67"
+              "version": "idf-release_v5.1-5a26d8ae8e"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-dc859c1e67",
+          "version": "idf-release_v5.1-5a26d8ae8e",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/da253aa56255b29a76ac5038db350cd9e4ebde1b",
-              "archiveFileName": "esp32-arduino-libs-da253aa56255b29a76ac5038db350cd9e4ebde1b.zip",
-              "checksum": "SHA-256:a3ce1e1aebe518d6be26006798b44b6c1a0bc8977a8da4d066ed9d9af1378c9e",
-              "size": "307528289"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
+              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
+              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
+              "size": "307847030"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-5a26d8ae8e"
+              "version": "idf-release_v5.1-b6b4727c58"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-5a26d8ae8e",
+          "version": "idf-release_v5.1-b6b4727c58",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/ea17f7d29f678a3f8dabcf89e94e88369be10191",
-              "archiveFileName": "esp32-arduino-libs-ea17f7d29f678a3f8dabcf89e94e88369be10191.zip",
-              "checksum": "SHA-256:c85278a6dd373306aa10bdace24c15d12709242b6734d6a6e38f8fee4863118f",
-              "size": "307847030"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
+              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
+              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
+              "size": "307857214"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 248cae4
esp-idf: release/v5.1 5a26d8ae8e
arduino: master 3a7eda1e
tinyusb: master cfbdc44a8
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.7.1
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.1
espressif__esp-zigbee-lib: 1.4.1
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.3.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
```
