### PR TITLE
IDF release/v5.3

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -91,7 +91,7 @@ function build_sketch(){ # build_sketch <ide_path> <user_path> <path-to-ino> [ex
             esp32c3_opts="PartitionScheme=huge_app,FlashMode=dio"
             esp32c6_opts="PartitionScheme=huge_app,FlashMode=dio"
             esp32h2_opts="PartitionScheme=huge_app,FlashMode=dio"
-            esp32p4_opts="PartitionScheme=huge_app,FlashMode=dio"
+            esp32p4_opts="PartitionScheme=huge_app,FlashMode=dio,USBMode=default"
 
             # Select the common part of the FQBN based on the target.  The rest will be
             # appended depending on the passed options.

--- a/boards.txt
+++ b/boards.txt
@@ -212,20 +212,37 @@ esp32p4.menu.JTAGAdapter.bridge=ESP USB Bridge
 esp32p4.menu.JTAGAdapter.bridge.build.openocdscript=esp32p4-bridge.cfg
 esp32p4.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
 
-esp32p4.menu.CDCOnBoot.default=Disabled
-esp32p4.menu.CDCOnBoot.default.build.cdc_on_boot=0
-esp32p4.menu.CDCOnBoot.cdc=Enabled
-esp32p4.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-
 esp32p4.menu.PSRAM.disabled=Disabled
 esp32p4.menu.PSRAM.disabled.build.defines=
 esp32p4.menu.PSRAM.enabled=Enabled
 esp32p4.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 
+esp32p4.menu.USBMode.hwcdc=Hardware CDC and JTAG
+esp32p4.menu.USBMode.hwcdc.build.usb_mode=1
+esp32p4.menu.USBMode.default=USB-OTG (TinyUSB)
+esp32p4.menu.USBMode.default.build.usb_mode=0
+
 esp32p4.menu.CDCOnBoot.default=Disabled
 esp32p4.menu.CDCOnBoot.default.build.cdc_on_boot=0
 esp32p4.menu.CDCOnBoot.cdc=Enabled
 esp32p4.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+esp32p4.menu.MSCOnBoot.default=Disabled
+esp32p4.menu.MSCOnBoot.default.build.msc_on_boot=0
+esp32p4.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+esp32p4.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+esp32p4.menu.DFUOnBoot.default=Disabled
+esp32p4.menu.DFUOnBoot.default.build.dfu_on_boot=0
+esp32p4.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+esp32p4.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+esp32p4.menu.UploadMode.default=UART0 / Hardware CDC
+esp32p4.menu.UploadMode.default.upload.use_1200bps_touch=false
+esp32p4.menu.UploadMode.default.upload.wait_for_upload_port=false
+esp32p4.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+esp32p4.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+esp32p4.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 
 esp32p4.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 esp32p4.menu.PartitionScheme.default.build.partitions=default

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -253,12 +253,10 @@ extern bool btInUse();
 #endif
 
 #if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
-#ifndef CONFIG_SPIRAM_BOOT_INIT
 ESP_SYSTEM_INIT_FN(init_psram_new, CORE, BIT(0), 99) {
   psramInit();
   return ESP_OK;
 }
-#endif
 #endif
 
 void initArduino() {

--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/ci.json
@@ -7,11 +7,7 @@
       "espressif:esp32:esp32h2:PartitionScheme=zigbee,ZigbeeMode=ed"
     ]
   },
-  "targets": {
-    "esp32": false,
-    "esp32c3": false,
-    "esp32s2": false,
-    "esp32s3": false,
-    "esp32p4": false
-  }
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
 }

--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/ci.json
@@ -11,6 +11,7 @@
     "esp32": false,
     "esp32c3": false,
     "esp32s2": false,
-    "esp32s3": false
+    "esp32s3": false,
+    "esp32p4": false
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/ci.json
@@ -7,11 +7,7 @@
       "espressif:esp32:esp32h2:PartitionScheme=zigbee_zczr,ZigbeeMode=zczr"
     ]
   },
-  "targets": {
-    "esp32": false,
-    "esp32c3": false,
-    "esp32s2": false,
-    "esp32s3": false,
-    "esp32p4": false
-  }
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
 }

--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/ci.json
@@ -11,6 +11,7 @@
     "esp32": false,
     "esp32c3": false,
     "esp32s2": false,
-    "esp32s3": false
+    "esp32s3": false,
+    "esp32p4": false
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Light/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Light/ci.json
@@ -7,11 +7,7 @@
       "espressif:esp32:esp32h2:PartitionScheme=zigbee,ZigbeeMode=ed"
     ]
   },
