### PR TITLE
fix(arduino): changes ESP32 definition in CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ target_compile_options(${COMPONENT_TARGET} PUBLIC
     -DARDUINO_ARCH_ESP32
     -DARDUINO_BOARD="${idf_target_caps}_DEV"
     -DARDUINO_VARIANT="${CONFIG_ARDUINO_VARIANT}"
-    -DESP32)
+    -DESP32=ESP32)
 
 if(CONFIG_AUTOSTART_ARDUINO)
     # in autostart mode, arduino-esp32 contains app_main() function and needs to


### PR DESCRIPTION
## Description of Change

Fixes an issue related to `esp_matter` component that defines a path using `ESP32` as folder.
Because Arduino defines `ESP32` to `1`, it causes an expansion error for folder using `ESP32` folder name.

`-DESP32` ==> `#define ESP32 1`
`#define CHIP_PLATFORM_CONFIG_INCLUDE <platform/ESP32/CHIPPlatformConfig.h>` 
will expand to
`#define CHIP_PLATFORM_CONFIG_INCLUDE <platform/1/CHIPPlatformConfig.h>`

## Tests scenarios

Building Arduino + Matter as IDF Component in the same project.

## Related links

https://github.com/espressif/arduino-esp32/issues/7432#issuecomment-2294706221