### PR TITLE
Fix spiTransaction not updating clock line immediately (backport of #9333 into v2.x branch)

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -1135,6 +1135,11 @@ void spiTransaction(spi_t * spi, uint32_t clockDiv, uint8_t dataMode, uint8_t bi
         spi->dev->ctrl.wr_bit_order = 1;
         spi->dev->ctrl.rd_bit_order = 1;
     }
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+    // Sync new config with hardware, backported from https://github.com/espressif/arduino-esp32/pull/9333
+    spi->dev->cmd.update = 1;
+    while (spi->dev->cmd.update);
+#endif
 }
 
 void spiSimpleTransaction(spi_t * spi)


### PR DESCRIPTION
This PR backports #9333 into `release/v2.x` branch as per discussion in #9221.