### PR TITLE
addition(3rd_party_board): Add Waveshare-S3-touch-lcd

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -42264,10 +42264,10 @@ waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.boot=qio
 waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.boot_freq=120m
 waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.flash_freq=80m
 
-waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.8M=8MB (64Mb)
-waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.8M.build.flash_size=8MB
-waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.16M=16MB (128Mb)
-waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.16M.build.flash_size=16MB
+waveshare_esp32_s3_touch_lcd_43.menu.FlashSize.8M=8MB (64Mb)
+waveshare_esp32_s3_touch_lcd_43.menu.FlashSize.8M.build.flash_size=8MB
+waveshare_esp32_s3_touch_lcd_43.menu.FlashSize.16M=16MB (128Mb)
+waveshare_esp32_s3_touch_lcd_43.menu.FlashSize.16M.build.flash_size=16MB
 
 waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.1=Core 1
 waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1

--- a/boards.txt
+++ b/boards.txt
@@ -42196,3 +42196,1197 @@ waveshare_esp32_s3_touch_amoled_241.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_amoled_241.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+
+waveshare_esp32_s3_touch_lcd_43.name=Waveshare ESP32-S3-Touch-LCD-4.3
+waveshare_esp32_s3_touch_lcd_43.vid.0=0x303a
+waveshare_esp32_s3_touch_lcd_43.pid.0=0x822E
+waveshare_esp32_s3_touch_lcd_43.upload_port.0.vid=0x303a
+waveshare_esp32_s3_touch_lcd_43.upload_port.0.pid=0x822E
+
+waveshare_esp32_s3_touch_lcd_43.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_43.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_43.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_43.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_43.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_43.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_43.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_43.upload.flags=
+waveshare_esp32_s3_touch_lcd_43.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_43.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_43.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_43.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_43.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_43.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_43.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_43.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_43.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_43.build.core=esp32
+waveshare_esp32_s3_touch_lcd_43.build.variant=waveshare_esp32_s3_touch_lcd_43
+waveshare_esp32_s3_touch_lcd_43.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_43
+
+waveshare_esp32_s3_touch_lcd_43.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_43.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_43.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_43.build.flash_size=8MB
+waveshare_esp32_s3_touch_lcd_43.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_43.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_43.build.partitions=default
+waveshare_esp32_s3_touch_lcd_43.build.defines=
+waveshare_esp32_s3_touch_lcd_43.build.loop_core=
+waveshare_esp32_s3_touch_lcd_43.build.event_core=
+waveshare_esp32_s3_touch_lcd_43.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_43.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_43.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_43.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_43.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_43.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_43.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_43.menu.PSRAM.enabled.build.psram_type=opi
+
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_43.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_43.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_43.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_43.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_43.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_43.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_43.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_43.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_43.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_43.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_43.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_43.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_43.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_43.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_43.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_43.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_43.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_43.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_43.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_43.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+waveshare_esp32_s3_touch_lcd_43B.name=Waveshare ESP32-S3-Touch-LCD-4.3B
+waveshare_esp32_s3_touch_lcd_43B.vid.0=0x303a
+waveshare_esp32_s3_touch_lcd_43B.pid.0=0x8231
+waveshare_esp32_s3_touch_lcd_43B.upload_port.0.vid=0x303a
+waveshare_esp32_s3_touch_lcd_43B.upload_port.0.pid=0x8231
+
+waveshare_esp32_s3_touch_lcd_43B.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_43B.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_43B.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_43B.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_43B.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_43B.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_43B.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_43B.upload.flags=
+waveshare_esp32_s3_touch_lcd_43B.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_43B.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_43B.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_43B.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_43B.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_43B.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_43B.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_43B.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_43B.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_43B.build.core=esp32
+waveshare_esp32_s3_touch_lcd_43B.build.variant=waveshare_esp32_s3_touch_lcd_43b
+waveshare_esp32_s3_touch_lcd_43B.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_43B
+
+waveshare_esp32_s3_touch_lcd_43B.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_43B.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43B.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43B.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_43B.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_43B.build.flash_size=16MB
+waveshare_esp32_s3_touch_lcd_43B.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_43B.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43B.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43B.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_43B.build.partitions=default
+waveshare_esp32_s3_touch_lcd_43B.build.defines=
+waveshare_esp32_s3_touch_lcd_43B.build.loop_core=
+waveshare_esp32_s3_touch_lcd_43B.build.event_core=
+waveshare_esp32_s3_touch_lcd_43B.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_43B.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_43B.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_43B.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_43B.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_43B.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_43B.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_43B.menu.PSRAM.enabled.build.psram_type=opi
+
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_43B.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_43B.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_43B.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_43B.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_43B.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_43B.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_43B.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_43B.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_43B.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_43B.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_43B.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_43B.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_43B.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_43B.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43B.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43B.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_43B.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43B.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43B.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43B.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_43B.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43B.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43B.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_43B.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_43B.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_43B.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_43B.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+waveshare_esp32_s3_touch_lcd_7.name=Waveshare ESP32-S3-Touch-LCD-7
+waveshare_esp32_s3_touch_lcd_7.vid.0=0x303a
+waveshare_esp32_s3_touch_lcd_7.pid.0=0x8234
+waveshare_esp32_s3_touch_lcd_7.upload_port.0.vid=0x303a
+waveshare_esp32_s3_touch_lcd_7.upload_port.0.pid=0x8234
+
+waveshare_esp32_s3_touch_lcd_7.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_7.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_7.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_7.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_7.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_7.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_7.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_7.upload.flags=
+waveshare_esp32_s3_touch_lcd_7.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_7.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_7.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_7.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_7.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_7.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_7.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_7.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_7.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_7.build.core=esp32
+waveshare_esp32_s3_touch_lcd_7.build.variant=waveshare_esp32_s3_touch_lcd_7
+waveshare_esp32_s3_touch_lcd_7.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_7
+
+waveshare_esp32_s3_touch_lcd_7.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_7.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_7.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_7.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_7.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_7.build.flash_size=8MB
+waveshare_esp32_s3_touch_lcd_7.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_7.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_7.build.boot=qio
+waveshare_esp32_s3_touch_lcd_7.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_7.build.partitions=default
+waveshare_esp32_s3_touch_lcd_7.build.defines=
+waveshare_esp32_s3_touch_lcd_7.build.loop_core=
+waveshare_esp32_s3_touch_lcd_7.build.event_core=
+waveshare_esp32_s3_touch_lcd_7.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_7.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_7.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_7.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_7.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_7.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_7.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_7.menu.PSRAM.enabled.build.psram_type=opi
+
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_7.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_7.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_7.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_7.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_7.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_7.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_7.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_7.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_7.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_7.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_7.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_7.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_7.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_7.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_7.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_7.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_7.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_7.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_7.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_7.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_7.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_7.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_7.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_7.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_7.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_7.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_7.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_7.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_7.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_7.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_7.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_7.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+waveshare_esp32_s3_touch_lcd_5.name=Waveshare ESP32-S3-Touch-LCD-5
+waveshare_esp32_s3_touch_lcd_5.vid.0=0x303a
+waveshare_esp32_s3_touch_lcd_5.pid.0=0x8237
+waveshare_esp32_s3_touch_lcd_5.upload_port.0.vid=0x303a
+waveshare_esp32_s3_touch_lcd_5.upload_port.0.pid=0x8237
+
+waveshare_esp32_s3_touch_lcd_5.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_5.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_5.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_5.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_5.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_5.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_5.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_5.upload.flags=
+waveshare_esp32_s3_touch_lcd_5.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_5.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_5.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_5.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_5.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_5.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_5.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_5.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_5.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_5.build.core=esp32
+waveshare_esp32_s3_touch_lcd_5.build.variant=waveshare_esp32_s3_touch_lcd_5
+waveshare_esp32_s3_touch_lcd_5.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_5
+
+waveshare_esp32_s3_touch_lcd_5.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_5.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_5.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_5.build.flash_size=16MB
+waveshare_esp32_s3_touch_lcd_5.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_5.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_5.build.boot=qio
+waveshare_esp32_s3_touch_lcd_5.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_5.build.partitions=default
+waveshare_esp32_s3_touch_lcd_5.build.defines=
+waveshare_esp32_s3_touch_lcd_5.build.loop_core=
+waveshare_esp32_s3_touch_lcd_5.build.event_core=
+waveshare_esp32_s3_touch_lcd_5.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_5.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_5.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_5.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_5.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_5.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_5.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_5.menu.PSRAM.enabled.build.psram_type=opi
+
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_5.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_5.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_5.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_5.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_5.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_5.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_5.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_5.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_5.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_5.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_5.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_5.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_5.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_5.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_5.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_5.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_5.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_5.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_5.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_5.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_5.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_5.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_5.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_5.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_5.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_5.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_5.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_5.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_5.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_5.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_5.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+waveshare_esp32_s3_touch_lcd_5B.name=Waveshare ESP32-S3-Touch-LCD-5B
+waveshare_esp32_s3_touch_lcd_5B.vid.0=0x303a
+waveshare_esp32_s3_touch_lcd_5B.pid.0=0x823A
+waveshare_esp32_s3_touch_lcd_5B.upload_port.0.vid=0x303a
+waveshare_esp32_s3_touch_lcd_5B.upload_port.0.pid=0x823A
+
+waveshare_esp32_s3_touch_lcd_5B.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_5B.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_5B.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_5B.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_5B.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_5B.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_5B.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_5B.upload.flags=
+waveshare_esp32_s3_touch_lcd_5B.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_5B.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_5B.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_5B.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_5B.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_5B.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_5B.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_5B.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_5B.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_5B.build.core=esp32
+waveshare_esp32_s3_touch_lcd_5B.build.variant=waveshare_esp32_s3_touch_lcd_5b
+waveshare_esp32_s3_touch_lcd_5B.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_5B
+
+waveshare_esp32_s3_touch_lcd_5B.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_5B.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5B.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5B.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_5B.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_5B.build.flash_size=16MB
+waveshare_esp32_s3_touch_lcd_5B.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_5B.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_5B.build.boot=qio
+waveshare_esp32_s3_touch_lcd_5B.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_5B.build.partitions=default
+waveshare_esp32_s3_touch_lcd_5B.build.defines=
+waveshare_esp32_s3_touch_lcd_5B.build.loop_core=
+waveshare_esp32_s3_touch_lcd_5B.build.event_core=
+waveshare_esp32_s3_touch_lcd_5B.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_5B.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_5B.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_5B.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_5B.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_5B.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_5B.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_5B.menu.PSRAM.enabled.build.psram_type=opi
+
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_5B.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_5B.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_5B.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_5B.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_5B.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_5B.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_5B.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_5B.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_5B.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_5B.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_5B.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_5B.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_5B.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_5B.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_5B.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5B.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_5B.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_5B.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_5B.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_5B.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_5B.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_5B.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_5B.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_5B.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_5B.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_5B.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_5B.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
+waveshare_esp32_s3_touch_lcd_4.name=Waveshare ESP32-S3-Touch-LCD-4
+waveshare_esp32_s3_touch_lcd_4.vid.0=0x303a
+waveshare_esp32_s3_touch_lcd_4.pid.0=0x823D
+waveshare_esp32_s3_touch_lcd_4.upload_port.0.vid=0x303a
+waveshare_esp32_s3_touch_lcd_4.upload_port.0.pid=0x823D
+
+waveshare_esp32_s3_touch_lcd_4.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_4.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_4.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_4.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_4.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_4.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_4.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_4.upload.flags=
+waveshare_esp32_s3_touch_lcd_4.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_4.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_4.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_4.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_4.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_4.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_4.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_4.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_4.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_4.build.core=esp32
+waveshare_esp32_s3_touch_lcd_4.build.variant=waveshare_esp32_s3_touch_lcd_4
+waveshare_esp32_s3_touch_lcd_4.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_4
+
+waveshare_esp32_s3_touch_lcd_4.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_4.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_4.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_4.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_4.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_4.build.flash_size=16MB
+waveshare_esp32_s3_touch_lcd_4.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_4.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_4.build.boot=qio
+waveshare_esp32_s3_touch_lcd_4.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_4.build.partitions=default
+waveshare_esp32_s3_touch_lcd_4.build.defines=
+waveshare_esp32_s3_touch_lcd_4.build.loop_core=
+waveshare_esp32_s3_touch_lcd_4.build.event_core=
+waveshare_esp32_s3_touch_lcd_4.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_4.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_4.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_4.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_4.menu.PSRAM.disabled.build.psram_type=qspi
+waveshare_esp32_s3_touch_lcd_4.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_4.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_4.menu.PSRAM.enabled.build.psram_type=opi
+
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_4.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_4.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_4.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_4.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_4.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_4.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_4.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_4.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_4.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_4.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_4.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_4.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_4.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_4.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_4.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_esp32_s3_touch_lcd_4.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_4.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_4.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_4.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_4.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_4.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_4.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_4.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_4.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_4.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_4.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_4.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_4.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_4.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_4.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_4.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_4.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_4.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/boards.txt
+++ b/boards.txt
@@ -42264,6 +42264,11 @@ waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.boot=qio
 waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.boot_freq=120m
 waveshare_esp32_s3_touch_lcd_43.menu.FlashMode.qio120.build.flash_freq=80m
 
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.8M=8MB (64Mb)
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.8M.build.flash_size=8MB
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.16M=16MB (128Mb)
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.16M.build.flash_size=16MB
+
 waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.1=Core 1
 waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
 waveshare_esp32_s3_touch_lcd_43.menu.LoopCore.0=Core 0
