### PR TITLE
feat(board): Add custom boards YB-ESP32-S3-AMP-V2 & YB-ESP32-S3-AMP-V3

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -47505,7 +47505,6 @@ Pcbcupid_GLYPH_C6.menu.ZigbeeMode.rcp.build.zigbee_mode=-DZIGBEE_MODE_RCP
 Pcbcupid_GLYPH_C6.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api_rcp -lesp_zb_cli_command -lzboss_stack.rcp -lzboss_port
 
 ##############################################################
-# YelloByte YB-ESP32-S3-AMP 2MB PSRAM (Rev.2)
 
 yb_esp32s3_amp_v2.name=YelloByte YB-ESP32-S3-AMP (Rev.2)
 
@@ -47713,7 +47712,6 @@ yb_esp32s3_amp_v2.menu.EraseFlash.all=Enabled
 yb_esp32s3_amp_v2.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
-# YelloByte YB-ESP32-S3-AMP 2MB PSRAM (Rev.3)
 
 yb_esp32s3_amp_v3.name=YelloByte YB-ESP32-S3-AMP (Rev.3)
 

--- a/boards.txt
+++ b/boards.txt
@@ -47505,3 +47505,422 @@ Pcbcupid_GLYPH_C6.menu.ZigbeeMode.rcp.build.zigbee_mode=-DZIGBEE_MODE_RCP
 Pcbcupid_GLYPH_C6.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api_rcp -lesp_zb_cli_command -lzboss_stack.rcp -lzboss_port
 
 ##############################################################
