### PR TITLE
feat(uart): uart break example improvement

### DIFF
--- a/libraries/ESP32/examples/Serial/OnReceiveError_BREAK_Demo/OnReceiveError_BREAK_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OnReceiveError_BREAK_Demo/OnReceiveError_BREAK_Demo.ino
@@ -80,7 +80,11 @@ void onReceiveFunction() {
   received_bytes = received_bytes + available;
   Serial.printf("onReceive Callback:: There are %d bytes available: {", available);
   while (available--) {
-    Serial.print((char)Serial1.read());
+    char c = Serial1.read();
+    Serial.printf("0x%x='%c'", c, c);
+    if (available) {
+      Serial.print(" ");
+    }
   }
   Serial.println("}");
 }


### PR DESCRIPTION
## Description of Change
Prints the received byte as HEXA and CHAR in order to allow the user to see why there is 1 extra char (0x00) when BREAK is received.

Targets 3.0.x and 3.1.x

## Tests scenarios
Using P4/S3 with  libraries/ESP32/examples/Serial/OnReceiveError_BREAK_Demo/OnReceiveError_BREAK_Demo.ino

#### Output:
```
================================
Test Case #3 BREAK at END
================================

Testing onReceive for receiving 26 bytes at 9600 baud, using RX FIFO Full = 5.
onReceive is called on both FIFO Full and RX Timeout events.
BREAK event will be sent at the END of the 26 bytes
onReceive Callback:: There are 5 bytes available: {0x41='A' 0x42='B' 0x43='C' 0x44='D' 0x45='E'}
onReceive Callback:: There are 5 bytes available: {0x46='F' 0x47='G' 0x48='H' 0x49='I' 0x4a='J'}
onReceive Callback:: There are 10 bytes available: {0x4b='K' 0x4c='L' 0x4d='M' 0x4e='N' 0x4f='O' 0x50='P' 0x51='Q' 0x52='R' 0x53='S' 0x54='T'}
onReceive Callback:: There are 7 bytes available: {0x55='U' 0x56='V' 0x57='W' 0x58='X' 0x59='Y' 0x5a='Z' 0x0=''}

It has sent 26 bytes from Serial1 TX to Serial1 RX
onReceive() has read a total of 27 bytes
```

## Related links
None