@@ -42661,6 +42666,11 @@ waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.flash_mode=dio
 waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.boot=qio
 waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.boot_freq=120m
 waveshare_esp32_s3_touch_lcd_7.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.8M=8MB (64Mb)
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.8M.build.flash_size=8MB
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.16M=16MB (128Mb)
+waveshare_esp32_s3_touch_lcd_7.menu.FlashSize.16M.build.flash_size=16MB
 
 waveshare_esp32_s3_touch_lcd_7.menu.LoopCore.1=Core 1
 waveshare_esp32_s3_touch_lcd_7.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1

--- a/variants/waveshare_esp32_s3_touch_lcd_4/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_4/pins_arduino.h
@@ -1,0 +1,73 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x823D 
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-4"
+#define USB_SERIAL       ""
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = -1;
+static const uint8_t SCL = -1;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_4/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_4/pins_arduino.h
@@ -7,7 +7,7 @@
 
 // BN: ESP32 Family Device
 #define USB_VID 0x303a
-#define USB_PID 0x823D 
+#define USB_PID 0x823D
 
 #define USB_MANUFACTURER "Waveshare"
 #define USB_PRODUCT      "ESP32-S3-Touch-LCD-4"

--- a/variants/waveshare_esp32_s3_touch_lcd_43/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_43/pins_arduino.h
@@ -1,0 +1,117 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x822E
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-4.3"
+#define USB_SERIAL       ""
+
+// display for ST7262
+#define WS_LCD_B3  14
+#define WS_LCD_B4  38
+#define WS_LCD_B5  18
+#define WS_LCD_B6  17
+#define WS_LCD_B7  10
+
+#define WS_LCD_G2  39
+#define WS_LCD_G3  0
+#define WS_LCD_G4  45
+#define WS_LCD_G5  48
+#define WS_LCD_G6  47
+#define WS_LCD_G7  21
+
+#define WS_LCD_R3  1
+#define WS_LCD_R4  2
+#define WS_LCD_R5  42
+#define WS_LCD_R6  41
+#define WS_LCD_R7  40
+
+#define WS_LCD_VSYNC  3
+#define WS_LCD_HSYNC  46
+#define WS_LCD_PCLK   7
+#define WS_LCD_DE     5
+
+// Touch for gt911
+#define WS_TP_SDA 8
+#define WS_TP_SCL 9
+#define WS_TP_RST -1
+#define WS_TP_INT 4
+
+//RS485
+#define WS_RS485_RXD 16
+#define WS_RS485_TXD 15
+
+//CAN
+#define WS_CAN_RXD 19
+#define WS_CAN_TXD 20
+
+//Onboard CH422G IO expander
+#define WS_CH422G_SDA 8
+#define WS_CH422G_SCL 9
+
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 10;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_43/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_43/pins_arduino.h
@@ -14,29 +14,29 @@
 #define USB_SERIAL       ""
 
 // display for ST7262
