### PR TITLE
fix(ci): Log default FQBN if not passed as argument

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -416,10 +416,17 @@ function build_sketches(){ # build_sketches <ide_path> <user_path> <target> <pat
     echo "Start Sketch: $start_num"
     echo "End Sketch  : $end_index"
 
+    #if fqbn is not passed then set it to default for compilation log
+    if [ -z $fqbn ]; then
+        log_fqbn="espressif:esp32:$target"
+    else
+        log_fqbn=$fqbn
+    fi
+
     sizes_file="$GITHUB_WORKSPACE/cli_compile_$chunk_index.json"
     if [ $log_compilation ]; then
         #echo board,target and start of sketches to sizes_file json
-        echo "{ \"board\": \"$fqbn\",
+        echo "{ \"board\": \"$log_fqbn\",
                 \"target\": \"$target\",
                 \"sketches\": [" >> "$sizes_file"
     fi


### PR DESCRIPTION
## Description of Change
As FQBN is now read in last step of building sketch, there was empty FQBN in the compilation log for sizes report.

## Tests scenarios

## Related links
