### PR TITLE
Adds a Minimum Code Matter Example

### DIFF
--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -1,0 +1,60 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * This example ha the smallest code that will create a Matter Device which can be
+ * commissioned and controlled from a Matter Environment APP.
+ * It doesn't control any light, but the ESP32 will send debug messages indicating the Matter activity.
+ * Therefore, turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.
+ */
+
+// Matter Manager
+#include <Matter.h>
+#include <WiFi.h>
+
+// List of Matter Endpoints for this Node
+// Single On/Off Light Endpoint - at least one per node
+MatterOnOffLight OnOffLight;
+
+// WiFi is manually set and started
+const char *ssid = "your-ssid";          // Change this to your WiFi SSID
+const char *password = "your-password";  // Change this to your WiFi password
+
+void setup() {
+  WiFi.enableIPv6(true);
+  // Manually connect to WiFi
+  WiFi.begin(ssid, password);
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+
+  // Initialize at least one Matter EndPoint
+  OnOffLight.begin();
+
+  // Matter beginning - Last step, after all EndPoints are initialized
+  Matter.begin();
+
+  if (!Matter.isDeviceCommissioned()) {
+    log_i("Matter Node is not commissioned yet.");
+    log_i("Initiate the device discovery in your Matter environment.");
+    log_i("Commission it to your Matter hub with the manual pairing code or QR code");
+    log_i("Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
+    log_i("QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
+  }
+}
+
+void loop() {
+  delay(500);
+}

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -27,11 +27,28 @@
 // Single On/Off Light Endpoint - at least one per node
 MatterOnOffLight OnOffLight;
 
+// Light GPIO that can be controlled by Matter APP
+#ifdef LED_BUILTIN
+const uint8_t ledPin = LED_BUILTIN;
+#else
+const uint8_t ledPin = 2;  // Set your pin here if your board has not defined LED_BUILTIN
+#endif
+
+// Matter Protocol Endpoint (On/OFF Light) Callback
+bool matterCB(bool state) {
+  digitalWrite(ledPin, state ? HIGH : LOW);
+  // This callback must return the success state to Matter core
+  return true;
+}
+
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
 
 void setup() {
+  // Initialise the LED GPIO
+  pinMode(ledPin, OUTPUT);
+  
   WiFi.enableIPv6(true);
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
@@ -42,6 +59,9 @@ void setup() {
 
   // Initialize at least one Matter EndPoint
   OnOffLight.begin();
+
+  // Associate a callback to the Matter Controller
+  OnOffLight.onChange(matterCB);
 
   // Matter beginning - Last step, after all EndPoints are initialized
   Matter.begin();

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -49,7 +49,7 @@ const char *password = "your-password";  // Change this to your WiFi password
 void setup() {
   // Initialise the LED GPIO
   pinMode(ledPin, OUTPUT);
-  
+
   WiFi.enableIPv6(true);
   // Manually connect to WiFi
   WiFi.begin(ssid, password);

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -15,7 +15,7 @@
 /*
  * This example is the smallest code that will create a Matter Device which can be
  * commissioned and controlled from a Matter Environment APP.
- * It doesn't control any light, but the ESP32 will send debug messages indicating the Matter activity.
+ * It controls a GPIO that may be used as LED, additionally the ESP32 will send debug messages indicating the Matter activity.
  * Therefore, turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.
  */
 

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -17,7 +17,7 @@
  * commissioned and controlled from a Matter Environment APP.
  * It controls a GPIO that could be attached to a LED for visualization.
  * Additionally the ESP32 will send debug messages indicating the Matter activity.
- * Turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.
+ * Turning DEBUG Level ON may be useful to following Matter Accessory and Controller messages.
  */
 
 // Matter Manager

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -15,7 +15,8 @@
 /*
  * This example is the smallest code that will create a Matter Device which can be
  * commissioned and controlled from a Matter Environment APP.
- * It controls a GPIO, that could be attached to a LED. Additionally the ESP32 will send debug messages indicating the Matter activity.
+ * It controls a GPIO that could be attached to a LED for visualization.
+ * Additionally the ESP32 will send debug messages indicating the Matter activity.
  * Turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.
  */
 

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -16,7 +16,7 @@
  * This example is the smallest code that will create a Matter Device which can be
  * commissioned and controlled from a Matter Environment APP.
  * It controls a GPIO that may be used as LED, additionally the ESP32 will send debug messages indicating the Matter activity.
- * Therefore, turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.
+ * Turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.
  */
 
 // Matter Manager

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -47,7 +47,7 @@ const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
 
 void setup() {
-  // Initialise the LED GPIO
+  // Initialize the LED GPIO
   pinMode(ledPin, OUTPUT);
 
   WiFi.enableIPv6(true);

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
- * This example ha the smallest code that will create a Matter Device which can be
+ * This example is the smallest code that will create a Matter Device which can be
  * commissioned and controlled from a Matter Environment APP.
  * It doesn't control any light, but the ESP32 will send debug messages indicating the Matter activity.
  * Therefore, turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -15,7 +15,7 @@
 /*
  * This example is the smallest code that will create a Matter Device which can be
  * commissioned and controlled from a Matter Environment APP.
- * It controls a GPIO that may be used as LED, additionally the ESP32 will send debug messages indicating the Matter activity.
+ * It controls a GPIO, that could be attached to a LED. Additionally the ESP32 will send debug messages indicating the Matter activity.
  * Turning DEBUG Level may be useful to follow Matter Accessory and Controller messages.
  */
 

--- a/libraries/Matter/examples/MatterMinimum/ci.json
+++ b/libraries/Matter/examples/MatterMinimum/ci.json
@@ -1,0 +1,7 @@
+{
+  "fqbn_append": "PartitionScheme=huge_app",
+  "requires": [
+    "CONFIG_SOC_WIFI_SUPPORTED=y",
+    "CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y"
+  ]
+}


### PR DESCRIPTION
## Description of Change
Adds the minimum Matter Accessory example code in order to ilustrate how simple it is to work with the new ESP32 Arduino Matter Library.

## Tests scenarios
ESP32-S3 with the provided example

## Related links
Related to #7432
