### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-77a3025a-v2"
+              "version": "idf-release_v5.1-77a3025a-v3"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-77a3025a-v2",
+          "version": "idf-release_v5.1-77a3025a-v3",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
-              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
-              "size": "306708345"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v3.zip",
+              "checksum": "SHA-256:b8f8e4026846c8a12bde236e6080b9624b7e348b249fc417bfe043129121d101",
+              "size": "306759798"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-9439479f"
+              "version": "idf-release_v5.1-77a3025a-v2"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-9439479f",
+          "version": "idf-release_v5.1-77a3025a-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v2.zip",
+              "checksum": "SHA-256:fac70951d20d87e9eca1b3daf941652db641409a35d3c9538e75e80ec816385a",
+              "size": "306708345"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.1 0fd5cbc
esp-idf: release/v5.1 77a3025ac1
arduino: release/v3.0.x 5cb8b656
tinyusb: master cb22301f9
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.2.1
espressif__esp_rainmaker: 1.5.1
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dl:
espressif__esp32-camera:
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.4
```
