### PR TITLE
fix(ESP-NOW): Remove all peers on ESP_NOW.end()

### DIFF
--- a/libraries/ESP_NOW/src/ESP32_NOW.cpp
+++ b/libraries/ESP_NOW/src/ESP32_NOW.cpp
@@ -191,7 +191,7 @@ bool ESP_NOW_Class::end() {
     return true;
   }
   //remove all peers
-  for(uint8_t i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
+  for (uint8_t i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
     if (_esp_now_peers[i] != NULL) {
       removePeer(*_esp_now_peers[i]);
     }

--- a/libraries/ESP_NOW/src/ESP32_NOW.cpp
+++ b/libraries/ESP_NOW/src/ESP32_NOW.cpp
@@ -190,13 +190,19 @@ bool ESP_NOW_Class::end() {
   if (!_esp_now_has_begun) {
     return true;
   }
-  //remove all peers?
+  //remove all peers
+  for(uint8_t i = 0; i < ESP_NOW_MAX_TOTAL_PEER_NUM; i++) {
+    if (_esp_now_peers[i] != NULL) {
+      removePeer(*_esp_now_peers[i]);
+    }
+  }
   esp_err_t err = esp_now_deinit();
   if (err != ESP_OK) {
     log_e("esp_now_deinit failed! 0x%x", err);
     return false;
   }
   _esp_now_has_begun = false;
+  //clear the peer list
   memset(_esp_now_peers, 0, sizeof(ESP_NOW_Peer *) * ESP_NOW_MAX_TOTAL_PEER_NUM);
   return true;
 }
@@ -260,6 +266,10 @@ size_t ESP_NOW_Class::write(const uint8_t *data, size_t len) {
 void ESP_NOW_Class::onNewPeer(void (*cb)(const esp_now_recv_info_t *info, const uint8_t *data, int len, void *arg), void *arg) {
   new_cb = cb;
   new_arg = arg;
+}
+
+bool ESP_NOW_Class::removePeer(ESP_NOW_Peer &peer) {
+  return peer.remove();
 }
 
 ESP_NOW_Class ESP_NOW;

--- a/libraries/ESP_NOW/src/ESP32_NOW.h
+++ b/libraries/ESP_NOW/src/ESP32_NOW.h
@@ -6,6 +6,31 @@
 #include "esp32-hal-log.h"
 #include "esp_mac.h"
 
+class ESP_NOW_Peer; //forward declaration for friend function
+
+class ESP_NOW_Class : public Print {
+public:
+  const uint8_t BROADCAST_ADDR[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+  ESP_NOW_Class();
+  ~ESP_NOW_Class();
+
+  bool begin(const uint8_t *pmk = NULL /* 16 bytes */);
+  bool end();
+
+  int getTotalPeerCount();
+  int getEncryptedPeerCount();
+
+  int availableForWrite();
+  size_t write(const uint8_t *data, size_t len);
+  size_t write(uint8_t data) {
+    return write(&data, 1);
+  }
+
+  void onNewPeer(void (*cb)(const esp_now_recv_info_t *info, const uint8_t *data, int len, void *arg), void *arg);
+  bool removePeer(ESP_NOW_Peer &peer);
+};
+
 class ESP_NOW_Peer {
 private:
   uint8_t mac[6];
@@ -47,28 +72,8 @@ public:
   virtual void onSent(bool success) {
     log_i("Message transmission to peer " MACSTR " %s", MAC2STR(mac), success ? "successful" : "failed");
   }
-};
 
-class ESP_NOW_Class : public Print {
-public:
-  const uint8_t BROADCAST_ADDR[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-
-  ESP_NOW_Class();
-  ~ESP_NOW_Class();
-
-  bool begin(const uint8_t *pmk = NULL /* 16 bytes */);
-  bool end();
-
-  int getTotalPeerCount();
-  int getEncryptedPeerCount();
-
-  int availableForWrite();
-  size_t write(const uint8_t *data, size_t len);
-  size_t write(uint8_t data) {
-    return write(&data, 1);
-  }
-
-  void onNewPeer(void (*cb)(const esp_now_recv_info_t *info, const uint8_t *data, int len, void *arg), void *arg);
+  friend bool ESP_NOW_Class::removePeer(ESP_NOW_Peer&);
 };
 
 extern ESP_NOW_Class ESP_NOW;

--- a/libraries/ESP_NOW/src/ESP32_NOW.h
+++ b/libraries/ESP_NOW/src/ESP32_NOW.h
@@ -6,7 +6,7 @@
 #include "esp32-hal-log.h"
 #include "esp_mac.h"
 
-class ESP_NOW_Peer; //forward declaration for friend function
+class ESP_NOW_Peer;  //forward declaration for friend function
 
 class ESP_NOW_Class : public Print {
 public:
@@ -73,7 +73,7 @@ public:
     log_i("Message transmission to peer " MACSTR " %s", MAC2STR(mac), success ? "successful" : "failed");
   }
 
-  friend bool ESP_NOW_Class::removePeer(ESP_NOW_Peer&);
+  friend bool ESP_NOW_Class::removePeer(ESP_NOW_Peer &);
 };
 
 extern ESP_NOW_Class ESP_NOW;


### PR DESCRIPTION
## Description of Change
This PR fixes ESP-NOW library, where on end() peers were not removed correctly.

## Tests scenarios
Locally with ESP-NOW examples.

## Related links
Related #10076 
