### PR TITLE
Add IOXESP32-C6 and ATD3.5-S3 board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -38494,6 +38494,8 @@ namino_bianco.menu.EraseFlash.all=Enabled
 namino_bianco.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+# IOXESP32, IOXESP32U
+
 ioxesp32.name=IOXESP32
 
 ioxesp32.bootloader.tool=esptool_py
@@ -38604,6 +38606,7 @@ ioxesp32.menu.EraseFlash.all=Enabled
 ioxesp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+# IOXESP32PS
 
 ioxesp32ps.name=IOXESP32PS
 
@@ -38715,6 +38718,178 @@ ioxesp32ps.menu.EraseFlash.all=Enabled
 ioxesp32ps.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+# IOXESP32-C6
+
+ioxesp32c6.name=IOXESP32-C6
+
+ioxesp32c6.bootloader.tool=esptool_py
+ioxesp32c6.bootloader.tool.default=esptool_py
+
+ioxesp32c6.upload.tool=esptool_py
+ioxesp32c6.upload.tool.default=esptool_py
+ioxesp32c6.upload.tool.network=esp_ota
+
+ioxesp32c6.upload.maximum_size=1310720
+ioxesp32c6.upload.maximum_data_size=327680
+ioxesp32c6.upload.flags=
+ioxesp32c6.upload.extra_flags=
+ioxesp32c6.upload.use_1200bps_touch=false
+ioxesp32c6.upload.wait_for_upload_port=false
+
+ioxesp32c6.serial.disableDTR=false
+ioxesp32c6.serial.disableRTS=false
+
+ioxesp32c6.build.tarch=riscv32
+ioxesp32c6.build.target=esp
+ioxesp32c6.build.mcu=esp32c6
+ioxesp32c6.build.core=esp32
+ioxesp32c6.build.variant=ioxesp32c6
+ioxesp32c6.build.board=ESP32C6_DEV
+ioxesp32c6.build.bootloader_addr=0x0
+
+ioxesp32c6.build.cdc_on_boot=0
+ioxesp32c6.build.f_cpu=160000000L
+ioxesp32c6.build.flash_size=4MB
+ioxesp32c6.build.flash_freq=80m
+ioxesp32c6.build.flash_mode=qio
+ioxesp32c6.build.boot=qio
+ioxesp32c6.build.partitions=default
+ioxesp32c6.build.defines=
+
+## IDE 2.0 Seems to not update the value
+ioxesp32c6.menu.JTAGAdapter.default=Disabled
+ioxesp32c6.menu.JTAGAdapter.default.build.copy_jtag_files=0
+ioxesp32c6.menu.JTAGAdapter.builtin=Integrated USB JTAG
+ioxesp32c6.menu.JTAGAdapter.builtin.build.openocdscript=esp32c6-builtin.cfg
+ioxesp32c6.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+ioxesp32c6.menu.JTAGAdapter.external=FTDI Adapter
+ioxesp32c6.menu.JTAGAdapter.external.build.openocdscript=esp32c6-ftdi.cfg
+ioxesp32c6.menu.JTAGAdapter.external.build.copy_jtag_files=1
+ioxesp32c6.menu.JTAGAdapter.bridge=ESP USB Bridge
+ioxesp32c6.menu.JTAGAdapter.bridge.build.openocdscript=esp32c6-bridge.cfg
+ioxesp32c6.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+ioxesp32c6.menu.CDCOnBoot.default=Disabled
+ioxesp32c6.menu.CDCOnBoot.default.build.cdc_on_boot=0
+ioxesp32c6.menu.CDCOnBoot.cdc=Enabled
+ioxesp32c6.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+ioxesp32c6.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+ioxesp32c6.menu.PartitionScheme.default.build.partitions=default
+ioxesp32c6.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+ioxesp32c6.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+ioxesp32c6.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+ioxesp32c6.menu.PartitionScheme.minimal.build.partitions=minimal
+ioxesp32c6.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
+ioxesp32c6.menu.PartitionScheme.no_fs.build.partitions=no_fs
+ioxesp32c6.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
+ioxesp32c6.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+ioxesp32c6.menu.PartitionScheme.no_ota.build.partitions=no_ota
+ioxesp32c6.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+ioxesp32c6.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+ioxesp32c6.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+ioxesp32c6.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+ioxesp32c6.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+ioxesp32c6.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+ioxesp32c6.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+ioxesp32c6.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+ioxesp32c6.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+ioxesp32c6.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+ioxesp32c6.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+ioxesp32c6.menu.PartitionScheme.huge_app.build.partitions=huge_app
+ioxesp32c6.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+ioxesp32c6.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+ioxesp32c6.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+ioxesp32c6.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+ioxesp32c6.menu.PartitionScheme.rainmaker=RainMaker 4MB
+ioxesp32c6.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+ioxesp32c6.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+ioxesp32c6.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+ioxesp32c6.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+ioxesp32c6.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+ioxesp32c6.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
+ioxesp32c6.menu.PartitionScheme.zigbee.build.partitions=zigbee
+ioxesp32c6.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
+ioxesp32c6.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+ioxesp32c6.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+ioxesp32c6.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+ioxesp32c6.menu.PartitionScheme.custom=Custom
+ioxesp32c6.menu.PartitionScheme.custom.build.partitions=
+ioxesp32c6.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+ioxesp32c6.menu.CPUFreq.160=160MHz (WiFi)
+ioxesp32c6.menu.CPUFreq.160.build.f_cpu=160000000L
+ioxesp32c6.menu.CPUFreq.120=120MHz (WiFi)
+ioxesp32c6.menu.CPUFreq.120.build.f_cpu=120000000L
+ioxesp32c6.menu.CPUFreq.80=80MHz (WiFi)
+ioxesp32c6.menu.CPUFreq.80.build.f_cpu=80000000L
+ioxesp32c6.menu.CPUFreq.40=40MHz
+ioxesp32c6.menu.CPUFreq.40.build.f_cpu=40000000L
+ioxesp32c6.menu.CPUFreq.20=20MHz
+ioxesp32c6.menu.CPUFreq.20.build.f_cpu=20000000L
+ioxesp32c6.menu.CPUFreq.10=10MHz
+ioxesp32c6.menu.CPUFreq.10.build.f_cpu=10000000L
+
+ioxesp32c6.menu.FlashMode.qio=QIO
+ioxesp32c6.menu.FlashMode.qio.build.flash_mode=dio
+ioxesp32c6.menu.FlashMode.qio.build.boot=qio
+ioxesp32c6.menu.FlashMode.dio=DIO
+ioxesp32c6.menu.FlashMode.dio.build.flash_mode=dio
+ioxesp32c6.menu.FlashMode.dio.build.boot=dio
+
+ioxesp32c6.menu.FlashFreq.80=80MHz
+ioxesp32c6.menu.FlashFreq.80.build.flash_freq=80m
+ioxesp32c6.menu.FlashFreq.40=40MHz
+ioxesp32c6.menu.FlashFreq.40.build.flash_freq=40m
+
+ioxesp32c6.menu.UploadSpeed.921600=921600
+ioxesp32c6.menu.UploadSpeed.921600.upload.speed=921600
+ioxesp32c6.menu.UploadSpeed.115200=115200
+ioxesp32c6.menu.UploadSpeed.115200.upload.speed=115200
+ioxesp32c6.menu.UploadSpeed.256000.windows=256000
+ioxesp32c6.menu.UploadSpeed.256000.upload.speed=256000
+ioxesp32c6.menu.UploadSpeed.230400.windows.upload.speed=256000
+ioxesp32c6.menu.UploadSpeed.230400=230400
+ioxesp32c6.menu.UploadSpeed.230400.upload.speed=230400
+ioxesp32c6.menu.UploadSpeed.460800.linux=460800
+ioxesp32c6.menu.UploadSpeed.460800.macosx=460800
+ioxesp32c6.menu.UploadSpeed.460800.upload.speed=460800
+ioxesp32c6.menu.UploadSpeed.512000.windows=512000
+ioxesp32c6.menu.UploadSpeed.512000.upload.speed=512000
+
+ioxesp32c6.menu.DebugLevel.none=None
+ioxesp32c6.menu.DebugLevel.none.build.code_debug=0
+ioxesp32c6.menu.DebugLevel.error=Error
+ioxesp32c6.menu.DebugLevel.error.build.code_debug=1
+ioxesp32c6.menu.DebugLevel.warn=Warn
+ioxesp32c6.menu.DebugLevel.warn.build.code_debug=2
+ioxesp32c6.menu.DebugLevel.info=Info
+ioxesp32c6.menu.DebugLevel.info.build.code_debug=3
+ioxesp32c6.menu.DebugLevel.debug=Debug
+ioxesp32c6.menu.DebugLevel.debug.build.code_debug=4
+ioxesp32c6.menu.DebugLevel.verbose=Verbose
+ioxesp32c6.menu.DebugLevel.verbose.build.code_debug=5
+
+ioxesp32c6.menu.EraseFlash.none=Disabled
+ioxesp32c6.menu.EraseFlash.none.upload.erase_cmd=
+ioxesp32c6.menu.EraseFlash.all=Enabled
+ioxesp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
+
+ioxesp32c6.menu.ZigbeeMode.default=Disabled
+ioxesp32c6.menu.ZigbeeMode.default.build.zigbee_mode=
+ioxesp32c6.menu.ZigbeeMode.default.build.zigbee_libs=
+ioxesp32c6.menu.ZigbeeMode.ed=Zigbee ED (end device)
+ioxesp32c6.menu.ZigbeeMode.ed.build.zigbee_mode=-DZIGBEE_MODE_ED
+ioxesp32c6.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api_ed -lesp_zb_cli_command -lzboss_stack.ed -lzboss_port
+ioxesp32c6.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator)
+ioxesp32c6.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+ioxesp32c6.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api_zczr -lesp_zb_cli_command -lzboss_stack.zczr -lzboss_port
+ioxesp32c6.menu.ZigbeeMode.rcp=Zigbee RCP (radio co-processor)
+ioxesp32c6.menu.ZigbeeMode.rcp.build.zigbee_mode=-DZIGBEE_MODE_RCP
+ioxesp32c6.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api_rcp -lesp_zb_cli_command -lzboss_stack.rcp -lzboss_port
+
+##############################################################
+# ATD1.47-S3
 
 atd147_s3.name=ATD1.47-S3
 
