### PR TITLE
feat(matter): adds a Pressure Sensor Matter Endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ set(ARDUINO_LIBRARY_Matter_SRCS
   libraries/Matter/src/MatterEndpoints/MatterFan.cpp
   libraries/Matter/src/MatterEndpoints/MatterTemperatureSensor.cpp
   libraries/Matter/src/MatterEndpoints/MatterHumiditySensor.cpp
+  libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
   libraries/Matter/src/Matter.cpp)
 
 set(ARDUINO_LIBRARY_PPP_SRCS

--- a/libraries/Matter/examples/MatterPressureSensor/MatterPressureSensor.ino
+++ b/libraries/Matter/examples/MatterPressureSensor/MatterPressureSensor.ino
@@ -1,0 +1,131 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * This example is an example code that will create a Matter Device which can be
+ * commissioned and controlled from a Matter Environment APP.
+ * Additionally the ESP32 will send debug messages indicating the Matter activity.
+ * Turning DEBUG Level ON may be useful to following Matter Accessory and Controller messages.
+ */
+
+// Matter Manager
+#include <Matter.h>
+#include <WiFi.h>
+
+// List of Matter Endpoints for this Node
+// Matter Pressure Sensor Endpoint
+MatterPressureSensor SimulatedPressureSensor;
+
+// set your board USER BUTTON pin here - decommissioning button
+const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
+
+// WiFi is manually set and started
+const char *ssid = "your-ssid";          // Change this to your WiFi SSID
+const char *password = "your-password";  // Change this to your WiFi password
+
+// Button control - decommision the Matter Node
+uint32_t button_time_stamp = 0;                 // debouncing control
+bool button_state = false;                      // false = released | true = pressed
+const uint32_t decommissioningTimeout = 5000;   // keep the button pressed for 5s, or longer, to decommission
+
+// Simulate a pressure sensor - add your preferred pressure sensor library code here
+float getSimulatedPressure() {
+  // The Endpoint implementation keeps an uint16_t as internal value information,
+  // which stores data in hPa (pressure measurement unit) 
+  static float simulatedPressureHWSensor = 950;
+
+  // it will increase from 950 to 1100 hPa in steps of 10 hPa to simulate a pressure sensor
+  simulatedPressureHWSensor = simulatedPressureHWSensor + 10;
+  if (simulatedPressureHWSensor > 1100) {
+    simulatedPressureHWSensor = 950;
+  }
+
+  return simulatedPressureHWSensor;
+}
+
+void setup() {
+  // Initialize the USER BUTTON (Boot button) that will be used to decommission the Matter Node
+  pinMode(buttonPin, INPUT_PULLUP);
+
+  Serial.begin(115200);
+
+  // Manually connect to WiFi
+  WiFi.begin(ssid, password);
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+
+  // set initial pressure sensor measurement
+  // Simulated Sensor - it shall initially print 900hPa and then move to the 950 to 1100 hPa as pressure range
+  SimulatedPressureSensor.begin(900.00);
+
+  // Matter beginning - Last step, after all EndPoints are initialized
+  Matter.begin();
+
+  // Check Matter Accessory Commissioning state, which may change during execution of loop()
+  if (!Matter.isDeviceCommissioned()) {
+    Serial.println("");
+    Serial.println("Matter Node is not commissioned yet.");
+    Serial.println("Initiate the device discovery in your Matter environment.");
+    Serial.println("Commission it to your Matter hub with the manual pairing code or QR code");
+    Serial.printf("Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
+    Serial.printf("QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
+    // waits for Matter Pressure Sensor Commissioning.
+    uint32_t timeCount = 0;
+    while (!Matter.isDeviceCommissioned()) {
+      delay(100);
+      if ((timeCount++ % 50) == 0) {  // 50*100ms = 5 sec
+        Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
+      }
+    }
+    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+  }
+}
+
+void loop() {
+  static uint32_t timeCounter = 0;
+ 
+  // Print the current pressure value every 5s
+  if (!(timeCounter++ % 10)) {  // delaying for 500ms x 10 = 5s
+    // Print the current pressure value
+    Serial.printf("Current Pressure is %.02fhPa\r\n", SimulatedPressureSensor.getPressure());
+    // Update Pressure from the (Simulated) Hardware Sensor
+    // Matter APP shall display the updated pressure percent
+    SimulatedPressureSensor.setPressure(getSimulatedPressure());
+  }
+
+  // Check if the button has been pressed
+  if (digitalRead(buttonPin) == LOW && !button_state) {
+    // deals with button debouncing
+    button_time_stamp = millis();  // record the time while the button is pressed.
+    button_state = true;           // pressed.
+  }
+
+  if (digitalRead(buttonPin) == HIGH && button_state) {
+    button_state = false;  // released
+  }
+
+  // Onboard User Button is kept pressed for longer than 5 seconds in order to decommission matter node
+  uint32_t time_diff = millis() - button_time_stamp;
+  if (button_state && time_diff > decommissioningTimeout) {
+    // Factory reset is triggered if the button is pressed longer than 10 seconds
+    Serial.println("Decommissioning the Light Matter Accessory. It shall be commissioned again.");
+    Matter.decommission();
+  }
+  
+  delay(500);
+}

--- a/libraries/Matter/examples/MatterPressureSensor/MatterPressureSensor.ino
+++ b/libraries/Matter/examples/MatterPressureSensor/MatterPressureSensor.ino
@@ -35,14 +35,14 @@ const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
 
 // Button control - decommision the Matter Node
-uint32_t button_time_stamp = 0;                 // debouncing control
-bool button_state = false;                      // false = released | true = pressed
-const uint32_t decommissioningTimeout = 5000;   // keep the button pressed for 5s, or longer, to decommission
+uint32_t button_time_stamp = 0;                // debouncing control
+bool button_state = false;                     // false = released | true = pressed
+const uint32_t decommissioningTimeout = 5000;  // keep the button pressed for 5s, or longer, to decommission
 
 // Simulate a pressure sensor - add your preferred pressure sensor library code here
 float getSimulatedPressure() {
   // The Endpoint implementation keeps an uint16_t as internal value information,
-  // which stores data in hPa (pressure measurement unit) 
+  // which stores data in hPa (pressure measurement unit)
   static float simulatedPressureHWSensor = 950;
 
   // it will increase from 950 to 1100 hPa in steps of 10 hPa to simulate a pressure sensor
@@ -98,7 +98,7 @@ void setup() {
 
 void loop() {
   static uint32_t timeCounter = 0;
- 
+
   // Print the current pressure value every 5s
   if (!(timeCounter++ % 10)) {  // delaying for 500ms x 10 = 5s
     // Print the current pressure value
@@ -126,6 +126,6 @@ void loop() {
     Serial.println("Decommissioning the Light Matter Accessory. It shall be commissioned again.");
     Matter.decommission();
   }
-  
+
   delay(500);
 }

--- a/libraries/Matter/examples/MatterPressureSensor/ci.json
+++ b/libraries/Matter/examples/MatterPressureSensor/ci.json
@@ -1,0 +1,7 @@
+{
+  "fqbn_append": "PartitionScheme=huge_app",
+  "requires": [
+    "CONFIG_SOC_WIFI_SUPPORTED=y",
+    "CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y"
+  ]
+}

--- a/libraries/Matter/keywords.txt
+++ b/libraries/Matter/keywords.txt
@@ -20,6 +20,7 @@ FanMode_t	KEYWORD1
 FanModeSequence_t	KEYWORD1
 MatterTemperatureSensor	KEYWORD1
 MatterHumiditySensor	KEYWORD1
+MatterPressureSensor	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -68,6 +69,8 @@ setTemperature	KEYWORD2
 getTemperature	KEYWORD2
 setHumidity	KEYWORD2
 getHumidity	KEYWORD2
+setPressure	KEYWORD2
+getPressure	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -28,6 +28,7 @@
 #include <MatterEndpoints/MatterFan.h>
 #include <MatterEndpoints/MatterTemperatureSensor.h>
 #include <MatterEndpoints/MatterHumiditySensor.h>
+#include <MatterEndpoints/MatterPressureSensor.h>
 
 using namespace esp_matter;
 
@@ -62,6 +63,7 @@ public:
   friend class MatterFan;
   friend class MatterTemperatureSensor;
   friend class MatterHumiditySensor;
+  friend class MatterPressureSensor;
 
 protected:
   static void _init();

--- a/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
@@ -86,7 +86,7 @@ bool MatterPressureSensor::setRawPressure(int16_t _rawPressure) {
     bool ret;
     ret = updateAttributeVal(PressureMeasurement::Id, PressureMeasurement::Attributes::MeasuredValue::Id, &pressureVal);
     if (!ret) {
-      log_e("Failed to update Fan Speed Percent Attribute.");
+      log_e("Failed to update Pressure Sensor Measurement Attribute.");
       return false;
     }
     rawPressure = _rawPressure;

--- a/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
@@ -1,0 +1,99 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sdkconfig.h>
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <Matter.h>
+#include <MatterEndpoints/MatterPressureSensor.h>
+
+using namespace esp_matter;
+using namespace esp_matter::endpoint;
+using namespace chip::app::Clusters;
+
+bool MatterPressureSensor::attributeChangeCB(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *val) {
+  bool ret = true;
+  if (!started) {
+    log_e("Matter Pressure Sensor device has not begun.");
+    return false;
+  }
+
+  log_d("Pressure Sensor Attr update callback: endpoint: %u, cluster: %u, attribute: %u, val: %u", endpoint_id, cluster_id, attribute_id, val->val.u32);
+  return ret;
+}
+
+MatterPressureSensor::MatterPressureSensor() {}
+
+MatterPressureSensor::~MatterPressureSensor() {
+  end();
+}
+
+bool MatterPressureSensor::begin(int16_t _rawPressure) {
+  ArduinoMatter::_init();
+
+  pressure_sensor::config_t pressure_sensor_config;
+  pressure_sensor_config.pressure_measurement.pressure_measured_value = _rawPressure;
+  pressure_sensor_config.pressure_measurement.pressure_min_measured_value = nullptr;
+  pressure_sensor_config.pressure_measurement.pressure_max_measured_value = nullptr;
+
+  // endpoint handles can be used to add/modify clusters
+  endpoint_t *endpoint = pressure_sensor::create(node::get(), &pressure_sensor_config, ENDPOINT_FLAG_NONE, (void *)this);
+  if (endpoint == nullptr) {
+    log_e("Failed to create Pressure Sensor endpoint");
+    return false;
+  }
+  rawPressure = _rawPressure;
+  setEndPointId(endpoint::get_id(endpoint));
+  log_i("Pressure Sensor created with endpoint_id %d", getEndPointId());
+  started = true;
+  return true;
+}
+
+void MatterPressureSensor::end() {
+  started = false;
+}
+
+bool MatterPressureSensor::setRawPressure(int16_t _rawPressure) {
+  if (!started) {
+    log_e("Matter Pressure Sensor device has not begun.");
+    return false;
+  }
+
+  // avoid processing the a "no-change"
+  if (rawPressure == _rawPressure) {
+    return true;
+  }
+
+  esp_matter_attr_val_t pressureVal = esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(PressureMeasurement::Id, PressureMeasurement::Attributes::MeasuredValue::Id, &pressureVal)) {
+    log_e("Failed to get Pressure Sensor Attribute.");
+    return false;
+  }
+  if (pressureVal.val.i16 != _rawPressure) {
+    pressureVal.val.i16 = _rawPressure;
+    bool ret;
+    ret = updateAttributeVal(PressureMeasurement::Id, PressureMeasurement::Attributes::MeasuredValue::Id, &pressureVal);
+    if (!ret) {
+      log_e("Failed to update Fan Speed Percent Attribute.");
+      return false;
+    }
+    rawPressure = _rawPressure;
+  }
+  log_v("Pressure Sensor set to %.02f Degrees", (float)_rawPressure / 100.00);
+
+  return true;
+}
+
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.h
@@ -1,0 +1,62 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <sdkconfig.h>
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <Matter.h>
+#include <MatterEndPoint.h>
+
+class MatterPressureSensor : public MatterEndPoint {
+public:
+  MatterPressureSensor();
+  ~MatterPressureSensor();
+  // begin Matter Pressure Sensor endpoint with initial float pressure
+  bool begin(double pressure = 0.00) {
+    return begin(static_cast<int16_t>(pressure));
+  }
+  // this will stop processing Pressure Sensor Matter events
+  void end();
+
+  // set the reported raw pressure in hPa
+  bool setPressure(double pressure) {
+    int16_t rawValue = static_cast<int16_t>(pressure);
+    return setRawPressure(rawValue);
+  }
+  // returns the reported float pressure in hPa
+  double getPressure() {
+    return (double)rawPressure;
+  }
+  // double conversion operator
+  void operator=(double pressure) {
+    setPressure(pressure);
+  }
+  // double conversion operator
+  operator double() {
+    return (double)getPressure();
+  }
+
+  // this function is called by Matter internal event processor. It could be overwritten by the application, if necessary.
+  bool attributeChangeCB(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *val);
+
+protected:
+  bool started = false;
+  // implementation keeps pressure in hPa
+  int16_t rawPressure = 0;
+  // internal function to set the raw pressure value (Matter Cluster)
+  bool setRawPressure(int16_t _rawPressure);
+  bool begin(int16_t _rawPressure);
+};
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */


### PR DESCRIPTION
## Description of Change
Adds a Pressure Sensor Matter Endpoint.
It work like all other sensors by reporting to the Matter Controller the pressure read by the device.

Tested with [Home Assistant + Matter Plugin](https://www.home-assistant.io/)

**Note:** This endpoint is not supported by some Matter Providers, such as Amazon Alexa and Apple HomeKit

## Tests scenarios
ESP32-C6 using the provided example

## Related links
Related to #7432 