### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-59550599"
+              "version": "idf-release_v5.3-a0f798cf"
             },
             {
               "packager": "esp32",
@@ -67,7 +67,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20240821"
+              "version": "v0.12.0-esp32-20241016"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-59550599",
+          "version": "idf-release_v5.3-a0f798cf",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-59550599.zip",
-              "checksum": "SHA-256:d2f18131dc7220c2d89ece7f8594fa3866523f8183612af37112ed0177f41af7",
-              "size": "343730097"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
+              "checksum": "SHA-256:cc0c44739a2ae9b4d17b0026907132592a3888fdf3bb910c2ad730931fc6c9dc",
+              "size": "344062217"
             }
           ]
         },
@@ -405,56 +405,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20240821",
+          "version": "v0.12.0-esp32-20241016",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240821/openocd-esp32-linux-amd64-0.12.0-esp32-20240821.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20240821.tar.gz",
-              "checksum": "SHA-256:f8c68541fa38307bc0c0763b7e1e3fe4e943d5d45da07d817a73b492e103b652",
-              "size": "2373094"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:e82b0f036dc99244bead5f09a86e91bb2365cbcd1122ac68261e5647942485df",
+              "size": "2398717"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240821/openocd-esp32-linux-arm64-0.12.0-esp32-20240821.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20240821.tar.gz",
-              "checksum": "SHA-256:4d6e263d84e447354dc685848557d6c284dda7fe007ee451f729a7edfa7baad7",
-              "size": "2251272"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:8f8daf5bd22ec5d2fa9257b0862ec33da18ee677e023fb9a9eb17f74ce208c76",
+              "size": "2271584"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240821/openocd-esp32-linux-armel-0.12.0-esp32-20240821.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20240821.tar.gz",
-              "checksum": "SHA-256:9d45679f2c4cf450d5e2350047cf57bb76dde2487d30cebce0a72c9173b5c45b",
-              "size": "2390074"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:bc9c020ecf20e2000f76cffa44305fd5bc44d2e688ea78cce423399d33f19767",
+              "size": "2414206"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240821/openocd-esp32-macos-0.12.0-esp32-20240821.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20240821.tar.gz",
-              "checksum": "SHA-256:565c8fabc5f19a6e7a0864a294d74b307eec30b9291d16d3fc90e273f0330cb4",
-              "size": "2485320"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:02a2dffe801a2d005fa9e614d80ff8173395b2cb0b5d3118d0229d094a9946a7",
+              "size": "2508089"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240821/openocd-esp32-macos-arm64-0.12.0-esp32-20240821.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20240821.tar.gz",
-              "checksum": "SHA-256:68c5c7cf3d15b9810939a5edabc6ff2c9f4fc32262de91fc292a180bc5cc0637",
-              "size": "2530336"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
+              "checksum": "SHA-256:c382f9e884d6565cb6089bff5f200f4810994667d885f062c3d3c5625a0fa9d6",
+              "size": "2552569"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240821/openocd-esp32-win32-0.12.0-esp32-20240821.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20240821.zip",
-              "checksum": "SHA-256:463fc2903ddaf03f86ff50836c5c63cc696550b0446140159eddfd2e85570c5d",
-              "size": "2916409"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win32-0.12.0-esp32-20241016.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20241016.zip",
+              "checksum": "SHA-256:3b5d615e0a72cc771a45dd469031312d5881c01d7b6bc9edb29b8b6bda8c2e90",
+              "size": "2946244"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20240821/openocd-esp32-win64-0.12.0-esp32-20240821.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20240821.zip",
-              "checksum": "SHA-256:550f57369f1f1f6cc600b5dffa3378fd6164d8ea8db7c567cf41091771f090cb",
-              "size": "2916408"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win64-0.12.0-esp32-20241016.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20241016.zip",
+              "checksum": "SHA-256:5e7b2fd1947d3a8625f6a11db7a2340cf2f41ff4c61284c022c7d7c32b18780a",
+              "size": "2946244"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.3 7977581
esp-idf: release/v5.3 a0f798cfc4
arduino: release/v3.1.x a3ee3766
tinyusb: master 8b1e40c3e
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.5.1
espressif__esp-zigbee-lib: 1.5.1
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.2
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.22
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
