### PR TITLE
fix(HardwareSerial): fix pin remapping in begin() on master

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -291,6 +291,10 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
   }
 #endif
 
+  // map logical pins to GPIO numbers
+  rxPin = digitalPinToGPIONumber(rxPin);
+  txPin = digitalPinToGPIONumber(txPin);
+
   HSERIAL_MUTEX_LOCK();
   // First Time or after end() --> set default Pins
   if (!uartIsDriverInstalled(_uart)) {
@@ -326,9 +330,6 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
     }
   }
 
-  // map logical pins to GPIO numbers
-  rxPin = digitalPinToGPIONumber(rxPin);
-  txPin = digitalPinToGPIONumber(txPin);
   // IDF UART driver keeps Pin setting on restarting. Negative Pin number will keep it unmodified.
   // it will detach previous UART attached pins
 


### PR DESCRIPTION
## Description of Change

The pin remapping functions have to be called as early as possible in the `HardwareSerial::begin()` function, to immediately convert the input parameters from the user to the GPIO numbers used everywhere in the core. However, there is code that assigns GPIO numbers to `txPin`/`rxPin` _before_ the call to `digitalPinToGPIONumber`.

This issue has always been dormant since the introduction of pin remapping in 9b4622d, but is evident on 3.x due to the full pinmuxing support that _actually detaches pins_ - disabling the default `Serial0` pins.

Move the pin remapping function calls earlier in the `begin()` function to fix this issue.

## Tests scenarios
Tested on the Nano ESP32 - `Serial0.begin(115200)` was selecting "random" pins instead of the expected defaults.  

## Related links
See also #10380 for the same fix on 2.x.