### PR TITLE
Fix missing virtual declarations in Stream.h

### DIFF
--- a/cores/esp32/Stream.h
+++ b/cores/esp32/Stream.h
@@ -61,6 +61,7 @@ public:
   Stream() {
     _timeout = 1000;
   }
+  virtual ~Stream() {}
 
   // parsing methods
 
@@ -105,8 +106,8 @@ public:
   float parseFloat(LookaheadMode lookahead = SKIP_ALL, char ignore = NO_IGNORE_CHAR);
   // float version of parseInt
 
-  size_t readBytes(char *buffer, size_t length);  // read chars from stream into buffer
-  size_t readBytes(uint8_t *buffer, size_t length) {
+  virtual size_t readBytes(char *buffer, size_t length);  // read chars from stream into buffer
+  virtual size_t readBytes(uint8_t *buffer, size_t length) {
     return readBytes((char *)buffer, length);
   }
   // terminates if length characters have been read or timeout (see setTimeout)
@@ -120,7 +121,7 @@ public:
   // returns the number of characters placed in the buffer (0 means no valid data found)
 
   // Arduino String functions to be added here
-  String readString();
+  virtual String readString();
   String readStringUntil(char terminator);
 
 protected:


### PR DESCRIPTION
## Description of Change
Fixes some changes made in PR #10328

- Virtual destructor was removed
- Some functions had `virtual` removed

These changes do cause issues when operating on a `Stream` pointer instead of the derived class.