### PR TITLE
feat(uart): [IDF 5.3] fixes HardwareSerial::updateBaudRate() using a baud rate higher 230400 - checks UART Clock Source

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -33,8 +33,8 @@
 #include "hal/gpio_hal.h"
 #include "esp_rom_gpio.h"
 
-static int s_uart_debug_nr = 0;  // UART number for debug output
-#define REF_TICK_BAUDRATE_LIMIT 250000 // this is maximum UART badrate using REF_TICK as clock
+static int s_uart_debug_nr = 0;         // UART number for debug output
+#define REF_TICK_BAUDRATE_LIMIT 250000  // this is maximum UART badrate using REF_TICK as clock
 
 struct uart_struct_t {
 


### PR DESCRIPTION
# EXCLUSIVE FOR IDF 5.3 - Arduino Core 3.1.x

## Description of Change

ESP32 and ESP32S2 use REF_TICK as UART clock source whenever the baud rate is lower then 250,000.
This is done within `HardwareSerial::begin(uint32_t baud)`
This prevents issues with chaning the APB clock to lower than 40MHz, specially when achieving lower power consumpition.

This PR also fixes it for the `HardwareSerial::updateBaudRate(uint32_t baud)` by checking the target baud rate and adjusting the UART Clock Source that will make it work correctly.

## Tests scenarios
Using this sketch (from the issue report) using ESP32 and ESP32S2

``` cpp
void setup() {
  // put your setup code here, to run once:
  Serial.begin(115200);
  delay(500);
  
  Serial1.begin(230400);
  Serial.printf("%d\n", Serial1.baudRate());
  // Clock is now UART_SCLK_REF_TICK

  Serial1.updateBaudRate(460800);
  Serial.printf("%d\n", Serial1.baudRate());
  // Clock is still UART_SCLK_REF_TICK

  Serial1.end();
  Serial1.begin(460800);
  Serial.printf("%d\n", Serial1.baudRate());
  // Clock is now UART_SCLK_APB <<---- FIXED by the PR
}

void loop() {
}
```

## Related links
Closes #10641 