-#define WS_LCD_B3  14
-#define WS_LCD_B4  38
-#define WS_LCD_B5  18
-#define WS_LCD_B6  17
-#define WS_LCD_B7  10
+#define WS_LCD_B3 14
+#define WS_LCD_B4 38
+#define WS_LCD_B5 18
+#define WS_LCD_B6 17
+#define WS_LCD_B7 10
 
-#define WS_LCD_G2  39
-#define WS_LCD_G3  0
-#define WS_LCD_G4  45
-#define WS_LCD_G5  48
-#define WS_LCD_G6  47
-#define WS_LCD_G7  21
+#define WS_LCD_G2 39
+#define WS_LCD_G3 0
+#define WS_LCD_G4 45
+#define WS_LCD_G5 48
+#define WS_LCD_G6 47
+#define WS_LCD_G7 21
 
-#define WS_LCD_R3  1
-#define WS_LCD_R4  2
-#define WS_LCD_R5  42
-#define WS_LCD_R6  41
-#define WS_LCD_R7  40
+#define WS_LCD_R3 1
+#define WS_LCD_R4 2
+#define WS_LCD_R5 42
+#define WS_LCD_R6 41
+#define WS_LCD_R7 40
 
-#define WS_LCD_VSYNC  3
-#define WS_LCD_HSYNC  46
-#define WS_LCD_PCLK   7
-#define WS_LCD_DE     5
+#define WS_LCD_VSYNC 3
+#define WS_LCD_HSYNC 46
+#define WS_LCD_PCLK  7
+#define WS_LCD_DE    5
 
 // Touch for gt911
 #define WS_TP_SDA 8
