### PR TITLE
fix(M5Stack Fire): Fixed TF reader SS pin value.

### DIFF
--- a/variants/m5stack_fire/pins_arduino.h
+++ b/variants/m5stack_fire/pins_arduino.h
@@ -9,7 +9,7 @@ static const uint8_t RX = 3;
 static const uint8_t SDA = 21;
 static const uint8_t SCL = 22;
 
-static const uint8_t SS = 5;
+static const uint8_t SS = 4;
 static const uint8_t MOSI = 23;
 static const uint8_t MISO = 19;
 static const uint8_t SCK = 18;


### PR DESCRIPTION
I just ran into this issue. The wrong pin is defined in `pinsArduino.h`.
The correct SS pin for the TF reader is GPIO4.

See the screenshot below from https://github.com/m5stack/m5unified

![correct-pin](https://github.com/user-attachments/assets/5cc74746-18ea-431e-ad04-d452189cc6b2)

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v3.0.7 with a M5Stack Fire with this scenario

## Related links
I could not find related issues.
