### PR TITLE
 change(ESP_NOW_Serial): No teardown on retry limit

### DIFF
--- a/libraries/ESP_NOW/src/ESP32_NOW_Serial.cpp
+++ b/libraries/ESP_NOW/src/ESP32_NOW_Serial.cpp
@@ -264,9 +264,10 @@ void ESP_NOW_Serial_Class::onSent(bool success) {
       //the data is lost in this case
       vRingbufferReturnItem(tx_ring_buf, queued_buff);
       queued_buff = NULL;
-      xSemaphoreGive(tx_sem);
-      end();
       log_e(MACSTR " : RE-SEND_MAX[%u]", MAC2STR(addr()), resend_count);
+      //send next packet?
+      //log_d(MACSTR ": NEXT", MAC2STR(addr()));
+      checkForTxData();
     }
   }
 }


### PR DESCRIPTION
## Description of Change

After max retries is met once the ESP_NOW_Serial_Class performs "end()" which removes the peer from ESP_NOW. Further messages to and from ESP_NOW_Serial are not received or sent. Peer should stay in ESP_NOW to re-establish connection even with data loss. This change will "retry and drop" the data piece by piece instead of aborting the connection. Description of Change

ESP_NOW_Serial "Peer" will not remove itself from ESP_NOW_Peer list when data sent is not received by a peer. ESP_NOW_Serial::end() is still called when ESP_NOW::send() fails Tests scenarios

## Tests scenarios

Tested on a pair of M5Stack Stamp ESP32-C3.
Confirmed that transmission is able to continue after:  disconnecting the Receiving module from power.
Attempting to send data.
Restoring power to Receiving module.

Previously, transmission halts as the cleanup/teardown in ESP_NOW_Serial::end() is triggered. 

## Related links

I did not create an issue for this.
Issue was NowSerial had to be re-initialized essentially for every byte without knowing if the peer was present/restored.

Workaround was to use broadcast address for TX and a separate ESP_NOW_Serial peer with MAC address for RX.
