### PR TITLE
[WiFiScan] Allow allocation in _scanDone() to fail and prevent memory leak

### DIFF
--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -117,8 +117,13 @@ int16_t
  */
 void WiFiScanClass::_scanDone() {
   esp_wifi_scan_get_ap_num(&(WiFiScanClass::_scanCount));
+  if (WiFiScanClass::_scanResult) {
+    delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
+    WiFiScanClass::_scanResult = 0;
+  }
+
   if (WiFiScanClass::_scanCount) {
-    WiFiScanClass::_scanResult = new wifi_ap_record_t[WiFiScanClass::_scanCount];
+    WiFiScanClass::_scanResult = new (std::nothrow) wifi_ap_record_t[WiFiScanClass::_scanCount];
     if (!WiFiScanClass::_scanResult) {
       WiFiScanClass::_scanCount = 0;
     } else if (esp_wifi_scan_get_ap_records(&(WiFiScanClass::_scanCount), (wifi_ap_record_t *)_scanResult) != ESP_OK) {

--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -48,7 +48,7 @@ uint32_t WiFiScanClass::_scanTimeout = 60000;
 uint16_t WiFiScanClass::_scanCount = 0;
 uint32_t WiFiScanClass::_scanActiveMinTime = 100;
 
-void *WiFiScanClass::_scanResult = 0;
+void *WiFiScanClass::_scanResult = nullptr;
 
 void WiFiScanClass::setScanTimeout(uint32_t ms) {
   WiFiScanClass::_scanTimeout = ms;
@@ -119,7 +119,7 @@ void WiFiScanClass::_scanDone() {
   esp_wifi_scan_get_ap_num(&(WiFiScanClass::_scanCount));
   if (WiFiScanClass::_scanResult) {
     delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
-    WiFiScanClass::_scanResult = 0;
+    WiFiScanClass::_scanResult = nullptr;
   }
 
   if (WiFiScanClass::_scanCount) {
@@ -128,7 +128,7 @@ void WiFiScanClass::_scanDone() {
       WiFiScanClass::_scanCount = 0;
     } else if (esp_wifi_scan_get_ap_records(&(WiFiScanClass::_scanCount), (wifi_ap_record_t *)_scanResult) != ESP_OK) {
       delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
-      WiFiScanClass::_scanResult = 0;
+      WiFiScanClass::_scanResult = nullptr;
       WiFiScanClass::_scanCount = 0;
     }
   }
@@ -181,7 +181,7 @@ void WiFiScanClass::scanDelete() {
   WiFiGenericClass::clearStatusBits(WIFI_SCAN_DONE_BIT);
   if (WiFiScanClass::_scanResult) {
     delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
-    WiFiScanClass::_scanResult = 0;
+    WiFiScanClass::_scanResult = nullptr;
     WiFiScanClass::_scanCount = 0;
   }
 }


### PR DESCRIPTION
## Description of Change
When there are many AP's seen during a scan, the allocation of `_scanResult` may fail. 
Thus add `(std::nothrow)` to the `new` call.  Without it, the next check for a valid pointer was not even done as the application would already have crashed.

Also it is possible the array was still present before allocating a new one, so we must make sure it is deleted first.


## Related links

Follow-up of this PR: https://github.com/espressif/arduino-esp32/pull/10312


## Possible (known) issue

There is 1 possible known issue left which is not being dealt with by this PR.
Since the `_scanDone()` function is called from a callback from an async scan, in theory it is possible someone is still processing a previous scan result via `_getScanInfoByIndex()`.
However if this does happen, then without this fix we would have had a memory leak for sure.

To work around such corner cases, quite a lot of code changes may be needed, which is out of scope of this PR.