### PR TITLE
fix compile of P4 caused from missing ")" in debug macro

### DIFF
--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -267,7 +267,7 @@ bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz) {
                                           : ((conf.source == SOC_CPU_CLK_SRC_APLL) ? "APLL"
                                           : ((conf.source == SOC_CPU_CLK_SRC_XTAL) ? "XTAL"
 #ifdef CONFIG_IDF_TARGET_ESP32P4
-                                          : "17.5M"),
+                                          : "17.5M")),
 #else
                                           : "8M")),
 #endif


### PR DESCRIPTION
Compile of P4 sketches do fail when log debug is enabled.

@me-no-dev 