### PR TITLE
feat(Rainmaker): Enable ESP32C2 for esp-rainmaker

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -45,7 +45,6 @@ esp32_family.build.board=ESP32_FAMILY
 ##############################################################
 
 esp32c2.name=ESP32C2 Dev Module
-esp32c2.hide=true
 
 esp32c2.bootloader.tool=esptool_py
 esp32c2.bootloader.tool.default=esptool_py
@@ -108,6 +107,12 @@ esp32c2.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
 esp32c2.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
 esp32c2.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
 esp32c2.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32c2.menu.PartitionScheme.rainmaker=RainMaker 4MB
+esp32c2.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32c2.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+esp32c2.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+esp32c2.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+esp32c2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 
 esp32c2.menu.FlashMode.qio=QIO
 esp32c2.menu.FlashMode.qio.build.flash_mode=dio

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -65,20 +65,14 @@ dependencies:
       - if: "target != esp32c2"
   espressif/esp_rainmaker:
     version: "^1.0.0"
-    rules:
-      - if: "target != esp32c2"
   espressif/rmaker_common:
     version: "^1.4.6"
-    rules:
-      - if: "target != esp32c2"
   espressif/esp_insights:
     version: "^1.2.1"
     rules:
       - if: "target != esp32c2"
   espressif/qrcode:
     version: "^0.1.0~1"
-    rules:
-      - if: "target != esp32c2"
   espressif/esp-sr:
     version: "^1.4.2"
     rules:


### PR DESCRIPTION
## Description of Change
Enable ESP32C2 for esp-rainmaker
Changes made to idf_component.yml and board.txt to allow building esp-rainmaker examples on esp32c2.

## Tests scenarios
To do: 
- [ ] Test with esp32c2 for runtime errors. 

Known Issue:
- [ ] although esp32c2 section in  board.txt is updated with rainmaker partition schemes, those are still not visible in Arduino IDE menu. 

