### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-c608177cf9"
+              "version": "idf-release_v5.1-d38afc77"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-c608177cf9",
+          "version": "idf-release_v5.1-d38afc77",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://codeload.github.com/espressif/esp32-arduino-libs/zip/7b015a59844d511b72663a266e5793fb98eecaa1",
-              "archiveFileName": "esp32-arduino-libs-7b015a59844d511b72663a266e5793fb98eecaa1.zip",
-              "checksum": "SHA-256:392c411dc6b8253a3d067fda6c41a3f67ade2f99259a1a707630568e8f80f055",
-              "size": "310235817"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
+              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
+              "size": "308243283"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-d38afc77"
+              "version": "idf-release_v5.1-e026fd1f"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-d38afc77",
+          "version": "idf-release_v5.1-e026fd1f",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-d38afc77.zip",
-              "checksum": "SHA-256:ab6659cf32833ab503de31d5b4ecd77979edf5e98c0104b456d70636c393b5c4",
-              "size": "308243283"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e026fd1f.zip",
+              "checksum": "SHA-256:b8cfce1f6de978684a04f9a368eea82a3b33dacf88bf87ae5ab215807bffd382",
+              "size": "308352144"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master a93dd64
esp-idf: release/v5.1 e026fd1f81
arduino: idf-release/v5.1 b951c8de
tinyusb: master 4485bffd1
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.4.1
espressif__esp-zigbee-lib: 1.4.1
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.4.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.0
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dl:
espressif__esp-sr: 1.9.0
espressif__esp32-camera:
```
