### PR TITLE
WiFiProv: Split provisioning into two parts for better synchronization.

### DIFF
--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -94,6 +94,8 @@ void setup() {
 
   RMaker.enableSystemService(SYSTEM_SERV_FLAGS_ALL, 2, 2, 2);
 
+  WiFiProv.initProvision(NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM);
+
   RMaker.start();
 
   WiFi.onEvent(sysProvEvent);  // Will call sysProvEvent() from another thread.

--- a/libraries/WiFiProv/src/WiFiProv.cpp
+++ b/libraries/WiFiProv/src/WiFiProv.cpp
@@ -1,4 +1,4 @@
-/*
+  /*
     WiFiProv.cpp - WiFiProv class for provisioning
     All rights reserved.
 
@@ -72,13 +72,14 @@ static void get_device_service_name(prov_scheme_t prov_scheme, char *service_nam
 #endif
 }
 
-void WiFiProvClass ::beginProvision(
-  prov_scheme_t prov_scheme, scheme_handler_t scheme_handler, network_prov_security_t security, const char *pop, const char *service_name,
-  const char *service_key, uint8_t *uuid, bool reset_provisioned
-) {
-  bool provisioned = false;
-  static char service_name_temp[32];
+bool provInitDone = false;
+bool provisioned = false;
 
+void WiFiProvClass ::initProvision(prov_scheme_t prov_scheme, scheme_handler_t scheme_handler, bool reset_provisioned) {
+  if (provInitDone) {
+    log_i("provInit was already done!");
+    return;
+  }
   network_prov_mgr_config_t config;
 #if CONFIG_BLUEDROID_ENABLED
   if (prov_scheme == NETWORK_PROV_SCHEME_BLE) {
@@ -123,6 +124,18 @@ void WiFiProvClass ::beginProvision(
     network_prov_mgr_deinit();
     return;
   }
+  provInitDone = true;
+}
+
+void WiFiProvClass ::beginProvision(
+  prov_scheme_t prov_scheme, scheme_handler_t scheme_handler, network_prov_security_t security, const char *pop, const char *service_name,
+  const char *service_key, uint8_t *uuid, bool reset_provisioned
+) {
+  if (!provInitDone) {
+    WiFiProvClass ::initProvision( prov_scheme, scheme_handler, reset_provisioned);
+    provInitDone = true;
+  }
+  static char service_name_temp[32];
   if (provisioned == false) {
 #if CONFIG_BLUEDROID_ENABLED
     if (prov_scheme == NETWORK_PROV_SCHEME_BLE) {

--- a/libraries/WiFiProv/src/WiFiProv.h
+++ b/libraries/WiFiProv/src/WiFiProv.h
@@ -48,6 +48,10 @@ typedef enum {
 //Provisioning class
 class WiFiProvClass {
 public:
+  void initProvision(
+    prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE,
+    bool reset_provisioned = false
+  );
   void beginProvision(
     prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE,
     network_prov_security_t security = NETWORK_PROV_SECURITY_1, const char *pop = "abcd1234", const char *service_name = NULL, const char *service_key = NULL,


### PR DESCRIPTION
- Split the beginProvision into initProvision and beginProvision.
- The user node association (cloud_user_assoc) endpoint failed to register in the provisioning workflow because provisioning began before the endpoint creation.