### PR TITLE
fix(uart): Add missing HP UARTs for ESP32-P4

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -81,12 +81,12 @@ void serialEventRun(void) {
   if (serialEvent && Serial0.available()) {
     serialEvent();
   }
-#if SOC_UART_NUM > 1
+#if SOC_UART_HP_NUM > 1
   if (serialEvent1 && Serial1.available()) {
     serialEvent1();
   }
 #endif
-#if SOC_UART_NUM > 2
+#if SOC_UART_HP_NUM > 2
   if (serialEvent2 && Serial2.available()) {
     serialEvent2();
   }

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -27,11 +27,11 @@ void serialEvent(void) __attribute__((weak));
 
 #if SOC_UART_HP_NUM > 1
 void serialEvent1(void) __attribute__((weak));
-#endif /* SOC_UART_NUM > 1 */
+#endif /* SOC_UART_HP_NUM > 1 */
 
 #if SOC_UART_HP_NUM > 2
 void serialEvent2(void) __attribute__((weak));
-#endif /* SOC_UART_NUM > 2 */
+#endif /* SOC_UART_HP_NUM > 2 */
 
 #if SOC_UART_HP_NUM > 3
 void serialEvent3(void) __attribute__((weak));

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -33,6 +33,14 @@ void serialEvent1(void) __attribute__((weak));
 void serialEvent2(void) __attribute__((weak));
 #endif /* SOC_UART_NUM > 2 */
 
+#if SOC_UART_HP_NUM > 3
+void serialEvent3(void) __attribute__((weak));
+#endif /* SOC_UART_HP_NUM > 3 */
+
+#if SOC_UART_HP_NUM > 4
+void serialEvent4(void) __attribute__((weak));
+#endif /* SOC_UART_HP_NUM > 4 */
+
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
 // There is always Seria0 for UART0
 HardwareSerial Serial0(0);
@@ -41,6 +49,12 @@ HardwareSerial Serial1(1);
 #endif
 #if SOC_UART_HP_NUM > 2
 HardwareSerial Serial2(2);
+#endif
+#if SOC_UART_HP_NUM > 3
+HardwareSerial Serial3(3);
+#endif
+#if SOC_UART_HP_NUM > 4
+HardwareSerial Serial4(4);
 #endif
 
 #if HWCDC_SERIAL_IS_DEFINED == 1  // Hardware JTAG CDC Event
@@ -75,6 +89,16 @@ void serialEventRun(void) {
 #if SOC_UART_NUM > 2
   if (serialEvent2 && Serial2.available()) {
     serialEvent2();
+  }
+#endif
+#if SOC_UART_HP_NUM > 3
+  if (serialEvent3 && Serial3.available()) {
+    serialEvent3();
+  }
+#endif
+#if SOC_UART_HP_NUM > 4
+  if (serialEvent4 && Serial4.available()) {
+    serialEvent4();
   }
 #endif
 }

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -375,6 +375,12 @@ extern HardwareSerial Serial1;
 #if SOC_UART_HP_NUM > 2
 extern HardwareSerial Serial2;
 #endif
+#if SOC_UART_HP_NUM > 3
+extern HardwareSerial Serial3;
+#endif
+#if SOC_UART_HP_NUM > 4
+extern HardwareSerial Serial4;
+#endif
 #endif  //!defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
 
 #endif  // HardwareSerial_h

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -67,6 +67,12 @@ static uart_t _uart_bus_array[] = {
 #if SOC_UART_HP_NUM > 2
   {2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0},
 #endif
+#if SOC_UART_HP_NUM > 3
+  {3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0},
+#endif
+#if SOC_UART_HP_NUM > 4
+  {4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0},
+#endif
 };
 
 #else
@@ -86,6 +92,12 @@ static uart_t _uart_bus_array[] = {
 #endif
 #if SOC_UART_HP_NUM > 2
   {NULL, 2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0},
+#endif
+#if SOC_UART_HP_NUM > 3
+  {NULL, 3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0},
+#endif
+#if SOC_UART_HP_NUM > 4
+  {NULL, 4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0},
 #endif
 };
 
@@ -835,6 +847,20 @@ static void ARDUINO_ISR_ATTR uart2_write_char(char c) {
 }
 #endif
 
+#if SOC_UART_HP_NUM > 3
+static void ARDUINO_ISR_ATTR uart3_write_char(char c) {
+  while (uart_ll_get_txfifo_len(&UART3) == 0);
+  uart_ll_write_txfifo(&UART3, (const uint8_t *)&c, 1);
+}
+#endif
+
+#if SOC_UART_HP_NUM > 4
+static void ARDUINO_ISR_ATTR uart4_write_char(char c) {
+  while (uart_ll_get_txfifo_len(&UART4) == 0);
+  uart_ll_write_txfifo(&UART4, (const uint8_t *)&c, 1);
+}
+#endif
+
 void uart_install_putc() {
   switch (s_uart_debug_nr) {
     case 0: ets_install_putc1((void (*)(char)) & uart0_write_char); break;
@@ -843,6 +869,12 @@ void uart_install_putc() {
 #endif
 #if SOC_UART_HP_NUM > 2
     case 2: ets_install_putc1((void (*)(char)) & uart2_write_char); break;
+#endif
+#if SOC_UART_HP_NUM > 3
+    case 3: ets_install_putc1((void (*)(char)) & uart3_write_char); break;
+#endif
+#if SOC_UART_HP_NUM > 4
+    case 4: ets_install_putc1((void (*)(char)) & uart4_write_char); break;
 #endif
     default: ets_install_putc1(NULL); break;
   }


### PR DESCRIPTION
## Description of Change

Add missing HP UART 3 and 4 for ESP32-P4

