### PR TITLE
fix(esp32): ESP32-U4WDH chip detection by ESP.getChipModel()

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -274,7 +274,7 @@ const char *EspClass::getChipModel(void) {
         return "ESP32-D0WD";
       }
     case EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5:   return "ESP32-D2WD";
-    case EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2:   return "ESP32-PICO-D2";
+    case EFUSE_RD_CHIP_VER_PKG_ESP32U4WDH:    return "ESP32-U4WDH";
     case EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4:   return "ESP32-PICO-D4";
     case EFUSE_RD_CHIP_VER_PKG_ESP32PICOV302: return "ESP32-PICO-V3-02";
     case EFUSE_RD_CHIP_VER_PKG_ESP32D0WDR2V3: return "ESP32-D0WDR2-V3";


### PR DESCRIPTION
The ESP.getChipModel() function does not correctly identify the ESP32-U4WDH chip as used in the ESP32-MINI-1 module.
It's currently identified as a ESP32-PICO-D2 chip.

This PR fixes that by changing the name from the PICO-D2 (which was supposedly never mass produced) to the ESP32-U4WDH chip.
This closes https://github.com/espressif/arduino-esp32/issues/10683
