### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-c608177cf9"
+              "version": "idf-release_v5.1-446ec3a899"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-c608177cf9",
+          "version": "idf-release_v5.1-446ec3a899",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
+              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
+              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
+              "size": "310243212"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-446ec3a899"
+              "version": "idf-release_v5.1-d38afc77db"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-446ec3a899",
+          "version": "idf-release_v5.1-d38afc77db",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23",
-              "archiveFileName": "esp32-arduino-libs-12d8053719a03fcefe0f46ecdf9ee2ce2f7c1f23.zip",
-              "checksum": "SHA-256:0408ede8e60064c87e181844eb247c991b89cff3c0fd6bc555f85cfc16763da4",
-              "size": "310243212"
+              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/1a029d52a9cbc5863b00d0316124d79be1de2922",
+              "archiveFileName": "esp32-arduino-libs-1a029d52a9cbc5863b00d0316124d79be1de2922.zip",
+              "checksum": "SHA-256:813daf0ce38288d952aecaf5884be056395b8c81168a66e7b8abcf84ad088ab2",
+              "size": "310243219"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 2a45ca0
esp-idf: release/v5.1 446ec3a899
arduino: master a7399e2b
tinyusb: master b8d3c0c4a
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.5.1
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-sr: 1.9.0
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.1
espressif__esp-zigbee-lib: 1.4.1
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.4.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__network_provisioning: 1.0.0
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
```
