### PR TITLE
fix(scan): Make sure scan struct is cleared before set

### DIFF
--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -77,6 +77,7 @@ int16_t
   scanDelete();
 
   wifi_scan_config_t config;
+  memset(&config, 0, sizeof(wifi_scan_config_t));
   config.ssid = (uint8_t *)ssid;
   config.bssid = (uint8_t *)bssid;
   config.channel = channel;


### PR DESCRIPTION
new parameters could cause issues if scan is not cleared

fixes: https://github.com/espressif/arduino-esp32/issues/10281