### PR TITLE
digitalPinToInterrupt: fix double pin remapping on 2.x cores

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -138,7 +138,7 @@
 #endif
 #define EXTERNAL_NUM_INTERRUPTS NUM_DIGITAL_PINS  // All GPIOs
 #define analogInputToDigitalPin(p)  (((p)<NUM_ANALOG_INPUTS)?(analogChannelToDigitalPin(p)):-1)
-#define digitalPinToInterrupt(p)    ((((uint8_t)digitalPinToGPIONumber(p))<NUM_DIGITAL_PINS)?digitalPinToGPIONumber(p):NOT_AN_INTERRUPT)
+#define digitalPinToInterrupt(p)    ((((uint8_t)digitalPinToGPIONumber(p))<NUM_DIGITAL_PINS)?(p):NOT_AN_INTERRUPT)
 #define digitalPinHasPWM(p)         (((uint8_t)digitalPinToGPIONumber(p))<NUM_DIGITAL_PINS)
 
 typedef bool boolean;


### PR DESCRIPTION
## Description of Change

The `digitalPinToInterrupt()` macro currently remaps the pin number to the GPIO number. This is not necessary, as most users will then use the returned value in `attachInterrupt()` or other similar API functions, which already perform the same remapping.

The first half of the macro (the condition) does indeed require the remapping to ensure the check operates on GPIO numbers.

## Related links

Fixes #10367 on 2.x (legacy) cores.
See also #10373 for the same fix on 3.x (current) cores.
