### PR TITLE
feature(rtos): Add Tasks status print function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(CORE_SRCS
   cores/esp32/esp32-hal-uart.c
   cores/esp32/esp32-hal-rmt.c
   cores/esp32/Esp.cpp
+  cores/esp32/freertos_stats.cpp
   cores/esp32/FunctionalInterrupt.cpp
   cores/esp32/HardwareSerial.cpp
   cores/esp32/HEXBuilder.cpp

--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -199,6 +199,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 #include "Udp.h"
 #include "HardwareSerial.h"
 #include "Esp.h"
+#include "freertos_stats.h"
 
 // Use float-compatible stl abs() and round(), we don't use Arduino macros to avoid issues with the C++ libraries
 using std::abs;

--- a/cores/esp32/freertos_stats.cpp
+++ b/cores/esp32/freertos_stats.cpp
@@ -1,7 +1,19 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "freertos_stats.h"
 #include "sdkconfig.h"
-//#undef CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
-//#undef CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
 
 #if CONFIG_FREERTOS_USE_TRACE_FACILITY
 #include "freertos/FreeRTOS.h"
@@ -97,5 +109,7 @@ void printRunningTasks(Print & printer) {
     vPortFree( pxTaskStatusArray );
     printer.println();
   }
+#else
+  printer.println("FreeRTOS trace facility is not enabled.");
 #endif /* CONFIG_FREERTOS_USE_TRACE_FACILITY */
 }

