### PR TITLE
ci(branches): Remove wildcard from branch triggers

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-    - release/*
+    - release/v2.x
     paths:
     - 'docs/**'
     - '.github/workflows/docs_build.yml'

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
   push:
     branches:
-    - release/*
+    - release/v2.x
     - master
     paths:
     - 'docs/**'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - master
-    - release/*
+    - release/v2.x
   pull_request:
     paths:
       - 'cores/**'


### PR DESCRIPTION
## Description of Change
Remove wildcard from branch triggers.
This will avoid triggering twice for some branches while testing. These branches can be later added to the triggers.
