### PR TITLE
Documentation Error for neopixelWrite()

### DIFF
--- a/cores/esp32/esp32-hal-rgb-led.c
+++ b/cores/esp32/esp32-hal-rgb-led.c
@@ -15,7 +15,7 @@ void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val, uint8_t blue
     return;
   }
 
-  int color[] = {green_val, red_val, blue_val};  // Color coding is in order GREEN, RED, BLUE
+  int color[] = {red_val, green_val, blue_val};
   int i = 0;
   for (int col = 0; col < 3; col++) {
     for (int bit = 0; bit < 8; bit++) {


### PR DESCRIPTION
The hint for the builtin neopixleWrite() function has the wrong information. It shows
void neopixelWrite(uint8_t pin, uint8_t red_val, uint8_t green_val,
uint8_t blue_val)

In fact, at least on my Lolin ESP32 C3 Pico card the correct order of the colors are green, red and blue, not red, green and blue as described. The BlinkRGB.ino example also is incorrect in the color order.