### PR TITLE
WebServer - change occurrence of client.flush() to clear()

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -262,7 +262,7 @@ bool WebServer::_parseRequest(NetworkClient &client) {
     }
     _parseArguments(searchStr);
   }
-  client.flush();
+  client.clear();
 
   log_v("Request: %s", url.c_str());
   log_v(" Arguments: %s", searchStr.c_str());


### PR DESCRIPTION
as follow up of changing flush() to clear() in networking with PR https://github.com/espressif/arduino-esp32/pull/9453, there is an unclear use of flush() in WebServer.

in Parsing.cpp the client.flush() is at the end of the processing of the HTTP request. the response is already sent. If the connection is not kept alive for the next request, then it is closed so why clearing it. If the connection is kept alive for the following HTTP request, then clear() could delete beginning of the following request. But characters remaining in the buffer would make the following request invalid too. So for a reused connection the processing of the request should ensure to read until the exact end of the request. I don't know if that is fulfilled.

Anyway client.flush() did clear the receive buffer in previous versions so this would return it to that.