### PR TITLE
changed SOC_I2C_NUM to SOC_HP_I2C_NUM

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -646,8 +646,8 @@ void TwoWire::onRequestService(uint8_t num, void *arg) {
 #endif /* SOC_I2C_SUPPORT_SLAVE */
 
 TwoWire Wire = TwoWire(0);
-#if SOC_I2C_NUM > 1
+#if SOC_HP_I2C_NUM > 1
 TwoWire Wire1 = TwoWire(1);
-#endif /* SOC_I2C_NUM */
+#endif /* SOC_HP_I2C_NUM */
 
 #endif /* SOC_I2C_SUPPORTED */

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -144,9 +144,9 @@ public:
 };
 
 extern TwoWire Wire;
-#if SOC_I2C_NUM > 1
+#if SOC_HP_I2C_NUM > 1
 extern TwoWire Wire1;
-#endif /* SOC_I2C_NUM */
+#endif /* SOC_HP_I2C_NUM */
 
 #endif /* SOC_I2C_SUPPORTED */
 #endif /* TwoWire_h */


### PR DESCRIPTION
## Description of Change
Changed `SOC_I2C_NUM` to `SOC_HP_I2C_NUM` as suggested by Jason2866 and commented by igrr 

## Tests scenarios
none

## Related links
https://github.com/espressif/arduino-esp32/commit/5d873c0787fa96675f74b68d16b9b8a3a2a048ea#commitcomment-147823189