+# YelloByte YB-ESP32-S3-AMP 2MB PSRAM (Rev.2)
+
+yb_esp32s3_amp_v2.name=YelloByte YB-ESP32-S3-AMP (Rev.2)
+
+yb_esp32s3_amp_v2.bootloader.tool=esptool_py
+yb_esp32s3_amp_v2.bootloader.tool.default=esptool_py
+
+yb_esp32s3_amp_v2.upload.tool=esptool_py
+yb_esp32s3_amp_v2.upload.tool.default=esptool_py
+yb_esp32s3_amp_v2.upload.tool.network=esp_ota
+
+yb_esp32s3_amp_v2.upload.maximum_size=1310720
+yb_esp32s3_amp_v2.upload.maximum_data_size=327680
+yb_esp32s3_amp_v2.upload.flags=
+yb_esp32s3_amp_v2.upload.extra_flags=
+yb_esp32s3_amp_v2.upload.use_1200bps_touch=false
+yb_esp32s3_amp_v2.upload.wait_for_upload_port=false
+
+yb_esp32s3_amp_v2.serial.disableDTR=false
+yb_esp32s3_amp_v2.serial.disableRTS=false
+
+yb_esp32s3_amp_v2.build.tarch=xtensa
+yb_esp32s3_amp_v2.build.bootloader_addr=0x0
+yb_esp32s3_amp_v2.build.target=esp32s3
+yb_esp32s3_amp_v2.build.mcu=esp32s3
+yb_esp32s3_amp_v2.build.core=esp32
+yb_esp32s3_amp_v2.build.variant=yb_esp32s3_amp_v2
+yb_esp32s3_amp_v2.build.board=YB_ESP32S3_AMP_V2
+
+yb_esp32s3_amp_v2.build.usb_mode=1
+yb_esp32s3_amp_v2.build.cdc_on_boot=0
+yb_esp32s3_amp_v2.build.msc_on_boot=0
+yb_esp32s3_amp_v2.build.dfu_on_boot=0
+yb_esp32s3_amp_v2.build.f_cpu=240000000L
+yb_esp32s3_amp_v2.build.flash_size=8MB
+yb_esp32s3_amp_v2.build.flash_freq=80m
+yb_esp32s3_amp_v2.build.flash_mode=dio
+yb_esp32s3_amp_v2.build.boot=qio
+yb_esp32s3_amp_v2.build.partitions=default
+yb_esp32s3_amp_v2.build.defines=
+yb_esp32s3_amp_v2.build.loop_core=
+yb_esp32s3_amp_v2.build.event_core=
+yb_esp32s3_amp_v2.build.flash_type=qio
+yb_esp32s3_amp_v2.build.psram_type=qspi
+yb_esp32s3_amp_v2.build.memory_type={build.flash_type}_{build.psram_type}
+
+yb_esp32s3_amp_v2.menu.JTAGAdapter.default=Disabled
+yb_esp32s3_amp_v2.menu.JTAGAdapter.default.build.copy_jtag_files=0
+yb_esp32s3_amp_v2.menu.JTAGAdapter.external=FTDI Adapter
+yb_esp32s3_amp_v2.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+yb_esp32s3_amp_v2.menu.JTAGAdapter.external.build.copy_jtag_files=1
+yb_esp32s3_amp_v2.menu.JTAGAdapter.bridge=ESP USB Bridge
+yb_esp32s3_amp_v2.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+yb_esp32s3_amp_v2.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+yb_esp32s3_amp_v2.menu.LoopCore.1=Core 1
+yb_esp32s3_amp_v2.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+yb_esp32s3_amp_v2.menu.LoopCore.0=Core 0
+yb_esp32s3_amp_v2.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+yb_esp32s3_amp_v2.menu.EventsCore.1=Core 1
+yb_esp32s3_amp_v2.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+yb_esp32s3_amp_v2.menu.EventsCore.0=Core 0
+yb_esp32s3_amp_v2.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+yb_esp32s3_amp_v2.menu.USBMode.hwcdc=Hardware CDC and JTAG
+yb_esp32s3_amp_v2.menu.USBMode.hwcdc.build.usb_mode=1
+yb_esp32s3_amp_v2.menu.USBMode.default=USB-OTG (TinyUSB)
+yb_esp32s3_amp_v2.menu.USBMode.default.build.usb_mode=0
+
+yb_esp32s3_amp_v2.menu.CDCOnBoot.default=Disabled
+yb_esp32s3_amp_v2.menu.CDCOnBoot.default.build.cdc_on_boot=0
+yb_esp32s3_amp_v2.menu.CDCOnBoot.cdc=Enabled
+yb_esp32s3_amp_v2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+yb_esp32s3_amp_v2.menu.MSCOnBoot.default=Disabled
+yb_esp32s3_amp_v2.menu.MSCOnBoot.default.build.msc_on_boot=0
+yb_esp32s3_amp_v2.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+yb_esp32s3_amp_v2.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+yb_esp32s3_amp_v2.menu.DFUOnBoot.default=Disabled
+yb_esp32s3_amp_v2.menu.DFUOnBoot.default.build.dfu_on_boot=0
+yb_esp32s3_amp_v2.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+yb_esp32s3_amp_v2.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+yb_esp32s3_amp_v2.menu.UploadMode.default=UART0 / Hardware CDC
+yb_esp32s3_amp_v2.menu.UploadMode.default.upload.use_1200bps_touch=false
+yb_esp32s3_amp_v2.menu.UploadMode.default.upload.wait_for_upload_port=false
+yb_esp32s3_amp_v2.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+yb_esp32s3_amp_v2.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+yb_esp32s3_amp_v2.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+yb_esp32s3_amp_v2.menu.PSRAM.enabled=QSPI PSRAM
+yb_esp32s3_amp_v2.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+yb_esp32s3_amp_v2.menu.PSRAM.enabled.build.psram_type=qspi
+yb_esp32s3_amp_v2.menu.PSRAM.disabled=Disabled
+yb_esp32s3_amp_v2.menu.PSRAM.disabled.build.defines=
+yb_esp32s3_amp_v2.menu.PSRAM.disabled.build.psram_type=qspi
+yb_esp32s3_amp_v2.menu.PSRAM.opi=OPI PSRAM
+yb_esp32s3_amp_v2.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+yb_esp32s3_amp_v2.menu.PSRAM.opi.build.psram_type=opi
+
+yb_esp32s3_amp_v2.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.default.build.partitions=default
+yb_esp32s3_amp_v2.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+yb_esp32s3_amp_v2.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+yb_esp32s3_amp_v2.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+yb_esp32s3_amp_v2.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.minimal.build.partitions=minimal
+yb_esp32s3_amp_v2.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.no_ota.build.partitions=no_ota
+yb_esp32s3_amp_v2.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+yb_esp32s3_amp_v2.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+yb_esp32s3_amp_v2.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.huge_app.build.partitions=huge_app
+yb_esp32s3_amp_v2.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+yb_esp32s3_amp_v2.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+yb_esp32s3_amp_v2.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+yb_esp32s3_amp_v2.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
+yb_esp32s3_amp_v2.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
+yb_esp32s3_amp_v2.menu.PartitionScheme.max_app_8MB.upload.maximum_size=8257536
+
+yb_esp32s3_amp_v2.menu.CPUFreq.240=240MHz (WiFi)
+yb_esp32s3_amp_v2.menu.CPUFreq.240.build.f_cpu=240000000L
+yb_esp32s3_amp_v2.menu.CPUFreq.160=160MHz (WiFi)
+yb_esp32s3_amp_v2.menu.CPUFreq.160.build.f_cpu=160000000L
+yb_esp32s3_amp_v2.menu.CPUFreq.80=80MHz (WiFi)
+yb_esp32s3_amp_v2.menu.CPUFreq.80.build.f_cpu=80000000L
+yb_esp32s3_amp_v2.menu.CPUFreq.40=40MHz
+yb_esp32s3_amp_v2.menu.CPUFreq.40.build.f_cpu=40000000L
+yb_esp32s3_amp_v2.menu.CPUFreq.20=20MHz
+yb_esp32s3_amp_v2.menu.CPUFreq.20.build.f_cpu=20000000L
+yb_esp32s3_amp_v2.menu.CPUFreq.10=10MHz
+yb_esp32s3_amp_v2.menu.CPUFreq.10.build.f_cpu=10000000L
+
+yb_esp32s3_amp_v2.menu.FlashMode.qio=QIO 80MHz
+yb_esp32s3_amp_v2.menu.FlashMode.qio.build.flash_mode=dio
+yb_esp32s3_amp_v2.menu.FlashMode.qio.build.boot=qio
+yb_esp32s3_amp_v2.menu.FlashMode.qio.build.boot_freq=80m
+yb_esp32s3_amp_v2.menu.FlashMode.qio.build.flash_freq=80m
+yb_esp32s3_amp_v2.menu.FlashMode.qio120=QIO 120MHz
+yb_esp32s3_amp_v2.menu.FlashMode.qio120.build.flash_mode=dio
+yb_esp32s3_amp_v2.menu.FlashMode.qio120.build.boot=qio
+yb_esp32s3_amp_v2.menu.FlashMode.qio120.build.boot_freq=120m
+yb_esp32s3_amp_v2.menu.FlashMode.qio120.build.flash_freq=80m
+yb_esp32s3_amp_v2.menu.FlashMode.dio=DIO 80MHz
+yb_esp32s3_amp_v2.menu.FlashMode.dio.build.flash_mode=dio
+yb_esp32s3_amp_v2.menu.FlashMode.dio.build.boot=dio
+yb_esp32s3_amp_v2.menu.FlashMode.dio.build.boot_freq=80m
+yb_esp32s3_amp_v2.menu.FlashMode.dio.build.flash_freq=80m
+yb_esp32s3_amp_v2.menu.FlashMode.opi=OPI 80MHz
+yb_esp32s3_amp_v2.menu.FlashMode.opi.build.flash_mode=dout
+yb_esp32s3_amp_v2.menu.FlashMode.opi.build.boot=opi
+yb_esp32s3_amp_v2.menu.FlashMode.opi.build.boot_freq=80m
+yb_esp32s3_amp_v2.menu.FlashMode.opi.build.flash_freq=80m
+
+yb_esp32s3_amp_v2.menu.FlashSize.4M=4MB (32Mb)
+yb_esp32s3_amp_v2.menu.FlashSize.4M.build.flash_size=4MB
+yb_esp32s3_amp_v2.menu.FlashSize.8M=8MB (64Mb)
+yb_esp32s3_amp_v2.menu.FlashSize.8M.build.flash_size=8MB
+yb_esp32s3_amp_v2.menu.FlashSize.16M=16MB (128Mb)
+yb_esp32s3_amp_v2.menu.FlashSize.16M.build.flash_size=16MB
+
+yb_esp32s3_amp_v2.menu.UploadSpeed.921600=921600
+yb_esp32s3_amp_v2.menu.UploadSpeed.921600.upload.speed=921600
+yb_esp32s3_amp_v2.menu.UploadSpeed.115200=115200
+yb_esp32s3_amp_v2.menu.UploadSpeed.115200.upload.speed=115200
+yb_esp32s3_amp_v2.menu.UploadSpeed.256000.windows=256000
+yb_esp32s3_amp_v2.menu.UploadSpeed.256000.upload.speed=256000
+yb_esp32s3_amp_v2.menu.UploadSpeed.230400.windows.upload.speed=256000
+yb_esp32s3_amp_v2.menu.UploadSpeed.230400=230400
+yb_esp32s3_amp_v2.menu.UploadSpeed.230400.upload.speed=230400
+yb_esp32s3_amp_v2.menu.UploadSpeed.460800.linux=460800
+yb_esp32s3_amp_v2.menu.UploadSpeed.460800.macosx=460800
+yb_esp32s3_amp_v2.menu.UploadSpeed.460800.upload.speed=460800
+yb_esp32s3_amp_v2.menu.UploadSpeed.512000.windows=512000
+yb_esp32s3_amp_v2.menu.UploadSpeed.512000.upload.speed=512000
+
+yb_esp32s3_amp_v2.menu.DebugLevel.none=None
+yb_esp32s3_amp_v2.menu.DebugLevel.none.build.code_debug=0
+yb_esp32s3_amp_v2.menu.DebugLevel.error=Error
+yb_esp32s3_amp_v2.menu.DebugLevel.error.build.code_debug=1
+yb_esp32s3_amp_v2.menu.DebugLevel.warn=Warn
+yb_esp32s3_amp_v2.menu.DebugLevel.warn.build.code_debug=2
+yb_esp32s3_amp_v2.menu.DebugLevel.info=Info
+yb_esp32s3_amp_v2.menu.DebugLevel.info.build.code_debug=3
+yb_esp32s3_amp_v2.menu.DebugLevel.debug=Debug
+yb_esp32s3_amp_v2.menu.DebugLevel.debug.build.code_debug=4
+yb_esp32s3_amp_v2.menu.DebugLevel.verbose=Verbose
+yb_esp32s3_amp_v2.menu.DebugLevel.verbose.build.code_debug=5
+
+yb_esp32s3_amp_v2.menu.EraseFlash.none=Disabled
+yb_esp32s3_amp_v2.menu.EraseFlash.none.upload.erase_cmd=
+yb_esp32s3_amp_v2.menu.EraseFlash.all=Enabled
+yb_esp32s3_amp_v2.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+# YelloByte YB-ESP32-S3-AMP 2MB PSRAM (Rev.3)
+
+yb_esp32s3_amp_v3.name=YelloByte YB-ESP32-S3-AMP (Rev.3)
+
+yb_esp32s3_amp_v3.bootloader.tool=esptool_py
+yb_esp32s3_amp_v3.bootloader.tool.default=esptool_py
+
+yb_esp32s3_amp_v3.upload.tool=esptool_py
+yb_esp32s3_amp_v3.upload.tool.default=esptool_py
+yb_esp32s3_amp_v3.upload.tool.network=esp_ota
+
+yb_esp32s3_amp_v3.upload.maximum_size=1310720
+yb_esp32s3_amp_v3.upload.maximum_data_size=327680
+yb_esp32s3_amp_v3.upload.flags=
+yb_esp32s3_amp_v3.upload.extra_flags=
+yb_esp32s3_amp_v3.upload.use_1200bps_touch=false
+yb_esp32s3_amp_v3.upload.wait_for_upload_port=false
+
+yb_esp32s3_amp_v3.serial.disableDTR=false
+yb_esp32s3_amp_v3.serial.disableRTS=false
+
+yb_esp32s3_amp_v3.build.tarch=xtensa
+yb_esp32s3_amp_v3.build.bootloader_addr=0x0
+yb_esp32s3_amp_v3.build.target=esp32s3
+yb_esp32s3_amp_v3.build.mcu=esp32s3
+yb_esp32s3_amp_v3.build.core=esp32
+yb_esp32s3_amp_v3.build.variant=yb_esp32s3_amp_v3
+yb_esp32s3_amp_v3.build.board=YB_ESP32S3_AMP_V3
+
+yb_esp32s3_amp_v3.build.usb_mode=1
+yb_esp32s3_amp_v3.build.cdc_on_boot=1
+yb_esp32s3_amp_v3.build.msc_on_boot=0
+yb_esp32s3_amp_v3.build.dfu_on_boot=0
+yb_esp32s3_amp_v3.build.f_cpu=240000000L
+yb_esp32s3_amp_v3.build.flash_size=8MB
+yb_esp32s3_amp_v3.build.flash_freq=80m
+yb_esp32s3_amp_v3.build.flash_mode=dio
+yb_esp32s3_amp_v3.build.boot=qio
+yb_esp32s3_amp_v3.build.partitions=default
+yb_esp32s3_amp_v3.build.defines=
+yb_esp32s3_amp_v3.build.loop_core=
+yb_esp32s3_amp_v3.build.event_core=
+yb_esp32s3_amp_v3.build.flash_type=qio
+yb_esp32s3_amp_v3.build.psram_type=qspi
+yb_esp32s3_amp_v3.build.memory_type={build.flash_type}_{build.psram_type}
+
+yb_esp32s3_amp_v3.menu.JTAGAdapter.default=Disabled
+yb_esp32s3_amp_v3.menu.JTAGAdapter.default.build.copy_jtag_files=0
+yb_esp32s3_amp_v3.menu.JTAGAdapter.builtin=Integrated USB JTAG
+yb_esp32s3_amp_v3.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
+yb_esp32s3_amp_v3.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+yb_esp32s3_amp_v3.menu.JTAGAdapter.external=FTDI Adapter
+yb_esp32s3_amp_v3.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+yb_esp32s3_amp_v3.menu.JTAGAdapter.external.build.copy_jtag_files=1
+yb_esp32s3_amp_v3.menu.JTAGAdapter.bridge=ESP USB Bridge
+yb_esp32s3_amp_v3.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+yb_esp32s3_amp_v3.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+yb_esp32s3_amp_v3.menu.LoopCore.1=Core 1
+yb_esp32s3_amp_v3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+yb_esp32s3_amp_v3.menu.LoopCore.0=Core 0
+yb_esp32s3_amp_v3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+yb_esp32s3_amp_v3.menu.EventsCore.1=Core 1
+yb_esp32s3_amp_v3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+yb_esp32s3_amp_v3.menu.EventsCore.0=Core 0
+yb_esp32s3_amp_v3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+yb_esp32s3_amp_v3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+yb_esp32s3_amp_v3.menu.USBMode.hwcdc.build.usb_mode=1
+yb_esp32s3_amp_v3.menu.USBMode.default=USB-OTG (TinyUSB)
+yb_esp32s3_amp_v3.menu.USBMode.default.build.usb_mode=0
+
+yb_esp32s3_amp_v3.menu.CDCOnBoot.cdc=Enabled
+yb_esp32s3_amp_v3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+yb_esp32s3_amp_v3.menu.CDCOnBoot.default=Disabled
+yb_esp32s3_amp_v3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+yb_esp32s3_amp_v3.menu.MSCOnBoot.default=Disabled
+yb_esp32s3_amp_v3.menu.MSCOnBoot.default.build.msc_on_boot=0
+yb_esp32s3_amp_v3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+yb_esp32s3_amp_v3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+yb_esp32s3_amp_v3.menu.DFUOnBoot.default=Disabled
+yb_esp32s3_amp_v3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+yb_esp32s3_amp_v3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+yb_esp32s3_amp_v3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+yb_esp32s3_amp_v3.menu.UploadMode.default=UART0 / Hardware CDC
+yb_esp32s3_amp_v3.menu.UploadMode.default.upload.use_1200bps_touch=false
+yb_esp32s3_amp_v3.menu.UploadMode.default.upload.wait_for_upload_port=false
+yb_esp32s3_amp_v3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+yb_esp32s3_amp_v3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+yb_esp32s3_amp_v3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+yb_esp32s3_amp_v3.menu.PSRAM.enabled=QSPI PSRAM
+yb_esp32s3_amp_v3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+yb_esp32s3_amp_v3.menu.PSRAM.enabled.build.psram_type=qspi
+yb_esp32s3_amp_v3.menu.PSRAM.disabled=Disabled
+yb_esp32s3_amp_v3.menu.PSRAM.disabled.build.defines=
+yb_esp32s3_amp_v3.menu.PSRAM.disabled.build.psram_type=qspi
+yb_esp32s3_amp_v3.menu.PSRAM.opi=OPI PSRAM
+yb_esp32s3_amp_v3.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+yb_esp32s3_amp_v3.menu.PSRAM.opi.build.psram_type=opi
+
+yb_esp32s3_amp_v3.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.default.build.partitions=default
+yb_esp32s3_amp_v3.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+yb_esp32s3_amp_v3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+yb_esp32s3_amp_v3.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+yb_esp32s3_amp_v3.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.minimal.build.partitions=minimal
+yb_esp32s3_amp_v3.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.no_ota.build.partitions=no_ota
+yb_esp32s3_amp_v3.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+yb_esp32s3_amp_v3.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+yb_esp32s3_amp_v3.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.huge_app.build.partitions=huge_app
+yb_esp32s3_amp_v3.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+yb_esp32s3_amp_v3.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+yb_esp32s3_amp_v3.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+yb_esp32s3_amp_v3.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
+yb_esp32s3_amp_v3.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
+yb_esp32s3_amp_v3.menu.PartitionScheme.max_app_8MB.upload.maximum_size=8257536
+
+yb_esp32s3_amp_v3.menu.CPUFreq.240=240MHz (WiFi)
+yb_esp32s3_amp_v3.menu.CPUFreq.240.build.f_cpu=240000000L
+yb_esp32s3_amp_v3.menu.CPUFreq.160=160MHz (WiFi)
+yb_esp32s3_amp_v3.menu.CPUFreq.160.build.f_cpu=160000000L
+yb_esp32s3_amp_v3.menu.CPUFreq.80=80MHz (WiFi)
+yb_esp32s3_amp_v3.menu.CPUFreq.80.build.f_cpu=80000000L
+yb_esp32s3_amp_v3.menu.CPUFreq.40=40MHz
+yb_esp32s3_amp_v3.menu.CPUFreq.40.build.f_cpu=40000000L
+yb_esp32s3_amp_v3.menu.CPUFreq.20=20MHz
+yb_esp32s3_amp_v3.menu.CPUFreq.20.build.f_cpu=20000000L
+yb_esp32s3_amp_v3.menu.CPUFreq.10=10MHz
+yb_esp32s3_amp_v3.menu.CPUFreq.10.build.f_cpu=10000000L
+
+yb_esp32s3_amp_v3.menu.FlashMode.qio=QIO 80MHz
+yb_esp32s3_amp_v3.menu.FlashMode.qio.build.flash_mode=dio
+yb_esp32s3_amp_v3.menu.FlashMode.qio.build.boot=qio
+yb_esp32s3_amp_v3.menu.FlashMode.qio.build.boot_freq=80m
+yb_esp32s3_amp_v3.menu.FlashMode.qio.build.flash_freq=80m
+yb_esp32s3_amp_v3.menu.FlashMode.qio120=QIO 120MHz
+yb_esp32s3_amp_v3.menu.FlashMode.qio120.build.flash_mode=dio
+yb_esp32s3_amp_v3.menu.FlashMode.qio120.build.boot=qio
+yb_esp32s3_amp_v3.menu.FlashMode.qio120.build.boot_freq=120m
+yb_esp32s3_amp_v3.menu.FlashMode.qio120.build.flash_freq=80m
+yb_esp32s3_amp_v3.menu.FlashMode.dio=DIO 80MHz
+yb_esp32s3_amp_v3.menu.FlashMode.dio.build.flash_mode=dio
+yb_esp32s3_amp_v3.menu.FlashMode.dio.build.boot=dio
+yb_esp32s3_amp_v3.menu.FlashMode.dio.build.boot_freq=80m
+yb_esp32s3_amp_v3.menu.FlashMode.dio.build.flash_freq=80m
+yb_esp32s3_amp_v3.menu.FlashMode.opi=OPI 80MHz
+yb_esp32s3_amp_v3.menu.FlashMode.opi.build.flash_mode=dout
+yb_esp32s3_amp_v3.menu.FlashMode.opi.build.boot=opi
+yb_esp32s3_amp_v3.menu.FlashMode.opi.build.boot_freq=80m
+yb_esp32s3_amp_v3.menu.FlashMode.opi.build.flash_freq=80m
+
+yb_esp32s3_amp_v3.menu.FlashSize.4M=4MB (32Mb)
+yb_esp32s3_amp_v3.menu.FlashSize.4M.build.flash_size=4MB
+yb_esp32s3_amp_v3.menu.FlashSize.8M=8MB (64Mb)
+yb_esp32s3_amp_v3.menu.FlashSize.8M.build.flash_size=8MB
+yb_esp32s3_amp_v3.menu.FlashSize.16M=16MB (128Mb)
+yb_esp32s3_amp_v3.menu.FlashSize.16M.build.flash_size=16MB
+
+yb_esp32s3_amp_v3.menu.UploadSpeed.921600=921600
+yb_esp32s3_amp_v3.menu.UploadSpeed.921600.upload.speed=921600
+yb_esp32s3_amp_v3.menu.UploadSpeed.115200=115200
+yb_esp32s3_amp_v3.menu.UploadSpeed.115200.upload.speed=115200
+yb_esp32s3_amp_v3.menu.UploadSpeed.256000.windows=256000
+yb_esp32s3_amp_v3.menu.UploadSpeed.256000.upload.speed=256000
+yb_esp32s3_amp_v3.menu.UploadSpeed.230400.windows.upload.speed=256000
+yb_esp32s3_amp_v3.menu.UploadSpeed.230400=230400
+yb_esp32s3_amp_v3.menu.UploadSpeed.230400.upload.speed=230400
+yb_esp32s3_amp_v3.menu.UploadSpeed.460800.linux=460800
+yb_esp32s3_amp_v3.menu.UploadSpeed.460800.macosx=460800
+yb_esp32s3_amp_v3.menu.UploadSpeed.460800.upload.speed=460800
+yb_esp32s3_amp_v3.menu.UploadSpeed.512000.windows=512000
+yb_esp32s3_amp_v3.menu.UploadSpeed.512000.upload.speed=512000
+
+yb_esp32s3_amp_v3.menu.DebugLevel.none=None
+yb_esp32s3_amp_v3.menu.DebugLevel.none.build.code_debug=0
+yb_esp32s3_amp_v3.menu.DebugLevel.error=Error
+yb_esp32s3_amp_v3.menu.DebugLevel.error.build.code_debug=1
+yb_esp32s3_amp_v3.menu.DebugLevel.warn=Warn
+yb_esp32s3_amp_v3.menu.DebugLevel.warn.build.code_debug=2
+yb_esp32s3_amp_v3.menu.DebugLevel.info=Info
+yb_esp32s3_amp_v3.menu.DebugLevel.info.build.code_debug=3
+yb_esp32s3_amp_v3.menu.DebugLevel.debug=Debug
+yb_esp32s3_amp_v3.menu.DebugLevel.debug.build.code_debug=4
+yb_esp32s3_amp_v3.menu.DebugLevel.verbose=Verbose
+yb_esp32s3_amp_v3.menu.DebugLevel.verbose.build.code_debug=5
+
+yb_esp32s3_amp_v3.menu.EraseFlash.none=Disabled
+yb_esp32s3_amp_v3.menu.EraseFlash.none.upload.erase_cmd=
+yb_esp32s3_amp_v3.menu.EraseFlash.all=Enabled
+yb_esp32s3_amp_v3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/variants/yb_esp32s3_amp_v2/pins_arduino.h
+++ b/variants/yb_esp32s3_amp_v2/pins_arduino.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 static const uint8_t LED_BUILTIN = 47;
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 
 static const uint8_t TX = 43;
