### PR TITLE
IDF release/v5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ endforeach()
 set(includedirs variants/${CONFIG_ARDUINO_VARIANT}/ cores/esp32/ ${ARDUINO_LIBRARIES_INCLUDEDIRS})
 set(srcs ${CORE_SRCS} ${ARDUINO_LIBRARIES_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash esp_partition mbedtls wifi_provisioning wpa_supplicant esp_adc esp_eth http_parser)
+set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser espressif__network_provisioning)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid usb esp_psram ${ARDUINO_LIBRARIES_REQUIRES})
 
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ endforeach()
 set(includedirs variants/${CONFIG_ARDUINO_VARIANT}/ cores/esp32/ ${ARDUINO_LIBRARIES_INCLUDEDIRS})
 set(srcs ${CORE_SRCS} ${ARDUINO_LIBRARIES_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser espressif__network_provisioning)
+set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid usb esp_psram ${ARDUINO_LIBRARIES_REQUIRES})
 
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThread)
@@ -301,6 +301,12 @@ if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThre
   #if(CONFIG_OPENTHREAD_ENABLED) # Does not work!
   if(IDF_TARGET STREQUAL "esp32c6" OR IDF_TARGET STREQUAL "esp32h2") # Sadly only this works
     list(APPEND requires openthread)
+  endif()
+endif()
+
+if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_RainMaker OR CONFIG_ARDUINO_SELECTIVE_WiFiProv)
+  if(NOT IDF_TARGET STREQUAL "esp32c2")
+    list(APPEND requires espressif__network_provisioning)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ endforeach()
 set(includedirs variants/${CONFIG_ARDUINO_VARIANT}/ cores/esp32/ ${ARDUINO_LIBRARIES_INCLUDEDIRS})
 set(srcs ${CORE_SRCS} ${ARDUINO_LIBRARIES_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser)
+set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser espressif__network_provisioning)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid usb esp_psram ${ARDUINO_LIBRARIES_REQUIRES})
 
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThread)
@@ -301,12 +301,6 @@ if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThre
   #if(CONFIG_OPENTHREAD_ENABLED) # Does not work!
   if(IDF_TARGET STREQUAL "esp32c6" OR IDF_TARGET STREQUAL "esp32h2") # Sadly only this works
     list(APPEND requires openthread)
-  endif()
-endif()
-
-if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_RainMaker OR CONFIG_ARDUINO_SELECTIVE_WiFiProv)
-  if(NOT IDF_TARGET STREQUAL "esp32c2")
-    list(APPEND requires espressif__network_provisioning)
   endif()
 endif()
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -49,6 +49,8 @@ dependencies:
     require: public
   espressif/esp_modem:
     version: "^1.1.0"
+  espressif/network_provisioning:
+    version: "~1.0.0"
   espressif/esp-zboss-lib:
     version: "^1.0.1"
     rules:

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -20,7 +20,7 @@
 #if SOC_WIFI_SUPPORTED
 #include "esp_wifi_types.h"
 #include "esp_smartconfig.h"
-#include "wifi_provisioning/wifi_config.h"
+#include "network_provisioning/network_config.h"
 #endif
 
 #if SOC_WIFI_SUPPORTED
@@ -105,7 +105,7 @@ typedef union {
   wifi_event_ap_stadisconnected_t wifi_ap_stadisconnected;
   wifi_event_ftm_report_t wifi_ftm_report;
   wifi_sta_config_t prov_cred_recv;
-  wifi_prov_sta_fail_reason_t prov_fail_reason;
+  network_prov_wifi_sta_fail_reason_t prov_fail_reason;
   smartconfig_event_got_ssid_pswd_t sc_got_ssid_pswd;
 #endif
 } arduino_event_info_t;

--- a/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
+++ b/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
@@ -101,9 +101,9 @@ void setup() {
 
   WiFi.onEvent(sysProvEvent);  // Will call sysProvEvent() from another thread.
 #if CONFIG_IDF_TARGET_ESP32S2
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE, NETWORK_PROV_SECURITY_1, pop, service_name);
 #else
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM, NETWORK_PROV_SECURITY_1, pop, service_name);
 #endif
 }
 

