### PR TITLE
fix(timer): Typo - milis instead of millis.

### DIFF
--- a/cores/esp32/esp32-hal-timer.c
+++ b/cores/esp32/esp32-hal-timer.c
@@ -202,7 +202,7 @@ uint64_t timerReadMicros(hw_timer_t *timer) {
   return timer_val * 1000000 / frequency;
 }
 
-uint64_t timerReadMilis(hw_timer_t *timer) {
+uint64_t timerReadMillis(hw_timer_t *timer) {
   uint64_t timer_val = timerRead(timer);
   uint32_t frequency = timerGetFrequency(timer);
   return timer_val * 1000 / frequency;

--- a/cores/esp32/esp32-hal-timer.h
+++ b/cores/esp32/esp32-hal-timer.h
@@ -42,7 +42,7 @@ void timerWrite(hw_timer_t *timer, uint64_t val);
 
 uint64_t timerRead(hw_timer_t *timer);
 uint64_t timerReadMicros(hw_timer_t *timer);
-uint64_t timerReadMilis(hw_timer_t *timer);
+uint64_t timerReadMillis(hw_timer_t *timer);
 double timerReadSeconds(hw_timer_t *timer);
 
 uint32_t timerGetFrequency(hw_timer_t *timer);

--- a/docs/en/api/timer.rst
+++ b/docs/en/api/timer.rst
@@ -119,14 +119,14 @@ This function is used to read counter value in microseconds of the timer.
 
 This function will return ``counter value`` of the timer in microseconds.
 
-timerReadMilis
+timerReadMillis
 **************
 
 This function is used to read counter value in milliseconds of the timer.
 
 .. code-block:: arduino
 
-    uint64_t timerReadMilis(hw_timer_t * timer);
+    uint64_t timerReadMillis(hw_timer_t * timer);
 
 * ``timer`` timer struct.
 


### PR DESCRIPTION
## Description of Change
The timer API (both source and documentation) has a typo! Function timerReadMilis should be named timerReadMillis (with double l). Since it would change the header file, I don't know whether this should be fixed already in the 3.x version. 
But since Arduino has the function millis(), I consider appropriate to fix the typo.

## Tests scenarios
N/A (just a "global" find and replace among all the project files)

Update relevant documentation: already in the commit