### PR TITLE
docs(vale): Enable vale, fix errors and misspellings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,8 @@
 exclude: |
   (?x)(
       ^\.github\/|
-      ^tests\/performance\/coremark\/.*\.[ch]$
+      ^tests\/performance\/coremark\/.*\.[ch]$|
+      LICENSE\.md$
   )
 
 default_language_version:
@@ -64,8 +65,6 @@ repos:
         pass_filenames: false
         args: [sync]
         types_or: [markdown, rst]
-        stages: [manual]
       - id: vale
         language_version: "1.21.6"
         types_or: [markdown, rst]
-        stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ exclude: |
   (?x)(
       ^\.github\/|
       ^tests\/performance\/coremark\/.*\.[ch]$|
+      ^tests\/performance\/superpi\/.*\.(cpp|h)$|
       LICENSE\.md$
   )
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -23,7 +23,7 @@ StylesPath = .vale/styles
 
 
 # Specify the minimum alert severity that Vale will report.
-MinAlertLevel = suggestion # "suggestion", "warning", or "error"
+MinAlertLevel = error # "suggestion", "warning", or "error"
 
 
 # Specify vocabulary for special treatment.

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -443,7 +443,7 @@ size_t HWCDC::write(const uint8_t *buffer, size_t size) {
       if (connected) {
         usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
       }
-      // tracks CDC trasmission progress to avoid hanging if CDC is unplugged while still sending data
+      // tracks CDC transmission progress to avoid hanging if CDC is unplugged while still sending data
       size_t last_toSend = to_send;
       uint32_t tries = tx_timeout_ms;  // waits 1ms per sending data attempt, in case CDC is unplugged
       while (connected && to_send) {
@@ -479,7 +479,7 @@ size_t HWCDC::write(const uint8_t *buffer, size_t size) {
         }
       }
     }
