### PR TITLE
Feat: Feather V2 and Qt PY larger SPIFFS PartitionScheme

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -13479,6 +13479,9 @@ adafruit_feather_esp32_v2.menu.PSRAM.disabled.build.defines=
 adafruit_feather_esp32_v2.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
 adafruit_feather_esp32_v2.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
 adafruit_feather_esp32_v2.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+adafruit_feather_esp32_v2.menu.PartitionScheme.large_spiffs_8MB=Large SPIFFS (1.2MB APP / 5.3MB SPIFFS)
+adafruit_feather_esp32_v2.menu.PartitionScheme.large_spiffs_8MB.build.partitions=large_spiffs_8MB
+adafruit_feather_esp32_v2.menu.PartitionScheme.large_spiffs_8MB.upload.maximum_size=1310720
 
 adafruit_feather_esp32_v2.menu.CPUFreq.240=240MHz (WiFi/BT)
 adafruit_feather_esp32_v2.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -15167,6 +15170,9 @@ adafruit_qtpy_esp32_pico.menu.PSRAM.disabled.build.defines=
 adafruit_qtpy_esp32_pico.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
 adafruit_qtpy_esp32_pico.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
 adafruit_qtpy_esp32_pico.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+adafruit_qtpy_esp32_pico.menu.PartitionScheme.large_spiffs_8MB=Large SPIFFS (1.2MB APP / 5.3MB SPIFFS)
+adafruit_qtpy_esp32_pico.menu.PartitionScheme.large_spiffs_8MB.build.partitions=large_spiffs_8MB
+adafruit_qtpy_esp32_pico.menu.PartitionScheme.large_spiffs_8MB.upload.maximum_size=1310720
 
 adafruit_qtpy_esp32_pico.menu.CPUFreq.240=240MHz (WiFi/BT)
 adafruit_qtpy_esp32_pico.menu.CPUFreq.240.build.f_cpu=240000000L


### PR DESCRIPTION
Default stays the same, additional option for larger SPIFFS area. Using existing partition CSV.

tested on Adafruit Feather V2
Arduino 2.3.3
ESP32 BSP 3.0.7

