### PR TITLE
fix(asyncudp): Fixes and implements tcpip thread locking

### DIFF
--- a/libraries/AsyncUDP/src/AsyncUDP.cpp
+++ b/libraries/AsyncUDP/src/AsyncUDP.cpp
@@ -488,6 +488,7 @@ bool AsyncUDP::_init() {
   UDP_MUTEX_LOCK();
   _pcb = udp_new();
   if (!_pcb) {
+    UDP_MUTEX_UNLOCK();
     return false;
   }
   udp_recv(_pcb, &_udp_recv, (void *)this);

--- a/libraries/AsyncUDP/src/AsyncUDP.cpp
+++ b/libraries/AsyncUDP/src/AsyncUDP.cpp
@@ -16,17 +16,19 @@ extern "C" {
 #include "lwip/priv/tcpip_priv.h"
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
-#define UDP_MUTEX_LOCK()      if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) { \
-                                LOCK_TCPIP_CORE();                                  \
-                              }
+#define UDP_MUTEX_LOCK()                                \
+  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) { \
+    LOCK_TCPIP_CORE();                                  \
+  }
 
-#define UDP_MUTEX_UNLOCK()    if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {  \
-                                UNLOCK_TCPIP_CORE();                                \
-                              }
-#else // CONFIG_LWIP_TCPIP_CORE_LOCKING
+#define UDP_MUTEX_UNLOCK()                             \
+  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) { \
+    UNLOCK_TCPIP_CORE();                               \
+  }
+#else  // CONFIG_LWIP_TCPIP_CORE_LOCKING
 #define UDP_MUTEX_LOCK()
 #define UDP_MUTEX_UNLOCK()
-#endif // CONFIG_LWIP_TCPIP_CORE_LOCKING
+#endif  // CONFIG_LWIP_TCPIP_CORE_LOCKING
 
 static const char *netif_ifkeys[TCPIP_ADAPTER_IF_MAX] = {"WIFI_STA_DEF", "WIFI_AP_DEF", "ETH_DEF", "PPP_DEF"};
 

