### PR TITLE
Update esp-insights version

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -72,7 +72,7 @@ dependencies:
     rules:
       - if: "target != esp32c2"
   espressif/esp_insights:
-    version: "^1.0.1"
+    version: "^1.2.1"
     rules:
       - if: "target != esp32c2"
   espressif/qrcode:


### PR DESCRIPTION

## Description of Change

Current esp_insights version in idf_component.yml (^1.0.1) pulls following versions of required components
`esp_insights : 1.0.1`
`esp_diagnostics: 1.0.2`
`esp_diag_data_store : 1.0.2`

With latest update to esp-insights and its components,  `esp_insights: 1.0.1` is not compatible with `esp_diag_data_store: 1.0.2` which causes compilation errors while building core. 

Updating `esp_insights` version to `1.2.1` fixes the issue. 

## Tests scenarios

Reproduced issue with Arduino-esp32 3.0.5 for  ESP32 S3 and ESPC3 boards. After this change build was successful. 

## Related links
[Latest Changes to esp-insights](https://github.com/espressif/esp-insights/commit/bbe13d1897b8272dc7bc350bd805e8852722e48d)
