### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-a0f798cf"
+              "version": "idf-release_v5.3-9a6aba74-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-a0f798cf",
+          "version": "idf-release_v5.3-9a6aba74-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-a0f798cf.zip",
-              "checksum": "SHA-256:f552d02ecef616389f1d0c973cb270718a192e6258db426656cd5965db3c6ed0",
-              "size": "339750940"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-9a6aba74-v1.zip",
+              "checksum": "SHA-256:e218500a539d4d2ba06f588efea1ed71c8a6a99916f4316e433758f41860b33d",
+              "size": "340725612"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.3 ac5db72
esp-idf: release/v5.3 9a6aba7401
arduino: release/v3.1.x de4824fc
tinyusb: master cb22301f9
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_modem: 1.2.1
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.3.0
espressif__esp32-camera:
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.4
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
