### PR TITLE
fix(get.py): Add version checking for installed tools

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -160,18 +160,18 @@ def is_latest_version(filename, destination, dirname, rename_to, cfile):
         if rename_to.startswith("esp32-arduino-libs"):
             # overwrite expected_version with the one from versions.txt
             if filename.endswith("tar.gz") or filename.endswith("tar.xz"):
-                expected_version = cfile.extractfile(os.path.join(dirname, "versions.txt")).read().decode("utf-8")
+                expected_version = cfile.extractfile(dirname + "/versions.txt").read().decode("utf-8")
             else:
-                expected_version = cfile.read(os.path.join(dirname, "versions.txt")).decode("utf-8")
+                expected_version = cfile.read(dirname + "/versions.txt").decode("utf-8")
             with open(os.path.join(destination, rename_to, "versions.txt"), "r") as f:
                 # cfile is zip
                 current_version = f.read()
         elif rename_to.startswith("mklittlefs"):
             # overwrite expected_version with the one from package.json
             if filename.endswith("tar.gz") or filename.endswith("tar.xz"):
-                expected_version = cfile.extractfile(os.path.join(dirname, "package.json")).read().decode("utf-8")
+                expected_version = cfile.extractfile(dirname + "/package.json").read().decode("utf-8")
             else:
-                expected_version = cfile.read(os.path.join(dirname, "package.json")).decode("utf-8")
+                expected_version = cfile.read(dirname + "/package.json").decode("utf-8")
             with open(os.path.join(destination, rename_to, "package.json"), "r") as f:
                 # cfile is tar.gz
                 current_version = f.read()
@@ -181,15 +181,15 @@ def is_latest_version(filename, destination, dirname, rename_to, cfile):
             current_version = re.search(regex, result.stdout).group(1)
         else:
             if rename_to.startswith("xtensa-esp-elf-gdb"):
-                bin_path = os.path.join(destination, rename_to, "bin/xtensa-esp32-elf-gdb")
+                bin_path = os.path.join(destination, rename_to, "bin", "xtensa-esp32-elf-gdb")
             elif rename_to.startswith("riscv32-esp-elf-gdb"):
-                bin_path = os.path.join(destination, rename_to, "bin/riscv32-esp-elf-gdb")
+                bin_path = os.path.join(destination, rename_to, "bin", "riscv32-esp-elf-gdb")
             elif rename_to.startswith("openocd"):
-                bin_path = os.path.join(destination, rename_to, "bin/openocd")
+                bin_path = os.path.join(destination, rename_to, "bin", "openocd")
             elif rename_to.startswith("mkspiffs"):
                 bin_path = os.path.join(destination, rename_to, "mkspiffs")
             else:
