### PR TITLE
fix(psram): Init PSRAM before app_main to fix mmu_map

### DIFF
--- a/cores/esp32/esp32-hal-log.h
+++ b/cores/esp32/esp32-hal-log.h
@@ -20,6 +20,7 @@ extern "C" {
 
 #include "sdkconfig.h"
 #include "esp_timer.h"
+#include "rom/ets_sys.h"
 
 #define ARDUHAL_LOG_LEVEL_NONE    (0)
 #define ARDUHAL_LOG_LEVEL_ERROR   (1)

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -253,7 +253,7 @@ extern bool btInUse();
 #if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
 #ifndef CONFIG_SPIRAM_BOOT_INIT
 ESP_SYSTEM_INIT_FN(init_psram_new, BIT(0), 99) {
-  return psramInit()?ESP_OK:ESP_FAIL;
+  return psramInit() ? ESP_OK : ESP_FAIL;
 }
 #endif
 #endif

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -24,6 +24,7 @@
 #ifdef CONFIG_APP_ROLLBACK_ENABLE
 #include "esp_ota_ops.h"
 #endif  //CONFIG_APP_ROLLBACK_ENABLE
+#include "esp_private/startup_internal.h"
 #ifdef CONFIG_BT_ENABLED
 #include "esp_bt.h"
 #endif  //CONFIG_BT_ENABLED
@@ -249,12 +250,17 @@ extern bool btInUse();
 #endif
 #endif
 
+#if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
+#ifndef CONFIG_SPIRAM_BOOT_INIT
+ESP_SYSTEM_INIT_FN(init_psram_new, BIT(0), 99) {
+  return psramInit()?ESP_OK:ESP_FAIL;
+}
+#endif
+#endif
+
 void initArduino() {
   //init proper ref tick value for PLL (uncomment if REF_TICK is different than 1MHz)
   //ESP_REG(APB_CTRL_PLL_TICK_CONF_REG) = APB_CLK_FREQ / REF_CLK_FREQ - 1;
-#if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
-  psramInit();
-#endif
 #ifdef CONFIG_APP_ROLLBACK_ENABLE
   if (!verifyRollbackLater()) {
     const esp_partition_t *running = esp_ota_get_running_partition();

--- a/cores/esp32/esp32-hal-psram.c
+++ b/cores/esp32/esp32-hal-psram.c
@@ -31,6 +31,8 @@
 #error Target CONFIG_IDF_TARGET is not supported
 #endif
 
+#define TAG "arduino-psram"
+
 static volatile bool spiramDetected = false;
 static volatile bool spiramFailed = false;
 
@@ -52,7 +54,7 @@ bool psramInit() {
   uint32_t pkg_ver = chip_ver & 0x7;
   if (pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5 || pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2) {
     spiramFailed = true;
-    log_w("PSRAM not supported!");
+    ESP_EARLY_LOGW(TAG, "PSRAM not supported!");
     return false;
   }
 #elif CONFIG_IDF_TARGET_ESP32S2
@@ -62,7 +64,7 @@ bool psramInit() {
 #endif
   if (esp_psram_init() != ESP_OK) {
     spiramFailed = true;
-    log_w("PSRAM init failed!");
+    ESP_EARLY_LOGW(TAG, "PSRAM init failed!");
 #if CONFIG_IDF_TARGET_ESP32
     if (pkg_ver != EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4) {
       pinMatrixOutDetach(16, false, false);
@@ -71,23 +73,22 @@ bool psramInit() {
 #endif
     return false;
   }
-
   //testSPIRAM() allows user to bypass SPI RAM test routine
   if (!testSPIRAM()) {
     spiramFailed = true;
-    log_e("PSRAM test failed!");
+    ESP_EARLY_LOGE(TAG, "PSRAM test failed!");
     return false;
   }
   if (esp_psram_extram_add_to_heap_allocator() != ESP_OK) {
     spiramFailed = true;
-    log_e("PSRAM could not be added to the heap!");
+    ESP_EARLY_LOGE(TAG, "PSRAM could not be added to the heap!");
     return false;
   }
 #if CONFIG_SPIRAM_USE_MALLOC && !CONFIG_ARDUINO_ISR_IRAM
   heap_caps_malloc_extmem_enable(CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL);
 #endif
+  ESP_EARLY_LOGI(TAG, "PSRAM enabled");
 #endif /* CONFIG_SPIRAM_BOOT_INIT */
-  log_i("PSRAM enabled");
   spiramDetected = true;
   return true;
 }


### PR DESCRIPTION
Makes sure that PSRAM is part of the map before app_main is called.
