### PR TITLE
fix(zigbee): Fix and bump zigbee version and stay on 1.6.0

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -52,11 +52,11 @@ dependencies:
   espressif/network_provisioning:
     version: "~1.0.0"
   espressif/esp-zboss-lib:
-    version: "^1.0.1"
+    version: "==1.6.0"
     rules:
       - if: "target != esp32c2"
   espressif/esp-zigbee-lib:
-    version: "^1.0.1"
+    version: "==1.6.0"
     rules:
       - if: "target != esp32c2"
   espressif/esp-dsp:

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -80,7 +80,6 @@ void ZigbeeTempSensor::reportTemperature() {
   esp_zb_zcl_report_attr_cmd_t report_attr_cmd;
   report_attr_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
   report_attr_cmd.attributeID = ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID;
-  report_attr_cmd.cluster_role = ESP_ZB_ZCL_CLUSTER_SERVER_ROLE;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
 

--- a/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
@@ -185,7 +185,7 @@ void ZigbeeThermostat::setTemperatureReporting(uint16_t min_interval, uint16_t m
   int16_t report_change = (int16_t)delta * 100;
   esp_zb_zcl_config_report_record_t records[] = {
     {
-      .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
+      .direction = ESP_ZB_ZCL_REPORT_DIRECTION_SEND,
       .attributeID = ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID,
       .attrType = ESP_ZB_ZCL_ATTR_TYPE_S16,
       .min_interval = min_interval,


### PR DESCRIPTION
## Description of Change
Fixes changes on Zigbee 1.6.0 version and keep that version fixed in idf_component.yml

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links

Requires https://github.com/espressif/arduino-esp32/pull/10544