### PR TITLE
ArduinoOTA - change occurrence of client.flush() to clear()

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -376,7 +376,7 @@ void ArduinoOTAClass::handle() {
   if (_udp_ota.parsePacket()) {
     _onRx();
   }
-  _udp_ota.flush();  // always flush, even zero length packets must be flushed.
+  _udp_ota.clear();  // always clear, even zero length packets must be cleared.
 }
 
 int ArduinoOTAClass::getCommand() {


### PR DESCRIPTION
as follow up of changing flush() to clear() in networking with PR https://github.com/espressif/arduino-esp32/pull/9453, there is an  unclear use of `flush()` in ArduinoOTA.

The UDP object in ArduinoOTA is used to receive and send messages in `handle()`. The function _onRx invoked in `handle()` before flush()) reads a message and then sends a response. So it is unclear what the flush() in handle() was meant to do. 

But the library would fail if for some reason _onRx doesn't read the whole incoming message because then all following parsePacket will always return 0 (and this is not a good behavior of the NetworkUDP class).