### PR TITLE
fix(wifi): fixes WiFi.isconnected() to return true when it is connected and it has an IP Addr

### DIFF
--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -215,7 +215,7 @@ bool WiFiSTAClass::bandwidth(wifi_bandwidth_t bandwidth) {
  * @return true if STA is connected to an AP
  */
 bool WiFiSTAClass::isConnected() {
-  return STA.connected();
+  return STA.connected() && STA.hasIP();
 }
 
 /**


### PR DESCRIPTION
## Description of Change
After 3.0.x (including 3.1.x) the function `WiFiSTAClass::isConnected()` returns when it is connected to the WiFi AP but not necessarily when it has an IP address.
This is a breaking change because 2.0.x only returns true when both, it is connected and it has an IP.

This PR fixes it.

## Tests scenarios
``` cpp
#include <Arduino.h>
#include <WiFi.h>

const char *SSID = "xxx";
const char *PSK = "xxx";

void setup()
{
    Serial.begin(115200);
    while (!Serial)
        delay(10);

    Serial.println("connecting..");

    WiFi.begin(SSID, PSK);

    while (!WiFi.isConnected())
        delay(10);

    Serial.println(WiFi.localIP());
}

void loop()
{
    delay(1000);
    Serial.println(WiFi.localIP());
}
```

## Related links
Fix #10580 