### PR TITLE
Adds the ability to set the clock source for the LEDC

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -47,6 +47,21 @@ ledc_periph_t ledc_handle = {0};
 
 static bool fade_initialized = false;
 
+ledc_clk_cfg_t clock_source = LEDC_DEFAULT_CLK;
+
+ledc_clk_cfg_t ledcReadClockSource(void) {
+  return clock_source;
+}
+
+bool ledcWriteClockSource(ledc_clk_cfg_t source) {
+  if (ledc_handle.used_channels) {
+    log_e("Cannot change LEDC clock source! LEDC channels in use.");
+    return false;
+  }
+  clock_source = source;
+  return true;
+}
+
 static bool ledcDetachBus(void *bus) {
   ledc_channel_handle_t *handle = (ledc_channel_handle_t *)bus;
   bool channel_found = false;
@@ -111,7 +126,7 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
       return false;
     }
   } else {
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = LEDC_DEFAULT_CLK};
+    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source};
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledc setup failed!");
       return false;
@@ -241,7 +256,7 @@ uint32_t ledcWriteTone(uint8_t pin, uint32_t freq) {
 
     uint8_t group = (bus->channel / 8), timer = ((bus->channel / 2) % 4);
 
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = 10, .freq_hz = freq, .clk_cfg = LEDC_DEFAULT_CLK};
+    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = 10, .freq_hz = freq, .clk_cfg = clock_source};
 
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledcWriteTone configuration failed!");
@@ -292,7 +307,7 @@ uint32_t ledcChangeFrequency(uint8_t pin, uint32_t freq, uint8_t resolution) {
     }
     uint8_t group = (bus->channel / 8), timer = ((bus->channel / 2) % 4);
 
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = LEDC_DEFAULT_CLK};
+    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source};
 
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledcChangeFrequency failed!");

--- a/cores/esp32/esp32-hal-ledc.h
+++ b/cores/esp32/esp32-hal-ledc.h
@@ -26,6 +26,7 @@ extern "C" {
 #include <stdbool.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
+#include "hal/ledc_types.h"
 
 typedef enum {
   NOTE_C,
@@ -56,6 +57,20 @@ typedef struct {
   SemaphoreHandle_t lock;  //xSemaphoreCreateBinary
 #endif
 } ledc_channel_handle_t;
+
+/**
+ * @brief Read the LEDC clock source.
+ *
+ * @return LEDC clock source.
+ */
+ledc_clk_cfg_t ledcReadClockSource(void);
+
+/**
+ * @brief Set the LEDC clock source.
+ *
+ * @return true if LEDC clock source was successfully set, false otherwise.
+ */
+bool ledcWriteClockSource(ledc_clk_cfg_t source);
 
 /**
  * @brief Attach a pin to the LEDC driver, with a given frequency and resolution.


### PR DESCRIPTION
Today the LEDC clock source is fixed, which limits the possibilities, such as light sleep compatibility "ledcWriteClockSource(LEDC_USE_RC_FAST_CLK)".