@@ -14,21 +14,21 @@ static const uint8_t SDA = 8;
 static const uint8_t SCL = 9;
 
 //I2S for onboard MAX98357A only
-static const uint8_t I2S_BCLK  = 5;
+static const uint8_t I2S_BCLK = 5;
 static const uint8_t I2S_LRCLK = 6;
-static const uint8_t I2S_DOUT  = 7;
+static const uint8_t I2S_DOUT = 7;
 
 // SPI for onboard microSD only
-static const uint8_t SS    = 10;
-static const uint8_t MOSI  = 11;
-static const uint8_t MISO  = 13;
-static const uint8_t SCK   = 12;
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 13;
+static const uint8_t SCK = 12;
 
 // SPI2 for public usage
-static const uint8_t SS2    = 38;
-static const uint8_t MOSI2  = 39;
-static const uint8_t MISO2  = 41;
-static const uint8_t SCK2   = 40;
+static const uint8_t SS2 = 38;
+static const uint8_t MOSI2 = 39;
+static const uint8_t MISO2 = 41;
+static const uint8_t SCK2 = 40;
 
 static const uint8_t A0 = 1;
 static const uint8_t A1 = 2;
@@ -52,6 +52,6 @@ static const uint8_t T9 = 9;
 static const uint8_t T10 = 10;
 static const uint8_t T14 = 14;
 
