### PR TITLE
[WebServer] Mark functions as const + reduce copy of strings

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -280,7 +280,7 @@ bool WebServer::_collectHeader(const char *headerName, const char *headerValue) 
   return false;
 }
 
-void WebServer::_parseArguments(String data) {
+void WebServer::_parseArguments(const String& data) {
   log_v("args: %s", data.c_str());
   if (_currentArgs) {
     delete[] _currentArgs;
@@ -387,7 +387,7 @@ int WebServer::_uploadReadByte(NetworkClient &client) {
   return res;
 }
 
-bool WebServer::_parseForm(NetworkClient &client, String boundary, uint32_t len) {
+bool WebServer::_parseForm(NetworkClient &client, const String& boundary, uint32_t len) {
   (void)len;
   log_v("Parse Form: Boundary: %s Length: %d", boundary.c_str(), len);
   String line;

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -280,7 +280,7 @@ bool WebServer::_collectHeader(const char *headerName, const char *headerValue) 
   return false;
 }
 
-void WebServer::_parseArguments(const String& data) {
+void WebServer::_parseArguments(const String &data) {
   log_v("args: %s", data.c_str());
   if (_currentArgs) {
     delete[] _currentArgs;
@@ -387,7 +387,7 @@ int WebServer::_uploadReadByte(NetworkClient &client) {
   return res;
 }
 
-bool WebServer::_parseForm(NetworkClient &client, const String& boundary, uint32_t len) {
+bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32_t len) {
   (void)len;
   log_v("Parse Form: Boundary: %s Length: %d", boundary.c_str(), len);
   String line;

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -680,7 +680,7 @@ String WebServer::pathArg(unsigned int i) const {
   return "";
 }
 
-String WebServer::arg(const String& name) const {
+String WebServer::arg(const String &name) const {
   for (int j = 0; j < _postArgsLen; ++j) {
     if (_postArgs[j].key == name) {
       return _postArgs[j].value;
@@ -712,7 +712,7 @@ int WebServer::args() const {
   return _currentArgCount;
 }
 
-bool WebServer::hasArg(const String& name) const {
+bool WebServer::hasArg(const String &name) const {
   for (int j = 0; j < _postArgsLen; ++j) {
     if (_postArgs[j].key == name) {
       return true;
@@ -726,7 +726,7 @@ bool WebServer::hasArg(const String& name) const {
   return false;
 }
 
-String WebServer::header(const String& name) const {
+String WebServer::header(const String &name) const {
   for (int i = 0; i < _headerKeysCount; ++i) {
     if (_currentHeaders[i].key.equalsIgnoreCase(name)) {
       return _currentHeaders[i].value;
@@ -766,7 +766,7 @@ int WebServer::headers() const {
   return _headerKeysCount;
 }
 
-bool WebServer::hasHeader(const String& name) const {
+bool WebServer::hasHeader(const String &name) const {
   for (int i = 0; i < _headerKeysCount; ++i) {
     if ((_currentHeaders[i].key.equalsIgnoreCase(name)) && (_currentHeaders[i].value.length() > 0)) {
       return true;

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -673,14 +673,14 @@ void WebServer::_streamFileCore(const size_t fileSize, const String &fileName, c
   send(code, contentType, "");
 }
 
-String WebServer::pathArg(unsigned int i) {
+String WebServer::pathArg(unsigned int i) const {
   if (_currentHandler != nullptr) {
     return _currentHandler->pathArg(i);
   }
   return "";
 }
 
-String WebServer::arg(String name) {
+String WebServer::arg(const String& name) const {
   for (int j = 0; j < _postArgsLen; ++j) {
     if (_postArgs[j].key == name) {
       return _postArgs[j].value;
@@ -694,25 +694,25 @@ String WebServer::arg(String name) {
   return "";
 }
 
-String WebServer::arg(int i) {
+String WebServer::arg(int i) const {
   if (i < _currentArgCount) {
     return _currentArgs[i].value;
   }
   return "";
 }
 
-String WebServer::argName(int i) {
+String WebServer::argName(int i) const {
   if (i < _currentArgCount) {
     return _currentArgs[i].key;
   }
   return "";
 }
 
-int WebServer::args() {
+int WebServer::args() const {
   return _currentArgCount;
 }
 
-bool WebServer::hasArg(String name) {
+bool WebServer::hasArg(const String& name) const {
   for (int j = 0; j < _postArgsLen; ++j) {
     if (_postArgs[j].key == name) {
       return true;
@@ -726,7 +726,7 @@ bool WebServer::hasArg(String name) {
   return false;
 }
 
-String WebServer::header(String name) {
+String WebServer::header(const String& name) const {
   for (int i = 0; i < _headerKeysCount; ++i) {
     if (_currentHeaders[i].key.equalsIgnoreCase(name)) {
       return _currentHeaders[i].value;
@@ -748,25 +748,25 @@ void WebServer::collectHeaders(const char *headerKeys[], const size_t headerKeys
   }
 }
 
-String WebServer::header(int i) {
+String WebServer::header(int i) const {
   if (i < _headerKeysCount) {
     return _currentHeaders[i].value;
   }
   return "";
 }
 
-String WebServer::headerName(int i) {
+String WebServer::headerName(int i) const {
   if (i < _headerKeysCount) {
     return _currentHeaders[i].key;
   }
   return "";
 }
 
-int WebServer::headers() {
+int WebServer::headers() const {
   return _headerKeysCount;
 }
 
-bool WebServer::hasHeader(String name) {
+bool WebServer::hasHeader(const String& name) const {
   for (int i = 0; i < _headerKeysCount; ++i) {
     if ((_currentHeaders[i].key.equalsIgnoreCase(name)) && (_currentHeaders[i].value.length() > 0)) {
       return true;
@@ -775,7 +775,7 @@ bool WebServer::hasHeader(String name) {
   return false;
 }
 
-String WebServer::hostHeader() {
+String WebServer::hostHeader() const {
   return _hostHeader;
 }
 

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -158,10 +158,10 @@ public:
   void onNotFound(THandlerFunction fn);     //called when handler is not assigned
   void onFileUpload(THandlerFunction ufn);  //handle file uploads
 
-  String uri() {
+  String uri() const {
     return _currentUri;
   }
-  HTTPMethod method() {
+  HTTPMethod method() const {
     return _currentMethod;
   }
   virtual NetworkClient &client() {
@@ -174,24 +174,24 @@ public:
     return *_currentRaw;
   }
 
-  String pathArg(unsigned int i);                                               // get request path argument by number
-  String arg(String name);                                                      // get request argument value by name
-  String arg(int i);                                                            // get request argument value by number
-  String argName(int i);                                                        // get request argument name by number
-  int args();                                                                   // get arguments count
-  bool hasArg(String name);                                                     // check if argument exists
+  String pathArg(unsigned int i) const;                                               // get request path argument by number
+  String arg(const String& name) const;                                                      // get request argument value by name
+  String arg(int i) const;                                                            // get request argument value by number
+  String argName(int i) const;                                                        // get request argument name by number
+  int args() const;                                                                   // get arguments count
+  bool hasArg(const String& name) const;                                                     // check if argument exists
   void collectHeaders(const char *headerKeys[], const size_t headerKeysCount);  // set the request headers to collect
-  String header(String name);                                                   // get request header value by name
-  String header(int i);                                                         // get request header value by number
-  String headerName(int i);                                                     // get request header name by number
-  int headers();                                                                // get header count
-  bool hasHeader(String name);                                                  // check if header exists
+  String header(const String& name) const;                                                   // get request header value by name
+  String header(int i) const;                                                         // get request header value by number
+  String headerName(int i) const;                                                     // get request header name by number
+  int headers() const;                                                                // get header count
+  bool hasHeader(const String& name) const;                                                  // check if header exists
 
-  int clientContentLength() {
+  int clientContentLength() const {
     return _clientContentLength;
   }  // return "content-length" of incoming HTTP header from "_currentClient"
 
-  String hostHeader();  // get request host header if available or empty String if not
+  String hostHeader() const;  // get request host header if available or empty String if not
 
   // send response to the client
   // code - HTTP response code, can be 200 or 404
@@ -240,9 +240,9 @@ protected:
   void _handleRequest();
   void _finalizeResponse();
   bool _parseRequest(NetworkClient &client);
-  void _parseArguments(String data);
+  void _parseArguments(const String& data);
   static String _responseCodeToString(int code);
-  bool _parseForm(NetworkClient &client, String boundary, uint32_t len);
+  bool _parseForm(NetworkClient &client, const String& boundary, uint32_t len);
   bool _parseFormUploadAborted();
   void _uploadWriteByte(uint8_t b);
   int _uploadReadByte(NetworkClient &client);

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -174,18 +174,18 @@ public:
     return *_currentRaw;
   }
 
-  String pathArg(unsigned int i) const;                                               // get request path argument by number
-  String arg(const String& name) const;                                                      // get request argument value by name
-  String arg(int i) const;                                                            // get request argument value by number
-  String argName(int i) const;                                                        // get request argument name by number
-  int args() const;                                                                   // get arguments count
-  bool hasArg(const String& name) const;                                                     // check if argument exists
+  String pathArg(unsigned int i) const;                                         // get request path argument by number
+  String arg(const String &name) const;                                         // get request argument value by name
+  String arg(int i) const;                                                      // get request argument value by number
+  String argName(int i) const;                                                  // get request argument name by number
+  int args() const;                                                             // get arguments count
+  bool hasArg(const String &name) const;                                        // check if argument exists
   void collectHeaders(const char *headerKeys[], const size_t headerKeysCount);  // set the request headers to collect
-  String header(const String& name) const;                                                   // get request header value by name
-  String header(int i) const;                                                         // get request header value by number
-  String headerName(int i) const;                                                     // get request header name by number
-  int headers() const;                                                                // get header count
-  bool hasHeader(const String& name) const;                                                  // check if header exists
+  String header(const String &name) const;                                      // get request header value by name
+  String header(int i) const;                                                   // get request header value by number
+  String headerName(int i) const;                                               // get request header name by number
+  int headers() const;                                                          // get header count
+  bool hasHeader(const String &name) const;                                     // check if header exists
 
   int clientContentLength() const {
     return _clientContentLength;
@@ -240,9 +240,9 @@ protected:
   void _handleRequest();
   void _finalizeResponse();
   bool _parseRequest(NetworkClient &client);
-  void _parseArguments(const String& data);
+  void _parseArguments(const String &data);
   static String _responseCodeToString(int code);
-  bool _parseForm(NetworkClient &client, const String& boundary, uint32_t len);
+  bool _parseForm(NetworkClient &client, const String &boundary, uint32_t len);
   bool _parseFormUploadAborted();
   void _uploadWriteByte(uint8_t b);
   int _uploadReadByte(NetworkClient &client);


### PR DESCRIPTION
## Description of Change
A few functions in WebServer does have `String` arguments, which does lead to copying of the strings when calling those functions.
For those where applicable, I changed the function arguments to `const String&`.

Also some functions which do not modify members, were not marked as `const`. Added those too.


