### PR TITLE
fix(client): Make flush() call clear() and deprecate it

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -369,7 +369,9 @@ int NetworkClient::read() {
   return data;
 }
 
-void NetworkClient::flush() {}
+void NetworkClient::flush() {
+  clear();
+}
 
 size_t NetworkClient::write(const uint8_t *buf, size_t size) {
   int res = 0;

--- a/libraries/Network/src/NetworkClient.h
+++ b/libraries/Network/src/NetworkClient.h
@@ -56,6 +56,7 @@ public:
   size_t write(const uint8_t *buf, size_t size);
   size_t write_P(PGM_P buf, size_t size);
   size_t write(Stream &stream);
+  [[deprecated("Use clear() instead.")]]
   void flush();  // Print::flush tx
   int available();
   int read();

--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -288,7 +288,9 @@ size_t NetworkUDP::write(const uint8_t *buffer, size_t size) {
   return i;
 }
 
-void NetworkUDP::flush() {}
+void NetworkUDP::flush() {
+  clear();
+}
 
 int NetworkUDP::parsePacket() {
   if (rx_buffer) {

--- a/libraries/Network/src/NetworkUdp.h
+++ b/libraries/Network/src/NetworkUdp.h
@@ -64,6 +64,7 @@ public:
   int endPacket();
   size_t write(uint8_t);
   size_t write(const uint8_t *buffer, size_t size);
+  [[deprecated("Use clear() instead.")]]
   void flush();  // Print::flush tx
   int parsePacket();
   int available();


### PR DESCRIPTION
This is a compromise for issues caused by https://github.com/espressif/arduino-esp32/pull/9453

Example output:
```
/var/folders/74/n3f3k71s7lv_snk832kfgjfw0000gn/T/arduino_modified_sketch_265854/WiFiIPv6.ino: In function 'void wifiConnectedLoop()':
/var/folders/74/n3f3k71s7lv_snk832kfgjfw0000gn/T/arduino_modified_sketch_265854/WiFiIPv6.ino:53:20: warning: 'virtual void NetworkUDP::flush()' is deprecated: Use clear() instead. [-Wdeprecated-declarations]
   53 |     ntpClient.flush();
      |     ~~~~~~~~~~~~~~~^~
In file included from /Users/user/Documents/Arduino/hardware/espressif/esp32/libraries/Network/src/Network.h:14,
                 from /Users/user/Documents/Arduino/hardware/espressif/esp32/libraries/WiFi/src/WiFiGeneric.h:39,
                 from /Users/user/Documents/Arduino/hardware/espressif/esp32/libraries/WiFi/src/WiFiSTA.h:29,
                 from /Users/user/Documents/Arduino/hardware/espressif/esp32/libraries/WiFi/src/WiFi.h:33,
                 from /var/folders/74/n3f3k71s7lv_snk832kfgjfw0000gn/T/arduino_modified_sketch_265854/WiFiIPv6.ino:1:
/Users/user/Documents/Arduino/hardware/espressif/esp32/libraries/Network/src/NetworkUdp.h:68:8: note: declared here
   68 |   void flush();  // Print::flush tx
      |        ^~~~~
```