### PR TITLE
change(esp_now_serial): No teardown on retry limit

### DIFF
--- a/libraries/ESP_NOW/src/ESP32_NOW_Serial.cpp
+++ b/libraries/ESP_NOW/src/ESP32_NOW_Serial.cpp
@@ -264,9 +264,10 @@ void ESP_NOW_Serial_Class::onSent(bool success) {
       //the data is lost in this case
       vRingbufferReturnItem(tx_ring_buf, queued_buff);
       queued_buff = NULL;
-      xSemaphoreGive(tx_sem);
-      end();
       log_e(MACSTR " : RE-SEND_MAX[%u]", MAC2STR(addr()), resend_count);
+      //send next packet?
+      //log_d(MACSTR ": NEXT", MAC2STR(addr()));
+      checkForTxData();
     }
   }
 }

--- a/libraries/ESP_NOW/src/ESP32_NOW_Serial.cpp
+++ b/libraries/ESP_NOW/src/ESP32_NOW_Serial.cpp
@@ -11,7 +11,7 @@
  *
 */
 
-ESP_NOW_Serial_Class::ESP_NOW_Serial_Class(const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface, const uint8_t *lmk)
+ESP_NOW_Serial_Class::ESP_NOW_Serial_Class(const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface, const uint8_t *lmk, bool remove_on_fail)
   : ESP_NOW_Peer(mac_addr, channel, iface, lmk) {
   tx_ring_buf = NULL;
   rx_queue = NULL;
@@ -19,6 +19,7 @@ ESP_NOW_Serial_Class::ESP_NOW_Serial_Class(const uint8_t *mac_addr, uint8_t chan
   queued_size = 0;
   queued_buff = NULL;
   resend_count = 0;
+  _remove_on_fail = remove_on_fail;
 }
 
 ESP_NOW_Serial_Class::~ESP_NOW_Serial_Class() {
@@ -265,7 +266,12 @@ void ESP_NOW_Serial_Class::onSent(bool success) {
       vRingbufferReturnItem(tx_ring_buf, queued_buff);
       queued_buff = NULL;
       log_e(MACSTR " : RE-SEND_MAX[%u]", MAC2STR(addr()), resend_count);
-      //send next packet?
+      //if we are not able to send the data and remove_on_fail is set, remove the peer
+      if (_remove_on_fail) {
+        xSemaphoreGive(tx_sem);
+        end();
+        return;
+      }
       //log_d(MACSTR ": NEXT", MAC2STR(addr()));
       checkForTxData();
     }

--- a/libraries/ESP_NOW/src/ESP32_NOW_Serial.h
+++ b/libraries/ESP_NOW/src/ESP32_NOW_Serial.h
@@ -17,12 +17,13 @@ private:
   size_t queued_size;
   uint8_t *queued_buff;
   size_t resend_count;
+  bool _remove_on_fail;
 
   bool checkForTxData();
   size_t tryToSend();
 
 public:
-  ESP_NOW_Serial_Class(const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface = WIFI_IF_AP, const uint8_t *lmk = NULL);
+  ESP_NOW_Serial_Class(const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface = WIFI_IF_AP, const uint8_t *lmk = NULL, bool remove_on_fail = true);
   ~ESP_NOW_Serial_Class();
   size_t setRxBufferSize(size_t);
   size_t setTxBufferSize(size_t);

--- a/libraries/ESP_NOW/src/ESP32_NOW_Serial.h
+++ b/libraries/ESP_NOW/src/ESP32_NOW_Serial.h
@@ -23,7 +23,7 @@ private:
   size_t tryToSend();
 
 public:
-  ESP_NOW_Serial_Class(const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface = WIFI_IF_AP, const uint8_t *lmk = NULL, bool remove_on_fail = true);
+  ESP_NOW_Serial_Class(const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface = WIFI_IF_AP, const uint8_t *lmk = NULL, bool remove_on_fail = false);
   ~ESP_NOW_Serial_Class();
   size_t setRxBufferSize(size_t);
   size_t setTxBufferSize(size_t);


### PR DESCRIPTION
## Description of Change

After max retries is met once the ESP_NOW_Serial_Class performs "end()" which removes the peer from ESP_NOW. 
Further messages to and from ESP_NOW_Serial are not received or sent. 
Peer should stay in ESP_NOW to re-establish connection even with data loss. 
This change will "retry and drop" the data piece by piece instead of aborting the connection.

ESP_NOW_Serial "Peer" will not remove itself from ESP_NOW_Peer list when data sent is not received by a peer. ESP_NOW_Serial::end() is still called when ESP_NOW::send() fails.

## Tests scenarios

Tested on a pair of M5Stack Stamp ESP32-C3.
Confirmed that transmission is able to continue after:  disconnecting the Receiving module from power.
Attempting to send data.
Restoring power to Receiving module.

Previously, transmission halts as the cleanup/teardown in ESP_NOW_Serial::end() is triggered. 

## Related links

I did not create an issue for this.
Issue was NowSerial had to be re-initialized essentially for every byte without knowing if the peer was present/restored.

Workaround was to use broadcast address for TX and a separate ESP_NOW_Serial peer with MAC address for RX.