@@ -38895,6 +39070,189 @@ atd147_s3.menu.EraseFlash.none=Disabled
 atd147_s3.menu.EraseFlash.none.upload.erase_cmd=
 atd147_s3.menu.EraseFlash.all=Enabled
 atd147_s3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+# ATD3.5-S3
+
+atd35s3.name=ATD3.5-S3
+
+atd35s3.bootloader.tool=esptool_py
+atd35s3.bootloader.tool.default=esptool_py
+
+atd35s3.upload.tool=esptool_py
+atd35s3.upload.tool.default=esptool_py
+atd35s3.upload.tool.network=esp_ota
+
+atd35s3.upload.maximum_size=1310720
+atd35s3.upload.maximum_data_size=327680
+atd35s3.upload.flags=
+atd35s3.upload.extra_flags=
+atd35s3.upload.use_1200bps_touch=false
+atd35s3.upload.wait_for_upload_port=false
+
+atd35s3.serial.disableDTR=false
+atd35s3.serial.disableRTS=false
+
+atd35s3.build.tarch=xtensa
+atd35s3.build.bootloader_addr=0x0
+atd35s3.build.target=esp32s3
+atd35s3.build.mcu=esp32s3
+atd35s3.build.core=esp32
+atd35s3.build.variant=atd35s3
+atd35s3.build.board=ATD143_S3
+
+atd35s3.build.usb_mode=1
+atd35s3.build.cdc_on_boot=0
+atd35s3.build.msc_on_boot=0
+atd35s3.build.dfu_on_boot=0
+atd35s3.build.f_cpu=240000000L
+atd35s3.build.flash_size=8MB
+atd35s3.build.flash_freq=80m
+atd35s3.build.flash_mode=dio
+atd35s3.build.boot=qio
+atd35s3.build.boot_freq=80m
+atd35s3.build.partitions=default_8MB
+atd35s3.build.defines=
+atd35s3.build.loop_core=
+atd35s3.build.event_core=
+atd35s3.build.psram_type=opi
+atd35s3.build.memory_type={build.boot}_{build.psram_type}
+
+## IDE 2.0 Seems to not update the value
+atd35s3.menu.JTAGAdapter.default=Disabled
+atd35s3.menu.JTAGAdapter.default.build.copy_jtag_files=0
+atd35s3.menu.JTAGAdapter.builtin=Integrated USB JTAG
+atd35s3.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
+atd35s3.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+atd35s3.menu.JTAGAdapter.external=FTDI Adapter
+atd35s3.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+atd35s3.menu.JTAGAdapter.external.build.copy_jtag_files=1
+atd35s3.menu.JTAGAdapter.bridge=ESP USB Bridge
+atd35s3.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+atd35s3.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+atd35s3.menu.PSRAM.disabled=Disabled
+atd35s3.menu.PSRAM.disabled.build.defines=
+atd35s3.menu.PSRAM.disabled.build.psram_type=opi
+atd35s3.menu.PSRAM.enabled=Enable
+atd35s3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+atd35s3.menu.PSRAM.enabled.build.psram_type=opi
+
+atd35s3.menu.LoopCore.1=Core 1
+atd35s3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+atd35s3.menu.LoopCore.0=Core 0
+atd35s3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+atd35s3.menu.EventsCore.1=Core 1
+atd35s3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+atd35s3.menu.EventsCore.0=Core 0
+atd35s3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+atd35s3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+atd35s3.menu.USBMode.hwcdc.build.usb_mode=1
+atd35s3.menu.USBMode.default=USB-OTG (TinyUSB)
+atd35s3.menu.USBMode.default.build.usb_mode=0
+
+atd35s3.menu.CDCOnBoot.default=Disabled
+atd35s3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+atd35s3.menu.CDCOnBoot.cdc=Enabled
+atd35s3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+atd35s3.menu.MSCOnBoot.default=Disabled
+atd35s3.menu.MSCOnBoot.default.build.msc_on_boot=0
+atd35s3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+atd35s3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+atd35s3.menu.DFUOnBoot.default=Disabled
+atd35s3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+atd35s3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+atd35s3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+atd35s3.menu.UploadMode.default=UART0 / Hardware CDC
+atd35s3.menu.UploadMode.default.upload.use_1200bps_touch=false
+atd35s3.menu.UploadMode.default.upload.wait_for_upload_port=false
+atd35s3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+atd35s3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+atd35s3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+atd35s3.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+atd35s3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+atd35s3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+atd35s3.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+atd35s3.menu.PartitionScheme.minimal.build.partitions=minimal
+atd35s3.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+atd35s3.menu.PartitionScheme.no_ota.build.partitions=no_ota
+atd35s3.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+atd35s3.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+atd35s3.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+atd35s3.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+atd35s3.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+atd35s3.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+atd35s3.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+atd35s3.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+atd35s3.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+atd35s3.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+atd35s3.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+atd35s3.menu.PartitionScheme.huge_app.build.partitions=huge_app
+atd35s3.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+atd35s3.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+atd35s3.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+atd35s3.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+atd35s3.menu.PartitionScheme.rainmaker=RainMaker 4MB
+atd35s3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+atd35s3.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+atd35s3.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+atd35s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+atd35s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+atd35s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+atd35s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+atd35s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
+
+atd35s3.menu.CPUFreq.240=240MHz (WiFi)
+atd35s3.menu.CPUFreq.240.build.f_cpu=240000000L
+atd35s3.menu.CPUFreq.160=160MHz (WiFi)
+atd35s3.menu.CPUFreq.160.build.f_cpu=160000000L
+atd35s3.menu.CPUFreq.80=80MHz (WiFi)
+atd35s3.menu.CPUFreq.80.build.f_cpu=80000000L
+atd35s3.menu.CPUFreq.40=40MHz
+atd35s3.menu.CPUFreq.40.build.f_cpu=40000000L
+atd35s3.menu.CPUFreq.20=20MHz
+atd35s3.menu.CPUFreq.20.build.f_cpu=20000000L
+atd35s3.menu.CPUFreq.10=10MHz
+atd35s3.menu.CPUFreq.10.build.f_cpu=10000000L
+
+atd35s3.menu.UploadSpeed.921600=921600
+atd35s3.menu.UploadSpeed.921600.upload.speed=921600
+atd35s3.menu.UploadSpeed.115200=115200
+atd35s3.menu.UploadSpeed.115200.upload.speed=115200
+atd35s3.menu.UploadSpeed.256000.windows=256000
+atd35s3.menu.UploadSpeed.256000.upload.speed=256000
+atd35s3.menu.UploadSpeed.230400.windows.upload.speed=256000
+atd35s3.menu.UploadSpeed.230400=230400
+atd35s3.menu.UploadSpeed.230400.upload.speed=230400
+atd35s3.menu.UploadSpeed.460800.linux=460800
+atd35s3.menu.UploadSpeed.460800.macosx=460800
+atd35s3.menu.UploadSpeed.460800.upload.speed=460800
+atd35s3.menu.UploadSpeed.512000.windows=512000
+atd35s3.menu.UploadSpeed.512000.upload.speed=512000
+
+atd35s3.menu.DebugLevel.none=None
+atd35s3.menu.DebugLevel.none.build.code_debug=0
+atd35s3.menu.DebugLevel.error=Error
+atd35s3.menu.DebugLevel.error.build.code_debug=1
+atd35s3.menu.DebugLevel.warn=Warn
+atd35s3.menu.DebugLevel.warn.build.code_debug=2
+atd35s3.menu.DebugLevel.info=Info
+atd35s3.menu.DebugLevel.info.build.code_debug=3
+atd35s3.menu.DebugLevel.debug=Debug
+atd35s3.menu.DebugLevel.debug.build.code_debug=4
+atd35s3.menu.DebugLevel.verbose=Verbose
+atd35s3.menu.DebugLevel.verbose.build.code_debug=5
+
+atd35s3.menu.EraseFlash.none=Disabled
+atd35s3.menu.EraseFlash.none.upload.erase_cmd=
+atd35s3.menu.EraseFlash.all=Enabled
+atd35s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 # ESP32-S3 PowerFeather

