### PR TITLE
IDF release/v5.3

### DIFF
--- a/cores/esp32/esp32-hal-psram.h
+++ b/cores/esp32/esp32-hal-psram.h
@@ -21,7 +21,8 @@ extern "C" {
 
 #include "sdkconfig.h"
 
-#ifndef BOARD_HAS_PSRAM
+// Clear flags in Arduino IDE when PSRAM is disabled
+#if defined(ESP32_ARDUINO_LIB_BUILDER) && !defined(BOARD_HAS_PSRAM)
 #ifdef CONFIG_SPIRAM_SUPPORT
 #undef CONFIG_SPIRAM_SUPPORT
 #endif

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d8edd2fcf990c5af4627c9446efd8c5badb34cfcccfcc3b63bb117d1da77bfae",
-              "size": "343729890"
+              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
+              "size": "343730097"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.3 e5e0324
esp-idf: release/v5.3 5955059940
arduino: idf-release/v5.3 17d05465
tinyusb: master 8b1e40c3e
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.5.1
espressif__esp-zigbee-lib: 1.5.1
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.3.0
espressif__esp32-camera:
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.2
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.22
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
