### PR TITLE
BOOT_PIN constant for all ESP32 SoC - Arduino v3.1.x (includes ESP32-P4)

### DIFF
--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -135,6 +135,18 @@ void arduino_phy_init();
 void initArduino();
 #endif
 
+// defines a constant that can be used to map BOOT pin for each different ESP32 SoC
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+const uint8_t BOOT_PIN = 0;
+#elif CONFIG_IDF_TARGET_ESP32P4
+const uint8_t BOOT_PIN = 35;
+#else
+// All other series C and HSoC use GPIO 9 as BOOT PIN
+const uint8_t BOOT_PIN = 9;
+#endif
+
+
+
 typedef struct {
   int core;                    // core which triggered panic
   const char *reason;          // exception string

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -141,7 +141,7 @@ const uint8_t BOOT_PIN = 0;
 #elif CONFIG_IDF_TARGET_ESP32P4
 const uint8_t BOOT_PIN = 35;
 #else
-// All other series C and HSoC use GPIO 9 as BOOT PIN
+// All other series C and H SoC use GPIO 9 as BOOT PIN
 const uint8_t BOOT_PIN = 9;
 #endif
 


### PR DESCRIPTION
## Description of Change
Adds a `const uint8_t BOOT_PIN` for each ESP32 SoC that can be used in the Arduino Sketch.

## Tests scenarios
CI and testing sketch:

``` cpp
void setup() {
  pinMode(BOOT_PIN, INPUT_PULLUP);
  Serial.begin(115200);
}

void loop() {
  if (digitalRead(BOOT_PIN) == LOW) {
    Serial.println("Boot Button is pressed.");
  } else {
    Serial.println("Boot Button is released.");
  }
  delay(3000);
}
```

## Related links
None
