### PR TITLE
fix(HardwareSerial): fix pin remapping in begin() for 2.x

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -282,6 +282,10 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
     }
 #endif
 
+    // map logical pins to GPIO numbers
+    rxPin = digitalPinToGPIONumber(rxPin);
+    txPin = digitalPinToGPIONumber(txPin);
+
     HSERIAL_MUTEX_LOCK();
     // First Time or after end() --> set default Pins
     if (!uartIsDriverInstalled(_uart)) {
@@ -317,9 +321,6 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
         }
     }
 
-    // map logical pins to GPIO numbers
-    rxPin = digitalPinToGPIONumber(rxPin);
-    txPin = digitalPinToGPIONumber(txPin);
     // IDF UART driver keeps Pin setting on restarting. Negative Pin number will keep it unmodified.
     // it will detach previous UART attached pins
 


### PR DESCRIPTION
## Description of Change

The pin remapping functions have to be called as early as possible in the begin() function, to immediately convert the input parameters from the user to the GPIO numbers used everywhere in the core. However, there is code that assigns GPIO numbers to `txPin`/`rxPin` _before_ the call to `digitalPinToGPIONumber`.

This issue has always been dormant since the introduction of pin remapping in 9b4622d, but was exposed by the recent UART pin detach support in 2.x, which actually disabled the default Serial0 pins.

Move the pin remapping function calls earlier in the begin() function to fix this issue.

## Tests scenarios
Tested on the Nano ESP32 - `Serial0.begin(115200)` was selecting "random" pins instead of the expected defaults.  

## Related links
See also #10379 for the same fix on master.