### PR TITLE
fix(workwi): Return OK even if PSRAM init fails

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -253,7 +253,8 @@ extern bool btInUse();
 #if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
 #ifndef CONFIG_SPIRAM_BOOT_INIT
 ESP_SYSTEM_INIT_FN(init_psram_new, BIT(0), 99) {
-  return psramInit() ? ESP_OK : ESP_FAIL;
+  psramInit();
+  return ESP_OK;
 }
 #endif
 #endif


### PR DESCRIPTION
If the board does not support PSRAM, but it is enabled, abort will be called. With this change, abort will not be called