### PR TITLE
IDF release/v5.3

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
@@ -24,55 +24,6 @@
 #include "esp32-hal-log.h"
 #endif
 
-// Face Detection will not work on boards without (or with disabled) PSRAM
-#ifdef BOARD_HAS_PSRAM
-// Face Recognition takes upward from 15 seconds per frame on chips other than ESP32S3
-// Makes no sense to have it enabled for them
-#if CONFIG_IDF_TARGET_ESP32S3
-#define CONFIG_ESP_FACE_RECOGNITION_ENABLED 1
-#define CONFIG_ESP_FACE_DETECT_ENABLED      1
-#else
-#define CONFIG_ESP_FACE_RECOGNITION_ENABLED 0
-#define CONFIG_ESP_FACE_DETECT_ENABLED      0
-#endif
-#else
-#define CONFIG_ESP_FACE_DETECT_ENABLED      0
-#define CONFIG_ESP_FACE_RECOGNITION_ENABLED 0
-#endif
-
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-
-#include <vector>
-#include "human_face_detect_msr01.hpp"
-#include "human_face_detect_mnp01.hpp"
-
-#define TWO_STAGE 1 /*<! 1: detect by two-stage which is more accurate but slower(with keypoints). */
-                    /*<! 0: detect by one-stage which is less accurate but faster(without keypoints). */
-
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-#pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#include "face_recognition_tool.hpp"
-#include "face_recognition_112_v1_s16.hpp"
-#include "face_recognition_112_v1_s8.hpp"
-#pragma GCC diagnostic error "-Wformat"
-#pragma GCC diagnostic warning "-Wstrict-aliasing"
-
-#define QUANT_TYPE 0  //if set to 1 => very large firmware, very slow, reboots when streaming...
-
-#define FACE_ID_SAVE_NUMBER 7
-#endif
-
-#define FACE_COLOR_WHITE  0x00FFFFFF
-#define FACE_COLOR_BLACK  0x00000000
-#define FACE_COLOR_RED    0x000000FF
-#define FACE_COLOR_GREEN  0x0000FF00
-#define FACE_COLOR_BLUE   0x00FF0000
-#define FACE_COLOR_YELLOW (FACE_COLOR_RED | FACE_COLOR_GREEN)
-#define FACE_COLOR_CYAN   (FACE_COLOR_BLUE | FACE_COLOR_GREEN)
-#define FACE_COLOR_PURPLE (FACE_COLOR_BLUE | FACE_COLOR_RED)
-#endif
-
 // Enable LED FLASH setting
 #define CONFIG_LED_ILLUMINATOR_ENABLED 1
 
@@ -99,32 +50,6 @@ static const char *_STREAM_PART = "Content-Type: image/jpeg\r\nContent-Length: %
 
 httpd_handle_t stream_httpd = NULL;
 httpd_handle_t camera_httpd = NULL;
-
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-
-static int8_t detection_enabled = 0;
-
-// #if TWO_STAGE
-// static HumanFaceDetectMSR01 s1(0.1F, 0.5F, 10, 0.2F);
-// static HumanFaceDetectMNP01 s2(0.5F, 0.3F, 5);
-// #else
-// static HumanFaceDetectMSR01 s1(0.3F, 0.5F, 10, 0.2F);
-// #endif
-
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-static int8_t recognition_enabled = 0;
-static int8_t is_enrolling = 0;
-
-#if QUANT_TYPE
-// S16 model
-FaceRecognition112V1S16 recognizer;
-#else
-// S8 model
-FaceRecognition112V1S8 recognizer;
-#endif
-#endif
-
-#endif
 
 typedef struct {
   size_t size;   //number of values used for filtering
@@ -164,105 +89,6 @@ static int ra_filter_run(ra_filter_t *filter, int value) {
   }
   return filter->sum / filter->count;
 }
