### PR TITLE
ESP32-P4 UART Pin Definitions

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -390,7 +390,7 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
     HSERIAL_MUTEX_UNLOCK();
     return;
   }
-  
+
   // IDF UART driver keeps Pin setting on restarting. Negative Pin number will keep it unmodified.
   // it will detach previous UART attached pins
 

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -313,6 +313,11 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
   // map logical pins to GPIO numbers
   rxPin = digitalPinToGPIONumber(rxPin);
   txPin = digitalPinToGPIONumber(txPin);
+  int8_t _rxPin = uart_get_RxPin(_uart_nr);
+  int8_t _txPin = uart_get_TxPin(_uart_nr);
+
+  rxPin = rxPin < 0 ? _rxPin : rxPin;
+  txPin = txPin < 0 ? _txPin : txPin;
 
   HSERIAL_MUTEX_LOCK();
   // First Time or after end() --> set default Pins
@@ -343,13 +348,9 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
           // do not change RX2/TX2 if it has already been set before
 #ifdef RX2
           rxPin = _rxPin < 0 ? (int8_t)RX2 : _rxPin;
-#else
-          rxPin = _rxPin;
 #endif
 #ifdef TX2
           txPin = _txPin < 0 ? (int8_t)TX2 : _txPin;
-#else
-          txPin = _txPin;
 #endif
         }
         break;
@@ -360,13 +361,9 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
           // do not change RX2/TX2 if it has already been set before
 #ifdef RX3
           rxPin = _rxPin < 0 ? (int8_t)RX3 : _rxPin;
-#else
-          rxPin = _rxPin;
 #endif
 #ifdef TX3
           txPin = _txPin < 0 ? (int8_t)TX3 : _txPin;
-#else
-          txPin = _txPin;
 #endif
         }
         break;
@@ -377,13 +374,9 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
           // do not change RX2/TX2 if it has already been set before
 #ifdef RX4
           rxPin = _rxPin < 0 ? (int8_t)RX4 : _rxPin;
-#else
-          rxPin = _rxPin;
 #endif
 #ifdef TX4
           txPin = _txPin < 0 ? (int8_t)TX4 : _txPin;
-#else
-          txPin = _txPin;
 #endif
         }
         break;

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -341,14 +341,63 @@ void HardwareSerial::begin(unsigned long baud, uint32_t config, int8_t rxPin, in
       case UART_NUM_2:
         if (rxPin < 0 && txPin < 0) {
           // do not change RX2/TX2 if it has already been set before
+#ifdef RX2
           rxPin = _rxPin < 0 ? (int8_t)RX2 : _rxPin;
+#else
+          rxPin = _rxPin;
+#endif
+#ifdef TX2
           txPin = _txPin < 0 ? (int8_t)TX2 : _txPin;
+#else
+          txPin = _txPin;
+#endif
+        }
+        break;
+#endif
+#if SOC_UART_HP_NUM > 3  // may save some flash bytes...
+      case UART_NUM_3:
+        if (rxPin < 0 && txPin < 0) {
+          // do not change RX2/TX2 if it has already been set before
+#ifdef RX3
+          rxPin = _rxPin < 0 ? (int8_t)RX3 : _rxPin;
+#else
+          rxPin = _rxPin;
+#endif
+#ifdef TX3
+          txPin = _txPin < 0 ? (int8_t)TX3 : _txPin;
+#else
+          txPin = _txPin;
+#endif
+        }
+        break;
+#endif
+#if SOC_UART_HP_NUM > 4  // may save some flash bytes...
+      case UART_NUM_4:
+        if (rxPin < 0 && txPin < 0) {
+          // do not change RX2/TX2 if it has already been set before
+#ifdef RX4
+          rxPin = _rxPin < 0 ? (int8_t)RX4 : _rxPin;
+#else
+          rxPin = _rxPin;
+#endif
+#ifdef TX4
+          txPin = _txPin < 0 ? (int8_t)TX4 : _txPin;
+#else
+          txPin = _txPin;
+#endif
         }
         break;
 #endif
     }
   }
 
