### PR TITLE
fix(networking): NetworkClientRxBuffer::clear() may not always clear

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -148,9 +148,13 @@ public:
 
   void clear() {
     if (r_available()) {
-      fillBuffer();
+      _pos = _fill;
+      while (fillBuffer()) {
+        _pos = _fill;
+      }
     }
-    _pos = _fill;
+    _pos = 0;
+    _fill = 0;
   }
 };
 


### PR DESCRIPTION
## Description of Change

See discussion in issue #10288

## Related links

Fixes: #10288