--- a/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
+++ b/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
@@ -36,8 +36,8 @@ void sysProvEvent(arduino_event_t *sys_event) {
       printQR(service_name, pop, "ble");
 #endif
       break;
-    case ARDUINO_EVENT_PROV_INIT:         wifi_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: wifi_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
+++ b/libraries/RainMaker/examples/RMakerCustom/RMakerCustom.ino
@@ -30,14 +30,14 @@ void sysProvEvent(arduino_event_t *sys_event) {
     case ARDUINO_EVENT_PROV_START:
 #if CONFIG_IDF_TARGET_ESP32S2
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
-      printQR(service_name, pop, "softap");
+      WiFiProv.printQR(service_name, pop, "softap");
 #else
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
-      printQR(service_name, pop, "ble");
+      WiFiProv.printQR(service_name, pop, "ble");
 #endif
       break;
-    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         WiFiProv.disableAutoStop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: WiFiProv.endProvision(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
+++ b/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
@@ -166,9 +166,9 @@ void setup() {
 
   WiFi.onEvent(sysProvEvent);  // Will call sysProvEvent() from another thread.
 #if CONFIG_IDF_TARGET_ESP32S2
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE, NETWORK_PROV_SECURITY_1, pop, service_name);
 #else
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM, NETWORK_PROV_SECURITY_1, pop, service_name);
 #endif
 }
 

--- a/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
+++ b/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
@@ -46,14 +46,14 @@ void sysProvEvent(arduino_event_t *sys_event) {
     case ARDUINO_EVENT_PROV_START:
 #if CONFIG_IDF_TARGET_ESP32S2
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
-      printQR(service_name, pop, "softap");
+      WiFiProv.printQR(service_name, pop, "softap");
 #else
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
-      printQR(service_name, pop, "ble");
+      WiFiProv.printQR(service_name, pop, "ble");
 #endif
       break;
-    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         WiFiProv.disableAutoStop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: WiFiProv.endProvision(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
+++ b/libraries/RainMaker/examples/RMakerCustomAirCooler/RMakerCustomAirCooler.ino
@@ -52,8 +52,8 @@ void sysProvEvent(arduino_event_t *sys_event) {
       printQR(service_name, pop, "ble");
 #endif
       break;
-    case ARDUINO_EVENT_PROV_INIT:         wifi_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: wifi_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
+++ b/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
@@ -40,18 +40,18 @@ void sysProvEvent(arduino_event_t *sys_event) {
     case ARDUINO_EVENT_PROV_START:
 #if CONFIG_IDF_TARGET_ESP32
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
-      printQR(service_name, pop, "ble");
+      WiFiProv.printQR(service_name, pop, "ble");
 #else
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
-      printQR(service_name, pop, "softap");
+      WiFiProv.printQR(service_name, pop, "softap");
 #endif
       break;
     case ARDUINO_EVENT_WIFI_STA_CONNECTED:
       Serial.printf("\nConnected to Wi-Fi!\n");
       digitalWrite(gpio_led, true);
       break;
-    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         WiFiProv.disableAutoStop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: WiFiProv.endProvision(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
+++ b/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
@@ -151,9 +151,9 @@ void setup() {
 
   WiFi.onEvent(sysProvEvent);  // Will call sysProvEvent() from another thread.
 #if CONFIG_IDF_TARGET_ESP32
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM, NETWORK_PROV_SECURITY_1, pop, service_name);
 #else
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE, NETWORK_PROV_SECURITY_1, pop, service_name);
 #endif
 }
 

--- a/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
+++ b/libraries/RainMaker/examples/RMakerSonoffDualR3/RMakerSonoffDualR3.ino
@@ -50,8 +50,8 @@ void sysProvEvent(arduino_event_t *sys_event) {
       Serial.printf("\nConnected to Wi-Fi!\n");
       digitalWrite(gpio_led, true);
       break;
-    case ARDUINO_EVENT_PROV_INIT:         wifi_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: wifi_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -31,14 +31,14 @@ void sysProvEvent(arduino_event_t *sys_event) {
     case ARDUINO_EVENT_PROV_START:
 #if CONFIG_IDF_TARGET_ESP32S2
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on SoftAP\n", service_name, pop);
-      printQR(service_name, pop, "softap");
+      WiFiProv.printQR(service_name, pop, "softap");
 #else
       Serial.printf("\nProvisioning Started with name \"%s\" and PoP \"%s\" on BLE\n", service_name, pop);
-      printQR(service_name, pop, "ble");
+      WiFiProv.printQR(service_name, pop, "ble");
 #endif
       break;
-    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         WiFiProv.disableAutoStop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: WiFiProv.endProvision(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -37,8 +37,8 @@ void sysProvEvent(arduino_event_t *sys_event) {
       printQR(service_name, pop, "ble");
 #endif
       break;
-    case ARDUINO_EVENT_PROV_INIT:         wifi_prov_mgr_disable_auto_stop(10000); break;
-    case ARDUINO_EVENT_PROV_CRED_SUCCESS: wifi_prov_mgr_stop_provisioning(); break;
+    case ARDUINO_EVENT_PROV_INIT:         network_prov_mgr_disable_auto_stop(10000); break;
+    case ARDUINO_EVENT_PROV_CRED_SUCCESS: network_prov_mgr_stop_provisioning(); break;
     default:                              ;
   }
 }

--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -98,9 +98,9 @@ void setup() {
 
   WiFi.onEvent(sysProvEvent);  // Will call sysProvEvent() from another thread.
 #if CONFIG_IDF_TARGET_ESP32S2
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE, NETWORK_PROV_SECURITY_1, pop, service_name);
 #else
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BTDM, WIFI_PROV_SECURITY_1, pop, service_name);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM, NETWORK_PROV_SECURITY_1, pop, service_name);
 #endif
 }
 

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -126,34 +126,34 @@ static void _arduino_event_cb(void *arg, esp_event_base_t event_base, int32_t ev
     /*
 	 * Provisioning
 	 * */
-  } else if (event_base == WIFI_PROV_EVENT && event_id == WIFI_PROV_INIT) {
+  } else if (event_base == NETWORK_PROV_EVENT && event_id == NETWORK_PROV_INIT) {
     log_v("Provisioning Initialized!");
     arduino_event.event_id = ARDUINO_EVENT_PROV_INIT;
-  } else if (event_base == WIFI_PROV_EVENT && event_id == WIFI_PROV_DEINIT) {
+  } else if (event_base == NETWORK_PROV_EVENT && event_id == NETWORK_PROV_DEINIT) {
     log_v("Provisioning Uninitialized!");
     arduino_event.event_id = ARDUINO_EVENT_PROV_DEINIT;
-  } else if (event_base == WIFI_PROV_EVENT && event_id == WIFI_PROV_START) {
+  } else if (event_base == NETWORK_PROV_EVENT && event_id == NETWORK_PROV_START) {
     log_v("Provisioning Start!");
     arduino_event.event_id = ARDUINO_EVENT_PROV_START;
-  } else if (event_base == WIFI_PROV_EVENT && event_id == WIFI_PROV_END) {
+  } else if (event_base == NETWORK_PROV_EVENT && event_id == NETWORK_PROV_END) {
     log_v("Provisioning End!");
-    wifi_prov_mgr_deinit();
+    network_prov_mgr_deinit();
     arduino_event.event_id = ARDUINO_EVENT_PROV_END;
-  } else if (event_base == WIFI_PROV_EVENT && event_id == WIFI_PROV_CRED_RECV) {
+  } else if (event_base == NETWORK_PROV_EVENT && event_id == NETWORK_PROV_WIFI_CRED_RECV) {
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_VERBOSE
     wifi_sta_config_t *event = (wifi_sta_config_t *)event_data;
     log_v("Provisioned Credentials: SSID: %s, Password: %s", (const char *)event->ssid, (const char *)event->password);
 #endif
     arduino_event.event_id = ARDUINO_EVENT_PROV_CRED_RECV;
     memcpy(&arduino_event.event_info.prov_cred_recv, event_data, sizeof(wifi_sta_config_t));
-  } else if (event_base == WIFI_PROV_EVENT && event_id == WIFI_PROV_CRED_FAIL) {
+  } else if (event_base == NETWORK_PROV_EVENT && event_id == NETWORK_PROV_WIFI_CRED_FAIL) {
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_ERROR
-    wifi_prov_sta_fail_reason_t *reason = (wifi_prov_sta_fail_reason_t *)event_data;
-    log_e("Provisioning Failed: Reason : %s", (*reason == WIFI_PROV_STA_AUTH_ERROR) ? "Authentication Failed" : "AP Not Found");
+    network_prov_wifi_sta_fail_reason_t *reason = (network_prov_wifi_sta_fail_reason_t *)event_data;
+    log_e("Provisioning Failed: Reason : %s", (*reason == NETWORK_PROV_WIFI_STA_AUTH_ERROR) ? "Authentication Failed" : "AP Not Found");
 #endif
     arduino_event.event_id = ARDUINO_EVENT_PROV_CRED_FAIL;
-    memcpy(&arduino_event.event_info.prov_fail_reason, event_data, sizeof(wifi_prov_sta_fail_reason_t));
-  } else if (event_base == WIFI_PROV_EVENT && event_id == WIFI_PROV_CRED_SUCCESS) {
+    memcpy(&arduino_event.event_info.prov_fail_reason, event_data, sizeof(network_prov_wifi_sta_fail_reason_t));
+  } else if (event_base == NETWORK_PROV_EVENT && event_id == NETWORK_PROV_WIFI_CRED_SUCCESS) {
     log_v("Provisioning Success!");
     arduino_event.event_id = ARDUINO_EVENT_PROV_CRED_SUCCESS;
   }
@@ -174,8 +174,8 @@ static bool initWiFiEvents() {
     return false;
   }
 
-  if (esp_event_handler_instance_register(WIFI_PROV_EVENT, ESP_EVENT_ANY_ID, &_arduino_event_cb, NULL, NULL)) {
-    log_e("event_handler_instance_register for WIFI_PROV_EVENT Failed!");
+  if (esp_event_handler_instance_register(NETWORK_PROV_EVENT, ESP_EVENT_ANY_ID, &_arduino_event_cb, NULL, NULL)) {
+    log_e("event_handler_instance_register for NETWORK_PROV_EVENT Failed!");
     return false;
   }
 
@@ -193,8 +193,8 @@ static bool deinitWiFiEvents() {
     return false;
   }
 
-  if (esp_event_handler_unregister(WIFI_PROV_EVENT, ESP_EVENT_ANY_ID, &_arduino_event_cb)) {
-    log_e("esp_event_handler_unregister for WIFI_PROV_EVENT Failed!");
+  if (esp_event_handler_unregister(NETWORK_PROV_EVENT, ESP_EVENT_ANY_ID, &_arduino_event_cb)) {
+    log_e("esp_event_handler_unregister for NETWORK_PROV_EVENT Failed!");
     return false;
   }
 

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -33,7 +33,7 @@
 #include "esp_smartconfig.h"
 #include "esp_netif_types.h"
 #include "esp_eth_driver.h"
-#include "wifi_provisioning/manager.h"
+#include "network_provisioning/manager.h"
 #include "lwip/ip_addr.h"
 
 #include "Network.h"

--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -38,7 +38,7 @@ void SysProvEvent(arduino_event_t *sys_event) {
     case ARDUINO_EVENT_PROV_CRED_FAIL:
     {
       Serial.println("\nProvisioning failed!\nPlease reset to factory and retry provisioning\n");
-      if (sys_event->event_info.prov_fail_reason == WIFI_PROV_STA_AUTH_ERROR) {
+      if (sys_event->event_info.prov_fail_reason == NETWORK_PROV_STA_AUTH_ERROR) {
         Serial.println("\nWi-Fi AP password incorrect");
       } else {
         Serial.println("\nWi-Fi AP not found....Add API \" nvs_flash_erase() \" before beginProvision()");
@@ -62,13 +62,13 @@ void setup() {
   // Sample uuid that user can pass during provisioning using BLE
   uint8_t uuid[16] = {0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf, 0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02};
   WiFiProv.beginProvision(
-    WIFI_PROV_SCHEME_BLE, WIFI_PROV_SCHEME_HANDLER_FREE_BLE, WIFI_PROV_SECURITY_1, pop, service_name, service_key, uuid, reset_provisioned
+    NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BLE, NETWORK_PROV_SECURITY_1, pop, service_name, service_key, uuid, reset_provisioned
   );
   log_d("ble qr");
   WiFiProv.printQR(service_name, pop, "ble");
 #else
   Serial.println("Begin Provisioning using Soft AP");
-  WiFiProv.beginProvision(WIFI_PROV_SCHEME_SOFTAP, WIFI_PROV_SCHEME_HANDLER_NONE, WIFI_PROV_SECURITY_1, pop, service_name, service_key);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE, NETWORK_PROV_SECURITY_1, pop, service_name, service_key);
   log_d("wifi qr");
   WiFiProv.printQR(service_name, pop, "softap");
 #endif

--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -38,7 +38,7 @@ void SysProvEvent(arduino_event_t *sys_event) {
     case ARDUINO_EVENT_PROV_CRED_FAIL:
     {
       Serial.println("\nProvisioning failed!\nPlease reset to factory and retry provisioning\n");
-      if (sys_event->event_info.prov_fail_reason == NETWORK_PROV_STA_AUTH_ERROR) {
+      if (sys_event->event_info.prov_fail_reason == NETWORK_PROV_WIFI_STA_AUTH_ERROR) {
         Serial.println("\nWi-Fi AP password incorrect");
       } else {
         Serial.println("\nWi-Fi AP not found....Add API \" nvs_flash_erase() \" before beginProvision()");

--- a/libraries/WiFiProv/src/WiFiProv.cpp
+++ b/libraries/WiFiProv/src/WiFiProv.cpp
@@ -72,8 +72,8 @@ static void get_device_service_name(prov_scheme_t prov_scheme, char *service_nam
 }
 
 void WiFiProvClass ::beginProvision(
-  prov_scheme_t prov_scheme, scheme_handler_t scheme_handler, network_prov_security_t security, const char *pop, const char *service_name, const char *service_key,
-  uint8_t *uuid, bool reset_provisioned
+  prov_scheme_t prov_scheme, scheme_handler_t scheme_handler, network_prov_security_t security, const char *pop, const char *service_name,
+  const char *service_key, uint8_t *uuid, bool reset_provisioned
 ) {
   bool provisioned = false;
   static char service_name_temp[32];

--- a/libraries/WiFiProv/src/WiFiProv.cpp
+++ b/libraries/WiFiProv/src/WiFiProv.cpp
@@ -34,10 +34,10 @@
 
 #include <nvs_flash.h>
 #if CONFIG_BLUEDROID_ENABLED
-#include "wifi_provisioning/scheme_ble.h"
+#include "network_provisioning/scheme_ble.h"
 #endif
-#include <wifi_provisioning/scheme_softap.h>
-#include <wifi_provisioning/manager.h>
+#include <network_provisioning/scheme_softap.h>
+#include <network_provisioning/manager.h>
 #undef IPADDR_NONE
 #include "WiFiProv.h"
 #if CONFIG_IDF_TARGET_ESP32
@@ -61,7 +61,7 @@ static void get_device_service_name(prov_scheme_t prov_scheme, char *service_nam
     return;
   }
 #if CONFIG_IDF_TARGET_ESP32 && defined(CONFIG_BLUEDROID_ENABLED)
-  if (prov_scheme == WIFI_PROV_SCHEME_BLE) {
+  if (prov_scheme == NETWORK_PROV_SCHEME_BLE) {
     snprintf(service_name, max, "%s%02X%02X%02X", SERV_NAME_PREFIX_PROV, eth_mac[3], eth_mac[4], eth_mac[5]);
   } else {
 #endif
@@ -72,36 +72,36 @@ static void get_device_service_name(prov_scheme_t prov_scheme, char *service_nam
 }
 
 void WiFiProvClass ::beginProvision(
-  prov_scheme_t prov_scheme, scheme_handler_t scheme_handler, wifi_prov_security_t security, const char *pop, const char *service_name, const char *service_key,
+  prov_scheme_t prov_scheme, scheme_handler_t scheme_handler, network_prov_security_t security, const char *pop, const char *service_name, const char *service_key,
   uint8_t *uuid, bool reset_provisioned
 ) {
   bool provisioned = false;
   static char service_name_temp[32];
 
-  wifi_prov_mgr_config_t config;
+  network_prov_mgr_config_t config;
 #if CONFIG_BLUEDROID_ENABLED
-  if (prov_scheme == WIFI_PROV_SCHEME_BLE) {
-    config.scheme = wifi_prov_scheme_ble;
+  if (prov_scheme == NETWORK_PROV_SCHEME_BLE) {
+    config.scheme = network_prov_scheme_ble;
   } else {
 #endif
-    config.scheme = wifi_prov_scheme_softap;
+    config.scheme = network_prov_scheme_softap;
 #if CONFIG_BLUEDROID_ENABLED
   }
 
-  if (scheme_handler == WIFI_PROV_SCHEME_HANDLER_NONE) {
+  if (scheme_handler == NETWORK_PROV_SCHEME_HANDLER_NONE) {
 #endif
-    wifi_prov_event_handler_t scheme_event_handler = WIFI_PROV_EVENT_HANDLER_NONE;
-    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(wifi_prov_event_handler_t));
+    network_prov_event_handler_t scheme_event_handler = NETWORK_PROV_EVENT_HANDLER_NONE;
+    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(network_prov_event_handler_t));
 #if CONFIG_BLUEDROID_ENABLED
-  } else if (scheme_handler == WIFI_PROV_SCHEME_HANDLER_FREE_BTDM) {
-    wifi_prov_event_handler_t scheme_event_handler = WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BTDM;
-    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(wifi_prov_event_handler_t));
-  } else if (scheme_handler == WIFI_PROV_SCHEME_HANDLER_FREE_BT) {
-    wifi_prov_event_handler_t scheme_event_handler = WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BT;
-    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(wifi_prov_event_handler_t));
-  } else if (scheme_handler == WIFI_PROV_SCHEME_HANDLER_FREE_BLE) {
-    wifi_prov_event_handler_t scheme_event_handler = WIFI_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BLE;
-    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(wifi_prov_event_handler_t));
+  } else if (scheme_handler == NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM) {
+    network_prov_event_handler_t scheme_event_handler = NETWORK_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BTDM;
+    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(network_prov_event_handler_t));
+  } else if (scheme_handler == NETWORK_PROV_SCHEME_HANDLER_FREE_BT) {
+    network_prov_event_handler_t scheme_event_handler = NETWORK_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BT;
+    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(network_prov_event_handler_t));
+  } else if (scheme_handler == NETWORK_PROV_SCHEME_HANDLER_FREE_BLE) {
+    network_prov_event_handler_t scheme_event_handler = NETWORK_PROV_SCHEME_BLE_EVENT_HANDLER_FREE_BLE;
+    memcpy(&config.scheme_event_handler, &scheme_event_handler, sizeof(network_prov_event_handler_t));
   } else {
     log_e("Unknown scheme handler!");
     return;
@@ -110,26 +110,26 @@ void WiFiProvClass ::beginProvision(
   config.app_event_handler.event_cb = NULL;
   config.app_event_handler.user_data = NULL;
   WiFi.STA.begin(false);
-  if (wifi_prov_mgr_init(config) != ESP_OK) {
-    log_e("wifi_prov_mgr_init failed!");
+  if (network_prov_mgr_init(config) != ESP_OK) {
+    log_e("network_prov_mgr_init failed!");
     return;
   }
   if (reset_provisioned) {
     log_i("Resetting provisioned data.");
-    wifi_prov_mgr_reset_provisioning();
-  } else if (wifi_prov_mgr_is_provisioned(&provisioned) != ESP_OK) {
-    log_e("wifi_prov_mgr_is_provisioned failed!");
-    wifi_prov_mgr_deinit();
+    network_prov_mgr_reset_wifi_provisioning();
+  } else if (network_prov_mgr_is_wifi_provisioned(&provisioned) != ESP_OK) {
+    log_e("network_prov_mgr_is_wifi_provisioned failed!");
+    network_prov_mgr_deinit();
     return;
   }
   if (provisioned == false) {
 #if CONFIG_BLUEDROID_ENABLED
-    if (prov_scheme == WIFI_PROV_SCHEME_BLE) {
+    if (prov_scheme == NETWORK_PROV_SCHEME_BLE) {
       service_key = NULL;
       if (uuid == NULL) {
         uuid = (uint8_t *)custom_service_uuid;
       }
-      wifi_prov_scheme_ble_set_service_uuid(uuid);
+      network_prov_scheme_ble_set_service_uuid(uuid);
     }
 #endif
 
@@ -139,7 +139,7 @@ void WiFiProvClass ::beginProvision(
     }
 
 #if CONFIG_BLUEDROID_ENABLED
-    if (prov_scheme == WIFI_PROV_SCHEME_BLE) {
+    if (prov_scheme == NETWORK_PROV_SCHEME_BLE) {
       log_i("Starting AP using BLE. service_name : %s, pop : %s", service_name, pop);
     } else {
 #endif
@@ -151,8 +151,8 @@ void WiFiProvClass ::beginProvision(
 #if CONFIG_BLUEDROID_ENABLED
     }
 #endif
-    if (wifi_prov_mgr_start_provisioning(security, pop, service_name, service_key) != ESP_OK) {
-      log_e("wifi_prov_mgr_start_provisioning failed!");
+    if (network_prov_mgr_start_provisioning(security, pop, service_name, service_key) != ESP_OK) {
+      log_e("network_prov_mgr_start_provisioning failed!");
       return;
     }
   } else {
@@ -163,7 +163,7 @@ void WiFiProvClass ::beginProvision(
     log_i("Attempting connect to AP: %s\n", conf.sta.ssid);
 #endif
     esp_wifi_start();
-    wifi_prov_mgr_deinit();
+    network_prov_mgr_deinit();
     WiFi.begin();
   }
 }

--- a/libraries/WiFiProv/src/WiFiProv.h
+++ b/libraries/WiFiProv/src/WiFiProv.h
@@ -23,32 +23,32 @@
 #if SOC_WIFI_SUPPORTED
 
 #include "WiFi.h"
-#include "wifi_provisioning/manager.h"
+#include "network_provisioning/manager.h"
 //Select the scheme using which you want to provision
 typedef enum {
-  WIFI_PROV_SCHEME_SOFTAP,
+  NETWORK_PROV_SCHEME_SOFTAP,
 #if CONFIG_BLUEDROID_ENABLED
-  WIFI_PROV_SCHEME_BLE,
+  NETWORK_PROV_SCHEME_BLE,
 #endif
-  WIFI_PROV_SCHEME_MAX
+  NETWORK_PROV_SCHEME_MAX
 } prov_scheme_t;
 
 typedef enum {
-  WIFI_PROV_SCHEME_HANDLER_NONE,
+  NETWORK_PROV_SCHEME_HANDLER_NONE,
 #if CONFIG_BLUEDROID_ENABLED
-  WIFI_PROV_SCHEME_HANDLER_FREE_BTDM,
-  WIFI_PROV_SCHEME_HANDLER_FREE_BLE,
-  WIFI_PROV_SCHEME_HANDLER_FREE_BT,
+  NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM,
+  NETWORK_PROV_SCHEME_HANDLER_FREE_BLE,
+  NETWORK_PROV_SCHEME_HANDLER_FREE_BT,
 #endif
-  WIFI_PROV_SCHEME_HANDLER_MAX
+  NETWORK_PROV_SCHEME_HANDLER_MAX
 } scheme_handler_t;
 
 //Provisioning class
 class WiFiProvClass {
 public:
   void beginProvision(
-    prov_scheme_t prov_scheme = WIFI_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = WIFI_PROV_SCHEME_HANDLER_NONE,
-    wifi_prov_security_t security = WIFI_PROV_SECURITY_1, const char *pop = "abcd1234", const char *service_name = NULL, const char *service_key = NULL,
+    prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE,
+    network_prov_security_t security = NETWORK_PROV_SECURITY_1, const char *pop = "abcd1234", const char *service_name = NULL, const char *service_key = NULL,
     uint8_t *uuid = NULL, bool reset_provisioned = false
   );
   void printQR(const char *name, const char *pop, const char *transport);

--- a/libraries/WiFiProv/src/WiFiProv.h
+++ b/libraries/WiFiProv/src/WiFiProv.h
@@ -23,6 +23,7 @@
 #if SOC_WIFI_SUPPORTED
 
 #include "WiFi.h"
+#include "HardwareSerial.h"
 #include "network_provisioning/manager.h"
 //Select the scheme using which you want to provision
 typedef enum {
@@ -51,7 +52,9 @@ public:
     network_prov_security_t security = NETWORK_PROV_SECURITY_1, const char *pop = "abcd1234", const char *service_name = NULL, const char *service_key = NULL,
     uint8_t *uuid = NULL, bool reset_provisioned = false
   );
-  void printQR(const char *name, const char *pop, const char *transport);
+  void endProvision();
+  bool disableAutoStop(uint32_t cleanup_delay);
+  void printQR(const char *name, const char *pop, const char *transport, Print &out = Serial);
 };
 
 extern WiFiProvClass WiFiProv;

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-5c57dfe949"
+              "version": "idf-release_v5.1-c608177cf9"
             },
             {
               "packager": "esp32",
@@ -77,7 +77,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20240318"
+              "version": "v0.12.0-esp32-20240726"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-5c57dfe949",
+          "version": "idf-release_v5.1-c608177cf9",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
-              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
-              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
-              "size": "310220538"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
+              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
+              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
+              "size": "310235817"
             }
           ]
         },
@@ -539,56 +539,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20240318",
+          "version": "v0.12.0-esp32-20240726",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:cf26c5cef4f6b04aa23cd2778675604e5a74a4ce4d8d17b854d05fbcb782d52c",
-              "size": "2252682"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240726/openocd-esp32-linux-amd64-0.12.0-esp32-20240726.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20240726.tar.gz",
+              "checksum": "SHA-256:31fabbda5f39262ea4ed8cbba8adedc1d39838f01043cfab95435743c126ac56",
+              "size": "2368175"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:9b97a37aa2cab94424a778c25c0b4aa0f90d6ef9cda764a1d9289d061305f4b7",
-              "size": "2132904"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240726/openocd-esp32-linux-arm64-0.12.0-esp32-20240726.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20240726.tar.gz",
+              "checksum": "SHA-256:05589effadc93440ecca4a8ecc64e78dc94185a4ab72bc54634751dd7b6060d0",
+              "size": "2239793"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-linux-armel-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:b7e82776ec374983807d3389df09c632ad9bc8341f2075690b6b500319dfeaf4",
-              "size": "2271761"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240726/openocd-esp32-linux-armel-0.12.0-esp32-20240726.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20240726.tar.gz",
+              "checksum": "SHA-256:25d241fd7467cc5aa8ec3256f2efca27d86bde7cf5577c32f742ad1cc598ad7d",
+              "size": "2388355"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:b16c3082c94df1079367c44d99f7a8605534cd48aabc18898e46e94a2c8c57e7",
-              "size": "2365588"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240726/openocd-esp32-macos-0.12.0-esp32-20240726.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20240726.tar.gz",
+              "checksum": "SHA-256:c3fb8209dd046f83e9fe98b054649020991aea0ac95cf175a41967d446330148",
+              "size": "2478569"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20240318.tar.gz",
-              "checksum": "SHA-256:534ec925ae6e35e869e4e4e6e4d2c4a1eb081f97ebcc2dd5efdc52d12f4c2f86",
-              "size": "2406377"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240726/openocd-esp32-macos-arm64-0.12.0-esp32-20240726.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20240726.tar.gz",
+              "checksum": "SHA-256:45b317f233ae7bf3059a93db925d8794affd393b170ef496da08fa3f2b360ac7",
+              "size": "2522358"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "checksum": "SHA-256:d379329eba052435173ab0d69c9b15bc164a6ce489e2a67cd11169d2dabff633",
-              "size": "2783915"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240726/openocd-esp32-win32-0.12.0-esp32-20240726.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240726.zip",
+              "checksum": "SHA-256:9735c9ada83bab1ff2b306f06b96421572fa12d01a751e09e10f243222fd95c4",
+              "size": "2907592"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240318/openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240318.zip",
-              "checksum": "SHA-256:d379329eba052435173ab0d69c9b15bc164a6ce489e2a67cd11169d2dabff633",
-              "size": "2783915"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240726/openocd-esp32-win64-0.12.0-esp32-20240726.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20240726.zip",
+              "checksum": "SHA-256:139d5ae128ea12023793e8bccdde7dd14383ad38c265cf66c9c6cc7c804e1333",
+              "size": "2907591"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-b6b4727c58"
+              "version": "idf-release_v5.1-5c57dfe949"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-b6b4727c58",
+          "version": "idf-release_v5.1-5c57dfe949",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/9857de432bff7b2d0e1e7773fc7165e5732afa0b",
-              "archiveFileName": "esp32-arduino-libs-9857de432bff7b2d0e1e7773fc7165e5732afa0b.zip",
-              "checksum": "SHA-256:262cb750d87dd3a865205ce820c1f5ffdc757cef6cf71306b927c6985f5a2202",
-              "size": "307857214"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/0761ee149081ebc3862d46060df4dc1f4b35fc8d",
+              "archiveFileName": "esp32-arduino-libs-0761ee149081ebc3862d46060df4dc1f4b35fc8d.zip",
+              "checksum": "SHA-256:e2c7929c47f4b534f9923e53e87f8216ce70dca18b7dd70bc73006704b2c1e14",
+              "size": "310220538"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 01e4365
esp-idf: release/v5.1 5c57dfe949
arduino: idf-release/v5.1 e64e090c
tinyusb: master b8d3c0c4a
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.5.1
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.9.0
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.1
espressif__esp-zigbee-lib: 1.4.1
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.4.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__network_provisioning: 1.0.0
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
```
