### PR TITLE
ci(workflows): General improvements and fixes

### DIFF
--- a/.github/scripts/set_push_chunks.sh
+++ b/.github/scripts/set_push_chunks.sh
@@ -4,73 +4,73 @@ build_all=false
 chunks_count=0
 
 if [[ $CORE_CHANGED == 'true' ]] || [[ $IS_PR != 'true' ]]; then
-  echo "Core files changed or not a PR. Building all."
-  build_all=true
-  chunks_count=$MAX_CHUNKS
+    echo "Core files changed or not a PR. Building all."
+    build_all=true
+    chunks_count=$MAX_CHUNKS
 elif [[ $LIB_CHANGED == 'true' ]]; then
-  echo "Libraries changed. Building only affected sketches."
-  if [[ $NETWORKING_CHANGED == 'true' ]]; then
-    echo "Networking libraries changed. Building networking related sketches."
-    networking_sketches="$(find libraries/WiFi -name *.ino) "
-    networking_sketches+="$(find libraries/Ethernet -name *.ino) "
-    networking_sketches+="$(find libraries/PPP -name *.ino) "
-    networking_sketches+="$(find libraries/NetworkClientSecure -name *.ino) "
-    networking_sketches+="$(find libraries/WebServer -name *.ino) "
-  fi
-  if [[ $FS_CHANGED == 'true' ]]; then
-    echo "FS libraries changed. Building FS related sketches."
-    fs_sketches="$(find libraries/SD -name *.ino) "
-    fs_sketches+="$(find libraries/SD_MMC -name *.ino) "
-    fs_sketches+="$(find libraries/SPIFFS -name *.ino) "
-    fs_sketches+="$(find libraries/LittleFS -name *.ino) "
-    fs_sketches+="$(find libraries/FFat -name *.ino) "
-  fi
-  sketches="$networking_sketches $fs_sketches"
-  for file in $LIB_FILES; do
-      if [[ $file == *.ino ]]; then
-          # If file ends with .ino, add it to the list of sketches
-          echo "Sketch found: $file"
-          sketches+="$file "
-      elif [[ $(basename $(dirname $file)) == "src" ]]; then
-          # If file is in a src directory, find all sketches in the parent/examples directory
-          echo "Library src file found: $file"
-          lib=$(dirname $(dirname $file))
-          if [[ -d $lib/examples ]]; then
-              lib_sketches=$(find $lib/examples -name *.ino)
-              sketches+="$lib_sketches "
-              echo "Library sketches: $lib_sketches"
-          fi
-      else
-          # If file is in a example folder but it is not a sketch, find all sketches in the current directory
-          echo "File in example folder found: $file"
-          sketch=$(find $(dirname $file) -name *.ino)
-          sketches+="$sketch "
-          echo "Sketch in example folder: $sketch"
-      fi
-      echo ""
-  done
+    echo "Libraries changed. Building only affected sketches."
+    if [[ $NETWORKING_CHANGED == 'true' ]]; then
+        echo "Networking libraries changed. Building networking related sketches."
+        networking_sketches="$(find libraries/WiFi -name *.ino) "
+        networking_sketches+="$(find libraries/Ethernet -name *.ino) "
+        networking_sketches+="$(find libraries/PPP -name *.ino) "
+        networking_sketches+="$(find libraries/NetworkClientSecure -name *.ino) "
+        networking_sketches+="$(find libraries/WebServer -name *.ino) "
+    fi
+    if [[ $FS_CHANGED == 'true' ]]; then
+        echo "FS libraries changed. Building FS related sketches."
+        fs_sketches="$(find libraries/SD -name *.ino) "
+        fs_sketches+="$(find libraries/SD_MMC -name *.ino) "
+        fs_sketches+="$(find libraries/SPIFFS -name *.ino) "
+        fs_sketches+="$(find libraries/LittleFS -name *.ino) "
+        fs_sketches+="$(find libraries/FFat -name *.ino) "
+    fi
+    sketches="$networking_sketches $fs_sketches"
+    for file in $LIB_FILES; do
+        lib=$(echo $file | awk -F "/" '{print $1"/"$2}')
+        if [[ "$file" == *.ino ]]; then
+            # If file ends with .ino, add it to the list of sketches
+            echo "Sketch found: $file"
+            sketches+="$file "
+        elif [[ "$file" == "$lib/src/"* ]]; then
+            # If file is inside the src directory, find all sketches in the lib/examples directory
+            echo "Library src file found: $file"
+            if [[ -d $lib/examples ]]; then
+                lib_sketches=$(find $lib/examples -name *.ino)
+                sketches+="$lib_sketches "
+                echo "Library sketches: $lib_sketches"
+            fi
+        else
+            # If file is in a example folder but it is not a sketch, find all sketches in the current directory
+            echo "File in example folder found: $file"
+            sketch=$(find $(dirname $file) -name *.ino)
+            sketches+="$sketch "
+            echo "Sketch in example folder: $sketch"
+        fi
+        echo ""
+    done
 fi
 
 if [[ -n $sketches ]]; then
