### PR TITLE
fix(tests): Add missing files to compilation tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,7 @@ on:
       - 'idf_component.yml'
       - 'Kconfig.projbuild'
       - 'package.json'
+      - 'CMakeLists.txt'
       - '.github/workflows/push.yml'
       - '.github/scripts/**'
       - '!.github/scripts/find_*'
@@ -92,6 +93,7 @@ jobs:
             idf:
               - 'idf_component.yml'
               - 'Kconfig.projbuild'
+              - 'CMakeLists.txt'
             platformio:
               - 'package.json'
               - '.github/scripts/install-platformio-esp32.sh'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -85,7 +85,6 @@ jobs:
               - "variants/esp32/**/*"
               - "variants/esp32s2/**/*"
               - "variants/esp32s3/**/*"
-              - "variants/esp32c2/**/*"
               - "variants/esp32c3/**/*"
               - "variants/esp32c6/**/*"
               - "variants/esp32h2/**/*"
@@ -108,6 +107,7 @@ jobs:
               - 'idf_component.yml'
               - 'Kconfig.projbuild'
               - 'CMakeLists.txt'
+              - "variants/esp32c2/**/*"
             platformio:
               - 'package.json'
               - '.github/scripts/install-platformio-esp32.sh'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,6 +28,13 @@ on:
       - '!.github/scripts/on-release.sh'
       - '!.github/scripts/tests_*'
       - '!.github/scripts/upload_*'
+      - "variants/esp32/**/*"
+      - "variants/esp32s2/**/*"
+      - "variants/esp32s3/**/*"
+      - "variants/esp32c2/**/*"
+      - "variants/esp32c3/**/*"
+      - "variants/esp32c6/**/*"
+      - "variants/esp32h2/**/*"
 
 concurrency:
   group: build-${{github.event.pull_request.number || github.ref}}
@@ -75,6 +82,13 @@ jobs:
               - '!tools/platformio-build.py'
               - 'platform.txt'
               - 'programmers.txt'
+              - "variants/esp32/**/*"
+              - "variants/esp32s2/**/*"
+              - "variants/esp32s3/**/*"
+              - "variants/esp32c2/**/*"
+              - "variants/esp32c3/**/*"
+              - "variants/esp32c6/**/*"
+              - "variants/esp32h2/**/*"
             libraries:
               - 'libraries/**/examples/**'
               - 'libraries/**/src/**'


### PR DESCRIPTION
## Description of Change

Add missing `CMakeLists.txt` and variant files to trigger compilation tests.
