### PR TITLE
fix(zigbee): Fix removed cluster_role attribute

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -104,7 +104,6 @@ void ZigbeeEP::reportBatteryPercentage() {
   esp_zb_zcl_report_attr_cmd_t report_attr_cmd;
   report_attr_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
   report_attr_cmd.attributeID = ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_PERCENTAGE_REMAINING_ID;
-  report_attr_cmd.cluster_role = ESP_ZB_ZCL_CLUSTER_SERVER_ROLE;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
 

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -120,7 +120,6 @@ void ZigbeeTempSensor::reportHumidity() {
   esp_zb_zcl_report_attr_cmd_t report_attr_cmd;
   report_attr_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
   report_attr_cmd.attributeID = ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID;
-  report_attr_cmd.cluster_role = ESP_ZB_ZCL_CLUSTER_SERVER_ROLE;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
 


### PR DESCRIPTION
## Description of Change
Remove cluster_role from attribute command structure, as it was removed in the last zigbee-sdk 1.6.0

## Tests scenarios

## Related links
