### PR TITLE
fix(boards): Correct typos in port prop. associations for "Bee" boards

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -34347,9 +34347,9 @@ department_of_alchemy_minimain_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
 Bee_Data_Logger.name=Bee Data Logger
 Bee_Data_Logger.vid.0=0x303a
-Bee_Data_Logger.pid.0=815C
+Bee_Data_Logger.pid.0=0x815C
 Bee_Data_Logger.upload_port.0.vid=0x303a
-Bee_Data_Logger.upload_port.0.pid=815C
+Bee_Data_Logger.upload_port.0.pid=0x815C
 
 Bee_Data_Logger.bootloader.tool=esptool_py
 Bee_Data_Logger.bootloader.tool.default=esptool_py

--- a/boards.txt
+++ b/boards.txt
@@ -34571,7 +34571,7 @@ Bee_Motion.name=Bee Motion
 Bee_Motion.vid.0=0x303a
 Bee_Motion.pid.0=0x810D
 Bee_Motion.vid.upload_port.0.vid=0x303a
-Bee_Motion.pid.upload_port.0.vid=0x810D
+Bee_Motion.pid.upload_port.0.pid=0x810D
 
 Bee_Motion.bootloader.tool=esptool_py
 Bee_Motion.bootloader.tool.default=esptool_py
@@ -34790,7 +34790,7 @@ Bee_S3.name=Bee S3
 Bee_S3.vid.0=0x303a
 Bee_S3.pid.0=0x8110
 Bee_S3.vid.upload_port.0.vid=0x303a
-Bee_S3.pid.upload_port.0.vid=0x8110
+Bee_S3.pid.upload_port.0.pid=0x8110
 
 Bee_S3.bootloader.tool=esptool_py
 Bee_S3.bootloader.tool.default=esptool_py


### PR DESCRIPTION
## Description of Change

These properties are intended to associate VID/PID pairs with the "Bee" board definitions:

https://arduino.github.io/arduino-cli/dev/platform-specification/#properties-from-pluggable-discovery:~:text=upload_port.vid%20and%20upload_port.pid%20properties

Typos caused incorrect VID and PID values to be associated. The result was that ports with this VID/PID pair were not identified by the Arduino development software as the board model as intended.

This pull request fixes the typos.

## Tests scenarios

Compile for the modified boards using the platform (at 0b8eedea5cf18e2b01f80975197b85f70a36caf3) with this patch applied.
