### PR TITLE
feat(zigbee): Add setLight APIs to manually operate lights

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/Zigbee_Color_Dimmable_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/Zigbee_Color_Dimmable_Light.ino
@@ -41,6 +41,10 @@ ZigbeeColorDimmableLight zbColorLight = ZigbeeColorDimmableLight(ZIGBEE_LIGHT_EN
 
 /********************* RGB LED functions **************************/
 void setRGBLight(bool state, uint8_t red, uint8_t green, uint8_t blue, uint8_t level) {
+  if(!state) {
+    rgbLedWrite(LED_PIN, 0, 0, 0);
+    return;
+  }
   float brightness = (float)level / 255;
   rgbLedWrite(LED_PIN, red * brightness, green * brightness, blue * brightness);
 }
@@ -98,6 +102,8 @@ void loop() {
         Zigbee.factoryReset();
       }
     }
+    // Increase blightness by 50 every time the button is pressed
+    zbColorLight.setLightLevel(zbColorLight.getLightLevel() + 50);
   }
   delay(100);
 }

--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/Zigbee_Color_Dimmable_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmable_Light/Zigbee_Color_Dimmable_Light.ino
@@ -41,7 +41,7 @@ ZigbeeColorDimmableLight zbColorLight = ZigbeeColorDimmableLight(ZIGBEE_LIGHT_EN
 
 /********************* RGB LED functions **************************/
 void setRGBLight(bool state, uint8_t red, uint8_t green, uint8_t blue, uint8_t level) {
-  if(!state) {
+  if (!state) {
     rgbLedWrite(LED_PIN, 0, 0, 0);
     return;
   }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Light/Zigbee_On_Off_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Light/Zigbee_On_Off_Light.ino
@@ -81,6 +81,8 @@ void loop() {
         Zigbee.factoryReset();
       }
     }
+    // Toggle light by pressing the button
+    zbLight.setLight(!zbLight.getLightState());
   }
   delay(100);
 }

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
@@ -21,9 +21,31 @@ public:
     lightChanged();
   }
 
+  void setLightState(bool state);
+  void setLightLevel(uint8_t level);
+  void setLightColor(uint8_t red, uint8_t green, uint8_t blue);
+  void setLight(bool state, uint8_t level, uint8_t red, uint8_t green, uint8_t blue);
+
+  bool getLightState() {
+    return _current_state;
+  }
+  uint8_t getLightLevel() {
+    return _current_level;
+  }
+  uint8_t getLightRed() {
+    return _current_red;
+  }
+  uint8_t getLightGreen() {
+    return _current_green;
+  }
+  uint8_t getLightBlue() {
+    return _current_blue;
+  }
+
 private:
   void zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message) override;
   void calculateRGB(uint16_t x, uint16_t y, uint8_t &red, uint8_t &green, uint8_t &blue);
+  void calculateXY(uint8_t red, uint8_t green, uint8_t blue, uint16_t &x, uint16_t &y);
 
   uint16_t getCurrentColorX();
   uint16_t getCurrentColorY();

--- a/libraries/Zigbee/src/ep/ZigbeeLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeLight.cpp
@@ -33,4 +33,17 @@ void ZigbeeLight::lightChanged() {
   }
 }
 
+void ZigbeeLight::setLight(bool state) {
+  _current_state = state;
+  lightChanged();
+
+  log_v("Updating on/off light state to %d", state);
+  /* Update on/off light state */
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false
+  );
+  esp_zb_lock_release();
+}
+
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeLight.h
@@ -14,12 +14,19 @@ public:
   ZigbeeLight(uint8_t endpoint);
   ~ZigbeeLight();
 
-  // Use tp set a cb function to be called on light change
+  // Use to set a cb function to be called on light change
   void onLightChange(void (*callback)(bool)) {
     _on_light_change = callback;
   }
+  // Use to restore light state
   void restoreLight() {
     lightChanged();
+  }
+  // Use to control light state
+  void setLight(bool state);
+  // Use to get light state
+  bool getLightState() {
+    return _current_state;
   }
 
 private:


### PR DESCRIPTION
## Description of Change
This PR adds APIs to the light endpoints to enable controlling them by itself.
The status of the Light is updated in the clusters, so the actual state is updated in the Smart home apps.

## Tests scenarios
Tested locally with HomeAssistant.

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
