### PR TITLE
fix(tests): Fix wrong selection of tests and add debug flag for testing

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -86,6 +86,10 @@ function build_sketch(){ # build_sketch <ide_path> <user_path> <path-to-ino> [ex
             shift
             log_compilation=$1
             ;;
+        -d )
+            shift
+            debug_level="DebugLevel=$1"
+            ;;
         * )
             break
             ;;
@@ -140,13 +144,15 @@ function build_sketch(){ # build_sketch <ide_path> <user_path> <path-to-ino> [ex
             fi
 
             # Default FQBN options if none were passed in the command line.
+            # Replace any double commas with a single one and strip leading and
+            # trailing commas.
 
-            esp32_opts="PSRAM=enabled${fqbn_append:+,$fqbn_append}"
-            esp32s2_opts="PSRAM=enabled${fqbn_append:+,$fqbn_append}"
-            esp32s3_opts="PSRAM=opi,USBMode=default${fqbn_append:+,$fqbn_append}"
-            esp32c3_opts="$fqbn_append"
-            esp32c6_opts="$fqbn_append"
-            esp32h2_opts="$fqbn_append"
+            esp32_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32s2_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32s3_opts=$(echo "PSRAM=opi,USBMode=default,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32c3_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32c6_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32h2_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
 
             # Select the common part of the FQBN based on the target.  The rest will be
             # appended depending on the passed options.

--- a/.github/scripts/tests_run.sh
+++ b/.github/scripts/tests_run.sh
@@ -109,14 +109,14 @@ function run_test() {
         rm $sketchdir/diagram.json 2>/dev/null || true
 
         result=0
-        printf "\033[95mpytest tests --build-dir $build_dir -k test_$sketchname --junit-xml=$report_file $extra_args\033[0m\n"
-        bash -c "set +e; pytest tests --build-dir $build_dir -k test_$sketchname --junit-xml=$report_file $extra_args; exit \$?" || result=$?
+        printf "\033[95mpytest $sketchdir/test_$sketchname.py --build-dir $build_dir --junit-xml=$report_file $extra_args\033[0m\n"
+        bash -c "set +e; pytest $sketchdir/test_$sketchname.py --build-dir $build_dir --junit-xml=$report_file $extra_args; exit \$?" || result=$?
         printf "\n"
         if [ $result -ne 0 ]; then
             result=0
             printf "\033[95mRetrying test: $sketchname -- Config: $i\033[0m\n"
-            printf "\033[95mpytest tests --build-dir $build_dir -k test_$sketchname --junit-xml=$report_file $extra_args\033[0m\n"
-            bash -c "set +e; pytest tests --build-dir $build_dir -k test_$sketchname --junit-xml=$report_file $extra_args; exit \$?" || result=$?
+            printf "\033[95mpytest $sketchdir/test_$sketchname.py --build-dir $build_dir --junit-xml=$report_file $extra_args\033[0m\n"
+            bash -c "set +e; pytest $sketchdir/test_$sketchname.py --build-dir $build_dir --junit-xml=$report_file $extra_args; exit \$?" || result=$?
             printf "\n"
             if [ $result -ne 0 ]; then
               printf "\033[91mFailed test: $sketchname -- Config: $i\033[0m\n\n"


### PR DESCRIPTION
## Description of Change

Using the `-k` flag in the pytest command might run more than the selected test. For example using `-k test_psram` will run both `test_psram` and `test_psramspeed`. To fix this we can directly pass the python file for the test.

Also, to help with testing, added a `-d` flag to the compilation process. This will be useful to compile tests with debug logs enabled. For example:

`./.github/scripts/tests_build.sh -s uart -t esp32 -d verbose`

## Tests scenarios

Tested locally
