### PR TITLE
fix(USB): OTG S2 and S3 debug print

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -895,7 +895,8 @@ int log_printfv(const char *format, va_list arg) {
     }
 #endif
 */
-#if (ARDUINO_USB_CDC_ON_BOOT == 1 && ARDUINO_USB_MODE == 0) || CONFIG_IDF_TARGET_ESP32C3 || ((CONFIG_IDF_TARGET_ESP32H2 || CONFIG_IDF_TARGET_ESP32C6) && ARDUINO_USB_CDC_ON_BOOT == 1)
+#if (ARDUINO_USB_CDC_ON_BOOT == 1 && ARDUINO_USB_MODE == 0) || CONFIG_IDF_TARGET_ESP32C3 \
+  || ((CONFIG_IDF_TARGET_ESP32H2 || CONFIG_IDF_TARGET_ESP32C6) && ARDUINO_USB_CDC_ON_BOOT == 1)
   vsnprintf(temp, len + 1, format, arg);
   ets_printf("%s", temp);
 #else

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -895,7 +895,7 @@ int log_printfv(const char *format, va_list arg) {
     }
 #endif
 */
-#if CONFIG_IDF_TARGET_ESP32C3 || ((CONFIG_IDF_TARGET_ESP32H2 || CONFIG_IDF_TARGET_ESP32C6) && ARDUINO_USB_CDC_ON_BOOT)
+#if (ARDUINO_USB_CDC_ON_BOOT && !ARDUINO_USB_MODE) || CONFIG_IDF_TARGET_ESP32C3 || ((CONFIG_IDF_TARGET_ESP32H2 || CONFIG_IDF_TARGET_ESP32C6) && ARDUINO_USB_CDC_ON_BOOT)
   vsnprintf(temp, len + 1, format, arg);
   ets_printf("%s", temp);
 #else

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -895,7 +895,7 @@ int log_printfv(const char *format, va_list arg) {
     }
 #endif
 */
-#if (ARDUINO_USB_CDC_ON_BOOT && !ARDUINO_USB_MODE) || CONFIG_IDF_TARGET_ESP32C3 || ((CONFIG_IDF_TARGET_ESP32H2 || CONFIG_IDF_TARGET_ESP32C6) && ARDUINO_USB_CDC_ON_BOOT)
+#if (ARDUINO_USB_CDC_ON_BOOT == 1 && ARDUINO_USB_MODE == 0) || CONFIG_IDF_TARGET_ESP32C3 || ((CONFIG_IDF_TARGET_ESP32H2 || CONFIG_IDF_TARGET_ESP32C6) && ARDUINO_USB_CDC_ON_BOOT == 1)
   vsnprintf(temp, len + 1, format, arg);
   ets_printf("%s", temp);
 #else


### PR DESCRIPTION
## Description of Change
ESP32-S2 and S3 using USB CDC OTG (TinyUSB) won't print any log information. This commit fixes that.

## Tests scenarios
Using ESP32-S2 and S3 with `USB CDC On Boot` enabled and in the case of S3, USB Mode shall be `USB OTG (TinyUSB)`.
Set log level to Verbose.

```cpp
#include <Arduino.h>
#include <esp_log.h>
#include <chip-debug-report.h> 

void setup() {
  neopixelWrite(RGB_BUILTIN, 32, 0, 0); // RED until Serial Monitor is open
  Serial.begin();
  Serial.setDebugOutput(true);

  while (!Serial) delay(100);
  printBeforeSetupInfo();
  esp_log_level_set("*", ESP_LOG_VERBOSE);
  neopixelWrite(RGB_BUILTIN, 0, 16, 0); // Green when Serial Monitor is open
}

void loop() {
  Serial.println("This is a Serial.println");

  log_e("This is a log_e error");
  ESP_LOGE("mainloop", "This is an ESP_LOGE error");
  delay(2000);
}
```

## Related links
Fixes #10121 