### PR TITLE
fix(IPaddress): IPv6 restore zone id

### DIFF
--- a/cores/esp32/IPAddress.cpp
+++ b/cores/esp32/IPAddress.cpp
@@ -204,10 +204,10 @@ bool IPAddress::fromString6(const char *address) {
       // netif_index_to_name crashes on latest esp-idf
       // _zone = netif_name_to_index(address);
       // in the interim, we parse the suffix as a zone number
-      while ((*address != '\0') && (!isdigit(*address))) {    // skip all non-digit after '%'
+      while ((*address != '\0') && (!isdigit(*address))) {  // skip all non-digit after '%'
         address++;
       }
-      _zone = atol(address) + 1;    // increase by one by convention, so we can have zone '0'
+      _zone = atol(address) + 1;  // increase by one by convention, so we can have zone '0'
       while (*address != '\0') {
         address++;
       }
@@ -361,7 +361,7 @@ size_t IPAddress::printTo(Print &p, bool includeZone) const {
     if (_zone > 0 && includeZone) {
       n += p.print('%');
       // look for the interface name
-      for (netif* intf = netif_list; intf != nullptr; intf = intf->next) {
+      for (netif *intf = netif_list; intf != nullptr; intf = intf->next) {
         if (_zone - 1 == intf->num) {
           n += p.print(intf->name[0]);
           n += p.print(intf->name[1]);

--- a/cores/esp32/IPAddress.cpp
+++ b/cores/esp32/IPAddress.cpp
@@ -201,7 +201,13 @@ bool IPAddress::fromString6(const char *address) {
       colons++;
       acc = 0;
     } else if (c == '%') {
-      _zone = netif_name_to_index(address);
+      // netif_index_to_name crashes on latest esp-idf
+      // _zone = netif_name_to_index(address);
+      // in the interim, we parse the suffix as a zone number
+      while ((*address != '\0') && (!isdigit(*address))) {    // skip all non-digit after '%'
+        address++;
+      }
+      _zone = atol(address) + 1;    // increase by one by convention, so we can have zone '0'
       while (*address != '\0') {
         address++;
       }
@@ -351,6 +357,19 @@ size_t IPAddress::printTo(Print &p, bool includeZone) const {
     //   netif_index_to_name(_zone, if_name);
     //   n += p.print(if_name);
     // }
+    // In the interim, we just output the index number
+    if (_zone > 0 && includeZone) {
+      n += p.print('%');
+      // look for the interface name
+      for (netif* intf = netif_list; intf != nullptr; intf = intf->next) {
+        if (_zone - 1 == intf->num) {
+          n += p.print(intf->name[0]);
+          n += p.print(intf->name[1]);
+          break;
+        }
+      }
+      n += p.print(_zone - 1);
+    }
     return n;
   }
 


### PR DESCRIPTION
This PR restores the IPv6 zone-id in String representation of IPv6 address as well as parsing. This follows https://github.com/espressif/arduino-esp32/commit/20a28b58bc3fd5ff613e2860d65e0953446f264b that disabled it due to a crash in netif_index_to_name()

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change

This PR restores the IPv6 zone-id in String representation of IPv6 address as well as parsing. This follows https://github.com/espressif/arduino-esp32/commit/20a28b58bc3fd5ff613e2860d65e0953446f264b that disabled it due to a crash in `netif_index_to_name()`.

The fixed code scans through `netif_list` to find the `netif` name and id.

Note: zone-id are incremented by 1 compared to `netif` id.

For example internal zoneid value `3` actually translates to `%st2`


## Tests scenarios

## Related links
https://github.com/espressif/arduino-esp32/commit/20a28b58bc3fd5ff613e2860d65e0953446f264b