### PR TITLE
Corrected parameter of mbedtls_aes_crypt_ecb in _decryptBuffer() of Updater.cpp

### DIFF
--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -328,7 +328,7 @@ bool UpdateClass::_decryptBuffer() {
         return false;
       }
     }
-    if (mbedtls_aes_crypt_ecb(&ctx, MBEDTLS_AES_ENCRYPT, _cryptBuffer, _cryptBuffer)) {  //use MBEDTLS_AES_ENCRYPT to decrypt flash code
+    if (mbedtls_aes_crypt_ecb(&ctx, MBEDTLS_AES_DECRYPT, _cryptBuffer, _cryptBuffer)) {  //use MBEDTLS_AES_DECRYPT to decrypt flash code
       return false;
     }
     for (int i = 0; i < ENCRYPTED_BLOCK_SIZE; i++) {


### PR DESCRIPTION
-----------
## Description of Change
Changed the parameter `MBEDTLS_AES_ENCRYPT` to `MBEDTLS_AES_DECRYPT` for the function `mbedtls_aes_crypt_ecb` in the method `_decryptBuffer()`. This change can affect anyone who currently uses the decryption functionality of the `Update.h` library.

I hope this helps, or that my understanding is corrected, thanks!

## Tests scenarios
As described in my [Issue](https://github.com/espressif/arduino-esp32/issues/10205#issue-2474339069):

-  Board: ESP32-S3-DevKitC-1 v1.0
- Version: 3.0.4
- IDE: PlatformIO
- Operating System: Windows 11

#### Description
A slightly modified version of the example sketch "OTAWebUpdater" to include 
```
const uint8_t key[32] = {/* PUT YOUR KEY HERE */};
Update.setupCrypt(key, 0, 0, U_AES_DECRYPT_ON);
```

## Related links

- [Issue opened](https://github.com/espressif/arduino-esp32/issues/10205#issue-2474339069), will be closed by this PR
- Corrected branch name from previous [pull request](https://github.com/espressif/arduino-esp32/pull/10207#issue-2474413280)