### PR TITLE
fix(uart): uses IDF 5.x API to set loopback

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1114,11 +1114,11 @@ unsigned long uartDetectBaudrate(uart_t *uart) {
    This function internally binds defined UARTs TX signal with defined RX pin of any UART (same or different).
    This creates a loop that lets us receive anything we send on the UART without external wires.
 */
-void uart_internal_loopback(uint8_t uartNum, int8_t rxPin) {
-  if (uartNum > SOC_UART_NUM - 1 || !GPIO_IS_VALID_GPIO(rxPin)) {
+void uart_internal_loopback(uint8_t uartNum, bool loop_back_en) {
+  if (uartNum > SOC_UART_NUM - 1) {
     return;
   }
-  esp_rom_gpio_connect_out_signal(rxPin, UART_TX_SIGNAL(uartNum), false, false);
+  uart_set_loop_back(uartNum, loop_back_en);
 }
 
 /*


### PR DESCRIPTION
## Description of Change
Uses void uart_internal_loopback(uint8_t uartNum, bool loop_back_en) IDF 5.x API.
Necessary to make it work with ESP32-P4.

## Tests scenarios
CI and PyTest Scripts

## Related links
None