### PR TITLE
fix(build): Fix sdkconfig copy for board manager

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -144,8 +144,8 @@ recipe.hooks.core.prebuild.1.pattern.windows=cmd /c echo "-DARDUINO_CORE_BUILD" 
 recipe.hooks.core.postbuild.1.pattern.windows=cmd /c type nul > "{file_opts.path}"
 
 # Copy sdkconfig to build folder
-recipe.hooks.prebuild.8.pattern=/usr/bin/env bash -c "cp -f "{runtime.platform.path}"/tools/esp32-arduino-libs/{build.mcu}/sdkconfig "{build.path}"/sdkconfig"
-recipe.hooks.prebuild.8.pattern.windows=cmd /c COPY /y "{runtime.platform.path}\tools\esp32-arduino-libs\{build.mcu}\sdkconfig" "{build.path}\sdkconfig"
+recipe.hooks.prebuild.8.pattern=/usr/bin/env bash -c "cp -f "{compiler.sdk.path}"/sdkconfig "{build.path}"/sdkconfig"
+recipe.hooks.prebuild.8.pattern.windows=cmd /c COPY /y "{compiler.sdk.path}\sdkconfig" "{build.path}\sdkconfig"
 
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.extra_flags} {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" -DARDUINO_VARIANT="{build.variant}" -DARDUINO_PARTITION_{build.partitions} {build.extra_flags} {compiler.cpreprocessor.flags} {includes} "@{build.opt.path}" "@{file_opts.path}" "{source_file}" -o "{object_file}"


### PR DESCRIPTION
## Description of Change

Fix sdkconfig copy when using Arduino CLI with board manager.

## Tests scenarios

Locally and fork.
