### PR TITLE
IDF release/v5.1

### DIFF
--- a/libraries/WiFi/examples/WPS/WPS.ino
+++ b/libraries/WiFi/examples/WPS/WPS.ino
@@ -25,7 +25,14 @@ WPS (pin is 00000000)
 #define ESP_WPS_MODE WPS_TYPE_PBC
 
 void wpsStart() {
-  esp_wps_config_t config = WPS_CONFIG_INIT_DEFAULT(ESP_WPS_MODE);
+  esp_wps_config_t config;
+  //Same as config = WPS_CONFIG_INIT_DEFAULT(ESP_WPS_MODE);
+  config.wps_type = ESP_WPS_MODE;
+  strcpy(config.factory_info.manufacturer, "ESPRESSIF");
+  strcpy(config.factory_info.model_number, CONFIG_IDF_TARGET);
+  strcpy(config.factory_info.model_name, "ESPRESSIF IOT");
+  strcpy(config.factory_info.device_name, "ESP DEVICE");
+  strcpy(config.pin, "00000000");
   esp_err_t err = esp_wifi_wps_enable(&config);
   if (err != ESP_OK) {
     Serial.printf("WPS Enable Failed: 0x%x: %s\n", err, esp_err_to_name(err));

--- a/libraries/WiFi/examples/WPS/WPS.ino
+++ b/libraries/WiFi/examples/WPS/WPS.ino
@@ -26,6 +26,7 @@ WPS (pin is 00000000)
 
 void wpsStart() {
   esp_wps_config_t config;
+  memset(&config, 0, sizeof(esp_wps_config_t));
   //Same as config = WPS_CONFIG_INIT_DEFAULT(ESP_WPS_MODE);
   config.wps_type = ESP_WPS_MODE;
   strcpy(config.factory_info.manufacturer, "ESPRESSIF");

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-33fbade6"
+              "version": "idf-release_v5.1-a13ab341"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-33fbade6",
+          "version": "idf-release_v5.1-a13ab341",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
+              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
+              "size": "341639302"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-a13ab341"
+              "version": "idf-release_v5.1-59274ae0"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-a13ab341",
+          "version": "idf-release_v5.1-59274ae0",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-a13ab341.zip",
-              "checksum": "SHA-256:c041e500d087271c0ea74ff3c4da798d0daf829bf4027d3f9cfbf1e87fadda4d",
-              "size": "341639302"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:802cf280a53a0ace50dbdc57ce89d8b8d532bf2885b3cf08aba15a2e1f830cfe",
+              "size": "341690576"
             }
           ]
         },

--- a/platform.txt
+++ b/platform.txt
@@ -103,7 +103,7 @@ build.code_debug=0
 build.defines=
 build.loop_core=
 build.event_core=
-build.extra_flags=-DARDUINO_HOST_OS="{runtime.os}" -DARDUINO_FQBN="{build.fqbn}" -DESP32 -DCORE_DEBUG_LEVEL={build.code_debug} {build.loop_core} {build.event_core} {build.defines} {build.extra_flags.{build.mcu}} {build.zigbee_mode}
+build.extra_flags=-DARDUINO_HOST_OS="{runtime.os}" -DARDUINO_FQBN="{build.fqbn}" -DESP32=ESP32 -DCORE_DEBUG_LEVEL={build.code_debug} {build.loop_core} {build.event_core} {build.defines} {build.extra_flags.{build.mcu}} {build.zigbee_mode}
 build.extra_libs=
 build.memory_type={build.boot}_qspi
 


### PR DESCRIPTION
```
lib-builder: master 5d4ed02
esp-idf: release/v5.1 a13ab34101
arduino: master b05f18da
tinyusb: master c8ab65fbb
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.2
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.5.0
espressif__esp-zigbee-lib: 1.5.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.5.2
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
```
