### PR TITLE
fix(eth): Set default clock in pin value to zero

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -210,7 +210,7 @@ bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int mdc, int mdio, i
 
 #if CONFIG_IDF_TARGET_ESP32
 #undef DEFAULT_RMII_CLK_GPIO
-#define DEFAULT_RMII_CLK_GPIO (emac_rmii_clock_gpio_t)(CONFIG_ETH_RMII_CLK_IN_GPIO)
+#define DEFAULT_RMII_CLK_GPIO (emac_rmii_clock_gpio_t)(0)
 #endif
 
   eth_esp32_emac_config_t mac_config = ETH_EMAC_DEFAULT_CONFIG();


### PR DESCRIPTION
When Arduino is used as component, `CONFIG_ETH_RMII_CLK_IN_GPIO` might not be defined, so we set it to const `0` to clear the issue.

Fixes: https://github.com/espressif/arduino-esp32/issues/10440