### PR TITLE
Update lib - User can choose if calc MD5 from encrypted or decrypted file

### DIFF
--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -139,7 +139,7 @@ public:
       sets the expected MD5 for the firmware (hexString)
       If calc_post_decryption is true, the update library will calculate the MD5 after the decryption, if false the calculation occurs before the decryption
     */
-  bool setMD5(const char *expected_md5, bool calc_post_decryption);
+  bool setMD5(const char *expected_md5, bool calc_post_decryption=true);
 
   /*
       returns the MD5 String of the successfully ended firmware

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -139,7 +139,7 @@ public:
       sets the expected MD5 for the firmware (hexString)
       If calc_post_decryption is true, the update library will calculate the MD5 after the decryption, if false the calculation occurs before the decryption
     */
-  bool setMD5(const char *expected_md5, bool calc_post_decryption=true);
+  bool setMD5(const char *expected_md5, bool calc_post_decryption = true);
 
   /*
       returns the MD5 String of the successfully ended firmware
@@ -257,9 +257,9 @@ private:
   uint32_t _command;
   const esp_partition_t *_partition;
 
-  String _target_md5; 
-  bool _target_md5_decrypted=true;
-  MD5Builder _md5; 
+  String _target_md5;
+  bool _target_md5_decrypted = true;
+  MD5Builder _md5;
 
   int _ledPin;
   uint8_t _ledOn;

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -137,8 +137,9 @@ public:
 
   /*
       sets the expected MD5 for the firmware (hexString)
+      calc_post_decryption if true che update library calc MD5 after decryption, if false the calc is before decryption
     */
-  bool setMD5(const char *expected_md5);
+  bool setMD5(const char *expected_md5, bool calc_post_decryption);
 
   /*
       returns the MD5 String of the successfully ended firmware
@@ -256,8 +257,9 @@ private:
   uint32_t _command;
   const esp_partition_t *_partition;
 
-  String _target_md5;
-  MD5Builder _md5;
+  String _target_md5; 
+  bool _target_md5_decrypted=true;
+  MD5Builder _md5; 
 
   int _ledPin;
   uint8_t _ledOn;

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -137,7 +137,7 @@ public:
 
   /*
       sets the expected MD5 for the firmware (hexString)
-      calc_post_decryption if true che update library calc MD5 after decryption, if false the calc is before decryption
+      If calc_post_decryption is true, the update library will calculate the MD5 after the decryption, if false the calculation occurs before the decryption
     */
   bool setMD5(const char *expected_md5, bool calc_post_decryption);
 

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -453,7 +453,7 @@ bool UpdateClass::_verifyEnd() {
   return false;
 }
 
-bool UpdateClass::setMD5(const char *expected_md5, bool calc_post_decryption=true) {
+bool UpdateClass::setMD5(const char *expected_md5, bool calc_post_decryption) {
   if (strlen(expected_md5) != 32) {
     return false;
   }

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -6,6 +6,7 @@
 
 #include "Update.h"
 #include "Arduino.h" 
+#include "spi_flash_mmap.h"
 #include "esp_ota_ops.h"
 #include "esp_image_format.h"
 #include "mbedtls/aes.h"
@@ -123,7 +124,7 @@ bool UpdateClass::begin(size_t size, int command, int ledPin, uint8_t ledOn, con
   _reset();
   _error = 0;
   _target_md5 = emptyString;
-  _md5 = MD5Builder(); 
+  _md5 = MD5Builder();
 
   if (size == 0) {
     _error = UPDATE_ERROR_SIZE;
@@ -170,7 +171,7 @@ bool UpdateClass::begin(size_t size, int command, int ledPin, uint8_t ledOn, con
   }
   _size = size;
   _command = command;
-  _md5.begin(); 
+  _md5.begin();
   return true;
 }
 
@@ -458,7 +459,6 @@ bool UpdateClass::setMD5(const char *expected_md5, bool calc_post_decryption=tru
   }
   _target_md5 = expected_md5;
   _target_md5.toLowerCase();
-
   _target_md5_decrypted=calc_post_decryption;
   return true;
 }
@@ -481,8 +481,7 @@ bool UpdateClass::end(bool evenIfRemaining) {
     _size = progress();
   }
 
-  _md5.calculate(); 
-
+  _md5.calculate();
   if (_target_md5.length()) {
     if (_target_md5 != _md5.toString()) {
       _abort(UPDATE_ERROR_MD5);

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -349,7 +349,7 @@ bool UpdateClass::_writeBuffer() {
     }
   }
 
-  if(!_target_md5_decrypted){
+  if (!_target_md5_decrypted) {
     _md5.add(_buffer, _bufferLen);
   }
 
@@ -409,9 +409,9 @@ bool UpdateClass::_writeBuffer() {
   if (!_progress && _command == U_FLASH) {
     _buffer[0] = ESP_IMAGE_HEADER_MAGIC;
   }
-  if(_target_md5_decrypted){
+  if (_target_md5_decrypted) {
     _md5.add(_buffer, _bufferLen);
-  } 
+  }
   _progress += _bufferLen;
   _bufferLen = 0;
   if (_progress_callback) {
@@ -459,7 +459,7 @@ bool UpdateClass::setMD5(const char *expected_md5, bool calc_post_decryption) {
   }
   _target_md5 = expected_md5;
   _target_md5.toLowerCase();
-  _target_md5_decrypted=calc_post_decryption;
+  _target_md5_decrypted = calc_post_decryption;
   return true;
 }
 

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "Update.h"
-#include "Arduino.h" 
+#include "Arduino.h"
 #include "spi_flash_mmap.h"
 #include "esp_ota_ops.h"
 #include "esp_image_format.h"


### PR DESCRIPTION
## Description of Change
I'm using OTA with pre-encrypted bin file.
So it's easy to calculate the MD5 of the encrypted file before send it to device.
Update function at the moment is calculating the MD5 of the decrypted file.
With this commit with
`Update.setMD5(md5, false);`
the check of MD5 will be done of encrypted file. Otherwise it will be calculate of the decrypted file.


## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v3.0.6 with ESP32
 
