### PR TITLE
fix(network): Avoid returning zero if connection is not dropped

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -549,7 +549,7 @@ uint8_t NetworkClient::connected() {
   }
   if (_connected) {
     uint8_t dummy;
-    int res = recv(fd(), &dummy, 0, MSG_DONTWAIT);
+    int res = recv(fd(), &dummy, 1, MSG_DONTWAIT | MSG_PEEK);
     // avoid unused var warning by gcc
     (void)res;
     // recv only sets errno if res is <= 0


### PR DESCRIPTION
## Description of Change

If the buffer is empty `recv()` will return size 0 and be interpreted as the connection being dropped when it is in fact active.
By using the peek flag we can ensure that 0 will only be returned in case of an error and not when the buffer is empty.

## Tests scenarios

Tested locally.

## Related links

Closes #10559
