### PR TITLE
Guard ethernet parts to make it possible to use without

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -19,13 +19,10 @@
  */
 
 // Disable the automatic pin remapping of the API calls in this file
-
-#include "sdkconfig.h"
-#if CONFIG_ETH_ENABLED
-
 #define ARDUINO_CORE_BUILD
 
 #include "ETH.h"
+#if CONFIG_ETH_ENABLED
 #include "esp_system.h"
 #include "esp_event.h"
 #include "esp_eth.h"

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -19,6 +19,10 @@
  */
 
 // Disable the automatic pin remapping of the API calls in this file
+
+#include "sdkconfig.h"
+#if CONFIG_ETH_ENABLED
+
 #define ARDUINO_CORE_BUILD
 
 #include "ETH.h"
@@ -1056,3 +1060,5 @@ size_t ETHClass::printDriverInfo(Print &out) const {
 }
 
 ETHClass ETH;
+
+#endif /* CONFIG_ETH_ENABLED */

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -18,6 +18,9 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "sdkconfig.h"
+#if CONFIG_ETH_ENABLED
+
 #ifndef _ETH_H_
 #define _ETH_H_
 
@@ -249,3 +252,4 @@ private:
 extern ETHClass ETH;
 
 #endif /* _ETH_H_ */
+#endif /* CONFIG_ETH_ENABLED */

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -5,18 +5,20 @@
  */
 #pragma once
 
+#include "sdkconfig.h"
 #include "soc/soc_caps.h"
 #include "esp_err.h"
 #include "esp_event.h"
 #include "esp_netif_types.h"
+#if CONFIG_ETH_ENABLED
 #include "esp_eth_driver.h"
+#endif
 #include <functional>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/event_groups.h"
-#include "sdkconfig.h"
 #if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
 #include <mutex>
 #endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
@@ -98,7 +100,9 @@ typedef union {
   ip_event_ap_staipassigned_t wifi_ap_staipassigned;
   ip_event_got_ip_t got_ip;
   ip_event_got_ip6_t got_ip6;
+#if CONFIG_ETH_ENABLED 
   esp_eth_handle_t eth_connected;
+#endif
 #if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED
   wifi_event_sta_scan_done_t wifi_scan_done;
   wifi_event_sta_authmode_change_t wifi_sta_authmode_change;

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -100,7 +100,7 @@ typedef union {
   ip_event_ap_staipassigned_t wifi_ap_staipassigned;
   ip_event_got_ip_t got_ip;
   ip_event_got_ip6_t got_ip6;
-#if CONFIG_ETH_ENABLED 
+#if CONFIG_ETH_ENABLED
   esp_eth_handle_t eth_connected;
 #endif
 #if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -33,7 +33,9 @@
 #include "IPAddress.h"
 #include "esp_smartconfig.h"
 #include "esp_netif_types.h"
+#if CONFIG_ETH_ENABLED
 #include "esp_eth_driver.h"
+#endif
 #if CONFIG_NETWORK_PROV_NETWORK_TYPE_WIFI
 #include "network_provisioning/manager.h"
 #endif


### PR DESCRIPTION
Currently it is not possible to switch off Ethernet support in IDF and compile Arduino as an component. This PR adds guards to make it possible to compile only with WiFi and no Ethernet.
Follow up from #10597

@me-no-dev 
