### PR TITLE
ESP32-P4 UART pins setup, begin, detach,  loopback function FIX

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -435,7 +435,6 @@ void HardwareSerial::end() {
   if (uartGetDebug() == _uart_nr) {
     uartSetDebug(0);
   }
-  uart_set_loop_back(_uart_nr, false);  // disable loopback mode, if previously enabled
   _rxFIFOFull = 0;
   uartEnd(_uart_nr);    // fully detach all pins and delete the UART driver
   _destroyEventTask();  // when IDF uart driver is deleted, _eventTask must finish too

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -200,8 +200,6 @@ typedef enum {
 #define RX2 (gpio_num_t)4
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define RX2 (gpio_num_t)19
-#elif CONFIG_IDF_TARGET_ESP32P4
-#define RX2 (gpio_num_t)15
 #endif
 #endif
 
@@ -210,8 +208,6 @@ typedef enum {
 #define TX2 (gpio_num_t)25
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define TX2 (gpio_num_t)20
-#elif CONFIG_IDF_TARGET_ESP32P4
-#define TX2 (gpio_num_t)14
 #endif
 #endif
 #endif /* SOC_UART_HP_NUM > 2 */

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1166,11 +1166,11 @@ unsigned long uartDetectBaudrate(uart_t *uart) {
    This function internally binds defined UARTs TX signal with defined RX pin of any UART (same or different).
    This creates a loop that lets us receive anything we send on the UART without external wires.
 */
-void uart_internal_loopback(uint8_t uartNum, int8_t rxPin) {
-  if (uartNum > SOC_UART_HP_NUM - 1 || !GPIO_IS_VALID_GPIO(rxPin)) {
+void uart_internal_loopback(uint8_t uartNum, bool loop_back_en) {
+  if (uartNum > SOC_UART_HP_NUM - 1) {
     return;
   }
-  esp_rom_gpio_connect_out_signal(rxPin, UART_TX_SIGNAL(uartNum), false, false);
+  uart_set_loop_back(uartNum, loop_back_en);
 }
 
 /*

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -166,6 +166,7 @@ static bool _uartDetachBus_RX(void *busptr) {
   // sanity check - it should never happen
   assert(busptr && "_uartDetachBus_RX bus NULL pointer.");
   uart_t *bus = (uart_t *)busptr;
+  uart_set_loop_back(bus->num, false); // disable loopback
   return _uartDetachPins(bus->num, bus->_rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
 }
 
@@ -173,6 +174,7 @@ static bool _uartDetachBus_TX(void *busptr) {
   // sanity check - it should never happen
   assert(busptr && "_uartDetachBus_TX bus NULL pointer.");
   uart_t *bus = (uart_t *)busptr;
+  uart_set_loop_back(bus->num, false); // disable loopback
   return _uartDetachPins(bus->num, UART_PIN_NO_CHANGE, bus->_txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
 }
 

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -106,7 +106,7 @@ unsigned long uartDetectBaudrate(uart_t *uart);
 
 // Make sure UART's RX signal is connected to TX pin
 // This creates a loop that lets us receive anything we send on the UART
-void uart_internal_loopback(uint8_t uartNum, int8_t rxPin);
+void uart_internal_loopback(uint8_t uartNum, bool loop_back_en);
 
 // Routines that generate BREAK in the UART for testing purpose
 


### PR DESCRIPTION
## Description of Change
In order to make ESP32-P4 UART loopback to work, the UART peripheral bit enables internal UART loop back.
It shall be turned off when the Serial port ends or when the RX or TX pins are detached.

This PR also deals with ESP32-P4 that has 5 UART ports.
There is definition for UART0 and UART1 pins.
Other UART shall have its pins setup in `begin()`.
This PR checks if the pins have been set and issues an error message in case no pins RX/TX are defined.

## Tests scenarios
ESP32-P4 only

``` cpp
#include "driver/uart.h"

bool loopbackUART1Test() {
  const char *sentMsg = "Testing!";
  Serial1.write(sentMsg, strlen(sentMsg));
  String readMsg = "";
  uint32_t testTimeout_ms = 500;
  uint32_t now_ms = millis();
  while (millis() < now_ms + testTimeout_ms) {
    if (Serial1.available()) {
      readMsg += (char) Serial1.read();
    }
  }
  Serial.printf("Sent[%s] == Received[%s]\r\n", sentMsg, readMsg.c_str());
  return !strcmp(sentMsg, readMsg.c_str());
}

void setup() {
  Serial.begin(115200);  // No error. Using default pins 36 and 37.
  //Serial2.begin(115200); // this shall issue an error message and do nothing.

  bool testStatus[3] = { true, true, true };
  const char *testCase[3] = {
    "UART0 Looback function",
    "UART0 end() -> Loopback off",
    "UART0 detach -> Lopback off"
  };
  // Test Case 1: UART Loopback is active
  Serial1.begin(115200); // No error. Using default pins 10 and 11.
  uart_set_loop_back(1, true); // IDF Function - sets loopback on UART 1
  if (!loopbackUART1Test()) {
    testStatus[0] = false;
  }

  // Test Case 2: Serial.end() shall set UART Loopback off
  Serial1.end(); // Shall turn loopback off
  Serial1.begin(115200); // No error. Using default pins 10 and 11.
  if (loopbackUART1Test()) {
    testStatus[1] = false;
  }

  // Test Case 3: UART detach shall set Loopback off
  bool testRMTInit = true;
  uart_set_loop_back(1, true); // IDF Function - sets loopback on UART 1
  if (!rmtInit(RX1, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 400000)) {  //2.5us tick
    testRMTInit = false;
  }
  if (loopbackUART1Test()) {
    testStatus[2] = false;
  }

  // Reporting
  Serial1.end();
  Serial.println("\r\n================================");
  for (uint8_t i = 0; i < 3; i++) {
    Serial.print(testCase[i]);
    Serial.print(" ==> ");
    Serial.println(testStatus[i] ? "OK" : "FAIL");
  }
  if (testRMTInit) {
    Serial.println("RMT initialization ==> OK");
  } else {
    Serial.println("RMT initialization ==> FAIL");
  }
}

void loop() {
}
```
## Related links
None