### PR TITLE
Guard WPA Enterprise support

### DIFF
--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -421,6 +421,7 @@ bool STAClass::connect(const char *ssid, const char *passphrase, int32_t channel
   return true;
 }
 
+#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
 /**
  * Start Wifi connection with a WPA2 Enterprise AP
  * if passphrase is set the most secure supported mode will be automatically selected
@@ -519,6 +520,7 @@ bool STAClass::connect(
 
   return connect(wpa2_ssid, NULL, channel, bssid, tryConnect);  //connect to wifi
 }
+#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
 
 bool STAClass::disconnect(bool eraseap, unsigned long timeout) {
   if (eraseap) {

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -63,6 +63,7 @@ wl_status_t WiFiSTAClass::status() {
   return STA.status();
 }
 
+#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
 wl_status_t WiFiSTAClass::begin(
   const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity, const char *wpa2_username, const char *wpa2_password, const char *ca_pem,
   const char *client_crt, const char *client_key, int ttls_phase2_type, int32_t channel, const uint8_t *bssid, bool connect
@@ -77,6 +78,7 @@ wl_status_t WiFiSTAClass::begin(
 
   return STA.status();
 }
+#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
 
 wl_status_t WiFiSTAClass::begin(const char *ssid, const char *passphrase, int32_t channel, const uint8_t *bssid, bool connect) {
   if (!STA.begin()) {

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -54,11 +54,13 @@ public:
 
   bool connect();
   bool connect(const char *ssid, const char *passphrase = NULL, int32_t channel = 0, const uint8_t *bssid = NULL, bool connect = true);
+#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
   bool connect(
     const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity = NULL, const char *wpa2_username = NULL, const char *wpa2_password = NULL,
     const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int ttls_phase2_type = -1, int32_t channel = 0,
     const uint8_t *bssid = 0, bool connect = true
   );
+#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
   bool disconnect(bool eraseap = false, unsigned long timeout = 0);
   bool reconnect();
   bool erase();
@@ -109,11 +111,13 @@ class WiFiSTAClass {
 public:
   STAClass STA;
 
+#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
   wl_status_t begin(
     const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity = NULL, const char *wpa2_username = NULL, const char *wpa2_password = NULL,
     const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int ttls_phase2_type = -1, int32_t channel = 0,
     const uint8_t *bssid = 0, bool connect = true
   );
+#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
   wl_status_t begin(
     const String &wpa2_ssid, wpa2_auth_method_t method, const String &wpa2_identity = (const char *)NULL, const String &wpa2_username = (const char *)NULL,
     const String &wpa2_password = (const char *)NULL, const String &ca_pem = (const char *)NULL, const String &client_crt = (const char *)NULL,

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -111,18 +111,19 @@ class WiFiSTAClass {
 public:
   STAClass STA;
 
-#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
   wl_status_t begin(
     const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity = NULL, const char *wpa2_username = NULL, const char *wpa2_password = NULL,
     const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int ttls_phase2_type = -1, int32_t channel = 0,
     const uint8_t *bssid = 0, bool connect = true
   );
-#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
+#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
   wl_status_t begin(
     const String &wpa2_ssid, wpa2_auth_method_t method, const String &wpa2_identity = (const char *)NULL, const String &wpa2_username = (const char *)NULL,
     const String &wpa2_password = (const char *)NULL, const String &ca_pem = (const char *)NULL, const String &client_crt = (const char *)NULL,
     const String &client_key = (const char *)NULL, int ttls_phase2_type = -1, int32_t channel = 0, const uint8_t *bssid = 0, bool connect = true
-  ) {
+  )
+#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
+  {
     return begin(
       wpa2_ssid.c_str(), method, wpa2_identity.c_str(), wpa2_username.c_str(), wpa2_password.c_str(), ca_pem.c_str(), client_crt.c_str(), client_key.c_str(),
       ttls_phase2_type, channel, bssid, connect

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -111,24 +111,24 @@ class WiFiSTAClass {
 public:
   STAClass STA;
 
+#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
   wl_status_t begin(
     const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity = NULL, const char *wpa2_username = NULL, const char *wpa2_password = NULL,
     const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int ttls_phase2_type = -1, int32_t channel = 0,
     const uint8_t *bssid = 0, bool connect = true
   );
-#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
   wl_status_t begin(
     const String &wpa2_ssid, wpa2_auth_method_t method, const String &wpa2_identity = (const char *)NULL, const String &wpa2_username = (const char *)NULL,
     const String &wpa2_password = (const char *)NULL, const String &ca_pem = (const char *)NULL, const String &client_crt = (const char *)NULL,
     const String &client_key = (const char *)NULL, int ttls_phase2_type = -1, int32_t channel = 0, const uint8_t *bssid = 0, bool connect = true
-  )
-#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
-  {
+  ) {
     return begin(
       wpa2_ssid.c_str(), method, wpa2_identity.c_str(), wpa2_username.c_str(), wpa2_password.c_str(), ca_pem.c_str(), client_crt.c_str(), client_key.c_str(),
       ttls_phase2_type, channel, bssid, connect
     );
   }
+#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
+
   wl_status_t begin(const char *ssid, const char *passphrase = NULL, int32_t channel = 0, const uint8_t *bssid = NULL, bool connect = true);
   wl_status_t begin(const String &ssid, const String &passphrase = (const char *)NULL, int32_t channel = 0, const uint8_t *bssid = NULL, bool connect = true) {
     return begin(ssid.c_str(), passphrase.c_str(), channel, bssid, connect);


### PR DESCRIPTION
enable WPA Enterprise code part only if support is there in the compiled Arduino libs.

Follow up of #10609 

@me-no-dev 