### PR TITLE
Adds HW Serial CDC as IDF component example

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -96,3 +96,4 @@ dependencies:
     require: public
 examples:
   - path: ./idf_component_examples/hello_world
+  - path: ./idf_component_examples/hw_cdc_hello_world

--- a/idf_component_examples/hw_cdc_hello_world/CMakeLists.txt
+++ b/idf_component_examples/hw_cdc_hello_world/CMakeLists.txt
@@ -1,0 +1,12 @@
+# For more information about build system see
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# Adds necessary definitions for compiling it using Serial symbol attached to the HW USB CDC port
+list(APPEND compile_definitions "ARDUINO_USB_CDC_ON_BOOT=1")
+list(APPEND compile_definitions "ARDUINO_USB_MODE=1")
+
+project(hw_cdc_hello_world)

--- a/idf_component_examples/hw_cdc_hello_world/README.md
+++ b/idf_component_examples/hw_cdc_hello_world/README.md
@@ -1,0 +1,63 @@
+| Supported Targets | ESP32-C3 | ESP32-C6 | ESP32-H2 | ESP32-S3 |
+| ----------------- | -------- | -------- | -------- | -------- |
+
+# _HW Serial USB CDC example_
+
+This is the simplest buildable example made to be used as a template for new projects running Arduino-ESP32 as an ESP-IDF component that will redefine the `Serial` interface to be attached to the USB CDC Harware Serial port.\
+See [arduino-esp32](https://components.espressif.com/components/espressif/arduino-esp32) in ESP Registry.
+
+## How to use example
+
+After cloning this repository, go to the `hw_cdc_hello_world` folder and select the target by executing\
+`idf.py set-target <SoC_target>`.\
+`<SoC_target>` can be one of the installed IDF version supported targets.
+
+It is possible to just clone this folder be executing\
+`idf.py create-project-from-example "espressif/arduino-esp32^3.0.5:hw_cdc_hello_world"`
+
+For IDF 5.1.x and forward, the list of targets that support Hardware USB CDC are, at least: esp32s3, esp32c3, esp32c6 and esp32h2.\
+Then just run command: `idf.py build` or `idf.py -p USB_PORT flash monitor`.
+
+Usually, it is necessary to make the ESP32 SoC to enter in `Download Mode` before uploading the firmware.\
+After that, just press `RESET/EN` to start the new firmware.
+
+## Example folder contents
+
+The project **hw_serial_example** contains one source file in C++ language [main.cpp](main/main.cpp). The file is located in folder [main](main).
+
+ESP-IDF projects are built using CMake. The project building configuration is contained in `CMakeLists.txt`
+file that provide a set of directives and instructions describing the project's source files and targets
+(executable, library, or both).
+
+Below is the minimum list of files in the project folder.
+
+```
+├── CMakeLists.txt             Global project CMake configuration file
+├── sdkconfig.defaults         sdkconfig setting for an Arduino project
+├── main                       
+│   ├── CMakeLists.txt         Arduino sketch CMake configuration file
+│   ├── idf_component.yml      List of IDF components necessary to build the project
+│   └── main.cpp               Arduino Sketch code - don't forget to add "#include <Arduino.h>" on it
+└── README.md                  This is the file you are currently reading
+```
+
+## Configuring the Hardware USB CDC Serial
+
+ESP32 Arduino has two macro defined symbols that control what `Serial` symbol will represent.
+Default `Serial` is the UART0 from `HardwareSerial` class.
+
+`Serial` can be changed to be attached to the HW Serial JTAG port fro the SoC.
+In order to make it work, it is necessary to define 2 symbols: `ARDUINO_USB_CDC_ON_BOOT` and `ARDUINO_USB_MODE` to `1`.
+This is achieved by adding a couple lines to the [Project Folder CMakeLists.txt](CMakeLists.txt) file.
+
+
+```
+# Adds necessary definitions for compiling it using Serial symbol attached to the HW USB CDC port
+list(APPEND compile_definitions "ARDUINO_USB_CDC_ON_BOOT=1")
+list(APPEND compile_definitions "ARDUINO_USB_MODE=1")
+
+```
+
+Those two lines will add a `-DSYMBOL=VAL` when compiling every source code file.
+
+In order to make sure that it is actually working correctly, the [sketch](main/main.cpp) will execute `Serial.begin();` with no baudrate, which only works for USB CDC. 

--- a/idf_component_examples/hw_cdc_hello_world/README.md
+++ b/idf_component_examples/hw_cdc_hello_world/README.md
@@ -34,7 +34,7 @@ Below is the minimum list of files in the project folder.
 ```
 ├── CMakeLists.txt             Global project CMake configuration file
 ├── sdkconfig.defaults         sdkconfig setting for an Arduino project
-├── main                       
+├── main  
 │   ├── CMakeLists.txt         Arduino sketch CMake configuration file
 │   ├── idf_component.yml      List of IDF components necessary to build the project
 │   └── main.cpp               Arduino Sketch code - don't forget to add "#include <Arduino.h>" on it
@@ -60,4 +60,4 @@ list(APPEND compile_definitions "ARDUINO_USB_MODE=1")
 
 Those two lines will add a `-DSYMBOL=VAL` when compiling every source code file.
 
-In order to make sure that it is actually working correctly, the [sketch](main/main.cpp) will execute `Serial.begin();` with no baudrate, which only works for USB CDC. 
+In order to make sure that it is actually working correctly, the [sketch](main/main.cpp) will execute `Serial.begin();` with no baudrate, which only works for USB CDC.

--- a/idf_component_examples/hw_cdc_hello_world/README.md
+++ b/idf_component_examples/hw_cdc_hello_world/README.md
@@ -3,7 +3,7 @@
 
 # _HW Serial USB CDC example_
 
-This is the simplest buildable example made to be used as a template for new projects running Arduino-ESP32 as an ESP-IDF component that will redefine the `Serial` interface to be attached to the USB CDC Harware Serial port.\
+This is the simplest buildable example made to be used as a template for new projects running Arduino-ESP32 as an ESP-IDF component that will redefine the `Serial` interface to be attached to the USB CDC Hardware Serial port.\
 See [arduino-esp32](https://components.espressif.com/components/espressif/arduino-esp32) in ESP Registry.
 
 ## How to use example

--- a/idf_component_examples/hw_cdc_hello_world/main/CMakeLists.txt
+++ b/idf_component_examples/hw_cdc_hello_world/main/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRC_DIRS     "."
+    INCLUDE_DIRS "."
+)

--- a/idf_component_examples/hw_cdc_hello_world/main/idf_component.yml
+++ b/idf_component_examples/hw_cdc_hello_world/main/idf_component.yml
@@ -1,0 +1,6 @@
+## IDF Component Manager Manifest File
+dependencies:
+  espressif/arduino-esp32:
+    version: "*"
+    override_path: "../../../"
+    pre_release: true

--- a/idf_component_examples/hw_cdc_hello_world/main/main.cpp
+++ b/idf_component_examples/hw_cdc_hello_world/main/main.cpp
@@ -1,0 +1,10 @@
+#include <Arduino.h>
+
+void setup() {
+  Serial.begin(); // USB CDC doens't need a baud rate
+}
+
+void loop() {
+  Serial.println("Hello world!");
+  delay(1000);
+}

--- a/idf_component_examples/hw_cdc_hello_world/main/main.cpp
+++ b/idf_component_examples/hw_cdc_hello_world/main/main.cpp
@@ -2,6 +2,8 @@
 
 void setup() {
   Serial.begin(); // USB CDC doens't need a baud rate
+  while(!Serial) delay(100); // wait for the Serial Monitor to be open
+  Serial.println("\r\nStarting...\r\n");
 }
 
 void loop() {

--- a/idf_component_examples/hw_cdc_hello_world/main/main.cpp
+++ b/idf_component_examples/hw_cdc_hello_world/main/main.cpp
@@ -3,12 +3,12 @@
 void setup() {
   // USB CDC doens't need a baud rate
   Serial.begin();
-  
+
   // wait for the Serial Monitor to be open
-  while(!Serial) {
+  while (!Serial) {
     delay(100);
   }
-  
+
   Serial.println("\r\nStarting...\r\n");
 }
 

--- a/idf_component_examples/hw_cdc_hello_world/main/main.cpp
+++ b/idf_component_examples/hw_cdc_hello_world/main/main.cpp
@@ -1,8 +1,14 @@
 #include <Arduino.h>
 
 void setup() {
-  Serial.begin(); // USB CDC doens't need a baud rate
-  while(!Serial) delay(100); // wait for the Serial Monitor to be open
+  // USB CDC doens't need a baud rate
+  Serial.begin();
+  
+  // wait for the Serial Monitor to be open
+  while(!Serial) {
+    delay(100);
+  }
+  
   Serial.println("\r\nStarting...\r\n");
 }
 

--- a/idf_component_examples/hw_cdc_hello_world/main/main.cpp
+++ b/idf_component_examples/hw_cdc_hello_world/main/main.cpp
@@ -1,7 +1,7 @@
 #include <Arduino.h>
 
 void setup() {
-  // USB CDC doens't need a baud rate
+  // USB CDC doesn't need a baud rate
   Serial.begin();
 
   // wait for the Serial Monitor to be open

--- a/idf_component_examples/hw_cdc_hello_world/sdkconfig.defaults
+++ b/idf_component_examples/hw_cdc_hello_world/sdkconfig.defaults
@@ -1,0 +1,12 @@
+#
+# Arduino ESP32
+#
+CONFIG_AUTOSTART_ARDUINO=y
+# end of Arduino ESP32
+
+#
+# FREERTOS
+#
+CONFIG_FREERTOS_HZ=1000
+# end of FREERTOS
+# end of Component config


### PR DESCRIPTION
## Description of Change
Adds a new example for building Arduino project as IDF component using the native HW CDC port.

## Tests scenarios
Tested using ESP32-C3, ESP32-C6 and ESP32-S3 - building it using Arduino as IDF Component.

## Related links
None