+  // if no RX/TX pins are defined, it will not start the UART driver
+  if (rxPin < 0 && txPin < 0) {
+    log_e("No RX/TX pins defined. Please set RX/TX pins.");
+    HSERIAL_MUTEX_UNLOCK();
+    return;
+  }
+  
   // IDF UART driver keeps Pin setting on restarting. Negative Pin number will keep it unmodified.
   // it will detach previous UART attached pins
 

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -200,8 +200,6 @@ typedef enum {
 #define RX2 (gpio_num_t)4
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define RX2 (gpio_num_t)19
-#elif CONFIG_IDF_TARGET_ESP32P4
-#define RX2 (gpio_num_t)15
 #endif
 #endif
 
@@ -210,8 +208,6 @@ typedef enum {
 #define TX2 (gpio_num_t)25
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define TX2 (gpio_num_t)20
-#elif CONFIG_IDF_TARGET_ESP32P4
-#define TX2 (gpio_num_t)14
 #endif
 #endif
 #endif /* SOC_UART_HP_NUM > 2 */

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -52,6 +52,14 @@
 #define NEW_TX1 10
 #endif
 
+// ESP32-P4 has no UART pin definition for RX2, TX2, RX3, TX3, RX4, TX4
+#ifndef RX2
+#define RX2 RX1
+#endif
+#ifndef TX2
+#define TX2 RX1
+#endif
+
 /* Utility global variables */
 
 static String recv_msg = "";


### PR DESCRIPTION
## Description of Change
ESP32-P4 has UART default pins only for UART0 and UART1.
This PR allows the board definition from pins_arduino.h to define RX2 ... RX4 and TX2 ... TX4 if necessary.
It also solves the issue of begin(baud) with no pins for UART2...4 by just sending an error message and returning doing nothing.

## Tests scenarios
ESP32-P4

``` cpp
void setup(){
   // UART parameters shall be visible in the logs using Verbose mode
  Serial.begin(115200);
  Serial.println("=============================================");
  Serial1.begin(115200); // no error message as there are default pins
  Serial.println("=============================================");
  
  Serial2.begin(115200); // it shall send an error because there are no default pins
  Serial.println("=============================================");
  Serial2.begin(115200, SERIAL_8N1, 14, 15); // no error - pins are defined
  Serial.println("=============================================");
  Serial2.begin(9600); // no error - pins already set - just changing the baud rate
  Serial.println("=============================================");
  Serial2.begin(115200, SERIAL_8N1, 16); // no error - pins are defined - just changing the RX pin
  Serial.println("=============================================");
}

void loop(){
}
```

### Expected Result (log output):
```
============ Before Setup End ============
[   510][V][esp32-hal-uart.c:422] uartBegin(): UART0 baud(115200) Mode(800001c) rxPin(11) txPin(10)
[   519][V][esp32-hal-uart.c:511] uartBegin(): UART0 not installed. Starting installation
[   527][V][esp32-hal-uart.c:576] uartBegin(): UART0 initialization done.
=============================================
[   534][V][esp32-hal-uart.c:422] uartBegin(): UART1 baud(115200) Mode(800001c) rxPin(37) txPin(36)
[   547][V][esp32-hal-uart.c:511] uartBegin(): UART1 not installed. Starting installation
[   555][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 37 successfully set to type UART_RX (2) with bus 0x3fc92a20
[   566][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 36 successfully set to type UART_TX (3) with bus 0x3fc92a20
[   577][V][esp32-hal-uart.c:576] uartBegin(): UART1 initialization done.
=============================================
[   583][E][HardwareSerial.cpp:360] begin(): No RX/TX pins defined. Please set RX/TX pins.
=============================================
[   595][V][esp32-hal-uart.c:422] uartBegin(): UART2 baud(115200) Mode(800001c) rxPin(14) txPin(15)
[   608][V][esp32-hal-uart.c:511] uartBegin(): UART2 not installed. Starting installation
[   616][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 14 successfully set to type UART_RX (2) with bus 0x3fc92a40
[   627][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 15 successfully set to type INIT (0) with bus 0x0
[   637][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 15 successfully set to type INIT (0) with bus 0x0
[   647][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 15 successfully set to type UART_TX (3) with bus 0x3fc92a40
[   658][V][esp32-hal-uart.c:576] uartBegin(): UART2 initialization done.
=============================================
[   664][V][esp32-hal-uart.c:422] uartBegin(): UART2 baud(9600) Mode(800001c) rxPin(14) txPin(15)
[   677][V][esp32-hal-uart.c:435] uartBegin(): UART2 Driver already installed.
[   684][V][esp32-hal-uart.c:450] uartBegin(): UART2 changed baudrate to 9600
=============================================
[   691][V][esp32-hal-uart.c:422] uartBegin(): UART2 baud(115200) Mode(800001c) rxPin(16) txPin(15)
[   704][V][esp32-hal-uart.c:435] uartBegin(): UART2 Driver already installed.
[   711][V][esp32-hal-uart.c:450] uartBegin(): UART2 changed baudrate to 115200
[   718][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 14 successfully set to type INIT (0) with bus 0x0
[   728][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 16 successfully set to type INIT (0) with bus 0x0
[   737][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 16 successfully set to type INIT (0) with bus 0x0
[   747][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 16 successfully set to type UART_RX (2) with bus 0x3fc92a40
[   758][V][esp32-hal-uart.c:490] uartBegin(): UART2 changed RX pin to 16
=============================================
=========== After Setup Start ============
```

## Related links
None