### PR TITLE
Add support for Waveshare ESP32-S3-Tiny base on ESP32-S3FH4R2 chip (Closes #10633)

### DIFF
--- a/variants/waveshare_esp32_s3_tiny/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_tiny/pins_arduino.h
@@ -1,0 +1,77 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID          0x303a
+#define USB_PID          0x1001
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Tiny"
+#define USB_SERIAL       ""  // Empty string for MAC address
+
+#define RGB_BUILTIN    38
+#define RGB_BRIGHTNESS 64
+
+#define MTDO 45
+#define MTDI 47
+#define MTMS 48
+#define MTCK 44
+
+// UART0 pins
+static const uint8_t TX = 49;
+static const uint8_t RX = 50;
+
+static const uint8_t SDA = -1;
+static const uint8_t SCL = -1;
+
+// Mapping based on the ESP32S3 data sheet - alternate for SPI2
+static const uint8_t SS = 32;    // FSPICS0
+static const uint8_t MOSI = 35;  // FSPID
+static const uint8_t MISO = 34;  // FSPIQ
+static const uint8_t SCK = 33;   // FSPICLK
+
+//static const uint8_t XTAL_32K_N = 22;
+//static const uint8_t XTAL_32K_P = 21;
+
+//static const uint8_t SPIWP = 31;
+//static const uint8_t SPIHD = 30;
+
+// Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
+static const uint8_t GPIO1 = 1;
+static const uint8_t GPIO2 = 2;
+static const uint8_t GPIO3 = 3;
+static const uint8_t GPIO4 = 4;
+static const uint8_t GPIO5 = 5;
+static const uint8_t GPIO6 = 6;
+static const uint8_t GPIO7 = 7;
+static const uint8_t GPIO8 = 8;
+static const uint8_t GPIO9 = 9;
+static const uint8_t GPIO10 = 10;
+static const uint8_t GPIO11 = 11;
+static const uint8_t GPIO12 = 12;
+static const uint8_t GPIO13 = 13;
+static const uint8_t GPIO14 = 14;
+static const uint8_t GPIO15 = 15;
+static const uint8_t GPIO16 = 16;
+static const uint8_t GPIO17 = 17;
+static const uint8_t GPIO18 = 18;
+
+static const uint8_t GPIO21 = 21;
+
+static const uint8_t GPIO33 = 33;
+static const uint8_t GPIO34 = 34;
+static const uint8_t GPIO35 = 35;
+static const uint8_t GPIO36 = 36;
+static const uint8_t GPIO37 = 37;
+static const uint8_t GPIO38 = 38;
+static const uint8_t GPIO39 = 39;
+static const uint8_t GPIO40 = 40;
+static const uint8_t GPIO41 = 41;
+static const uint8_t GPIO42 = 42;
+
+static const uint8_t GPIO45 = 45;
+
+static const uint8_t GPIO47 = 47;
+static const uint8_t GPIO48 = 48;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

-----------
## Description of Change
Add pin definition of the [Waveshare board ESP32-S3-Tiny](https://www.waveshare.com/wiki/ESP32-S3-Tiny)

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.17 based on ESP-IDF 4.4.7 with ESP32-S3-Tiny Board with this scenario
with PlatformIO on VsCode

## Related links
Closes #10633
Adding Support in PlatformIO for [Waveshare ESP32-S3-Tiny board](https://github.com/platformio/platform-espressif32/pull/1496)