### PR TITLE
Fix(NetworkEvents): Don't skip event callbacks in NetworkEvents::remo…

### DIFF
--- a/libraries/Network/src/NetworkEvents.cpp
+++ b/libraries/Network/src/NetworkEvents.cpp
@@ -134,10 +134,73 @@ void NetworkEvents::checkForEvent() {
   free(event);
 }
 
+uint32_t NetworkEvents::findEvent(NetworkEventCb cbEvent, arduino_event_id_t event) {
+  uint32_t i;
+
+  if (!cbEvent) {
+    return cbEventList.size();
+  }
+
+  for (i = 0; i < cbEventList.size(); i++) {
+    NetworkEventCbList_t entry = cbEventList[i];
+    if (entry.cb == cbEvent && entry.event == event) {
+      break;
+    }
+  }
+  return i;
+}
+
+template<typename T, typename... U> static size_t getStdFunctionAddress(std::function<T(U...)> f) {
+  typedef T(fnType)(U...);
+  fnType **fnPointer = f.template target<fnType *>();
+  if (fnPointer != nullptr) {
+    return (size_t)*fnPointer;
+  }
+  return (size_t)fnPointer;
+}
+
+uint32_t NetworkEvents::findEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event) {
+  uint32_t i;
+
+  if (!cbEvent) {
+    return cbEventList.size();
+  }
+
+  for (i = 0; i < cbEventList.size(); i++) {
+    NetworkEventCbList_t entry = cbEventList[i];
+    if (getStdFunctionAddress(entry.fcb) == getStdFunctionAddress(cbEvent) && entry.event == event) {
+      break;
+    }
+  }
+  return i;
+}
+
+uint32_t NetworkEvents::findEvent(NetworkEventSysCb cbEvent, arduino_event_id_t event) {
+  uint32_t i;
+
+  if (!cbEvent) {
+    return cbEventList.size();
+  }
+
+  for (i = 0; i < cbEventList.size(); i++) {
+    NetworkEventCbList_t entry = cbEventList[i];
+    if (entry.scb == cbEvent && entry.event == event) {
+      break;
+    }
+  }
+  return i;
+}
+
 network_event_handle_t NetworkEvents::onEvent(NetworkEventCb cbEvent, arduino_event_id_t event) {
   if (!cbEvent) {
     return 0;
   }
+
+  if (findEvent(cbEvent, event) < cbEventList.size()) {
+    log_e("Attempt to add duplicate event handler!");
+    return 0;
+  }
+
   NetworkEventCbList_t newEventHandler;
   newEventHandler.cb = cbEvent;
   newEventHandler.fcb = NULL;
@@ -151,6 +214,12 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventFuncCb cbEvent, arduin
   if (!cbEvent) {
     return 0;
   }
+
+  if (findEvent(cbEvent, event) < cbEventList.size()) {
+    log_e("Attempt to add duplicate event handler!");
+    return 0;
+  }
+
   NetworkEventCbList_t newEventHandler;
   newEventHandler.cb = NULL;
   newEventHandler.fcb = cbEvent;
@@ -164,6 +233,12 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventSysCb cbEvent, arduino
   if (!cbEvent) {
     return 0;
   }
+
+  if (findEvent(cbEvent, event) < cbEventList.size()) {
+    log_e("Attempt to add duplicate event handler!");
+    return 0;
+  }
+
   NetworkEventCbList_t newEventHandler;
   newEventHandler.cb = NULL;
   newEventHandler.fcb = NULL;
@@ -177,6 +252,12 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventCb cbEvent, arduino
   if (!cbEvent) {
     return 0;
   }
+
+  if (findEvent(cbEvent, event) < cbEventList.size()) {
+    log_e("Attempt to add duplicate event handler!");
+    return 0;
+  }
+
   NetworkEventCbList_t newEventHandler;
   newEventHandler.cb = cbEvent;
   newEventHandler.fcb = NULL;
@@ -190,6 +271,12 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventFuncCb cbEvent, ard
   if (!cbEvent) {
     return 0;
   }
+
+  if (findEvent(cbEvent, event) < cbEventList.size()) {
+    log_e("Attempt to add duplicate event handler!");
+    return 0;
+  }
+
   NetworkEventCbList_t newEventHandler;
   newEventHandler.cb = NULL;
   newEventHandler.fcb = cbEvent;
@@ -203,6 +290,12 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventSysCb cbEvent, ardu
   if (!cbEvent) {
     return 0;
   }
+
+  if (findEvent(cbEvent, event) < cbEventList.size()) {
+    log_e("Attempt to add duplicate event handler!");
+    return 0;
+  }
+
   NetworkEventCbList_t newEventHandler;
   newEventHandler.cb = NULL;
   newEventHandler.fcb = NULL;
@@ -213,48 +306,51 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventSysCb cbEvent, ardu
 }
 
 void NetworkEvents::removeEvent(NetworkEventCb cbEvent, arduino_event_id_t event) {
+  uint32_t i;
+
   if (!cbEvent) {
     return;
   }
 
-  for (uint32_t i = 0; i < cbEventList.size(); i++) {
-    NetworkEventCbList_t entry = cbEventList[i];
-    if (entry.cb == cbEvent && entry.event == event) {
-      cbEventList.erase(cbEventList.begin() + i);
-    }
+  i = findEvent(cbEvent, event);
+  if (i >= cbEventList.size()) {
+    log_e("Event handler not found!");
+    return;
   }
-}
 
-template<typename T, typename... U> static size_t getStdFunctionAddress(std::function<T(U...)> f) {
-  typedef T(fnType)(U...);
-  fnType **fnPointer = f.template target<fnType *>();
-  return (size_t)*fnPointer;
+  cbEventList.erase(cbEventList.begin() + i);
 }
 
 void NetworkEvents::removeEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event) {
+  uint32_t i;
+
   if (!cbEvent) {
     return;
   }
 
-  for (uint32_t i = 0; i < cbEventList.size(); i++) {
-    NetworkEventCbList_t entry = cbEventList[i];
-    if (getStdFunctionAddress(entry.fcb) == getStdFunctionAddress(cbEvent) && entry.event == event) {
-      cbEventList.erase(cbEventList.begin() + i);
-    }
+  i = findEvent(cbEvent, event);
+  if (i >= cbEventList.size()) {
+    log_e("Event handler not found!");
+    return;
   }
+
+  cbEventList.erase(cbEventList.begin() + i);
 }
 
 void NetworkEvents::removeEvent(NetworkEventSysCb cbEvent, arduino_event_id_t event) {
+  uint32_t i;
+
   if (!cbEvent) {
     return;
   }
 
-  for (uint32_t i = 0; i < cbEventList.size(); i++) {
-    NetworkEventCbList_t entry = cbEventList[i];
-    if (entry.scb == cbEvent && entry.event == event) {
-      cbEventList.erase(cbEventList.begin() + i);
-    }
+  i = findEvent(cbEvent, event);
+  if (i >= cbEventList.size()) {
+    log_e("Event handler not found!");
+    return;
   }
+
+  cbEventList.erase(cbEventList.begin() + i);
 }
 
 void NetworkEvents::removeEvent(network_event_handle_t id) {
@@ -262,8 +358,10 @@ void NetworkEvents::removeEvent(network_event_handle_t id) {
     NetworkEventCbList_t entry = cbEventList[i];
     if (entry.id == id) {
       cbEventList.erase(cbEventList.begin() + i);
+      return;
     }
   }
+  log_e("Event handler not found!");
 }
 
 int NetworkEvents::setStatusBits(int bits) {

--- a/libraries/Network/src/NetworkEvents.cpp
+++ b/libraries/Network/src/NetworkEvents.cpp
@@ -197,7 +197,7 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventCb cbEvent, arduino_ev
   }
 
   if (findEvent(cbEvent, event) < cbEventList.size()) {
-    log_e("Attempt to add duplicate event handler!");
+    log_w("Attempt to add duplicate event handler!");
     return 0;
   }
 
@@ -216,7 +216,7 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventFuncCb cbEvent, arduin
   }
 
   if (findEvent(cbEvent, event) < cbEventList.size()) {
-    log_e("Attempt to add duplicate event handler!");
+    log_w("Attempt to add duplicate event handler!");
     return 0;
   }
 
@@ -235,7 +235,7 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventSysCb cbEvent, arduino
   }
 
   if (findEvent(cbEvent, event) < cbEventList.size()) {
-    log_e("Attempt to add duplicate event handler!");
+    log_w("Attempt to add duplicate event handler!");
     return 0;
   }
 
