### PR TITLE
fix(boards): Remove port property assoc. for non-unique VID/PID pairs

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -4507,8 +4507,6 @@ S_ODI_Ultra.menu.EraseFlash.all.upload.erase_cmd=-e
 ##############################################################
 
 lilygo_t_display.name=LilyGo T-Display
-lilygo_t_display.vid.0=0x1a86
-lilygo_t_display.pid.0=0x55d4
 
 lilygo_t_display.upload.tool=esptool_py
 lilygo_t_display.upload.tool.default=esptool_py
@@ -27574,8 +27572,6 @@ fm-devkit.menu.EraseFlash.all.upload.erase_cmd=-e
 ### Fri3d Badge 2024 (ESP32-S3-WROOM-1)
 
 fri3d_2024_esp32s3.name=Fri3d Badge 2024 (ESP32-S3-WROOM-1)
-fri3d_2024_esp32s3.vid.0=0x303a
-fri3d_2024_esp32s3.pid.0=0x1001
 
 fri3d_2024_esp32s3.bootloader.tool=esptool_py
 fri3d_2024_esp32s3.bootloader.tool.default=esptool_py
@@ -39913,8 +39909,6 @@ waveshare_esp32_s3_lcd_169.menu.EraseFlash.all.upload.erase_cmd=-e
 ##############################################################
 
 waveshare_esp32s3_touch_lcd_128.name=Waveshare ESP32S3 Touch LCD 128
-waveshare_esp32s3_touch_lcd_128.vid.0=0x1a86
-waveshare_esp32s3_touch_lcd_128.pid.0=0x55d3
 
 waveshare_esp32s3_touch_lcd_128.upload.tool=esptool_py
 waveshare_esp32s3_touch_lcd_128.upload.tool.default=esptool_py
@@ -40584,8 +40578,6 @@ walter.menu.EraseFlash.all.upload.erase_cmd=-e
 ##############################################################
 
 elecrow_crowpanel_7.name=Elecrow CrowPanel 7.0P
-elecrow_crowpanel_7.vid.0=0x1a86
-elecrow_crowpanel_7.pid.0=0x7523
 
 elecrow_crowpanel_7.upload.tool=esptool_py
 elecrow_crowpanel_7.upload.tool.default=esptool_py


### PR DESCRIPTION
## Description of Change

The Arduino boards platform framework allows properties of a port to be [associated with a board definition](https://arduino.github.io/arduino-cli/dev/platform-specification/#properties-from-pluggable-discovery:~:text=upload_port.vid%20and%20upload_port.pid%20properties). The Arduino development software will identify a port having the associated properties as that board.

This should only be done for properties that are unique to the ports produced by that board model. In cases where a board model does not produce a port with properties unique to that model, it is irresponsible to associate those properties with the board definition as this will cause other models to be inappropriately identified.

The authors of these board definitions associated them with non-unique USB VID/PID pairs so those associations must be removed. The `303a:1001` VID/PID pair is of the hardware CDC serial port of the native USB ESP32 chips. The others are stock VID/PID pairs of general purpose USB to serial bridge chips that are used on many different board models.

## Tests scenarios

Compile for the modified boards using the platform (at 0b8eedea5cf18e2b01f80975197b85f70a36caf3) with this patch (0a8c586953327af6d38280ca10c612a82b4d1be7) applied.

## Related links

Originally reported at https://forum.arduino.cc/t/i-dont-have-elecrow-crowpanel-7-0p/1293026

- https://github.com/espressif/arduino-esp32/issues/6384
- https://github.com/espressif/arduino-esp32/issues/7292
- https://github.com/espressif/arduino-esp32/issues/9702
- https://forum.arduino.cc/t/issue-with-arduino-cloud-device-recognition-esp32-dev-module-detected-as-lilygo-t-display/1295971
