### PR TITLE
replace outdated wrong `SOC_I2C_NUM` and use `SOC_HP_I2C_NUM`

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -646,8 +646,8 @@ void TwoWire::onRequestService(uint8_t num, void *arg) {
 #endif /* SOC_I2C_SUPPORT_SLAVE */
 
 TwoWire Wire = TwoWire(0);
-#if SOC_I2C_NUM > 1
+#if SOC_HP_I2C_NUM > 1
 TwoWire Wire1 = TwoWire(1);
-#endif /* SOC_I2C_NUM */
+#endif /* SOC_HP_I2C_NUM */
 
 #endif /* SOC_I2C_SUPPORTED */

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -144,9 +144,9 @@ public:
 };
 
 extern TwoWire Wire;
-#if SOC_I2C_NUM > 1
+#if SOC_HP_I2C_NUM > 1
 extern TwoWire Wire1;
-#endif /* SOC_I2C_NUM */
+#endif /* SOC_HP_I2C_NUM */
 
 #endif /* SOC_I2C_SUPPORTED */
 #endif /* TwoWire_h */


### PR DESCRIPTION
Fixes wrong if check for i2c bus in wire
@me-no-dev as asked for

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
