### PR TITLE
fix(esp-rainmaker): update esp-rainmaker version to 1.5.0

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -64,7 +64,7 @@ dependencies:
     rules:
       - if: "target != esp32c2"
   espressif/esp_rainmaker:
-    version: "^1.0.0"
+    version: "^1.5.0"
     rules:
       - if: "target != esp32c2"
   espressif/rmaker_common:


### PR DESCRIPTION
Update esp-rainmaker version to 1.5.0 as asked in https://github.com/espressif/arduino-esp32/pull/10456
(New PR targeting `release 3.0.x` as asked [here](https://github.com/espressif/arduino-esp32/pull/10470#issuecomment-2416592275))