-#define PIN_DAC_MUTE 47 // only if solder bridge "DAC_MUTE" is closed
+#define PIN_DAC_MUTE 47  // only if solder bridge "DAC_MUTE" is closed
 
 #endif /* Pins_Arduino_h */

--- a/variants/yb_esp32s3_amp_v2/pins_arduino.h
+++ b/variants/yb_esp32s3_amp_v2/pins_arduino.h
@@ -1,0 +1,57 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t LED_BUILTIN = 47;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+//I2S for onboard MAX98357A only
+static const uint8_t I2S_BCLK  = 5;
+static const uint8_t I2S_LRCLK = 6;
+static const uint8_t I2S_DOUT  = 7;
+
+// SPI for onboard microSD only
+static const uint8_t SS    = 10;
+static const uint8_t MOSI  = 11;
+static const uint8_t MISO  = 13;
+static const uint8_t SCK   = 12;
+
+// SPI2 for public usage
+static const uint8_t SS2    = 38;
+static const uint8_t MOSI2  = 39;
+static const uint8_t MISO2  = 41;
+static const uint8_t SCK2   = 40;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 8;
+static const uint8_t A5 = 9;
+static const uint8_t A6 = 10;
+static const uint8_t A7 = 14;
+static const uint8_t A8 = 15;
+static const uint8_t A9 = 16;
+static const uint8_t A10 = 17;
+static const uint8_t A11 = 18;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T14 = 14;
+
+#define PIN_DAC_MUTE 47 // only if solder bridge "DAC_MUTE" is closed
+
+#endif /* Pins_Arduino_h */

