### PR TITLE
fix(ssl): Add size arg to NetworkClientSecure::setCACertBundle

### DIFF
--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
@@ -339,9 +339,9 @@ void NetworkClientSecure::setCACert(const char *rootCA) {
   _use_insecure = false;
 }
 
-void NetworkClientSecure::setCACertBundle(const uint8_t *bundle) {
-  if (bundle != NULL) {
-    esp_crt_bundle_set(bundle, sizeof(bundle));
+void NetworkClientSecure::setCACertBundle(const uint8_t *bundle, size_t size) {
+  if (bundle != NULL && size > 0) {
+    esp_crt_bundle_set(bundle, size);
     attach_ssl_certificate_bundle(sslclient.get(), true);
     _use_ca_bundle = true;
   } else {

--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.h
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.h
@@ -73,7 +73,7 @@ public:
   void setCertificate(const char *client_ca);
   void setPrivateKey(const char *private_key);
   bool loadCACert(Stream &stream, size_t size);
-  void setCACertBundle(const uint8_t *bundle);
+  void setCACertBundle(const uint8_t *bundle, size_t size);
   bool loadCertificate(Stream &stream, size_t size);
   bool loadPrivateKey(Stream &stream, size_t size);
   bool verify(const char *fingerprint, const char *domain_name);


### PR DESCRIPTION
Fixes: https://github.com/espressif/arduino-esp32/issues/10099