### PR TITLE
fix(wokwi): Delete generated diagram to avoid issues running locally

### DIFF
--- a/.github/scripts/tests_run.sh
+++ b/.github/scripts/tests_run.sh
@@ -125,6 +125,8 @@ function run_test() {
             extra_args="--embedded-services esp,arduino"
         fi
 
+        rm $sketchdir/diagram.json 2>/dev/null || true
+
         result=0
         printf "\033[95mpytest tests --build-dir $build_dir -k test_$sketchname --junit-xml=$report_file $extra_args\033[0m\n"
         bash -c "set +e; pytest tests --build-dir $build_dir -k test_$sketchname --junit-xml=$report_file $extra_args; exit \$?" || result=$?


### PR DESCRIPTION
## Description of Change

Depending on the order of actions when running tests locally. Wokwi can execute it's test with an out of date diagram file.

To avoid that we can delete any existing generated diagrams so we ensure that a new one is properly created when executing the tests.

## Tests scenarios

Tested locally.
