### PR TITLE
change(build): add -Werror=return-type to default C and C++ flags

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -46,10 +46,14 @@ compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall
 compiler.warning_flags.all=-Wall -Wextra
 
+# Additional flags specific to Arduino (not based on IDF flags).
+# Update tools/platformio-build.py when changing these flags.
+compiler.common_werror_flags=-Werror=return-type
+
 # Compile Flags
 compiler.cpreprocessor.flags="@{compiler.sdk.path}/flags/defines" "-I{build.source.path}" -iprefix "{compiler.sdk.path}/include/" "@{compiler.sdk.path}/flags/includes" "-I{compiler.sdk.path}/{build.memory_type}/include"
-compiler.c.flags="@{compiler.sdk.path}/flags/c_flags" {compiler.warning_flags} {compiler.optimization_flags}
-compiler.cpp.flags="@{compiler.sdk.path}/flags/cpp_flags" {compiler.warning_flags} {compiler.optimization_flags}
+compiler.c.flags="@{compiler.sdk.path}/flags/c_flags" {compiler.warning_flags} {compiler.optimization_flags} {compiler.common_werror_flags}
+compiler.cpp.flags="@{compiler.sdk.path}/flags/cpp_flags" {compiler.warning_flags} {compiler.optimization_flags} {compiler.common_werror_flags}
 compiler.S.flags="@{compiler.sdk.path}/flags/S_flags" {compiler.warning_flags} {compiler.optimization_flags}
 compiler.c.elf.flags="@{compiler.sdk.path}/flags/ld_flags" "@{compiler.sdk.path}/flags/ld_scripts"
 compiler.c.elf.libs="@{compiler.sdk.path}/flags/ld_libs"

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -165,6 +165,15 @@ SConscript(
 )
 
 #
+# Additional flags specific to Arduino core (not based on IDF)
+#
+
+env.Append(
+    CFLAGS=["-Werror=return-type"],
+    CXXFLAGS=["-Werror=return-type"],
+)
+
+#
 # Target: Build Core Library
 #
 


### PR DESCRIPTION
## Description of Change

`-Werror=return-type` should help catch potential causes of run-time UB.

See https://github.com/esp8266/Arduino/discussions/8160 for the original issue report.

This flag has been:
- added in esp8266/Arduino for all IDE warning levels in 2021: https://github.com/esp8266/Arduino/pull/8165
- already used in ESP-IDF at its default warning/error setting (-Wall -Werror, https://github.com/espressif/esp-idf/issues/8244#issuecomment-1014690475)
- accepted in principle in arduino-esp32 in https://github.com/esp8266/Arduino/pull/8165#issuecomment-867410223
- submitted in a PR in https://github.com/espressif/arduino-esp32/pull/5321, which was closed
- requested in https://github.com/espressif/arduino-esp32/issues/5867#issuecomment-1937769823

## Tests scenarios

1. Compiled test.ino:
   ```c++
   void setup(){}
   void loop(){}
   int shouldreturn(){}
   ```
   
   Resulted in, at "Default" warnings level:
   ```
   /private/var/folders/3x/0ct1xt4n12jd90qfl3z4fp8m0000gn/T/.arduinoIDE-unsaved2024721-55698-dqoy19.1q5zo/sketch_aug21a/sketch_aug21a.ino: In function 'int shouldreturn()':
   /private/var/folders/3x/0ct1xt4n12jd90qfl3z4fp8m0000gn/T/.arduinoIDE-unsaved2024721-55698-dqoy19.1q5zo/sketch_aug21a/sketch_aug21a.ino:3:23: error: no return statement in function returning non-void [-Werror=return-type]
       3 |    int shouldreturn(){}
         |                       ^
   cc1plus: some warnings being treated as errors
   
   exit status 1
   
   Compilation error: no return statement in function returning non-void [-Werror=return-type]
   ```
   
2. At "None" warnings level, compilation is successful.
3. Same code, compiled in a .c file instead of .ino

   ```
   /private/var/folders/3x/0ct1xt4n12jd90qfl3z4fp8m0000gn/T/.arduinoIDE-unsaved2024721-55698-dqoy19.1q5zo/sketch_aug21a/1.c: In function 'shouldreturn':
   /private/var/folders/3x/0ct1xt4n12jd90qfl3z4fp8m0000gn/T/.arduinoIDE-unsaved2024721-55698-dqoy19.1q5zo/sketch_aug21a/1.c:3:23: error: control reaches end of non-void function [-Werror=return-type]
       3 |    int shouldreturn(){}
         |                       ^
   cc1: some warnings being treated as errors

   exit status 1

   Compilation error: control reaches end of non-void function [-Werror=return-type]
   ```

## Additional considerations

In esp8266/Arduino, special care is taken so that this flag is not disabled when "None" warnings level is selected in the IDE (see [this](https://github.com/esp8266/Arduino/blob/master/tools/warnings/README.md) and [this](https://github.com/esp8266/Arduino/blob/master/tools/warnings/none-cppflags)). However,

1. this would be more difficult to implement in arduino-esp32, since part of the warning flags are taking from IDF, hence generating this list would require changes in the lib builder
2. a point can be made that there should be a way to still compile code with this warning, if it somehow used to work. In other words, I would like to avoid making this a complete showstopper to somebody upgrading to a new version of Arduino core who happens to have this bug in one of their dependencies.

So I kept the simpler behavior that this warning doesn't occur when "None" warnings level is selected.

## Related links

Closes https://github.com/espressif/arduino-esp32/issues/5867