-                bin_path = os.path.join(destination, rename_to, "bin/" + rename_to + "-gcc")
+                bin_path = os.path.join(destination, rename_to, "bin", rename_to + "-gcc")
 
             result = subprocess.run([bin_path, "--version"], text=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             current_version = re.search(regex, result.stdout).group(1)

--- a/tools/get.py
+++ b/tools/get.py
@@ -151,16 +151,9 @@ def is_latest_version(destination, dirname, rename_to, cfile, checksum):
     expected_version = None
 
     try:
-        if rename_to.startswith("esp32-arduino-libs"):
-            # Remove this when moving to new release system
-            expected_version = cfile.read(dirname + "/versions.txt").decode("utf-8")
-            with open(os.path.join(destination, rename_to, "versions.txt"), "r") as f:
-                # cfile is zip
-                current_version = f.read()
-        else:
-            expected_version = checksum
-            with open(os.path.join(destination, rename_to, ".package_checksum"), "r") as f:
-                current_version = f.read()
+        expected_version = checksum
+        with open(os.path.join(destination, rename_to, ".package_checksum"), "r") as f:
+            current_version = f.read()
 
         if verbose:
             print(f"\nTool: {rename_to}")
@@ -361,7 +354,7 @@ def get_tool(tool, force_download, force_extract):
         print("Tool {0} already downloaded".format(archive_name))
         sys.stdout.flush()
 
-    if "esp32-arduino-libs" not in archive_name and sha256sum(local_path) != checksum:
+    if sha256sum(local_path) != checksum:
         print("Checksum mismatch for {0}".format(archive_name))
         return False
 

--- a/tools/get.py
+++ b/tools/get.py
@@ -159,13 +159,19 @@ def is_latest_version(filename, destination, dirname, rename_to, cfile):
     try:
         if rename_to.startswith("esp32-arduino-libs"):
             # overwrite expected_version with the one from versions.txt
-            expected_version = cfile.read(os.path.join(dirname, "versions.txt")).decode("utf-8")
+            if filename.endswith("tar.gz") or filename.endswith("tar.xz"):
+                expected_version = cfile.extractfile(os.path.join(dirname, "versions.txt")).read().decode("utf-8")
+            else:
+                expected_version = cfile.read(os.path.join(dirname, "versions.txt")).decode("utf-8")
             with open(os.path.join(destination, rename_to, "versions.txt"), "r") as f:
                 # cfile is zip
                 current_version = f.read()
         elif rename_to.startswith("mklittlefs"):
             # overwrite expected_version with the one from package.json
-            expected_version = cfile.extractfile(os.path.join(dirname, "package.json")).read().decode("utf-8")
+            if filename.endswith("tar.gz") or filename.endswith("tar.xz"):
+                expected_version = cfile.extractfile(os.path.join(dirname, "package.json")).read().decode("utf-8")
+            else:
+                expected_version = cfile.read(os.path.join(dirname, "package.json")).decode("utf-8")
             with open(os.path.join(destination, rename_to, "package.json"), "r") as f:
                 # cfile is tar.gz
                 current_version = f.read()

--- a/tools/get.py
+++ b/tools/get.py
@@ -146,6 +146,7 @@ def verify_files(filename, destination, rename_to):
 
     return True
 
+
 def is_latest_version(destination, dirname, rename_to, cfile, checksum):
     current_version = None
     expected_version = None
@@ -173,6 +174,7 @@ def is_latest_version(destination, dirname, rename_to, cfile, checksum):
             print(f"Falied to verify version for {rename_to}: {e}")
 
     return False
+
 
 def unpack(filename, destination, force_extract, checksum):  # noqa: C901
     dirname = ""
@@ -409,21 +411,17 @@ def identify_platform():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Download and extract tools")
 
-    parser.add_argument("-v", "--verbose", action='store_true', required=False, help="Print verbose output")
+    parser.add_argument("-v", "--verbose", action="store_true", required=False, help="Print verbose output")
+
+    parser.add_argument("-d", "--force_download", action="store_true", required=False, help="Force download of tools")
+
+    parser.add_argument("-e", "--force_extract", action="store_true", required=False, help="Force extraction of tools")
 
     parser.add_argument(
-        "-d", "--force_download", action='store_true', required=False, help="Force download of tools"
+        "-f", "--force_all", action="store_true", required=False, help="Force download and extraction of tools"
     )
 
-    parser.add_argument(
-        "-e", "--force_extract", action='store_true', required=False, help="Force extraction of tools"
-    )
-
-    parser.add_argument(
-        "-f", "--force_all", action='store_true', required=False, help="Force download and extraction of tools"
-    )
-
-    parser.add_argument("-t", "--test", action='store_true', required=False, help=argparse.SUPPRESS)
+    parser.add_argument("-t", "--test", action="store_true", required=False, help=argparse.SUPPRESS)
 
     args = parser.parse_args()
 

--- a/tools/get.py
+++ b/tools/get.py
@@ -24,7 +24,6 @@ import zipfile
 import re
 import time
 import argparse
-import subprocess
 
 # Initialize start_time globally
 start_time = -1
@@ -147,12 +146,13 @@ def verify_files(filename, destination, rename_to):
 
     return True
 
-def is_latest_version(filename, destination, dirname, rename_to, cfile, checksum):
+def is_latest_version(destination, dirname, rename_to, cfile, checksum):
     current_version = None
     expected_version = None
 
     try:
         if rename_to.startswith("esp32-arduino-libs"):
+            # Remove this when moving to new release system
             expected_version = cfile.read(dirname + "/versions.txt").decode("utf-8")
             with open(os.path.join(destination, rename_to, "versions.txt"), "r") as f:
                 # cfile is zip
@@ -230,7 +230,7 @@ def unpack(filename, destination, force_extract, checksum):  # noqa: C901
         rename_to = "esp32-arduino-libs"
 
     if not force_extract:
-        if is_latest_version(filename, destination, dirname, rename_to, cfile, checksum):
+        if is_latest_version(destination, dirname, rename_to, cfile, checksum):
             if verify_files(filename, destination, rename_to):
                 print(" Files ok. Skipping Extraction")
                 return True


### PR DESCRIPTION
## Description of Change
This PR aims to fix some issues with not extracting the correct libs when downgrading and upgrading the libs using the script.

For example the issue that @P-R-O-C-H-Y had:

- switch to 2.X branch and run get.py
- now you can successfully use 2.x code
- switch to master and run get.py -> it will skip extraction of everything
- if you restart IDE, try to compile any sketch you will get this error:
   `xtensa-esp32s2-elf-g++: error: unrecognized command line option '-std=gnu++2b'; did you mean '-std=gnu++2a'?`

This PR also fixes an issue where the flags required a boolen argument.

## Tests scenarios
Tested using:
- [x] MacOS
- [x] Linux
- [x] Windows

