### PR TITLE
docs: correct Float type size in Preferences API and Tutorial documentation

### DIFF
--- a/docs/en/api/preferences.rst
+++ b/docs/en/api/preferences.rst
@@ -269,6 +269,7 @@ Arduino-esp32 Preferences API
        size_t putUInt(const char* key, uint32_t value)
        size_t putLong(const char* key, int32_t value)
        size_t putULong(const char* key, uint32_t value)
+       size_t putFloat(const char* key, float_t value)
 
    ..
 
@@ -298,7 +299,6 @@ Arduino-esp32 Preferences API
 
        size_t putLong64(const char* key, int64_t value)
        size_t putULong64(const char* key, uint64_t value)
-       size_t putFloat(const char* key, float_t value)
        size_t putDouble(const char* key, double_t value)
 
    ..

--- a/docs/en/api/preferences.rst
+++ b/docs/en/api/preferences.rst
@@ -62,11 +62,11 @@ Preferences directly supports the following data types:
    +-------------------+-------------------+---------------+
    | ULong             | uint32_t          | 4             |
    +-------------------+-------------------+---------------+
+   | Float             | float_t           | 4             |
+   +-------------------+-------------------+---------------+
    | Long64            | int64_t           | 8             |
    +-------------------+-------------------+---------------+
    | ULong64           | uint64_t          | 8             |
-   +-------------------+-------------------+---------------+
-   | Float             | float_t           | 8             |
    +-------------------+-------------------+---------------+
    | Double            | double_t          | 8             |
    +-------------------+-------------------+---------------+
@@ -76,7 +76,6 @@ Preferences directly supports the following data types:
    +-------------------+-------------------+---------------+
    | Bytes             | uint8_t           | variable      |
    +-------------------+-------------------+---------------+
-
 String values can be stored and retrieved either as an Arduino String or as a null terminated ``char`` array (c-string).
 
 Bytes type is used for storing and retrieving an arbitrary number of bytes in a namespace.
@@ -259,6 +258,8 @@ Arduino-esp32 Preferences API
 ********************
 ``putLong, putULong``
 **********************
+``putFloat``
+**********************
 
    Store a value against a given key in the currently open namespace.
 
@@ -288,8 +289,8 @@ Arduino-esp32 Preferences API
 
 ``putLong64, putULong64``
 *************************
-``putFloat, putDouble``
-***********************
+``putDouble``
+*************************
 
    Store a value against a given key in the currently open namespace.
 

--- a/docs/en/api/preferences.rst
+++ b/docs/en/api/preferences.rst
@@ -76,6 +76,7 @@ Preferences directly supports the following data types:
    +-------------------+-------------------+---------------+
    | Bytes             | uint8_t           | variable      |
    +-------------------+-------------------+---------------+
+
 String values can be stored and retrieved either as an Arduino String or as a null terminated ``char`` array (c-string).
 
 Bytes type is used for storing and retrieving an arbitrary number of bytes in a namespace.

--- a/docs/en/tutorials/preferences.rst
+++ b/docs/en/tutorials/preferences.rst
@@ -70,16 +70,16 @@ Preferences directly supports the following data types:
    +-------------------+-------------------+---------------+
    | ULong             | uint32_t          | 4             |
    +-------------------+-------------------+---------------+
+   | Float             | float_t           | 4             |
+   +-------------------+-------------------+---------------+
    | Long64            | int64_t           | 8             |
    +-------------------+-------------------+---------------+
    | ULong64           | uint64_t          | 8             |
    +-------------------+-------------------+---------------+
-   | Float             | float_t           | 8             |
-   +-------------------+-------------------+---------------+
    | Double            | double_t          | 8             |
    +-------------------+-------------------+---------------+
-   |                   | const char*       |               |
-   | String            +-------------------+ variable      |
+   |                   | const char*       | variable      |
+   | String            +-------------------+               |
    |                   | String            |               |
    +-------------------+-------------------+---------------+
    | Bytes             | uint8_t           | variable      |
@@ -233,9 +233,9 @@ Like so:
 
 .. code-block:: arduino
 
-   float myFloat = myPreferences.getFloat("pi");
+   float_t myFloat = myPreferences.getFloat("pi");
 
-This will retrieve the float value from the namespace key ``"pi"`` and assign it to the float type variable ``myFloat``.
+This will retrieve the float_t value from the namespace key ``"pi"`` and assign it to the float_t type variable ``myFloat``.
 
 
 Summary


### PR DESCRIPTION
## Description of Change
Correct the size of the Preferences Float type in the API and Tutorial documentation

## Tests scenarios
Verified by running a sketch that returns the `sizeof()` a `float_t` and a `float` variable.

## Related links
None
