### PR TITLE
feat(board):Add Heltec Vision Master series boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -25575,8 +25575,6 @@ heltec_ht_de01.menu.EraseFlash.all.upload.erase_cmd=-e
 ##############################################################
 
 heltec_vision_master_e290.name=Heltec Vision Master E290
-heltec_vision_master_e290.vid.0=0x303a
-heltec_vision_master_e290.pid.0=0x1001
 
 heltec_vision_master_e290.bootloader.tool=esptool_py
 heltec_vision_master_e290.bootloader.tool.default=esptool_py
@@ -25752,8 +25750,6 @@ heltec_vision_master_e290.menu.EraseFlash.all.upload.erase_cmd=-e
 ##############################################################
 
 heltec_vision_master_t190.name=Heltec Vision Master T190
-heltec_vision_master_t190.vid.0=0x303a
-heltec_vision_master_t190.pid.0=0x1001
 
 heltec_vision_master_t190.bootloader.tool=esptool_py
 heltec_vision_master_t190.bootloader.tool.default=esptool_py
@@ -25929,8 +25925,6 @@ heltec_vision_master_t190.menu.EraseFlash.all.upload.erase_cmd=-e
 ##############################################################
 
 heltec_vision_master_e_213.name=Heltec Vision Master E213
-heltec_vision_master_e_213.vid.0=0x303a
-heltec_vision_master_e_213.pid.0=0x1001
 
 heltec_vision_master_e_213.bootloader.tool=esptool_py
 heltec_vision_master_e_213.bootloader.tool.default=esptool_py

--- a/boards.txt
+++ b/boards.txt
@@ -25599,7 +25599,7 @@ heltec_vision_master_e290.build.target=esp32s3
 heltec_vision_master_e290.build.mcu=esp32s3
 heltec_vision_master_e290.build.core=esp32
 heltec_vision_master_e290.build.variant=heltec_vision_master_e290
-heltec_vision_master_e290.build.board=Heltec_Vision_Master_E290
+heltec_vision_master_e290.build.board=HELTEC_VISION_MASTER_E290
 
 heltec_vision_master_e290.build.usb_mode=1
 heltec_vision_master_e290.build.cdc_on_boot=0
@@ -25740,7 +25740,7 @@ heltec_vision_master_e290.menu.SLOW_CLK_TPYE.0.build.SLOW_CLK_TPYE=0
 heltec_vision_master_e290.menu.SLOW_CLK_TPYE.1=External 32K
 heltec_vision_master_e290.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 
-heltec_vision_master_e290.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=37 -DVision_Master_E290 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
+heltec_vision_master_e290.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=37 -DHELTEC_VISION_MASTER_E290 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_vision_master_e290.menu.EraseFlash.none=Disabled
 heltec_vision_master_e290.menu.EraseFlash.none.upload.erase_cmd=
@@ -25774,7 +25774,7 @@ heltec_vision_master_t190.build.target=esp32s3
 heltec_vision_master_t190.build.mcu=esp32s3
 heltec_vision_master_t190.build.core=esp32
 heltec_vision_master_t190.build.variant=heltec_vision_master_t190
-heltec_vision_master_t190.build.board=Heltec_Vision_Master_T190
+heltec_vision_master_t190.build.board=HELTEC_VISION_MASTER_T190
 
 heltec_vision_master_t190.build.usb_mode=1
 heltec_vision_master_t190.build.cdc_on_boot=0
@@ -25915,7 +25915,7 @@ heltec_vision_master_t190.menu.SLOW_CLK_TPYE.0.build.SLOW_CLK_TPYE=0
 heltec_vision_master_t190.menu.SLOW_CLK_TPYE.1=External 32K
 heltec_vision_master_t190.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 
-heltec_vision_master_t190.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=38 -DVision_Master_T190 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
+heltec_vision_master_t190.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=38 -DHELTEC_VISION_MASTER_T190 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_vision_master_t190.menu.EraseFlash.none=Disabled
 heltec_vision_master_t190.menu.EraseFlash.none.upload.erase_cmd=
@@ -25949,7 +25949,7 @@ heltec_vision_master_e_213.build.target=esp32s3
 heltec_vision_master_e_213.build.mcu=esp32s3
 heltec_vision_master_e_213.build.core=esp32
 heltec_vision_master_e_213.build.variant=heltec_vision_master_e_213
-heltec_vision_master_e_213.build.board=Heltec_Vision_Master_E_213
+heltec_vision_master_e_213.build.board=HELTEC_VISION_MASTER_E_213
 
 heltec_vision_master_e_213.build.usb_mode=1
 heltec_vision_master_e_213.build.cdc_on_boot=0
@@ -26090,7 +26090,7 @@ heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.0.build.SLOW_CLK_TPYE=0
 heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.1=External 32K
 heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 
-heltec_vision_master_e_213.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=36 -DVision_Master_E_213 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
+heltec_vision_master_e_213.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=36 -DHELTEC_VISION_MASTER_E_213 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_vision_master_e_213.menu.EraseFlash.none=Disabled
 heltec_vision_master_e_213.menu.EraseFlash.none.upload.erase_cmd=