-#endif
-
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-static void rgb_print(fb_data_t *fb, uint32_t color, const char *str) {
-  fb_gfx_print(fb, (fb->width - (strlen(str) * 14)) / 2, 10, color, str);
-}
-
-static int rgb_printf(fb_data_t *fb, uint32_t color, const char *format, ...) {
-  char loc_buf[64];
-  char *temp = loc_buf;
-  int len;
-  va_list arg;
-  va_list copy;
-  va_start(arg, format);
-  va_copy(copy, arg);
-  len = vsnprintf(loc_buf, sizeof(loc_buf), format, arg);
-  va_end(copy);
-  if (len >= sizeof(loc_buf)) {
-    temp = (char *)malloc(len + 1);
-    if (temp == NULL) {
-      return 0;
-    }
-  }
-  vsnprintf(temp, len + 1, format, arg);
-  va_end(arg);
-  rgb_print(fb, color, temp);
-  if (len > 64) {
-    free(temp);
-  }
-  return len;
-}
-#endif
-static void draw_face_boxes(fb_data_t *fb, std::list<dl::detect::result_t> *results, int face_id) {
-  int x, y, w, h;
-  uint32_t color = FACE_COLOR_YELLOW;
-  if (face_id < 0) {
-    color = FACE_COLOR_RED;
-  } else if (face_id > 0) {
-    color = FACE_COLOR_GREEN;
-  }
-  if (fb->bytes_per_pixel == 2) {
-    //color = ((color >> 8) & 0xF800) | ((color >> 3) & 0x07E0) | (color & 0x001F);
-    color = ((color >> 16) & 0x001F) | ((color >> 3) & 0x07E0) | ((color << 8) & 0xF800);
-  }
-  int i = 0;
-  for (std::list<dl::detect::result_t>::iterator prediction = results->begin(); prediction != results->end(); prediction++, i++) {
-    // rectangle box
-    x = (int)prediction->box[0];
-    y = (int)prediction->box[1];
-    w = (int)prediction->box[2] - x + 1;
-    h = (int)prediction->box[3] - y + 1;
-    if ((x + w) > fb->width) {
-      w = fb->width - x;
-    }
-    if ((y + h) > fb->height) {
-      h = fb->height - y;
-    }
-    fb_gfx_drawFastHLine(fb, x, y, w, color);
-    fb_gfx_drawFastHLine(fb, x, y + h - 1, w, color);
-    fb_gfx_drawFastVLine(fb, x, y, h, color);
-    fb_gfx_drawFastVLine(fb, x + w - 1, y, h, color);
-#if TWO_STAGE
-    // landmarks (left eye, mouth left, nose, right eye, mouth right)
-    int x0, y0, j;
-    for (j = 0; j < 10; j += 2) {
-      x0 = (int)prediction->keypoint[j];
-      y0 = (int)prediction->keypoint[j + 1];
-      fb_gfx_fillRect(fb, x0, y0, 3, 3, color);
-    }
-#endif
-  }
-}
-
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-static int run_face_recognition(fb_data_t *fb, std::list<dl::detect::result_t> *results) {
-  std::vector<int> landmarks = results->front().keypoint;
-  int id = -1;
-
-  Tensor<uint8_t> tensor;
-  tensor.set_element((uint8_t *)fb->data).set_shape({fb->height, fb->width, 3}).set_auto_free(false);
-
-  int enrolled_count = recognizer.get_enrolled_id_num();
-
-  if (enrolled_count < FACE_ID_SAVE_NUMBER && is_enrolling) {
-    id = recognizer.enroll_id(tensor, landmarks, "", true);
-    log_i("Enrolled ID: %d", id);
-    rgb_printf(fb, FACE_COLOR_CYAN, "ID[%u]", id);
-  }
-
-  face_info_t recognize = recognizer.recognize(tensor, landmarks);
-  if (recognize.id >= 0) {
-    rgb_printf(fb, FACE_COLOR_GREEN, "ID[%u]: %.2f", recognize.id, recognize.similarity);
-  } else {
-    rgb_print(fb, FACE_COLOR_RED, "Intruder Alert!");
-  }
-  return recognize.id;
-}
-#endif
 #endif
 
 #if CONFIG_LED_ILLUMINATOR_ENABLED
