### PR TITLE
feat(uart): only enable on_receive task if necessary

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -368,11 +368,6 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
       _uart = NULL;
     }
   }
-  // create a task to deal with Serial Events when, for example, calling begin() twice to change the baudrate,
-  // or when setting the callback before calling begin()
-  if (_uart != NULL && (_onReceiveCB != NULL || _onReceiveErrorCB != NULL) && _eventTask == NULL) {
-    _createEventTask(this);
-  }
 
   // Set UART RX timeout
   uartSetRxTimeout(_uart, _rxTimeout);


### PR DESCRIPTION
## Description of Change
The onReceive Task was created by default when Serial.begin() is executed. This creates a additonal Task that degrades the performance of the whole arduino sketch.

This will be done now only if onReceive() is called.

## Tests scenarios

``` cpp
uint32_t  Loopcounter = 0;
static uint32_t msTick;      

void setup() 
{
 Serial.begin(115200);                     // Setup the serial port to 115200 baud //
 msTick = millis(); 

 Serial0.begin(115200); // THIS Line starts UART Arduino Driver and also starts an additional Task that "eats" CPU time...
}

void loop() 
{
 Loopcounter++;
 EverySecondCheck();
}

//--------------------------------------------//
// COMMON Update routine done every second
//--------------------------------------------
void EverySecondCheck(void)
{
 uint32_t msLeap = millis() - msTick;     // 
 if (msLeap >999)                         // Every second enter the loop
 {
  msTick = millis();
 Serial.printf("Loops per second: %u\n",Loopcounter);
 Loopcounter = 0;
 }  
}
```

## Related links
closes #10397 
closes #10420