### PR TITLE
fix(wifiprov): Fix starting Wifi when already provisioned

### DIFF
--- a/libraries/WiFiProv/src/WiFiProv.cpp
+++ b/libraries/WiFiProv/src/WiFiProv.cpp
@@ -109,7 +109,7 @@ void WiFiProvClass ::beginProvision(
 #endif
   config.app_event_handler.event_cb = NULL;
   config.app_event_handler.user_data = NULL;
-  wifiLowLevelInit(true);
+  WiFi.STA.begin(false);
   if (wifi_prov_mgr_init(config) != ESP_OK) {
     log_e("wifi_prov_mgr_init failed!");
     return;


### PR DESCRIPTION
## Description of Change
This PR fixes WiFi STA was not starting when already provisioned after device reset.

## Tests scenarios
Tested with RainMaker Switch example

## Related links
Related #10119
