### PR TITLE
Fix use after free in SD library

### DIFF
--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -671,8 +671,10 @@ uint8_t sdcard_uninit(uint8_t pdrv) {
   if (pdrv >= FF_VOLUMES || card == NULL) {
     return 1;
   }
-  AcquireSPI lock(card);
-  sdTransaction(pdrv, GO_IDLE_STATE, 0, NULL);
+  {
+    AcquireSPI lock(card);
+    sdTransaction(pdrv, GO_IDLE_STATE, 0, NULL);
+  } // lock is destructed here
   ff_diskio_register(pdrv, NULL);
   s_cards[pdrv] = NULL;
   esp_err_t err = ESP_OK;

--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -674,7 +674,7 @@ uint8_t sdcard_uninit(uint8_t pdrv) {
   {
     AcquireSPI lock(card);
     sdTransaction(pdrv, GO_IDLE_STATE, 0, NULL);
-  } // lock is destructed here
+  }  // lock is destructed here
   ff_diskio_register(pdrv, NULL);
   s_cards[pdrv] = NULL;
   esp_err_t err = ESP_OK;


### PR DESCRIPTION
## Description of Change
The destructor of `AcquireSPI`  uses `card` after `card` has been freed.

The issue causes constant crashes for me.

(Sidenote: `s_cards[pdrv]` is accessed before `pdrv` is checked to be valid throughout the file)

## Tests scenarios
Tested on a ESP32-S3 via platformio framework "espidf, arduino".

## Related links
Introduced in https://github.com/espressif/arduino-esp32/commit/b6ca5a863047469c3a786ae6d4c34a9bce6cf7d3