--- a/boards.txt
+++ b/boards.txt
@@ -25574,6 +25574,537 @@ heltec_ht_de01.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+heltec_vision_master_e290.name=Heltec Vision Master E290
+heltec_vision_master_e290.vid.0=0x303a
+heltec_vision_master_e290.pid.0=0x1001
+
+heltec_vision_master_e290.bootloader.tool=esptool_py
+heltec_vision_master_e290.bootloader.tool.default=esptool_py
+
+heltec_vision_master_e290.upload.tool=esptool_py
+heltec_vision_master_e290.upload.tool.default=esptool_py
+heltec_vision_master_e290.upload.tool.network=esp_ota
+
+heltec_vision_master_e290.upload.maximum_size=3342336
+heltec_vision_master_e290.upload.maximum_data_size=327680
+heltec_vision_master_e290.upload.flags=
+heltec_vision_master_e290.upload.extra_flags=
+heltec_vision_master_e290.upload.use_1200bps_touch=false
+heltec_vision_master_e290.upload.wait_for_upload_port=false
+
+heltec_vision_master_e290.serial.disableDTR=false
+heltec_vision_master_e290.serial.disableRTS=false
+
+heltec_vision_master_e290.build.tarch=xtensa
+heltec_vision_master_e290.build.bootloader_addr=0x0
+heltec_vision_master_e290.build.target=esp32s3
+heltec_vision_master_e290.build.mcu=esp32s3
+heltec_vision_master_e290.build.core=esp32
+heltec_vision_master_e290.build.variant=heltec_vision_master_e290
+heltec_vision_master_e290.build.board=Heltec_Vision_Master_E290
+
+heltec_vision_master_e290.build.usb_mode=1
+heltec_vision_master_e290.build.cdc_on_boot=0
+heltec_vision_master_e290.build.msc_on_boot=0
+heltec_vision_master_e290.build.dfu_on_boot=0
+heltec_vision_master_e290.build.f_cpu=240000000L
+heltec_vision_master_e290.build.flash_size=8MB
+heltec_vision_master_e290.build.flash_freq=80m
+heltec_vision_master_e290.build.flash_mode=dio
+heltec_vision_master_e290.build.boot=qio
+heltec_vision_master_e290.build.boot_freq=80m
+heltec_vision_master_e290.build.partitions=default_8MB
+heltec_vision_master_e290.build.loop_core=
+heltec_vision_master_e290.build.event_core=
+heltec_vision_master_e290.build.psram_type=qspi
+heltec_vision_master_e290.build.memory_type={build.boot}_{build.psram_type}
+
+heltec_vision_master_e290.menu.LoopCore.1=Core 1
+heltec_vision_master_e290.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+heltec_vision_master_e290.menu.LoopCore.0=Core 0
+heltec_vision_master_e290.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+heltec_vision_master_e290.menu.EventsCore.1=Core 1
+heltec_vision_master_e290.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+heltec_vision_master_e290.menu.EventsCore.0=Core 0
+heltec_vision_master_e290.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+heltec_vision_master_e290.menu.USBMode.hwcdc=Hardware CDC and JTAG
+heltec_vision_master_e290.menu.USBMode.hwcdc.build.usb_mode=1
+heltec_vision_master_e290.menu.USBMode.default=USB-OTG (TinyUSB)
+heltec_vision_master_e290.menu.USBMode.default.build.usb_mode=0
+
+heltec_vision_master_e290.menu.CDCOnBoot.default=Enabled
+heltec_vision_master_e290.menu.CDCOnBoot.default.build.cdc_on_boot=1
+heltec_vision_master_e290.menu.CDCOnBoot.cdc=Disabled
+heltec_vision_master_e290.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+heltec_vision_master_e290.menu.MSCOnBoot.default=Disabled
+heltec_vision_master_e290.menu.MSCOnBoot.default.build.msc_on_boot=0
+heltec_vision_master_e290.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+heltec_vision_master_e290.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+heltec_vision_master_e290.menu.DFUOnBoot.default=Disabled
+heltec_vision_master_e290.menu.DFUOnBoot.default.build.dfu_on_boot=0
+heltec_vision_master_e290.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+heltec_vision_master_e290.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+heltec_vision_master_e290.menu.UploadMode.default=UART0 / Hardware CDC
+heltec_vision_master_e290.menu.UploadMode.default.upload.use_1200bps_touch=false
+heltec_vision_master_e290.menu.UploadMode.default.upload.wait_for_upload_port=false
+heltec_vision_master_e290.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+heltec_vision_master_e290.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+heltec_vision_master_e290.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+heltec_vision_master_e290.menu.CPUFreq.240=240MHz (WiFi)
+heltec_vision_master_e290.menu.CPUFreq.240.build.f_cpu=240000000L
+heltec_vision_master_e290.menu.CPUFreq.160=160MHz (WiFi)
+heltec_vision_master_e290.menu.CPUFreq.160.build.f_cpu=160000000L
+heltec_vision_master_e290.menu.CPUFreq.80=80MHz (WiFi)
+heltec_vision_master_e290.menu.CPUFreq.80.build.f_cpu=80000000L
+heltec_vision_master_e290.menu.CPUFreq.40=40MHz
+heltec_vision_master_e290.menu.CPUFreq.40.build.f_cpu=40000000L
+heltec_vision_master_e290.menu.CPUFreq.20=20MHz
+heltec_vision_master_e290.menu.CPUFreq.20.build.f_cpu=20000000L
+heltec_vision_master_e290.menu.CPUFreq.10=10MHz
+heltec_vision_master_e290.menu.CPUFreq.10.build.f_cpu=10000000L
+
+heltec_vision_master_e290.menu.UploadSpeed.921600=921600
+heltec_vision_master_e290.menu.UploadSpeed.921600.upload.speed=921600
+heltec_vision_master_e290.menu.UploadSpeed.115200=115200
+heltec_vision_master_e290.menu.UploadSpeed.115200.upload.speed=115200
+heltec_vision_master_e290.menu.UploadSpeed.256000.windows=256000
+heltec_vision_master_e290.menu.UploadSpeed.256000.upload.speed=256000
+heltec_vision_master_e290.menu.UploadSpeed.230400.windows.upload.speed=256000
+heltec_vision_master_e290.menu.UploadSpeed.230400=230400
+heltec_vision_master_e290.menu.UploadSpeed.230400.upload.speed=230400
+heltec_vision_master_e290.menu.UploadSpeed.460800.linux=460800
+heltec_vision_master_e290.menu.UploadSpeed.460800.macosx=460800
+heltec_vision_master_e290.menu.UploadSpeed.460800.upload.speed=460800
+heltec_vision_master_e290.menu.UploadSpeed.512000.windows=512000
+heltec_vision_master_e290.menu.UploadSpeed.512000.upload.speed=512000
+
+heltec_vision_master_e290.menu.DebugLevel.none=None
+heltec_vision_master_e290.menu.DebugLevel.none.build.code_debug=0
+heltec_vision_master_e290.menu.DebugLevel.error=Error
+heltec_vision_master_e290.menu.DebugLevel.error.build.code_debug=1
+heltec_vision_master_e290.menu.DebugLevel.warn=Warn
+heltec_vision_master_e290.menu.DebugLevel.warn.build.code_debug=2
+heltec_vision_master_e290.menu.DebugLevel.info=Info
+heltec_vision_master_e290.menu.DebugLevel.info.build.code_debug=3
+heltec_vision_master_e290.menu.DebugLevel.debug=Debug
+heltec_vision_master_e290.menu.DebugLevel.debug.build.code_debug=4
+heltec_vision_master_e290.menu.DebugLevel.verbose=Verbose
+heltec_vision_master_e290.menu.DebugLevel.verbose.build.code_debug=5
+
+heltec_vision_master_e290.menu.LORAWAN_REGION.0=REGION_EU868
+heltec_vision_master_e290.menu.LORAWAN_REGION.0.build.band=REGION_EU868
+heltec_vision_master_e290.menu.LORAWAN_REGION.1=REGION_EU433
+heltec_vision_master_e290.menu.LORAWAN_REGION.1.build.band=REGION_EU433
+heltec_vision_master_e290.menu.LORAWAN_REGION.2=REGION_CN470
+heltec_vision_master_e290.menu.LORAWAN_REGION.2.build.band=REGION_CN470
+heltec_vision_master_e290.menu.LORAWAN_REGION.3=REGION_US915
+heltec_vision_master_e290.menu.LORAWAN_REGION.3.build.band=REGION_US915
+heltec_vision_master_e290.menu.LORAWAN_REGION.4=REGION_AU915
+heltec_vision_master_e290.menu.LORAWAN_REGION.4.build.band=REGION_AU915
+heltec_vision_master_e290.menu.LORAWAN_REGION.5=REGION_CN779
+heltec_vision_master_e290.menu.LORAWAN_REGION.5.build.band=REGION_CN779
+heltec_vision_master_e290.menu.LORAWAN_REGION.6=REGION_AS923
+heltec_vision_master_e290.menu.LORAWAN_REGION.6.build.band=REGION_AS923
+heltec_vision_master_e290.menu.LORAWAN_REGION.7=REGION_KR920
+heltec_vision_master_e290.menu.LORAWAN_REGION.7.build.band=REGION_KR920
+heltec_vision_master_e290.menu.LORAWAN_REGION.8=REGION_IN865
+heltec_vision_master_e290.menu.LORAWAN_REGION.8.build.band=REGION_IN865
+heltec_vision_master_e290.menu.LORAWAN_REGION.9=REGION_US915_HYBRID
+heltec_vision_master_e290.menu.LORAWAN_REGION.9.build.band=REGION_US915_HYBRID
+
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.0=None
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.0.build.LoRaWanDebugLevel=0
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.1=Freq
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.1.build.LoRaWanDebugLevel=1
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.2=Freq && DIO
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.2.build.LoRaWanDebugLevel=2
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.3=Freq && DIO && PW
+heltec_vision_master_e290.menu.LoRaWanDebugLevel.3.build.LoRaWanDebugLevel=3
+
+heltec_vision_master_e290.menu.LORAWAN_DEVEUI.0=CUSTOM
+heltec_vision_master_e290.menu.LORAWAN_DEVEUI.0.build.LORAWAN_DEVEUI_AUTO=0
+heltec_vision_master_e290.menu.LORAWAN_DEVEUI.1=Generate By ChipID
+heltec_vision_master_e290.menu.LORAWAN_DEVEUI.1.build.LORAWAN_DEVEUI_AUTO=1
+
+heltec_vision_master_e290.menu.LORAWAN_PREAMBLE_LENGTH.0=8(default)
+heltec_vision_master_e290.menu.LORAWAN_PREAMBLE_LENGTH.0.build.LORAWAN_PREAMBLE_LENGTH=8
+heltec_vision_master_e290.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
+heltec_vision_master_e290.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
+
+heltec_vision_master_e290.menu.SLOW_CLK_TPYE.0=Internal (default)
+heltec_vision_master_e290.menu.SLOW_CLK_TPYE.0.build.SLOW_CLK_TPYE=0
+heltec_vision_master_e290.menu.SLOW_CLK_TPYE.1=External 32K
+heltec_vision_master_e290.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
+
+heltec_vision_master_e290.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=37 -DVision_Master_E290 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
+
+heltec_vision_master_e290.menu.EraseFlash.none=Disabled
+heltec_vision_master_e290.menu.EraseFlash.none.upload.erase_cmd=
+heltec_vision_master_e290.menu.EraseFlash.all=Enabled
+heltec_vision_master_e290.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+heltec_vision_master_t190.name=Heltec Vision Master T190
+heltec_vision_master_t190.vid.0=0x303a
+heltec_vision_master_t190.pid.0=0x1001
+
+heltec_vision_master_t190.bootloader.tool=esptool_py
+heltec_vision_master_t190.bootloader.tool.default=esptool_py
+
+heltec_vision_master_t190.upload.tool=esptool_py
+heltec_vision_master_t190.upload.tool.default=esptool_py
+heltec_vision_master_t190.upload.tool.network=esp_ota
+
+heltec_vision_master_t190.upload.maximum_size=3342336
+heltec_vision_master_t190.upload.maximum_data_size=327680
+heltec_vision_master_t190.upload.flags=
+heltec_vision_master_t190.upload.extra_flags=
+heltec_vision_master_t190.upload.use_1200bps_touch=false
+heltec_vision_master_t190.upload.wait_for_upload_port=false
+
+heltec_vision_master_t190.serial.disableDTR=false
+heltec_vision_master_t190.serial.disableRTS=false
+
+heltec_vision_master_t190.build.tarch=xtensa
+heltec_vision_master_t190.build.bootloader_addr=0x0
+heltec_vision_master_t190.build.target=esp32s3
+heltec_vision_master_t190.build.mcu=esp32s3
+heltec_vision_master_t190.build.core=esp32
+heltec_vision_master_t190.build.variant=heltec_vision_master_t190
+heltec_vision_master_t190.build.board=Heltec_Vision_Master_T190
+
+heltec_vision_master_t190.build.usb_mode=1
+heltec_vision_master_t190.build.cdc_on_boot=0
+heltec_vision_master_t190.build.msc_on_boot=0
+heltec_vision_master_t190.build.dfu_on_boot=0
+heltec_vision_master_t190.build.f_cpu=240000000L
+heltec_vision_master_t190.build.flash_size=8MB
+heltec_vision_master_t190.build.flash_freq=80m
+heltec_vision_master_t190.build.flash_mode=dio
+heltec_vision_master_t190.build.boot=qio
+heltec_vision_master_t190.build.boot_freq=80m
+heltec_vision_master_t190.build.partitions=default_8MB
+heltec_vision_master_t190.build.loop_core=
+heltec_vision_master_t190.build.event_core=
+heltec_vision_master_t190.build.psram_type=qspi
+heltec_vision_master_t190.build.memory_type={build.boot}_{build.psram_type}
+
+heltec_vision_master_t190.menu.LoopCore.1=Core 1
+heltec_vision_master_t190.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+heltec_vision_master_t190.menu.LoopCore.0=Core 0
+heltec_vision_master_t190.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+heltec_vision_master_t190.menu.EventsCore.1=Core 1
+heltec_vision_master_t190.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+heltec_vision_master_t190.menu.EventsCore.0=Core 0
+heltec_vision_master_t190.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+heltec_vision_master_t190.menu.USBMode.hwcdc=Hardware CDC and JTAG
+heltec_vision_master_t190.menu.USBMode.hwcdc.build.usb_mode=1
+heltec_vision_master_t190.menu.USBMode.default=USB-OTG (TinyUSB)
+heltec_vision_master_t190.menu.USBMode.default.build.usb_mode=0
+
+heltec_vision_master_t190.menu.CDCOnBoot.default=Enabled
+heltec_vision_master_t190.menu.CDCOnBoot.default.build.cdc_on_boot=1
+heltec_vision_master_t190.menu.CDCOnBoot.cdc=Disabled
+heltec_vision_master_t190.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+heltec_vision_master_t190.menu.MSCOnBoot.default=Disabled
+heltec_vision_master_t190.menu.MSCOnBoot.default.build.msc_on_boot=0
+heltec_vision_master_t190.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+heltec_vision_master_t190.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+heltec_vision_master_t190.menu.DFUOnBoot.default=Disabled
+heltec_vision_master_t190.menu.DFUOnBoot.default.build.dfu_on_boot=0
+heltec_vision_master_t190.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+heltec_vision_master_t190.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+heltec_vision_master_t190.menu.UploadMode.default=UART0 / Hardware CDC
+heltec_vision_master_t190.menu.UploadMode.default.upload.use_1200bps_touch=false
+heltec_vision_master_t190.menu.UploadMode.default.upload.wait_for_upload_port=false
+heltec_vision_master_t190.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+heltec_vision_master_t190.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+heltec_vision_master_t190.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+heltec_vision_master_t190.menu.CPUFreq.240=240MHz (WiFi)
+heltec_vision_master_t190.menu.CPUFreq.240.build.f_cpu=240000000L
+heltec_vision_master_t190.menu.CPUFreq.160=160MHz (WiFi)
+heltec_vision_master_t190.menu.CPUFreq.160.build.f_cpu=160000000L
+heltec_vision_master_t190.menu.CPUFreq.80=80MHz (WiFi)
+heltec_vision_master_t190.menu.CPUFreq.80.build.f_cpu=80000000L
+heltec_vision_master_t190.menu.CPUFreq.40=40MHz
+heltec_vision_master_t190.menu.CPUFreq.40.build.f_cpu=40000000L
+heltec_vision_master_t190.menu.CPUFreq.20=20MHz
+heltec_vision_master_t190.menu.CPUFreq.20.build.f_cpu=20000000L
+heltec_vision_master_t190.menu.CPUFreq.10=10MHz
+heltec_vision_master_t190.menu.CPUFreq.10.build.f_cpu=10000000L
+
+heltec_vision_master_t190.menu.UploadSpeed.921600=921600
+heltec_vision_master_t190.menu.UploadSpeed.921600.upload.speed=921600
+heltec_vision_master_t190.menu.UploadSpeed.115200=115200
+heltec_vision_master_t190.menu.UploadSpeed.115200.upload.speed=115200
+heltec_vision_master_t190.menu.UploadSpeed.256000.windows=256000
+heltec_vision_master_t190.menu.UploadSpeed.256000.upload.speed=256000
+heltec_vision_master_t190.menu.UploadSpeed.230400.windows.upload.speed=256000
+heltec_vision_master_t190.menu.UploadSpeed.230400=230400
+heltec_vision_master_t190.menu.UploadSpeed.230400.upload.speed=230400
+heltec_vision_master_t190.menu.UploadSpeed.460800.linux=460800
+heltec_vision_master_t190.menu.UploadSpeed.460800.macosx=460800
+heltec_vision_master_t190.menu.UploadSpeed.460800.upload.speed=460800
+heltec_vision_master_t190.menu.UploadSpeed.512000.windows=512000
+heltec_vision_master_t190.menu.UploadSpeed.512000.upload.speed=512000
+
+heltec_vision_master_t190.menu.DebugLevel.none=None
+heltec_vision_master_t190.menu.DebugLevel.none.build.code_debug=0
+heltec_vision_master_t190.menu.DebugLevel.error=Error
+heltec_vision_master_t190.menu.DebugLevel.error.build.code_debug=1
+heltec_vision_master_t190.menu.DebugLevel.warn=Warn
+heltec_vision_master_t190.menu.DebugLevel.warn.build.code_debug=2
+heltec_vision_master_t190.menu.DebugLevel.info=Info
+heltec_vision_master_t190.menu.DebugLevel.info.build.code_debug=3
+heltec_vision_master_t190.menu.DebugLevel.debug=Debug
+heltec_vision_master_t190.menu.DebugLevel.debug.build.code_debug=4
+heltec_vision_master_t190.menu.DebugLevel.verbose=Verbose
+heltec_vision_master_t190.menu.DebugLevel.verbose.build.code_debug=5
+
+heltec_vision_master_t190.menu.LORAWAN_REGION.0=REGION_EU868
+heltec_vision_master_t190.menu.LORAWAN_REGION.0.build.band=REGION_EU868
+heltec_vision_master_t190.menu.LORAWAN_REGION.1=REGION_EU433
+heltec_vision_master_t190.menu.LORAWAN_REGION.1.build.band=REGION_EU433
+heltec_vision_master_t190.menu.LORAWAN_REGION.2=REGION_CN470
+heltec_vision_master_t190.menu.LORAWAN_REGION.2.build.band=REGION_CN470
+heltec_vision_master_t190.menu.LORAWAN_REGION.3=REGION_US915
+heltec_vision_master_t190.menu.LORAWAN_REGION.3.build.band=REGION_US915
+heltec_vision_master_t190.menu.LORAWAN_REGION.4=REGION_AU915
+heltec_vision_master_t190.menu.LORAWAN_REGION.4.build.band=REGION_AU915
+heltec_vision_master_t190.menu.LORAWAN_REGION.5=REGION_CN779
+heltec_vision_master_t190.menu.LORAWAN_REGION.5.build.band=REGION_CN779
+heltec_vision_master_t190.menu.LORAWAN_REGION.6=REGION_AS923
+heltec_vision_master_t190.menu.LORAWAN_REGION.6.build.band=REGION_AS923
+heltec_vision_master_t190.menu.LORAWAN_REGION.7=REGION_KR920
+heltec_vision_master_t190.menu.LORAWAN_REGION.7.build.band=REGION_KR920
+heltec_vision_master_t190.menu.LORAWAN_REGION.8=REGION_IN865
+heltec_vision_master_t190.menu.LORAWAN_REGION.8.build.band=REGION_IN865
+heltec_vision_master_t190.menu.LORAWAN_REGION.9=REGION_US915_HYBRID
+heltec_vision_master_t190.menu.LORAWAN_REGION.9.build.band=REGION_US915_HYBRID
+
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.0=None
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.0.build.LoRaWanDebugLevel=0
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.1=Freq
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.1.build.LoRaWanDebugLevel=1
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.2=Freq && DIO
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.2.build.LoRaWanDebugLevel=2
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.3=Freq && DIO && PW
+heltec_vision_master_t190.menu.LoRaWanDebugLevel.3.build.LoRaWanDebugLevel=3
+
+heltec_vision_master_t190.menu.LORAWAN_DEVEUI.0=CUSTOM
+heltec_vision_master_t190.menu.LORAWAN_DEVEUI.0.build.LORAWAN_DEVEUI_AUTO=0
+heltec_vision_master_t190.menu.LORAWAN_DEVEUI.1=Generate By ChipID
+heltec_vision_master_t190.menu.LORAWAN_DEVEUI.1.build.LORAWAN_DEVEUI_AUTO=1
+
+heltec_vision_master_t190.menu.LORAWAN_PREAMBLE_LENGTH.0=8(default)
+heltec_vision_master_t190.menu.LORAWAN_PREAMBLE_LENGTH.0.build.LORAWAN_PREAMBLE_LENGTH=8
+heltec_vision_master_t190.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
+heltec_vision_master_t190.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
+
+heltec_vision_master_t190.menu.SLOW_CLK_TPYE.0=Internal (default)
+heltec_vision_master_t190.menu.SLOW_CLK_TPYE.0.build.SLOW_CLK_TPYE=0
+heltec_vision_master_t190.menu.SLOW_CLK_TPYE.1=External 32K
+heltec_vision_master_t190.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
+
+heltec_vision_master_t190.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=38 -DVision_Master_T190 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
+
+heltec_vision_master_t190.menu.EraseFlash.none=Disabled
+heltec_vision_master_t190.menu.EraseFlash.none.upload.erase_cmd=
+heltec_vision_master_t190.menu.EraseFlash.all=Enabled
+heltec_vision_master_t190.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+heltec_vision_master_e_213.name=Heltec Vision Master E213
+heltec_vision_master_e_213.vid.0=0x303a
+heltec_vision_master_e_213.pid.0=0x1001
+
+heltec_vision_master_e_213.bootloader.tool=esptool_py
+heltec_vision_master_e_213.bootloader.tool.default=esptool_py
+
+heltec_vision_master_e_213.upload.tool=esptool_py
+heltec_vision_master_e_213.upload.tool.default=esptool_py
+heltec_vision_master_e_213.upload.tool.network=esp_ota
+
+heltec_vision_master_e_213.upload.maximum_size=3342336
+heltec_vision_master_e_213.upload.maximum_data_size=327680
+heltec_vision_master_e_213.upload.flags=
+heltec_vision_master_e_213.upload.extra_flags=
+heltec_vision_master_e_213.upload.use_1200bps_touch=false
+heltec_vision_master_e_213.upload.wait_for_upload_port=false
+
+heltec_vision_master_e_213.serial.disableDTR=false
+heltec_vision_master_e_213.serial.disableRTS=false
+
+heltec_vision_master_e_213.build.tarch=xtensa
+heltec_vision_master_e_213.build.bootloader_addr=0x0
+heltec_vision_master_e_213.build.target=esp32s3
+heltec_vision_master_e_213.build.mcu=esp32s3
+heltec_vision_master_e_213.build.core=esp32
+heltec_vision_master_e_213.build.variant=heltec_vision_master_e_213
+heltec_vision_master_e_213.build.board=Heltec_Vision_Master_E_213
+
+heltec_vision_master_e_213.build.usb_mode=1
+heltec_vision_master_e_213.build.cdc_on_boot=0
+heltec_vision_master_e_213.build.msc_on_boot=0
+heltec_vision_master_e_213.build.dfu_on_boot=0
+heltec_vision_master_e_213.build.f_cpu=240000000L
+heltec_vision_master_e_213.build.flash_size=8MB
+heltec_vision_master_e_213.build.flash_freq=80m
+heltec_vision_master_e_213.build.flash_mode=dio
+heltec_vision_master_e_213.build.boot=qio
+heltec_vision_master_e_213.build.boot_freq=80m
+heltec_vision_master_e_213.build.partitions=default_8MB
+heltec_vision_master_e_213.build.loop_core=
+heltec_vision_master_e_213.build.event_core=
+heltec_vision_master_e_213.build.psram_type=qspi
+heltec_vision_master_e_213.build.memory_type={build.boot}_{build.psram_type}
+
+heltec_vision_master_e_213.menu.LoopCore.1=Core 1
+heltec_vision_master_e_213.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+heltec_vision_master_e_213.menu.LoopCore.0=Core 0
+heltec_vision_master_e_213.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+heltec_vision_master_e_213.menu.EventsCore.1=Core 1
+heltec_vision_master_e_213.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+heltec_vision_master_e_213.menu.EventsCore.0=Core 0
+heltec_vision_master_e_213.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+heltec_vision_master_e_213.menu.USBMode.hwcdc=Hardware CDC and JTAG
+heltec_vision_master_e_213.menu.USBMode.hwcdc.build.usb_mode=1
+heltec_vision_master_e_213.menu.USBMode.default=USB-OTG (TinyUSB)
+heltec_vision_master_e_213.menu.USBMode.default.build.usb_mode=0
+
+heltec_vision_master_e_213.menu.CDCOnBoot.default=Enabled
+heltec_vision_master_e_213.menu.CDCOnBoot.default.build.cdc_on_boot=1
+heltec_vision_master_e_213.menu.CDCOnBoot.cdc=Disabled
+heltec_vision_master_e_213.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+heltec_vision_master_e_213.menu.MSCOnBoot.default=Disabled
+heltec_vision_master_e_213.menu.MSCOnBoot.default.build.msc_on_boot=0
+heltec_vision_master_e_213.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+heltec_vision_master_e_213.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+heltec_vision_master_e_213.menu.DFUOnBoot.default=Disabled
+heltec_vision_master_e_213.menu.DFUOnBoot.default.build.dfu_on_boot=0
+heltec_vision_master_e_213.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+heltec_vision_master_e_213.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+heltec_vision_master_e_213.menu.UploadMode.default=UART0 / Hardware CDC
+heltec_vision_master_e_213.menu.UploadMode.default.upload.use_1200bps_touch=false
+heltec_vision_master_e_213.menu.UploadMode.default.upload.wait_for_upload_port=false
+heltec_vision_master_e_213.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+heltec_vision_master_e_213.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+heltec_vision_master_e_213.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+heltec_vision_master_e_213.menu.CPUFreq.240=240MHz (WiFi)
+heltec_vision_master_e_213.menu.CPUFreq.240.build.f_cpu=240000000L
+heltec_vision_master_e_213.menu.CPUFreq.160=160MHz (WiFi)
+heltec_vision_master_e_213.menu.CPUFreq.160.build.f_cpu=160000000L
+heltec_vision_master_e_213.menu.CPUFreq.80=80MHz (WiFi)
+heltec_vision_master_e_213.menu.CPUFreq.80.build.f_cpu=80000000L
+heltec_vision_master_e_213.menu.CPUFreq.40=40MHz
+heltec_vision_master_e_213.menu.CPUFreq.40.build.f_cpu=40000000L
+heltec_vision_master_e_213.menu.CPUFreq.20=20MHz
+heltec_vision_master_e_213.menu.CPUFreq.20.build.f_cpu=20000000L
+heltec_vision_master_e_213.menu.CPUFreq.10=10MHz
+heltec_vision_master_e_213.menu.CPUFreq.10.build.f_cpu=10000000L
+
+heltec_vision_master_e_213.menu.UploadSpeed.921600=921600
+heltec_vision_master_e_213.menu.UploadSpeed.921600.upload.speed=921600
+heltec_vision_master_e_213.menu.UploadSpeed.115200=115200
+heltec_vision_master_e_213.menu.UploadSpeed.115200.upload.speed=115200
+heltec_vision_master_e_213.menu.UploadSpeed.256000.windows=256000
+heltec_vision_master_e_213.menu.UploadSpeed.256000.upload.speed=256000
+heltec_vision_master_e_213.menu.UploadSpeed.230400.windows.upload.speed=256000
+heltec_vision_master_e_213.menu.UploadSpeed.230400=230400
+heltec_vision_master_e_213.menu.UploadSpeed.230400.upload.speed=230400
+heltec_vision_master_e_213.menu.UploadSpeed.460800.linux=460800
+heltec_vision_master_e_213.menu.UploadSpeed.460800.macosx=460800
+heltec_vision_master_e_213.menu.UploadSpeed.460800.upload.speed=460800
+heltec_vision_master_e_213.menu.UploadSpeed.512000.windows=512000
+heltec_vision_master_e_213.menu.UploadSpeed.512000.upload.speed=512000
+
+heltec_vision_master_e_213.menu.DebugLevel.none=None
+heltec_vision_master_e_213.menu.DebugLevel.none.build.code_debug=0
+heltec_vision_master_e_213.menu.DebugLevel.error=Error
+heltec_vision_master_e_213.menu.DebugLevel.error.build.code_debug=1
+heltec_vision_master_e_213.menu.DebugLevel.warn=Warn
+heltec_vision_master_e_213.menu.DebugLevel.warn.build.code_debug=2
+heltec_vision_master_e_213.menu.DebugLevel.info=Info
+heltec_vision_master_e_213.menu.DebugLevel.info.build.code_debug=3
+heltec_vision_master_e_213.menu.DebugLevel.debug=Debug
+heltec_vision_master_e_213.menu.DebugLevel.debug.build.code_debug=4
+heltec_vision_master_e_213.menu.DebugLevel.verbose=Verbose
+heltec_vision_master_e_213.menu.DebugLevel.verbose.build.code_debug=5
+
+heltec_vision_master_e_213.menu.LORAWAN_REGION.0=REGION_EU868
+heltec_vision_master_e_213.menu.LORAWAN_REGION.0.build.band=REGION_EU868
+heltec_vision_master_e_213.menu.LORAWAN_REGION.1=REGION_EU433
+heltec_vision_master_e_213.menu.LORAWAN_REGION.1.build.band=REGION_EU433
+heltec_vision_master_e_213.menu.LORAWAN_REGION.2=REGION_CN470
+heltec_vision_master_e_213.menu.LORAWAN_REGION.2.build.band=REGION_CN470
+heltec_vision_master_e_213.menu.LORAWAN_REGION.3=REGION_US915
+heltec_vision_master_e_213.menu.LORAWAN_REGION.3.build.band=REGION_US915
+heltec_vision_master_e_213.menu.LORAWAN_REGION.4=REGION_AU915
+heltec_vision_master_e_213.menu.LORAWAN_REGION.4.build.band=REGION_AU915
+heltec_vision_master_e_213.menu.LORAWAN_REGION.5=REGION_CN779
+heltec_vision_master_e_213.menu.LORAWAN_REGION.5.build.band=REGION_CN779
+heltec_vision_master_e_213.menu.LORAWAN_REGION.6=REGION_AS923
+heltec_vision_master_e_213.menu.LORAWAN_REGION.6.build.band=REGION_AS923
+heltec_vision_master_e_213.menu.LORAWAN_REGION.7=REGION_KR920
+heltec_vision_master_e_213.menu.LORAWAN_REGION.7.build.band=REGION_KR920
+heltec_vision_master_e_213.menu.LORAWAN_REGION.8=REGION_IN865
+heltec_vision_master_e_213.menu.LORAWAN_REGION.8.build.band=REGION_IN865
+heltec_vision_master_e_213.menu.LORAWAN_REGION.9=REGION_US915_HYBRID
+heltec_vision_master_e_213.menu.LORAWAN_REGION.9.build.band=REGION_US915_HYBRID
+
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.0=None
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.0.build.LoRaWanDebugLevel=0
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.1=Freq
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.1.build.LoRaWanDebugLevel=1
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.2=Freq && DIO
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.2.build.LoRaWanDebugLevel=2
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.3=Freq && DIO && PW
+heltec_vision_master_e_213.menu.LoRaWanDebugLevel.3.build.LoRaWanDebugLevel=3
+
+heltec_vision_master_e_213.menu.LORAWAN_DEVEUI.0=CUSTOM
+heltec_vision_master_e_213.menu.LORAWAN_DEVEUI.0.build.LORAWAN_DEVEUI_AUTO=0
+heltec_vision_master_e_213.menu.LORAWAN_DEVEUI.1=Generate By ChipID
+heltec_vision_master_e_213.menu.LORAWAN_DEVEUI.1.build.LORAWAN_DEVEUI_AUTO=1
+
+heltec_vision_master_e_213.menu.LORAWAN_PREAMBLE_LENGTH.0=8(default)
+heltec_vision_master_e_213.menu.LORAWAN_PREAMBLE_LENGTH.0.build.LORAWAN_PREAMBLE_LENGTH=8
+heltec_vision_master_e_213.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
+heltec_vision_master_e_213.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
+
+heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.0=Internal (default)
+heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.0.build.SLOW_CLK_TPYE=0
+heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.1=External 32K
+heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
+
+heltec_vision_master_e_213.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=36 -DVision_Master_E_213 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
+
+heltec_vision_master_e_213.menu.EraseFlash.none=Disabled
+heltec_vision_master_e_213.menu.EraseFlash.none.upload.erase_cmd=
+heltec_vision_master_e_213.menu.EraseFlash.all=Enabled
+heltec_vision_master_e_213.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 espectro32.name=ESPectro32
 
 espectro32.bootloader.tool=esptool_py