@@ -55,7 +55,6 @@
 //Onboard CH422G IO expander
 #define WS_CH422G_SDA 8
 #define WS_CH422G_SCL 9
-
 
 // UART0 pins
 static const uint8_t TX = 43;

--- a/variants/waveshare_esp32_s3_touch_lcd_43b/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_43b/pins_arduino.h
@@ -1,0 +1,117 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x8231
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-4.3B"
+#define USB_SERIAL       ""
+
+// display for ST7262
+#define WS_LCD_B3  14
+#define WS_LCD_B4  38
+#define WS_LCD_B5  18
+#define WS_LCD_B6  17
+#define WS_LCD_B7  10
+
+#define WS_LCD_G2  39
+#define WS_LCD_G3  0
+#define WS_LCD_G4  45
+#define WS_LCD_G5  48
+#define WS_LCD_G6  47
+#define WS_LCD_G7  21
+
+#define WS_LCD_R3  1
+#define WS_LCD_R4  2
+#define WS_LCD_R5  42
+#define WS_LCD_R6  41
+#define WS_LCD_R7  40
+
+#define WS_LCD_VSYNC  3
+#define WS_LCD_HSYNC  46
+#define WS_LCD_PCLK   7
+#define WS_LCD_DE     5
+
+// Touch for gt911
+#define WS_TP_SDA 8
+#define WS_TP_SCL 9
+#define WS_TP_RST -1
+#define WS_TP_INT 4
+
+//RS485
+#define WS_RS485_RXD 43
+#define WS_RS485_TXD 44
+
+//CAN
+#define WS_CAN_RXD 15
+#define WS_CAN_TXD 16
+
+//Onboard CH422G IO expander
+#define WS_CH422G_SDA 8
+#define WS_CH422G_SCL 9
+
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 10;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_43b/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_43b/pins_arduino.h
@@ -14,29 +14,29 @@
 #define USB_SERIAL       ""
 
 // display for ST7262
