### PR TITLE
feat(Example): Remove o call to a no existing method from Serial example

### DIFF
--- a/libraries/ESP32/examples/Serial/Serial_All_CPU_Freqs/Serial_All_CPU_Freqs.ino
+++ b/libraries/ESP32/examples/Serial/Serial_All_CPU_Freqs/Serial_All_CPU_Freqs.ino
@@ -46,7 +46,6 @@ void setup() {
     Serial.printf("\n------- Trying CPU Freq = %d ---------\n", cpufreqs[i]);
     Serial.flush();  // wait to empty the UART FIFO before changing the CPU Freq.
     setCpuFrequencyMhz(cpufreqs[i]);
-    Serial.updateBaudRate(115200);
 
     Freq = getCpuFrequencyMhz();
     Serial.print("CPU Freq = ");


### PR DESCRIPTION
## Description of Change
On the exemple *Serial_ALL_CPU_Freqs* there were a call to a method that does not exit o the library,
** Serial.updateBaudRate(115200) **.

## Tests scenarios
The used hardware was a ESP32-S3-BOX
I was only trying to run the exemple code.
