### PR TITLE
fix(sntp): Lock / Unlock LWIP if CONFIG_LWIP_TCPIP_CORE_LOCKING is set

### DIFF
--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -17,6 +17,10 @@
 //#include "tcpip_adapter.h"
 #include "esp_netif.h"
 
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+  #include "lwip/priv/tcpip_priv.h"
+#endif
+
 static void setTimeZone(long offset, int daylight) {
   char cst[17] = {0};
   char cdt[17] = "DST";
@@ -50,11 +54,23 @@ void configTime(long gmtOffset_sec, int daylightOffset_sec, const char *server1,
   if (sntp_enabled()) {
     sntp_stop();
   }
+
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+    LOCK_TCPIP_CORE();
+#endif
+
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
   sntp_setservername(0, (char *)server1);
   sntp_setservername(1, (char *)server2);
   sntp_setservername(2, (char *)server3);
   sntp_init();
+
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+    UNLOCK_TCPIP_CORE();
+#endif
+
   setTimeZone(-gmtOffset_sec, daylightOffset_sec);
 }
 
@@ -68,11 +84,23 @@ void configTzTime(const char *tz, const char *server1, const char *server2, cons
   if (sntp_enabled()) {
     sntp_stop();
   }
+
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+    LOCK_TCPIP_CORE();
+#endif
+
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
   sntp_setservername(0, (char *)server1);
   sntp_setservername(1, (char *)server2);
   sntp_setservername(2, (char *)server3);
   sntp_init();
+
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+    UNLOCK_TCPIP_CORE();
+#endif
+
   setenv("TZ", tz, 1);
   tzset();
 }

--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -18,7 +18,7 @@
 #include "esp_netif.h"
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
-  #include "lwip/priv/tcpip_priv.h"
+#include "lwip/priv/tcpip_priv.h"
 #endif
 
 static void setTimeZone(long offset, int daylight) {
@@ -56,8 +56,9 @@ void configTime(long gmtOffset_sec, int daylightOffset_sec, const char *server1,
   }
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
-  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
     LOCK_TCPIP_CORE();
+  }
 #endif
 
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
@@ -67,8 +68,9 @@ void configTime(long gmtOffset_sec, int daylightOffset_sec, const char *server1,
   sntp_init();
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
-  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
     UNLOCK_TCPIP_CORE();
+  }
 #endif
 
   setTimeZone(-gmtOffset_sec, daylightOffset_sec);
@@ -86,8 +88,9 @@ void configTzTime(const char *tz, const char *server1, const char *server2, cons
   }
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
-  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
     LOCK_TCPIP_CORE();
+  }
 #endif
 
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
@@ -97,8 +100,9 @@ void configTzTime(const char *tz, const char *server1, const char *server2, cons
   sntp_init();
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
-  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER))
+  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
     UNLOCK_TCPIP_CORE();
+  }
 #endif
 
   setenv("TZ", tz, 1);


### PR DESCRIPTION
Calling `configTime` and `configTzTime` crashes with error message: "Required to lock TCPIP core functionality" on Arduino 3.1.0 RC2 following activation of `LWIP_TCPIP_CORE_LOCKING` and `LWIP_CHECK_THREAD_SAFETY` for Matter.

Fixes: https://github.com/espressif/arduino-esp32/issues/10526
