### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-33fbade6"
+              "version": "idf-release_v5.1-59274ae0"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-33fbade6",
+          "version": "idf-release_v5.1-59274ae0",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-33fbade6.zip",
-              "checksum": "SHA-256:578f325fa9fca635d9c6c3b19726cb26077751e3155b677317bde2e0b371df7d",
-              "size": "309285463"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-59274ae0.zip",
+              "checksum": "SHA-256:7697c5e990f2ab44be8dd2d2830fca1db07326558b26079e4acc7a44891024f1",
+              "size": "309487871"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.1 40fb05e
esp-idf: release/v5.1 59274ae0d6
arduino: release/v3.0.x ea50cf6f
tinyusb: master eda3cceab
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.5.0
espressif__esp-zigbee-lib: 1.5.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dl:
espressif__esp32-camera:
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.2
```
