### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-632e0c2a"
+              "version": "idf-release_v5.1-f12cfcbc"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-632e0c2a",
+          "version": "idf-release_v5.1-f12cfcbc",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip",
-              "checksum": "SHA-256:41f67e1c11f68b57d651955c93b63d6a8d35808ce6aff6ba3d1e1476178758f2",
-              "size": "309895581"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-f12cfcbc.zip",
+              "checksum": "SHA-256:de5a065fa279246420864c350fcdd1a310af1e70fcd4d13e7bd4ecee589d419d",
+              "size": "309928841"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.1 769c168
esp-idf: release/v5.1 f12cfcbcdb
arduino: release/v3.0.x 3bfa3e0a
tinyusb: master 8b1e40c3e
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.2
espressif__esp-tflite-micro: 1.3.1
espressif__esp-zboss-lib: 1.5.1
espressif__esp-zigbee-lib: 1.5.1
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.1.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~1
espressif__mdns: 1.4.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.5.2
```
