### PR TITLE
fix(example): print correct fade direction

### DIFF
--- a/libraries/ESP32/examples/AnalogOut/LEDCFade/LEDCFade.ino
+++ b/libraries/ESP32/examples/AnalogOut/LEDCFade/LEDCFade.ino
@@ -21,7 +21,7 @@
 #define LEDC_FADE_TIME   (3000)
 
 bool fade_ended = false;  // status of LED fade
-bool fade_on = true;
+bool fade_in = true;
 
 void ARDUINO_ISR_ATTR LED_FADE_ISR() {
   fade_ended = true;
@@ -55,15 +55,15 @@ void loop() {
     Serial.println("LED fade ended");
     fade_ended = false;
 
-    // Check if last fade was fade on
-    if (fade_on) {
+    // Check what fade shoud be started next
+    if (fade_in) {
       ledcFadeWithInterrupt(LED_PIN, LEDC_START_DUTY, LEDC_TARGET_DUTY, LEDC_FADE_TIME, LED_FADE_ISR);
-      Serial.println("LED Fade on started.");
-      fade_on = false;
+      Serial.println("LED Fade in started.");
+      fade_in = false;
     } else {
       ledcFadeWithInterrupt(LED_PIN, LEDC_TARGET_DUTY, LEDC_START_DUTY, LEDC_FADE_TIME, LED_FADE_ISR);
-      Serial.println("LED Fade off started.");
-      fade_on = true;
+      Serial.println("LED Fade out started.");
+      fade_in = true;
     }
   }
 }

--- a/libraries/ESP32/examples/AnalogOut/LEDCFade/LEDCFade.ino
+++ b/libraries/ESP32/examples/AnalogOut/LEDCFade/LEDCFade.ino
@@ -55,7 +55,7 @@ void loop() {
     Serial.println("LED fade ended");
     fade_ended = false;
 
-    // Check what fade shoud be started next
+    // Check what fade should be started next
     if (fade_in) {
       ledcFadeWithInterrupt(LED_PIN, LEDC_START_DUTY, LEDC_TARGET_DUTY, LEDC_FADE_TIME, LED_FADE_ISR);
       Serial.println("LED Fade in started.");

--- a/libraries/ESP32/examples/AnalogOut/LEDCFade/LEDCFade.ino
+++ b/libraries/ESP32/examples/AnalogOut/LEDCFade/LEDCFade.ino
@@ -58,11 +58,11 @@ void loop() {
     // Check if last fade was fade on
     if (fade_on) {
       ledcFadeWithInterrupt(LED_PIN, LEDC_START_DUTY, LEDC_TARGET_DUTY, LEDC_FADE_TIME, LED_FADE_ISR);
-      Serial.println("LED Fade off started.");
+      Serial.println("LED Fade on started.");
       fade_on = false;
     } else {
       ledcFadeWithInterrupt(LED_PIN, LEDC_TARGET_DUTY, LEDC_START_DUTY, LEDC_FADE_TIME, LED_FADE_ISR);
-      Serial.println("LED Fade on started.");
+      Serial.println("LED Fade off started.");
       fade_on = true;
     }
   }


### PR DESCRIPTION
## Description of Change
Fixes print of fade direction in ledcFade example.

## Tests scenarios
Locally

## Related links