@@ -254,7 +254,7 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventCb cbEvent, arduino
   }
 
   if (findEvent(cbEvent, event) < cbEventList.size()) {
-    log_e("Attempt to add duplicate event handler!");
+    log_w("Attempt to add duplicate event handler!");
     return 0;
   }
 
@@ -273,7 +273,7 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventFuncCb cbEvent, ard
   }
 
   if (findEvent(cbEvent, event) < cbEventList.size()) {
-    log_e("Attempt to add duplicate event handler!");
+    log_w("Attempt to add duplicate event handler!");
     return 0;
   }
 
@@ -292,7 +292,7 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventSysCb cbEvent, ardu
   }
 
   if (findEvent(cbEvent, event) < cbEventList.size()) {
-    log_e("Attempt to add duplicate event handler!");
+    log_w("Attempt to add duplicate event handler!");
     return 0;
   }
 
@@ -314,7 +314,7 @@ void NetworkEvents::removeEvent(NetworkEventCb cbEvent, arduino_event_id_t event
 
   i = findEvent(cbEvent, event);
   if (i >= cbEventList.size()) {
-    log_e("Event handler not found!");
+    log_w("Event handler not found!");
     return;
   }
 
@@ -330,7 +330,7 @@ void NetworkEvents::removeEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t e
 
   i = findEvent(cbEvent, event);
   if (i >= cbEventList.size()) {
-    log_e("Event handler not found!");
+    log_w("Event handler not found!");
     return;
   }
 
@@ -346,7 +346,7 @@ void NetworkEvents::removeEvent(NetworkEventSysCb cbEvent, arduino_event_id_t ev
 
   i = findEvent(cbEvent, event);
   if (i >= cbEventList.size()) {
-    log_e("Event handler not found!");
+    log_w("Event handler not found!");
     return;
   }
 
@@ -361,7 +361,7 @@ void NetworkEvents::removeEvent(network_event_handle_t id) {
       return;
     }
   }
-  log_e("Event handler not found!");
+  log_w("Event handler not found!");
 }
 
 int NetworkEvents::setStatusBits(int bits) {

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -155,6 +155,9 @@ public:
 
 protected:
   bool initNetworkEvents();
+  uint32_t findEvent(NetworkEventCb cbEvent, arduino_event_id_t event);
+  uint32_t findEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event);
+  uint32_t findEvent(NetworkEventSysCb cbEvent, arduino_event_id_t event);
   network_event_handle_t onSysEvent(NetworkEventCb cbEvent, arduino_event_id_t event = ARDUINO_EVENT_MAX);
   network_event_handle_t onSysEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event = ARDUINO_EVENT_MAX);
   network_event_handle_t onSysEvent(NetworkEventSysCb cbEvent, arduino_event_id_t event = ARDUINO_EVENT_MAX);


