### PR TITLE
fix: Split provisioning into two parts for better synchronization

### DIFF
--- a/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
+++ b/libraries/RainMaker/examples/RMakerSwitch/RMakerSwitch.ino
@@ -94,6 +94,12 @@ void setup() {
 
   RMaker.enableSystemService(SYSTEM_SERV_FLAGS_ALL, 2, 2, 2);
 
+#if CONFIG_IDF_TARGET_ESP32S2
+  WiFiProv.initProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE);
+#else
+  WiFiProv.initProvision(NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BTDM);
+#endif
+
   RMaker.start();
 
   WiFi.onEvent(sysProvEvent);  // Will call sysProvEvent() from another thread.

--- a/libraries/WiFiProv/src/WiFiProv.cpp
+++ b/libraries/WiFiProv/src/WiFiProv.cpp
@@ -1,4 +1,4 @@
-  /*
+/*
     WiFiProv.cpp - WiFiProv class for provisioning
     All rights reserved.
 
@@ -129,7 +129,7 @@ void WiFiProvClass ::beginProvision(
   const char *service_key, uint8_t *uuid, bool reset_provisioned
 ) {
   if (!this->provInitDone) {
-    WiFiProvClass ::initProvision( prov_scheme, scheme_handler, reset_provisioned);
+    WiFiProvClass ::initProvision(prov_scheme, scheme_handler, reset_provisioned);
   }
   static char service_name_temp[32];
   if (provisioned == false) {

--- a/libraries/WiFiProv/src/WiFiProv.h
+++ b/libraries/WiFiProv/src/WiFiProv.h
@@ -47,7 +47,14 @@ typedef enum {
 
 //Provisioning class
 class WiFiProvClass {
+private:
+  bool provInitDone = false;
+  bool provisioned = false;
 public:
+  void initProvision(
+    prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE,
+    bool reset_provisioned = false
+  );
   void beginProvision(
     prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE,
     network_prov_security_t security = NETWORK_PROV_SECURITY_1, const char *pop = "abcd1234", const char *service_name = NULL, const char *service_key = NULL,

--- a/libraries/WiFiProv/src/WiFiProv.h
+++ b/libraries/WiFiProv/src/WiFiProv.h
@@ -50,10 +50,10 @@ class WiFiProvClass {
 private:
   bool provInitDone = false;
   bool provisioned = false;
+
 public:
   void initProvision(
-    prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE,
-    bool reset_provisioned = false
+    prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE, bool reset_provisioned = false
   );
   void beginProvision(
     prov_scheme_t prov_scheme = NETWORK_PROV_SCHEME_SOFTAP, scheme_handler_t scheme_handler = NETWORK_PROV_SCHEME_HANDLER_NONE,


### PR DESCRIPTION

## Description of Change
Split provisioning into two parts for better synchronization.
The user node association (cloud_user_assoc) endpoint failed to register in the provisioning workflow because provisioning began before the endpoint creation.
