### PR TITLE
fix: DNSServer Lib - improper startup code in WiFi mode

### DIFF
--- a/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
+++ b/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
@@ -39,7 +39,10 @@ void setup() {
 
   // by default DNSServer is started serving any "*" domain name. It will reply
   // AccessPoint's IP to all DNS request (this is required for Captive Portal detection)
-  dnsServer.start();
+  if ( dnsServer.start() )
+    Serial.println("Started DNS server in captive portal-mode");
+  else
+    Serial.println("Err: Can't start DNS server!");
 
   // serve a simple root page
   server.on("/", handleRoot);

--- a/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
+++ b/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
@@ -39,10 +39,11 @@ void setup() {
 
   // by default DNSServer is started serving any "*" domain name. It will reply
   // AccessPoint's IP to all DNS request (this is required for Captive Portal detection)
-  if ( dnsServer.start() )
+  if (dnsServer.start()) {
     Serial.println("Started DNS server in captive portal-mode");
-  else
+  } else {
     Serial.println("Err: Can't start DNS server!");
+  }
 
   // serve a simple root page
   server.on("/", handleRoot);

--- a/libraries/DNSServer/src/DNSServer.cpp
+++ b/libraries/DNSServer/src/DNSServer.cpp
@@ -22,10 +22,12 @@ bool DNSServer::start() {
 #if SOC_WIFI_SUPPORTED
     if (WiFi.getMode() & WIFI_AP) {
       _resolvedIP = WiFi.softAPIP();
-      return true;
-    }
+    } else
+      return false; // won't run if WiFi is not in AP mode, or no WiFi 
+#else
+    return false;   // for other non WiFi-AP networking an overloaded method must be used to get device's IP
+                    // start(uint16_t port, const String &domainName, const IPAddress &resolvedIP)
 #endif
-    return false;  // won't run if WiFi is not in AP mode
   }
 
   _udp.close();

--- a/libraries/DNSServer/src/DNSServer.cpp
+++ b/libraries/DNSServer/src/DNSServer.cpp
@@ -22,11 +22,12 @@ bool DNSServer::start() {
 #if SOC_WIFI_SUPPORTED
     if (WiFi.getMode() & WIFI_AP) {
       _resolvedIP = WiFi.softAPIP();
-    } else
-      return false; // won't run if WiFi is not in AP mode, or no WiFi 
+    } else {
+      return false;  // won't run if WiFi is not in AP mode, or no WiFi
+    }
 #else
-    return false;   // for other non WiFi-AP networking an overloaded method must be used to get device's IP
-                    // start(uint16_t port, const String &domainName, const IPAddress &resolvedIP)
+    return false;  // for other non WiFi-AP networking an overloaded method must be used to get device's IP
+                   // start(uint16_t port, const String &domainName, const IPAddress &resolvedIP)
 #endif
   }
 


### PR DESCRIPTION
When running on WiFi-AP mode server's start() method returned true while in fact UDP listening socket was never created
Regression introduced in #8760
Closes #10330

