### PR TITLE
Revert "FS library position() to return (size_t) -1 on error (#10002)"

### DIFF
--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -105,7 +105,7 @@ bool File::seek(uint32_t pos, SeekMode mode) {
 
 size_t File::position() const {
   if (!*this) {
-    return (size_t)-1;
+    return 0;
   }
 
   return _p->position();

--- a/libraries/FS/src/FS.h
+++ b/libraries/FS/src/FS.h
@@ -64,7 +64,7 @@ public:
   bool seek(uint32_t pos) {
     return seek(pos, SeekSet);
   }
-  size_t position() const;  // returns (size_t)-1 on error
+  size_t position() const;
   size_t size() const;
   bool setBufferSize(size_t size);
   void close();


### PR DESCRIPTION
## Description of Change
This reverts commit 0ab2c58b6c14f6dbc8b9ab0e61d776cd3ac5de66. 

## Related links

Fixes: #10360
