### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-0bbd7281"
+              "version": "idf-release_v5.3-2c46030b"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-0bbd7281",
+          "version": "idf-release_v5.3-2c46030b",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-0bbd7281.zip",
-              "checksum": "SHA-256:e436e8ba703cf78ec81d80e956d2ae4a5e754f280950520ad7c425bb56738a80",
-              "size": "319140606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-2c46030b.zip",
+              "checksum": "SHA-256:c61c83d0c456ba6ed8a6aa04fbd95e9e9b1c92b2863b2d49b768704e512b63b8",
+              "size": "319142534"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.3 f7cf4b4
esp-idf: release/v5.3 2c46030bbf
arduino: release/v3.1.x 22fb4026
tinyusb: master 29e025cbf
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.15
espressif__esp-nn: 1.0.2
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.5.0
espressif__esp-zigbee-lib: 1.5.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.4.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.1
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dl:
espressif__esp-sr: 1.9.0
espressif__esp32-camera:
```