-#define WS_LCD_B3  14
-#define WS_LCD_B4  38
-#define WS_LCD_B5  18
-#define WS_LCD_B6  17
-#define WS_LCD_B7  10
+#define WS_LCD_B3 14
+#define WS_LCD_B4 38
+#define WS_LCD_B5 18
+#define WS_LCD_B6 17
+#define WS_LCD_B7 10
 
-#define WS_LCD_G2  39
-#define WS_LCD_G3  0
-#define WS_LCD_G4  45
-#define WS_LCD_G5  48
-#define WS_LCD_G6  47
-#define WS_LCD_G7  21
+#define WS_LCD_G2 39
+#define WS_LCD_G3 0
+#define WS_LCD_G4 45
+#define WS_LCD_G5 48
+#define WS_LCD_G6 47
+#define WS_LCD_G7 21
 
-#define WS_LCD_R3  1
-#define WS_LCD_R4  2
-#define WS_LCD_R5  42
-#define WS_LCD_R6  41
-#define WS_LCD_R7  40
+#define WS_LCD_R3 1
+#define WS_LCD_R4 2
+#define WS_LCD_R5 42
+#define WS_LCD_R6 41
+#define WS_LCD_R7 40
 
-#define WS_LCD_VSYNC  3
-#define WS_LCD_HSYNC  46
-#define WS_LCD_PCLK   7
-#define WS_LCD_DE     5
+#define WS_LCD_VSYNC 3
+#define WS_LCD_HSYNC 46
+#define WS_LCD_PCLK  7
+#define WS_LCD_DE    5
 
 // Touch for gt911
 #define WS_TP_SDA 8
@@ -55,7 +55,6 @@
 //Onboard CH422G IO expander
 #define WS_CH422G_SDA 8
 #define WS_CH422G_SCL 9
-
 
 // UART0 pins
 static const uint8_t TX = 43;

