### PR TITLE
Reduce copy of Strings in WebServer RequestHandler

### DIFF
--- a/libraries/WebServer/examples/WebServer/WebServer.ino
+++ b/libraries/WebServer/examples/WebServer/WebServer.ino
@@ -146,16 +146,16 @@ public:
   // @param requestMethod method of the http request line.
   // @param requestUri request resource from the http request line.
   // @return true when method can be handled.
-  bool canHandle(WebServer &server, HTTPMethod requestMethod, String uri) override {
+  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String&  uri) override {
     return ((requestMethod == HTTP_POST) || (requestMethod == HTTP_DELETE));
   }  // canHandle()
 
-  bool canUpload(WebServer &server, String uri) override {
+  bool canUpload(WebServer &server, const String&  uri) override {
     // only allow upload on root fs level.
     return (uri == "/");
   }  // canUpload()
 
-  bool handle(WebServer &server, HTTPMethod requestMethod, String requestUri) override {
+  bool handle(WebServer &server, HTTPMethod requestMethod, const String&  requestUri) override {
     // ensure that filename starts with '/'
     String fName = requestUri;
     if (!fName.startsWith("/")) {
@@ -177,7 +177,7 @@ public:
   }  // handle()
 
   // uploading process
-  void upload(WebServer UNUSED &server, String requestUri, HTTPUpload &upload) override {
+  void upload(WebServer UNUSED &server, const String&  requestUri, HTTPUpload &upload) override {
     // ensure that filename starts with '/'
     static size_t uploadSize;
 

--- a/libraries/WebServer/examples/WebServer/WebServer.ino
+++ b/libraries/WebServer/examples/WebServer/WebServer.ino
@@ -146,16 +146,16 @@ public:
   // @param requestMethod method of the http request line.
   // @param requestUri request resource from the http request line.
   // @return true when method can be handled.
-  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String&  uri) override {
+  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String &uri) override {
     return ((requestMethod == HTTP_POST) || (requestMethod == HTTP_DELETE));
   }  // canHandle()
 
-  bool canUpload(WebServer &server, const String&  uri) override {
+  bool canUpload(WebServer &server, const String &uri) override {
     // only allow upload on root fs level.
     return (uri == "/");
   }  // canUpload()
 
-  bool handle(WebServer &server, HTTPMethod requestMethod, const String&  requestUri) override {
+  bool handle(WebServer &server, HTTPMethod requestMethod, const String &requestUri) override {
     // ensure that filename starts with '/'
     String fName = requestUri;
     if (!fName.startsWith("/")) {
@@ -177,7 +177,7 @@ public:
   }  // handle()
 
   // uploading process
-  void upload(WebServer UNUSED &server, const String&  requestUri, HTTPUpload &upload) override {
+  void upload(WebServer UNUSED &server, const String &requestUri, HTTPUpload &upload) override {
     // ensure that filename starts with '/'
     static size_t uploadSize;
 

--- a/libraries/WebServer/src/detail/RequestHandler.h
+++ b/libraries/WebServer/src/detail/RequestHandler.h
@@ -12,16 +12,16 @@ public:
     note: old handler API for backward compatibility
   */
 
-  virtual bool canHandle(HTTPMethod method, const String& uri) {
+  virtual bool canHandle(HTTPMethod method, const String &uri) {
     (void)method;
     (void)uri;
     return false;
   }
-  virtual bool canUpload(const String& uri) {
+  virtual bool canUpload(const String &uri) {
     (void)uri;
     return false;
   }
-  virtual bool canRaw(const String& uri) {
+  virtual bool canRaw(const String &uri) {
     (void)uri;
     return false;
   }
@@ -30,34 +30,34 @@ public:
     note: new handler API with support for filters etc.
   */
 
-  virtual bool canHandle(WebServer &server, HTTPMethod method, const String& uri) {
+  virtual bool canHandle(WebServer &server, HTTPMethod method, const String &uri) {
     (void)server;
     (void)method;
     (void)uri;
     return false;
   }
-  virtual bool canUpload(WebServer &server, const String& uri) {
+  virtual bool canUpload(WebServer &server, const String &uri) {
     (void)server;
     (void)uri;
     return false;
   }
-  virtual bool canRaw(WebServer &server, const String& uri) {
+  virtual bool canRaw(WebServer &server, const String &uri) {
     (void)server;
     (void)uri;
     return false;
   }
-  virtual bool handle(WebServer &server, HTTPMethod requestMethod, const String&  requestUri) {
+  virtual bool handle(WebServer &server, HTTPMethod requestMethod, const String &requestUri) {
     (void)server;
     (void)requestMethod;
     (void)requestUri;
     return false;
   }
-  virtual void upload(WebServer &server, const String&  requestUri, HTTPUpload &upload) {
+  virtual void upload(WebServer &server, const String &requestUri, HTTPUpload &upload) {
     (void)server;
     (void)requestUri;
     (void)upload;
   }
-  virtual void raw(WebServer &server, const String&  requestUri, HTTPRaw &raw) {
+  virtual void raw(WebServer &server, const String &requestUri, HTTPRaw &raw) {
     (void)server;
     (void)requestUri;
     (void)raw;

--- a/libraries/WebServer/src/detail/RequestHandler.h
+++ b/libraries/WebServer/src/detail/RequestHandler.h
@@ -12,16 +12,16 @@ public:
     note: old handler API for backward compatibility
   */
 
-  virtual bool canHandle(HTTPMethod method, String uri) {
+  virtual bool canHandle(HTTPMethod method, const String& uri) {
     (void)method;
     (void)uri;
     return false;
   }
-  virtual bool canUpload(String uri) {
+  virtual bool canUpload(const String& uri) {
     (void)uri;
     return false;
   }
-  virtual bool canRaw(String uri) {
+  virtual bool canRaw(const String& uri) {
     (void)uri;
     return false;
   }
@@ -30,34 +30,34 @@ public:
     note: new handler API with support for filters etc.
   */
 
-  virtual bool canHandle(WebServer &server, HTTPMethod method, String uri) {
+  virtual bool canHandle(WebServer &server, HTTPMethod method, const String& uri) {
     (void)server;
     (void)method;
     (void)uri;
     return false;
   }
-  virtual bool canUpload(WebServer &server, String uri) {
+  virtual bool canUpload(WebServer &server, const String& uri) {
     (void)server;
     (void)uri;
     return false;
   }
-  virtual bool canRaw(WebServer &server, String uri) {
+  virtual bool canRaw(WebServer &server, const String& uri) {
     (void)server;
     (void)uri;
     return false;
   }
-  virtual bool handle(WebServer &server, HTTPMethod requestMethod, String requestUri) {
+  virtual bool handle(WebServer &server, HTTPMethod requestMethod, const String&  requestUri) {
     (void)server;
     (void)requestMethod;
     (void)requestUri;
     return false;
   }
-  virtual void upload(WebServer &server, String requestUri, HTTPUpload &upload) {
+  virtual void upload(WebServer &server, const String&  requestUri, HTTPUpload &upload) {
     (void)server;
     (void)requestUri;
     (void)upload;
   }
-  virtual void raw(WebServer &server, String requestUri, HTTPRaw &raw) {
+  virtual void raw(WebServer &server, const String&  requestUri, HTTPRaw &raw) {
     (void)server;
     (void)requestUri;
     (void)raw;

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -21,7 +21,7 @@ public:
     delete _uri;
   }
 
-  bool canHandle(HTTPMethod requestMethod, String requestUri) override {
+  bool canHandle(HTTPMethod requestMethod, const String& requestUri) override {
     if (_method != HTTP_ANY && _method != requestMethod) {
       return false;
     }
@@ -29,7 +29,7 @@ public:
     return _uri->canHandle(requestUri, pathArgs);
   }
 
-  bool canUpload(String requestUri) override {
+  bool canUpload(const String& requestUri) override {
     if (!_ufn || !canHandle(HTTP_POST, requestUri)) {
       return false;
     }
@@ -37,7 +37,7 @@ public:
     return true;
   }
 
-  bool canRaw(String requestUri) override {
+  bool canRaw(const String& requestUri) override {
     if (!_ufn || _method == HTTP_GET) {
       return false;
     }
@@ -45,7 +45,7 @@ public:
     return true;
   }
 
-  bool canHandle(WebServer &server, HTTPMethod requestMethod, String requestUri) override {
+  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
     if (_method != HTTP_ANY && _method != requestMethod) {
       return false;
     }
@@ -53,7 +53,7 @@ public:
     return _uri->canHandle(requestUri, pathArgs) && (_filter != NULL ? _filter(server) : true);
   }
 
-  bool canUpload(WebServer &server, String requestUri) override {
+  bool canUpload(WebServer &server, const String& requestUri) override {
     if (!_ufn || !canHandle(server, HTTP_POST, requestUri)) {
       return false;
     }
@@ -61,7 +61,7 @@ public:
     return true;
   }
 
-  bool canRaw(WebServer &server, String requestUri) override {
+  bool canRaw(WebServer &server, const String& requestUri) override {
     if (!_ufn || _method == HTTP_GET || (_filter != NULL ? _filter(server) == false : false)) {
       return false;
     }
@@ -69,7 +69,7 @@ public:
     return true;
   }
 
-  bool handle(WebServer &server, HTTPMethod requestMethod, String requestUri) override {
+  bool handle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
     if (!canHandle(server, requestMethod, requestUri)) {
       return false;
     }
@@ -78,14 +78,14 @@ public:
     return true;
   }
 
-  void upload(WebServer &server, String requestUri, HTTPUpload &upload) override {
+  void upload(WebServer &server, const String& requestUri, HTTPUpload &upload) override {
     (void)upload;
     if (canUpload(server, requestUri)) {
       _ufn();
     }
   }
 
-  void raw(WebServer &server, String requestUri, HTTPRaw &raw) override {
+  void raw(WebServer &server, const String& requestUri, HTTPRaw &raw) override {
     (void)raw;
     if (canRaw(server, requestUri)) {
       _ufn();
@@ -118,7 +118,7 @@ public:
     _baseUriLength = _uri.length();
   }
 
-  bool canHandle(HTTPMethod requestMethod, String requestUri) override {
+  bool canHandle(HTTPMethod requestMethod, const String& requestUri) override {
     if (requestMethod != HTTP_GET) {
       return false;
     }
@@ -130,7 +130,7 @@ public:
     return true;
   }
 
-  bool canHandle(WebServer &server, HTTPMethod requestMethod, String requestUri) override {
+  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
     if (requestMethod != HTTP_GET) {
       return false;
     }
@@ -146,7 +146,7 @@ public:
     return true;
   }
 
-  bool handle(WebServer &server, HTTPMethod requestMethod, String requestUri) override {
+  bool handle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
     if (!canHandle(server, requestMethod, requestUri)) {
       return false;
     }
@@ -154,13 +154,12 @@ public:
     log_v("StaticRequestHandler::handle: request=%s _uri=%s\r\n", requestUri.c_str(), _uri.c_str());
 
     String path(_path);
-    String eTagCode;
 
     if (!_isFile) {
       // Base URI doesn't point to a file.
       // If a directory is requested, look for index file.
       if (requestUri.endsWith("/")) {
-        requestUri += "index.htm";
+        return handle(server, requestMethod, String(requestUri + "index.htm"));
       }
 
       // Append whatever follows this URI in request to get the file path.
@@ -183,6 +182,8 @@ public:
     if (!f || !f.available()) {
       return false;
     }
+
+    String eTagCode;
 
     if (server._eTagEnabled) {
       if (server._eTagFunction) {

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -21,7 +21,7 @@ public:
     delete _uri;
   }
 
-  bool canHandle(HTTPMethod requestMethod, const String& requestUri) override {
+  bool canHandle(HTTPMethod requestMethod, const String &requestUri) override {
     if (_method != HTTP_ANY && _method != requestMethod) {
       return false;
     }
@@ -29,7 +29,7 @@ public:
     return _uri->canHandle(requestUri, pathArgs);
   }
 
-  bool canUpload(const String& requestUri) override {
+  bool canUpload(const String &requestUri) override {
     if (!_ufn || !canHandle(HTTP_POST, requestUri)) {
       return false;
     }
@@ -37,7 +37,7 @@ public:
     return true;
   }
 
-  bool canRaw(const String& requestUri) override {
+  bool canRaw(const String &requestUri) override {
     if (!_ufn || _method == HTTP_GET) {
       return false;
     }
@@ -45,7 +45,7 @@ public:
     return true;
   }
 
-  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
+  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String &requestUri) override {
     if (_method != HTTP_ANY && _method != requestMethod) {
       return false;
     }
@@ -53,7 +53,7 @@ public:
     return _uri->canHandle(requestUri, pathArgs) && (_filter != NULL ? _filter(server) : true);
   }
 
-  bool canUpload(WebServer &server, const String& requestUri) override {
+  bool canUpload(WebServer &server, const String &requestUri) override {
     if (!_ufn || !canHandle(server, HTTP_POST, requestUri)) {
       return false;
     }
@@ -61,7 +61,7 @@ public:
     return true;
   }
 
-  bool canRaw(WebServer &server, const String& requestUri) override {
+  bool canRaw(WebServer &server, const String &requestUri) override {
     if (!_ufn || _method == HTTP_GET || (_filter != NULL ? _filter(server) == false : false)) {
       return false;
     }
@@ -69,7 +69,7 @@ public:
     return true;
   }
 
-  bool handle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
+  bool handle(WebServer &server, HTTPMethod requestMethod, const String &requestUri) override {
     if (!canHandle(server, requestMethod, requestUri)) {
       return false;
     }
@@ -78,14 +78,14 @@ public:
     return true;
   }
 
-  void upload(WebServer &server, const String& requestUri, HTTPUpload &upload) override {
+  void upload(WebServer &server, const String &requestUri, HTTPUpload &upload) override {
     (void)upload;
     if (canUpload(server, requestUri)) {
       _ufn();
     }
   }
 
-  void raw(WebServer &server, const String& requestUri, HTTPRaw &raw) override {
+  void raw(WebServer &server, const String &requestUri, HTTPRaw &raw) override {
     (void)raw;
     if (canRaw(server, requestUri)) {
       _ufn();
@@ -118,7 +118,7 @@ public:
     _baseUriLength = _uri.length();
   }
 
-  bool canHandle(HTTPMethod requestMethod, const String& requestUri) override {
+  bool canHandle(HTTPMethod requestMethod, const String &requestUri) override {
     if (requestMethod != HTTP_GET) {
       return false;
     }
@@ -130,7 +130,7 @@ public:
     return true;
   }
 
-  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
+  bool canHandle(WebServer &server, HTTPMethod requestMethod, const String &requestUri) override {
     if (requestMethod != HTTP_GET) {
       return false;
     }
@@ -146,7 +146,7 @@ public:
     return true;
   }
 
-  bool handle(WebServer &server, HTTPMethod requestMethod, const String& requestUri) override {
+  bool handle(WebServer &server, HTTPMethod requestMethod, const String &requestUri) override {
     if (!canHandle(server, requestMethod, requestUri)) {
       return false;
     }


### PR DESCRIPTION
## Description of Change
Nearly each function of WebServer RequestHandler does copy the String arguments instead of using `const String&`.

N.B. This might break some classes which inherit from `RequestHandler`