-    // CDC was diconnected while sending data ==> flush the TX buffer keeping the last data
+    // CDC was disconnected while sending data ==> flush the TX buffer keeping the last data
     if (to_send && !usb_serial_jtag_ll_txfifo_writable()) {
       connected = false;
       flushTXBuffer(buffer + so_far, to_send);

--- a/docs/en/api/adc.rst
+++ b/docs/en/api/adc.rst
@@ -53,7 +53,7 @@ analogReadResolution
 ^^^^^^^^^^^^^^^^^^^^
 
 This function is used to set the resolution of ``analogRead`` return value. Default is 12 bits (range from 0 to 4095)
-for all chips except ESP32S3 where default is 13 bits (range from 0 to 8191).
+for all chips except ESP32-S3 where default is 13 bits (range from 0 to 8191).
 When different resolution is set, the values read will be shifted to match the given resolution.
 
 Range is 1 - 16 .The default value will be used, if this function is not used.
@@ -146,7 +146,7 @@ analogSetWidth
 .. note:: This function is only available for ESP32 chip.
 
 This function is used to set the hardware sample bits and read resolution.
-Default is 12bit (0 - 4095).
+Default is 12 bits (0 - 4095).
 Range is 9 - 12.
 
 .. code-block:: arduino
@@ -250,13 +250,13 @@ This function is used to set the attenuation for ADC continuous peripheral. For 
 
     void analogContinuousSetAtten(adc_attenuation_t attenuation);
 
-* ``attenuation`` sets the attenuation (default is 11db).
+* ``attenuation`` sets the attenuation (default is 11 dB).
 
 analogContinuousSetWidth
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 This function is used to set the hardware resolution bits.
-Default value for all chips is 12bit (0 - 4095).
+Default value for all chips is 12 bits (0 - 4095).
 
 .. note:: This function will take effect only for ESP32 chip, as it allows to set resolution in range 9-12 bits.
 

--- a/docs/en/api/dac.rst
+++ b/docs/en/api/dac.rst
@@ -33,7 +33,7 @@ This function is used to set the DAC value for a given pin/DAC channel.
     void dacWrite(uint8_t pin, uint8_t value);
 
 * ``pin`` GPIO pin.
-* ``value`` to be set. Range is 0 - 255 (equals 0V - 3.3V).
+* ``value`` to be set. Range is 0 - 255 (equals 0 V - 3.3 V).
 
 dacDisable
 **********

--- a/docs/en/api/espnow.rst
+++ b/docs/en/api/espnow.rst
@@ -104,7 +104,7 @@ Create an instance of the `ESP_NOW_Peer` class.
 
 * ``mac_addr``: MAC address of the peer device.
 * ``channel``: Communication channel.
-* ``iface``: WiFi interface.
+* ``iface``: Wi-Fi interface.
 * ``lmk``: Optional. Pass the local master key (LMK) if encryption is enabled.
 
 add
@@ -190,24 +190,24 @@ Set the communication channel of the peer.
 getInterface
 ^^^^^^^^^^^^
 
-Get the WiFi interface of the peer.
+Get the Wi-Fi interface of the peer.
 
 .. code-block:: cpp
 
     wifi_interface_t getInterface() const;
 
-Returns the WiFi interface.
+Returns the Wi-Fi interface.
 
 setInterface
 ^^^^^^^^^^^^
 
-Set the WiFi interface of the peer.
+Set the Wi-Fi interface of the peer.
 
 .. code-block:: cpp
 
     void setInterface(wifi_interface_t iface);
 
-* ``iface``: WiFi interface.
+* ``iface``: Wi-Fi interface.
 
 isEncrypted
 ^^^^^^^^^^^

--- a/docs/en/api/i2c.rst
+++ b/docs/en/api/i2c.rst
@@ -103,7 +103,7 @@ This function will return the current frequency configuration.
 setTimeOut
 ^^^^^^^^^^
 
-Set the bus timeout given in milliseconds. The default value is 50ms.
+Set the bus timeout given in milliseconds. The default value is 50 ms.
 
 .. code-block:: arduino
 

--- a/docs/en/api/insights.rst
+++ b/docs/en/api/insights.rst
@@ -5,7 +5,7 @@ ESP Insights
 About
 -----
 
-ESP Insights is a remote diagnostics solution that allows users to remotely monitor the health of ESP devices in the field.
+ESP Insights is a remote diagnostics solution that allows users to remotely monitor the health of Espressif devices in the field.
 
 Developers normally prefer debugging issues by physically probing them using gdb or observing the logs. This surely helps debug issues, but there are often cases wherein issues are seen only in specific environments under specific conditions. Even things like casings and placement of the product can affect the behavior. A few examples are
 
@@ -156,8 +156,8 @@ This function will return
 Insights.metrics.dumpWiFi
 *************************
 
-Dumps the wifi metrics and prints them to the console.
-This API can be used to collect wifi metrics at any given point in time.
+Dumps the Wi-Fi metrics and prints them to the console.
+This API can be used to collect Wi-Fi metrics at any given point in time.
 
 .. code-block:: arduino
 
@@ -185,8 +185,8 @@ Insights.metrics.setWiFiPeriod
 ******************************
 
 Reset the periodic interval
-By default, wifi metrics are collected every 30 seconds, this function can be used to change the interval.
-If the interval is set to 0, wifi metrics collection disabled.
+By default, Wi-Fi metrics are collected every 30 seconds, this function can be used to change the interval.
+If the interval is set to 0, Wi-Fi metrics collection disabled.
 
 .. code-block:: arduino
 

--- a/docs/en/api/rainmaker.rst
+++ b/docs/en/api/rainmaker.rst
@@ -29,7 +29,7 @@ ESP RainMaker Agent API
 RMaker.initNode
 ***************
 
-This initializes the ESP RainMaker agent, wifi and creates the node.
+This initializes the ESP RainMaker agent, Wi-Fi and creates the node.
 
 You can also set the configuration of the node using the following API
 
@@ -54,7 +54,7 @@ It starts the ESP RainMaker agent.
 **NOTE**:
 
 1. ESP RainMaker agent should be initialized before this call.
-2. Once ESP RainMaker agent starts, compulsorily call WiFi.beginProvision() API.
+2. Once ESP RainMaker agent starts, compulsorily call ``WiFi.beginProvision()`` API.
 
 .. code-block:: arduino
 

--- a/docs/en/api/touch.rst
+++ b/docs/en/api/touch.rst
@@ -36,7 +36,7 @@ touchSetCycles
 ^^^^^^^^^^^^^^
 
 This function is used to set cycles that measurement operation takes. The result from touchRead, threshold and detection accuracy depend on these values.
-The defaults are setting touchRead to take ~0.5ms.
+The defaults are setting touchRead to take ~0.5 ms.
 
 .. code-block:: arduino
 
@@ -112,8 +112,8 @@ the threshold value. Default is lower.
 
     void touchInterruptSetThresholdDirection(bool mustbeLower);
 
-TOUCH API specific for ESP32S2 and ESP32S3 chip (TOUCH_V2)
-**********************************************************
+TOUCH API specific for ESP32-S2 and ESP32-S3 chip (TOUCH_V2)
+************************************************************
 
 touchInterruptGetLastStatus
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/api/usb.rst
+++ b/docs/en/api/usb.rst
@@ -154,7 +154,7 @@ Get the USB power configuration.
 
     uint16_t usbPower(void);
 
-Return the current in mA. The default value is: ``0x500`` (500mA).
+Return the current in mA. The default value is: ``0x500`` (500 mA).
 
 usbClass
 ^^^^^^^^

--- a/docs/en/api/wifi.rst
+++ b/docs/en/api/wifi.rst
@@ -43,7 +43,7 @@ This is the mode to be used if you want to connect your project to the Internet.
 API Description
 ---------------
 
-Here is the description of the WiFi API.
+Here is the description of the Wi-Fi API.
 
 Common API
 ----------
@@ -53,7 +53,7 @@ Here are the common APIs that are used for both modes, AP and STA.
 onEvent (and removeEvent)
 *************************
 
-Registers a caller-supplied function to be called when WiFi events
+Registers a caller-supplied function to be called when Wi-Fi events
 occur. Several forms are available.
 
 Function pointer callback taking the event ID:
@@ -92,7 +92,7 @@ A similar set of functions are available to remove callbacks:
 
 In all cases, the subscribing function accepts an optional event type to
 invoke the callback only for that specific event; with the default
-``ARDUINO_EVENT_MAX``, the callback will be invoked for all WiFi events.
+``ARDUINO_EVENT_MAX``, the callback will be invoked for all Wi-Fi events.
 
 Any callback function is given the event type in a parameter.
 Some of the possible callback function formats also take an
@@ -141,9 +141,9 @@ may be retrieved:
 
 .. warning::
 
-    The ``setHostname()`` function must be called BEFORE WiFi is started with
+    The ``setHostname()`` function must be called BEFORE Wi-Fi is started with
     ``WiFi.begin()``, ``WiFi.softAP()``, ``WiFi.mode()``, or ``WiFi.run()``.
-    To change the name, reset WiFi with ``WiFi.mode(WIFI_MODE_NULL)``,
+    To change the name, reset Wi-Fi with ``WiFi.mode(WIFI_MODE_NULL)``,
     then proceed with ``WiFi.setHostname(...)`` and restart WiFi from scratch.
 
 useStaticBuffers
@@ -619,7 +619,7 @@ WiFiScan
 
 To perform the Wi-Fi scan for networks, you can use the following functions:
 
-Start scan WiFi networks available.
+Start scan Wi-Fi networks available.
 
 .. code-block:: arduino
 
@@ -637,7 +637,7 @@ Delete last scan result from RAM.
 
     void scanDelete();
 
-Loads all infos from a scanned wifi in to the ptr parameters.
+Loads all infos from a scanned Wi-Fi in to the ptr parameters.
 
 .. code-block:: arduino
 
@@ -648,7 +648,7 @@ To see how to use the ``WiFiScan``, take a look at the ``WiFiScan.ino`` or ``WiF
 Examples
 --------
 
-`Complete list of WiFi examples <https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFi/examples>`_.
+`Complete list of Wi-Fi examples <https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFi/examples>`_.
 
 .. _ap example:
 

--- a/docs/en/boards/ESP32-C3-DevKitM-1.rst
+++ b/docs/en/boards/ESP32-C3-DevKitM-1.rst
@@ -7,8 +7,8 @@ The ESP32-C3-DevKitM-1 development board is one of Espressif's official boards. 
 Specifications
 --------------
 
-- Small­ sized 2.4 GHz Wi­Fi (802.11 b/g/n) and Bluetooth® 5 module
-- Built around ESP32­C3 series of SoCs, RISC­V single­core microprocessor
+- Small sized 2.4 GHz Wi-Fi (802.11b/g/n) and Bluetooth® 5 module
+- Built around ESP32-C3 series of SoCs, RISC-V single-core microprocessor
 - 4 MB flash in chip package
 - 15 available GPIOs (module)
 - Peripherals
@@ -30,7 +30,7 @@ Specifications
         - 2 × 54-bit general-purpose timers
         - 3 × watchdog timers
         - 1 × 52-bit system timer
-- On­board PCB antenna or external antenna connector
+- Onboard PCB antenna or external antenna connector
 
 Header Block
 ------------
@@ -40,6 +40,9 @@ Header Block
 
 J1
 ^^^
+
+.. vale off
+
 ===  ====  ==========  ===================================
 No.  Name  Type [1]_   Function
 ===  ====  ==========  ===================================
@@ -59,6 +62,8 @@ No.  Name  Type [1]_   Function
 14   5V    P           5 V power supply
 15   GND   G           Ground
 ===  ====  ==========  ===================================
+
+.. vale on
 
 J3
 ^^^

--- a/docs/en/boards/ESP32-DevKitC-1.rst
+++ b/docs/en/boards/ESP32-DevKitC-1.rst
@@ -7,7 +7,7 @@ The `ESP32-DevKitC-1`_ development board is one of Espressif's official boards. 
 Specifications
 --------------
 
-- Wi-Fi 802.11 b/g/n (802.11n up to 150 Mbps)
+- Wi-Fi 802.11b/g/n (802.11n up to 150 Mbps)
 - Bluetooth v4.2 BR/EDR and BLE specification
 - Built around ESP32 series of SoCs
 - Integrated 4 MB SPI flash
@@ -28,7 +28,7 @@ Specifications
     - ADC
     - DAC
     - Two-Wire Automotive Interface (TWAI®, compatible with ISO11898-1)
-- On­board PCB antenna or external antenna connector
+- Onboard PCB antenna or external antenna connector
 
 Header Block
 ------------
@@ -38,6 +38,9 @@ Header Block
 
 J1
 ^^^
+
+.. vale off
+
 ===  ====  =====  ===================================
 No.  Name  Type   Function
 ===  ====  =====  ===================================
@@ -61,6 +64,8 @@ No.  Name  Type   Function
 18   IO11  I/O    GPIO11, CMD
 19   5V0   P      5 V power supply
 ===  ====  =====  ===================================
+
+.. vale on
 
 J3
 ^^^
@@ -110,7 +115,7 @@ Some of the GPIO's have important features during the booting process. Here is t
 ====  =========  =====================================================================  ============  ==============
 GPIO   Default    Function                                                               Pull-up       Pull-down
 ====  =========  =====================================================================  ============  ==============
-IO12  Pull-down  Voltage of Internal LDO (VDD_SDIO)                                     1V8           3V3
+IO12  Pull-down  Voltage of Internal LDO (VDD_SDIO)                                     1.8 V         3.3 V
 IO0   Pull-up    Booting Mode                                                           SPI Boot      Download Boot
 IO2   Pull-down  Booting Mode                                                           Don't Care    Download Boot
 IO15  Pull-up    Enabling/Disabling Log Print During Booting and Timing of SDIO Slave   U0TXD Active  U0TXD Silent

--- a/docs/en/boards/ESP32-S2-Saola-1.rst
+++ b/docs/en/boards/ESP32-S2-Saola-1.rst
@@ -7,7 +7,7 @@ The `ESP32-S2-Saola-1`_ development board is one of Espressif's official boards.
 Specifications
 --------------
 
-- Wi-Fi 802.11 b/g/n (802.11n up to 150 Mbps)
+- Wi-Fi 802.11b/g/n (802.11n up to 150 Mbps)
 - Built around ESP32-S2 series of SoCs Xtensa® single-core
 - Integrated 4 MB SPI flash
 - Integrated 2 MB PSRAM
@@ -28,7 +28,7 @@ Specifications
     - 1 × LCD interface (8-bit serial RGB/8080/6800), implemented using the hardware resources of SPI2
     - 1 × LCD interface (8/16/24-bit parallel), implemented using the hardware resources of I2S
     - 1 × TWAI® controller (compatible with ISO 11898-1)
-- On­board PCB antenna or external antenna connector
+- Onboard PCB antenna or external antenna connector
 
 Header Block
 ------------
@@ -38,6 +38,9 @@ Header Block
 
 J2
 ^^^
+
+.. vale off
+
 ===  ====  =====  ===================================
 No.  Name  Type   Function
 ===  ====  =====  ===================================
@@ -63,6 +66,8 @@ No.  Name  Type   Function
 20   5V0   P      5 V power supply
 21   GND   G      Ground
 ===  ====  =====  ===================================
+
+.. vale on
 
 J3
 ^^^
@@ -114,7 +119,7 @@ Some of the GPIO's have important features during the booting process. Here is t
 ====  =========  =====================================================================  ============  ==============
 GPIO   Default    Function                                                               Pull-up       Pull-down
 ====  =========  =====================================================================  ============  ==============
-IO45  Pull-down  Voltage of Internal LDO (VDD_SDIO)                                     1V8           3V3
+IO45  Pull-down  Voltage of Internal LDO (VDD_SDIO)                                     1.8 V         3.3 V
 IO0   Pull-up    Booting Mode                                                           SPI Boot      Download Boot
 IO46  Pull-down  Booting Mode                                                           Don't Care    Download Boot
 IO46  Pull-up    Enabling/Disabling Log Print During Booting and Timing of SDIO Slave   U0TXD Active  U0TXD Silent

--- a/docs/en/boards/generic.rst
+++ b/docs/en/boards/generic.rst
@@ -12,6 +12,9 @@ Header Block
 
 Header1
 ^^^^^^^
+
+.. vale off
+
 ===  ====  =====  ===================================
 No.  Name  Type   Function
 ===  ====  =====  ===================================
@@ -20,6 +23,8 @@ No.  Name  Type   Function
 3    5V0   P      5 V power supply
 4    GND   G      Ground
 ===  ====  =====  ===================================
+
+.. vale on
 
 Pin Layout
 ----------

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -15,7 +15,8 @@ Before Contributing
 
 Before sending us a Pull Request, please consider this:
 
-* Is the contribution entirely your own work, or is it already licensed under an LGPL 2.1 compatible Open Source License? If not, cannot accept it.
+* Is the contribution entirely your own work, or is it already licensed under an LGPL 2.1 compatible Open Source License?
+  If not, cannot accept it.
 
 * Is the code adequately commented and can people understand how it is structured?
 
@@ -25,9 +26,10 @@ Before sending us a Pull Request, please consider this:
 
 * Example contributions are also welcome.
 
-  * If you are contributing by adding a new example, please use the `Arduino style guide`_ and the example guideline below.
+  * If you are contributing by adding a new example, please use the `Arduino style guide`_ and the example guideline below.
 
-* If the contribution contains multiple commits, are they grouped together into logical changes (one major change per pull request)? Are any commits with names like "fixed typo" `squashed into previous commits <https://eli.thegreenplace.net/2014/02/19/squashing-github-pull-requests-into-a-single-commit/>`_?
+* If the contribution contains multiple commits, are they grouped together into logical changes (one major change per pull request)?
+  Are any commits with names like "fixed typo" `squashed into previous commits <https://eli.thegreenplace.net/2014/02/19/squashing-github-pull-requests-into-a-single-commit/>`_?
 
 If you're unsure about any of these points, please open the Pull Request anyhow and then ask us for feedback.
 
@@ -49,20 +51,22 @@ Checklist
 * Check if your example proposal has no similarities to the project (**already existing examples**)
 * Use the `Arduino style guide`_
 * Add the header to all source files
-* Add the `README.md` file
+* Add the ``README.md`` file
 * Add inline comments if needed
 * Test the example
 
 Header
 ******
 
-All the source files must include the header with the example name and license, if applicable. You can change this header as you wish, but it will be reviewed by the community and may not be accepted.
+All the source files must include the header with the example name and license, if applicable. You can change this header as you wish,
+but it will be reviewed by the community and may not be accepted.
 
-Ideally, you can add some description about the example, links to the documentation, or the author's name. Just have in mind to keep it simple and short.
+Ideally, you can add some description about the example, links to the documentation, or the author's name.
+Just have in mind to keep it simple and short.
 
 **Header Example**
 
-.. code-block:: arduino
+.. code-block:: arduino
 
     /* Wi-Fi FTM Initiator Arduino Example
 
@@ -77,9 +81,9 @@ Ideally, you can add some description about the example, links to the documentat
 README file
 ***********
 
-The **README.md** file should contain the example details.
+The ``README.md`` file should contain the example details.
 
-Please see the recommended **README.md** file in the `example template folder <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Template/ExampleTemplate>`_.
+Please see the recommended ``README.md`` file in the `example template folder <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Template/ExampleTemplate>`_.
 
 Inline Comments
 ***************
@@ -88,17 +92,16 @@ Inline comments are important if the example contains complex algorithms or spec
 
 Brief and clear inline comments are really helpful for the example understanding and it's fast usage.
 
-**Example**
+See the `FTM example <https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/examples/FTM/FTM_Initiator/FTM_Initiator.ino>`_
+as a reference:
 
-See the `FTM example <https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/examples/FTM/FTM_Initiator/FTM_Initiator.ino>`_ as a reference.
-
-.. code-block:: arduino
+.. code-block:: arduino
 
     // Number of FTM frames requested in terms of 4 or 8 bursts (allowed values - 0 (No pref), 16, 24, 32, 64)
 
-and
+Also:
 
-.. code-block:: arduino
+.. code-block:: arduino
 
     const char * WIFI_FTM_SSID = "WiFi_FTM_Responder"; // SSID of AP that has FTM Enabled
     const char * WIFI_FTM_PASS = "ftm_responder"; // STA Password
@@ -106,19 +109,33 @@ and
 Testing
 *******
 
-Be sure you have tested the example in all the supported targets. If the example works only with specific targets, add this information in the **README.md** file on the **Supported Targets** and in the example code as an inline comment.
+Be sure you have tested the example in all the supported targets. If the example works only with specific targets,
+edit/add the ``ci.json`` in the same folder as the sketch to specify the supported targets. By default,
+all targets are assumed to be supported.
 
-**Example**
+Here is an example of the ``ci.json`` file where the example does not support ESP32-H2 and ESP32-S2:
 
-.. code-block:: arduino
+.. code-block:: json
+
+    {
+      "targets": {
+        "esp32h2": false,
+        "esp32s2": false
+      }
+    }
+
+You also need to add this information in the ``README.md`` file, on the **Supported Targets**, and in the example code as an inline comment.
+For example, in the sketch:
+
+.. code-block:: arduino
 
     /*
       THIS FEATURE IS SUPPORTED ONLY BY ESP32-S2 AND ESP32-C3
     */
 
-and
+And in the ``README.md`` file:
 
-.. code-block:: markdown
+.. code-block:: markdown
 
     Currently, this example supports the following targets.
 
@@ -128,11 +145,262 @@ and
 Example Template
 ****************
 
-The example template can be found `here <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Template/ExampleTemplate>`_ and can be used as a reference.
+The example template can be found `here <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Template/ExampleTemplate>`_
+and can be used as a reference.
+
+Documentation
+-------------
+
+If you are contributing to the documentation, please follow the instructions described in the
+`documentation guidelines <guides/docs_contributing>`_ to properly format and test your changes.
+
+Testing and CI
+--------------
+
+After you have made your changes, you should test them. You can do this in different ways depending on the type of change you have made.
+
+Examples
+********
+
+The easiest way to test an example is to load it into the Arduino IDE and run it on your board. If you have multiple boards,
+you should test it on all of them to ensure that the example works on all supported targets.
+
+You can refer to the `Example Contribution Guideline`_ section for more information on how to write and test examples.
+
+Library Changes
+***************
+
+If you have made changes to a library, you should test it on all supported targets. You can do this by loading the library examples (or creating new ones)
+into the Arduino IDE and running them on your board. If you have multiple boards, you should test it on all of them to ensure that the library
+works as expected on all targets.
+
+You can also add a new test suite to automatically check the library. You can refer to the `Adding a New Test Suite`_ section for more information.
+
+Core Changes
+************
+
+If you have made changes to the core, it is important to ensure that the changes do not break the existing functionality. You can do this by running the
+tests on all supported targets. You can refer to the `Runtime Tests`_ section for more information.
+
+CI
+**
+
+In our repository, we have a Continuous Integration (CI) system that runs tests and fixes on every Pull Request. This system will run the tests
+on all supported targets and check if everything is working as expected.
+
+We have many types of tests and checks, including:
+
+* Compilation tests;
+* Runtime tests;
+* Documentation checks;
+* Code style checks;
+* And more.
+
+Let's go deeper into each type of test in the CI system:
+
+Compilation Tests
+^^^^^^^^^^^^^^^^^
+
+The compilation tests are the first type of tests in the CI system. They check if the code compiles on all supported targets.
+If the code does not compile, the CI system will fail the test and the Pull Request will not be merged.
+This is important to ensure that the code is compatible with all supported targets and no broken code is merged.
+
+It will go through all the sketches in the repository and check if they compile on all supported targets. This process is automated and controlled
+by GitHub Actions. The CI system will run the ``arduino-cli`` tool to compile the sketches on all supported targets.
+
+Testing it locally using the CI scripts would be too time consuming, so we recommend running the tests locally using the Arduino IDE with
+a sketch that uses the changes you made (you can also add the sketch as an example if your change is not covered by the existing ones).
+Make sure to set ``Compiler Warnings`` to ``All`` in the Arduino IDE to catch any potential issues.
+
+Runtime Tests
+^^^^^^^^^^^^^
+
+Another type of test is the runtime tests. They check if the code runs and behaves as expected on all supported targets. If the
+code does not run as expected, the CI system will fail the test and the Pull Request will not be merged. This is important to ensure that the code
+works as expected on all supported targets and no unintended crashes or bugs are introduced.
+
+These tests are specialized sketches that run on the target board and check if the code behaves as expected. This process is automated and
+controlled by the ``pytest_embedded`` tool. You can read more about this tool in its
+`documentation <https://docs.espressif.com/projects/pytest-embedded/en/latest/>`_.
+
+The tests are devided into two categories inside the ``tests`` folder:
+
+* ``validation``: These tests are used to validate the behavior of the Arduino core and libraries. They are used to check if the core and libraries
+  are working as expected;
+* ``performance``: These tests are used to check the performance of the Arduino core and libraries. They are used to check if the changes made
+  to the core and libraries have any big impact on the performance. These tests usually run for a longer time than the validation tests and include
+  common benchmark tools like `CoreMark <https://github.com/eembc/coremark>`_.
+
+To run the runtime tests locally, first install the required dependencies by running:
+
+.. code-block:: bash
+
+    pip install -U -r tests/requirements.txt
+
+Before running the test, we need to build it by running:
+
+.. code-block:: bash
+
+    ./.github/scripts/tests_build.sh -s <test_name> -t <target>
+
+The ``<test_name>`` is the name of the test you want to run (you can check the available tests in the ``tests/validation`` and
+``tests/performance`` folders), and the ``<target>`` is the target board you want to run the test on. For example, to run the ``uart`` test on the
+ESP32-C3 target, you would run:
+
+.. code-block:: bash
+
+    ./.github/scripts/tests_build.sh -s uart -t esp32c3
+
+You should see the output of the build process and the test binary should be generated in the ``~/.arduino/tests/<test_name>/build.tmp`` folder.
+
+Now that the test is built, you can run it in the target board. Connect the target board to your computer and run:
+
+.. code-block:: bash
+
+    ./.github/scripts/tests_run.sh -s <test_name> -t <target>
+
+For example, to run the ``uart`` test on the ESP32-C3 target, you would run:
+
+.. code-block:: bash
+
+    ./.github/scripts/tests_run.sh -s uart -t esp32c3
+
+The test will run on the target board and you should see the output of the test in the terminal:
+
+.. code-block:: bash
+
+    lucassvaz@Lucas--MacBook-Pro esp32 % ./.github/scripts/tests_run.sh -s uart -t esp32c3
+    Sketch uart test type: validation
+    Running test: uart -- Config: Default
+    pytest tests --build-dir /Users/lucassvaz/.arduino/tests/uart/build.tmp -k test_uart --junit-xml=/Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/uart/esp32c3/uart.xml --embedded-services esp,arduino
+    =============================================================================================== test session starts ================================================================================================
+    platform darwin -- Python 3.12.3, pytest-8.2.2, pluggy-1.5.0
+    rootdir: /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests
+    configfile: pytest.ini
+    plugins: cov-5.0.0, embedded-1.11.5, anyio-4.4.0
+    collected 15 items / 14 deselected / 1 selected
+
+    tests/validation/uart/test_uart.py::test_uart
+    -------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------
+    2024-08-22 11:49:30 INFO Target: esp32c3, Port: /dev/cu.usbserial-2120
+    PASSED                                                                                                                                                                                                       [100%]
+    ------------------------------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------------------------------
+    2024-08-22 11:49:52 INFO Created unity output junit report: /private/var/folders/vp/g9wctsvn7b91k3pv_7cwpt_h0000gn/T/pytest-embedded/2024-08-22_14-49-30-392993/test_uart/dut.xml
+
+
+    ---------------------------------------------- generated xml file: /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/uart/esp32c3/uart.xml ----------------------------------------------
+    ======================================================================================== 1 passed, 14 deselected in 22.18s =========================================================================================
+
+After the test is finished, you can check the output in the terminal and the generated XML file in the test folder.
+Additionally, for performance tests, you can check the generated JSON file in the same folder.
+
+You can also run the tests in `Wokwi <https://docs.wokwi.com/>`_ or `Espressif's QEMU <https://github.com/espressif/esp-toolchain-docs/tree/main/qemu>`_
+by using the ``-W <timeout_in_ms>`` and ``-Q`` flags respectively. You will need to have the Wokwi and/or QEMU installed in your system
+and set the ``WOKWI_CLI_TOKEN`` and/or ``QEMU_PATH`` environment variables. The ``WOKWI_CLI_TOKEN`` is the CI token that can be obtained from the
+`Wokwi website <https://wokwi.com/dashboard/ci>`_ and the ``QEMU_PATH`` is the path to the QEMU binary.
+
+For example, to run the ``uart`` test using Wokwi, you would run:
+
+.. code-block:: bash
+
+    WOKWI_CLI_TOKEN=<your_wokwi_token> ./.github/scripts/tests_run.sh -s uart -t esp32c3 -W <timeout_in_ms>
+
+And to run the ``uart`` test using QEMU, you would run:
+
+.. code-block:: bash
+
+    QEMU_PATH=<path_to_qemu_binary> ./.github/scripts/tests_run.sh -s uart -t esp32c3 -Q
+
+.. note::
+
+    Not all tests are supported by Wokwi and QEMU. QEMU is only supported for ESP32 and ESP32-C3 targets.
+    Wokwi support depends on the `currently implemented peripherals <https://docs.wokwi.com/guides/esp32#simulation-features>`_.
+
+Adding a New Test Suite
+#######################
+
+If you want to add a new test suite, you can create a new folder inside ``tests/validation`` or ``tests/performance`` with the name of the test suite.
+You can use the ``hello_world`` test suite as a starting point and the other test suites as a reference.
+
+A test suite contains the following files:
+
+* ``test_<test_name>.py``: The test file that contains the test cases. Required.
+* ``<test_name>.ino``: The sketch that will be tested. Required.
+* ``ci.json``: The file that specifies how the test suite will be run in the CI system. Optional.
+* ``diagram.<target>.json``: The diagram file that specifies the connections between the components in Wokwi. Optional.
+* ``scenario.yaml``: The scenario file that specifies how Wokwi will interact with the components. Optional.
+* Any other files that are needed for the test suite.
+
+You can read more about the test python API in the `pytest-embedded documentation <https://docs.espressif.com/projects/pytest-embedded/en/latest/usages/expecting.html>`_.
+For more information about the Unity testing framework, you can check the `Unity documentation <https://github.com/ThrowTheSwitch/Unity>`_.
+
+After creating the test suite, make sure to test it locally and run it in the CI system to ensure that it works as expected.
+
+CI JSON File
+############
+
+The ``ci.json`` file is used to specify how the test suite and sketches will handled by the CI system. It can contain the following fields:
+
+* ``targets``: A dictionary that specifies the supported targets. The key is the target name and the value is a boolean that specifies if the
+  target is supported. By default, all targets are assumed to be supported. This field is also valid for examples.
+* ``platforms``: A dictionary that specifies the supported platforms. The key is the platform name and the value is a boolean that specifies if
+  the platform is supported. By default, all platforms are assumed to be supported.
+* ``extra_tags``: A list of extra tags that the runner will require when running the test suite in hardware. By default, no extra tags are required.
+* ``fqbn``: A dictionary that specifies the FQBNs that will be used to compile the sketch. The key is the target name and the value is a list
+  of FQBNs. The `default FQBNs <https://github.com/espressif/arduino-esp32/blob/a31a5fca1739993173caba995f7785b8eed6b30e/.github/scripts/sketch_utils.sh#L86-L91>`_
+  are used if this field is not specified.
+
+The ``wifi`` test suite is a good example of how to use the ``ci.json`` file:
+
+.. literalinclude:: ../../../tests/validation/wifi/ci.json
+    :language: json
+
+Documentation Checks
+^^^^^^^^^^^^^^^^^^^^
+
+The CI also checks the documentation for any compilation errors. This is important to ensure that the documentation layout is not broken.
+To build the documentation locally, please refer to the `documentation guidelines <guides/docs_contributing>`_.
+
+Code Style Checks
+^^^^^^^^^^^^^^^^^
+
+For checking the code style and other code quality checks, we use pre-commit hooks.
+These hooks will be automatically run by the CI when a Pull Request is marked as ``Status: Pending Merge``.
+You can check which hooks are being run in the ``.pre-commit-config.yaml`` file.
+
+You can read more about the pre-commit hooks in the `pre-commit documentation <https://pre-commit.com/>`_.
+
+If you want to run the pre-commit hooks locally, you first need to install the required dependencies by running:
+
+.. code-block:: bash
+
+    pip install -U -r tools/pre-commit/requirements.txt
+
+Then, you can run the pre-commit hooks staging your changes and running:
+
+.. code-block:: bash
+
+    pre-commit run
+
+To run a specific hook, you can use the hook name as an argument. For example, to run the ``codespell`` hook, you would run:
+
+.. code-block:: bash
+
+    pre-commit run codespell --hook-stage manual
+
+As some hooks are only enabled to run manually, you need to use the ``--hook-stage manual`` flag to run them.
+
+If you want to run the pre-commit hooks automatically against the changed files on every ``git commit``,
+you can install the pre-commit hooks by running:
+
+.. code-block:: bash
+
+    pre-commit install
 
 Legal Part
 ----------
 
-Before a contribution can be accepted, you will need to sign our contributor agreement. You will be prompted for this automatically as part of the Pull Request process.
+Before a contribution can be accepted, you will need to sign our contributor agreement. You will be prompted for this automatically as part of
+the Pull Request process.
 
 .. _Arduino style guide: https://docs.arduino.cc/learn/contributions/arduino-writing-style-guide

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -352,7 +352,7 @@ The ``ci.json`` file is used to specify how the test suite and sketches will han
 
 The ``wifi`` test suite is a good example of how to use the ``ci.json`` file:
 
-.. literalinclude:: ../../../tests/validation/wifi/ci.json
+.. literalinclude:: ../../tests/validation/wifi/ci.json
     :language: json
 
 Documentation Checks

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -223,7 +223,7 @@ These tests are specialized sketches that run on the target board and check if t
 controlled by the ``pytest_embedded`` tool. You can read more about this tool in its
 `documentation <https://docs.espressif.com/projects/pytest-embedded/en/latest/>`_.
 
-The tests are devided into two categories inside the ``tests`` folder:
+The tests are divided into two categories inside the ``tests`` folder:
 
 * ``validation``: These tests are used to validate the behavior of the Arduino core and libraries. They are used to check if the core and libraries
   are working as expected;

--- a/docs/en/esp-idf_component.rst
+++ b/docs/en/esp-idf_component.rst
@@ -178,12 +178,14 @@ If you are writing code that does not require Arduino to compile and you want yo
 FreeRTOS Tick Rate (Hz)
 -----------------------
 
-The Arduino component requires the FreeRTOS tick rate `CONFIG_FREERTOS_HZ` set to 1000Hz in `make menuconfig` -> `Component config` -> `FreeRTOS` -> `Tick rate`.
+The Arduino component requires the FreeRTOS tick rate `CONFIG_FREERTOS_HZ` set to 1000 Hz in `make menuconfig` -> `Component config` -> `FreeRTOS` -> `Tick rate`.
 
 Compilation Errors
 ------------------
 
-As commits are made to esp-idf and submodules, the codebases can develop incompatibilities that cause compilation errors.  If you have problems compiling, follow the instructions in `Issue #1142 <https://github.com/espressif/arduino-esp32/issues/1142>`_ to roll esp-idf back to a different version.
+As commits are made to ESP-IDF and submodules, the codebases can develop incompatibilities that cause compilation errors.
+If you have problems compiling, follow the instructions in `Issue #1142 <https://github.com/espressif/arduino-esp32/issues/1142>`_
+to roll ESP-IDF back to a different version.
 
 Adding arduino library
 ----------------------

--- a/docs/en/getting_started.rst
+++ b/docs/en/getting_started.rst
@@ -64,14 +64,14 @@ Supported Operating Systems
 ---------------------------
 
 +-------------------+-------------------+-------------------+
-| |windows-logo|    | |linux-logo|      | |macos-logo|      |
+| |windows-logo|    | |linux-logo|      | |macOS-logo|      |
 +-------------------+-------------------+-------------------+
 | Windows           | Linux             | macOS             |
 +-------------------+-------------------+-------------------+
 
 .. |windows-logo| image:: ../_static/logo_windows.png
 .. |linux-logo| image:: ../_static/logo_linux.png
-.. |macos-logo| image:: ../_static/logo_macos.png
+.. |macOS-logo| image:: ../_static/logo_macos.png
 
 Supported IDEs
 ---------------------------

--- a/docs/en/guides/docs_contributing.rst
+++ b/docs/en/guides/docs_contributing.rst
@@ -104,7 +104,7 @@ If everything is ok, you will see some output logs similar to this one:
     dumping object inventory... done
     build succeeded.
 
-The HTML pages are in `_build/en/generic/html`.
+The HTML pages are in ``_build/en/generic/html``.
 
 Sections
 --------

--- a/docs/en/guides/docs_contributing.rst
+++ b/docs/en/guides/docs_contributing.rst
@@ -316,7 +316,7 @@ After that, you can use the following structure to include the image in the docs
 
 You can adjust the ``width`` according to the image size.
 
-Be sure the file size does not exceed 600kB.
+Be sure the file size does not exceed 600 kB.
 
 Support
 *******

--- a/docs/en/guides/tools_menu.rst
+++ b/docs/en/guides/tools_menu.rst
@@ -66,12 +66,12 @@ Flash Frequency
 
 Use this function to select the flash memory frequency. The frequency will be dependent on the memory model.
 
-* **40MHz**
-* **80MHz**
+* **40 MHz**
+* **80 MHz**
 
-If you don't know if your memory supports **80Mhz**, you can try to upload the sketch using the **80MHz** option and watch the log output via the serial monitor.
+If you don't know if your memory supports **80 MHz**, you can try to upload the sketch using the **80 MHz** option and watch the log output via the serial monitor.
 
-.. note:: In some boards/SoC, the flash frequency is automatically selected according to the flash mode. In some cases (i.e ESP32-S3), the flash frequency is up to 120MHz.
+.. note:: In some boards/SoC, the flash frequency is automatically selected according to the flash mode. In some cases (i.e ESP32-S3), the flash frequency is up to 120 MHz.
 
 Flash Mode
 **********
@@ -95,17 +95,17 @@ Depending on the application, this mode can be changed in order to increase the 
 * **OPI** - Octal I/O
     * Eight SPI pins are used to write and to read from the flash.
 
-If you don't know how the board flash is physically connected or the flash memory model, try the **QIO** at **80MHz** first.
+If you don't know how the board flash is physically connected or the flash memory model, try the **QIO** at **80 MHz** first.
 
 Flash Size
 **********
 
 This option is used to select the flash size. The flash size should be selected according to the flash model used on your board.
 
-* **2MB** (16Mb)
-* **4MB** (32Mb)
-* **8MB** (64Mb)
-* **16MB** (128Mb)
+* **2 MB** (16 Mb)
+* **4 MB** (32 Mb)
+* **8 MB** (64 Mb)
+* **16 MB** (128 Mb)
 
 If you choose the wrong size, you may have issues when selecting the partition scheme.
 
@@ -118,13 +118,13 @@ Some SoC has embedded flash. The ESP32-S3 is a good example.
 
 Example: **ESP32-S3FH4R2**
 
-This particular ESP32-S3 variant comes with 4MB Flash and 2MB PSRAM.
+This particular ESP32-S3 variant comes with 4 MB Flash and 2 MB PSRAM.
 
 **Options for Embedded Flash**
 
-* **Fx4** 4MB Flash (*QIO*)
-* **Fx8** 8MB Flash (*QIO*)
-* **V** 1.8V SPI
+* **Fx4** 4 MB Flash (*QIO*)
+* **Fx8** 8 MB Flash (*QIO*)
+* **V** 1.8 V SPI
 
 The **x** stands for the temperature range specification.
 
@@ -169,13 +169,13 @@ Some SoC has embedded PSRAM. The ESP32-S3 is a good example.
 
 Example: **ESP32-S3FH4R2**
 
-This particular ESP32-S3 comes with 4MB Flash and 2MB PSRAM.
+This particular ESP32-S3 comes with 4 MB Flash and 2 MB PSRAM.
 
 **Options for Embedded Flash and PSRAM**
 
-* **R2** 2MB PSRAM (*QSPI*)
-* **R8** 8MB PSRAM (*OPI*)
-* **V** 1.8V SPI
+* **R2** 2 MB PSRAM (*QSPI*)
+* **R8** 8 MB PSRAM (*OPI*)
+* **V** 1.8 V SPI
 
 The **x** stands for the temperature range specification.
 

--- a/docs/en/installing.rst
+++ b/docs/en/installing.rst
@@ -355,7 +355,7 @@ Where ``~/Documents/Arduino`` represents your sketch book location as per "Ardui
 
 - Try ``python3`` instead of ``python`` if you get the error: ``IOError: [Errno socket error] [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:590)`` when running ``python get.py``
 
-- If you get the following error when running ``python get.py`` urllib.error.URLError: <urlopen error SSL: CERTIFICATE_VERIFY_FAILED, go to Macintosh HD > Applications > Python3.6 folder (or any other python version), and run the following scripts: Install Certificates.command and Update Shell Profile.command
+- If you get the following error when running ``python get.py``: ``urllib.error.URLError: <urlopen error SSL: CERTIFICATE_VERIFY_FAILED``, go to ``Macintosh HD > Applications > Python3.6 folder (or any other python version)``, and run the following scripts: Install Certificates.command and Update Shell Profile.command
 
 - Restart Arduino IDE.
 

--- a/docs/en/lib_builder.rst
+++ b/docs/en/lib_builder.rst
@@ -172,7 +172,7 @@ Set the build type. ex. 'build' to build the project and prepare for uploading t
 Additional Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Specify additional configs to be applied. ex. 'qio 80m' to compile for QIO Flash@80MHz.
+Specify additional configs to be applied. ex. ``qio 80m`` to compile for QIO Flash at 80 MHz.
 
 .. note:: This command requires the ``-b`` to work properly.
 

--- a/docs/en/migration_guides/2.x_to_3.0.rst
+++ b/docs/en/migration_guides/2.x_to_3.0.rst
@@ -217,8 +217,8 @@ Functional changes
 * ``begin(baud)`` will not change any pins that have been set before this call, through a previous ``begin(baud, rx, tx)`` or ``setPin()``.
 * If the application only uses RX or TX, ``begin(baud, -1, tx)`` or ``begin(baud, rx)`` will change only the assigned pin and keep the other unchanged.
 
-WiFi
-****
+Wi-Fi
+*****
 
 Functional changes
 ^^^^^^^^^^^^^^^^^^

--- a/docs/en/troubleshooting.rst
+++ b/docs/en/troubleshooting.rst
@@ -62,8 +62,8 @@ Here are some steps that you can try:
 * Make sure that nothing is connected to pins labeled **TX** and **RX**. Please refer to the pin layout table - some TX and RX pins may not be labeled on the dev board.
 * In some instances, you must keep **GPIO0** LOW during the uploading process via the serial interface.
 * Hold down the **“BOOT”** button on your ESP32 board while uploading/flashing.
-* Solder a **10uF** capacitor in parallel with **RST** and **GND**.
-* If you are using external power connected to pins, it is easy to confuse pins **CMD** (which is usually next to the 5V pin) and **GND**.
+* Solder a **10 uF** capacitor in parallel with **RST** and **GND**.
+* If you are using external power connected to pins, it is easy to confuse pins **CMD** (which is usually next to the ``5V`` pin) and **GND**.
 
 In some development boards, you can try adding the reset delay circuit, as described in the *Power-on Sequence* section on the `ESP32 Hardware Design Guidelines <https://www.espressif.com/sites/default/files/documentation/esp32_hardware_design_guidelines_en.pdf>`_ to get into the download mode automatically.
 
@@ -131,7 +131,7 @@ I have uploaded firmware to the ESP32 device, but I don't see any response from 
 Solution
 ^^^^^^^^
 
-Newer ESP32 variants have two possible USB connectors- USB and UART.  The UART connector will go through a USB->UART adapter, and will typically present itself with the name of that mfr (eg, Silicon Labs CP210x UART Bridge).  The USB connector can be used as a USB-CDC bridge and will appear as an Espressif device (Espressif USB JTAG/serial debug unit).  On Espressif devkits, both connections are available, and will be labeled.  ESP32 can only use UART, so will only have one connector.  Other variants with one connector will typically be using USB.  Please check in the product [datasheet](https://products.espressif.com) or [hardware guide](https://www.espressif.com/en/products/devkits) to find Espressif products with the appropriate USB connections for your needs.
+Newer ESP32 variants have two possible USB connectors - USB and UART. The UART connector will go through a USB->UART adapter, and will typically present itself with the name of that mfr (eg, Silicon Labs CP210x UART Bridge). The USB connector can be used as a USB-CDC bridge and will appear as an Espressif device (Espressif USB JTAG/serial debug unit). On Espressif devkits, both connections are available, and will be labeled. ESP32 can only use UART, so will only have one connector. Other variants with one connector will typically be using USB. Please check in the product [datasheet](https://products.espressif.com) or [hardware guide](https://www.espressif.com/en/products/devkits) to find Espressif products with the appropriate USB connections for your needs.
 If you use the UART connector, you should disable USB-CDC on boot under the Tools menu (-D ARDUINO_USB_CDC_ON_BOOT=0). If you use the USB connector, you should have that enabled (-D ARDUINO_USB_CDC_ON_BOOT=1) and set USB Mode to "Hardware CDC and JTAG" (-D ARDUINO_USB_MODE=0).
 USB-CDC may not be able to initialize in time to catch all the data if your device is in a tight reboot loop. This can make it difficult to troubleshoot initialization issues.
 

--- a/docs/en/tutorials/partition_table.rst
+++ b/docs/en/tutorials/partition_table.rst
@@ -39,25 +39,25 @@ Where:
        ``ota``
 
            The ota subtype is used to store the OTA information. This partition is used only when the OTA is used to select the initialization partition, otherwise no need to add it to your custom partition table.
-           The size of this partition should be a fixed size of 8kB (0x2000 bytes).
+           The size of this partition should be a fixed size of 8 kB (0x2000 bytes).
 
        ``nvs``
 
-           The nvs partition subtype is used to define the partition to store general data, like the WiFi data, device PHY calibration data and any other data to be stored on the non-volatile memory.
+           The nvs partition subtype is used to define the partition to store general data, like the Wi-Fi data, device PHY calibration data and any other data to be stored on the non-volatile memory.
            This kind of partition is suitable for small custom configuration data, cloud certificates, etc. Another usage for the NVS is to store sensitive data, since the NVS supports encryption.
-           It is highly recommended to add at least one nvs partition, labeled with the name nvs, in your custom partition tables with size of at least 12kB (0x3000 bytes). If needed, you can increase the size of the nvs partition.
-           The recommended size for this partition is from 12kb to 64kb. Although larger NVS partitions can be defined, we recommend using FAT or SPIFFS filesystem for storage of larger amounts of data.
+           It is highly recommended to add at least one nvs partition, labeled with the name nvs, in your custom partition tables with size of at least 12 kB (0x3000 bytes). If needed, you can increase the size of the nvs partition.
+           The recommended size for this partition is from 12 kB to 64 kB. Although larger NVS partitions can be defined, we recommend using FAT or SPIFFS filesystem for storage of larger amounts of data.
 
        ``coredump``
 
            The coredump partition subtype is used to store the core dump on the flash. The core dump is used to analyze critical errors like crash and panic.
            This function must be enabled in the project configuration menu and set the data destination to flash.
-           The recommended size for this partition is 64kB (0x10000).
+           The recommended size for this partition is 64 kB (0x10000).
 
        ``nvs_keys``
 
            The nvs_keys partition subtype is used to store the keys when the NVS encryption is used.
-           The size for this partition is 4kB (0x1000).
+           The size for this partition is 4 kB (0x1000).
 
        ``fat``
 
@@ -90,7 +90,7 @@ Where:
     The offset defines the partition start address. The offset is defined by the sum of the offset and the size of the earlier partition.
 
 .. note::
-    Offset must be multiple of 4kB (0x1000) and for app partitions it must be aligned by 64kB (0x10000).
+    Offset must be multiple of 4 kB (0x1000) and for app partitions it must be aligned by 64 kB (0x10000).
     If left blank, the offset will be automatically calculated based on the end of the previous partition, including any necessary alignment, however, the offset for the first partition must be always set as **0x9000** and for the first application partition **0x10000**.
 
 5. **Size**
@@ -129,13 +129,13 @@ Here is an example you can use for a custom partition table:
     app1,     app,  ota_1,   ,        2M,
     spiffs,   data, spiffs,  ,        8M,
 
-This partition will use about 12MB of the 16MB flash. The offset will be automatically calculated after the first application partition and the units are in K and M.
+This partition will use about 12 MB of the 16 MB flash. The offset will be automatically calculated after the first application partition and the units are in K and M.
 
 An alternative is to create the new partition table as a new file in the `tools/partitions <https://github.com/espressif/arduino-esp32/tree/master/tools/partitions>`_ folder and edit the `boards.txt <https://github.com/espressif/arduino-esp32/tree/master/boards.txt>`_ file to add your custom partition table.
 
 Another alternative is to create the new partition table as a new file, and place it in the `variants <https://github.com/espressif/arduino-esp32/tree/master/variants>`_ folder under your boards folder, and edit the `boards.txt <https://github.com/espressif/arduino-esp32/tree/master/boards.txt>`_ file to add your custom partition table, noting that in order for the compiler to find your custom partition table file you must use the '.build.custom_partitions=' option in the boards.txt file, rather than the standard '.build.partitions=' option. The '.build.variant=' option has the name of the folder holding your custom partition table in the variants folder.
 
-An example of the PartitionScheme listing using the ESP32S3 Dev Module as a reference, would be to have the following:
+An example of the PartitionScheme listing using the ESP32-S3 Dev Module as a reference, would be to have the following:
 
 **Custom Partition - CSV file in /variants/custom_esp32s3/ folder**
 
@@ -150,7 +150,7 @@ An example of the PartitionScheme listing using the ESP32S3 Dev Module as a refe
 Examples
 --------
 
-**2MB no OTA**
+**2 MB no OTA**
 
 .. code-block::
 
@@ -158,7 +158,7 @@ Examples
     nvs,      data, nvs,     36K,     20K,
     factory,  app,  factory, 64K,     1900K,
 
-**4MB no OTA**
+**4 MB no OTA**
 
 .. code-block::
 
@@ -166,7 +166,7 @@ Examples
     nvs,      data, nvs,     36K,     20K,
     factory,  app,  factory, 64K,     4000K,
 
-**4MB with OTA**
+**4 MB with OTA**
 
 .. code-block::
 
@@ -176,7 +176,7 @@ Examples
     app0,     app,  ota_0,   64K,     1900K,
     app1,     app,  ota_1,   ,        1900K,
 
-**8MB no OTA with Storage**
+**8 MB no OTA with Storage**
 
 .. code-block::
 
@@ -185,7 +185,7 @@ Examples
     factory,  app,  factory, 64K,     2M,
     spiffs,   data, spiffs,  ,        5M,
 
-**8MB with OTA and Storage**
+**8 MB with OTA and Storage**
 
 .. code-block::
 

--- a/docs/en/tutorials/preferences.rst
+++ b/docs/en/tutorials/preferences.rst
@@ -386,7 +386,7 @@ To send to the serial monitor the number of available entries the following coul
 
 The number of available entries in the key table changes depending on the number of keys in the namespace and also the dynamic size of certain types of data stored in the namespace. Details are in the `Preferences API Reference`_.
 
-Do note that the number of entries in the key table does not guarantee that there is room in the opened NVS namespace for all the data to be stored in that namespace. Refer to the espressif `Non-volatile storage library`_ documentation for full details.
+Do note that the number of entries in the key table does not guarantee that there is room in the opened NVS namespace for all the data to be stored in that namespace. Refer to the Espressif `Non-volatile storage library`_ documentation for full details.
 
 
 Determining the Type of a key-value Pair

--- a/libraries/BLE/README.md
+++ b/libraries/BLE/README.md
@@ -1,5 +1,5 @@
 # ESP32 BLE for Arduino
-The Arduino IDE provides an excellent library package manager where versions of libraries can be downloaded and installed.  This Github project provides the repository for the ESP32 BLE support for Arduino.
+The Arduino IDE provides an excellent library package manager where versions of libraries can be downloaded and installed. This Github project provides the repository for the ESP32 BLE support for Arduino.
 
 The original source of the project, **which is not maintained anymore**, can be found here: https://github.com/nkolban/esp32-snippets
 

--- a/libraries/EEPROM/README.md
+++ b/libraries/EEPROM/README.md
@@ -1,4 +1,4 @@
 ## EEPROM
 
-EEPROM is deprecated.  For new applications on ESP32, use Preferences.  EEPROM is provided for backwards compatibility with existing Arduino applications.
-EEPROM is implemented using a single blob within NVS, so it is a container within a container. As such, it is not going to be a high performance storage method.  Preferences will directly use nvs, and store each entry as a single object therein.
+EEPROM is deprecated. For new applications on ESP32, use Preferences. EEPROM is provided for backwards compatibility with existing Arduino applications.
+EEPROM is implemented using a single blob within NVS, so it is a container within a container. As such, it is not going to be a high performance storage method. Preferences will directly use nvs, and store each entry as a single object therein.

--- a/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
+++ b/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
@@ -81,7 +81,7 @@ void setup() {
   /*
     If there are no external pull-up/downs, tie wakeup pins to inactive level with internal pull-up/downs via RTC IO
          during deepsleep. However, RTC IO relies on the RTC_PERIPH power domain. Keeping this power domain on will
-         increase some power comsumption. However, if we turn off the RTC_PERIPH domain or if certain chips lack the RTC_PERIPH
+         increase some power consumption. However, if we turn off the RTC_PERIPH domain or if certain chips lack the RTC_PERIPH
          domain, we will use the HOLD feature to maintain the pull-up and pull-down on the pins during sleep.
   */
   rtc_gpio_pulldown_en(WAKEUP_GPIO);  // GPIO33 is tie to GND in order to wake up in HIGH

--- a/libraries/ESP32/examples/FreeRTOS/BasicMultiThreading/README.md
+++ b/libraries/ESP32/examples/FreeRTOS/BasicMultiThreading/README.md
@@ -32,7 +32,7 @@ It is also worth mentioning that two or more tasks running the same function wil
 ```
   - **pxTaskCode**      is the name of your function which will run as a task
   - **pcName**          is a string of human-readable descriptions for your task
-  - **usStackDepth**    is the number of words (word = 4B) available to the task. If you see an error similar to this "Debug exception reason: Stack canary watchpoint triggered (Task Blink)" you should increase it
+  - **usStackDepth**    is the number of words (word = 4 B) available to the task. If you see an error similar to this "Debug exception reason: Stack canary watchpoint triggered (Task Blink)" you should increase it
   - **pvParameters**    is a parameter that will be passed to the task function - it must be explicitly converted to (void*) and in your function explicitly converted back to the intended data type.
   - **uxPriority**      is a number from 0 to configMAX_PRIORITIES which determines how the FreeRTOS will allow the tasks to run. 0 is the lowest priority.
   - **pxCreatedTask**   task handle is a pointer to the task which allows you to manipulate the task - delete it, suspend and resume.

--- a/libraries/ESP32/examples/Zigbee/Zigbee_Light_Bulb/README.md
+++ b/libraries/ESP32/examples/Zigbee/Zigbee_Light_Bulb/README.md
@@ -39,7 +39,7 @@ You can do the following:
 * In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`
 * In the sketch uncomment function `esp_zb_nvram_erase_at_start(true);` located in `esp_zb_task` function.
 
-By default, the coordinator network is open for 180s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
+By default, the coordinator network is open for 180 s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
 You can change it by editing `esp_zb_bdb_open_network(180);` in `esp_zb_app_signal_handler` function.
 
 ***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***

--- a/libraries/ESP32/examples/Zigbee/Zigbee_Light_Switch/README.md
+++ b/libraries/ESP32/examples/Zigbee/Zigbee_Light_Switch/README.md
@@ -39,7 +39,7 @@ You can do the following:
 * In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`.
 * In the `Zigbee_Light_Bulb` example sketch uncomment function `esp_zb_nvram_erase_at_start(true);` located in `esp_zb_task` function.
 
-By default, the coordinator network is open for 180s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
+By default, the coordinator network is open for 180 s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
 You can change it by editing `esp_zb_bdb_open_network(180);` in `esp_zb_app_signal_handler` function.
 
 ***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***

--- a/libraries/ESP32/examples/Zigbee/Zigbee_Light_Switch/Zigbee_Light_Switch.ino
+++ b/libraries/ESP32/examples/Zigbee/Zigbee_Light_Switch/Zigbee_Light_Switch.ino
@@ -159,7 +159,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
           esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_NETWORK_FORMATION);
         } else {
           log_i("Device rebooted");
-          log_i("Openning network for joining for %d seconds", 180);
+          log_i("Opening network for joining for %d seconds", 180);
           esp_zb_bdb_open_network(180);
         }
       } else {

--- a/libraries/ESP32/examples/Zigbee/Zigbee_Temperature_Sensor/README.md
+++ b/libraries/ESP32/examples/Zigbee/Zigbee_Temperature_Sensor/README.md
@@ -49,7 +49,7 @@ You can do the following:
 * In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`
 * In the sketch uncomment function `esp_zb_nvram_erase_at_start(true);` located in `esp_zb_task` function.
 
-By default, the coordinator network is open for 180s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
+By default, the coordinator network is open for 180 s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
 You can change it by editing `esp_zb_bdb_open_network(180);` in `esp_zb_app_signal_handler` function.
 
 ***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***

--- a/libraries/ESP32/examples/Zigbee/Zigbee_Thermostat/README.md
+++ b/libraries/ESP32/examples/Zigbee/Zigbee_Thermostat/README.md
@@ -48,7 +48,7 @@ You can do the following:
 * In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`.
 * In the `Zigbee_Temperature_Sensor` example sketch uncomment function `esp_zb_nvram_erase_at_start(true);` located in `esp_zb_task` function.
 
-By default, the coordinator network is open for 180s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
+By default, the coordinator network is open for 180 s after rebooting or flashing new firmware. After that, the network is closed for adding new devices.
 You can change it by editing `esp_zb_bdb_open_network(180);` in `esp_zb_app_signal_handler` function.
 
 ***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***

--- a/libraries/ESP32/examples/Zigbee/Zigbee_Thermostat/Zigbee_Thermostat.ino
+++ b/libraries/ESP32/examples/Zigbee/Zigbee_Thermostat/Zigbee_Thermostat.ino
@@ -279,7 +279,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
           esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_NETWORK_FORMATION);
         } else {
           log_i("Device rebooted");
-          log_i("Openning network for joining for %d seconds", 180);
+          log_i("Opening network for joining for %d seconds", 180);
           esp_zb_bdb_open_network(180);
         }
       } else {

--- a/libraries/Insights/examples/DiagnosticsSmokeTest/README.md
+++ b/libraries/Insights/examples/DiagnosticsSmokeTest/README.md
@@ -23,8 +23,8 @@ Copy Auth Key to the example
 const char insights_auth_key[] = "<ENTER YOUR AUTH KEY>";
 ```
 
-### Enter WiFi Credentials
-Inside the example sketch, enter your WiFi credentials in `WIFI_SSID` and `WIFI_PASSPHRASE` macros.
+### Enter Wi-Fi Credentials
+Inside the example sketch, enter your Wi-Fi credentials in `WIFI_SSID` and `WIFI_PASSPHRASE` macros.
 
 ### Setup
 * Build and flash the sketch and monitor the console

--- a/libraries/Insights/examples/MinimalDiagnostics/README.md
+++ b/libraries/Insights/examples/MinimalDiagnostics/README.md
@@ -5,9 +5,9 @@
 
 ## What to expect in this example?
 - This example demonstrates the use of ESP Insights framework in minimal way
-- Device will try to connect with the configured WiFi network
+- Device will try to connect with the configured Wi-Fi network
 - ESP Insights is enabled in this example, so any error/warning logs, crashes will be reported to cloud
-- This example collects heap and wifi metrics every 10 minutes and network variables are collected when they change
+- This example collects heap and Wi-Fi metrics every 10 minutes and network variables are collected when they change
 
 ## Try out the example
 
@@ -19,8 +19,8 @@ Copy Auth Key to the example
 const char insights_auth_key[] = "<ENTER YOUR AUTH KEY>";
 ```
 
-### Enter WiFi Credentials
-Inside the example sketch, enter your WiFi credentials in `WIFI_SSID` and `WIFI_PASSPHRASE` macros.
+### Enter Wi-Fi Credentials
+Inside the example sketch, enter your Wi-Fi credentials in `WIFI_SSID` and `WIFI_PASSPHRASE` macros.
 
 ### Get the Node ID
 - Start the Serial monitor

--- a/libraries/LittleFS/examples/LITTLEFS_PlatformIO/README.md
+++ b/libraries/LittleFS/examples/LITTLEFS_PlatformIO/README.md
@@ -65,4 +65,4 @@ Deleting file: /test.txt
 - file deleted
 Test complete
 ```
-- If you have a module with more than 4MB flash, you can uncomment **partitions_custom.csv** in **platformio.ini** and modify the csv file accordingly
+- If you have a module with more than 4 MB flash, you can uncomment **partitions_custom.csv** in **platformio.ini** and modify the csv file accordingly

--- a/libraries/NetworkClientSecure/README.md
+++ b/libraries/NetworkClientSecure/README.md
@@ -113,14 +113,14 @@ Examples
 #### NetworkClientInsecure
 Demonstrates usage of insecure connection using `NetworkClientSecure::setInsecure()`
 #### NetworkClientPSK
-Wifi secure connection example for ESP32 using a pre-shared key (PSK)
+Wi-Fi secure connection example for ESP32 using a pre-shared key (PSK)
 This is useful with MQTT servers instead of using a self-signed cert, tested with mosquitto.
 Running on TLS 1.2 using mbedTLS
 #### NetworkClientSecure
-Wifi secure connection example for ESP32
+Wi-Fi secure connection example for ESP32
 Running on TLS 1.2 using mbedTLS
 #### NetworkClientSecureEnterprise
-This example demonstrates a secure connection to a WiFi network using WPA/WPA2 Enterprise (for example eduroam),
+This example demonstrates a secure connection to a Wi-Fi network using WPA/WPA2 Enterprise (for example eduroam),
 and establishing a secure HTTPS connection with an external server (for example arduino.php5.sk) using the defined anonymous identity, user identity, and password.
 
 .. note::

--- a/libraries/OpenThread/examples/COAP/coap_lamp/coap_lamp.ino
+++ b/libraries/OpenThread/examples/COAP/coap_lamp/coap_lamp.ino
@@ -90,7 +90,7 @@ bool otDeviceSetup(const char **otSetupCmds, uint8_t nCmds1, const char **otCoap
 }
 
 void setupNode() {
-  // tries to set the Thread Network node and only returns when succeded
+  // tries to set the Thread Network node and only returns when succeeded
   bool startedCorrectly = false;
   while (!startedCorrectly) {
     startedCorrectly |=

--- a/libraries/OpenThread/examples/COAP/coap_switch/coap_switch.ino
+++ b/libraries/OpenThread/examples/COAP/coap_switch/coap_switch.ino
@@ -79,12 +79,12 @@ bool otDeviceSetup(
   }
   Serial.println("OpenThread setup done. Node is ready.");
   // all fine! LED goes and stays Blue
-  neopixelWrite(RGB_BUILTIN, 0, 0, 64);  // BLUE ... Swtich is ready!
+  neopixelWrite(RGB_BUILTIN, 0, 0, 64);  // BLUE ... Switch is ready!
   return true;
 }
 
 void setupNode() {
-  // tries to set the Thread Network node and only returns when succeded
+  // tries to set the Thread Network node and only returns when succeeded
   bool startedCorrectly = false;
   while (!startedCorrectly) {
     startedCorrectly |= otDeviceSetup(
@@ -138,11 +138,11 @@ bool otCoapPUT(bool lampState) {
   return false;
 }
 
-// this fucntion is used by the Switch mode to check the BOOT Button and send the user action to the Lamp node
+// this function is used by the Switch mode to check the BOOT Button and send the user action to the Lamp node
 void checkUserButton() {
   static long unsigned int lastPress = 0;
   const long unsigned int debounceTime = 500;
-  static bool lastLampState = true;  // first button press will turn the Lamp OFF from inital Green
+  static bool lastLampState = true;  // first button press will turn the Lamp OFF from initial Green
 
   pinMode(USER_BUTTON, INPUT_PULLUP);  // C6/H2 User Button
   if (millis() > lastPress + debounceTime && digitalRead(USER_BUTTON) == LOW) {
@@ -150,7 +150,7 @@ void checkUserButton() {
     if (!otCoapPUT(lastLampState)) {  // failed: Lamp Node is not responding due to be off or unreachable
       // timeout from the CoAP PUT message... restart the node.
       neopixelWrite(RGB_BUILTIN, 255, 0, 0);  // RED ... something failed!
-      Serial.println("Reseting the Node as Switch... wait.");
+      Serial.println("Resetting the Node as Switch... wait.");
       // start over...
       setupNode();
     }

--- a/libraries/OpenThread/src/OThreadCLI_Util.cpp
+++ b/libraries/OpenThread/src/OThreadCLI_Util.cpp
@@ -117,7 +117,7 @@ bool otExecCommand(const char *cmd, const char *arg, ot_cmd_return_t *returnCode
           i--;  // search for ' ' before ":'
         }
         if (*i == ' ') {
-          i++;  // move it forward to the number begining
+          i++;  // move it forward to the number beginning
           returnCode->errorCode = atoi(i);
           returnCode->errorMessage = m;
         }  // otherwise, it will keep the "bad error message" information

--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -226,7 +226,7 @@ bool PPPClass::setPins(int8_t tx, int8_t rx, int8_t rts, int8_t cts, esp_modem_f
 bool PPPClass::begin(ppp_modem_model_t model, uint8_t uart_num, int baud_rate) {
   esp_err_t ret = ESP_OK;
   bool pin_ok = false;
-  int trys = 0;
+  int tries = 0;
 
   if (_esp_netif != NULL || _dce != NULL) {
     log_w("PPP Already Started");
@@ -313,11 +313,11 @@ bool PPPClass::begin(ppp_modem_model_t model, uint8_t uart_num, int baud_rate) {
   if (_pin_rst >= 0) {
     // wait to be able to talk to the modem
     log_v("Waiting for response from the modem");
-    while (esp_modem_sync(_dce) != ESP_OK && trys < 100) {
-      trys++;
+    while (esp_modem_sync(_dce) != ESP_OK && tries < 100) {
+      tries++;
       delay(500);
     }
-    if (trys >= 100) {
+    if (tries >= 100) {
       log_e("Failed to wait for communication");
       goto err;
     }

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -1,9 +1,9 @@
 # ESP32 Libraries
 
-arduino-esp32 includes libraries for Arduino compatibility along with some object wrappers around hardware specific devices.  Examples are included in the examples folder under each library folder.  The ESP32 includes additional examples which need no special drivers.
+arduino-esp32 includes libraries for Arduino compatibility along with some object wrappers around hardware specific devices. Examples are included in the examples folder under each library folder. The ESP32 includes additional examples which need no special drivers.
 
 ### ArduinoOTA
-  Over The Air firmware update daemon.  Use espota.py to upload to the device.
+  Over The Air firmware update daemon. Use espota.py to upload to the device.
 
 ### AsyncUDP
   Asynchronous task driven UDP datagram client/server
@@ -100,11 +100,13 @@ arduino-esp32 includes libraries for Arduino compatibility along with some objec
 ### WebServer
   A simple HTTP daemon
 
+<!-- vale off -->
 ### WiFi
-  Arduino compatible WiFi driver (includes Ethernet driver)
+<!-- vale on -->
+  Arduino compatible Wi-Fi driver
 
 ### NetworkClientSecure
-  Arduino compatible WiFi client object using embedded encryption
+  Arduino compatible Wi-Fi client object using embedded encryption
 
 ### Wire
   Arduino compatible I2C driver

--- a/libraries/RainMaker/README.md
+++ b/libraries/RainMaker/README.md
@@ -41,7 +41,7 @@ NOTE : ESP RainMaker library is currently supported for ESP32 board only.
 ## ESP RainMaker Agent API
 
 ### RMaker.initNode()
-This initializes the ESP RainMaker agent, wifi and creates the node.
+This initializes the ESP RainMaker agent, Wi-Fi and creates the node.
 ```
 Node initNode(const char *name, const char *type);
 ```
@@ -67,7 +67,7 @@ esp_err_t start()
 
 > NOTE :
 > 1. ESP RainMaker agent should be initialized before this call.
-> 2. Once ESP RainMaker agent starts, compulsorily call WiFi.beginProvision() API.
+> 2. Once ESP RainMaker agent starts, compulsorily call `WiFi.beginProvision()` API.
 
 ### RMaker.stop()
 It stops the ESP RainMaker agent which was started using `RMaker.start()`.

--- a/libraries/RainMaker/examples/README.md
+++ b/libraries/RainMaker/examples/README.md
@@ -2,7 +2,7 @@
 
 While building any examples for ESP RainMaker, take care of the following:
 
-1. Change the partition scheme that fits your flash size in Arduino IDE to "RainMaker 4MB", "RainMaker 4MB no OTA" or "RainMaker 8MB" (Tools -> Partition Scheme -> RainMaker).
+1. Change the partition scheme that fits your flash size in Arduino IDE to `RainMaker 4MB`, `RainMaker 4MB no OTA` or `RainMaker 8MB` (Tools -> Partition Scheme -> RainMaker).
 2. Once ESP RainMaker gets started, compulsorily call `WiFi.beginProvision()` which is responsible for user-node mapping.
 3. Use the appropriate provisioning scheme as per the board.
     - ESP32 Board: BLE Provisioning

--- a/libraries/SD/README.md
+++ b/libraries/SD/README.md
@@ -37,7 +37,7 @@ Tip: If you are using a microSD card and have a spare adapter to full-sized SD, 
 **What is the difference between SD and SD_MMC libraries?**
 
 SD runs on SPI, and SD_MMC uses the SDMMC hardware bus on the ESP32.
-The SPI uses 4 communication pins + 2 power connections and operates on up to 80MHz. The SPI option offers flexibility on pin connection because the data connections can be routed through GPIO matrix to any data pin.
+The SPI uses 4 communication pins + 2 power connections and operates on up to 80 MHz. The SPI option offers flexibility on pin connection because the data connections can be routed through GPIO matrix to any data pin.
 SD-SPI speed is approximately half of the SD-MMC even when used on 1-bit line.
 You can read more about SD SPI in the [documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/sdspi_host.html)
 

--- a/libraries/SD_MMC/README.md
+++ b/libraries/SD_MMC/README.md
@@ -102,7 +102,7 @@ Tip: If you are using a microSD card and have a spare adapter to full-sized SD, 
 #### What is the difference between SD and SD_MMC libraries?
 
 SD runs on SPI, and SD_MMC uses the SDMMC hardware bus on the ESP32.
-The SPI uses 4 communication pins + 2 power connections and operates on up to 80MHz. The SPI option offers flexibility on pin connection because the data connections can be routed through GPIO matrix to any data pin.
+The SPI uses 4 communication pins + 2 power connections and operates on up to 80 MHz. The SPI option offers flexibility on pin connection because the data connections can be routed through GPIO matrix to any data pin.
 SD-SPI speed is approximately half of the SD-MMC even when used on 1-bit line.
 You can read more about SD SPI in the [documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/sdspi_host.html)
 

--- a/libraries/WebServer/examples/MultiHomedServers/README.md
+++ b/libraries/WebServer/examples/MultiHomedServers/README.md
@@ -2,7 +2,7 @@
 
 This example tests support for multi-homed servers, i.e. a distinct web servers on distinct IP interface.
 
-It only tests the case n=2 because on a basic ESP32 device, we only have two IP interfaces, namely the WiFi station interfaces and the WiFi soft AP interface.
+It only tests the case n=2 because on a basic ESP32 device, we only have two IP interfaces, namely the Wi-Fi station interfaces and the Wi-Fi soft AP interface.
 For this to work, the WebServer and the NetworkServer classes must correctly handle the case where an IP address is passed to their relevant constructor.
 It also requires WebServer to work with multiple, simultaneous instances.
 
@@ -55,7 +55,7 @@ Currently, this example supports the following targets.
 
 ## How to Use Example
 
-Change the SSID and password in the example to your WiFi and flash the example.
+Change the SSID and password in the example to your Wi-Fi and flash the example.
 Open a serial terminal and the example will write the exact addresses with used IP addresses you can use to test the servers.
 
 * How to install the Arduino IDE: [Install Arduino IDE](https://github.com/espressif/arduino-esp32/tree/master/docs/arduino-ide).

--- a/libraries/WebServer/examples/WebServer/README.md
+++ b/libraries/WebServer/examples/WebServer/README.md
@@ -6,8 +6,8 @@ It is a small project in it's own and has some files to use on the web server to
 
 This example requires some space for a filesystem and runs fine on supported SoCs with 4 MByte or more flash by selecting the proper partition table:
 
-* For using SPIFFS(LittleFS): Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)  
-* For using FATFS: Default 4MB with ffat (1.2MB APP/1.5MB FATFS)  
+* For using SPIFFS(LittleFS): `Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)`
+* For using FATFS: `Default 4MB with ffat (1.2MB APP/1.5MB FATFS)`
 
 
 It features
@@ -36,7 +36,7 @@ Currently, this example supports the following targets.
 
 How to install the Arduino IDE: [Install Arduino IDE](https://github.com/espressif/arduino-esp32/tree/master/docs/arduino-ide).
 
-* In the file `secrets.h` you can add the home WiFi network name ans password.
+* In the file `secrets.h` you can add the home Wi-Fi network name ans password.
 * Compile and upload to the device.
 * Have a look into the monitoring output.
 * Open <http://webserver> or <http://(ip-address)> using a browser.
@@ -56,9 +56,9 @@ It offers plug-in capabilities by registering specific functionalities that will
 
 In the setup() function in the webserver.ino sketch file the following steps are implemented to make the webserver available on the local network.
 
-* Create a webserver listening to port 80 for http requests.
+* Create a webserver listening to port 80 for HTTP requests.
 * Initialize the access to the filesystem in the free flash memory.
-* Connect to the local WiFi network. Here is only a straight-forward implementation hard-coding network name and passphrase. You may consider to use something like the WiFiManager library in real applications.
+* Connect to the local Wi-Fi network. Here is only a straight-forward implementation hard-coding network name and passphrase. You may consider to use something like the WiFiManager library in real applications.
 * Register the device in DNS using a known hostname.
 * Registering several plug-ins (see below).
 * Starting the web server.

--- a/libraries/WebServer/examples/WebServer/WebServer.ino
+++ b/libraries/WebServer/examples/WebServer/WebServer.ino
@@ -243,7 +243,7 @@ void setup(void) {
 
   TRACE("Starting WebServer example...\n");
 
-  // ----- check partitions for finding the fileystem type -----
+  // ----- check partitions for finding the filesystem type -----
   esp_partition_iterator_t i;
 
   i = esp_partition_find(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_FAT, nullptr);

--- a/libraries/WiFi/examples/WiFiClient/README.md
+++ b/libraries/WiFi/examples/WiFiClient/README.md
@@ -4,7 +4,7 @@ This example demonstrates reading and writing data from and to a web service whi
 
 # Supported Targets
 
-Currently, this example supports all SoC with WiFi.
+Currently, this example supports all SoC with Wi-Fi.
 
 
 | Supported Targets | ESP32 | ESP32-S2 | ESP32-C3 | ESP32-S3 |
@@ -18,7 +18,7 @@ Please note that this public channel can be accessed by anyone and it is possibl
 
 ### Configure the Project
 
-Change `SSID` and `password` to connect to your WiFi.
+Change `SSID` and `password` to connect to your Wi-Fi.
 Default values will allow you to use this example without any changes. If you want to use your own channel and you don't have one already follow these steps:
 
 * Create an account on [thingspeak.com](https://www.thingspeak.com).
@@ -79,7 +79,7 @@ load:0x403cc710,len:0x918
 load:0x403ce710,len:0x24e4
 entry 0x403cc710
 ```
-Follows the setup output where connection to your WiFi happens:
+Follows the setup output where connection to your Wi-Fi happens:
 ```
 ******************************************************
 Connecting to your-ssid
@@ -139,7 +139,7 @@ After this the write+read log repeat every 10 seconds.
 
 ***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***
 
-* **WiFi not connected:** Check the SSID and password and also that the signal has sufficient strength.
+* **Wi-Fi not connected:** Check the SSID and password and also that the signal has sufficient strength.
 * **400 Bad Request:** Check the writeApiKey.
 * **404 Not Found:** Check the channel ID.
 * **No data on chart / reading NULL:** Data must be sent as an integer, without commas.

--- a/libraries/WiFi/examples/WiFiClientConnect/README.md
+++ b/libraries/WiFi/examples/WiFiClientConnect/README.md
@@ -1,6 +1,6 @@
 # NetworkClientConnect Example
 
-This example demonstrates how to connect to the WiFi and manage the status and disconnection from STA.
+This example demonstrates how to connect to the Wi-Fi and manage the status and disconnection from STA.
 
 # Supported Targets
 

--- a/libraries/WiFi/examples/WiFiClientEnterprise/README.md
+++ b/libraries/WiFi/examples/WiFiClientEnterprise/README.md
@@ -1,5 +1,5 @@
 # ESP32-Eduroam
-* Eduroam wifi connection with university login identity
+* Eduroam Wi-Fi connection with university login identity
 * Working under Eduroam networks worldwide
 * Methods: PEAP + MsCHAPv2
 
@@ -15,6 +15,7 @@
 * Board will auto reconnect to Eduroam if it lost connection
 
 # Tested locations
+<!-- vale off -->
 |University|Board|Method|Result|
 |-------------|-------------| -----|------|
 |Technical University in Košice (Slovakia)|ESP32 Devkit v1|PEAP + MsCHAPv2|Working|
@@ -29,13 +30,14 @@
 |Universidade Federal de Santa Catarina (Brazil)|xxx|EAP-TTLS + MsCHAPv2|Working|
 |University of Central Florida (Orlando, Florida)|ESP32 Built-in OLED – Heltec WiFi Kit 32|PEAP + MsCHAPv2|Working|
 |Université de Montpellier (France)|NodeMCU-32S|PEAP + MsCHAPv2|Working|
+<!-- vale on -->
 
 # Common errors - Switch to Debug mode for Serial monitor prints
 |Error|Appearance|Solution|
 |-------------|-------------|-------------|
-|wifi: Set status to INIT|Frequent|Hold EN button for few seconds|
+|Wi-Fi: Set status to INIT|Frequent|Hold EN button for few seconds|
 |HANDSHAKE_TIMEOUT|Rare|Bug was found under Zeroshell RADIUS authentization - Unsuccessful connection|
-|AUTH_EXPIRE|Common|In the case of weak wifi network signal, this error is quite common, bring your device closer to AP|
+|AUTH_EXPIRE|Common|In the case of weak Wi-Fi network signal, this error is quite common, bring your device closer to AP|
 |ASSOC_EXPIRE|Rare|-|
 # Successful connection example
  ![alt text](https://i.nahraj.to/f/24Kc.png)

--- a/libraries/WiFi/examples/WiFiScan/README.md
+++ b/libraries/WiFi/examples/WiFiScan/README.md
@@ -1,6 +1,6 @@
 # WiFiScan Example
 
-This example demonstrates how to use the WiFi library to scan available WiFi networks and print the results.
+This example demonstrates how to use the Wi-Fi library to scan available Wi-Fi networks and print the results.
 
 ## Supported Targets
 

--- a/libraries/WiFi/examples/WiFiScanAsync/README.md
+++ b/libraries/WiFi/examples/WiFiScanAsync/README.md
@@ -1,6 +1,6 @@
 # WiFiScanAsync Example
 
-This example demonstrates how to use the WiFi library to scan available WiFi networks in asynchronous mode and print the results.
+This example demonstrates how to use the Wi-Fi library to scan available Wi-Fi networks in asynchronous mode and print the results.
 
 ## Supported Targets
 

--- a/libraries/WiFi/examples/WiFiScanDualAntenna/README.md
+++ b/libraries/WiFi/examples/WiFiScanDualAntenna/README.md
@@ -1,6 +1,6 @@
 # WiFiScan Example
 
-This example demonstrates how to use the WiFi library to scan available WiFi networks and print the results.
+This example demonstrates how to use the Wi-Fi library to scan available Wi-Fi networks and print the results.
 
 This example shows the basic functionality of the dual antenna capability.
 

--- a/libraries/WiFi/examples/WiFiScanTime/README.md
+++ b/libraries/WiFi/examples/WiFiScanTime/README.md
@@ -1,6 +1,6 @@
 # WiFiScanTime Example
 
-This example demonstrates how to use the WiFi library to scan available WiFi networks with custom scan timing and print the results.
+This example demonstrates how to use the Wi-Fi library to scan available Wi-Fi networks with custom scan timing and print the results.
 
 ## Supported Targets
 

--- a/libraries/WiFiProv/examples/WiFiProv/README.md
+++ b/libraries/WiFiProv/examples/WiFiProv/README.md
@@ -8,12 +8,16 @@ This example allows Arduino users to choose either BLE or SOFTAP as the mode of 
 
 ## APIs introduced for provisioning
 
+<!-- vale off -->
 ### WiFi.onEvent()
+<!-- vale on -->
 
 This API can be used to register a function to be called from another
-thread for WiFi Events and Provisioning Events.
+thread for Wi-Fi Events and Provisioning Events.
 
+<!-- vale off -->
 ### WiFi.beginProvision()
+<!-- vale on -->
 
 ```
 WiFi.beginProvision(void (*scheme_cb)(), wifi_prov_scheme_event_handler_t scheme_event_handler, wifi_prov_security_t security, char *pop, char *service_name, char *service_key, uint8_t *uuid);
@@ -50,7 +54,7 @@ WiFi.beginProvision(void (*scheme_cb)(), wifi_prov_scheme_event_handler_t scheme
 { 0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf, 0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02 }
 ```
 
-- `reset_provisioned`: Resets previously provisioned data before initializing. Using this prevents problem when the device automatically connects to previously connected WiFi and therefore cannot be found.
+- `reset_provisioned`: Resets previously provisioned data before initializing. Using this prevents problem when the device automatically connects to previously connected Wi-Fi and therefore cannot be found.
 
 **NOTE:** If none of the parameters are specified in `beginProvision`, default provisioning takes place using SoftAP with the following settings:
 - `scheme = WIFI_PROV_SCHEME_SOFTAP`
@@ -65,7 +69,7 @@ WiFi.beginProvision(void (*scheme_cb)(), wifi_prov_scheme_event_handler_t scheme
 ## Flashing
 This sketch takes up a lot of space for the app and may not be able to flash with default setting on some chips.
 If you see Error like this: "Sketch too big"
-In Arduino IDE go to: Tools > Partition scheme > chose anything that has more than 1.4MB APP for example `No OTA (2MB APP/2MB SPIFFS)`
+In Arduino IDE go to: Tools > Partition scheme > chose anything that has more than 1.4 MB APP for example `No OTA (2MB APP/2MB SPIFFS)`
 
 ## Log Output
 - To enable debugging: Go to Tools -> Core Debug Level -> Info.

--- a/tools/get.py
+++ b/tools/get.py
@@ -171,7 +171,7 @@ def is_latest_version(destination, dirname, rename_to, cfile, checksum):
 
     except Exception as e:
         if verbose:
-            print(f"Falied to verify version for {rename_to}: {e}")
+            print(f"Failed to verify version for {rename_to}: {e}")
 
     return False
 

--- a/variants/alfredo-nou3/pins_arduino.h
+++ b/variants/alfredo-nou3/pins_arduino.h
@@ -5,7 +5,7 @@
 #define USB_PID          0x0003
 #define USB_MANUFACTURER "Alfredo"
 #define USB_PRODUCT      "NoU3"
-#define USB_SERIAL       ""  // Empty string for MAC adddress
+#define USB_SERIAL       ""  // Empty string for MAC address
 
 // User LED
 #define LED_BUILTIN 45

--- a/variants/circuitart_zero_s3/pins_arduino.h
+++ b/variants/circuitart_zero_s3/pins_arduino.h
@@ -7,7 +7,7 @@
 #define USB_PID          0x80DB
 #define USB_MANUFACTURER "CircuitART"
 #define USB_PRODUCT      "ZeroS3"
-#define USB_SERIAL       ""  // Empty string for MAC adddress
+#define USB_SERIAL       ""  // Empty string for MAC address
 
 // User LED
 #define LED_BUILTIN 46


### PR DESCRIPTION
## Description of Change

- Change vale error level to "error";
- Enable vale in pre-commit hooks;
- Fix errors detected by vale;
- Fix misspellings detected by codespell.

## Tests scenarios

Tested locally

## Related links

Requires #10221