--- a/variants/atd35s3/pins_arduino.h
+++ b/variants/atd35s3/pins_arduino.h
@@ -1,0 +1,78 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 13;
+static const uint8_t SCK = 12;
+
+// LCD pin
+#define LCD_CS  SS
+#define LCD_SCK SCK
+#define LCD_SDA MOSI
+static const uint8_t LCD_DC = 21;
+static const uint8_t LCD_RES = 14;
+static const uint8_t LCD_BL = 3;
+
+// MicroSD Card pin
+static const uint8_t SD_CS = 18;
+static const uint8_t SD_CD = 17;
+
+static const uint8_t BTN_A = 4;
+#define KEY_BUILTIN BTN_A
+
+static const uint8_t LED_BUILTIN = 5;
+
+// DAC pin
+static const uint8_t DAC_DIN = 47;
+static const uint8_t DAC_BCLK = 48;
+static const uint8_t DAC_WS = 45;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/ioxesp32c6/pins_arduino.h
+++ b/variants/ioxesp32c6/pins_arduino.h
@@ -1,0 +1,35 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define PIN_RGB_LED 8
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
+static const uint8_t TX = 16;
+static const uint8_t RX = 17;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS = 18;
+static const uint8_t MOSI = 23;
+static const uint8_t MISO = 20;
+static const uint8_t SCK = 19;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+static const uint8_t A6 = 6;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
This Pull Request add support to three new hardware on the market using ESP32-C6 and ESP32-S3 modules, IOXESP32-C6, ATD3.5-S3. Links to the hardware is provided below

IOXESP32-C6
https://www.artronshop.co.th/product/647/ioxesp32-c6-%E0%B8%9A%E0%B8%AD%E0%B8%A3%E0%B9%8C%E0%B8%94-esp32-c6-%E0%B9%80%E0%B8%8A%E0%B8%B7%E0%B9%88%E0%B8%AD%E0%B8%A1%E0%B8%95%E0%B9%88%E0%B8%AD-wifi-6-bluetooth-5-thread-zigbee

ATD3.5-S3
https://www.artronshop.co.th/product/567/atd3-5-s3-%E0%B8%9A%E0%B8%AD%E0%B8%A3%E0%B9%8C%E0%B8%94-esp32-s3-%E0%B8%9E%E0%B8%A3%E0%B9%89%E0%B8%AD%E0%B8%A1%E0%B8%88%E0%B8%AD-3-5-%E0%B8%99%E0%B8%B4%E0%B9%89%E0%B8%A7-%E0%B8%97%E0%B8%B1%E0%B8%8A-capacitive

These boards are used by Students, Maker and Engineer in Thailand

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v3.0.5 with real hardware

## Related links
-