--- a/libraries/AsyncUDP/src/AsyncUDP.cpp
+++ b/libraries/AsyncUDP/src/AsyncUDP.cpp
@@ -15,6 +15,19 @@ extern "C" {
 
 #include "lwip/priv/tcpip_priv.h"
 
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+#define UDP_MUTEX_LOCK()      if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) { \
+                                LOCK_TCPIP_CORE();                                  \
+                              }
+
+#define UDP_MUTEX_UNLOCK()    if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {  \
+                                UNLOCK_TCPIP_CORE();                                \
+                              }
+#else // CONFIG_LWIP_TCPIP_CORE_LOCKING
+#define UDP_MUTEX_LOCK()
+#define UDP_MUTEX_UNLOCK()
+#endif // CONFIG_LWIP_TCPIP_CORE_LOCKING
+
 static const char *netif_ifkeys[TCPIP_ADAPTER_IF_MAX] = {"WIFI_STA_DEF", "WIFI_AP_DEF", "ETH_DEF", "PPP_DEF"};
 
 static esp_err_t tcpip_adapter_get_netif(tcpip_adapter_if_t tcpip_if, void **netif) {
@@ -28,7 +41,9 @@ static esp_err_t tcpip_adapter_get_netif(tcpip_adapter_if_t tcpip_if, void **net
     if (netif_index < 0) {
       return ESP_FAIL;
     }
+    UDP_MUTEX_LOCK();
     *netif = (void *)netif_get_by_index(netif_index);
+    UDP_MUTEX_UNLOCK();
   } else {
     *netif = netif_default;
   }
@@ -231,9 +246,6 @@ static bool _udp_task_stop(){
     _udp_queue = NULL;
 }
 */
-
-#define UDP_MUTEX_LOCK()    //xSemaphoreTake(_lock, portMAX_DELAY)
-#define UDP_MUTEX_UNLOCK()  //xSemaphoreGive(_lock)
 
 AsyncUDPMessage::AsyncUDPMessage(size_t size) {
   _index = 0;
@@ -473,12 +485,13 @@ bool AsyncUDP::_init() {
   if (_pcb) {
     return true;
   }
+  UDP_MUTEX_LOCK();
   _pcb = udp_new();
   if (!_pcb) {
     return false;
   }
-  //_lock = xSemaphoreCreateMutex();
   udp_recv(_pcb, &_udp_recv, (void *)this);
+  UDP_MUTEX_UNLOCK();
   return true;
 }
 
@@ -493,14 +506,12 @@ AsyncUDP::~AsyncUDP() {
   close();
   UDP_MUTEX_LOCK();
   udp_recv(_pcb, NULL, NULL);
+  UDP_MUTEX_UNLOCK();
   _udp_remove(_pcb);
   _pcb = NULL;
-  UDP_MUTEX_UNLOCK();
-  //vSemaphoreDelete(_lock);
 }
 
 void AsyncUDP::close() {
-  UDP_MUTEX_LOCK();
   if (_pcb != NULL) {
     if (_connected) {
       _udp_disconnect(_pcb);
@@ -508,7 +519,6 @@ void AsyncUDP::close() {
     _connected = false;
     //todo: unjoin multicast group
   }
-  UDP_MUTEX_UNLOCK();
 }
 
 bool AsyncUDP::connect(const ip_addr_t *addr, uint16_t port) {
@@ -520,14 +530,11 @@ bool AsyncUDP::connect(const ip_addr_t *addr, uint16_t port) {
     return false;
   }
   close();
-  UDP_MUTEX_LOCK();
   _lastErr = _udp_connect(_pcb, addr, port);
   if (_lastErr != ERR_OK) {
-    UDP_MUTEX_UNLOCK();
     return false;
   }
   _connected = true;
-  UDP_MUTEX_UNLOCK();
   return true;
 }
 
@@ -544,13 +551,10 @@ bool AsyncUDP::listen(const ip_addr_t *addr, uint16_t port) {
     IP_SET_TYPE_VAL(_pcb->local_ip, addr->type);
     IP_SET_TYPE_VAL(_pcb->remote_ip, addr->type);
   }
-  UDP_MUTEX_LOCK();
   if (_udp_bind(_pcb, addr, port) != ERR_OK) {
-    UDP_MUTEX_UNLOCK();
     return false;
   }
   _connected = true;
-  UDP_MUTEX_UNLOCK();
   return true;
 }
 
@@ -624,12 +628,10 @@ bool AsyncUDP::listenMulticast(const ip_addr_t *addr, uint16_t port, uint8_t ttl
     return false;
   }
 
-  UDP_MUTEX_LOCK();
   _pcb->mcast_ttl = ttl;
   _pcb->remote_port = port;
   ip_addr_copy(_pcb->remote_ip, *addr);
   //ip_addr_copy(_pcb->remote_ip, ip_addr_any_type);
-  UDP_MUTEX_UNLOCK();
 
   return true;
 }
@@ -651,7 +653,6 @@ size_t AsyncUDP::writeTo(const uint8_t *data, size_t len, const ip_addr_t *addr,
   if (pbt != NULL) {
     uint8_t *dst = reinterpret_cast<uint8_t *>(pbt->payload);
     memcpy(dst, data, len);
-    UDP_MUTEX_LOCK();
     if (tcpip_if < TCPIP_ADAPTER_IF_MAX) {
       void *nif = NULL;
       tcpip_adapter_get_netif((tcpip_adapter_if_t)tcpip_if, &nif);
@@ -663,7 +664,6 @@ size_t AsyncUDP::writeTo(const uint8_t *data, size_t len, const ip_addr_t *addr,
     } else {
       _lastErr = _udp_sendto(_pcb, pbt, addr, port);
     }
-    UDP_MUTEX_UNLOCK();
     pbuf_free(pbt);
     if (_lastErr < ERR_OK) {
       return 0;


### PR DESCRIPTION
## Description of Change
Implements and fixes TCPIP Core locking in AsyncUDP when enabled.

AsyncUDP calls Raw LwIP APIs that are not safe to call from other threads without locking. While some raw APIs are being [called by using `tcpip_api_call()`](https://github.com/espressif/arduino-esp32/blob/733373a049d8a06fab00628bcae585550fac6d07/libraries/AsyncUDP/src/AsyncUDP.cpp#L48-L135), other calls are not considering this method, as [[1]](https://github.com/espressif/arduino-esp32/blob/733373a049d8a06fab00628bcae585550fac6d07/libraries/AsyncUDP/src/AsyncUDP.cpp#L31), [[2]](https://github.com/espressif/arduino-esp32/blob/733373a049d8a06fab00628bcae585550fac6d07/libraries/AsyncUDP/src/AsyncUDP.cpp#L476-L481), [[3]](https://github.com/espressif/arduino-esp32/blob/733373a049d8a06fab00628bcae585550fac6d07/libraries/AsyncUDP/src/AsyncUDP.cpp#L495), and [[4]](https://github.com/espressif/arduino-esp32/blob/master/libraries/AsyncUDP/src/AsyncUDP.cpp#L640).

When `CONFIG_LWIP_CHECK_THREAD_SAFETY` is enabled, the system gets aborted when the lwip core is not locked; Therefore exposing a source of bugs.

Any call to `tcpip_api_call()` in tcpip core locked results in a deadlock, thus removed the corresponding calls.

I've prefered to check against the state before locking and unlocking, helpful when any concerned AsyncUDP API being called from within LwIP thread, highly through callbacks, if any.

This will not affect the direct Arduino users but until [esp32-arduino-libs-builder PR](https://github.com/espressif/esp32-arduino-lib-builder/pull/186) gets merged it will fix a source of bugs.

Currently: Arduino-as-ESPIDF-component users can easily have this fix by enabling `CONFIG_LWIP_TCPIP_CORE_LOCKING` option.

## Related links

https://www.nongnu.org/lwip/2_1_x/multithreading.html

https://github.com/espressif/arduino-esp32/issues/10391#issuecomment-2385443646
