### PR TITLE
fix(zigbee): Increase timeout, commision again on failure + setScanDuration

### DIFF
--- a/libraries/Zigbee/keywords.txt
+++ b/libraries/Zigbee/keywords.txt
@@ -40,6 +40,8 @@ getRadioConfig	KEYWORD2
 setHostConfig	KEYWORD2
 getHostConfig	KEYWORD2
 setPrimaryChannelMask	KEYWORD2
+setScanDuration	KEYWORD2
+getScanDuration	KEYWORD2
 setRebootOpenNetwork	KEYWORD2
 openNetwork	KEYWORD2
 scanNetworks	KEYWORD2

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -20,7 +20,7 @@ ZigbeeCore::ZigbeeCore() {
   _scan_status = ZB_SCAN_FAILED;
   _started = false;
   _connected = false;
-  _scan_duration = 4; // maximum scan duration
+  _scan_duration = 4;  // maximum scan duration
   if (!lock) {
     lock = xSemaphoreCreateBinary();
     if (lock == NULL) {
@@ -182,7 +182,7 @@ void ZigbeeCore::setPrimaryChannelMask(uint32_t mask) {
 }
 
 void ZigbeeCore::setScanDuration(uint8_t duration) {
-  if(duration < 1 || duration > 4) {
+  if (duration < 1 || duration > 4) {
     log_e("Invalid scan duration, must be between 1 and 4");
     return;
   }

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -6,7 +6,7 @@
 #include "ZigbeeHandlers.cpp"
 #include "Arduino.h"
 
-#define ZB_INIT_TIMEOUT 10000  // 10 seconds
+#define ZB_INIT_TIMEOUT 30000  // 30 seconds
 
 extern "C" void zb_set_ed_node_descriptor(bool power_src, bool rx_on_when_idle, bool alloc_addr);
 static bool edBatteryPowered = false;
@@ -20,6 +20,7 @@ ZigbeeCore::ZigbeeCore() {
   _scan_status = ZB_SCAN_FAILED;
   _started = false;
   _connected = false;
+  _scan_duration = 4; // maximum scan duration
   if (!lock) {
     lock = xSemaphoreCreateBinary();
     if (lock == NULL) {
@@ -90,6 +91,8 @@ void ZigbeeCore::addEndpoint(ZigbeeEP *ep) {
 }
 
 static void esp_zb_task(void *pvParameters) {
+  esp_zb_bdb_set_scan_duration(Zigbee.getScanDuration());
+
   /* initialize Zigbee stack */
   ESP_ERROR_CHECK(esp_zb_start(false));
 
@@ -178,6 +181,14 @@ void ZigbeeCore::setPrimaryChannelMask(uint32_t mask) {
   _primary_channel_mask = mask;
 }
 
+void ZigbeeCore::setScanDuration(uint8_t duration) {
+  if(duration < 1 || duration > 4) {
+    log_e("Invalid scan duration, must be between 1 and 4");
+    return;
+  }
+  _scan_duration = duration;
+}
+
 void ZigbeeCore::setRebootOpenNetwork(uint8_t time) {
   _open_network = time;
 }
@@ -235,8 +246,8 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
         }
       } else {
         /* commissioning failed */
-        log_e("Failed to initialize Zigbee stack (status: %s)", esp_err_to_name(err_status));
-        xSemaphoreGive(Zigbee.lock);
+        log_w("Commissioning failed, trying again...", esp_err_to_name(err_status));
+        esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb, ESP_ZB_BDB_MODE_INITIALIZATION, 500);
       }
       break;
     case ESP_ZB_BDB_SIGNAL_FORMATION:  // Coordinator

--- a/libraries/Zigbee/src/ZigbeeCore.h
+++ b/libraries/Zigbee/src/ZigbeeCore.h
@@ -110,8 +110,8 @@ public:
   void setHostConfig(esp_zb_host_config_t config);
   esp_zb_host_config_t getHostConfig();
 
-  void setPrimaryChannelMask(uint32_t mask); // By default all channels are scanned (11-26) -> mask 0x07FFF800
-  void setScanDuration(uint8_t duration); // Can be set from 1 - 4. 1 is fastest, 4 is slowest
+  void setPrimaryChannelMask(uint32_t mask);  // By default all channels are scanned (11-26) -> mask 0x07FFF800
+  void setScanDuration(uint8_t duration);     // Can be set from 1 - 4. 1 is fastest, 4 is slowest
   uint8_t getScanDuration() {
     return _scan_duration;
   }

--- a/libraries/Zigbee/src/ZigbeeCore.h
+++ b/libraries/Zigbee/src/ZigbeeCore.h
@@ -66,6 +66,7 @@ private:
   esp_zb_host_config_t _host_config;
   uint32_t _primary_channel_mask;
   int16_t _scan_status;
+  uint8_t _scan_duration;
 
   esp_zb_ep_list_t *_zb_ep_list;
   zigbee_role_t _role;
@@ -109,7 +110,12 @@ public:
   void setHostConfig(esp_zb_host_config_t config);
   esp_zb_host_config_t getHostConfig();
 
-  void setPrimaryChannelMask(uint32_t mask);
+  void setPrimaryChannelMask(uint32_t mask); // By default all channels are scanned (11-26) -> mask 0x07FFF800
+  void setScanDuration(uint8_t duration); // Can be set from 1 - 4. 1 is fastest, 4 is slowest
+  uint8_t getScanDuration() {
+    return _scan_duration;
+  }
+
   void setRebootOpenNetwork(uint8_t time);
   void openNetwork(uint8_t time);
 


### PR DESCRIPTION
## Description of Change
This PR adds a fix, so there is no need to restart the device after commissioning fails.
The Zigbee will try to connect for 30s to the already joined network, if not successful the `Zigbee.begin()` returns `false` meaning a need to device restart.

Also added an API to set the scan duration, used when discovering the networks when trying to join.
By default I set the biggest value 4. It can be set within 1-4. 

## Tests scenarios
Tested locally, no need for device restart at all now.
Always connects / rejoins.

## Related links
#10612
#10601