### PR TITLE
Additional UART_DATA check and pass bits back to callBack

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -241,8 +241,11 @@ void HardwareSerial::_uartEventTask(void *args) {
         hardwareSerial_error_t currentErr = UART_NO_ERROR;
         switch (event.type) {
           case UART_DATA:
-            if (uart->_onReceiveCB && uart->available() > 0 && ((uart->_onReceiveTimeout && event.timeout_flag) || !uart->_onReceiveTimeout)) {
-              uart->_onReceiveCB();
+            if (uart->_onReceiveCB && uart->available() > 0) {
+              size_t available = uart->available();
+              if ((uart->_onReceiveTimeout && event.timeout_flag) || (!uart->_onReceiveTimeout && available >= uart->_rxFIFOFull)) {
+                uart->_onReceiveCB(available);
+              }
             }
             break;
           case UART_FIFO_OVF:

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -237,9 +237,12 @@ void HardwareSerial::_uartEventTask(void *args) {
   if (uartEventQueue != NULL) {
     for (;;) {
       //Waiting for UART event.
+
       if (xQueueReceive(uartEventQueue, (void *)&event, (TickType_t)portMAX_DELAY)) {
         hardwareSerial_error_t currentErr = UART_NO_ERROR;
+      
         switch (event.type) {
+      
           case UART_DATA:
             if (uart->_onReceiveCB && uart->available() > 0) {
               size_t available = uart->available();
@@ -248,28 +251,38 @@ void HardwareSerial::_uartEventTask(void *args) {
               }
             }
             break;
+      
           case UART_FIFO_OVF:
             log_w("UART%d FIFO Overflow. Consider adding Hardware Flow Control to your Application.", uart->_uart_nr);
             currentErr = UART_FIFO_OVF_ERROR;
             break;
+      
           case UART_BUFFER_FULL:
             log_w("UART%d Buffer Full. Consider increasing your buffer size of your Application.", uart->_uart_nr);
             currentErr = UART_BUFFER_FULL_ERROR;
             break;
+      
           case UART_BREAK:
             log_v("UART%d RX break.", uart->_uart_nr);
             currentErr = UART_BREAK_ERROR;
             break;
+      
           case UART_PARITY_ERR:
             log_v("UART%d parity error.", uart->_uart_nr);
             currentErr = UART_PARITY_ERROR;
             break;
+      
           case UART_FRAME_ERR:
             log_v("UART%d frame error.", uart->_uart_nr);
             currentErr = UART_FRAME_ERROR;
             break;
+      
+      
           default: log_v("UART%d unknown event type %d.", uart->_uart_nr, event.type); break;
+      
         }
+      
+      
         if (currentErr != UART_NO_ERROR) {
           if (uart->_onReceiveErrorCB) {
             uart->_onReceiveErrorCB(currentErr);


### PR DESCRIPTION
The proposed change should ensure that the callback is only triggered when appropriate conditions are met and that it passes the number of available bytes to the callback.