--- a/variants/waveshare_esp32_s3_touch_lcd_5/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_5/pins_arduino.h
@@ -7,36 +7,36 @@
 
 // BN: ESP32 Family Device
 #define USB_VID 0x303a
-#define USB_PID 0x8237 
+#define USB_PID 0x8237
 
 #define USB_MANUFACTURER "Waveshare"
 #define USB_PRODUCT      "ESP32-S3-Touch-LCD-5"
 #define USB_SERIAL       ""
 
 // display for ST7262
-#define WS_LCD_B3  14
-#define WS_LCD_B4  38
-#define WS_LCD_B5  18
-#define WS_LCD_B6  17
-#define WS_LCD_B7  10
+#define WS_LCD_B3 14
+#define WS_LCD_B4 38
+#define WS_LCD_B5 18
+#define WS_LCD_B6 17
+#define WS_LCD_B7 10
 
-#define WS_LCD_G2  39
-#define WS_LCD_G3  0
-#define WS_LCD_G4  45
-#define WS_LCD_G5  48
-#define WS_LCD_G6  47
-#define WS_LCD_G7  21
+#define WS_LCD_G2 39
+#define WS_LCD_G3 0
+#define WS_LCD_G4 45
+#define WS_LCD_G5 48
+#define WS_LCD_G6 47
+#define WS_LCD_G7 21
 
-#define WS_LCD_R3  1
-#define WS_LCD_R4  2
-#define WS_LCD_R5  42
-#define WS_LCD_R6  41
-#define WS_LCD_R7  40
+#define WS_LCD_R3 1
+#define WS_LCD_R4 2
+#define WS_LCD_R5 42
+#define WS_LCD_R6 41
+#define WS_LCD_R7 40
 
-#define WS_LCD_VSYNC  3
-#define WS_LCD_HSYNC  46
-#define WS_LCD_PCLK   7
-#define WS_LCD_DE     5
+#define WS_LCD_VSYNC 3
+#define WS_LCD_HSYNC 46
+#define WS_LCD_PCLK  7
+#define WS_LCD_DE    5
 
 // Touch for gt911
 #define WS_TP_SDA 8
@@ -55,7 +55,6 @@
 //Onboard CH422G IO expander
 #define WS_CH422G_SDA 8
 #define WS_CH422G_SCL 9
-
 
 // UART0 pins
 static const uint8_t TX = 43;

--- a/variants/waveshare_esp32_s3_touch_lcd_5/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_5/pins_arduino.h
@@ -1,0 +1,117 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x8237 
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-5"
+#define USB_SERIAL       ""
+
+// display for ST7262
+#define WS_LCD_B3  14
+#define WS_LCD_B4  38
+#define WS_LCD_B5  18
+#define WS_LCD_B6  17
+#define WS_LCD_B7  10
+
+#define WS_LCD_G2  39
+#define WS_LCD_G3  0
+#define WS_LCD_G4  45
+#define WS_LCD_G5  48
+#define WS_LCD_G6  47
+#define WS_LCD_G7  21
+
+#define WS_LCD_R3  1
+#define WS_LCD_R4  2
+#define WS_LCD_R5  42
+#define WS_LCD_R6  41
+#define WS_LCD_R7  40
+
+#define WS_LCD_VSYNC  3
+#define WS_LCD_HSYNC  46
+#define WS_LCD_PCLK   7
+#define WS_LCD_DE     5
+
+// Touch for gt911
+#define WS_TP_SDA 8
+#define WS_TP_SCL 9
+#define WS_TP_RST -1
+#define WS_TP_INT 4
+
+//RS485
+#define WS_RS485_RXD 43
+#define WS_RS485_TXD 44
+
+//CAN
+#define WS_CAN_RXD 15
+#define WS_CAN_TXD 16
+
+//Onboard CH422G IO expander
+#define WS_CH422G_SDA 8
+#define WS_CH422G_SCL 9
+
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 10;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_5b/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_5b/pins_arduino.h
@@ -1,0 +1,117 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x823A
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-5B"
+#define USB_SERIAL       ""
+
+// display for ST7262
+#define WS_LCD_B3  14
+#define WS_LCD_B4  38
+#define WS_LCD_B5  18
+#define WS_LCD_B6  17
+#define WS_LCD_B7  10
+
+#define WS_LCD_G2  39
+#define WS_LCD_G3  0
+#define WS_LCD_G4  45
+#define WS_LCD_G5  48
+#define WS_LCD_G6  47
+#define WS_LCD_G7  21
+
+#define WS_LCD_R3  1
+#define WS_LCD_R4  2
+#define WS_LCD_R5  42
+#define WS_LCD_R6  41
+#define WS_LCD_R7  40
+
+#define WS_LCD_VSYNC  3
+#define WS_LCD_HSYNC  46
+#define WS_LCD_PCLK   7
+#define WS_LCD_DE     5
+
+// Touch for gt911
+#define WS_TP_SDA 8
+#define WS_TP_SCL 9
+#define WS_TP_RST -1
+#define WS_TP_INT 4
+
+//RS485
+#define WS_RS485_RXD 43
+#define WS_RS485_TXD 44
+
+//CAN
+#define WS_CAN_RXD 15
+#define WS_CAN_TXD 16
+
+//Onboard CH422G IO expander
+#define WS_CH422G_SDA 8
+#define WS_CH422G_SCL 9
+
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 10;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_5b/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_5b/pins_arduino.h
@@ -14,29 +14,29 @@
 #define USB_SERIAL       ""
 
 // display for ST7262
