### PR TITLE
Prevents the buffer size from changing while the UART is active.

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -522,8 +522,8 @@ bool HardwareSerial::setMode(SerialMode mode) {
 size_t HardwareSerial::setRxBufferSize(size_t new_size) {
 
   if (_uart) {
-    log_e("RX Buffer can't be resized when Serial is already running. Set it before calling begin().");
-    return 0;
+    log_e("RX Buffer can't be resized when Serial is already running. Call end() first.");
+    return _rxBufferSize;
   }
 
   if (new_size <= SOC_UART_FIFO_LEN) {


### PR DESCRIPTION
This change returns the buffer size rather than 0, the goal is to keep the buffer from changing its size while we're using the UART functionality.


-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
