### PR TITLE
fix(i2s): Use separate variables when reading and writing

### DIFF
--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -806,17 +806,19 @@ bool I2SClass::configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slo
 
 size_t I2SClass::readBytes(char *buffer, size_t size) {
   size_t bytes_read = 0;
+  size_t bytes_to_read = 0;
   size_t total_size = 0;
   last_error = ESP_FAIL;
   if (rx_chan == NULL) {
     return total_size;
   }
   while (total_size < size) {
-    bytes_read = size - total_size;
-    if (rx_transform_buf != NULL && bytes_read > I2S_READ_CHUNK_SIZE) {
-      bytes_read = I2S_READ_CHUNK_SIZE;
+    bytes_read = 0;
+    bytes_to_read = size - total_size;
+    if (rx_transform_buf != NULL && bytes_to_read > I2S_READ_CHUNK_SIZE) {
+      bytes_to_read = I2S_READ_CHUNK_SIZE;
     }
-    I2S_ERROR_CHECK_RETURN(rx_fn(rx_chan, rx_transform_buf, (char *)(buffer + total_size), bytes_read, &bytes_read, _timeout), 0);
+    I2S_ERROR_CHECK_RETURN(rx_fn(rx_chan, rx_transform_buf, (char *)(buffer + total_size), bytes_to_read, &bytes_read, _timeout), 0);
     total_size += bytes_read;
   }
   return total_size;
@@ -825,13 +827,15 @@ size_t I2SClass::readBytes(char *buffer, size_t size) {
 size_t I2SClass::write(const uint8_t *buffer, size_t size) {
   size_t written = 0;
   size_t bytes_sent = 0;
+  size_t bytes_to_send = 0;
   last_error = ESP_FAIL;
   if (tx_chan == NULL) {
     return written;
   }
   while (written < size) {
-    bytes_sent = size - written;
-    esp_err_t err = i2s_channel_write(tx_chan, (char *)(buffer + written), bytes_sent, &bytes_sent, _timeout);
+    bytes_sent = 0;
+    bytes_to_send = size - written;
+    esp_err_t err = i2s_channel_write(tx_chan, (char *)(buffer + written), bytes_to_send, &bytes_sent, _timeout);
     setWriteError(err);
     I2S_ERROR_CHECK_RETURN(err, written);
     written += bytes_sent;


### PR DESCRIPTION
When reading and writing we should use separate variables for what we are sending/receiving and what has actually been sent/received. Failing to do so may cause wrong data on the output