### PR TITLE
fix(uart): sleep retention

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -498,7 +498,7 @@ uart_t *uartBegin(
   }
   uart_config_t uart_config;
   memset(&uart_config, 0, sizeof(uart_config_t));
-  uart_config.flags.backup_before_sleep = false; // new flag from IDF v5.3
+  uart_config.flags.backup_before_sleep = false;  // new flag from IDF v5.3
   uart_config.data_bits = (config & 0xc) >> 2;
   uart_config.parity = (config & 0x3);
   uart_config.stop_bits = (config & 0x30) >> 4;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -497,6 +497,7 @@ uart_t *uartBegin(
     log_v("UART%d not installed. Starting installation", uart_nr);
   }
   uart_config_t uart_config;
+  uart_config.flags.backup_before_sleep = false; // necessary within IDF 5.3
   uart_config.data_bits = (config & 0xc) >> 2;
   uart_config.parity = (config & 0x3);
   uart_config.stop_bits = (config & 0x30) >> 4;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -497,7 +497,7 @@ uart_t *uartBegin(
     log_v("UART%d not installed. Starting installation", uart_nr);
   }
   uart_config_t uart_config;
-  memset(&uart_config, 0, sizeof(uart_config_t);
+  memset(&uart_config, 0, sizeof(uart_config_t));
   uart_config.flags.backup_before_sleep = false; // new flag from IDF v5.3
   uart_config.data_bits = (config & 0xc) >> 2;
   uart_config.parity = (config & 0x3);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -497,7 +497,8 @@ uart_t *uartBegin(
     log_v("UART%d not installed. Starting installation", uart_nr);
   }
   uart_config_t uart_config;
-  uart_config.flags.backup_before_sleep = false; // necessary within IDF v5.3
+  memset(&uart_config, 0, sizeof(uart_config_t);
+  uart_config.flags.backup_before_sleep = false; // new flag from IDF v5.3
   uart_config.data_bits = (config & 0xc) >> 2;
   uart_config.parity = (config & 0x3);
   uart_config.stop_bits = (config & 0x30) >> 4;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -497,7 +497,7 @@ uart_t *uartBegin(
     log_v("UART%d not installed. Starting installation", uart_nr);
   }
   uart_config_t uart_config;
-  uart_config.flags.backup_before_sleep = false; // necessary within IDF 5.3
+  uart_config.flags.backup_before_sleep = false; // necessary within IDF v5.3
   uart_config.data_bits = (config & 0xc) >> 2;
   uart_config.parity = (config & 0x3);
   uart_config.stop_bits = (config & 0x30) >> 4;


### PR DESCRIPTION
## Description of Change

IDF 5.3 introduces a new feature `SOC_UART_SUPPORT_SLEEP_RETENTION` that adds a new field to `uart_config_t` called `flags.backup_before_sleep`.

When this field is not set, it causes an error when `HardwareSerial::begin()` is executed.

## Tests scenarios

Tested with ESP32, ESP32-S3, ESP32-C6.

``` cpp
void setup() {
  Serial.begin(115200);
}

void loop() {
  Serial.println("Hello World!");
  delay(1000);
}
```

## Related links

None

(*eg. Closes #number of issue*)