-  "targets": {
-    "esp32": false,
-    "esp32c3": false,
-    "esp32s2": false,
-    "esp32s3": false,
-    "esp32p4": false
-  }
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
 }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Light/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Light/ci.json
@@ -11,6 +11,7 @@
     "esp32": false,
     "esp32c3": false,
     "esp32s2": false,
-    "esp32s3": false
+    "esp32s3": false,
+    "esp32p4": false
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Switch/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Switch/ci.json
@@ -7,11 +7,7 @@
       "espressif:esp32:esp32h2:PartitionScheme=zigbee_zczr,ZigbeeMode=zczr"
     ]
   },
-  "targets": {
-    "esp32": false,
-    "esp32c3": false,
-    "esp32s2": false,
-    "esp32s3": false,
-    "esp32p4": false
-  }
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
 }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Switch/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Switch/ci.json
@@ -11,6 +11,7 @@
     "esp32": false,
     "esp32c3": false,
     "esp32s2": false,
-    "esp32s3": false
+    "esp32s3": false,
+    "esp32p4": false
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_Scan_Networks/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Scan_Networks/ci.json
@@ -7,11 +7,7 @@
       "espressif:esp32:esp32h2:PartitionScheme=zigbee,ZigbeeMode=ed"
     ]
   },
-  "targets": {
-    "esp32": false,
-    "esp32c3": false,
-    "esp32s2": false,
-    "esp32s3": false,
-    "esp32p4": false
-  }
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
 }

--- a/libraries/Zigbee/examples/Zigbee_Scan_Networks/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Scan_Networks/ci.json
@@ -11,6 +11,7 @@
     "esp32": false,
     "esp32c3": false,
     "esp32s2": false,
-    "esp32s3": false
+    "esp32s3": false,
+    "esp32p4": false
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/ci.json
@@ -7,11 +7,7 @@
       "espressif:esp32:esp32h2:PartitionScheme=zigbee,ZigbeeMode=ed"
     ]
   },
-  "targets": {
-    "esp32": false,
-    "esp32c3": false,
-    "esp32s2": false,
-    "esp32s3": false,
-    "esp32p4": false
-  }
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
 }

--- a/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/ci.json
@@ -11,6 +11,7 @@
     "esp32": false,
     "esp32c3": false,
     "esp32s2": false,
-    "esp32s3": false
+    "esp32s3": false,
+    "esp32p4": false
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_Thermostat/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Thermostat/ci.json
@@ -7,11 +7,7 @@
       "espressif:esp32:esp32h2:PartitionScheme=zigbee_zczr,ZigbeeMode=zczr"
     ]
   },
-  "targets": {
-    "esp32": false,
-    "esp32c3": false,
-    "esp32s2": false,
-    "esp32s3": false,
-    "esp32p4": false
-  }
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
 }

--- a/libraries/Zigbee/examples/Zigbee_Thermostat/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Thermostat/ci.json
@@ -11,6 +11,7 @@
     "esp32": false,
     "esp32c3": false,
     "esp32s2": false,
-    "esp32s3": false
+    "esp32s3": false,
+    "esp32p4": false
   }
 }

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-4d0db704"
+              "version": "idf-release_v5.3-707d097b"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-4d0db704",
+          "version": "idf-release_v5.3-707d097b",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-4d0db704.zip",
-              "checksum": "SHA-256:645b7579d22e7de73c87cce1d52629f9780de9f18be5b5b066ac0f2c210e9bef",
-              "size": "360076736"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
+              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
+              "size": "399730073"
             }
           ]
         },

--- a/platform.txt
+++ b/platform.txt
@@ -84,7 +84,7 @@ build.extra_flags.esp32c2=-DARDUINO_USB_CDC_ON_BOOT=0
 build.extra_flags.esp32c3=-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot}
 build.extra_flags.esp32c6=-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot}
 build.extra_flags.esp32h2=-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot}
-build.extra_flags.esp32p4=-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot}
+build.extra_flags.esp32p4=-DARDUINO_USB_MODE={build.usb_mode} -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot} -DARDUINO_USB_MSC_ON_BOOT={build.msc_on_boot} -DARDUINO_USB_DFU_ON_BOOT={build.dfu_on_boot}
 
 # This can be overriden in boards.txt
 build.zigbee_mode=


### PR DESCRIPTION
```
lib-builder: release/v5.3 ac25609
esp-idf: release/v5.3 707d097b01
arduino: release/v3.1.x 58c0bbc0
tinyusb: master eda3cceab
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.16
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.2
espressif__esp-zboss-lib: 1.5.0
espressif__esp-zigbee-lib: 1.5.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.5.2
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
```
