### PR TITLE
fix(scan): Make sure that we do not leak memory if reading the APs fails

### DIFF
--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -119,7 +119,11 @@ void WiFiScanClass::_scanDone() {
   esp_wifi_scan_get_ap_num(&(WiFiScanClass::_scanCount));
   if (WiFiScanClass::_scanCount) {
     WiFiScanClass::_scanResult = new wifi_ap_record_t[WiFiScanClass::_scanCount];
-    if (!WiFiScanClass::_scanResult || esp_wifi_scan_get_ap_records(&(WiFiScanClass::_scanCount), (wifi_ap_record_t *)_scanResult) != ESP_OK) {
+    if (!WiFiScanClass::_scanResult) {
+      WiFiScanClass::_scanCount = 0;
+    } else if (esp_wifi_scan_get_ap_records(&(WiFiScanClass::_scanCount), (wifi_ap_record_t *)_scanResult) != ESP_OK) {
+      delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
+      WiFiScanClass::_scanResult = 0;
       WiFiScanClass::_scanCount = 0;
     }
   }


### PR DESCRIPTION
As it was written, it was possible to leak the scan result array if esp_wifi_scan_get_ap_records() failed. Change will ensure that the array is deleted in that case.
