### PR TITLE
Wire library: Add conditional compilation for second I2C interface based on SOC_I2C_NUM

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -646,6 +646,8 @@ void TwoWire::onRequestService(uint8_t num, void *arg) {
 #endif /* SOC_I2C_SUPPORT_SLAVE */
 
 TwoWire Wire = TwoWire(0);
+#if SOC_I2C_NUM > 1
 TwoWire Wire1 = TwoWire(1);
+#endif /* SOC_I2C_NUM */
 
 #endif /* SOC_I2C_SUPPORTED */

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -144,7 +144,9 @@ public:
 };
 
 extern TwoWire Wire;
+#if SOC_I2C_NUM > 1
 extern TwoWire Wire1;
+#endif /* SOC_I2C_NUM */
 
 #endif /* SOC_I2C_SUPPORTED */
 #endif /* TwoWire_h */


### PR DESCRIPTION
The ESP32, ESP32-S and ESP32-H series have two I2C interfaces, while the ESP32-C series has only one.

-----------
## Description of Change
The `Wire1` object is conditionally compiled and is not available on MCUs that only have a single I2C interface (e.g. MCUs of the ESP32-C series).

## Tests scenarios
I tested my pull request on Arduino-esp32 core v3.1.0 with ESP32, ESP32-S3 and ESP32-C3 board with this scenario.
For the test I modified the [WireScan example](https://github.com/espressif/arduino-esp32/tree/master/libraries/Wire/examples/WireScan) to use the `Wire1` object. On an ESP32-C3 based board the compilation failed which is the expected behaviour and intention of this PR.

## Related links
[ESP32 Arduino Wire not working](https://community.platformio.org/t/twowire-wire-twowire-1-causing-null-tx-buffer-pointer-error/43584)