--- a/variants/heltec_vision_master_e290/pins_arduino.h
+++ b/variants/heltec_vision_master_e290/pins_arduino.h
@@ -1,0 +1,72 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define Vision_Master_E290 true
+#define DISPLAY_HEIGHT 128
+#define DISPLAY_WIDTH  296
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 39;
+static const uint8_t SCL = 38;
+
+static const uint8_t SS    = 8;
+static const uint8_t MOSI  = 10;
+static const uint8_t MISO  = 11;
+static const uint8_t SCK   = 9;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+static const uint8_t Vext = 18;
+static const uint8_t Eink_SDI = 1;
+static const uint8_t Eink_CLK = 2;
+static const uint8_t Eink_CS = 3;
+static const uint8_t Eink_DC = 4;
+static const uint8_t Eink_RST = 5;
+static const uint8_t Eink_BUSY = 6;
+
+static const uint8_t RST_LoRa = 12;
+static const uint8_t BUSY_LoRa = 13;
+static const uint8_t DIO0 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/heltec_vision_master_e290/pins_arduino.h
+++ b/variants/heltec_vision_master_e290/pins_arduino.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 #define Vision_Master_E290 true
-#define DISPLAY_HEIGHT 128
-#define DISPLAY_WIDTH  296
+#define DISPLAY_HEIGHT     128
+#define DISPLAY_WIDTH      296
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
@@ -16,10 +16,10 @@ static const uint8_t RX = 44;
 static const uint8_t SDA = 39;
 static const uint8_t SCL = 38;
 
