### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-0526c35e"
+              "version": "idf-release_v5.3-0bbd7281"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-0526c35e",
+          "version": "idf-release_v5.3-0bbd7281",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
-              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
-              "size": "318864105"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
+              "checksum": "SHA-256:15e6a36d17f19b38dbdce87dfdc531f3951d4af004a77576fa50dd058a479561",
+              "size": "318962004"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-466a392a"
+              "version": "idf-release_v5.3-0526c35e"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-466a392a",
+          "version": "idf-release_v5.3-0526c35e",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-466a392a.zip",
-              "checksum": "SHA-256:8c2d36bd4be5b6a9446efd3c2b2f93f544f4b2a22dab23c4991aec5711c72884",
-              "size": "318864212"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0526c35e.zip",
+              "checksum": "SHA-256:ee92174bb507a687328e47e103fe6e5c0787a847376163db676a55c432713c3b",
+              "size": "318864105"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.3 807bddb
esp-idf: release/v5.3 0526c35ec3
arduino: release/v3.1.x c7e01e72
tinyusb: master 5f519819b
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.1
espressif__esp-zigbee-lib: 1.4.1
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.4.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.3.2
espressif__network_provisioning: 1.0.0
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dl:
espressif__esp32-camera:
espressif__esp-sr: 1.9.0
```