-#define WS_LCD_B3  14
-#define WS_LCD_B4  38
-#define WS_LCD_B5  18
-#define WS_LCD_B6  17
-#define WS_LCD_B7  10
+#define WS_LCD_B3 14
+#define WS_LCD_B4 38
+#define WS_LCD_B5 18
+#define WS_LCD_B6 17
+#define WS_LCD_B7 10
 
-#define WS_LCD_G2  39
-#define WS_LCD_G3  0
-#define WS_LCD_G4  45
-#define WS_LCD_G5  48
-#define WS_LCD_G6  47
-#define WS_LCD_G7  21
+#define WS_LCD_G2 39
+#define WS_LCD_G3 0
+#define WS_LCD_G4 45
+#define WS_LCD_G5 48
+#define WS_LCD_G6 47
+#define WS_LCD_G7 21
 
-#define WS_LCD_R3  1
-#define WS_LCD_R4  2
-#define WS_LCD_R5  42
-#define WS_LCD_R6  41
-#define WS_LCD_R7  40
+#define WS_LCD_R3 1
+#define WS_LCD_R4 2
+#define WS_LCD_R5 42
+#define WS_LCD_R6 41
+#define WS_LCD_R7 40
 
-#define WS_LCD_VSYNC  3
-#define WS_LCD_HSYNC  46
-#define WS_LCD_PCLK   7
-#define WS_LCD_DE     5
+#define WS_LCD_VSYNC 3
+#define WS_LCD_HSYNC 46
+#define WS_LCD_PCLK  7
+#define WS_LCD_DE    5
 
 // Touch for gt911
 #define WS_TP_SDA 8
@@ -55,7 +55,6 @@
 //Onboard CH422G IO expander
 #define WS_CH422G_SDA 8
 #define WS_CH422G_SCL 9
-
 
 // UART0 pins
 static const uint8_t TX = 43;

--- a/variants/waveshare_esp32_s3_touch_lcd_7/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_7/pins_arduino.h
@@ -1,0 +1,117 @@
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BN: ESP32 Family Device
+#define USB_VID 0x303a
+#define USB_PID 0x8234 
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-7"
+#define USB_SERIAL       ""
+
+// display for ST7262
+#define WS_LCD_B3  14
+#define WS_LCD_B4  38
+#define WS_LCD_B5  18
+#define WS_LCD_B6  17
+#define WS_LCD_B7  10
+
+#define WS_LCD_G2  39
+#define WS_LCD_G3  0
+#define WS_LCD_G4  45
+#define WS_LCD_G5  48
+#define WS_LCD_G6  47
+#define WS_LCD_G7  21
+
+#define WS_LCD_R3  1
+#define WS_LCD_R4  2
+#define WS_LCD_R5  42
+#define WS_LCD_R6  41
+#define WS_LCD_R7  40
+
+#define WS_LCD_VSYNC  3
+#define WS_LCD_HSYNC  46
+#define WS_LCD_PCLK   7
+#define WS_LCD_DE     5
+
+// Touch for gt911
+#define WS_TP_SDA 8
+#define WS_TP_SCL 9
+#define WS_TP_RST -1
+#define WS_TP_INT 4
+
+//RS485
+#define WS_RS485_RXD 16
+#define WS_RS485_TXD 15
+
+//CAN
+#define WS_CAN_RXD 19
+#define WS_CAN_TXD 20
+
+//Onboard CH422G IO expander
+#define WS_CH422G_SDA 8
+#define WS_CH422G_SCL 9
+
+
+// UART0 pins
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Def for I2C that shares the IMU I2C pins
+static const uint8_t SDA = 11;
+static const uint8_t SCL = 10;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 34;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 37;  // FSPIQ
+static const uint8_t SCK = 36;   // FSPICLK
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t OUTPUT_IO2 = 2;
+static const uint8_t OUTPUT_IO3 = 3;
+static const uint8_t OUTPUT_IO17 = 17;
+static const uint8_t OUTPUT_IO18 = 18;
+
+// Analog capable pins on the header
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+
+// GPIO capable pins on the header
+static const uint8_t D0 = 7;
+static const uint8_t D1 = 6;
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 4;
+static const uint8_t D4 = 3;
+static const uint8_t D5 = 2;
+static const uint8_t D6 = 1;
+static const uint8_t D7 = 44;
+static const uint8_t D8 = 43;
+static const uint8_t D9 = 40;
+static const uint8_t D10 = 39;
+static const uint8_t D11 = 38;
+static const uint8_t D12 = 37;
+static const uint8_t D13 = 36;
+static const uint8_t D14 = 35;
+static const uint8_t D15 = 34;
+static const uint8_t D16 = 33;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_7/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_7/pins_arduino.h
@@ -7,36 +7,36 @@
 
 // BN: ESP32 Family Device
 #define USB_VID 0x303a
