### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:7af392cc8c0079f3eea5e49706f3ea296bd42c4ce89d48909a135310caa69c96",
-              "size": "399730073"
+              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
+              "size": "399729605"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.3 0232d0a
esp-idf: release/v5.3 707d097b01
arduino: release/v3.1.x 341dc180
tinyusb: master eda3cceab
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.16
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.2
espressif__esp-zboss-lib: 1.5.0
espressif__esp-zigbee-lib: 1.5.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.5.2
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
```
