### PR TITLE
feat(Zigbee): Recall bounded devices after reboot + IEEE address option for commands

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/Zigbee_Color_Dimmer_Switch.ino
+++ b/libraries/Zigbee/examples/Zigbee_Color_Dimmer_Switch/Zigbee_Color_Dimmer_Switch.ino
@@ -145,6 +145,6 @@ void loop() {
   static uint32_t last_print = 0;
   if (millis() - last_print > 30000) {
     last_print = millis();
-    zbSwitch.printBoundDevices();
+    zbSwitch.printBoundDevices(Serial);
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
@@ -147,8 +147,8 @@ void setup() {
       "IEEE Address: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X\n", device->ieee_addr[0], device->ieee_addr[1], device->ieee_addr[2], device->ieee_addr[3],
       device->ieee_addr[4], device->ieee_addr[5], device->ieee_addr[6], device->ieee_addr[7]
     );
-    Serial.printf("Light manufacturer: %s", zbSwitch.readManufacturer(device->endpoint, device->short_addr));
-    Serial.printf("Light model: %s", zbSwitch.readModel(device->endpoint, device->short_addr));
+    Serial.printf("Light manufacturer: %s", zbSwitch.readManufacturer(device->endpoint, device->short_addr, device->ieee_addr));
+    Serial.printf("Light model: %s", zbSwitch.readModel(device->endpoint, device->short_addr, device->ieee_addr));
   }
 
   Serial.println();

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
@@ -190,6 +190,6 @@ void loop() {
   static uint32_t lastPrint = 0;
   if (millis() - lastPrint > 10000) {
     lastPrint = millis();
-    zbSwitch.printBoundDevices(&Serial);
+    zbSwitch.printBoundDevices(Serial);
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
@@ -137,18 +137,17 @@ void setup() {
     Serial.printf(".");
     delay(500);
   }
-
-  // Optional: read manufacturer and model name from the bound light
+  
+  // Optional: List all bound devices and read manufacturer and model name
   std::list<zb_device_params_t *> boundLights = zbSwitch.getBoundDevices();
-  //List all bound lights
   for (const auto &device : boundLights) {
-    Serial.printf("Device on endpoint %d, short address: 0x%x\n", device->endpoint, device->short_addr);
+    Serial.printf("Device on endpoint %d, short address: 0x%x\r\n", device->endpoint, device->short_addr);
     Serial.printf(
-      "IEEE Address: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X\n", device->ieee_addr[0], device->ieee_addr[1], device->ieee_addr[2], device->ieee_addr[3],
-      device->ieee_addr[4], device->ieee_addr[5], device->ieee_addr[6], device->ieee_addr[7]
+      "IEEE Address: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X\r\n", device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], 
+      device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]
     );
-    Serial.printf("Light manufacturer: %s", zbSwitch.readManufacturer(device->endpoint, device->short_addr, device->ieee_addr));
-    Serial.printf("Light model: %s", zbSwitch.readModel(device->endpoint, device->short_addr, device->ieee_addr));
+    Serial.printf("Light manufacturer: %s\r\n", zbSwitch.readManufacturer(device->endpoint, device->short_addr, device->ieee_addr));
+    Serial.printf("Light model: %s\r\n", zbSwitch.readModel(device->endpoint, device->short_addr, device->ieee_addr));
   }
 
   Serial.println();
@@ -191,6 +190,6 @@ void loop() {
   static uint32_t lastPrint = 0;
   if (millis() - lastPrint > 10000) {
     lastPrint = millis();
-    zbSwitch.printBoundDevices();
+    zbSwitch.printBoundDevices(&Serial);
   }
 }

--- a/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_Switch/Zigbee_On_Off_Switch.ino
@@ -137,14 +137,14 @@ void setup() {
     Serial.printf(".");
     delay(500);
   }
-  
+
   // Optional: List all bound devices and read manufacturer and model name
   std::list<zb_device_params_t *> boundLights = zbSwitch.getBoundDevices();
   for (const auto &device : boundLights) {
     Serial.printf("Device on endpoint %d, short address: 0x%x\r\n", device->endpoint, device->short_addr);
     Serial.printf(
-      "IEEE Address: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X\r\n", device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], 
-      device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]
+      "IEEE Address: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X\r\n", device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4],
+      device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]
     );
     Serial.printf("Light manufacturer: %s\r\n", zbSwitch.readManufacturer(device->endpoint, device->short_addr, device->ieee_addr));
     Serial.printf("Light model: %s\r\n", zbSwitch.readModel(device->endpoint, device->short_addr, device->ieee_addr));

--- a/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
+++ b/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
@@ -128,6 +128,7 @@ void loop() {
         // If key pressed for more than 3secs, factory reset Zigbee and reboot
         Serial.println("Resetting Zigbee to factory and rebooting in 1s.");
         delay(1000);
+        Zigbee.factoryReset();
       }
     }
   }

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -243,6 +243,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
           } else {
             Zigbee._connected = true;
           }
