### PR TITLE
fix(ci): Boards test set fail-fast to false

### DIFF
--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -42,6 +42,7 @@ jobs:
           name: "espressif:esp32"
 
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.find-boards.outputs.fqbns) }}
 
     steps:


### PR DESCRIPTION
## Description of Change
Add fail-fast: false to the boards.yml, so failure of 1 board does not cancel other boards to run.

## Tests scenarios

## Related links