### PR TITLE
NetworkUDP - in parsePacket handle previous parsed packet

### DIFF
--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -292,7 +292,10 @@ void NetworkUDP::flush() {}
 
 int NetworkUDP::parsePacket() {
   if (rx_buffer) {
-    return 0;
+    if (rx_buffer->full()) { // packet was not read yet
+      return rx_buffer->available();
+    }
+    clear(); // discard the rest of the packet
   }
   struct sockaddr_storage si_other_storage;  // enough storage for v4 and v6
   socklen_t slen = sizeof(sockaddr_storage);


### PR DESCRIPTION
`parsePacket` now returns 0 if  previous packet was not read. what is the logic of that?

this PR proposes to changes it to return the existing packet if it was not read yet and discard the packet if the user read some part of it.