### PR DESCRIPTION
## Description of Change
Summary:
* Fixes [Issue 10318](https://github.com/espressif/arduino-esp32/issues/10318)
* Includes [pull request 10321](https://github.com/espressif/arduino-esp32/issues/10321) that fixes [10316](https://github.com/espressif/arduino-esp32/issues/10316)
* Adds code to find the event callbacks
* Issues error when duplicate callbacks insertion attempts are made
* Issues error when callbacks are not found during removal

The fix for [10316](https://github.com/espressif/arduino-esp32/issues/10316) is required to get beyond the crash and detect [Issue 10318](https://github.com/espressif/arduino-esp32/issues/10318).

Moved code from removeEvent to scan for the matching event into findEvent routines.  The findEvent routines return the "id" or zero if the handler was not found.

Reworked removeEvent routines to use findEvent.  Added log_e in the event callback handler not found path in removeEvent.

Added code to onEvent and onSysEvent routines to check for duplicate entries using findEvent.  Added log_e that displays when the duplicate event is found.

## Tests scenarios
Used the updated test sketch below

## Related links
Closes [10318](https://github.com/espressif/arduino-esp32/issues/10318)

## Test Sketch
```// bug-NetworkEvents-removeEvent.ino

#define wifiSSID        "Your_WiFi_SSID"
#define wifiPassword    "Your_WiFi_Password"

#include <WiFi.h>

bool RTK_CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC = false;
network_event_handle_t wifiId;
network_event_handle_t ethernetId;
network_event_handle_t pppId;

//----------------------------------------
// System initialization
void setup()
{
    Serial.begin(115200);
    Serial.println();
    Serial.println("bug-NetworkEvents-removeEvent.ino");

    // Listen for wifi events
Serial.println("----------");
    Serial.printf("Registering WiFi callback handler: %p\r\n", (void *)wifiEvent);
    wifiId = Network.onEvent(wifiEvent);
Serial.println("----------");
    Serial.printf("Registering duplicate WiFi callback handler: %p, expecting error\r\n", (void *)wifiEvent);
    Network.onEvent(wifiEvent);

Serial.println("----------");
    Serial.printf("Registering Ethernet callback handler: %p\r\n", (void *)ethernetEvent);
    ethernetId = Network.onEvent(ethernetEvent);

Serial.println("----------");
    Serial.printf("Registering PPP callback handler: %p\r\n", (void *)pppEvent);
    pppId = Network.onEvent(pppEvent);

    // Start displaying the events
    Serial.println("==================== Receiving 3 events / actual event ====================");

    // Start WiFi
    WiFi.begin(wifiSSID, wifiPassword);
}

//----------------------------------------
// Main loop
void loop()
{
    static bool allCbsRemoved;
    static bool eventRemoved;
    static uint32_t lastTimeMillis;
    static bool wifiState;

    uint32_t currentMillis = millis();
    if ((currentMillis - lastTimeMillis) >= (10 * 1000))
    {
        lastTimeMillis = currentMillis;

        // Toggle the Wifi state
        wifiState ^= 1;
        if (wifiState)
        {
            Serial.println("---------- WiFi.disconnect ----------");
            WiFi.disconnect(true);
        }
        else
        {
            Serial.println("---------- WiFi.begin ----------");
            WiFi.begin(wifiSSID, wifiPassword);
        }
    }
    if ((!eventRemoved) && (currentMillis >= (30 * 1000)))
    {
        // Removing the WiFi event handler
        // This should remove them all!!!!!!
        Serial.println("==================== Removing the WiFi Event Handler ======================");
        Network.removeEvent(wifiEvent);
        eventRemoved = true;
        Serial.println("==================== Receiving 2 events / actual event ====================");
    }
    if ((!allCbsRemoved) && (currentMillis >= (60 * 1000)))
    {
        // Removing all handlers
        // This should remove them all!!!!!!
        Serial.println("==================== Removing all Event Handlers ============================");
        Network.removeEvent(ethernetEvent);
        Serial.println("Attempting duplicate function removal, expecting error");
        Network.removeEvent(ethernetEvent);
        Network.removeEvent(pppId);
        Serial.println("Attempting duplicate id removal, expecting error");
        Network.removeEvent(pppId);
        allCbsRemoved = true;
        Serial.println("==================== No Event Output Should Be Displayed ====================");
    }
}

//----------------------------------------
void wifiEvent(arduino_event_id_t event, arduino_event_info_t info)
{
    char ssid[sizeof(info.wifi_sta_connected.ssid) + 1];
    IPAddress ipAddress;

    // Handle the event
    switch (event)
    {
    default:
        Serial.printf("ERROR: Unknown WiFi event: %d\r\n", event);
        break;

    case ARDUINO_EVENT_WIFI_OFF:
        Serial.println("WiFi Off");
        break;

    case ARDUINO_EVENT_WIFI_READY:
        Serial.println("WiFi Ready");
        break;

    case ARDUINO_EVENT_WIFI_SCAN_DONE:
        Serial.println("WiFi Scan Done");
        // wifi_event_sta_scan_done_t info.wifi_scan_done;
        break;

    case ARDUINO_EVENT_WIFI_STA_START:
        Serial.println("WiFi STA Started");
        break;

    case ARDUINO_EVENT_WIFI_STA_STOP:
        Serial.println("WiFi STA Stopped");
        break;

    case ARDUINO_EVENT_WIFI_STA_CONNECTED:
        memcpy(ssid, info.wifi_sta_connected.ssid, info.wifi_sta_connected.ssid_len);
        ssid[info.wifi_sta_connected.ssid_len] = 0;
        Serial.printf("WiFi STA connected to %s\r\n", ssid);
        break;

    case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
        memcpy(ssid, info.wifi_sta_disconnected.ssid, info.wifi_sta_disconnected.ssid_len);
        ssid[info.wifi_sta_disconnected.ssid_len] = 0;
        Serial.printf("WiFi STA disconnected from %s\r\n", ssid);
        // wifi_event_sta_disconnected_t info.wifi_sta_disconnected;
        break;

    case ARDUINO_EVENT_WIFI_STA_AUTHMODE_CHANGE:
        Serial.println("WiFi STA Auth Mode Changed");
        // wifi_event_sta_authmode_change_t info.wifi_sta_authmode_change;
        break;

    case ARDUINO_EVENT_WIFI_STA_GOT_IP:
        ipAddress = WiFi.localIP();
        Serial.print("WiFi STA Got IPv4: ");
        Serial.println(ipAddress);
        break;

    case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
        Serial.print("WiFi STA Got IPv6: ");
        Serial.println(ipAddress);
        break;

    case ARDUINO_EVENT_WIFI_STA_LOST_IP:
        Serial.println("WiFi STA Lost IP");
        break;
    }
}

//----------------------------------------
void ethernetEvent(arduino_event_id_t event, arduino_event_info_t info)
{
    wifiEvent(event, info);
}

//----------------------------------------
void pppEvent(arduino_event_id_t event, arduino_event_info_t info)
{
    wifiEvent(event, info);
}
```