-static const uint8_t SS    = 8;
-static const uint8_t MOSI  = 10;
-static const uint8_t MISO  = 11;
-static const uint8_t SCK   = 9;
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 10;
+static const uint8_t MISO = 11;
+static const uint8_t SCK = 9;
 
 static const uint8_t A0 = 1;
 static const uint8_t A1 = 2;

--- a/variants/heltec_vision_master_e_213/pins_arduino.h
+++ b/variants/heltec_vision_master_e_213/pins_arduino.h
@@ -1,0 +1,72 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define Vision_Master_E213 true
+#define DISPLAY_HEIGHT 122
+#define DISPLAY_WIDTH  250
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 39;
+static const uint8_t SCL = 38;
+
+static const uint8_t SS    = 8;
+static const uint8_t MOSI  = 10;
+static const uint8_t MISO  = 11;
+static const uint8_t SCK   = 9;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+static const uint8_t Vext = 18;
+static const uint8_t Eink_BUSY = 1;
+static const uint8_t Eink_DC = 2;
+static const uint8_t Eink_RST = 3;
+static const uint8_t Eink_CLK = 4;
+static const uint8_t Eink_CS = 5;
+static const uint8_t Eink_SDI = 6;
+
+static const uint8_t RST_LoRa = 12;
+static const uint8_t BUSY_LoRa = 13;
+static const uint8_t DIO0 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/heltec_vision_master_e_213/pins_arduino.h
+++ b/variants/heltec_vision_master_e_213/pins_arduino.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 #define Vision_Master_E213 true
-#define DISPLAY_HEIGHT 122
-#define DISPLAY_WIDTH  250
+#define DISPLAY_HEIGHT     122
+#define DISPLAY_WIDTH      250
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
@@ -16,10 +16,10 @@ static const uint8_t RX = 44;
 static const uint8_t SDA = 39;
 static const uint8_t SCL = 38;
 
