### PR TITLE
Update FreeRTOS Symbols in OThreadCLI

### DIFF
--- a/libraries/OpenThread/README.md
+++ b/libraries/OpenThread/README.md
@@ -19,7 +19,7 @@ Below are the details of the class:
 ```cpp
 class OpenThreadCLI : public Stream {
 private:
-  static size_t setBuffer(xQueueHandle &queue, size_t len);
+  static size_t setBuffer(QueueHandle_t &queue, size_t len);
   bool otStarted = false;
 
 public:

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -21,8 +21,8 @@
 
 static TaskHandle_t s_cli_task = NULL;
 static TaskHandle_t s_console_cli_task = NULL;
-static xQueueHandle rx_queue = NULL;
-static xQueueHandle tx_queue = NULL;
+static QueueHandle_t rx_queue = NULL;
+static QueueHandle_t tx_queue = NULL;
 
 static esp_openthread_platform_config_t ot_native_config;
 static TaskHandle_t s_ot_task = NULL;
@@ -389,7 +389,7 @@ size_t OpenThreadCLI::write(uint8_t c) {
   return 1;
 }
 
-size_t OpenThreadCLI::setBuffer(xQueueHandle &queue, size_t queue_len) {
+size_t OpenThreadCLI::setBuffer(QueueHandle_t &queue, size_t queue_len) {
   if (queue) {
     vQueueDelete(queue);
     queue = NULL;

--- a/libraries/OpenThread/src/OThreadCLI.h
+++ b/libraries/OpenThread/src/OThreadCLI.h
@@ -22,7 +22,7 @@ typedef std::function<void(void)> OnReceiveCb_t;
 
 class OpenThreadCLI : public Stream {
 private:
-  static size_t setBuffer(xQueueHandle &queue, size_t len);
+  static size_t setBuffer(QueueHandle_t &queue, size_t len);
   bool otStarted = false;
 
 public:


### PR DESCRIPTION
## Description of Change

TARGET: 3.0.x and 3.1.x

Fixes FreeRTOS types.
This affects certain ways of building applications using IDF Components.

## Tests scenarios

CI only.

## Related links
