### PR TITLE
fix(arduino): rain maker common version

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -68,7 +68,7 @@ dependencies:
     rules:
       - if: "target != esp32c2"
   espressif/rmaker_common:
-    version: "^1.4.3"
+    version: "^1.4.6"
     rules:
       - if: "target != esp32c2"
   espressif/esp_insights:


### PR DESCRIPTION
## Description of Change
Fixes Arduino Managed Components declaration when building Arduino as IDF component using Windows 11 + IDF 5.1.4.

Error Message:
```
Dependencies lock doesn't exist, solving dependencies.
CMake Error at C:/Espressif/frameworks/esp-idf-v5.1.4/tools/cmake/build.cmake:540 (message):
  WARNING: From https://github.com/espressif/arduino-esp32

   * [new ref]             refs/pull/10335/head  -> refs/pull/10335/head
   * [new ref]             refs/pull/10335/merge -> refs/pull/10335/merge



  ERROR: Because espressif/arduino-esp32
  (4e9eb35752a36bd4e03739dc7e1c3ac246c49d3c) depends on
  espressif/rmaker_common (^1.4.3) which doesn't match any versions,
  espressif/arduino-esp32 is forbidden.

  So, because project depends on espressif/arduino-esp32
  (4e9eb35752a36bd4e03739dc7e1c3ac246c49d3c), version solving failed.

Call Stack (most recent call first):
  C:/Espressif/frameworks/esp-idf-v5.1.4/tools/cmake/project.cmake:604 (idf_build_process)
  CMakeLists.txt:11 (project)


....................................................-- Configuring incomplete, errors occurred!
```


## Tests scenarios
Using Windows 11 and building a "hello world" sketch using Arduino as IDF Component.


## Related links
none
