### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-b6b4727c58"
+              "version": "idf-release_v5.1-5c57dfe949"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-b6b4727c58",
+          "version": "idf-release_v5.1-5c57dfe949",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b",
+              "archiveFileName": "esp32-arduino-libs-dcdbef76bbc8ec5c3f8481f48a8f831f9e23263b.zip",
+              "checksum": "SHA-256:10a8e2ac9457a765c2e869abee884532f2aa5aed3e418335128fcb533051ae36",
+              "size": "310220498"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 01e4365
esp-idf: release/v5.1 5c57dfe949
arduino: master 4aab8179
tinyusb: master b8d3c0c4a
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.5.1
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.9.0
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.1
espressif__esp-zigbee-lib: 1.4.1
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.4.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__network_provisioning: 1.0.0
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
```
