### PR TITLE
fix(spiram): Fix OPI PSRAM init

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -251,12 +251,10 @@ extern bool btInUse();
 #endif
 
 #if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
-#ifndef CONFIG_SPIRAM_BOOT_INIT
 ESP_SYSTEM_INIT_FN(init_psram_new, BIT(0), 99) {
   psramInit();
   return ESP_OK;
 }
-#endif
 #endif
 
 void initArduino() {


### PR DESCRIPTION
OPI PSRAM was not registered as started and was preventing it from working.
