### PR TITLE
Fix(UART): ESP32 | ESP32-S2 UART Clock Source

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -508,8 +508,8 @@ uart_t *uartBegin(
 #if SOC_UART_SUPPORT_XTAL_CLK
   uart_config.source_clk = UART_SCLK_XTAL;  // valid for C2, S3, C3, C6, H2 and P4
 #elif SOC_UART_SUPPORT_REF_TICK
-  if (baudrate <= 1000000) {
-    uart_config.source_clk = UART_SCLK_REF_TICK;  // valid for ESP32, S2 - MAX supported baud rate is 1MHz
+  if (baudrate <= 250000) {
+    uart_config.source_clk = UART_SCLK_REF_TICK;  // valid for ESP32, S2 - MAX supported baud rate is 250 Kbps
   } else {
     uart_config.source_clk = UART_SCLK_APB;  // baudrate may change with the APB Frequency!
   }


### PR DESCRIPTION
## Description of Change
Problem detected with ESP32 and ESP32-S2 when the baudrate goes to 460600 bps.

REF_TICK (2MHz) seem not to work properly.
Limiting the use of REF_TICK for up to 205 Kbps.

## Tests scenarios
ESP32 / S2.

```cpp
#include <HardwareSerial.h>

HardwareSerial MySerial(1);
const int MySerialRX = 16;
const int MySerialTX = 17;

uint8_t rBuffer[2048]; 

void setup() 
{
    MySerial.begin(460800, SERIAL_8N1, MySerialRX, MySerialTX);
    Serial.begin(115200);
}

void loop() 
{
    while (MySerial.available() > 0) {
        int s = MySerial.readBytes(rBuffer, sizeof(rBuffer));
          Serial.write(rBuffer, s);
    }
}
```

## Related links
Fix #10161 
Fix #10117
