### PR TITLE
Fixed Stream find hang.

### DIFF
--- a/cores/esp32/Stream.cpp
+++ b/cores/esp32/Stream.cpp
@@ -122,10 +122,11 @@ int Stream::findMulti(struct Stream::MultiTarget *targets, int tCount) {
   }
 
   while (1) {
-    int c = timedRead();
-    if (c < 0) {
+    int cc = timedRead();
+    if (cc < 0) {
       return -1;
     }
+    char c = cc;
 
     for (struct MultiTarget *t = targets; t < targets + tCount; ++t) {
       // the simple case is if we match, deal with that first.


### PR DESCRIPTION
## Description of Change
Check `timedRead` is < 0, then use `char` (rather than `int`) for the rest of `findMulti`. This avoids sign extension and incorrect comparisons which result in a hang.

## Tests scenarios
This code hangs forever, even when Serial repeatedly receives 0xCA, tested on Arduino Mega 2560 R3:
```
while (!Serial1.find(0xCA)) ;
```

The reason is in Stream `findMulti`:
https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/Stream.cpp#L132

Consider this comparison:
```
if (c == t->str[t->index]) {
```
`c` is `int` with an unsigned value 0xCA.
`t->str` is `const char *` with (on Arduino Mega 2560 R3) a signed value -54 decimal which as an unsigned value is 0xCA.
In the comparison, the char is sign extended to an int, resulting in 0xFFFFFFCA giving:
```
if (0xCA == 0xFFFFFFCA) {
```
This is never true and not the intention. There appear to be other comparisons in Stream.cpp with this problem.