### PR TITLE
fix(build): Allow Arduino to compile in IDF without components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,6 @@ set(ARDUINO_ALL_LIBRARIES
   )
 
 set(ARDUINO_LIBRARY_ArduinoOTA_SRCS libraries/ArduinoOTA/src/ArduinoOTA.cpp)
-set(ARDUINO_LIBRARY_ArduinoOTA_REQUIRES esp_https_ota)
 
 set(ARDUINO_LIBRARY_AsyncUDP_SRCS libraries/AsyncUDP/src/AsyncUDP.cpp)
 
@@ -160,7 +159,6 @@ set(ARDUINO_LIBRARY_HTTPUpdate_SRCS libraries/HTTPUpdate/src/HTTPUpdate.cpp)
 set(ARDUINO_LIBRARY_Insights_SRCS libraries/Insights/src/Insights.cpp)
 
 set(ARDUINO_LIBRARY_LittleFS_SRCS libraries/LittleFS/src/LittleFS.cpp)
-set(ARDUINO_LIBRARY_LittleFS_REQUIRES joltwallet__littlefs)
 
 set(ARDUINO_LIBRARY_NetBIOS_SRCS libraries/NetBIOS/src/NetBIOS.cpp)
 
@@ -325,7 +323,7 @@ endforeach()
 set(includedirs variants/${CONFIG_ARDUINO_VARIANT}/ cores/esp32/ ${ARDUINO_LIBRARIES_INCLUDEDIRS})
 set(srcs ${CORE_SRCS} ${ARDUINO_LIBRARIES_SRCS})
 set(priv_includes cores/esp32/libb64)
-set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser esp_ringbuf esp_driver_gptimer esp_driver_usb_serial_jtag driver espressif__network_provisioning)
+set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser esp_ringbuf esp_driver_gptimer esp_driver_usb_serial_jtag driver)
 set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid usb esp_psram ${ARDUINO_LIBRARIES_REQUIRES})
 
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThread)
@@ -390,4 +388,10 @@ if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_ESP_SR)
 endif()
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_Matter)
     maybe_add_component(espressif__esp_matter)
+endif()
+if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_LittleFS)
+    maybe_add_component(joltwallet__littlefs)
+endif()
+if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_WiFiProv)
+    maybe_add_component(espressif__network_provisioning)
 endif()

