### PR TITLE
Fix(NetworkEvents): Don't skip event callbacks in NetworkEvents::removeEvent

### DIFF
--- a/libraries/Network/src/NetworkEvents.cpp
+++ b/libraries/Network/src/NetworkEvents.cpp
@@ -221,6 +221,7 @@ void NetworkEvents::removeEvent(NetworkEventCb cbEvent, arduino_event_id_t event
     NetworkEventCbList_t entry = cbEventList[i];
     if (entry.cb == cbEvent && entry.event == event) {
       cbEventList.erase(cbEventList.begin() + i);
+      i--; // Don't skip over any entries in the list
     }
   }
 }
@@ -240,6 +241,7 @@ void NetworkEvents::removeEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t e
     NetworkEventCbList_t entry = cbEventList[i];
     if (getStdFunctionAddress(entry.fcb) == getStdFunctionAddress(cbEvent) && entry.event == event) {
       cbEventList.erase(cbEventList.begin() + i);
+      i--; // Don't skip over any entries in the list
     }
   }
 }
@@ -253,6 +255,7 @@ void NetworkEvents::removeEvent(NetworkEventSysCb cbEvent, arduino_event_id_t ev
     NetworkEventCbList_t entry = cbEventList[i];
     if (entry.scb == cbEvent && entry.event == event) {
       cbEventList.erase(cbEventList.begin() + i);
+      i--; // Don't skip over any entries in the list
     }
   }
 }
@@ -262,6 +265,7 @@ void NetworkEvents::removeEvent(network_event_handle_t id) {
     NetworkEventCbList_t entry = cbEventList[i];
     if (entry.id == id) {
       cbEventList.erase(cbEventList.begin() + i);
+      i--; // Don't skip over any entries in the list
     }
   }
 }


### PR DESCRIPTION
## Description of Change
Modified the four (4) NetworkEvents::removeEvent routines in libraries/Network/src/NetworkEvents.cpp to decrement "i" after the event callback is erased.

## Tests scenarios
Requires Fix [10317] to prevent crashes.

Used the submitted sketch for issue [10318](https://github.com/espressif/arduino-esp32/issues/10318).  Without this change each actual event generates 4 callbacks initially and 2 callbacks after calling removeEvent.  With this change all event handlers are removed and no further callbacks are called.

## Related links
Closes issue [10318](https://github.com/espressif/arduino-esp32/issues/10318)
