### PR TITLE
fix(tests): Use proper API and check for required token

### DIFF
--- a/.github/scripts/tests_run.sh
+++ b/.github/scripts/tests_run.sh
@@ -132,6 +132,10 @@ while [ ! -z "$1" ]; do
     -W )
         shift
         wokwi_timeout=$1
+        if [[ -z $WOKWI_CLI_TOKEN ]]; then
+            echo "Wokwi CLI token is not set"
+            exit 1
+        fi
         platform="wokwi"
         ;;
     -o )

--- a/tests/validation/democfg/test_democfg.py
+++ b/tests/validation/democfg/test_democfg.py
@@ -1,2 +1,2 @@
 def test_cfg(dut):
-    dut.expect("Hello cfg!")
+    dut.expect_exact("Hello cfg!")

--- a/tests/validation/hello_world/test_hello_world.py
+++ b/tests/validation/hello_world/test_hello_world.py
@@ -1,2 +1,2 @@
 def test_hello_world(dut):
-    dut.expect("Hello Arduino!")
+    dut.expect_exact("Hello Arduino!")

--- a/tests/validation/nvs/test_nvs.py
+++ b/tests/validation/nvs/test_nvs.py
@@ -1,4 +1,4 @@
 def test_nvs(dut):
-    dut.expect("Current counter value: 0")
-    dut.expect("Current counter value: 1")
-    dut.expect("Current counter value: 2")
+    dut.expect_exact("Current counter value: 0")
+    dut.expect_exact("Current counter value: 1")
+    dut.expect_exact("Current counter value: 2")


### PR DESCRIPTION
## Description of Change

Fix using `expect` (regex) instead of `expect_exact` (string) in tests.
Also check for `WOKWI_CLI_TOKEN` before running Wokwi tests

## Tests scenarios

Tested locally

