### PR TITLE
fix(zigbee): Enable the internal pull-up resistor for BUTTON_PIN

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/Zigbee_Color_Dimmable_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/Zigbee_Color_Dimmable_Light.ino
@@ -65,7 +65,7 @@ void setup() {
   rgbLedWrite(LED_PIN, 0, 0, 0);
 
   // Init button for factory reset
-  pinMode(BUTTON_PIN, INPUT);
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
 
   // Set callback function for light change
   zbColorLight.onLightChange(setRGBLight);

--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/Zigbee_Color_Dimmer_Switch.ino
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/Zigbee_Color_Dimmer_Switch.ino
@@ -54,7 +54,7 @@ void setup() {
   }
 
   //Init button switch
-  pinMode(SWITCH_PIN, INPUT);
+  pinMode(SWITCH_PIN, INPUT_PULLUP);
 
   //Optional: set Zigbee device name and model
   zbSwitch.setManufacturerAndModel("Espressif", "ZigbeeSwitch");

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Light/Zigbee_On_Off_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Light/Zigbee_On_Off_Light.ino
@@ -51,7 +51,7 @@ void setup() {
   digitalWrite(LED_PIN, LOW);
 
   // Init button for factory reset
-  pinMode(BUTTON_PIN, INPUT);
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
 
   //Optional: set Zigbee device name and model
   zbLight.setManufacturerAndModel("Espressif", "ZBLightBulb");

--- a/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/Zigbee_Temperature_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/Zigbee_Temperature_Sensor.ino
@@ -59,7 +59,7 @@ void setup() {
   }
 
   // Init button switch
-  pinMode(BUTTON_PIN, INPUT);
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
 
   // Optional: set Zigbee device name and model
   zbTempSensor.setManufacturerAndModel("Espressif", "ZigbeeTempSensor");

--- a/libraries/Zigbee/examples/Zigbee_Thermostat/Zigbee_Thermostat.ino
+++ b/libraries/Zigbee/examples/Zigbee_Thermostat/Zigbee_Thermostat.ino
@@ -65,7 +65,7 @@ void setup() {
   }
 
   // Init button switch
-  pinMode(BUTTON_PIN, INPUT);
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
 
   // Set callback functions for temperature and configuration receive
   zbThermostat.onTempRecieve(recieveSensorTemp);


### PR DESCRIPTION
## Description of Change
Configure `BUTTON_PIN`/`SWITCH_PIN` as an input and enable the internal pull-up resistor.
I am facing a factory reset loop using a Waveshare ESP32-H2-DEV-KIT-N4 board witout enabling pull-up.

## Tests scenarios
I tested this with :
Waveshare ESP32-H2-DEV-KIT-N4 board
ESP32-C6-WROOM-1 board

## Related links
Please provide links to related issue, PRs etc.