@@ -359,134 +185,28 @@ static esp_err_t capture_handler(httpd_req_t *req) {
   snprintf(ts, 32, "%lld.%06ld", fb->timestamp.tv_sec, fb->timestamp.tv_usec);
   httpd_resp_set_hdr(req, "X-Timestamp", (const char *)ts);
 
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-  size_t out_len, out_width, out_height;
-  uint8_t *out_buf;
-  bool s;
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-  bool detected = false;
+  size_t fb_len = 0;
 #endif
-  int face_id = 0;
-  if (!detection_enabled || fb->width > 400) {
-#endif
+  if (fb->format == PIXFORMAT_JPEG) {
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-    size_t fb_len = 0;
+    fb_len = fb->len;
 #endif
-    if (fb->format == PIXFORMAT_JPEG) {
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-      fb_len = fb->len;
-#endif
-      res = httpd_resp_send(req, (const char *)fb->buf, fb->len);
-    } else {
-      jpg_chunking_t jchunk = {req, 0};
-      res = frame2jpg_cb(fb, 80, jpg_encode_stream, &jchunk) ? ESP_OK : ESP_FAIL;
-      httpd_resp_send_chunk(req, NULL, 0);
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-      fb_len = jchunk.len;
-#endif
-    }
-    esp_camera_fb_return(fb);
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-    int64_t fr_end = esp_timer_get_time();
-#endif
-    log_i("JPG: %uB %ums", (uint32_t)(fb_len), (uint32_t)((fr_end - fr_start) / 1000));
-    return res;
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-  }
-
-  jpg_chunking_t jchunk = {req, 0};
-
-  if (fb->format == PIXFORMAT_RGB565
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-      && !recognition_enabled
-#endif
-  ) {
-#if TWO_STAGE
-    HumanFaceDetectMSR01 s1(0.1F, 0.5F, 10, 0.2F);
-    HumanFaceDetectMNP01 s2(0.5F, 0.3F, 5);
-    std::list<dl::detect::result_t> &candidates = s1.infer((uint16_t *)fb->buf, {(int)fb->height, (int)fb->width, 3});
-    std::list<dl::detect::result_t> &results = s2.infer((uint16_t *)fb->buf, {(int)fb->height, (int)fb->width, 3}, candidates);
-#else
-    HumanFaceDetectMSR01 s1(0.3F, 0.5F, 10, 0.2F);
-    std::list<dl::detect::result_t> &results = s1.infer((uint16_t *)fb->buf, {(int)fb->height, (int)fb->width, 3});
-#endif
-    if (results.size() > 0) {
-      fb_data_t rfb;
-      rfb.width = fb->width;
-      rfb.height = fb->height;
-      rfb.data = fb->buf;
-      rfb.bytes_per_pixel = 2;
-      rfb.format = FB_RGB565;
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-      detected = true;
-#endif
-      draw_face_boxes(&rfb, &results, face_id);
-    }
-    s = fmt2jpg_cb(fb->buf, fb->len, fb->width, fb->height, PIXFORMAT_RGB565, 90, jpg_encode_stream, &jchunk);
-    esp_camera_fb_return(fb);
+    res = httpd_resp_send(req, (const char *)fb->buf, fb->len);
   } else {
-    out_len = fb->width * fb->height * 3;
-    out_width = fb->width;
-    out_height = fb->height;
-    out_buf = (uint8_t *)malloc(out_len);
-    if (!out_buf) {
-      log_e("out_buf malloc failed");
-      httpd_resp_send_500(req);
-      return ESP_FAIL;
-    }
-    s = fmt2rgb888(fb->buf, fb->len, fb->format, out_buf);
-    esp_camera_fb_return(fb);
-    if (!s) {
-      free(out_buf);
-      log_e("To rgb888 failed");
-      httpd_resp_send_500(req);
-      return ESP_FAIL;
-    }
-
-    fb_data_t rfb;
-    rfb.width = out_width;
-    rfb.height = out_height;
-    rfb.data = out_buf;
-    rfb.bytes_per_pixel = 3;
-    rfb.format = FB_BGR888;
-
-#if TWO_STAGE
-    HumanFaceDetectMSR01 s1(0.1F, 0.5F, 10, 0.2F);
-    HumanFaceDetectMNP01 s2(0.5F, 0.3F, 5);
-    std::list<dl::detect::result_t> &candidates = s1.infer((uint8_t *)out_buf, {(int)out_height, (int)out_width, 3});
-    std::list<dl::detect::result_t> &results = s2.infer((uint8_t *)out_buf, {(int)out_height, (int)out_width, 3}, candidates);
-#else
-    HumanFaceDetectMSR01 s1(0.3F, 0.5F, 10, 0.2F);
-    std::list<dl::detect::result_t> &results = s1.infer((uint8_t *)out_buf, {(int)out_height, (int)out_width, 3});
-#endif
-
-    if (results.size() > 0) {
+    jpg_chunking_t jchunk = {req, 0};
+    res = frame2jpg_cb(fb, 80, jpg_encode_stream, &jchunk) ? ESP_OK : ESP_FAIL;
+    httpd_resp_send_chunk(req, NULL, 0);
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-      detected = true;
+    fb_len = jchunk.len;
 #endif
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-      if (recognition_enabled) {
-        face_id = run_face_recognition(&rfb, &results);
-      }
-#endif
-      draw_face_boxes(&rfb, &results, face_id);
-    }
-
-    s = fmt2jpg_cb(out_buf, out_len, out_width, out_height, PIXFORMAT_RGB888, 90, jpg_encode_stream, &jchunk);
-    free(out_buf);
   }
-
-  if (!s) {
-    log_e("JPEG compression failed");
-    httpd_resp_send_500(req);
-    return ESP_FAIL;
-  }
+  esp_camera_fb_return(fb);
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
   int64_t fr_end = esp_timer_get_time();
 #endif
-  log_i("FACE: %uB %ums %s%d", (uint32_t)(jchunk.len), (uint32_t)((fr_end - fr_start) / 1000), detected ? "DETECTED " : "", face_id);
+  log_i("JPG: %uB %ums", (uint32_t)(fb_len), (uint32_t)((fr_end - fr_start) / 1000));
   return res;
-#endif
 }
 
 static esp_err_t stream_handler(httpd_req_t *req) {
@@ -496,26 +216,6 @@ static esp_err_t stream_handler(httpd_req_t *req) {
   size_t _jpg_buf_len = 0;
   uint8_t *_jpg_buf = NULL;
   char *part_buf[128];
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-  bool detected = false;
-  int64_t fr_ready = 0;
-  int64_t fr_recognize = 0;
-  int64_t fr_encode = 0;
-  int64_t fr_face = 0;
-  int64_t fr_start = 0;
-#endif
-  int face_id = 0;
-  size_t out_len = 0, out_width = 0, out_height = 0;
-  uint8_t *out_buf = NULL;
-  bool s = false;
-#if TWO_STAGE
-  HumanFaceDetectMSR01 s1(0.1F, 0.5F, 10, 0.2F);
-  HumanFaceDetectMNP01 s2(0.5F, 0.3F, 5);
-#else
-  HumanFaceDetectMSR01 s1(0.3F, 0.5F, 10, 0.2F);
-#endif
-#endif
 
   static int64_t last_frame = 0;
   if (!last_frame) {
@@ -536,13 +236,6 @@ static esp_err_t stream_handler(httpd_req_t *req) {
 #endif
 
   while (true) {
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-    detected = false;
-#endif
-    face_id = 0;
-#endif
-
     fb = esp_camera_fb_get();
     if (!fb) {
       log_e("Camera capture failed");
@@ -550,138 +243,18 @@ static esp_err_t stream_handler(httpd_req_t *req) {
     } else {
       _timestamp.tv_sec = fb->timestamp.tv_sec;
       _timestamp.tv_usec = fb->timestamp.tv_usec;
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-      fr_start = esp_timer_get_time();
-      fr_ready = fr_start;
-      fr_encode = fr_start;
-      fr_recognize = fr_start;
-      fr_face = fr_start;
-#endif
-      if (!detection_enabled || fb->width > 400) {
-#endif
-        if (fb->format != PIXFORMAT_JPEG) {
-          bool jpeg_converted = frame2jpg(fb, 80, &_jpg_buf, &_jpg_buf_len);
-          esp_camera_fb_return(fb);
-          fb = NULL;
-          if (!jpeg_converted) {
-            log_e("JPEG compression failed");
-            res = ESP_FAIL;
-          }
-        } else {
-          _jpg_buf_len = fb->len;
-          _jpg_buf = fb->buf;
+      if (fb->format != PIXFORMAT_JPEG) {
+        bool jpeg_converted = frame2jpg(fb, 80, &_jpg_buf, &_jpg_buf_len);
+        esp_camera_fb_return(fb);
+        fb = NULL;
+        if (!jpeg_converted) {
+          log_e("JPEG compression failed");
+          res = ESP_FAIL;
         }
-#if CONFIG_ESP_FACE_DETECT_ENABLED
       } else {
-        if (fb->format == PIXFORMAT_RGB565
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-            && !recognition_enabled
-#endif
-        ) {
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-          fr_ready = esp_timer_get_time();
-#endif
-#if TWO_STAGE
-          std::list<dl::detect::result_t> &candidates = s1.infer((uint16_t *)fb->buf, {(int)fb->height, (int)fb->width, 3});
-          std::list<dl::detect::result_t> &results = s2.infer((uint16_t *)fb->buf, {(int)fb->height, (int)fb->width, 3}, candidates);
-#else
-          std::list<dl::detect::result_t> &results = s1.infer((uint16_t *)fb->buf, {(int)fb->height, (int)fb->width, 3});
-#endif
-#if CONFIG_ESP_FACE_DETECT_ENABLED && ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-          fr_face = esp_timer_get_time();
-          fr_recognize = fr_face;
-#endif
-          if (results.size() > 0) {
-            fb_data_t rfb;
-            rfb.width = fb->width;
-            rfb.height = fb->height;
-            rfb.data = fb->buf;
-            rfb.bytes_per_pixel = 2;
-            rfb.format = FB_RGB565;
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-            detected = true;
-#endif
-            draw_face_boxes(&rfb, &results, face_id);
-          }
-          s = fmt2jpg(fb->buf, fb->len, fb->width, fb->height, PIXFORMAT_RGB565, 80, &_jpg_buf, &_jpg_buf_len);
-          esp_camera_fb_return(fb);
-          fb = NULL;
-          if (!s) {
-            log_e("fmt2jpg failed");
-            res = ESP_FAIL;
-          }
-#if CONFIG_ESP_FACE_DETECT_ENABLED && ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-          fr_encode = esp_timer_get_time();
-#endif
-        } else {
-          out_len = fb->width * fb->height * 3;
-          out_width = fb->width;
-          out_height = fb->height;
-          out_buf = (uint8_t *)malloc(out_len);
-          if (!out_buf) {
-            log_e("out_buf malloc failed");
-            res = ESP_FAIL;
-          } else {
-            s = fmt2rgb888(fb->buf, fb->len, fb->format, out_buf);
-            esp_camera_fb_return(fb);
-            fb = NULL;
-            if (!s) {
-              free(out_buf);
-              log_e("To rgb888 failed");
-              res = ESP_FAIL;
-            } else {
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-              fr_ready = esp_timer_get_time();
-#endif
-
-              fb_data_t rfb;
-              rfb.width = out_width;
-              rfb.height = out_height;
-              rfb.data = out_buf;
-              rfb.bytes_per_pixel = 3;
-              rfb.format = FB_BGR888;
-
-#if TWO_STAGE
-              std::list<dl::detect::result_t> &candidates = s1.infer((uint8_t *)out_buf, {(int)out_height, (int)out_width, 3});
-              std::list<dl::detect::result_t> &results = s2.infer((uint8_t *)out_buf, {(int)out_height, (int)out_width, 3}, candidates);
-#else
-              std::list<dl::detect::result_t> &results = s1.infer((uint8_t *)out_buf, {(int)out_height, (int)out_width, 3});
-#endif
-
-#if CONFIG_ESP_FACE_DETECT_ENABLED && ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-              fr_face = esp_timer_get_time();
-              fr_recognize = fr_face;
-#endif
-
-              if (results.size() > 0) {
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-                detected = true;
-#endif
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-                if (recognition_enabled) {
-                  face_id = run_face_recognition(&rfb, &results);
-#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-                  fr_recognize = esp_timer_get_time();
-#endif
-                }
-#endif
-                draw_face_boxes(&rfb, &results, face_id);
-              }
-              s = fmt2jpg(out_buf, out_len, out_width, out_height, PIXFORMAT_RGB888, 90, &_jpg_buf, &_jpg_buf_len);
-              free(out_buf);
-              if (!s) {
-                log_e("fmt2jpg failed");
-                res = ESP_FAIL;
-              }
-#if CONFIG_ESP_FACE_DETECT_ENABLED && ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-              fr_encode = esp_timer_get_time();
-#endif
-            }
-          }
-        }
+        _jpg_buf_len = fb->len;
+        _jpg_buf = fb->buf;
       }
-#endif
     }
     if (res == ESP_OK) {
       res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
@@ -707,30 +280,14 @@ static esp_err_t stream_handler(httpd_req_t *req) {
     }
     int64_t fr_end = esp_timer_get_time();
 
-#if CONFIG_ESP_FACE_DETECT_ENABLED && ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
-    int64_t ready_time = (fr_ready - fr_start) / 1000;
-    int64_t face_time = (fr_face - fr_ready) / 1000;
-    int64_t recognize_time = (fr_recognize - fr_face) / 1000;
-    int64_t encode_time = (fr_encode - fr_recognize) / 1000;
-    int64_t process_time = (fr_encode - fr_start) / 1000;
-#endif
-
     int64_t frame_time = fr_end - last_frame;
     frame_time /= 1000;
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
     uint32_t avg_frame_time = ra_filter_run(&ra_filter, frame_time);
 #endif
     log_i(
-      "MJPG: %uB %ums (%.1ffps), AVG: %ums (%.1ffps)"
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-      ", %u+%u+%u+%u=%u %s%d"
-#endif
-      ,
-      (uint32_t)(_jpg_buf_len), (uint32_t)frame_time, 1000.0 / (uint32_t)frame_time, avg_frame_time, 1000.0 / avg_frame_time
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-      ,
-      (uint32_t)ready_time, (uint32_t)face_time, (uint32_t)recognize_time, (uint32_t)encode_time, (uint32_t)process_time, (detected) ? "DETECTED " : "", face_id
-#endif
+      "MJPG: %uB %ums (%.1ffps), AVG: %ums (%.1ffps)", (uint32_t)(_jpg_buf_len), (uint32_t)frame_time, 1000.0 / (uint32_t)frame_time, avg_frame_time,
+      1000.0 / avg_frame_time
     );
   }
 
@@ -842,28 +399,6 @@ static esp_err_t cmd_handler(httpd_req_t *req) {
     }
   }
 #endif
-
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-  else if (!strcmp(variable, "face_detect")) {
-    detection_enabled = val;
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-    if (!detection_enabled) {
-      recognition_enabled = 0;
-    }
-#endif
-  }
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-  else if (!strcmp(variable, "face_enroll")) {
-    is_enrolling = !is_enrolling;
-    log_i("Enrolling: %s", is_enrolling ? "true" : "false");
-  } else if (!strcmp(variable, "face_recognize")) {
-    recognition_enabled = val;
-    if (recognition_enabled) {
-      detection_enabled = val;
-    }
-  }
-#endif
-#endif
   else {
     log_i("Unknown command: %s", variable);
     res = -1;
@@ -947,13 +482,6 @@ static esp_err_t status_handler(httpd_req_t *req) {
   p += sprintf(p, ",\"led_intensity\":%u", led_duty);
 #else
   p += sprintf(p, ",\"led_intensity\":%d", -1);
-#endif
-#if CONFIG_ESP_FACE_DETECT_ENABLED
-  p += sprintf(p, ",\"face_detect\":%u", detection_enabled);
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-  p += sprintf(p, ",\"face_enroll\":%u,", is_enrolling);
-  p += sprintf(p, "\"face_recognize\":%u", recognition_enabled);
-#endif
 #endif
   *p++ = '}';
   *p++ = 0;
@@ -1289,12 +817,6 @@ void startCameraServer() {
 
   ra_filter_init(&ra_filter, 20);
 
-#if CONFIG_ESP_FACE_RECOGNITION_ENABLED
-  recognizer.set_partition(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "fr");
-
-  // load ids from flash partition
-  recognizer.set_ids_from_flash();
-#endif
   log_i("Starting web server on port: '%d'", config.server_port);
   if (httpd_start(&camera_httpd, &config) == ESP_OK) {
     httpd_register_uri_handler(camera_httpd, &index_uri);

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-707d097b.zip",
-              "checksum": "SHA-256:f8624bf7eab91e0a3bb3be4cc385fef5a05a725bc6ff978f3d4e2562f2805b1e",
-              "size": "399729605"
+              "checksum": "SHA-256:b4d431c8e6e9eb26c78cb187b9082055544956a4dac8e224ff884f770e5f0e5a",
+              "size": "351074410"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.3 11b9bf9
esp-idf: release/v5.3 707d097b01
arduino: release/v3.1.x ba9a3a1d
tinyusb: master ffdf81f53
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.16
espressif__esp-serial-flasher: 0.0.11
espressif__esp-zboss-lib: 1.5.0
espressif__esp-zigbee-lib: 1.5.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.2.0
espressif__esp_insights: 1.2.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.4.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.2
```
