### PR TITLE
feat(uart) 3.1.x Core: fixes serialEventRun() to avoid calling available() if serialEvent() is not declared

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -24,16 +24,13 @@
 #endif
 
 void serialEvent(void) __attribute__((weak));
-void serialEvent(void) {}
 
 #if SOC_UART_NUM > 1
 void serialEvent1(void) __attribute__((weak));
-void serialEvent1(void) {}
 #endif /* SOC_UART_NUM > 1 */
 
 #if SOC_UART_NUM > 2
 void serialEvent2(void) __attribute__((weak));
-void serialEvent2(void) {}
 #endif /* SOC_UART_NUM > 2 */
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
@@ -48,37 +45,35 @@ HardwareSerial Serial2(2);
 
 #if HWCDC_SERIAL_IS_DEFINED == 1  // Hardware JTAG CDC Event
 extern void HWCDCSerialEvent(void) __attribute__((weak));
-void HWCDCSerialEvent(void) {}
 #endif
 
 #if USB_SERIAL_IS_DEFINED == 1  // Native USB CDC Event
 // Used by Hardware Serial for USB CDC events
 extern void USBSerialEvent(void) __attribute__((weak));
-void USBSerialEvent(void) {}
 #endif
 
 void serialEventRun(void) {
 #if HWCDC_SERIAL_IS_DEFINED == 1  // Hardware JTAG CDC Event
-  if (HWCDCSerial.available()) {
+  if (HWCDCSerialEvent && HWCDCSerial.available()) {
     HWCDCSerialEvent();
   }
 #endif
 #if USB_SERIAL_IS_DEFINED == 1  // Native USB CDC Event
-  if (USBSerial.available()) {
+  if (USBSerialEvent && USBSerial.available()) {
     USBSerialEvent();
   }
 #endif
   // UART0 is default serialEvent()
-  if (Serial0.available()) {
+  if (serialEvent && Serial0.available()) {
     serialEvent();
   }
 #if SOC_UART_NUM > 1
-  if (Serial1.available()) {
+  if (serialEvent1 && Serial1.available()) {
     serialEvent1();
   }
 #endif
 #if SOC_UART_NUM > 2
-  if (Serial2.available()) {
+  if (serialEvent2 && Serial2.available()) {
     serialEvent2();
   }
 #endif


### PR DESCRIPTION
## Description of Change
loop() calls Serial Events functions when those are declared. 
The way it was declared, was forcing to always call avalable() to then call an empty function.
This commit fixes it.

Now when the sketch has no serialEvent() function declared, it won't be executed neither will available().
There are is a performance degradation when calling available() every single time when loop() was executed, whenever Serial.begin() is executed.

It shall be merged to 3.0.x and 3.1.x

## Tests scenarios

``` cpp
uint32_t  Loopcounter = 0;
static uint32_t msTick;      

void setup() 
{
 Serial.begin(115200);                     // Setup the serial port to 115200 baud //
 msTick = millis(); 

 Serial0.begin(115200); // THIS Line starts UART Arduino Driver and also forces to executing serialEventRun() that "eats" CPU time...
}

void loop() 
{
 Loopcounter++;
 EverySecondCheck();
}

//--------------------------------------------//
// COMMON Update routine done every second
//--------------------------------------------
void EverySecondCheck(void)
{
 uint32_t msLeap = millis() - msTick;     // 
 if (msLeap >999)                         // Every second enter the loop
 {
  msTick = millis();
 Serial.printf("Loops per second: %u\n",Loopcounter);
 Loopcounter = 0;
 }  
}
```

## Related links
Closes #10397 