### PR TITLE
Guard crypto parts in "Update" to save resources 

### DIFF
--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -63,6 +63,7 @@ public:
     */
   bool begin(size_t size = UPDATE_SIZE_UNKNOWN, int command = U_FLASH, int ledPin = -1, uint8_t ledOn = LOW, const char *label = NULL);
 
+#ifdef UPDATE_CRYPT
   /*
      Setup decryption configuration
      Crypt Key is 32bytes(256bits) block of data, use the same key as used to encrypt image file
@@ -71,6 +72,7 @@ public:
      Crypt Mode,    used to select if image files should be decrypted or not
     */
   bool setupCrypt(const uint8_t *cryptKey = 0, size_t cryptAddress = 0, uint8_t cryptConfig = 0xf, int cryptMode = U_AES_DECRYPT_AUTO);
+#endif /* UPDATE_CRYPT */
 
   /*
       Writes a buffer to the flash and increments the address
@@ -99,6 +101,7 @@ public:
     */
   bool end(bool evenIfRemaining = false);
 
+#ifdef UPDATE_CRYPT
   /*
       sets AES256 key(32 bytes) used for decrypting image file
     */
@@ -122,6 +125,7 @@ public:
   void setCryptConfig(const uint8_t cryptConfig) {
     _cryptCfg = cryptConfig & 0x0f;
   }
+#endif /* UPDATE_CRYPT */
 
   /*
       Aborts the running update
@@ -139,7 +143,11 @@ public:
       sets the expected MD5 for the firmware (hexString)
       If calc_post_decryption is true, the update library will calculate the MD5 after the decryption, if false the calculation occurs before the decryption
     */
-  bool setMD5(const char *expected_md5, bool calc_post_decryption = true);
+  bool setMD5(const char *expected_md5
+#ifdef UPDATE_CRYPT
+, bool calc_post_decryption = true
+#endif /* #ifdef UPDATE_CRYPT */
+);
 
   /*
       returns the MD5 String of the successfully ended firmware
@@ -236,8 +244,10 @@ public:
 private:
   void _reset();
   void _abort(uint8_t err);
+#ifdef UPDATE_CRYPT
   void _cryptKeyTweak(size_t cryptAddress, uint8_t *tweaked_key);
   bool _decryptBuffer();
+#endif /* UPDATE_CRYPT */
   bool _writeBuffer();
   bool _verifyHeader(uint8_t data);
   bool _verifyEnd();
@@ -245,8 +255,10 @@ private:
   bool _chkDataInBlock(const uint8_t *data, size_t len) const;  // check if block contains any data or is empty
 
   uint8_t _error;
+#ifdef UPDATE_CRYPT
   uint8_t *_cryptKey;
   uint8_t *_cryptBuffer;
+#endif /* UPDATE_CRYPT */
   uint8_t *_buffer;
   uint8_t *_skipBuffer;
   size_t _bufferLen;
@@ -258,15 +270,19 @@ private:
   const esp_partition_t *_partition;
 
   String _target_md5;
+#ifdef UPDATE_CRYPT
   bool _target_md5_decrypted = true;
+#endif /* UPDATE_CRYPT */
   MD5Builder _md5;
 
   int _ledPin;
   uint8_t _ledOn;
 
+#ifdef UPDATE_CRYPT
   uint8_t _cryptMode;
   size_t _cryptAddress;
   uint8_t _cryptCfg;
+#endif /* UPDATE_CRYPT */
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_UPDATE)

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -75,9 +75,9 @@ UpdateClass::UpdateClass()
 #ifdef UPDATE_CRYPT
 _cryptKey(0), _cryptBuffer(0),
 #endif /* UPDATE_CRYPT */
-_buffer(0), _skipBuffer(0), _bufferLen(0), _size(0), _progress_callback(NULL), _progress(0), _paroffset(0), _command(U_FLASH), _partition(NULL),
+_buffer(0), _skipBuffer(0), _bufferLen(0), _size(0), _progress_callback(NULL), _progress(0), _paroffset(0), _command(U_FLASH), _partition(NULL)
 #ifdef UPDATE_CRYPT
-_cryptMode(U_AES_DECRYPT_AUTO), _cryptAddress(0), _cryptCfg(0xf)
+, _cryptMode(U_AES_DECRYPT_AUTO), _cryptAddress(0), _cryptCfg(0xf)
 #endif /* UPDATE_CRYPT */
 {}
 


### PR DESCRIPTION
This PR guards the crypto parts in library Update.
By doing this flash space is saved, since most users don't use crypto updates. To enable the possibility of crypto updates again just adding #define UPDATE_CRYPT to the sketch to enable the functionality again.
(similar to https://github.com/espressif/arduino-esp32/pull/9893)