-static const uint8_t SS    = 8;
-static const uint8_t MOSI  = 10;
-static const uint8_t MISO  = 11;
-static const uint8_t SCK   = 9;
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 10;
+static const uint8_t MISO = 11;
+static const uint8_t SCK = 9;
 
 static const uint8_t A0 = 1;
 static const uint8_t A1 = 2;

--- a/variants/heltec_vision_master_t190/pins_arduino.h
+++ b/variants/heltec_vision_master_t190/pins_arduino.h
@@ -1,0 +1,71 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define Vision_Master_T190 true
+#define DISPLAY_HEIGHT 170
+#define DISPLAY_WIDTH  320
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 2;
+static const uint8_t SCL = 1;
+
+static const uint8_t SS    = 8;
+static const uint8_t MOSI  = 10;
+static const uint8_t MISO  = 11;
+static const uint8_t SCK   = 9;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+static const uint8_t Vext = 5;
+static const uint8_t TFT_SCL = 38;
+static const uint8_t TFT_CS = 39;
+static const uint8_t TFT_RST = 40;
+static const uint8_t TFT_RS = 47;
+static const uint8_t TFT_SDA = 48;
+
+static const uint8_t RST_LoRa = 12;
+static const uint8_t BUSY_LoRa = 13;
+static const uint8_t DIO0 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/heltec_vision_master_t190/pins_arduino.h
+++ b/variants/heltec_vision_master_t190/pins_arduino.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 #define Vision_Master_T190 true
-#define DISPLAY_HEIGHT 170
-#define DISPLAY_WIDTH  320
+#define DISPLAY_HEIGHT     170
+#define DISPLAY_WIDTH      320
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001
@@ -16,10 +16,10 @@ static const uint8_t RX = 44;
 static const uint8_t SDA = 2;
 static const uint8_t SCL = 1;
 
-static const uint8_t SS    = 8;
-static const uint8_t MOSI  = 10;
-static const uint8_t MISO  = 11;
-static const uint8_t SCK   = 9;
+static const uint8_t SS = 8;
+static const uint8_t MOSI = 10;
+static const uint8_t MISO = 11;
+static const uint8_t SCK = 9;
 
 static const uint8_t A0 = 1;
 static const uint8_t A1 = 2;


### PR DESCRIPTION
Add the new series of development boards launched by Heltec.
Based on the ESP32-S3R8 chip, it integrates displays with various functions and is paired with LoRa modules as an option, allowing users to choose different options for different situations.

[Vision Master E213](https://heltec.org/project/vision-master-e213/)
[Vision Master E290](https://heltec.org/project/vision-master-e290/)
[Vision Master T190](https://heltec.org/project/vision-master-t190/)