--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -120,10 +120,12 @@ void ArduinoOTAClass::begin() {
     sprintf(tmp, "esp32-%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
     _hostname = tmp;
   }
+#ifdef CONFIG_MDNS_MAX_INTERFACES
   if (_mdnsEnabled) {
     MDNS.begin(_hostname.c_str());
     MDNS.enableArduino(_port, (_password.length() > 0));
   }
+#endif
   _initialized = true;
   _state = OTA_IDLE;
   log_i("OTA server at: %s.local:%u", _hostname.c_str(), _port);
@@ -358,9 +360,11 @@ void ArduinoOTAClass::_runUpdate() {
 void ArduinoOTAClass::end() {
   _initialized = false;
   _udp_ota.stop();
+#ifdef CONFIG_MDNS_MAX_INTERFACES
   if (_mdnsEnabled) {
     MDNS.end();
   }
+#endif
   _state = OTA_IDLE;
   log_i("OTA server stopped.");
 }

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -7,7 +7,9 @@
 
 #include "esp32-hal-periman.h"
 #include "wav_header.h"
+#if ARDUINO_HAS_MP3_DECODER
 #include "mp3dec.h"
+#endif
 
 #define I2S_READ_CHUNK_SIZE 1920
 
@@ -1014,6 +1016,7 @@ void I2SClass::playWAV(uint8_t *data, size_t len) {
   write(data + WAVE_HEADER_SIZE + data_offset, data_chunk->subchunk_size);
 }
 
+#if ARDUINO_HAS_MP3_DECODER
 bool I2SClass::playMP3(uint8_t *src, size_t src_len) {
   int16_t outBuf[MAX_NCHAN * MAX_NGRAN * MAX_NSAMP];
   uint8_t *readPtr = NULL;
@@ -1051,5 +1054,6 @@ bool I2SClass::playMP3(uint8_t *src, size_t src_len) {
   MP3FreeDecoder(decoder);
   return true;
 }
+#endif
 
 #endif /* SOC_I2S_SUPPORTED */

--- a/libraries/ESP_I2S/src/ESP_I2S.h
+++ b/libraries/ESP_I2S/src/ESP_I2S.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if defined __has_include && __has_include("mp3dec.h")
+#define ARDUINO_HAS_MP3_DECODER 1
+#endif
+
 #include "soc/soc_caps.h"
 #if SOC_I2S_SUPPORTED
 
@@ -85,8 +89,10 @@ public:
   uint8_t *recordWAV(size_t rec_seconds, size_t *out_size);
   // Play short PCM WAV from memory
   void playWAV(uint8_t *data, size_t len);
+#if ARDUINO_HAS_MP3_DECODER
   // Play short MP3 from memory
   bool playMP3(uint8_t *src, size_t src_len);
+#endif
 
 private:
   esp_err_t last_error;

--- a/libraries/ESPmDNS/src/ESPmDNS.cpp
+++ b/libraries/ESPmDNS/src/ESPmDNS.cpp
@@ -39,6 +39,7 @@ License (MIT license):
 #endif
 
 #include "ESPmDNS.h"
+#ifdef CONFIG_MDNS_MAX_INTERFACES
 #include <functional>
 #include "esp_mac.h"
 #include "soc/soc_caps.h"
@@ -391,3 +392,5 @@ String MDNSResponder::txtKey(int idx, int txtIdx) {
 }
 
 MDNSResponder MDNS;
+
+#endif /* CONFIG_MDNS_MAX_INTERFACES */

--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -41,6 +41,9 @@ License (MIT license):
 #ifndef ESP32MDNS_H
 #define ESP32MDNS_H
 
+#include "sdkconfig.h"
+#ifdef CONFIG_MDNS_MAX_INTERFACES
+
 #include "Arduino.h"
 #include "mdns.h"
 #include "esp_interface.h"
@@ -125,4 +128,5 @@ private:
 
 extern MDNSResponder MDNS;
 
+#endif /* CONFIG_MDNS_MAX_INTERFACES */
 #endif  //ESP32MDNS_H

--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -128,5 +128,5 @@ private:
 
 extern MDNSResponder MDNS;
 
-#endif /* CONFIG_MDNS_MAX_INTERFACES */
+#endif  /* CONFIG_MDNS_MAX_INTERFACES */
 #endif  //ESP32MDNS_H

--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "LittleFS.h"
+
+#ifdef CONFIG_LITTLEFS_PAGE_SIZE
 #include "vfs_api.h"
 
 extern "C" {
 #include <sys/unistd.h>
 #include <sys/stat.h>
 #include <dirent.h>
-}
-#include "sdkconfig.h"
-#include "LittleFS.h"
-
-#ifdef CONFIG_LITTLEFS_PAGE_SIZE
-extern "C" {
 #include "esp_littlefs.h"
 }
 
@@ -125,4 +122,4 @@ size_t LittleFSFS::usedBytes() {
 }
 
 LittleFSFS LittleFS;
-#endif
+#endif /* CONFIG_LITTLEFS_PAGE_SIZE */

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -14,6 +14,10 @@
 #ifndef _LITTLEFS_H_
 #define _LITTLEFS_H_
 
+#include "sdkconfig.h"
+
+#ifdef CONFIG_LITTLEFS_PAGE_SIZE
+
 #include "FS.h"
 
 namespace fs {
@@ -36,4 +40,5 @@ private:
 
 extern fs::LittleFSFS LittleFS;
 
+#endif /* CONFIG_LITTLEFS_PAGE_SIZE */
 #endif

--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -1,6 +1,6 @@
 #define ARDUINO_CORE_BUILD
 #include "PPP.h"
-#if CONFIG_LWIP_PPP_SUPPORT
+#if CONFIG_LWIP_PPP_SUPPORT && ARDUINO_HAS_ESP_MODEM
 #include "esp32-hal-periman.h"
 #include "esp_netif.h"
 #include "esp_netif_ppp.h"

--- a/libraries/PPP/src/PPP.h
+++ b/libraries/PPP/src/PPP.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "sdkconfig.h"
-#if CONFIG_LWIP_PPP_SUPPORT
+#if defined __has_include && __has_include("esp_modem_c_api_types.h")
+#define ARDUINO_HAS_ESP_MODEM 1
+#endif
+
+#if CONFIG_LWIP_PPP_SUPPORT && ARDUINO_HAS_ESP_MODEM
 #include "Network.h"
 #include "esp_modem_c_api_types.h"
 
@@ -109,5 +113,4 @@ private:
 };
 
 extern PPPClass PPP;
-
-#endif /* CONFIG_LWIP_PPP_SUPPORT */
+#endif /* CONFIG_LWIP_PPP_SUPPORT && ARDUINO_HAS_ESP_MODEM */

--- a/libraries/PPP/src/ppp.c
+++ b/libraries/PPP/src/ppp.c
@@ -1,5 +1,5 @@
 #include "sdkconfig.h"
-#if CONFIG_LWIP_PPP_SUPPORT
+#if CONFIG_LWIP_PPP_SUPPORT && defined __has_include && __has_include("esp_modem_api.h")
 #include "esp_modem_api.h"
 
 esp_err_t _esp_modem_at(esp_modem_dce_t *dce_wrap, const char *at, char *p_out, int timeout) {


### PR DESCRIPTION
This adds guards for the rest of the extra components