+          Zigbee.searchBindings();
         }
       } else {
         /* commissioning failed */
@@ -309,8 +310,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
             Bit 6 – Security capability
             Bit 7 – Reserved
         */
-
-        // for each endpoint in the list call the findEndpoint function if not bounded or allowed to bind multiple devices
+        // for each endpoint in the list call the findEndpoint function if not bounded or allowed to bind multiple devices        
         for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
           if (!(*it)->bound() || (*it)->epAllowMultipleBinding()) {
             (*it)->findEndpoint(&cmd_req);
@@ -389,6 +389,71 @@ void ZigbeeCore::scanDelete() {
     _scan_result = nullptr;
   }
   _scan_status = ZB_SCAN_FAILED;
+}
+
+// Recall bounded devices from the binding table after reboot
+void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_info, void *user_ctx)
+{
+  bool done = true;
+  esp_zb_zdo_mgmt_bind_param_t *req = (esp_zb_zdo_mgmt_bind_param_t *)user_ctx;
+  esp_zb_zdp_status_t zdo_status = (esp_zb_zdp_status_t)table_info->status;
+  log_d("Binding table callback for address 0x%04x with status %d", req->dst_addr, zdo_status);
+  if (zdo_status == ESP_ZB_ZDP_STATUS_SUCCESS) {
+    // Print binding table log simple
+    log_d("Binding table info: total %d, index %d, count %d", table_info->total, table_info->index, table_info->count);
+
+    if(table_info->total == 0) {
+      log_d("No binding table entries found");
+      free(req);
+      return;
+    }
+
+    esp_zb_zdo_binding_table_record_t *record = table_info->record;
+    for (int i = 0; i < table_info->count; i++) {
+      log_d("Binding table record: src_endp %d, dst_endp %d, cluster_id 0x%04x, dst_addr_mode %d", record->src_endp, record->dst_endp, record->cluster_id, record->dst_addr_mode);
+      log_d("Short address: 0x%04x", record->dst_address.addr_short);
+      log_d("ieee_address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", record->dst_address.addr_long[7], record->dst_address.addr_long[6], record->dst_address.addr_long[5], record->dst_address.addr_long[4], record->dst_address.addr_long[3], record->dst_address.addr_long[2], record->dst_address.addr_long[1], record->dst_address.addr_long[0]); 
+
+      zb_device_params_t *device = (zb_device_params_t *)calloc(1, sizeof(zb_device_params_t));
+      device->endpoint = record->dst_endp;
+      if(record->dst_addr_mode == ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT || record->dst_addr_mode == ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT) {
+        device->short_addr = record->dst_address.addr_short;
+      } else { //ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT
+        memcpy(device->ieee_addr, record->dst_address.addr_long, sizeof(esp_zb_ieee_addr_t));
+      }
+      log_d("Bound device: endpoint %d, short address 0x%04x to endpoint %d", record->dst_endp, record->dst_address.addr_short, record->src_endp);
+
+      // Add to list of bound devices of proper endpoint
+      for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
+        if ((*it)->getEndpoint() == record->src_endp) {
+          (*it)->addBoundDevice(device);
+        }
+      }
+      record = record->next;
+    }
+
+    // Continue reading the binding table
+    if (table_info->index + table_info->count < table_info->total) {
+      /* There are unreported binding table entries, request for them. */
+      req->start_index = table_info->index + table_info->count;
+      esp_zb_zdo_binding_table_req(req, bindingTableCb, req);
+      done = false;
+    }
+  }
+
+  if (done) {
+    // Print bound devices
+    log_d("Filling bounded devices finished");
+    free(req);
+  }
+}
+
+void ZigbeeCore::searchBindings(){
+  esp_zb_zdo_mgmt_bind_param_t *mb_req = (esp_zb_zdo_mgmt_bind_param_t *)malloc(sizeof(esp_zb_zdo_mgmt_bind_param_t));
+  mb_req->dst_addr = esp_zb_get_short_address();
+  mb_req->start_index = 0;
+  log_d("Requesting binding table for address 0x%04x", mb_req->dst_addr);
+  esp_zb_zdo_binding_table_req(mb_req, bindingTableCb, (void *)mb_req);
 }
 
 // Function to convert enum value to string

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -329,7 +329,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
         }
       }
       break;
-    case ESP_ZB_ZDO_SIGNAL_LEAVE: // End Device
+    case ESP_ZB_ZDO_SIGNAL_LEAVE: // End Device + Router
       // Device was removed from the network, factory reset the device
       if ((zigbee_role_t)Zigbee.getRole() != ZIGBEE_COORDINATOR) {
         Zigbee.factoryReset();

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -329,6 +329,12 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
         }
       }
       break;
+    case ESP_ZB_ZDO_SIGNAL_LEAVE: // End Device
+      // Device was removed from the network, factory reset the device
+      if ((zigbee_role_t)Zigbee.getRole() != ZIGBEE_COORDINATOR) {
+        Zigbee.factoryReset();
+      }
+      break;
     default: log_v("ZDO signal: %s (0x%x), status: %s", esp_zb_zdo_signal_to_string(sig_type), sig_type, esp_err_to_name(err_status)); break;
   }
 }

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -310,7 +310,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
             Bit 6 – Security capability
             Bit 7 – Reserved
         */
-        // for each endpoint in the list call the findEndpoint function if not bounded or allowed to bind multiple devices        
+        // for each endpoint in the list call the findEndpoint function if not bounded or allowed to bind multiple devices
         for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
           if (!(*it)->bound() || (*it)->epAllowMultipleBinding()) {
             (*it)->findEndpoint(&cmd_req);
@@ -329,7 +329,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
         }
       }
       break;