--- a/cores/esp32/freertos_stats.cpp
+++ b/cores/esp32/freertos_stats.cpp
@@ -44,7 +44,7 @@ void printRunningTasks(Print & printer) {
 #endif
     printer.printf("Tasks: %u"
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-      ", Runtime: %us, Period: %uus"
+      ", Runtime: %lus, Period: %luus"
 #endif
       "\n", uxArraySize
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS

--- a/cores/esp32/freertos_stats.cpp
+++ b/cores/esp32/freertos_stats.cpp
@@ -53,7 +53,7 @@ void printRunningTasks(Print & printer) {
     );
     printer.printf("Num\t            Name"
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-      "\t     Load"
+      "\tLoad"
 #endif
       "\tPrio\t Free"
 #if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
@@ -72,7 +72,7 @@ void printRunningTasks(Print & printer) {
 #endif
       printer.printf("%3u\t%16s"
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-      "\t%8lu%%"
+      "\t%3lu%%"
 #endif
       "\t%4u\t%5lu"
 #if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID

--- a/cores/esp32/freertos_stats.cpp
+++ b/cores/esp32/freertos_stats.cpp
@@ -21,10 +21,10 @@
 #include "freertos/portable.h"
 #endif /* CONFIG_FREERTOS_USE_TRACE_FACILITY */
 
-void printRunningTasks(Print & printer) {
+void printRunningTasks(Print &printer) {
 #if CONFIG_FREERTOS_USE_TRACE_FACILITY
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-#define FREERTOS_TASK_NUMBER_MAX_NUM 256 // RunTime stats for how many Tasks to be stored
+#define FREERTOS_TASK_NUMBER_MAX_NUM 256  // RunTime stats for how many Tasks to be stored
   static configRUN_TIME_COUNTER_TYPE ulRunTimeCounters[FREERTOS_TASK_NUMBER_MAX_NUM];
   static configRUN_TIME_COUNTER_TYPE ulLastRunTime = 0;
   configRUN_TIME_COUNTER_TYPE ulCurrentRunTime = 0, ulTaskRunTime = 0;
@@ -32,20 +32,13 @@ void printRunningTasks(Print & printer) {
   configRUN_TIME_COUNTER_TYPE ulTotalRunTime = 0;
   TaskStatus_t *pxTaskStatusArray = NULL;
   volatile UBaseType_t uxArraySize = 0, x = 0;
-  const char * taskStates[] = {
-    "Running",
-    "Ready",
-    "Blocked",
-    "Suspended",
-    "Deleted",
-    "Invalid"
-  };
+  const char *taskStates[] = {"Running", "Ready", "Blocked", "Suspended", "Deleted", "Invalid"};
 
   // Take a snapshot of the number of tasks in case it changes while this function is executing.
   uxArraySize = uxTaskGetNumberOfTasks();
 
   // Allocate a TaskStatus_t structure for each task.
-  pxTaskStatusArray = (TaskStatus_t*)pvPortMalloc(uxArraySize * sizeof(TaskStatus_t));
+  pxTaskStatusArray = (TaskStatus_t *)pvPortMalloc(uxArraySize * sizeof(TaskStatus_t));
 
   if (pxTaskStatusArray != NULL) {
     // Generate raw status information about each task.
@@ -55,52 +48,54 @@ void printRunningTasks(Print & printer) {
     ulCurrentRunTime = ulTotalRunTime - ulLastRunTime;
     ulLastRunTime = ulTotalRunTime;
 #endif
-    printer.printf("Tasks: %u"
+    printer.printf(
+      "Tasks: %u"
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
       ", Runtime: %lus, Period: %luus"
 #endif
-      "\n", uxArraySize
+      "\n",
+      uxArraySize
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-      , ulTotalRunTime / 1000000, ulCurrentRunTime
+      ,
+      ulTotalRunTime / 1000000, ulCurrentRunTime
 #endif
     );
     printer.printf("Num\t            Name"
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-      "\tLoad"
+                   "\tLoad"
 #endif
-      "\tPrio\t Free"
+                   "\tPrio\t Free"
 #if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
-      "\tCore"
+                   "\tCore"
 #endif
-      "\tState\r\n");
+                   "\tState\r\n");
     for (x = 0; x < uxArraySize; x++) {
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
       if (pxTaskStatusArray[x].xTaskNumber < FREERTOS_TASK_NUMBER_MAX_NUM) {
         ulTaskRunTime = (pxTaskStatusArray[x].ulRunTimeCounter - ulRunTimeCounters[pxTaskStatusArray[x].xTaskNumber]);
         ulRunTimeCounters[pxTaskStatusArray[x].xTaskNumber] = pxTaskStatusArray[x].ulRunTimeCounter;
-        ulTaskRunTime = (ulTaskRunTime * 100) / ulCurrentRunTime; // in percentage
+        ulTaskRunTime = (ulTaskRunTime * 100) / ulCurrentRunTime;  // in percentage
       } else {
         ulTaskRunTime = 0;
       }
 #endif
-      printer.printf("%3u\t%16s"
+      printer.printf(
+        "%3u\t%16s"
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-      "\t%3lu%%"
+        "\t%3lu%%"
 #endif
-      "\t%4u\t%5lu"
+        "\t%4u\t%5lu"
 #if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
-      "\t%4c"
+        "\t%4c"
 #endif
-      "\t%s\r\n",
-        pxTaskStatusArray[x].xTaskNumber,
-        pxTaskStatusArray[x].pcTaskName,
+        "\t%s\r\n",
+        pxTaskStatusArray[x].xTaskNumber, pxTaskStatusArray[x].pcTaskName,
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
         ulTaskRunTime,
 #endif
-        pxTaskStatusArray[x].uxCurrentPriority,
-        pxTaskStatusArray[x].usStackHighWaterMark,
+        pxTaskStatusArray[x].uxCurrentPriority, pxTaskStatusArray[x].usStackHighWaterMark,
 #if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
-        (pxTaskStatusArray[x].xCoreID == tskNO_AFFINITY)?'*':('0'+pxTaskStatusArray[x].xCoreID),
+        (pxTaskStatusArray[x].xCoreID == tskNO_AFFINITY) ? '*' : ('0' + pxTaskStatusArray[x].xCoreID),
 #endif
         taskStates[pxTaskStatusArray[x].eCurrentState]
       );

--- a/cores/esp32/freertos_stats.cpp
+++ b/cores/esp32/freertos_stats.cpp
@@ -1,0 +1,101 @@
+#include "freertos_stats.h"
+#include "sdkconfig.h"
+//#undef CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
+//#undef CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+
+#if CONFIG_FREERTOS_USE_TRACE_FACILITY
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/portable.h"
+#endif /* CONFIG_FREERTOS_USE_TRACE_FACILITY */
+
+void printRunningTasks(Print & printer) {
+#if CONFIG_FREERTOS_USE_TRACE_FACILITY
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+#define FREERTOS_TASK_NUMBER_MAX_NUM 256
+  static UBaseType_t ulRunTimeCounters[FREERTOS_TASK_NUMBER_MAX_NUM];
+  static configRUN_TIME_COUNTER_TYPE ulLastRunTime = 0;
+#endif
+  TaskStatus_t *pxTaskStatusArray = NULL;
+  volatile UBaseType_t uxArraySize = 0, x = 0;
+  configRUN_TIME_COUNTER_TYPE ulTotalRunTime = 0, uiCurrentRunTime = 0, uiTaskRunTime = 0;
+  const char * taskStates[] = {
+    "Running",
+    "Ready",
+    "Blocked",
+    "Suspended",
+    "Deleted",
+    "Invalid"
+  };
+
+  // Take a snapshot of the number of tasks in case it changes while this function is executing.
+  uxArraySize = uxTaskGetNumberOfTasks();
+  //printer.printf("Running tasks: %u\n", uxArraySize);
+
+  // Allocate a TaskStatus_t structure for each task.
+  pxTaskStatusArray = (TaskStatus_t*)pvPortMalloc( uxArraySize * sizeof( TaskStatus_t ) );
+
+  if( pxTaskStatusArray != NULL ) {
+    // Generate raw status information about each task.
+    uxArraySize = uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, &ulTotalRunTime );
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+    uiCurrentRunTime = ulTotalRunTime - ulLastRunTime;
+    ulLastRunTime = ulTotalRunTime;
+#endif
+    printer.printf("Tasks: %u"
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+      ", Runtime: %us, Period: %uus"
+#endif
+      "\n", uxArraySize
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+      , ulTotalRunTime / 1000000, uiCurrentRunTime
+#endif
+    );
+    printer.printf("Num\t            Name"
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+      "\t     Load"
+#endif
+      "\tPrio\t Free"
+#if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
+      "\tCore"
+#endif
+      "\tState\r\n");
+    for( x = 0; x < uxArraySize; x++ ) {
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+      if (pxTaskStatusArray[ x ].xTaskNumber < FREERTOS_TASK_NUMBER_MAX_NUM) {
+        uiTaskRunTime = (pxTaskStatusArray[ x ].ulRunTimeCounter - ulRunTimeCounters[pxTaskStatusArray[ x ].xTaskNumber]);
+        ulRunTimeCounters[pxTaskStatusArray[ x ].xTaskNumber] = pxTaskStatusArray[ x ].ulRunTimeCounter;
+        uiTaskRunTime = (uiTaskRunTime * 100) / uiCurrentRunTime; // in percentage
+      } else {
+        uiTaskRunTime = 0;
+      }
+#endif
+      printer.printf("%3u\t%16s"
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+      "\t%8lu%%"
+#endif
+      "\t%4u\t%5lu"
+#if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
+      "\t%4c"
+#endif
+      "\t%s\r\n",
+        pxTaskStatusArray[ x ].xTaskNumber,
+        pxTaskStatusArray[ x ].pcTaskName,
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+        uiTaskRunTime,
+#endif
+        pxTaskStatusArray[ x ].uxCurrentPriority,
+        pxTaskStatusArray[ x ].usStackHighWaterMark,
+#if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
+        (pxTaskStatusArray[ x ].xCoreID == tskNO_AFFINITY)?'*':('0'+pxTaskStatusArray[ x ].xCoreID),
+#endif
+        taskStates[pxTaskStatusArray[ x ].eCurrentState]
+      );
+    }
+
+    // The array is no longer needed, free the memory it consumes.
+    vPortFree( pxTaskStatusArray );
+    printer.println();
+  }
+#endif /* CONFIG_FREERTOS_USE_TRACE_FACILITY */
+}

--- a/cores/esp32/freertos_stats.h
+++ b/cores/esp32/freertos_stats.h
@@ -1,4 +1,28 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
+
+#ifdef __cplusplus
+
 #include "Print.h"
 
+/*
+ * Executing this function will cause interrupts and
+ * the scheduler to be blocked for some time.
+ * Please use only for debugging purposes.
+ */
 void printRunningTasks(Print & printer);
+
+#endif

--- a/cores/esp32/freertos_stats.h
+++ b/cores/esp32/freertos_stats.h
@@ -23,6 +23,6 @@
  * the scheduler to be blocked for some time.
  * Please use only for debugging purposes.
  */
-void printRunningTasks(Print & printer);
+void printRunningTasks(Print &printer);
 
 #endif

--- a/cores/esp32/freertos_stats.h
+++ b/cores/esp32/freertos_stats.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "Print.h"
+
+void printRunningTasks(Print & printer);


### PR DESCRIPTION
Example output on ESP32-P4 with WiFi and ETH running:
```
Tasks: 17, Runtime: 151s, Period: 2083447us
Num	            Name	     Load	Prio	 Free	Core	State
  8	        loopTask	       0%	   1	 5736	   1	Running
  5	           IDLE0	      99%	   0	  684	   0	Ready
  6	           IDLE1	      99%	   0	  748	   1	Ready
 10	             tiT	       0%	  18	 3664	   0	Blocked
 12	  arduino_events	       0%	  19	 2384	   1	Blocked
 17	      sdio_write	       0%	  23	 4304	   *	Blocked
  1	            ipc0	       0%	  24	  716	   0	Suspended
 19	          rpc_tx	       0%	  23	 4240	   *	Blocked
  7	         Tmr Svc	       0%	   1	 1708	   *	Blocked
 18	          rpc_rx	       0%	  23	 3068	   *	Blocked
  3	       esp_timer	       0%	  22	 4292	   0	Suspended
 13	         emac_rx	       0%	  15	 3568	   *	Suspended
 15	       sdio_read	       0%	  23	 2760	   1	Blocked
 14	     sdio_rx_buf	       0%	  23	 4604	   *	Blocked
 16	 sdio_process_rx	       0%	  23	 4596	   *	Blocked
  2	            ipc1	       0%	  24	  716	   1	Suspended
 11	         sys_evt	       0%	  20	  800	   0	Blocked
```

Connected to: https://github.com/espressif/arduino-esp32/issues/4746 and https://github.com/espressif/arduino-esp32/issues/7179
Requires: https://github.com/espressif/esp32-arduino-lib-builder/pull/234
