### PR TITLE
Issue 10316: Workaround bug in NetworkEvents.cpp getStdFunctionAddress

### DIFF
--- a/libraries/Network/src/NetworkEvents.cpp
+++ b/libraries/Network/src/NetworkEvents.cpp
@@ -225,10 +225,8 @@ void NetworkEvents::removeEvent(NetworkEventCb cbEvent, arduino_event_id_t event
   }
 }
 
-template<typename T, typename... U> static size_t getStdFunctionAddress(std::function<T(U...)> f) {
-  typedef T(fnType)(U...);
-  fnType **fnPointer = f.template target<fnType *>();
-  return (size_t)*fnPointer;
+static size_t getStdFunctionAddress(NetworkEventFuncCb cbEvent) {
+  return *(size_t *)(void *)&cbEvent;
 }
 
 void NetworkEvents::removeEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event) {


### PR DESCRIPTION
1. PR Title: Issue 10316: Workaround bug in NetworkEvents.cpp getStdFunctionAddress
2. Issue 10316: NetworkEvents: NetworkEvents::removeEvent crashes when multiple event handlers are present
3. None

## Description of Change
Modified getStdFunctionAddress in libraries/Network/src/NetworkEvents.cpp to eliminate the crash.

## Tests scenarios
Testing done using example Sketch supplied with the issue

## Related links
Closes issue #10316