--- a/variants/yb_esp32s3_amp_v3/pins_arduino.h
+++ b/variants/yb_esp32s3_amp_v3/pins_arduino.h
@@ -7,7 +7,7 @@
 #define USB_PID 0x1001
 
 static const uint8_t LED_BUILTIN = 47;
-#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 
 static const uint8_t TX = 43;
@@ -17,21 +17,21 @@ static const uint8_t SDA = 8;
 static const uint8_t SCL = 9;
 
 //I2S for onboard MAX98357A only
-static const uint8_t I2S_BCLK  = 5;
+static const uint8_t I2S_BCLK = 5;
 static const uint8_t I2S_LRCLK = 6;
-static const uint8_t I2S_DOUT  = 7;
+static const uint8_t I2S_DOUT = 7;
 
 // SPI for onboard microSD only
-static const uint8_t SS    = 10;
-static const uint8_t MOSI  = 11;
-static const uint8_t MISO  = 13;
-static const uint8_t SCK   = 12;
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 13;
+static const uint8_t SCK = 12;
 
 // SPI2 for public usage
-static const uint8_t SS2    = 38;
-static const uint8_t MOSI2  = 39;
-static const uint8_t MISO2  = 41;
-static const uint8_t SCK2   = 40;
+static const uint8_t SS2 = 38;
+static const uint8_t MOSI2 = 39;
+static const uint8_t MISO2 = 41;
+static const uint8_t SCK2 = 40;
 
 static const uint8_t A0 = 1;
 static const uint8_t A1 = 2;
