### PR TITLE
Added variant for Waveshare ESP32-S3-Touch-LCD-1.69 & ESP32-S3-LCD-1.69 board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -38079,7 +38079,7 @@ waveshare_esp32_s3_touch_lcd_169.build.memory_type={build.boot}_{build.psram_typ
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled=Disabled
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled.build.defines=
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled.build.psram_type=qspi
-waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled=Disabled
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled=Enabled
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled.build.psram_type=opi
 
@@ -38278,7 +38278,7 @@ waveshare_esp32_s3_lcd_169.build.memory_type={build.boot}_{build.psram_type}
 waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled=Disabled
 waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled.build.defines=
 waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled.build.psram_type=qspi
-waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled=Disabled
+waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled=Enabled
 waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled.build.psram_type=opi
 

--- a/boards.txt
+++ b/boards.txt
@@ -38079,7 +38079,7 @@ waveshare_esp32_s3_touch_lcd_169.build.memory_type={build.boot}_{build.psram_typ
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled=Disabled
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled.build.defines=
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled.build.psram_type=qspi
-waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled=Disabled
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled.build.psram_type=opi
 
@@ -38278,7 +38278,7 @@ waveshare_esp32_s3_lcd_169.build.memory_type={build.boot}_{build.psram_type}
 waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled=Disabled
 waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled.build.defines=
 waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled.build.psram_type=qspi
-waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled=Disabled
 waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled.build.psram_type=opi
 

--- a/boards.txt
+++ b/boards.txt
@@ -38027,6 +38027,396 @@ ws_esp32_s3_matrix.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+waveshare_esp32_s3_touch_lcd_169.name=Waveshare ESP32-S3-Touch-LCD-1.69
+waveshare_esp32_s3_touch_lcd_169.vid.0=0x303a
+waveshare_esp32_s3_touch_lcd_169.pid.0=0x821E
+waveshare_esp32_s3_touch_lcd_169.upload_port.0.vid=0x303a
+waveshare_esp32_s3_touch_lcd_169.upload_port.0.pid=0x821E
+
+waveshare_esp32_s3_touch_lcd_169.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_169.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_169.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_169.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_169.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_169.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_169.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_169.upload.flags=
+waveshare_esp32_s3_touch_lcd_169.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_169.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_169.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_169.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_169.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_169.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_169.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_169.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_169.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_169.build.core=esp32
+waveshare_esp32_s3_touch_lcd_169.build.variant=waveshare_esp32_s3_touch_lcd_169
+waveshare_esp32_s3_touch_lcd_169.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_169
+
+waveshare_esp32_s3_touch_lcd_169.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_169.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_169.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_169.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_169.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_169.build.flash_size=4MB
+waveshare_esp32_s3_touch_lcd_169.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_169.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_169.build.boot=qio
+waveshare_esp32_s3_touch_lcd_169.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_169.build.partitions=default
+waveshare_esp32_s3_touch_lcd_169.build.defines=
+waveshare_esp32_s3_touch_lcd_169.build.loop_core=
+waveshare_esp32_s3_touch_lcd_169.build.event_core=
+waveshare_esp32_s3_touch_lcd_169.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_169.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_169.menu.PSRAM.enabled.build.psram_type=qspi
+
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_169.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_169.menu.FlashSize.4M=4MB (32Mb)
+waveshare_esp32_s3_touch_lcd_169.menu.FlashSize.4M.build.flash_size=4MB
+
+waveshare_esp32_s3_touch_lcd_169.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_169.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_169.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_169.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_169.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_169.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_169.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_169.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_169.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_169.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_169.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_169.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_169.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_169.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_169.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_169.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_169.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_169.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_169.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_169.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_169.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_169.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_169.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_169.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_169.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_169.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_169.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_169.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_169.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_169.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_169.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_169.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+waveshare_esp32_s3_lcd_169.name=Waveshare ESP32-S3-LCD-1.69
+waveshare_esp32_s3_lcd_169.vid.0=0x303a
+waveshare_esp32_s3_lcd_169.pid.0=0x8221
+waveshare_esp32_s3_lcd_169.upload_port.0.vid=0x303a
+waveshare_esp32_s3_lcd_169.upload_port.0.pid=0x8221
+
+waveshare_esp32_s3_lcd_169.bootloader.tool=esptool_py
+waveshare_esp32_s3_lcd_169.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_lcd_169.upload.tool=esptool_py
+waveshare_esp32_s3_lcd_169.upload.tool.default=esptool_py
+waveshare_esp32_s3_lcd_169.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_lcd_169.upload.maximum_size=1310720
+
+waveshare_esp32_s3_lcd_169.upload.maximum_data_size=327680
+waveshare_esp32_s3_lcd_169.upload.flags=
+waveshare_esp32_s3_lcd_169.upload.extra_flags=
+waveshare_esp32_s3_lcd_169.upload.use_1200bps_touch=false
+waveshare_esp32_s3_lcd_169.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_lcd_169.serial.disableDTR=false
+waveshare_esp32_s3_lcd_169.serial.disableRTS=false
+
+waveshare_esp32_s3_lcd_169.build.tarch=xtensa
+waveshare_esp32_s3_lcd_169.build.bootloader_addr=0x0
+waveshare_esp32_s3_lcd_169.build.target=esp32s3
+waveshare_esp32_s3_lcd_169.build.mcu=esp32s3
+waveshare_esp32_s3_lcd_169.build.core=esp32
+waveshare_esp32_s3_lcd_169.build.variant=waveshare_esp32_s3_lcd_169
+waveshare_esp32_s3_lcd_169.build.board=WAVESHARE_ESP32_S3_LCD_169
+
+waveshare_esp32_s3_lcd_169.build.usb_mode=1
+waveshare_esp32_s3_lcd_169.build.cdc_on_boot=0
+waveshare_esp32_s3_lcd_169.build.msc_on_boot=0
+waveshare_esp32_s3_lcd_169.build.dfu_on_boot=0
+waveshare_esp32_s3_lcd_169.build.f_cpu=240000000L
+waveshare_esp32_s3_lcd_169.build.flash_size=4MB
+waveshare_esp32_s3_lcd_169.build.flash_freq=80m
+waveshare_esp32_s3_lcd_169.build.flash_mode=dio
+waveshare_esp32_s3_lcd_169.build.boot=qio
+waveshare_esp32_s3_lcd_169.build.boot_freq=80m
+waveshare_esp32_s3_lcd_169.build.partitions=default
+waveshare_esp32_s3_lcd_169.build.defines=
+waveshare_esp32_s3_lcd_169.build.loop_core=
+waveshare_esp32_s3_lcd_169.build.event_core=
+waveshare_esp32_s3_lcd_169.build.psram_type=qspi
+waveshare_esp32_s3_lcd_169.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_lcd_169.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_lcd_169.menu.PSRAM.enabled.build.psram_type=qspi
+
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_lcd_169.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_lcd_169.menu.FlashSize.4M=4MB (32Mb)
+waveshare_esp32_s3_lcd_169.menu.FlashSize.4M.build.flash_size=4MB
+
+waveshare_esp32_s3_lcd_169.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_lcd_169.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_lcd_169.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_lcd_169.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_lcd_169.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_lcd_169.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_lcd_169.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_lcd_169.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_lcd_169.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_lcd_169.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_lcd_169.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_lcd_169.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_lcd_169.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_lcd_169.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_lcd_169.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_lcd_169.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_lcd_169.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_lcd_169.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_lcd_169.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_lcd_169.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_lcd_169.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_lcd_169.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_lcd_169.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_lcd_169.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_lcd_169.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_lcd_169.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_lcd_169.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_lcd_169.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_lcd_169.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_lcd_169.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_lcd_169.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_lcd_169.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.none=None
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.error=Error
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.info=Info
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_lcd_169.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_lcd_169.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_lcd_169.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_lcd_169.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_lcd_169.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 waveshare_esp32s3_touch_lcd_128.name=Waveshare ESP32S3 Touch LCD 128
 waveshare_esp32s3_touch_lcd_128.vid.0=0x1a86
 waveshare_esp32s3_touch_lcd_128.pid.0=0x55d3

--- a/variants/waveshare_esp32_s3_lcd_169/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_lcd_169/pins_arduino.h
@@ -14,18 +14,18 @@
 #define USB_SERIAL       ""
 
 // display for ST7789V2
-#define WS_LCD_DC 4
-#define WS_LCD_CS 5
+#define WS_LCD_DC  4
+#define WS_LCD_CS  5
 #define WS_LCD_SCL 6
 #define WS_LCD_SDA 7
 #define WS_LCD_RST 8
-#define WS_LCD_BL 15
+#define WS_LCD_BL  15
 
 // Onboard RTC for PCF85063
-#define WS_RTC_SCL 10
-#define WS_RTC_SDA 11
+#define WS_RTC_SCL     10
+#define WS_RTC_SDA     11
 #define WS_RTC_ADDRESS 0x51
-#define WS_RTC_INT 41
+#define WS_RTC_INT     41
 
 // Onboard  QMI8658 IMU
 #define WS_QMI8658_SDA     11
@@ -35,9 +35,9 @@
 
 // Onboard Electric buzzer & Custom buttons
 // GPIO and PSRAM conflict, need to pay attention when using
-#define WS_BUZZ 33  // Please pull down the level when using
+#define WS_BUZZ    33  // Please pull down the level when using
 #define WS_SYS_OUT 36
-#define WS_SYS_EN 35
+#define WS_SYS_EN  35
 
 // Partial voltage measurement method
 #define WS_BAT_ADC 1

--- a/variants/waveshare_esp32_s3_lcd_169/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_lcd_169/pins_arduino.h
@@ -1,0 +1,102 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x8221
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-LCD-1.69"
+#define USB_SERIAL       ""
+
+// display for ST7789V2
+#define WS_LCD_DC 4
+#define WS_LCD_CS 5
+#define WS_LCD_SCL 6
+#define WS_LCD_SDA 7
+#define WS_LCD_RST 8
+#define WS_LCD_BL 15
+
+// Onboard RTC for PCF85063
+#define WS_RTC_SCL 10
+#define WS_RTC_SDA 11
+#define WS_RTC_ADDRESS 0x51
+#define WS_RTC_INT 41
+
+// Onboard  QMI8658 IMU
+#define WS_QMI8658_SDA     11
+#define WS_QMI8658_SCL     10
+#define WS_QMI8658_ADDRESS 0x6B
+#define WS_QMI8658_INT1    38
+
+// Onboard Electric buzzer & Custom buttons
+// GPIO and PSRAM conflict, need to pay attention when using
+#define WS_BUZZ 33  // Please pull down the level when using
+#define WS_SYS_OUT 36
+#define WS_SYS_EN 35
+
+// Partial voltage measurement method
+#define WS_BAT_ADC 1
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 10;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_169/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_169/pins_arduino.h
@@ -1,0 +1,109 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x821e
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-1.69"
+#define USB_SERIAL       ""
+
+// display for ST7789V2
+#define WS_LCD_DC 4
+#define WS_LCD_CS 5
+#define WS_LCD_SCL 6
+#define WS_LCD_SDA 7
+#define WS_LCD_RST 8
+#define WS_LCD_BL 15
+
+// Touch for CST816T
+#define WS_TP_SCL 10
+#define WS_TP_SDA 11
+#define WS_TP_RST 13
+#define WS_TP_INT 14
+
+// Onboard RTC for PCF85063
+#define WS_RTC_SCL 10
+#define WS_RTC_SDA 11
+#define WS_RTC_ADDRESS 0x51
+#define WS_RTC_INT 41
+
+// Onboard  QMI8658 IMU
+#define WS_QMI8658_SDA     11
+#define WS_QMI8658_SCL     10
+#define WS_QMI8658_ADDRESS 0x6B
+#define WS_QMI8658_INT1    38
+
+// Onboard Electric buzzer & Custom buttons
+// GPIO and PSRAM conflict, need to pay attention when using
+#define WS_BUZZ 33  // Please pull down the level when using
+#define WS_SYS_OUT 36
+#define WS_SYS_EN 35
+
+// Partial voltage measurement method
+#define WS_BAT_ADC 1
+
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 10;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_169/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_169/pins_arduino.h
@@ -14,12 +14,12 @@
 #define USB_SERIAL       ""
 
 // display for ST7789V2
-#define WS_LCD_DC 4
-#define WS_LCD_CS 5
+#define WS_LCD_DC  4
+#define WS_LCD_CS  5
 #define WS_LCD_SCL 6
 #define WS_LCD_SDA 7
 #define WS_LCD_RST 8
-#define WS_LCD_BL 15
+#define WS_LCD_BL  15
 
 // Touch for CST816T
 #define WS_TP_SCL 10
@@ -28,10 +28,10 @@
 #define WS_TP_INT 14
 
 // Onboard RTC for PCF85063
-#define WS_RTC_SCL 10
-#define WS_RTC_SDA 11
+#define WS_RTC_SCL     10
+#define WS_RTC_SDA     11
 #define WS_RTC_ADDRESS 0x51
-#define WS_RTC_INT 41
+#define WS_RTC_INT     41
 
 // Onboard  QMI8658 IMU
 #define WS_QMI8658_SDA     11
@@ -41,13 +41,12 @@
 
 // Onboard Electric buzzer & Custom buttons
 // GPIO and PSRAM conflict, need to pay attention when using
-#define WS_BUZZ 33  // Please pull down the level when using
+#define WS_BUZZ    33  // Please pull down the level when using
 #define WS_SYS_OUT 36
-#define WS_SYS_EN 35
+#define WS_SYS_EN  35
 
 // Partial voltage measurement method
 #define WS_BAT_ADC 1
-
 
 // UART0 pins
 static const uint8_t TX = 43;


### PR DESCRIPTION
## Description of Change
Adding variant for Waveshare ESP32-S3-Touch-LCD-1.69 & ESP32-S3-LCD-1.69 board containing MCU, LCD, RTC, and IMU.

## Tests scenarios
Untested, pin definition is based on information in Waveshare wiki.

## Related links

Wiki For [ESP32-S3-Touch-LCD-1.69](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.69)
Wiki For [ESP32-S3-LCD-1.69](https://www.waveshare.com/wiki/ESP32-S3-LCD-1.69)

Pending USB VID PR: [espressif/usb-pids/pull/169](https://github.com/espressif/usb-pids/pull/169)