### PR TITLE
feat(uart): [IDF5.1] fixes HardwareSerial::updateBaudRate() using a baud rate higher 230400 - checks UART Clock Source

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -34,6 +34,7 @@
 #include "esp_rom_gpio.h"
 
 static int s_uart_debug_nr = 0;  // UART number for debug output
+#define REF_TICK_BAUDRATE_LIMIT 250000  // this is maximum UART badrate using REF_TICK as clock source
 
 struct uart_struct_t {
 
@@ -508,7 +509,7 @@ uart_t *uartBegin(
 #if SOC_UART_SUPPORT_XTAL_CLK
   uart_config.source_clk = UART_SCLK_XTAL;  // valid for C2, S3, C3, C6, H2 and P4
 #elif SOC_UART_SUPPORT_REF_TICK
-  if (baudrate <= 250000) {
+  if (baudrate <= REF_TICK_BAUDRATE_LIMIT) {
     uart_config.source_clk = UART_SCLK_REF_TICK;  // valid for ESP32, S2 - MAX supported baud rate is 250 Kbps
   } else {
     uart_config.source_clk = UART_SCLK_APB;  // baudrate may change with the APB Frequency!
@@ -790,6 +791,10 @@ void uartSetBaudRate(uart_t *uart, uint32_t baud_rate) {
     return;
   }
   UART_MUTEX_LOCK();
+#if !SOC_UART_SUPPORT_XTAL_CLK
+  uart_sclk_t newClkSrc = baud_rate <= REF_TICK_BAUDRATE_LIMIT ? UART_SCLK_REF_TICK : UART_SCLK_APB;
+  uart_ll_set_sclk(UART_LL_GET_HW(uart->num), newClkSrc);
+#endif
   if (uart_set_baudrate(uart->num, baud_rate) == ESP_OK) {
     uart->_baudrate = baud_rate;
   } else {

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -33,7 +33,7 @@
 #include "hal/gpio_hal.h"
 #include "esp_rom_gpio.h"
 
-static int s_uart_debug_nr = 0;  // UART number for debug output
+static int s_uart_debug_nr = 0;         // UART number for debug output
 #define REF_TICK_BAUDRATE_LIMIT 250000  // this is maximum UART badrate using REF_TICK as clock source
 
 struct uart_struct_t {

--- a/libraries/OpenThread/examples/COAP/coap_lamp/coap_lamp.ino
+++ b/libraries/OpenThread/examples/COAP/coap_lamp/coap_lamp.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "OThreadCLI.h"
 #include "OThreadCLI_Util.h"
 

--- a/libraries/OpenThread/examples/COAP/coap_switch/coap_switch.ino
+++ b/libraries/OpenThread/examples/COAP/coap_switch/coap_switch.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "OThreadCLI.h"
 #include "OThreadCLI_Util.h"
 

--- a/libraries/OpenThread/examples/SimpleCLI/SimpleCLI.ino
+++ b/libraries/OpenThread/examples/SimpleCLI/SimpleCLI.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
  * OpenThread.begin(false) will not automatically start a node in a Thread Network
  * The user will need to start it manually using the OpenThread CLI commands

--- a/libraries/OpenThread/examples/SimpleNode/SimpleNode.ino
+++ b/libraries/OpenThread/examples/SimpleNode/SimpleNode.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
  * OpenThread.begin() will automatically start a node in a Thread Network
  * If NVS is empty, default configuration will be as follow:

--- a/libraries/OpenThread/examples/SimpleThreadNetwork/ExtendedRouterNode/ExtendedRouterNode.ino
+++ b/libraries/OpenThread/examples/SimpleThreadNetwork/ExtendedRouterNode/ExtendedRouterNode.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "OThreadCLI.h"
 #include "OThreadCLI_Util.h"
 

--- a/libraries/OpenThread/examples/SimpleThreadNetwork/LeaderNode/LeaderNode.ino
+++ b/libraries/OpenThread/examples/SimpleThreadNetwork/LeaderNode/LeaderNode.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
    OpenThread.begin(false) will not automatically start a node in a Thread Network
    A Leader node is the first device, that has a complete dataset, to start Thread

--- a/libraries/OpenThread/examples/SimpleThreadNetwork/RouterNode/RouterNode.ino
+++ b/libraries/OpenThread/examples/SimpleThreadNetwork/RouterNode/RouterNode.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
    OpenThread.begin(false) will not automatically start a node in a Thread Network
    A Router/Child node is the device that will join an existing Thread Network

--- a/libraries/OpenThread/examples/ThreadScan/ThreadScan.ino
+++ b/libraries/OpenThread/examples/ThreadScan/ThreadScan.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
    OpenThread.begin(true) will automatically start a node in a Thread Network
    Full scanning requires the thread node to be at least in Child state.

--- a/libraries/OpenThread/examples/onReceive/onReceive.ino
+++ b/libraries/OpenThread/examples/onReceive/onReceive.ino
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
    OpenThread.begin() will automatically start a node in a Thread Network
    This will demonstrate how to capture the CLI response in a callback function

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "OThreadCLI.h"
 #if SOC_IEEE802154_SUPPORTED
 #if CONFIG_OPENTHREAD_ENABLED

--- a/libraries/OpenThread/src/OThreadCLI.h
+++ b/libraries/OpenThread/src/OThreadCLI.h
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include "soc/soc_caps.h"
 #include "sdkconfig.h"

--- a/libraries/OpenThread/src/OThreadCLI_Util.cpp
+++ b/libraries/OpenThread/src/OThreadCLI_Util.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "OThreadCLI.h"
 #if SOC_IEEE802154_SUPPORTED
 #if CONFIG_OPENTHREAD_ENABLED

--- a/libraries/OpenThread/src/OThreadCLI_Util.h
+++ b/libraries/OpenThread/src/OThreadCLI_Util.h
@@ -1,3 +1,17 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 #include "soc/soc_caps.h"
 #include "sdkconfig.h"


### PR DESCRIPTION
# EXCLUSIVE FOR IDF 5.1 - Arduino Core 3.0.x

## Description of Change

ESP32 and ESP32S2 use REF_TICK as UART clock source whenever the baud rate is lower then 250,000.
This is done within `HardwareSerial::begin(uint32_t baud)`
This prevents issues with chaning the APB clock to lower than 40MHz, specially when achieving lower power consumpition.

This PR also fixes it for the `HardwareSerial::updateBaudRate(uint32_t baud)` by checking the target baud rate and adjusting the UART Clock Source that will make it work correctly.

## Tests scenarios
Using this sketch (from the issue report) using ESP32 and ESP32S2

``` cpp
void setup() {
  // put your setup code here, to run once:
  Serial.begin(115200);
  delay(500);
  
  Serial1.begin(230400);
  Serial.printf("%d\n", Serial1.baudRate());
  // Clock is now UART_SCLK_REF_TICK

  Serial1.updateBaudRate(460800);
  Serial.printf("%d\n", Serial1.baudRate());
  // Clock is still UART_SCLK_REF_TICK

  Serial1.end();
  Serial1.begin(460800);
  Serial.printf("%d\n", Serial1.baudRate());
  // Clock is now UART_SCLK_APB <<---- FIXED by the PR
}

void loop() {
}
```

## Related links
Closes #10641 