-  # Remove duplicates
-  sketches=$(echo $sketches | tr ' ' '\n' | sort | uniq)
-  for sketch in $sketches; do
-      echo $sketch >> sketches_found.txt
-      chunks_count=$((chunks_count+1))
-  done
-  echo "Number of sketches found: $chunks_count"
-  echo "Sketches:"
-  echo "$sketches"
+    # Remove duplicates
+    sketches=$(echo $sketches | tr ' ' '\n' | sort | uniq)
+    for sketch in $sketches; do
+        echo $sketch >> sketches_found.txt
+        chunks_count=$((chunks_count+1))
+    done
+    echo "Number of sketches found: $chunks_count"
+    echo "Sketches:"
+    echo "$sketches"
 
-  if [[ $chunks_count -gt $MAX_CHUNKS ]]; then
-    echo "More sketches than the allowed number of chunks found. Limiting to $MAX_CHUNKS chunks."
-    chunks_count=$MAX_CHUNKS
-  fi
+    if [[ $chunks_count -gt $MAX_CHUNKS ]]; then
+        echo "More sketches than the allowed number of chunks found. Limiting to $MAX_CHUNKS chunks."
+        chunks_count=$MAX_CHUNKS
+    fi
 fi
 
 chunks='["0"'
 for i in $(seq 1 $(( $chunks_count - 1 )) ); do
-  chunks+=",\"$i\""
+    chunks+=",\"$i\""
 done
 chunks+="]"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled]
 
 concurrency:
   group: pre-commit-${{github.event.pull_request.number || github.ref}}
@@ -15,8 +15,10 @@ concurrency:
 jobs:
   lint:
     if: |
+      github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'Status: Pending Merge') ||
-      github.event_name != 'pull_request'
+      contains(github.event.pull_request.labels.*.name, 'Re-trigger Pre-commit Hooks')
+
     name: Check if fixes are needed
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +26,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Remove Label
+        if: contains(github.event.pull_request.labels.*.name, 'Re-trigger Pre-commit Hooks')
+        run: gh pr edit ${{ github.event.number }} --remove-label 'Re-trigger Pre-commit Hooks'
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Set up Python 3
         uses: actions/setup-python@v5
@@ -65,7 +73,7 @@ jobs:
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       - name: Push changes using pre-commit-ci-lite
-        uses: pre-commit-ci/lite-action@v1.0.2
+        uses: pre-commit-ci/lite-action@v1.1.0
         # Only push changes in PRs
         if: ${{ always() && github.event_name == 'pull_request' }}
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - master
-    - release/v2.x
+    - release/*
   pull_request:
     paths:
       - 'cores/**'
@@ -47,6 +47,7 @@ jobs:
   cmake-check:
     name: Check cmake file
     runs-on: ubuntu-latest
+    if: ${{ !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')) }}
     steps:
     - uses: actions/checkout@v4
     - run: bash ./.github/scripts/check-cmakelists.sh
@@ -54,6 +55,7 @@ jobs:
   gen-chunks:
     name: Generate chunks
     runs-on: ubuntu-latest
+    if: ${{ !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')) }}
     outputs:
       build_all: ${{ steps.set-chunks.outputs.build_all }}
       build_libraries: ${{ steps.set-chunks.outputs.build_libraries }}
@@ -307,7 +309,7 @@ jobs:
   #Upload PR number as artifact
   upload-pr-number:
     name: Upload PR number
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Save the PR number in an artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,9 @@ on:
       - '!.github/scripts/upload_py_tools.sh'
       - 'tests/**'
       - 'cores/**'
-      - 'libraries/**'
-      - '!libraries/**.md'
-      - '!libraries/**.txt'
-      - '!libraries/**.properties'
+      - 'libraries/*/src/**.cpp'
+      - 'libraries/*/src/**.h'
+      - 'libraries/*/src/**.c'
       - 'package/**'
   schedule:
     - cron: '0 2 * * *'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 cryptography==43.0.1
 --only-binary cryptography
 pytest-cov==5.0.0
-pytest-embedded-serial-esp==1.11.6
-pytest-embedded-arduino==1.11.6
-pytest-embedded-wokwi==1.11.6
-pytest-embedded-qemu==1.11.6
+pytest-embedded-serial-esp==1.11.8
+pytest-embedded-arduino==1.11.8
+pytest-embedded-wokwi==1.11.8
+pytest-embedded-qemu==1.11.8

--- a/tools/pre-commit/requirements.txt
+++ b/tools/pre-commit/requirements.txt
@@ -1,2 +1,2 @@
-pre-commit==3.7.1
+pre-commit==4.0.1
 docutils==0.16


### PR DESCRIPTION
## Description of Change

This PR aims to fix a few things with CI:

- Bump `pre-commit` and `pytest-embedded` versions. P4 tests will work as expected after this.
- Make sure that pushes to `release/*` branches will not trigger PR workflows if one is open, only push workflows.
- Make sure that changing libraries' sketches will not trigger runtime tests
- Sometimes `pre-commit` acts funky. Add a manual re-trigger label to force execution until some permanent solution can be found.
- Fix the detection of libs and formatting of the chunk generator script

## Tests scenarios

Tested in fork