-    case ESP_ZB_ZDO_SIGNAL_LEAVE: // End Device + Router
+    case ESP_ZB_ZDO_SIGNAL_LEAVE:  // End Device + Router
       // Device was removed from the network, factory reset the device
       if ((zigbee_role_t)Zigbee.getRole() != ZIGBEE_COORDINATOR) {
         Zigbee.factoryReset();
@@ -398,8 +398,7 @@ void ZigbeeCore::scanDelete() {
 }
 
 // Recall bounded devices from the binding table after reboot
-void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_info, void *user_ctx)
-{
+void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_info, void *user_ctx) {
   bool done = true;
   esp_zb_zdo_mgmt_bind_param_t *req = (esp_zb_zdo_mgmt_bind_param_t *)user_ctx;
   esp_zb_zdp_status_t zdo_status = (esp_zb_zdp_status_t)table_info->status;
@@ -408,7 +407,7 @@ void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_inf
     // Print binding table log simple
     log_d("Binding table info: total %d, index %d, count %d", table_info->total, table_info->index, table_info->count);
 
-    if(table_info->total == 0) {
+    if (table_info->total == 0) {
       log_d("No binding table entries found");
       free(req);
       return;
@@ -416,13 +415,16 @@ void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_inf
 
     esp_zb_zdo_binding_table_record_t *record = table_info->record;
     for (int i = 0; i < table_info->count; i++) {
-      log_d("Binding table record: src_endp %d, dst_endp %d, cluster_id 0x%04x, dst_addr_mode %d", record->src_endp, record->dst_endp, record->cluster_id, record->dst_addr_mode);
+      log_d(
+        "Binding table record: src_endp %d, dst_endp %d, cluster_id 0x%04x, dst_addr_mode %d", record->src_endp, record->dst_endp, record->cluster_id,
+        record->dst_addr_mode
+      );
 
       zb_device_params_t *device = (zb_device_params_t *)calloc(1, sizeof(zb_device_params_t));
       device->endpoint = record->dst_endp;
-      if(record->dst_addr_mode == ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT || record->dst_addr_mode == ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT) {
+      if (record->dst_addr_mode == ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT || record->dst_addr_mode == ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT) {
         device->short_addr = record->dst_address.addr_short;
-      } else { //ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT
+      } else {  //ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT
         memcpy(device->ieee_addr, record->dst_address.addr_long, sizeof(esp_zb_ieee_addr_t));
       }
 
@@ -430,8 +432,11 @@ void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_inf
       for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
         if ((*it)->getEndpoint() == record->src_endp) {
           (*it)->addBoundDevice(device);
-          log_d("Device bound to EP %d -> device endpoint: %d, short addr: 0x%04x, ieee addr: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", record->src_endp, device->endpoint, device->short_addr, 
-          device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
+          log_d(
+            "Device bound to EP %d -> device endpoint: %d, short addr: 0x%04x, ieee addr: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", record->src_endp,
+            device->endpoint, device->short_addr, device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3],
+            device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]
+          );
         }
       }
       record = record->next;
@@ -453,7 +458,7 @@ void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_inf
   }
 }
 
-void ZigbeeCore::searchBindings(){
+void ZigbeeCore::searchBindings() {
   esp_zb_zdo_mgmt_bind_param_t *mb_req = (esp_zb_zdo_mgmt_bind_param_t *)malloc(sizeof(esp_zb_zdo_mgmt_bind_param_t));
   mb_req->dst_addr = esp_zb_get_short_address();
   mb_req->start_index = 0;

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -411,8 +411,6 @@ void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_inf
     esp_zb_zdo_binding_table_record_t *record = table_info->record;
     for (int i = 0; i < table_info->count; i++) {
       log_d("Binding table record: src_endp %d, dst_endp %d, cluster_id 0x%04x, dst_addr_mode %d", record->src_endp, record->dst_endp, record->cluster_id, record->dst_addr_mode);
-      log_d("Short address: 0x%04x", record->dst_address.addr_short);
-      log_d("ieee_address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", record->dst_address.addr_long[7], record->dst_address.addr_long[6], record->dst_address.addr_long[5], record->dst_address.addr_long[4], record->dst_address.addr_long[3], record->dst_address.addr_long[2], record->dst_address.addr_long[1], record->dst_address.addr_long[0]); 
 
       zb_device_params_t *device = (zb_device_params_t *)calloc(1, sizeof(zb_device_params_t));
       device->endpoint = record->dst_endp;
@@ -421,12 +419,13 @@ void ZigbeeCore::bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_inf
       } else { //ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT
         memcpy(device->ieee_addr, record->dst_address.addr_long, sizeof(esp_zb_ieee_addr_t));
       }
-      log_d("Bound device: endpoint %d, short address 0x%04x to endpoint %d", record->dst_endp, record->dst_address.addr_short, record->src_endp);
 
       // Add to list of bound devices of proper endpoint
       for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
         if ((*it)->getEndpoint() == record->src_endp) {
           (*it)->addBoundDevice(device);
+          log_d("Device bound to EP %d -> device endpoint: %d, short addr: 0x%04x, ieee addr: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", record->src_endp, device->endpoint, device->short_addr, 
+          device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
         }
       }
       record = record->next;

--- a/libraries/Zigbee/src/ZigbeeCore.h
+++ b/libraries/Zigbee/src/ZigbeeCore.h
@@ -80,6 +80,8 @@ private:
   bool zigbeeInit(esp_zb_cfg_t *zb_cfg, bool erase_nvs);
   static void scanCompleteCallback(esp_zb_zdp_status_t zdo_status, uint8_t count, esp_zb_network_descriptor_t *nwk_descriptor);
   const char *getDeviceTypeString(esp_zb_ha_standard_devices_t deviceId);
+  void searchBindings();
+  static void bindingTableCb(const esp_zb_zdo_binding_table_info_t *table_info, void *user_ctx);
 
 public:
   ZigbeeCore();

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -186,21 +186,21 @@ char *ZigbeeEP::readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_add
   return _read_model;
 }
 
-void ZigbeeEP::printBoundDevices(Print *print) {
-  if (print == nullptr) {
-    log_i("Bound devices:");
-    for ([[maybe_unused]]
-    const auto &device : _bound_devices) {
-      log_i("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", device->endpoint, device->short_addr, 
-      device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
-      }
-  } else {
-    print->println("Bound devices:");
-    for ([[maybe_unused]]
-    const auto &device : _bound_devices) {
-      print->printf("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\r\n", device->endpoint, device->short_addr, 
-      device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
+void ZigbeeEP::printBoundDevices() {
+  log_i("Bound devices:");
+  for ([[maybe_unused]]
+  const auto &device : _bound_devices) {
+    log_i("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", device->endpoint, device->short_addr, 
+    device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
     }
+}
+
+void ZigbeeEP::printBoundDevices(Print &print) {
+  print.println("Bound devices:");
+  for ([[maybe_unused]]
+  const auto &device : _bound_devices) {
+    print.printf("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\r\n", device->endpoint, device->short_addr, 
+    device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
   }
 }
 

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -118,7 +118,7 @@ char *ZigbeeEP::readManufacturer(uint8_t endpoint, uint16_t short_addr, esp_zb_i
   /* Read peer Manufacture Name & Model Identifier */
   esp_zb_zcl_read_attr_cmd_t read_req;
 
-  if(short_addr != 0){
+  if (short_addr != 0) {
     read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     read_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
   } else {
@@ -154,7 +154,7 @@ char *ZigbeeEP::readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_add
   /* Read peer Manufacture Name & Model Identifier */
   esp_zb_zcl_read_attr_cmd_t read_req;
 
-  if(short_addr != 0){
+  if (short_addr != 0) {
     read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     read_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
   } else {
@@ -189,18 +189,24 @@ char *ZigbeeEP::readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_add
 void ZigbeeEP::printBoundDevices() {
   log_i("Bound devices:");
   for ([[maybe_unused]]
-  const auto &device : _bound_devices) {
-    log_i("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", device->endpoint, device->short_addr, 
-    device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
-    }
+       const auto &device : _bound_devices) {
+    log_i(
+      "Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", device->endpoint, device->short_addr,
+      device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1],
+      device->ieee_addr[0]
+    );
+  }
 }
 
 void ZigbeeEP::printBoundDevices(Print &print) {
   print.println("Bound devices:");
   for ([[maybe_unused]]
-  const auto &device : _bound_devices) {
-    print.printf("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\r\n", device->endpoint, device->short_addr, 
-    device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
+       const auto &device : _bound_devices) {
+    print.printf(
+      "Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\r\n", device->endpoint, device->short_addr,
+      device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1],
+      device->ieee_addr[0]
+    );
   }
 }
 

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -139,7 +139,9 @@ char *ZigbeeEP::readManufacturer(uint8_t endpoint, uint16_t short_addr, esp_zb_i
   // clear read manufacturer
   _read_manufacturer = nullptr;
 
+  esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_read_attr_cmd_req(&read_req);
+  esp_zb_lock_release();
 
   //Wait for response or timeout
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -173,22 +175,32 @@ char *ZigbeeEP::readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_add
   // clear read model
   _read_model = nullptr;
 
+  esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_read_attr_cmd_req(&read_req);
+  esp_zb_lock_release();
 
   //Wait for response or timeout
-  //Semaphore take
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
     log_e("Error while reading model");
   }
   return _read_model;
 }
 
-void ZigbeeEP::printBoundDevices() {
-  log_i("Bound devices:");
-  for ([[maybe_unused]]
-       const auto &device : _bound_devices) {
-    log_i("Device on endpoint %d, short address: 0x%x", device->endpoint, device->short_addr);
-    print_ieee_addr(device->ieee_addr);
+void ZigbeeEP::printBoundDevices(Print *print) {
+  if (print == nullptr) {
+    log_i("Bound devices:");
+    for ([[maybe_unused]]
+    const auto &device : _bound_devices) {
+      log_i("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", device->endpoint, device->short_addr, 
+      device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
+      }
+  } else {
+    print->println("Bound devices:");
+    for ([[maybe_unused]]
+    const auto &device : _bound_devices) {
+      print->printf("Device on endpoint %d, short address: 0x%x, ieee address: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\r\n", device->endpoint, device->short_addr, 
+      device->ieee_addr[7], device->ieee_addr[6], device->ieee_addr[5], device->ieee_addr[4], device->ieee_addr[3], device->ieee_addr[2], device->ieee_addr[1], device->ieee_addr[0]);
+    }
   }
 }
 

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -108,7 +108,6 @@ public:
   }
 
 private:
-
   char *_read_manufacturer;
   char *_read_model;
   void (*_on_identify)(uint16_t time);

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -9,8 +9,6 @@
 
 /* Useful defines */
 #define ZB_ARRAY_LENTH(arr) (sizeof(arr) / sizeof(arr[0]))
-#define print_ieee_addr(addr) \
-  log_i("IEEE Address: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7])
 #define XYZ_TO_RGB(X, Y, Z, r, g, b)                                \
   {                                                                 \
     r = (float)(3.240479 * (X) - 1.537150 * (Y) - 0.498535 * (Z));  \
@@ -68,7 +66,7 @@ public:
     return _endpoint;
   }
 
-  void printBoundDevices();
+  void printBoundDevices(Print *print = nullptr);
   std::list<zb_device_params_t *> getBoundDevices() const {
     return _bound_devices;
   }
@@ -128,7 +126,6 @@ protected:
     _bound_devices.push_back(device);
     _is_bound = true;
   }
-  
   friend class ZigbeeCore;
 };
 

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -87,8 +87,8 @@ public:
   void reportBatteryPercentage();
 
   // Methods to read manufacturer and model name from selected endpoint and short address
-  char *readManufacturer(uint8_t endpoint, uint16_t short_addr);
-  char *readModel(uint8_t endpoint, uint16_t short_addr);
+  char *readManufacturer(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_addr_t ieee_addr);
+  char *readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_addr_t ieee_addr);
 
   bool epAllowMultipleBinding() {
     return _allow_multiple_binding;
@@ -108,7 +108,7 @@ public:
   }
 
 private:
-  static bool _allow_multiple_binding;
+
   char *_read_manufacturer;
   char *_read_model;
   void (*_on_identify)(uint16_t time);
@@ -119,10 +119,16 @@ protected:
   esp_zb_endpoint_config_t _ep_config;
   esp_zb_cluster_list_t *_cluster_list;
   static bool _is_bound;
+  static bool _allow_multiple_binding;
   std::list<zb_device_params_t *> _bound_devices;
   SemaphoreHandle_t lock;
   zb_power_source_t _power_source;
 
+  void addBoundDevice(zb_device_params_t *device) {
+    _bound_devices.push_back(device);
+    _is_bound = true;
+  }
+  
   friend class ZigbeeCore;
 };
 

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -66,7 +66,9 @@ public:
     return _endpoint;
   }
 
-  void printBoundDevices(Print *print = nullptr);
+  void printBoundDevices();
+  void printBoundDevices(Print &print);
+
   std::list<zb_device_params_t *> getBoundDevices() const {
     return _bound_devices;
   }

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
@@ -99,7 +99,9 @@ void ZigbeeColorDimmerSwitch::lightToggle() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -113,7 +115,9 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to group address 0x%x", group_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -128,7 +132,9 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint8_t endpoint, uint16_t short_addr)
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -144,7 +150,9 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t i
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
     log_v("Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
     endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -157,7 +165,9 @@ void ZigbeeColorDimmerSwitch::lightOn() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -171,7 +181,9 @@ void ZigbeeColorDimmerSwitch::lightOn(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to group address 0x%x", group_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -186,7 +198,9 @@ void ZigbeeColorDimmerSwitch::lightOn(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -202,7 +216,9 @@ void ZigbeeColorDimmerSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
     log_v("Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
     endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -215,7 +231,9 @@ void ZigbeeColorDimmerSwitch::lightOff() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -229,7 +247,9 @@ void ZigbeeColorDimmerSwitch::lightOff(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to group address 0x%x", group_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -244,7 +264,9 @@ void ZigbeeColorDimmerSwitch::lightOff(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -260,7 +282,9 @@ void ZigbeeColorDimmerSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
     log_v("Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
     endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
@@ -79,7 +79,7 @@ void ZigbeeColorDimmerSwitch::findCb(esp_zb_zdp_status_t zdo_status, uint16_t ad
 // find on_off light endpoint
 void ZigbeeColorDimmerSwitch::findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req) {
   uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL,
-                            ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL};
+                             ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL};
   esp_zb_zdo_match_desc_req_param_t color_dimmable_light_req = {
     .dst_nwk_addr = cmd_req->dst_nwk_addr,
     .addr_of_interest = cmd_req->addr_of_interest,
@@ -148,8 +148,10 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t i
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
-    log_v("Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
+      ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -214,8 +216,10 @@ void ZigbeeColorDimmerSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
-    log_v("Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
+      ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -280,8 +284,10 @@ void ZigbeeColorDimmerSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
-    log_v("Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
+      ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -397,8 +403,10 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, esp
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
     cmd_req.level = level;
     cmd_req.transition_time = 0xffff;
-    log_v("Sending 'set light level' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'set light level' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
+      ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -406,7 +414,6 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, esp
     log_e("Light not bound");
   }
 }
-
 
 void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t blue) {
   if (_is_bound) {
@@ -488,8 +495,10 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
     cmd_req.color_x = color_x;
     cmd_req.color_y = color_y;
     cmd_req.transition_time = 0;
-    log_v("Sending 'set light color' command to endpoint %d,  ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'set light color' command to endpoint %d,  ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
+      ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
     esp_zb_lock_release();

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
@@ -78,17 +78,17 @@ void ZigbeeColorDimmerSwitch::findCb(esp_zb_zdp_status_t zdo_status, uint16_t ad
 
 // find on_off light endpoint
 void ZigbeeColorDimmerSwitch::findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req) {
-    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL,
-                              ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL};
-    esp_zb_zdo_match_desc_req_param_t color_dimmable_light_req = {
-      .dst_nwk_addr = cmd_req->dst_nwk_addr,
-      .addr_of_interest = cmd_req->addr_of_interest,
-      .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
-      .num_in_clusters = 3,
-      .num_out_clusters = 3,
-      .cluster_list = cluster_list,
-    };
-    esp_zb_zdo_match_cluster(&color_dimmable_light_req, findCb, &_endpoint);
+  uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL,
+                            ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL};
+  esp_zb_zdo_match_desc_req_param_t color_dimmable_light_req = {
+    .dst_nwk_addr = cmd_req->dst_nwk_addr,
+    .addr_of_interest = cmd_req->addr_of_interest,
+    .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
+    .num_in_clusters = 3,
+    .num_out_clusters = 3,
+    .cluster_list = cluster_list,
+  };
+  esp_zb_zdo_match_cluster(&color_dimmable_light_req, findCb, &_endpoint);
 }
 
 // Methods to control the light

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
@@ -78,17 +78,17 @@ void ZigbeeColorDimmerSwitch::findCb(esp_zb_zdp_status_t zdo_status, uint16_t ad
 
 // find on_off light endpoint
 void ZigbeeColorDimmerSwitch::findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req) {
-  uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL,
-                             ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL};
-  esp_zb_zdo_match_desc_req_param_t color_dimmable_light_req = {
-    .dst_nwk_addr = cmd_req->dst_nwk_addr,
-    .addr_of_interest = cmd_req->addr_of_interest,
-    .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
-    .num_in_clusters = 3,
-    .num_out_clusters = 3,
-    .cluster_list = cluster_list,
-  };
-  esp_zb_zdo_match_cluster(&color_dimmable_light_req, findCb, &_endpoint);
+    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL,
+                              ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL};
+    esp_zb_zdo_match_desc_req_param_t color_dimmable_light_req = {
+      .dst_nwk_addr = cmd_req->dst_nwk_addr,
+      .addr_of_interest = cmd_req->addr_of_interest,
+      .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
+      .num_in_clusters = 3,
+      .num_out_clusters = 3,
+      .cluster_list = cluster_list,
+    };
+    esp_zb_zdo_match_cluster(&color_dimmable_light_req, findCb, &_endpoint);
 }
 
 // Methods to control the light
@@ -98,10 +98,8 @@ void ZigbeeColorDimmerSwitch::lightToggle() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
-    log_i("Sending 'light toggle' command");
-    //esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light toggle' command");
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    //esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -114,10 +112,8 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint16_t group_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
-    log_i("Sending 'light toggle' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light toggle' command to group address 0x%x", group_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -131,10 +127,24 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint8_t endpoint, uint16_t short_addr)
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
-    log_i("Sending 'light toggle' command to endpoint %d, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light toggle' command to endpoint %d, address 0x%x", endpoint, short_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+  } else {
+    log_e("Light not bound");
+  }
+}
+
+void ZigbeeColorDimmerSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_on_off_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    log_v("Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
   }
@@ -146,10 +156,8 @@ void ZigbeeColorDimmerSwitch::lightOn() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
-    log_i("Sending 'light on' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light on' command");
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -162,10 +170,8 @@ void ZigbeeColorDimmerSwitch::lightOn(uint16_t group_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
-    log_i("Sending 'light on' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light on' command to group address 0x%x", group_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -179,10 +185,24 @@ void ZigbeeColorDimmerSwitch::lightOn(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
-    log_i("Sending 'light on' command to endpoint %d, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light on' command to endpoint %d, address 0x%x", endpoint, short_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+  } else {
+    log_e("Light not bound");
+  }
+}
+
+void ZigbeeColorDimmerSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_on_off_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    log_v("Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
   }
@@ -194,10 +214,8 @@ void ZigbeeColorDimmerSwitch::lightOff() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
-    log_i("Sending 'light off' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light off' command");
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -210,10 +228,8 @@ void ZigbeeColorDimmerSwitch::lightOff(uint16_t group_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
-    log_i("Sending 'light off' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light off' command to group address 0x%x", group_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -227,10 +243,24 @@ void ZigbeeColorDimmerSwitch::lightOff(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
-    log_i("Sending 'light off' command to endpoint %d, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    log_v("Sending 'light off' command to endpoint %d, address 0x%x", endpoint, short_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+  } else {
+    log_e("Light not bound");
+  }
+}
+
+void ZigbeeColorDimmerSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_on_off_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    log_v("Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
   }
@@ -243,7 +273,7 @@ void ZigbeeColorDimmerSwitch::lightOffWithEffect(uint8_t effect_id, uint8_t effe
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.effect_id = effect_id;
     cmd_req.effect_variant = effect_variant;
-    log_i("Sending 'light off with effect' command");
+    log_v("Sending 'light off with effect' command");
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_off_with_effect_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -257,7 +287,7 @@ void ZigbeeColorDimmerSwitch::lightOnWithSceneRecall() {
     esp_zb_zcl_on_off_on_with_recall_global_scene_cmd_t cmd_req;
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
-    log_i("Sending 'light on with scene recall' command");
+    log_v("Sending 'light on with scene recall' command");
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_on_with_recall_global_scene_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -274,7 +304,7 @@ void ZigbeeColorDimmerSwitch::lightOnWithTimedOff(uint8_t on_off_control, uint16
     cmd_req.on_off_control = on_off_control;  //TODO: Test how it works, then maybe change API
     cmd_req.on_time = time_on;
     cmd_req.off_wait_time = time_off;
-    log_i("Sending 'light on with time off' command");
+    log_v("Sending 'light on with time off' command");
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_on_with_timed_off_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -290,7 +320,7 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.level = level;
     cmd_req.transition_time = 0xffff;
-    log_i("Sending 'set light level' command");
+    log_v("Sending 'set light level' command");
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -307,7 +337,7 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint16_t group_addr) 
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.level = level;
     cmd_req.transition_time = 0xffff;
-    log_i("Sending 'set light level' command to group address 0x%x", group_addr);
+    log_v("Sending 'set light level' command to group address 0x%x", group_addr);
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -325,7 +355,7 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, uin
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.level = level;
     cmd_req.transition_time = 0xffff;
-    log_i("Sending 'set light level' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    log_v("Sending 'set light level' command to endpoint %d, address 0x%x", endpoint, short_addr);
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -333,6 +363,26 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, uin
     log_e("Light not bound");
   }
 }
+
+void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_move_to_level_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    cmd_req.level = level;
+    cmd_req.transition_time = 0xffff;
+    log_v("Sending 'set light level' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
+    esp_zb_lock_release();
+  } else {
+    log_e("Light not bound");
+  }
+}
+
 
 void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t blue) {
   if (_is_bound) {
@@ -346,7 +396,7 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
     cmd_req.color_x = color_x;
     cmd_req.color_y = color_y;
     cmd_req.transition_time = 0;
-    log_i("Sending 'set light color' command");
+    log_v("Sending 'set light color' command");
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -368,7 +418,7 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
     cmd_req.color_x = color_x;
     cmd_req.color_y = color_y;
     cmd_req.transition_time = 0;
-    log_i("Sending 'set light color' command to group address 0x%x", group_addr);
+    log_v("Sending 'set light color' command to group address 0x%x", group_addr);
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -391,7 +441,31 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
     cmd_req.color_x = color_x;
     cmd_req.color_y = color_y;
     cmd_req.transition_time = 0;
-    log_i("Sending 'set light color' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    log_v("Sending 'set light color' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
+    esp_zb_lock_release();
+  } else {
+    log_e("Light not bound");
+  }
+}
+
+void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    //Convert RGB to XY
+    uint16_t color_x, color_y;
+    calculateXY(red, green, blue, color_x, color_y);
+
+    esp_zb_zcl_color_move_to_color_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    cmd_req.color_x = color_x;
+    cmd_req.color_y = color_y;
+    cmd_req.transition_time = 0;
+    log_v("Sending 'set light color' command to endpoint %d,  ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
     esp_zb_lock_release();

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.h
@@ -18,14 +18,17 @@ public:
   void lightToggle();
   void lightToggle(uint16_t group_addr);
   void lightToggle(uint8_t endpoint, uint16_t short_addr);
+  void lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
   void lightOn();
   void lightOn(uint16_t group_addr);
   void lightOn(uint8_t endpoint, uint16_t short_addr);
+  void lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
   void lightOff();
   void lightOff(uint16_t group_addr);
   void lightOff(uint8_t endpoint, uint16_t short_addr);
+  void lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
   void lightOffWithEffect(uint8_t effect_id, uint8_t effect_variant);
   void lightOnWithTimedOff(uint8_t on_off_control, uint16_t time_on, uint16_t time_off);
@@ -34,10 +37,12 @@ public:
   void setLightLevel(uint8_t level);
   void setLightLevel(uint8_t level, uint16_t group_addr);
   void setLightLevel(uint8_t level, uint8_t endpoint, uint16_t short_addr);
+  void setLightLevel(uint8_t level, uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
   void setLightColor(uint8_t red, uint8_t green, uint8_t blue);
   void setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint16_t group_addr);
   void setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t endpoint, uint16_t short_addr);
+  void setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
 private:
   // save instance of the class in order to use it in static functions

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
@@ -50,16 +50,16 @@ void ZigbeeSwitch::findCb(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t
 
 // find on_off light endpoint
 void ZigbeeSwitch::findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req) {
-    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF};
-    esp_zb_zdo_match_desc_req_param_t on_off_req = {
-      .dst_nwk_addr = cmd_req->dst_nwk_addr,
-      .addr_of_interest = cmd_req->addr_of_interest,
-      .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
-      .num_in_clusters = 1,
-      .num_out_clusters = 1,
-      .cluster_list = cluster_list,
-    };
-    esp_zb_zdo_match_cluster(&on_off_req, findCb, &_endpoint);
+  uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF};
+  esp_zb_zdo_match_desc_req_param_t on_off_req = {
+    .dst_nwk_addr = cmd_req->dst_nwk_addr,
+    .addr_of_interest = cmd_req->addr_of_interest,
+    .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
+    .num_in_clusters = 1,
+    .num_out_clusters = 1,
+    .cluster_list = cluster_list,
+  };
+  esp_zb_zdo_match_cluster(&on_off_req, findCb, &_endpoint);
 }
 
 // Methods to control the light

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
@@ -50,17 +50,16 @@ void ZigbeeSwitch::findCb(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t
 
 // find on_off light endpoint
 void ZigbeeSwitch::findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req) {
-  uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF};
-  esp_zb_zdo_match_desc_req_param_t on_off_req = {
-    .dst_nwk_addr = cmd_req->dst_nwk_addr,
-    .addr_of_interest = cmd_req->addr_of_interest,
-    .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
-    .num_in_clusters = 1,
-    .num_out_clusters = 1,
-    .cluster_list = cluster_list,
-  };
-
-  esp_zb_zdo_match_cluster(&on_off_req, findCb, &_endpoint);
+    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF};
+    esp_zb_zdo_match_desc_req_param_t on_off_req = {
+      .dst_nwk_addr = cmd_req->dst_nwk_addr,
+      .addr_of_interest = cmd_req->addr_of_interest,
+      .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
+      .num_in_clusters = 1,
+      .num_out_clusters = 1,
+      .cluster_list = cluster_list,
+    };
+    esp_zb_zdo_match_cluster(&on_off_req, findCb, &_endpoint);
 }
 
 // Methods to control the light
@@ -70,7 +69,7 @@ void ZigbeeSwitch::lightToggle() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
-    log_i("Sending 'light toggle' command");
+    log_v("Sending 'light toggle' command");
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -84,7 +83,7 @@ void ZigbeeSwitch::lightToggle(uint16_t group_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
-    log_i("Sending 'light toggle' command to group address 0x%x", group_addr);
+    log_v("Sending 'light toggle' command to group address 0x%x", group_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -99,7 +98,23 @@ void ZigbeeSwitch::lightToggle(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
-    log_i("Sending 'light toggle' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    log_v("Sending 'light toggle' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_zcl_on_off_cmd_req(&cmd_req);
+  } else {
+    log_e("Light not bound");
+  }
+}
+
+void ZigbeeSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_on_off_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    log_v("Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -112,7 +127,7 @@ void ZigbeeSwitch::lightOn() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
-    log_i("Sending 'light on' command");
+    log_v("Sending 'light on' command");
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -126,7 +141,7 @@ void ZigbeeSwitch::lightOn(uint16_t group_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
-    log_i("Sending 'light on' command to group address 0x%x", group_addr);
+    log_v("Sending 'light on' command to group address 0x%x", group_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -141,7 +156,23 @@ void ZigbeeSwitch::lightOn(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
-    log_i("Sending 'light on' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    log_v("Sending 'light on' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_zcl_on_off_cmd_req(&cmd_req);
+  } else {
+    log_e("Light not bound");
+  }
+}
+
+void ZigbeeSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_on_off_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    log_v("Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -154,7 +185,7 @@ void ZigbeeSwitch::lightOff() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
-    log_i("Sending 'light off' command");
+    log_v("Sending 'light off' command");
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -168,7 +199,7 @@ void ZigbeeSwitch::lightOff(uint16_t group_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
-    log_i("Sending 'light off' command to group address 0x%x", group_addr);
+    log_v("Sending 'light off' command to group address 0x%x", group_addr);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -183,7 +214,23 @@ void ZigbeeSwitch::lightOff(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
-    log_i("Sending 'light off' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    log_v("Sending 'light off' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_zcl_on_off_cmd_req(&cmd_req);
+  } else {
+    log_e("Light not bound");
+  }
+}
+
+void ZigbeeSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_on_off_cmd_t cmd_req;
+    cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
+    memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    log_v("Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
+    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -197,7 +244,7 @@ void ZigbeeSwitch::lightOffWithEffect(uint8_t effect_id, uint8_t effect_variant)
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.effect_id = effect_id;
     cmd_req.effect_variant = effect_variant;
-    log_i("Sending 'light off with effect' command");
+    log_v("Sending 'light off with effect' command");
     esp_zb_zcl_on_off_off_with_effect_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -209,7 +256,7 @@ void ZigbeeSwitch::lightOnWithSceneRecall() {
     esp_zb_zcl_on_off_on_with_recall_global_scene_cmd_t cmd_req;
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
-    log_i("Sending 'light on with scene recall' command");
+    log_v("Sending 'light on with scene recall' command");
     esp_zb_zcl_on_off_on_with_recall_global_scene_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");
@@ -223,7 +270,7 @@ void ZigbeeSwitch::lightOnWithTimedOff(uint8_t on_off_control, uint16_t time_on,
     cmd_req.on_off_control = on_off_control;  //TODO: Test how it works, then maybe change API
     cmd_req.on_time = time_on;
     cmd_req.off_wait_time = time_off;
-    log_i("Sending 'light on with time off' command");
+    log_v("Sending 'light on with time off' command");
     esp_zb_zcl_on_off_on_with_timed_off_cmd_req(&cmd_req);
   } else {
     log_e("Light not bound");

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
@@ -119,8 +119,10 @@ void ZigbeeSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
-    log_v("Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
+      ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -185,8 +187,10 @@ void ZigbeeSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
-    log_v("Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
+      ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
     esp_zb_lock_release();
@@ -251,8 +255,10 @@ void ZigbeeSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
-    log_v("Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
-    endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    log_v(
+      "Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
+      ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
+    );
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
     esp_zb_lock_release();

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
@@ -70,7 +70,9 @@ void ZigbeeSwitch::lightToggle() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -84,7 +86,9 @@ void ZigbeeSwitch::lightToggle(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to group address 0x%x", group_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -99,7 +103,9 @@ void ZigbeeSwitch::lightToggle(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -115,7 +121,9 @@ void ZigbeeSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
     log_v("Sending 'light toggle' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
     endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -128,7 +136,9 @@ void ZigbeeSwitch::lightOn() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -142,7 +152,9 @@ void ZigbeeSwitch::lightOn(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to group address 0x%x", group_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -157,7 +169,9 @@ void ZigbeeSwitch::lightOn(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -173,7 +187,9 @@ void ZigbeeSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
     log_v("Sending 'light on' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
     endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -186,7 +202,9 @@ void ZigbeeSwitch::lightOff() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -200,7 +218,9 @@ void ZigbeeSwitch::lightOff(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to group address 0x%x", group_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -215,7 +235,9 @@ void ZigbeeSwitch::lightOff(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to endpoint %d, address 0x%x", endpoint, short_addr);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -231,7 +253,9 @@ void ZigbeeSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
     log_v("Sending 'light off' command to endpoint %d, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", 
     endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]);
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -245,7 +269,9 @@ void ZigbeeSwitch::lightOffWithEffect(uint8_t effect_id, uint8_t effect_variant)
     cmd_req.effect_id = effect_id;
     cmd_req.effect_variant = effect_variant;
     log_v("Sending 'light off with effect' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_off_with_effect_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -257,7 +283,9 @@ void ZigbeeSwitch::lightOnWithSceneRecall() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     log_v("Sending 'light on with scene recall' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_on_with_recall_global_scene_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }
@@ -271,7 +299,9 @@ void ZigbeeSwitch::lightOnWithTimedOff(uint8_t on_off_control, uint16_t time_on,
     cmd_req.on_time = time_on;
     cmd_req.off_wait_time = time_off;
     log_v("Sending 'light on with time off' command");
+    esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_zcl_on_off_on_with_timed_off_cmd_req(&cmd_req);
+    esp_zb_lock_release();
   } else {
     log_e("Light not bound");
   }

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.h
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.h
@@ -18,14 +18,17 @@ public:
   void lightToggle();
   void lightToggle(uint16_t group_addr);
   void lightToggle(uint8_t endpoint, uint16_t short_addr);
+  void lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
   void lightOn();
   void lightOn(uint16_t group_addr);
   void lightOn(uint8_t endpoint, uint16_t short_addr);
+  void lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
   void lightOff();
   void lightOff(uint16_t group_addr);
   void lightOff(uint8_t endpoint, uint16_t short_addr);
+  void lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
   void lightOffWithEffect(uint8_t effect_id, uint8_t effect_variant);
   void lightOnWithTimedOff(uint8_t on_off_control, uint16_t time_on, uint16_t time_off);

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -60,7 +60,9 @@ void ZigbeeTempSensor::setReporting(uint16_t min_interval, uint16_t max_interval
       },
     .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
   };
+  esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_update_reporting_info(&reporting_info);
+  esp_zb_lock_release();
 }
 
 void ZigbeeTempSensor::setTemperature(float temperature) {
@@ -158,7 +160,9 @@ void ZigbeeTempSensor::setHumidityReporting(uint16_t min_interval, uint16_t max_
       },
     .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
   };
+  esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_update_reporting_info(&reporting_info);
+  esp_zb_lock_release();
 }
 
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
@@ -91,12 +91,12 @@ void ZigbeeThermostat::findCb(esp_zb_zdp_status_t zdo_status, uint16_t addr, uin
 }
 
 void ZigbeeThermostat::findEndpoint(esp_zb_zdo_match_desc_req_param_t *param) {
-    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT};
-    param->profile_id = ESP_ZB_AF_HA_PROFILE_ID;
-    param->num_in_clusters = 1;
-    param->num_out_clusters = 0;
-    param->cluster_list = cluster_list;
-    esp_zb_zdo_match_cluster(param, findCb, &_endpoint);
+  uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT};
+  param->profile_id = ESP_ZB_AF_HA_PROFILE_ID;
+  param->num_in_clusters = 1;
+  param->num_out_clusters = 0;
+  param->cluster_list = cluster_list;
+  esp_zb_zdo_match_cluster(param, findCb, &_endpoint);
 }
 
 void ZigbeeThermostat::zbAttributeRead(uint16_t cluster_id, const esp_zb_zcl_attribute_t *attribute) {

--- a/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
@@ -91,12 +91,12 @@ void ZigbeeThermostat::findCb(esp_zb_zdp_status_t zdo_status, uint16_t addr, uin
 }
 
 void ZigbeeThermostat::findEndpoint(esp_zb_zdo_match_desc_req_param_t *param) {
-  uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT};
-  param->profile_id = ESP_ZB_AF_HA_PROFILE_ID;
-  param->num_in_clusters = 1;
-  param->num_out_clusters = 0;
-  param->cluster_list = cluster_list;
-  esp_zb_zdo_match_cluster(param, findCb, &_endpoint);
+    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT};
+    param->profile_id = ESP_ZB_AF_HA_PROFILE_ID;
+    param->num_in_clusters = 1;
+    param->num_out_clusters = 0;
+    param->cluster_list = cluster_list;
+    esp_zb_zdo_match_cluster(param, findCb, &_endpoint);
 }
 
 void ZigbeeThermostat::zbAttributeRead(uint16_t cluster_id, const esp_zb_zcl_attribute_t *attribute) {


### PR DESCRIPTION
## Description of Change
This PR adds new feature/fix to recall bounded devices from the binding table after device reboot, with that also the isBound() will return correct value, as the devices will be found if there were some before rebooting.

Other updates:
- Fixes print of the IEEE address, which had reverted bytes order
- `printBoundDevices()` can now be called with Print parameter, so printing to serial instead of log_i is possible.
- Added missing Zigbee locks, fixing the `assert failed: vPortExitCritical port.c:632 (port_uxCriticalNesting[0] > 0)` error
- Added a cmd timeout 10s for reading manufacturer and model 
- mirror updates on Switch/ColorDimSwitch, so there is now option to send the command also to the endpoint num + ieee (long address) combination.

## Tests scenarios
Tested locally with Switch example + 1 or 3 light/s connected

## Related links
Closes #10646 