@@ -55,6 +55,6 @@ static const uint8_t T9 = 9;
 static const uint8_t T10 = 10;
 static const uint8_t T14 = 14;
 
-#define PIN_DAC_MUTE 47 // only if solder bridge "DAC_MUTE" is closed
+#define PIN_DAC_MUTE 47  // only if solder bridge "DAC_MUTE" is closed
 
 #endif /* Pins_Arduino_h */

--- a/variants/yb_esp32s3_amp_v3/pins_arduino.h
+++ b/variants/yb_esp32s3_amp_v3/pins_arduino.h
@@ -1,0 +1,60 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x303A
+#define USB_PID 0x1001
+
+static const uint8_t LED_BUILTIN = 47;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+//I2S for onboard MAX98357A only
+static const uint8_t I2S_BCLK  = 5;
+static const uint8_t I2S_LRCLK = 6;
+static const uint8_t I2S_DOUT  = 7;
+
+// SPI for onboard microSD only
+static const uint8_t SS    = 10;
+static const uint8_t MOSI  = 11;
+static const uint8_t MISO  = 13;
+static const uint8_t SCK   = 12;
+
+// SPI2 for public usage
+static const uint8_t SS2    = 38;
+static const uint8_t MOSI2  = 39;
+static const uint8_t MISO2  = 41;
+static const uint8_t SCK2   = 40;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 8;
+static const uint8_t A5 = 9;
+static const uint8_t A6 = 10;
+static const uint8_t A7 = 14;
+static const uint8_t A8 = 15;
+static const uint8_t A9 = 16;
+static const uint8_t A10 = 17;
+static const uint8_t A11 = 18;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T14 = 14;
+
+#define PIN_DAC_MUTE 47 // only if solder bridge "DAC_MUTE" is closed
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
New boards YB-ESP32-S3-AMP-V2 and YB-ESP32-S3-AMP-V3 added to board list.

## Tests scenarios
Builds successfully tested with both boards on actual Arduino-esp32 core revision.

## Related links
Closes: https://github.com/espressif/arduino-esp32/issues/10656
Board info: https://github.com/yellobyte/ESP32-DevBoards-Getting-Started/tree/main/boards/YB-ESP32-S3-AMP