-#define USB_PID 0x8234 
+#define USB_PID 0x8234
 
 #define USB_MANUFACTURER "Waveshare"
 #define USB_PRODUCT      "ESP32-S3-Touch-LCD-7"
 #define USB_SERIAL       ""
 
 // display for ST7262
-#define WS_LCD_B3  14
-#define WS_LCD_B4  38
-#define WS_LCD_B5  18
-#define WS_LCD_B6  17
-#define WS_LCD_B7  10
+#define WS_LCD_B3 14
+#define WS_LCD_B4 38
+#define WS_LCD_B5 18
+#define WS_LCD_B6 17
+#define WS_LCD_B7 10
 
-#define WS_LCD_G2  39
-#define WS_LCD_G3  0
-#define WS_LCD_G4  45
-#define WS_LCD_G5  48
-#define WS_LCD_G6  47
-#define WS_LCD_G7  21
+#define WS_LCD_G2 39
+#define WS_LCD_G3 0
+#define WS_LCD_G4 45
+#define WS_LCD_G5 48
+#define WS_LCD_G6 47
+#define WS_LCD_G7 21
 
-#define WS_LCD_R3  1
-#define WS_LCD_R4  2
-#define WS_LCD_R5  42
-#define WS_LCD_R6  41
-#define WS_LCD_R7  40
+#define WS_LCD_R3 1
+#define WS_LCD_R4 2
+#define WS_LCD_R5 42
+#define WS_LCD_R6 41
+#define WS_LCD_R7 40
 
-#define WS_LCD_VSYNC  3
-#define WS_LCD_HSYNC  46
-#define WS_LCD_PCLK   7
-#define WS_LCD_DE     5
+#define WS_LCD_VSYNC 3
+#define WS_LCD_HSYNC 46
+#define WS_LCD_PCLK  7
+#define WS_LCD_DE    5
 
 // Touch for gt911
 #define WS_TP_SDA 8
@@ -55,7 +55,6 @@
 //Onboard CH422G IO expander
 #define WS_CH422G_SDA 8
 #define WS_CH422G_SCL 9
-
 
 // UART0 pins
 static const uint8_t TX = 43;


### PR DESCRIPTION
## Description of Change
Adding variant for Waveshare ESP32-S3-Touch-LCD-4 & ESP32-S3-Touch-LCD-4.3 & ESP32-S3-Touch-LCD-4.3B & ESP32-S3-Touch-LCD-5 & ESP32-S3-Touch-LCD-5B ESP32-S3-Touch-LCD-7 board

## Tests scenarios
Untested, pin definition is based on information in Waveshare wiki.

## Related links
Wiki for [ESP32-S3-Touch-LCD-4](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4)
Wiki for [ESP32-S3-Touch-LCD-4.3](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3)
Wiki for [ESP32-S3-Touch-LCD-4.3B](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3B)
Wiki for [ESP32-S3-Touch-LCD-5](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-5)
Wiki for [ESP32-S3-Touch-LCD-5B](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-5)
Wiki for [ESP32-S3-Touch-LCD-7](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-7)