### PR TITLE
feat(zigbee): Add pressure, flow, ccupancy and carbon dioxide sensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,9 @@ set(ARDUINO_LIBRARY_Zigbee_SRCS
   libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
   libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
   libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
+  libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
+  libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+  libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
   )
 
 set(ARDUINO_LIBRARY_BLE_SRCS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ set(ARDUINO_LIBRARY_Zigbee_SRCS
   libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
   libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
   libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
+  libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
   )
 
 set(ARDUINO_LIBRARY_BLE_SRCS

--- a/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/README.md
+++ b/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/README.md
@@ -1,0 +1,72 @@
+# Arduino-ESP32 Carbon dioxide (CO2) Sensor Example
+
+This example shows how to configure the Zigbee end device and use it as a Home Automation (HA) simple sensor device type with carbon dioxide measuring.
+
+# Supported Targets
+
+Currently, this example supports the following targets.
+
+| Supported Targets | ESP32-C6 | ESP32-H2 |
+| ----------------- | -------- | -------- |
+
+## Pressure + Flow Sensor Functions
+
+ * After this board first starts up, it would be configured locally to report the carbon dioxide on every 30 seconds.
+ * By clicking the button (BOOT) on this board, this board will immediately send a report of the current measured carbon dioxide to the network.
+
+## Hardware Required
+
+* A USB cable for power supply and programming
+
+### Configure the Project
+
+In this example, the internal temperature sensor is used to demonstrate reading of the carbon dioxide sensors.
+Set the Button GPIO by changing the `button` variable. By default, it's the pin `BOOT_PIN` (BOOT button on ESP32-C6 and ESP32-H2).
+
+#### Using Arduino IDE
+
+To get more information about the Espressif boards see [Espressif Development Kits](https://www.espressif.com/en/products/devkits).
+
+* Before Compile/Verify, select the correct board: `Tools -> Board`.
+* Select the End device Zigbee mode: `Tools -> Zigbee mode: Zigbee ED (end device)`
+* Select Partition Scheme for Zigbee: `Tools -> Partition Scheme: Zigbee 4MB with spiffs`
+* Select the COM port: `Tools -> Port: xxx` where the `xxx` is the detected COM port.
+* Optional: Set debug level to verbose to see all logs from Zigbee stack: `Tools -> Core Debug Level: Verbose`.
+
+## Troubleshooting
+
+If the End device flashed with this example is not connecting to the coordinator, erase the flash of the End device before flashing the example to the board. It is recommended to do this if you re-flash the coordinator.
+You can do the following:
+
+* In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`.
+* Add to the sketch `Zigbee.factoryReset();` to reset the device and Zigbee stack.
+
+By default, the coordinator network is closed after rebooting or flashing new firmware.
+To open the network you have 2 options:
+
+* Open network after reboot by setting `Zigbee.setRebootOpenNetwork(time);` before calling `Zigbee.begin();`.
+* In application you can anytime call `Zigbee.openNetwork(time);` to open the network for devices to join.
+
+***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***
+
+* **LED not blinking:** Check the wiring connection and the IO selection.
+* **Programming Fail:** If the programming/flash procedure fails, try reducing the serial connection speed.
+* **COM port not detected:** Check the USB cable and the USB to Serial driver installation.
+
+If the error persists, you can ask for help at the official [ESP32 forum](https://esp32.com) or see [Contribute](#contribute).
+
+## Contribute
+
+To know how to contribute to this project, see [How to contribute.](https://github.com/espressif/arduino-esp32/blob/master/CONTRIBUTING.rst)
+
+If you have any **feedback** or **issue** to report on this example/library, please open an issue or fix it by creating a new PR. Contributions are more than welcome!
+
+Before creating a new issue, be sure to try Troubleshooting and check if the same issue was already created by someone else.
+
+## Resources
+
+* Official ESP32 Forum: [Link](https://esp32.com)
+* Arduino-ESP32 Official Repository: [espressif/arduino-esp32](https://github.com/espressif/arduino-esp32)
+* ESP32-C6 Datasheet: [Link to datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf)
+* ESP32-H2 Datasheet: [Link to datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf)
+* Official ESP-IDF documentation: [ESP-IDF](https://idf.espressif.com)

--- a/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/Zigbee_CarbonDioxide_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/Zigbee_CarbonDioxide_Sensor.ino
@@ -81,7 +81,7 @@ void loop() {
   // Read carbon dioxide sensor every 2s
   if (!(timeCounter++ % 20)) {  // delaying for 100ms x 20 = 2s
     // Read sensor value - here is chip temperature used + 300 as a dummy value for demonstration
-    uint16_t carbon_dioxide_value = 300+(uint16_t)temperatureRead();
+    uint16_t carbon_dioxide_value = 300 + (uint16_t)temperatureRead();
     Serial.printf("Updating carbon dioxide sensor value to %d ppm\r\n", carbon_dioxide_value);
     zbCarbonDioxideSensor.setCarbonDioxide(carbon_dioxide_value);
   }

--- a/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/Zigbee_CarbonDioxide_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/Zigbee_CarbonDioxide_Sensor.ino
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 /**
- * @brief This example demonstrates Zigbee temperature sensor.
+ * @brief This example demonstrates Zigbee carbon dioxide sensor.
  *
- * The example demonstrates how to use Zigbee library to create a end device temperature sensor.
- * The temperature sensor is a Zigbee end device, which is controlled by a Zigbee coordinator.
+ * The example demonstrates how to use Zigbee library to create a end device carbon dioxide sensor.
  *
  * Proper Zigbee mode must be selected in Tools->Zigbee mode
  * and also the correct partition scheme must be selected in Tools->Partition Scheme.
@@ -32,14 +31,11 @@
 
 #include "Zigbee.h"
 
-/* Zigbee flow + pressure sensor configuration */
-#define FLOW_SENSOR_ENDPOINT_NUMBER 10
-#define PRESSURE_SENSOR_ENDPOINT_NUMBER 11
-
+/* Zigbee carbon dioxide sensor configuration */
+#define CARBON_DIOXIDE_SENSOR_ENDPOINT_NUMBER 10
 uint8_t button = BOOT_PIN;
 
-ZigbeeFlowSensor zbFlowSensor = ZigbeeFlowSensor(FLOW_SENSOR_ENDPOINT_NUMBER);
-ZigbeePressureSensor zbPressureSensor = ZigbeePressureSensor(PRESSURE_SENSOR_ENDPOINT_NUMBER);
+ZigbeeCarbonDioxideSensor zbCarbonDioxideSensor = ZigbeeCarbonDioxideSensor(CARBON_DIOXIDE_SENSOR_ENDPOINT_NUMBER);
 
 void setup() {
   Serial.begin(115200);
@@ -48,26 +44,13 @@ void setup() {
   pinMode(button, INPUT_PULLUP);
 
   // Optional: set Zigbee device name and model
-  zbFlowSensor.setManufacturerAndModel("Espressif", "ZigbeeFlowSensor");
+  zbCarbonDioxideSensor.setManufacturerAndModel("Espressif", "ZigbeeCarbonDioxideSensor");
 
-  // Set minimum and maximum flow measurement value in 0,1 m3/h
-  zbFlowSensor.setMinMaxValue(0.0, 100.0);
-
-  // Optional: Set tolerance for flow measurement in 0,1 m3/h
-  zbFlowSensor.setTolerance(1.0);
-
-  // Optional: set Zigbee device name and model
-  zbPressureSensor.setManufacturerAndModel("Espressif", "ZigbeePressureSensor");
-
-  // Set minimum and maximum pressure measurement value in hPa
-  zbPressureSensor.setMinMaxValue(0, 10000);
-
-  // Optional: Set tolerance for pressure measurement in hPa
-  zbPressureSensor.setTolerance(1);
+  // Set minimum and maximum carbon dioxide measurement value in ppm
+  zbCarbonDioxideSensor.setMinMaxValue(0, 1500);
 
   // Add endpoints to Zigbee Core
-  Zigbee.addEndpoint(&zbFlowSensor);
-  Zigbee.addEndpoint(&zbPressureSensor);
+  Zigbee.addEndpoint(&zbCarbonDioxideSensor);
 
   Serial.println("Starting Zigbee...");
   // When all EPs are registered, start Zigbee in End Device mode
@@ -85,26 +68,22 @@ void setup() {
   }
   Serial.println();
 
-  // Set reporting interval for flow and pressure measurement in seconds, must be called after Zigbee.begin()
-  // min_interval and max_interval in seconds, delta (pressure change in hPa, flow change in 0,1 m3/h)
-  // if min = 1 and max = 0, reporting is sent only when temperature changes by delta
-  // if min = 0 and max = 10, reporting is sent every 10 seconds or temperature changes by delta
+  // Set reporting interval for carbon dioxide measurement to be done every 30 seconds, must be called after Zigbee.begin()
+  // min_interval and max_interval in seconds, delta (carbon dioxide change in ppm)
+  // if min = 1 and max = 0, reporting is sent only when carbon dioxide changes by delta
+  // if min = 0 and max = 10, reporting is sent every 10 seconds or when carbon dioxide changes by delta
   // if min = 0, max = 10 and delta = 0, reporting is sent every 10 seconds regardless of delta change
-  zbFlowSensor.setReporting(0, 30, 1.0);
-  zbPressureSensor.setReporting(0, 30, 1);
+  zbCarbonDioxideSensor.setReporting(0, 30, 0);
 }
 
 void loop() {
   static uint32_t timeCounter = 0;
-
-  // Read flow and pressure sensors every 2s
+  // Read carbon dioxide sensor every 2s
   if (!(timeCounter++ % 20)) {  // delaying for 100ms x 20 = 2s
-    float flow_value = temperatureRead();
-    uint16_t pressure_value = (uint16_t)temperatureRead()*100; //*100 for demonstration so the value is in 1000-3000hPa
-    Serial.printf("Updating flow sensor value to %.2f m3/h\r\n", flow_value);
-    zbFlowSensor.setFlow(flow_value);
-    Serial.printf("Updating pressure sensor value to %d hPa\r\n", pressure_value);
-    zbPressureSensor.setPressure(pressure_value);
+    // Read sensor value - here is chip temperature used + 300 as a dummy value for demonstration
+    uint16_t carbon_dioxide_value = 300+(uint16_t)temperatureRead();
+    Serial.printf("Updating carbon dioxide sensor value to %d ppm\r\n", carbon_dioxide_value);
+    zbCarbonDioxideSensor.setCarbonDioxide(carbon_dioxide_value);
   }
 
   // Checking button for factory reset and reporting
@@ -121,8 +100,7 @@ void loop() {
         Zigbee.factoryReset();
       }
     }
-    zbFlowSensor.report();
-    zbPressureSensor.report();
+    zbCarbonDioxideSensor.report();
   }
   delay(100);
 }

--- a/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_CarbonDioxide_Sensor/ci.json
@@ -1,0 +1,6 @@
+{
+  "fqbn_append": "PartitionScheme=zigbee,ZigbeeMode=ed",
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
+}

--- a/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/README.md
+++ b/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/README.md
@@ -1,6 +1,6 @@
-# Arduino-ESP32 Zigbee Temperature Sensor Example
+# Arduino-ESP32 Zigbee Occupancy Sensor Example
 
-This example shows how to configure the Zigbee end device and use it as a Home Automation (HA) temperature sensor.
+This example shows how to configure the Zigbee end device and use it as a Home Automation (HA) occupancy sensor (PIR).
 
 # Supported Targets
 
@@ -9,26 +9,14 @@ Currently, this example supports the following targets.
 | Supported Targets | ESP32-C6 | ESP32-H2 |
 | ----------------- | -------- | -------- |
 
-## Temperature Sensor Functions
-
-Note:
- * This board means the board (e.g. ESP32-H2 / C6) loaded with `Zigbee_Temperature_Sensor` example.
- * The remote board means the board (e.g. ESP32-H2 / C6) loaded with `Zigbee_Thermostat` example.
-
-Functions:
- * After this board first starts up, it would be configured locally to report the temperature on 1 degree change and no periodic reporting to the remote board.
- * By clicking the button (BOOT) on this board, this board will immediately send a report of the current measured temperature to the remote board.
-
 ## Hardware Required
 
-* One development board (ESP32-H2 or ESP32-C6) acting as Zigbee coordinator (loaded with `Zigbee_Thermostat` example)
 * A USB cable for power supply and programming
-* Choose another board (ESP32-H2 or ESP32-C6) as Zigbee end device and upload the `Zigbee_Temperature_Sensor` example
 
 ### Configure the Project
 
-In this example, the internal temperature sensor task is reading the chip temperature.
 Set the Button GPIO by changing the `button` variable. By default, it's the pin `BOOT_PIN` (BOOT button on ESP32-C6 and ESP32-H2).
+Set the Sensor GPIO by changing the `sensor_pin` variable.
 
 #### Using Arduino IDE
 
@@ -42,17 +30,7 @@ To get more information about the Espressif boards see [Espressif Development Ki
 
 ## Troubleshooting
 
-If the End device flashed with this example is not connecting to the coordinator, erase the flash of the End device before flashing the example to the board. It is recommended to do this if you re-flash the coordinator.
-You can do the following:
-
-* In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`.
-* Add to the sketch `Zigbee.factoryReset();` to reset the device and Zigbee stack.
-
-By default, the coordinator network is closed after rebooting or flashing new firmware.
-To open the network you have 2 options:
-
-* Open network after reboot by setting `Zigbee.setRebootOpenNetwork(time);` before calling `Zigbee.begin();`.
-* In application you can anytime call `Zigbee.openNetwork(time);` to open the network for devices to join.
+If the End device flashed with this example is not connecting to the coordinator, erase the flash of the End device before flashing the example to the board. 
 
 ***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***
 

--- a/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/README.md
+++ b/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/README.md
@@ -30,7 +30,7 @@ To get more information about the Espressif boards see [Espressif Development Ki
 
 ## Troubleshooting
 
-If the End device flashed with this example is not connecting to the coordinator, erase the flash of the End device before flashing the example to the board. 
+If the End device flashed with this example is not connecting to the coordinator, erase the flash of the End device before flashing the example to the board.
 
 ***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***
 

--- a/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/Zigbee_Occupancy_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/Zigbee_Occupancy_Sensor.ino
@@ -73,7 +73,7 @@ void setup() {
 void loop() {
   // Checking PIR sensor for occupancy change
   static bool occupancy = false;
-  if(digitalRead(sensor_pin) == HIGH && !occupancy) {
+  if (digitalRead(sensor_pin) == HIGH && !occupancy) {
     // Update occupancy sensor value
     zbOccupancySensor.setOccupancy(true);
     zbOccupancySensor.report();

--- a/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/Zigbee_Occupancy_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/Zigbee_Occupancy_Sensor.ino
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 /**
- * @brief This example demonstrates Zigbee temperature sensor.
+ * @brief This example demonstrates Zigbee occupancy sensor.
  *
- * The example demonstrates how to use Zigbee library to create a end device temperature sensor.
- * The temperature sensor is a Zigbee end device, which is controlled by a Zigbee coordinator.
+ * The example demonstrates how to use Zigbee library to create a end device occupancy sensor.
+ * The occupancy sensor is a Zigbee end device, which is reporting data to the Zigbee network.
+ * Tested with PIR sensor HC-SR501 connected to GPIO4.
  *
  * Proper Zigbee mode must be selected in Tools->Zigbee mode
  * and also the correct partition scheme must be selected in Tools->Partition Scheme.
@@ -32,42 +33,26 @@
 
 #include "Zigbee.h"
 
-/* Zigbee temperature sensor configuration */
-#define TEMP_SENSOR_ENDPOINT_NUMBER 10
+/* Zigbee occupancy sensor configuration */
+#define OCCUPANCY_SENSOR_ENDPOINT_NUMBER 10
 uint8_t button = BOOT_PIN;
+uint8_t sensor_pin = 4;
 
-ZigbeeTempSensor zbTempSensor = ZigbeeTempSensor(TEMP_SENSOR_ENDPOINT_NUMBER);
-
-/************************ Temp sensor *****************************/
-static void temp_sensor_value_update(void *arg) {
-  for (;;) {
-    // Read temperature sensor value
-    float tsens_value = temperatureRead();
-    Serial.printf("Updated temperature sensor value to %.2f°C\r\n", tsens_value);
-    // Update temperature value in Temperature sensor EP
-    zbTempSensor.setTemperature(tsens_value);
-    delay(1000);
-  }
-}
+ZigbeeOccupancySensor zbOccupancySensor = ZigbeeOccupancySensor(OCCUPANCY_SENSOR_ENDPOINT_NUMBER);
 
 /********************* Arduino functions **************************/
 void setup() {
   Serial.begin(115200);
 
-  // Init button switch
+  // Init button + PIR sensor
   pinMode(button, INPUT_PULLUP);
+  pinMode(sensor_pin, INPUT);
 
   // Optional: set Zigbee device name and model
-  zbTempSensor.setManufacturerAndModel("Espressif", "ZigbeeTempSensor");
-
-  // Set minimum and maximum temperature measurement value (10-50°C is default range for chip temperature measurement)
-  zbTempSensor.setMinMaxValue(10, 50);
-
-  // Optional: Set tolerance for temperature measurement in °C (lowest possible value is 0.01°C)
-  zbTempSensor.setTolerance(1);
+  zbOccupancySensor.setManufacturerAndModel("Espressif", "ZigbeeOccupancyPIRSensor");
 
   // Add endpoint to Zigbee Core
-  Zigbee.addEndpoint(&zbTempSensor);
+  Zigbee.addEndpoint(&zbOccupancySensor);
 
   Serial.println("Starting Zigbee...");
   // When all EPs are registered, start Zigbee in End Device mode
@@ -84,19 +69,22 @@ void setup() {
     delay(100);
   }
   Serial.println();
-
-  // Start Temperature sensor reading task
-  xTaskCreate(temp_sensor_value_update, "temp_sensor_update", 2048, NULL, 10, NULL);
-
-  // Set reporting interval for temperature measurement in seconds, must be called after Zigbee.begin()
-  // min_interval and max_interval in seconds, delta (temp change in 0,1 °C)
-  // if min = 1 and max = 0, reporting is sent only when temperature changes by delta
-  // if min = 0 and max = 10, reporting is sent every 10 seconds or temperature changes by delta
-  // if min = 0, max = 10 and delta = 0, reporting is sent every 10 seconds regardless of temperature change
-  zbTempSensor.setReporting(1, 0, 1);
 }
 
 void loop() {
+  // Checking PIR sensor for occupancy change
+  static bool occupancy = false;
+  if(digitalRead(sensor_pin) == HIGH && !occupancy) {
+    // Update occupancy sensor value
+    zbOccupancySensor.setOccupancy(true);
+    zbOccupancySensor.report();
+    occupancy = true;
+  } else if (digitalRead(sensor_pin) == LOW && occupancy) {
+    zbOccupancySensor.setOccupancy(false);
+    zbOccupancySensor.report();
+    occupancy = false;
+  }
+
   // Checking button for factory reset
   if (digitalRead(button) == LOW) {  // Push button pressed
     // Key debounce handling
@@ -111,7 +99,6 @@ void loop() {
         Zigbee.factoryReset();
       }
     }
-    zbTempSensor.reportTemperature();
   }
   delay(100);
 }

--- a/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/Zigbee_Occupancy_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/Zigbee_Occupancy_Sensor.ino
@@ -40,7 +40,6 @@ uint8_t sensor_pin = 4;
 
 ZigbeeOccupancySensor zbOccupancySensor = ZigbeeOccupancySensor(OCCUPANCY_SENSOR_ENDPOINT_NUMBER);
 
-/********************* Arduino functions **************************/
 void setup() {
   Serial.begin(115200);
 

--- a/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Occupancy_Sensor/ci.json
@@ -1,0 +1,6 @@
+{
+  "fqbn_append": "PartitionScheme=zigbee,ZigbeeMode=ed",
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
+}

--- a/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/README.md
+++ b/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/README.md
@@ -1,6 +1,6 @@
-# Arduino-ESP32 Zigbee Temperature Sensor Example
+# Arduino-ESP32 Zigbee Pressure + Flow Sensor Example
 
-This example shows how to configure the Zigbee end device and use it as a Home Automation (HA) temperature sensor.
+This example shows how to configure the Zigbee end device and use it as a Home Automation (HA) simple sensor device type with pressure and flow measuring.
 
 # Supported Targets
 
@@ -9,25 +9,18 @@ Currently, this example supports the following targets.
 | Supported Targets | ESP32-C6 | ESP32-H2 |
 | ----------------- | -------- | -------- |
 
-## Temperature Sensor Functions
+## Pressure + Flow Sensor Functions
 
-Note:
- * This board means the board (e.g. ESP32-H2 / C6) loaded with `Zigbee_Temperature_Sensor` example.
- * The remote board means the board (e.g. ESP32-H2 / C6) loaded with `Zigbee_Thermostat` example.
-
-Functions:
- * After this board first starts up, it would be configured locally to report the temperature on 1 degree change and no periodic reporting to the remote board.
- * By clicking the button (BOOT) on this board, this board will immediately send a report of the current measured temperature to the remote board.
+ * After this board first starts up, it would be configured locally to report the pressure and flow on change or every 30 seconds.
+ * By clicking the button (BOOT) on this board, this board will immediately send a report of the current measured flow and pressure to the network.
 
 ## Hardware Required
 
-* One development board (ESP32-H2 or ESP32-C6) acting as Zigbee coordinator (loaded with `Zigbee_Thermostat` example)
 * A USB cable for power supply and programming
-* Choose another board (ESP32-H2 or ESP32-C6) as Zigbee end device and upload the `Zigbee_Temperature_Sensor` example
 
 ### Configure the Project
 
-In this example, the internal temperature sensor task is reading the chip temperature.
+In this example, the internal temperature sensor is used to demonstrate reading of the flow and pressure sensors.
 Set the Button GPIO by changing the `button` variable. By default, it's the pin `BOOT_PIN` (BOOT button on ESP32-C6 and ESP32-H2).
 
 #### Using Arduino IDE

--- a/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/Zigbee_Pressure_Flow_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/Zigbee_Pressure_Flow_Sensor.ino
@@ -33,7 +33,7 @@
 #include "Zigbee.h"
 
 /* Zigbee flow + pressure sensor configuration */
-#define FLOW_SENSOR_ENDPOINT_NUMBER 10
+#define FLOW_SENSOR_ENDPOINT_NUMBER     10
 #define PRESSURE_SENSOR_ENDPOINT_NUMBER 11
 
 uint8_t button = BOOT_PIN;
@@ -100,7 +100,7 @@ void loop() {
   // Read flow and pressure sensors every 2s
   if (!(timeCounter++ % 20)) {  // delaying for 100ms x 20 = 2s
     float flow_value = temperatureRead();
-    uint16_t pressure_value = (uint16_t)temperatureRead()*100; //*100 for demonstration so the value is in 1000-3000hPa
+    uint16_t pressure_value = (uint16_t)temperatureRead() * 100;  //*100 for demonstration so the value is in 1000-3000hPa
     Serial.printf("Updating flow sensor value to %.2f m3/h\r\n", flow_value);
     zbFlowSensor.setFlow(flow_value);
     Serial.printf("Updating pressure sensor value to %d hPa\r\n", pressure_value);

--- a/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/Zigbee_Pressure_Flow_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/Zigbee_Pressure_Flow_Sensor.ino
@@ -49,7 +49,7 @@ static void sensors_reading(void *arg) {
     uint16_t pressure_value = (uint16_t)temperatureRead()*100; //*100 for demonstration so the value is in 1-3hPa
     Serial.printf("Updating flow sensor value to %.2f\r\n", flow_value);
     zbFlowSensor.setFlow(flow_value);
-    Serial.printf("Updating pressure sensor value to %.2f\r\n", pressure_value);
+    Serial.printf("Updating pressure sensor value to %d\r\n", pressure_value);
     zbPressureSensor.setPressure(pressure_value);
     delay(1000);
   }

--- a/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Pressure_Flow_Sensor/ci.json
@@ -1,0 +1,6 @@
+{
+  "fqbn_append": "PartitionScheme=zigbee,ZigbeeMode=ed",
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
+}

--- a/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/README.md
+++ b/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/README.md
@@ -24,7 +24,7 @@ Currently, this example supports the following targets.
 ### Configure the Project
 
 In this example, to demonstrate the functionality the chip temperature is used and reported as temperature and humidity.
-Set the Button GPIO by changing the `BUTTON_PIN` definition. By default, it's the pin `9` (BOOT button on ESP32-C6 and ESP32-H2).
+Set the Button GPIO by changing the `button` variable. By default, it's the pin `BOOT_PIN` (BOOT button on ESP32-C6 and ESP32-H2).
 
 #### Using Arduino IDE
 

--- a/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
+++ b/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
@@ -55,10 +55,11 @@ void meausureAndSleep() {
   zbTempSensor.setHumidity(humidity);
 
   // Report temperature and humidity values
-  zbTempSensor.reportTemperature();
-  zbTempSensor.reportHumidity();
-
+  zbTempSensor.report();
   Serial.printf("Reported temperature: %.2f°C, Humidity: %.2f%%\r\n", temperature, humidity);
+
+  // Add small delay to allow the data to be sent before going to sleep
+  delay(100);
 
   // Put device to deep sleep
   Serial.println("Going to sleep now");

--- a/libraries/Zigbee/keywords.txt
+++ b/libraries/Zigbee/keywords.txt
@@ -123,6 +123,9 @@ setPressure	KEYWORD2
 setOccupancy	KEYWORD2
 setSensorType	KEYWORD2
 
+# ZigbeeCarbonDioxideSensor
+setCarbonDioxide	KEYWORD2
+
 #######################################
 # Constants (LITERAL1)
 #######################################

--- a/libraries/Zigbee/keywords.txt
+++ b/libraries/Zigbee/keywords.txt
@@ -18,6 +18,9 @@ ZigbeeColorDimmableLight	KEYWORD1
 ZigbeeColorDimmerSwitch	KEYWORD1
 ZigbeeTempSensor	KEYWORD1
 ZigbeeThermostat	KEYWORD1
+ZigbeeFlowSensor	KEYWORD1
+ZigbeePressureSensor	KEYWORD1
+ZigbeeOccupancySensor	KEYWORD1
 
 # Other
 zigbee_role_t	KEYWORD1
@@ -89,23 +92,36 @@ lightOnWithSceneRecall	KEYWORD2
 setLightLevel	KEYWORD2
 setLightColor	KEYWORD2
 
-# ZigbeeTempSensor + humidity
-setTemperature	KEYWORD2
-setMinMaxValue	KEYWORD2
-setTolerance	KEYWORD2
-setReporting	KEYWORD2
-reportTemperature	KEYWORD2
-addHumiditySensor	KEYWORD2
-setHumidity	KEYWORD2
-setHumidityReporting	KEYWORD2
-reportHumidity	KEYWORD2
-
 # ZigbeeThermostat
 onTempRecieve	KEYWORD2
 onConfigRecieve	KEYWORD2
 getTemperature	KEYWORD2
 getSensorSettings	KEYWORD2
 setTemperatureReporting	KEYWORD2
+
+# Common Zigbee Sensor
+setMinMaxValue	KEYWORD2
+setTolerance	KEYWORD2
+setReporting	KEYWORD2
+report	KEYWORD2
+
+# ZigbeeTempSensor + humidity
+setTemperature	KEYWORD2
+reportTemperature	KEYWORD2
+addHumiditySensor	KEYWORD2
+setHumidity	KEYWORD2
+setHumidityReporting	KEYWORD2
+reportHumidity	KEYWORD2
+
+# ZigbeeFlowSensor
+setFlow	KEYWORD2
+
+# ZigbeePressureSensor
+setPressure	KEYWORD2
+
+# ZigbeeOccupancySensor
+setOccupancy	KEYWORD2
+setSensorType	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/Zigbee/src/Zigbee.h
+++ b/libraries/Zigbee/src/Zigbee.h
@@ -13,3 +13,6 @@
 #include "ep/ZigbeeColorDimmerSwitch.h"
 #include "ep/ZigbeeTempSensor.h"
 #include "ep/ZigbeeThermostat.h"
+#include "ep/ZigbeePressureSensor.h"
+#include "ep/ZigbeeFlowSensor.h"
+#include "ep/ZigbeeOccupancySensor.h"

--- a/libraries/Zigbee/src/Zigbee.h
+++ b/libraries/Zigbee/src/Zigbee.h
@@ -16,3 +16,4 @@
 #include "ep/ZigbeePressureSensor.h"
 #include "ep/ZigbeeFlowSensor.h"
 #include "ep/ZigbeeOccupancySensor.h"
+#include "ep/ZigbeeCarbonDioxideSensor.h"

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -1,0 +1,104 @@
+#include "ZigbeeCarbonDioxideSensor.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+esp_zb_cluster_list_t  *zigbee_carbon_dioxide_sensor_clusters_create(zigbee_carbon_dioxide_sensor_cfg_t *carbon_dioxide_sensor)
+{
+    esp_zb_basic_cluster_cfg_t *basic_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->basic_cfg) : NULL;
+    esp_zb_identify_cluster_cfg_t *identify_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->identify_cfg) : NULL;
+    esp_zb_carbon_dioxide_measurement_cluster_cfg_t *carbon_dioxide_meas_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->carbon_dioxide_meas_cfg) : NULL;
+    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_carbon_dioxide_measurement_cluster(cluster_list, esp_zb_carbon_dioxide_measurement_cluster_create(carbon_dioxide_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    return cluster_list;
+}
+
+ZigbeeCarbonDioxideSensor::ZigbeeCarbonDioxideSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
+  _device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID;
+
+  //Create custom pressure sensor configuration
+  zigbee_carbon_dioxide_sensor_cfg_t carbon_dioxide_sensor_cfg = ZIGBEE_DEFAULT_CARBON_DIOXIDE_SENSOR_CONFIG();
+  _cluster_list = zigbee_carbon_dioxide_sensor_clusters_create(&carbon_dioxide_sensor_cfg);
+
+  _ep_config = {
+    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
+  };
+}
+
+void ZigbeeCarbonDioxideSensor::setMinMaxValue(float min, float max) {
+  float zb_min = min/1000000.0f;
+  float zb_max = max/1000000.0f;
+  esp_zb_attribute_list_t *carbon_dioxide_measure_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_update_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MIN_MEASURED_VALUE_ID, (void *)&zb_min);
+  esp_zb_cluster_update_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MAX_MEASURED_VALUE_ID, (void *)&zb_max);
+}
+
+void ZigbeeCarbonDioxideSensor::setTolerance(float tolerance) {
+  float zb_tolerance = tolerance/1000000.0f;
+  esp_zb_attribute_list_t *carbon_dioxide_measure_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_temperature_meas_cluster_add_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_TOLERANCE_ID, (void *)&zb_tolerance);
+}
+
+void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta) {
+  esp_zb_zcl_reporting_info_t reporting_info = {
+    .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
+    .ep = _endpoint,
+    .cluster_id = ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT,
+    .cluster_role = ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
+    .attr_id = ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID,
+    .u =
+      {
+        .send_info =
+          {
+            .min_interval = min_interval,
+            .max_interval = max_interval,
+            .delta =
+              {
+                .u16 = delta, // x ppm
+              },
+            .def_min_interval = min_interval,
+            .def_max_interval = max_interval,
+          },
+      },
+    .dst =
+      {
+        .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
+      },
+    .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
+  };
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_update_reporting_info(&reporting_info);
+  esp_zb_lock_release();
+}
+
+void ZigbeeCarbonDioxideSensor::setCarbonDioxide(float carbon_dioxide) {
+  float zb_carbon_dioxide = carbon_dioxide/1000000.0f;
+  log_v("Updating carbon dioxide sensor value...");
+  /* Update carbon dioxide sensor measured value */
+  log_d("Setting carbon dioxide to %0.1f", carbon_dioxide);
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID, &zb_carbon_dioxide, false
+  );
+  esp_zb_lock_release();
+}
+
+void ZigbeeCarbonDioxideSensor::report() {
+  /* Send report attributes command */
+  esp_zb_zcl_report_attr_cmd_t report_attr_cmd;
+  report_attr_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+  report_attr_cmd.attributeID = ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID;
+  report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
+  report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT;
+  report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
+
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
+  esp_zb_lock_release();
+  log_v("Carbon dioxide report sent");
+}
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -43,6 +43,9 @@ void ZigbeeCarbonDioxideSensor::setTolerance(float tolerance) {
 }
 
 void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta) {
+  if(delta > 0) {
+    log_e("Delta reporting is currently not supported by the carbon dioxide sensor");
+  }
   esp_zb_zcl_reporting_info_t reporting_info = {
     .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
     .ep = _endpoint,
@@ -57,7 +60,7 @@ void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max
             .max_interval = max_interval,
             .delta =
               {
-                .u16 = delta, // x ppm
+                .u16 = delta,
               },
             .def_min_interval = min_interval,
             .def_max_interval = max_interval,

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -1,17 +1,18 @@
 #include "ZigbeeCarbonDioxideSensor.h"
 #if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
-esp_zb_cluster_list_t  *zigbee_carbon_dioxide_sensor_clusters_create(zigbee_carbon_dioxide_sensor_cfg_t *carbon_dioxide_sensor)
-{
-    esp_zb_basic_cluster_cfg_t *basic_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->basic_cfg) : NULL;
-    esp_zb_identify_cluster_cfg_t *identify_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->identify_cfg) : NULL;
-    esp_zb_carbon_dioxide_measurement_cluster_cfg_t *carbon_dioxide_meas_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->carbon_dioxide_meas_cfg) : NULL;
-    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
-    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_carbon_dioxide_measurement_cluster(cluster_list, esp_zb_carbon_dioxide_measurement_cluster_create(carbon_dioxide_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    return cluster_list;
+esp_zb_cluster_list_t *zigbee_carbon_dioxide_sensor_clusters_create(zigbee_carbon_dioxide_sensor_cfg_t *carbon_dioxide_sensor) {
+  esp_zb_basic_cluster_cfg_t *basic_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->basic_cfg) : NULL;
+  esp_zb_identify_cluster_cfg_t *identify_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->identify_cfg) : NULL;
+  esp_zb_carbon_dioxide_measurement_cluster_cfg_t *carbon_dioxide_meas_cfg = carbon_dioxide_sensor ? &(carbon_dioxide_sensor->carbon_dioxide_meas_cfg) : NULL;
+  esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+  esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_carbon_dioxide_measurement_cluster(
+    cluster_list, esp_zb_carbon_dioxide_measurement_cluster_create(carbon_dioxide_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE
+  );
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  return cluster_list;
 }
 
 ZigbeeCarbonDioxideSensor::ZigbeeCarbonDioxideSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
@@ -21,14 +22,12 @@ ZigbeeCarbonDioxideSensor::ZigbeeCarbonDioxideSensor(uint8_t endpoint) : ZigbeeE
   zigbee_carbon_dioxide_sensor_cfg_t carbon_dioxide_sensor_cfg = ZIGBEE_DEFAULT_CARBON_DIOXIDE_SENSOR_CONFIG();
   _cluster_list = zigbee_carbon_dioxide_sensor_clusters_create(&carbon_dioxide_sensor_cfg);
 
-  _ep_config = {
-    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
-  };
+  _ep_config = {.endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0};
 }
 
 void ZigbeeCarbonDioxideSensor::setMinMaxValue(float min, float max) {
-  float zb_min = min/1000000.0f;
-  float zb_max = max/1000000.0f;
+  float zb_min = min / 1000000.0f;
+  float zb_max = max / 1000000.0f;
   esp_zb_attribute_list_t *carbon_dioxide_measure_cluster =
     esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
   esp_zb_cluster_update_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MIN_MEASURED_VALUE_ID, (void *)&zb_min);
@@ -36,14 +35,14 @@ void ZigbeeCarbonDioxideSensor::setMinMaxValue(float min, float max) {
 }
 
 void ZigbeeCarbonDioxideSensor::setTolerance(float tolerance) {
-  float zb_tolerance = tolerance/1000000.0f;
+  float zb_tolerance = tolerance / 1000000.0f;
   esp_zb_attribute_list_t *carbon_dioxide_measure_cluster =
     esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
   esp_zb_temperature_meas_cluster_add_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_TOLERANCE_ID, (void *)&zb_tolerance);
 }
 
 void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta) {
-  if(delta > 0) {
+  if (delta > 0) {
     log_e("Delta reporting is currently not supported by the carbon dioxide sensor");
   }
   // clang-format off
@@ -80,13 +79,14 @@ void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max
 }
 
 void ZigbeeCarbonDioxideSensor::setCarbonDioxide(float carbon_dioxide) {
-  float zb_carbon_dioxide = carbon_dioxide/1000000.0f;
+  float zb_carbon_dioxide = carbon_dioxide / 1000000.0f;
   log_v("Updating carbon dioxide sensor value...");
   /* Update carbon dioxide sensor measured value */
   log_d("Setting carbon dioxide to %0.1f", carbon_dioxide);
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID, &zb_carbon_dioxide, false
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID,
+    &zb_carbon_dioxide, false
   );
   esp_zb_lock_release();
 }

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -46,6 +46,7 @@ void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max
   if(delta > 0) {
     log_e("Delta reporting is currently not supported by the carbon dioxide sensor");
   }
+  // clang-format off
   esp_zb_zcl_reporting_info_t reporting_info = {
     .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
     .ep = _endpoint,
@@ -72,6 +73,7 @@ void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max
       },
     .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
   };
+  // clang-format on
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_update_reporting_info(&reporting_info);
   esp_zb_lock_release();

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
@@ -1,0 +1,58 @@
+/* Class of Zigbee Pressure sensor endpoint inherited from common EP class */
+
+#pragma once
+
+#include "soc/soc_caps.h"
+#include "sdkconfig.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+#include "ZigbeeEP.h"
+#include "ha/esp_zigbee_ha_standard.h"
+
+#define ZIGBEE_DEFAULT_CARBON_DIOXIDE_SENSOR_CONFIG()                             \
+    {                                                                             \
+        .basic_cfg =                                                              \
+            {                                                                     \
+                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,        \
+                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,      \
+            },                                                                    \
+        .identify_cfg =                                                           \
+            {                                                                     \
+                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE, \
+            },                                                                    \
+        .carbon_dioxide_meas_cfg =                                                \
+            {                                                                     \
+                .measured_value = 0.0,                                            \
+                .min_measured_value = 0.0,                                        \
+                .max_measured_value = 1.0,                                        \
+            },                                                                    \
+    }
+
+typedef struct zigbee_carbon_dioxide_sensor_cfg_s {
+    esp_zb_basic_cluster_cfg_t basic_cfg;     
+    esp_zb_identify_cluster_cfg_t identify_cfg;
+    esp_zb_carbon_dioxide_measurement_cluster_cfg_t carbon_dioxide_meas_cfg;
+} zigbee_carbon_dioxide_sensor_cfg_t;
+
+class ZigbeeCarbonDioxideSensor : public ZigbeeEP {
+public:
+  ZigbeeCarbonDioxideSensor(uint8_t endpoint);
+  ~ZigbeeCarbonDioxideSensor();
+
+  // Set the carbon dioxide value in ppm
+  void setCarbonDioxide(float carbon_dioxide);
+
+  // Set the min and max value for the carbon dioxide sensor in ppm
+  void setMinMaxValue(float min, float max);
+
+  // Set the tolerance value for the carbon dioxide sensor in ppm
+  void setTolerance(float tolerance);
+
+  // Set the reporting interval for carbon dioxide measurement in seconds and delta (carbon dioxide change in ppm)
+  void setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta);
+
+  // Report the carbon dioxide value
+  void report();
+};
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
@@ -10,24 +10,24 @@
 #include "ha/esp_zigbee_ha_standard.h"
 
 // clang-format off
-#define ZIGBEE_DEFAULT_CARBON_DIOXIDE_SENSOR_CONFIG()                             \
-    {                                                                             \
-        .basic_cfg =                                                              \
-            {                                                                     \
-                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,        \
-                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,      \
-            },                                                                    \
-        .identify_cfg =                                                           \
-            {                                                                     \
-                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE, \
-            },                                                                    \
-        .carbon_dioxide_meas_cfg =                                                \
-            {                                                                     \
-                .measured_value = 0.0,                                            \
-                .min_measured_value = 0.0,                                        \
-                .max_measured_value = 1.0,                                        \
-            },                                                                    \
-    }
+#define ZIGBEE_DEFAULT_CARBON_DIOXIDE_SENSOR_CONFIG()                     \
+  {                                                                       \
+    .basic_cfg =                                                          \
+      {                                                                   \
+        .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,        \
+        .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,      \
+      },                                                                  \
+    .identify_cfg =                                                       \
+      {                                                                   \
+        .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE, \
+      },                                                                  \
+    .carbon_dioxide_meas_cfg =                                            \
+      {                                                                   \
+        .measured_value = 0.0,                                            \
+        .min_measured_value = 0.0,                                        \
+        .max_measured_value = 1.0,                                        \
+      },                                                                  \
+  }
 // clang-format on
 
 typedef struct zigbee_carbon_dioxide_sensor_cfg_s {

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
@@ -9,6 +9,7 @@
 #include "ZigbeeEP.h"
 #include "ha/esp_zigbee_ha_standard.h"
 
+// clang-format off
 #define ZIGBEE_DEFAULT_CARBON_DIOXIDE_SENSOR_CONFIG()                             \
     {                                                                             \
         .basic_cfg =                                                              \
@@ -27,6 +28,7 @@
                 .max_measured_value = 1.0,                                        \
             },                                                                    \
     }
+// clang-format on
 
 typedef struct zigbee_carbon_dioxide_sensor_cfg_s {
     esp_zb_basic_cluster_cfg_t basic_cfg;     

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
@@ -49,6 +49,7 @@ public:
   void setTolerance(float tolerance);
 
   // Set the reporting interval for carbon dioxide measurement in seconds and delta (carbon dioxide change in ppm)
+  // NOTE: Delta reporting is currently not supported by the carbon dioxide sensor
   void setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta);
 
   // Report the carbon dioxide value

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
@@ -31,9 +31,9 @@
 // clang-format on
 
 typedef struct zigbee_carbon_dioxide_sensor_cfg_s {
-    esp_zb_basic_cluster_cfg_t basic_cfg;     
-    esp_zb_identify_cluster_cfg_t identify_cfg;
-    esp_zb_carbon_dioxide_measurement_cluster_cfg_t carbon_dioxide_meas_cfg;
+  esp_zb_basic_cluster_cfg_t basic_cfg;
+  esp_zb_identify_cluster_cfg_t identify_cfg;
+  esp_zb_carbon_dioxide_measurement_cluster_cfg_t carbon_dioxide_meas_cfg;
 } zigbee_carbon_dioxide_sensor_cfg_t;
 
 class ZigbeeCarbonDioxideSensor : public ZigbeeEP {

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
@@ -1,0 +1,105 @@
+#include "ZigbeeFlowSensor.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+esp_zb_cluster_list_t  *zigbee_flow_sensor_clusters_create(zigbee_flow_sensor_cfg_t *flow_sensor)
+{
+    esp_zb_basic_cluster_cfg_t *basic_cfg = flow_sensor ? &(flow_sensor->basic_cfg) : NULL;
+    esp_zb_identify_cluster_cfg_t *identify_cfg = flow_sensor ? &(flow_sensor->identify_cfg) : NULL;
+    esp_zb_flow_meas_cluster_cfg_t *flow_meas_cfg = flow_sensor ? &(flow_sensor->flow_meas_cfg) : NULL;
+    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_flow_meas_cluster(cluster_list, esp_zb_flow_meas_cluster_create(flow_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    return cluster_list;
+}
+
+ZigbeeFlowSensor::ZigbeeFlowSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
+  _device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID;
+
+  //Create custom pressure sensor configuration
+  zigbee_flow_sensor_cfg_t flow_sensor_cfg = ZIGBEE_DEFAULT_FLOW_SENSOR_CONFIG();
+  _cluster_list = zigbee_flow_sensor_clusters_create(&flow_sensor_cfg);
+
+  _ep_config = {
+    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
+  };
+}
+
+void ZigbeeFlowSensor::setMinMaxValue(float min, float max) {
+  uint16_t zb_min = (uint16_t)(min * 10);
+  uint16_t zb_max = (uint16_t)(max * 10);
+  esp_zb_attribute_list_t *flow_measure_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_update_attr(flow_measure_cluster, ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_MIN_VALUE_ID, (void *)&zb_min);
+  esp_zb_cluster_update_attr(flow_measure_cluster, ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_MAX_VALUE_ID, (void *)&zb_max);
+}
+
+void ZigbeeFlowSensor::setTolerance(float tolerance) {
+  // Convert tolerance to ZCL uint16_t
+  uint16_t zb_tolerance = (uint16_t)(tolerance * 10);
+  esp_zb_attribute_list_t *flow_measure_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_flow_meas_cluster_add_attr(flow_measure_cluster, ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_TOLERANCE_ID, (void *)&zb_tolerance);
+}
+
+void ZigbeeFlowSensor::setReporting(uint16_t min_interval, uint16_t max_interval, float delta) {
+  esp_zb_zcl_reporting_info_t reporting_info = {
+    .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
+    .ep = _endpoint,
+    .cluster_id = ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT,
+    .cluster_role = ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
+    .attr_id = ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_VALUE_ID,
+    .u =
+      {
+        .send_info =
+          {
+            .min_interval = min_interval,
+            .max_interval = max_interval,
+            .delta =
+              {
+                .u16 = (uint16_t)(delta * 10),  // Convert delta to ZCL uint16_t
+              },
+            .def_min_interval = min_interval,
+            .def_max_interval = max_interval,
+          },
+      },
+    .dst =
+      {
+        .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
+      },
+    .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
+  };
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_update_reporting_info(&reporting_info);
+  esp_zb_lock_release();
+}
+
+void ZigbeeFlowSensor::setFlow(float flow) {
+  uint16_t zb_flow = (uint16_t)(flow * 10);
+  log_v("Updating flow sensor value...");
+  /* Update temperature sensor measured value */
+  log_d("Setting flow to %d", zb_flow);
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_VALUE_ID, &zb_flow, false
+  );
+  esp_zb_lock_release();
+}
+
+void ZigbeeFlowSensor::report() {
+  /* Send report attributes command */
+  esp_zb_zcl_report_attr_cmd_t report_attr_cmd;
+  report_attr_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+  report_attr_cmd.attributeID = ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_VALUE_ID;
+  report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
+  report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT;
+  report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
+
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
+  esp_zb_lock_release();
+  log_v("Flow report sent");
+}
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
@@ -1,17 +1,16 @@
 #include "ZigbeeFlowSensor.h"
 #if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
-esp_zb_cluster_list_t  *zigbee_flow_sensor_clusters_create(zigbee_flow_sensor_cfg_t *flow_sensor)
-{
-    esp_zb_basic_cluster_cfg_t *basic_cfg = flow_sensor ? &(flow_sensor->basic_cfg) : NULL;
-    esp_zb_identify_cluster_cfg_t *identify_cfg = flow_sensor ? &(flow_sensor->identify_cfg) : NULL;
-    esp_zb_flow_meas_cluster_cfg_t *flow_meas_cfg = flow_sensor ? &(flow_sensor->flow_meas_cfg) : NULL;
-    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
-    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_flow_meas_cluster(cluster_list, esp_zb_flow_meas_cluster_create(flow_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    return cluster_list;
+esp_zb_cluster_list_t *zigbee_flow_sensor_clusters_create(zigbee_flow_sensor_cfg_t *flow_sensor) {
+  esp_zb_basic_cluster_cfg_t *basic_cfg = flow_sensor ? &(flow_sensor->basic_cfg) : NULL;
+  esp_zb_identify_cluster_cfg_t *identify_cfg = flow_sensor ? &(flow_sensor->identify_cfg) : NULL;
+  esp_zb_flow_meas_cluster_cfg_t *flow_meas_cfg = flow_sensor ? &(flow_sensor->flow_meas_cfg) : NULL;
+  esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+  esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_flow_meas_cluster(cluster_list, esp_zb_flow_meas_cluster_create(flow_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  return cluster_list;
 }
 
 ZigbeeFlowSensor::ZigbeeFlowSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
@@ -21,9 +20,7 @@ ZigbeeFlowSensor::ZigbeeFlowSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
   zigbee_flow_sensor_cfg_t flow_sensor_cfg = ZIGBEE_DEFAULT_FLOW_SENSOR_CONFIG();
   _cluster_list = zigbee_flow_sensor_clusters_create(&flow_sensor_cfg);
 
-  _ep_config = {
-    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
-  };
+  _ep_config = {.endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0};
 }
 
 void ZigbeeFlowSensor::setMinMaxValue(float min, float max) {

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
@@ -44,6 +44,7 @@ void ZigbeeFlowSensor::setTolerance(float tolerance) {
 }
 
 void ZigbeeFlowSensor::setReporting(uint16_t min_interval, uint16_t max_interval, float delta) {
+  // clang-format off
   esp_zb_zcl_reporting_info_t reporting_info = {
     .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
     .ep = _endpoint,
@@ -70,6 +71,7 @@ void ZigbeeFlowSensor::setReporting(uint16_t min_interval, uint16_t max_interval
       },
     .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
   };
+  // clang-format on
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_update_reporting_info(&reporting_info);
   esp_zb_lock_release();

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
@@ -10,24 +10,24 @@
 #include "ha/esp_zigbee_ha_standard.h"
 
 // clang-format off
-#define ZIGBEE_DEFAULT_FLOW_SENSOR_CONFIG()                                                         \
-    {                                                                                               \
-        .basic_cfg =                                                                                \
-            {                                                                                       \
-                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                          \
-                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                        \
-            },                                                                                      \
-        .identify_cfg =                                                                             \
-            {                                                                                       \
-                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                   \
-            },                                                                                      \
-        .flow_meas_cfg =                                                                            \
-            {                                                                                       \
-                .measured_value = 0,                                                                \
-                .min_value = 0,                                                                     \
-                .max_value = 0x7FFF,                                                                \
-            },                                                                                      \
-    }
+#define ZIGBEE_DEFAULT_FLOW_SENSOR_CONFIG()                               \
+  {                                                                       \
+    .basic_cfg =                                                          \
+      {                                                                   \
+        .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,        \
+        .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,      \
+      },                                                                  \
+    .identify_cfg =                                                       \
+      {                                                                   \
+        .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE, \
+      },                                                                  \
+    .flow_meas_cfg =                                                      \
+      {                                                                   \
+        .measured_value = 0,                                              \
+        .min_value = 0,                                                   \
+        .max_value = 0x7FFF,                                              \
+      },                                                                  \
+  }
 // clang-format on
 
 typedef struct zigbee_flow_sensor_cfg_s {

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
@@ -1,0 +1,58 @@
+/* Class of Zigbee Flow sensor endpoint inherited from common EP class */
+
+#pragma once
+
+#include "soc/soc_caps.h"
+#include "sdkconfig.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+#include "ZigbeeEP.h"
+#include "ha/esp_zigbee_ha_standard.h"
+
+#define ZIGBEE_DEFAULT_FLOW_SENSOR_CONFIG()                                                         \
+    {                                                                                               \
+        .basic_cfg =                                                                                \
+            {                                                                                       \
+                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                          \
+                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                        \
+            },                                                                                      \
+        .identify_cfg =                                                                             \
+            {                                                                                       \
+                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                   \
+            },                                                                                      \
+        .flow_meas_cfg =                                                                            \
+            {                                                                                       \
+                .measured_value = 0,                                                                \
+                .min_value = 0,                                                                     \
+                .max_value = 0x7FFF,                                                                \
+            },                                                                                      \
+    }
+
+typedef struct zigbee_flow_sensor_cfg_s {
+    esp_zb_basic_cluster_cfg_t basic_cfg;     
+    esp_zb_identify_cluster_cfg_t identify_cfg;
+    esp_zb_flow_meas_cluster_cfg_t flow_meas_cfg;
+} zigbee_flow_sensor_cfg_t;
+
+class ZigbeeFlowSensor : public ZigbeeEP {
+public:
+  ZigbeeFlowSensor(uint8_t endpoint);
+  ~ZigbeeFlowSensor();
+
+  // Set the flow value in 0,01 m3/h
+  void setFlow(float value);
+
+  // Set the min and max value for the flow sensor in 0,1 m3/h
+  void setMinMaxValue(float min, float max);
+
+  // Set the tolerance value for the flow sensor in 0,01 m3/h
+  void setTolerance(float tolerance);
+
+  // Set the reporting interval for flow measurement in seconds and delta (temp change in 0,01 m3/h)
+  void setReporting(uint16_t min_interval, uint16_t max_interval, float delta);
+
+  // Report the flow value
+  void report();
+};
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
@@ -39,7 +39,7 @@ public:
   ZigbeeFlowSensor(uint8_t endpoint);
   ~ZigbeeFlowSensor();
 
-  // Set the flow value in 0,01 m3/h
+  // Set the flow value in 0,1 m3/h
   void setFlow(float value);
 
   // Set the min and max value for the flow sensor in 0,1 m3/h
@@ -48,7 +48,7 @@ public:
   // Set the tolerance value for the flow sensor in 0,01 m3/h
   void setTolerance(float tolerance);
 
-  // Set the reporting interval for flow measurement in seconds and delta (temp change in 0,01 m3/h)
+  // Set the reporting interval for flow measurement in seconds and delta (temp change in 0,1 m3/h)
   void setReporting(uint16_t min_interval, uint16_t max_interval, float delta);
 
   // Report the flow value

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
@@ -9,6 +9,7 @@
 #include "ZigbeeEP.h"
 #include "ha/esp_zigbee_ha_standard.h"
 
+// clang-format off
 #define ZIGBEE_DEFAULT_FLOW_SENSOR_CONFIG()                                                         \
     {                                                                                               \
         .basic_cfg =                                                                                \
@@ -27,6 +28,7 @@
                 .max_value = 0x7FFF,                                                                \
             },                                                                                      \
     }
+// clang-format on
 
 typedef struct zigbee_flow_sensor_cfg_s {
     esp_zb_basic_cluster_cfg_t basic_cfg;     

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
@@ -31,9 +31,9 @@
 // clang-format on
 
 typedef struct zigbee_flow_sensor_cfg_s {
-    esp_zb_basic_cluster_cfg_t basic_cfg;     
-    esp_zb_identify_cluster_cfg_t identify_cfg;
-    esp_zb_flow_meas_cluster_cfg_t flow_meas_cfg;
+  esp_zb_basic_cluster_cfg_t basic_cfg;
+  esp_zb_identify_cluster_cfg_t identify_cfg;
+  esp_zb_flow_meas_cluster_cfg_t flow_meas_cfg;
 } zigbee_flow_sensor_cfg_t;
 
 class ZigbeeFlowSensor : public ZigbeeEP {

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
@@ -1,0 +1,63 @@
+#include "ZigbeeOccupancySensor.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+esp_zb_cluster_list_t  *zigbee_occupancy_sensor_clusters_create(zigbee_occupancy_sensor_cfg_t *occupancy_sensor)
+{
+    esp_zb_basic_cluster_cfg_t *basic_cfg = occupancy_sensor ? &(occupancy_sensor->basic_cfg) : NULL;
+    esp_zb_identify_cluster_cfg_t *identify_cfg = occupancy_sensor ? &(occupancy_sensor->identify_cfg) : NULL;
+    esp_zb_occupancy_sensing_cluster_cfg_t *occupancy_meas_cfg = occupancy_sensor ? &(occupancy_sensor->occupancy_meas_cfg) : NULL;
+    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_occupancy_sensing_cluster(cluster_list, esp_zb_occupancy_sensing_cluster_create(occupancy_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    return cluster_list;
+}
+
+ZigbeeOccupancySensor::ZigbeeOccupancySensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
+  _device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID;
+
+  //Create custom occupancy sensor configuration
+  zigbee_occupancy_sensor_cfg_t occupancy_sensor_cfg = ZIGBEE_DEFAULT_OCCUPANCY_SENSOR_CONFIG();
+  _cluster_list = zigbee_occupancy_sensor_clusters_create(&occupancy_sensor_cfg);
+
+  _ep_config = {
+    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
+  };
+}
+
+void ZigbeeOccupancySensor::setSensorType(uint8_t sensor_type) {
+  uint8_t sensor_type_bitmap = 1 << sensor_type;
+  esp_zb_attribute_list_t *occupancy_sens_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_update_attr(occupancy_sens_cluster, ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_ID, (void *)&sensor_type);
+  esp_zb_cluster_update_attr(occupancy_sens_cluster, ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_BITMAP_ID, (void *)&sensor_type_bitmap);
+}
+
+void ZigbeeOccupancySensor::setOccupancy(bool occupied) {
+  log_v("Updating occupancy sensor value...");
+  /* Update occupancy sensor value */
+  log_d("Setting occupancy to %d", occupied);
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID, &occupied, false
+  );
+  esp_zb_lock_release();
+}
+
+void ZigbeeOccupancySensor::report() {
+  /* Send report attributes command */
+  esp_zb_zcl_report_attr_cmd_t report_attr_cmd;
+  report_attr_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+  report_attr_cmd.attributeID = ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID;
+  report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
+  report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING;
+  report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
+
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
+  esp_zb_lock_release();
+  log_v("Occupancy report sent");
+}
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
@@ -1,17 +1,16 @@
 #include "ZigbeeOccupancySensor.h"
 #if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
-esp_zb_cluster_list_t  *zigbee_occupancy_sensor_clusters_create(zigbee_occupancy_sensor_cfg_t *occupancy_sensor)
-{
-    esp_zb_basic_cluster_cfg_t *basic_cfg = occupancy_sensor ? &(occupancy_sensor->basic_cfg) : NULL;
-    esp_zb_identify_cluster_cfg_t *identify_cfg = occupancy_sensor ? &(occupancy_sensor->identify_cfg) : NULL;
-    esp_zb_occupancy_sensing_cluster_cfg_t *occupancy_meas_cfg = occupancy_sensor ? &(occupancy_sensor->occupancy_meas_cfg) : NULL;
-    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
-    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_occupancy_sensing_cluster(cluster_list, esp_zb_occupancy_sensing_cluster_create(occupancy_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    return cluster_list;
+esp_zb_cluster_list_t *zigbee_occupancy_sensor_clusters_create(zigbee_occupancy_sensor_cfg_t *occupancy_sensor) {
+  esp_zb_basic_cluster_cfg_t *basic_cfg = occupancy_sensor ? &(occupancy_sensor->basic_cfg) : NULL;
+  esp_zb_identify_cluster_cfg_t *identify_cfg = occupancy_sensor ? &(occupancy_sensor->identify_cfg) : NULL;
+  esp_zb_occupancy_sensing_cluster_cfg_t *occupancy_meas_cfg = occupancy_sensor ? &(occupancy_sensor->occupancy_meas_cfg) : NULL;
+  esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+  esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_occupancy_sensing_cluster(cluster_list, esp_zb_occupancy_sensing_cluster_create(occupancy_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  return cluster_list;
 }
 
 ZigbeeOccupancySensor::ZigbeeOccupancySensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
@@ -21,9 +20,7 @@ ZigbeeOccupancySensor::ZigbeeOccupancySensor(uint8_t endpoint) : ZigbeeEP(endpoi
   zigbee_occupancy_sensor_cfg_t occupancy_sensor_cfg = ZIGBEE_DEFAULT_OCCUPANCY_SENSOR_CONFIG();
   _cluster_list = zigbee_occupancy_sensor_clusters_create(&occupancy_sensor_cfg);
 
-  _ep_config = {
-    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
-  };
+  _ep_config = {.endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0};
 }
 
 void ZigbeeOccupancySensor::setSensorType(uint8_t sensor_type) {

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
@@ -10,24 +10,24 @@
 #include "ha/esp_zigbee_ha_standard.h"
 
 // clang-format off
-#define ZIGBEE_DEFAULT_OCCUPANCY_SENSOR_CONFIG()                                                     \
-    {                                                                                                \
-        .basic_cfg =                                                                                 \
-            {                                                                                        \
-                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                           \
-                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                         \
-            },                                                                                       \
-        .identify_cfg =                                                                              \
-            {                                                                                        \
-                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                    \
-            },                                                                                       \
-        .occupancy_meas_cfg =                                                                        \
-            {                                                                                        \
-                .occupancy = ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_UNOCCUPIED,                      \
-                .sensor_type = ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_PIR,               \
-                .sensor_type_bitmap = (1 << ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_PIR), \
-            },                                                                                       \
-    }
+#define ZIGBEE_DEFAULT_OCCUPANCY_SENSOR_CONFIG()                                             \
+  {                                                                                          \
+    .basic_cfg =                                                                             \
+      {                                                                                      \
+        .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                           \
+        .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                         \
+      },                                                                                     \
+    .identify_cfg =                                                                          \
+      {                                                                                      \
+        .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                    \
+      },                                                                                     \
+    .occupancy_meas_cfg =                                                                    \
+      {                                                                                      \
+        .occupancy = ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_UNOCCUPIED,                      \
+        .sensor_type = ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_PIR,               \
+        .sensor_type_bitmap = (1 << ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_PIR), \
+      },                                                                                     \
+  }
 // clang-format on
 
 typedef struct zigbee_occupancy_sensor_cfg_s {

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
@@ -9,6 +9,7 @@
 #include "ZigbeeEP.h"
 #include "ha/esp_zigbee_ha_standard.h"
 
+// clang-format off
 #define ZIGBEE_DEFAULT_OCCUPANCY_SENSOR_CONFIG()                                                     \
     {                                                                                                \
         .basic_cfg =                                                                                 \
@@ -27,6 +28,7 @@
                 .sensor_type_bitmap = (1 << ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_PIR), \
             },                                                                                       \
     }
+// clang-format on
 
 typedef struct zigbee_occupancy_sensor_cfg_s {
     esp_zb_basic_cluster_cfg_t basic_cfg;     

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
@@ -31,9 +31,9 @@
 // clang-format on
 
 typedef struct zigbee_occupancy_sensor_cfg_s {
-    esp_zb_basic_cluster_cfg_t basic_cfg;     
-    esp_zb_identify_cluster_cfg_t identify_cfg;
-    esp_zb_occupancy_sensing_cluster_cfg_t occupancy_meas_cfg;
+  esp_zb_basic_cluster_cfg_t basic_cfg;
+  esp_zb_identify_cluster_cfg_t identify_cfg;
+  esp_zb_occupancy_sensing_cluster_cfg_t occupancy_meas_cfg;
 } zigbee_occupancy_sensor_cfg_t;
 
 class ZigbeeOccupancySensor : public ZigbeeEP {

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
@@ -1,0 +1,52 @@
+/* Class of Zigbee Pressure sensor endpoint inherited from common EP class */
+
+#pragma once
+
+#include "soc/soc_caps.h"
+#include "sdkconfig.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+#include "ZigbeeEP.h"
+#include "ha/esp_zigbee_ha_standard.h"
+
+#define ZIGBEE_DEFAULT_OCCUPANCY_SENSOR_CONFIG()                                                     \
+    {                                                                                                \
+        .basic_cfg =                                                                                 \
+            {                                                                                        \
+                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                           \
+                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                         \
+            },                                                                                       \
+        .identify_cfg =                                                                              \
+            {                                                                                        \
+                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                    \
+            },                                                                                       \
+        .occupancy_meas_cfg =                                                                        \
+            {                                                                                        \
+                .occupancy = ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_UNOCCUPIED,                      \
+                .sensor_type = ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_PIR,               \
+                .sensor_type_bitmap = (1 << ESP_ZB_ZCL_OCCUPANCY_SENSING_OCCUPANCY_SENSOR_TYPE_PIR), \
+            },                                                                                       \
+    }
+
+typedef struct zigbee_occupancy_sensor_cfg_s {
+    esp_zb_basic_cluster_cfg_t basic_cfg;     
+    esp_zb_identify_cluster_cfg_t identify_cfg;
+    esp_zb_occupancy_sensing_cluster_cfg_t occupancy_meas_cfg;
+} zigbee_occupancy_sensor_cfg_t;
+
+class ZigbeeOccupancySensor : public ZigbeeEP {
+public:
+  ZigbeeOccupancySensor(uint8_t endpoint);
+  ~ZigbeeOccupancySensor();
+
+  // Set the occupancy value. True for occupied, false for unoccupied
+  void setOccupancy(bool occupied);
+
+  // Set the sensor type, see esp_zb_zcl_occupancy_sensing_occupancy_sensor_type_t
+  void setSensorType(uint8_t sensor_type);
+
+  // Report the occupancy value
+  void report();
+};
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -1,0 +1,101 @@
+#include "ZigbeePressureSensor.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+esp_zb_cluster_list_t  *zigbee_pressure_sensor_clusters_create(zigbee_pressure_sensor_cfg_t *pressure_sensor)
+{
+    esp_zb_basic_cluster_cfg_t *basic_cfg = pressure_sensor ? &(pressure_sensor->basic_cfg) : NULL;
+    esp_zb_identify_cluster_cfg_t *identify_cfg = pressure_sensor ? &(pressure_sensor->identify_cfg) : NULL;
+    esp_zb_pressure_meas_cluster_cfg_t *pressure_meas_cfg = pressure_sensor ? &(pressure_sensor->pressure_meas_cfg) : NULL;
+    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_pressure_meas_cluster(cluster_list, esp_zb_pressure_meas_cluster_create(pressure_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    return cluster_list;
+}
+
+ZigbeePressureSensor::ZigbeePressureSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
+  _device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID;
+
+  //Create custom pressure sensor configuration
+  zigbee_pressure_sensor_cfg_t presssure_sensor_cfg = ZIGBEE_DEFAULT_PRESSURE_SENSOR_CONFIG();
+  _cluster_list = zigbee_pressure_sensor_clusters_create(&presssure_sensor_cfg);
+
+  _ep_config = {
+    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
+  };
+}
+
+void ZigbeePressureSensor::setMinMaxValue(int16_t min, int16_t max) {
+
+  esp_zb_attribute_list_t *pressure_measure_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_update_attr(pressure_measure_cluster, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_MIN_VALUE_ID, (void *)&min);
+  esp_zb_cluster_update_attr(pressure_measure_cluster, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_MAX_VALUE_ID, (void *)&max);
+}
+
+void ZigbeePressureSensor::setTolerance(uint16_t tolerance) {
+  esp_zb_attribute_list_t *pressure_measure_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_temperature_meas_cluster_add_attr(pressure_measure_cluster, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_TOLERANCE_ID, (void *)&tolerance);
+}
+
+void ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta) {
+  esp_zb_zcl_reporting_info_t reporting_info = {
+    .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
+    .ep = _endpoint,
+    .cluster_id = ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT,
+    .cluster_role = ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
+    .attr_id = ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID,
+    .u =
+      {
+        .send_info =
+          {
+            .min_interval = min_interval,
+            .max_interval = max_interval,
+            .delta =
+              {
+                .u16 = delta, // x Pa
+              },
+            .def_min_interval = min_interval,
+            .def_max_interval = max_interval,
+          },
+      },
+    .dst =
+      {
+        .profile_id = ESP_ZB_AF_HA_PROFILE_ID,
+      },
+    .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
+  };
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_update_reporting_info(&reporting_info);
+  esp_zb_lock_release();
+}
+
+void ZigbeePressureSensor::setPressure(int16_t pressure) {
+  log_v("Updating pressure sensor value...");
+  /* Update temperature sensor measured value */
+  log_d("Setting pressure to %d Pa", pressure);
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &pressure, false
+  );
+  esp_zb_lock_release();
+}
+
+void ZigbeePressureSensor::report() {
+  /* Send report attributes command */
+  esp_zb_zcl_report_attr_cmd_t report_attr_cmd;
+  report_attr_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+  report_attr_cmd.attributeID = ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID;
+  report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
+  report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT;
+  report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
+
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
+  esp_zb_lock_release();
+  log_v("Pressure report sent");
+}
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -41,6 +41,7 @@ void ZigbeePressureSensor::setTolerance(uint16_t tolerance) {
 }
 
 void ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta) {
+  // clang-format off
   esp_zb_zcl_reporting_info_t reporting_info = {
     .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV,
     .ep = _endpoint,
@@ -67,6 +68,7 @@ void ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_inte
       },
     .manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
   };
+  // clang-format on
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_update_reporting_info(&reporting_info);
   esp_zb_lock_release();

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -1,17 +1,16 @@
 #include "ZigbeePressureSensor.h"
 #if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
-esp_zb_cluster_list_t  *zigbee_pressure_sensor_clusters_create(zigbee_pressure_sensor_cfg_t *pressure_sensor)
-{
-    esp_zb_basic_cluster_cfg_t *basic_cfg = pressure_sensor ? &(pressure_sensor->basic_cfg) : NULL;
-    esp_zb_identify_cluster_cfg_t *identify_cfg = pressure_sensor ? &(pressure_sensor->identify_cfg) : NULL;
-    esp_zb_pressure_meas_cluster_cfg_t *pressure_meas_cfg = pressure_sensor ? &(pressure_sensor->pressure_meas_cfg) : NULL;
-    esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
-    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_pressure_meas_cluster(cluster_list, esp_zb_pressure_meas_cluster_create(pressure_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-    return cluster_list;
+esp_zb_cluster_list_t *zigbee_pressure_sensor_clusters_create(zigbee_pressure_sensor_cfg_t *pressure_sensor) {
+  esp_zb_basic_cluster_cfg_t *basic_cfg = pressure_sensor ? &(pressure_sensor->basic_cfg) : NULL;
+  esp_zb_identify_cluster_cfg_t *identify_cfg = pressure_sensor ? &(pressure_sensor->identify_cfg) : NULL;
+  esp_zb_pressure_meas_cluster_cfg_t *pressure_meas_cfg = pressure_sensor ? &(pressure_sensor->pressure_meas_cfg) : NULL;
+  esp_zb_cluster_list_t *cluster_list = esp_zb_zcl_cluster_list_create();
+  esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(basic_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_identify_cluster_create(identify_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_pressure_meas_cluster(cluster_list, esp_zb_pressure_meas_cluster_create(pressure_meas_cfg), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(cluster_list, esp_zb_zcl_attr_list_create(ESP_ZB_ZCL_CLUSTER_ID_IDENTIFY), ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  return cluster_list;
 }
 
 ZigbeePressureSensor::ZigbeePressureSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
@@ -21,9 +20,7 @@ ZigbeePressureSensor::ZigbeePressureSensor(uint8_t endpoint) : ZigbeeEP(endpoint
   zigbee_pressure_sensor_cfg_t presssure_sensor_cfg = ZIGBEE_DEFAULT_PRESSURE_SENSOR_CONFIG();
   _cluster_list = zigbee_pressure_sensor_clusters_create(&presssure_sensor_cfg);
 
-  _ep_config = {
-    .endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0
-  };
+  _ep_config = {.endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_SIMPLE_SENSOR_DEVICE_ID, .app_device_version = 0};
 }
 
 void ZigbeePressureSensor::setMinMaxValue(int16_t min, int16_t max) {

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -55,7 +55,7 @@ void ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_inte
             .max_interval = max_interval,
             .delta =
               {
-                .u16 = delta, // x Pa
+                .u16 = delta, // x hPa
               },
             .def_min_interval = min_interval,
             .def_max_interval = max_interval,
@@ -75,7 +75,7 @@ void ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_inte
 void ZigbeePressureSensor::setPressure(int16_t pressure) {
   log_v("Updating pressure sensor value...");
   /* Update temperature sensor measured value */
-  log_d("Setting pressure to %d Pa", pressure);
+  log_d("Setting pressure to %d hPa", pressure);
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_set_attribute_val(
     _endpoint, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &pressure, false

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
@@ -39,16 +39,16 @@ public:
   ZigbeePressureSensor(uint8_t endpoint);
   ~ZigbeePressureSensor();
 
-  // Set the pressure value in 1 Pa
+  // Set the pressure value in 1 hPa
   void setPressure(int16_t value);
 
-  // Set the min and max value for the pressure sensor in 1 Pa
+  // Set the min and max value for the pressure sensor in 1 hPa
   void setMinMaxValue(int16_t min, int16_t max);
 
-  // Set the tolerance value for the pressure sensor in 1 Pa
+  // Set the tolerance value for the pressure sensor in 1 hPa
   void setTolerance(uint16_t tolerance);
 
-  // Set the reporting interval for pressure measurement in seconds and delta (pressure change in 1 Pa)
+  // Set the reporting interval for pressure measurement in seconds and delta (pressure change in 1 hPa)
   void setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta);
 
   // Report the pressure value

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
@@ -1,0 +1,58 @@
+/* Class of Zigbee Pressure sensor endpoint inherited from common EP class */
+
+#pragma once
+
+#include "soc/soc_caps.h"
+#include "sdkconfig.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
+
+#include "ZigbeeEP.h"
+#include "ha/esp_zigbee_ha_standard.h"
+
+#define ZIGBEE_DEFAULT_PRESSURE_SENSOR_CONFIG()                                                     \
+    {                                                                                               \
+        .basic_cfg =                                                                                \
+            {                                                                                       \
+                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                          \
+                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                        \
+            },                                                                                      \
+        .identify_cfg =                                                                             \
+            {                                                                                       \
+                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                   \
+            },                                                                                      \
+        .pressure_meas_cfg =                                                                        \
+            {                                                                                       \
+                .measured_value = ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_DEFAULT_VALUE,         \
+                .min_value = ESP_ZB_ZCL_PATTR_RESSURE_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE,          \
+                .max_value = ESP_ZB_ZCL_PATTR_RESSURE_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE,          \
+            },                                                                                      \
+    }
+
+typedef struct zigbee_pressure_sensor_cfg_s {
+    esp_zb_basic_cluster_cfg_t basic_cfg;     
+    esp_zb_identify_cluster_cfg_t identify_cfg;
+    esp_zb_pressure_meas_cluster_cfg_t pressure_meas_cfg;
+} zigbee_pressure_sensor_cfg_t;
+
+class ZigbeePressureSensor : public ZigbeeEP {
+public:
+  ZigbeePressureSensor(uint8_t endpoint);
+  ~ZigbeePressureSensor();
+
+  // Set the pressure value in 1 Pa
+  void setPressure(int16_t value);
+
+  // Set the min and max value for the pressure sensor in 1 Pa
+  void setMinMaxValue(int16_t min, int16_t max);
+
+  // Set the tolerance value for the pressure sensor in 1 Pa
+  void setTolerance(uint16_t tolerance);
+
+  // Set the reporting interval for pressure measurement in seconds and delta (pressure change in 1 Pa)
+  void setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta);
+
+  // Report the pressure value
+  void report();
+};
+
+#endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
@@ -9,6 +9,7 @@
 #include "ZigbeeEP.h"
 #include "ha/esp_zigbee_ha_standard.h"
 
+// clang-format off
 #define ZIGBEE_DEFAULT_PRESSURE_SENSOR_CONFIG()                                                     \
     {                                                                                               \
         .basic_cfg =                                                                                \
@@ -27,6 +28,7 @@
                 .max_value = ESP_ZB_ZCL_PATTR_RESSURE_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE,          \
             },                                                                                      \
     }
+// clang-format on
 
 typedef struct zigbee_pressure_sensor_cfg_s {
     esp_zb_basic_cluster_cfg_t basic_cfg;     

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
@@ -31,9 +31,9 @@
 // clang-format on
 
 typedef struct zigbee_pressure_sensor_cfg_s {
-    esp_zb_basic_cluster_cfg_t basic_cfg;     
-    esp_zb_identify_cluster_cfg_t identify_cfg;
-    esp_zb_pressure_meas_cluster_cfg_t pressure_meas_cfg;
+  esp_zb_basic_cluster_cfg_t basic_cfg;
+  esp_zb_identify_cluster_cfg_t identify_cfg;
+  esp_zb_pressure_meas_cluster_cfg_t pressure_meas_cfg;
 } zigbee_pressure_sensor_cfg_t;
 
 class ZigbeePressureSensor : public ZigbeeEP {

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -3,6 +3,7 @@
 
 ZigbeeTempSensor::ZigbeeTempSensor(uint8_t endpoint) : ZigbeeEP(endpoint) {
   _device_id = ESP_ZB_HA_TEMPERATURE_SENSOR_DEVICE_ID;
+  _humidity_sensor = false;
 
   esp_zb_temperature_sensor_cfg_t temp_sensor_cfg = ESP_ZB_DEFAULT_TEMPERATURE_SENSOR_CONFIG();
   _cluster_list = esp_zb_temperature_sensor_clusters_create(&temp_sensor_cfg);
@@ -103,6 +104,7 @@ void ZigbeeTempSensor::addHumiditySensor(float min, float max, float tolerance) 
   esp_zb_humidity_meas_cluster_add_attr(humidity_cluster, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_MAX_VALUE_ID, &zb_max);
   esp_zb_humidity_meas_cluster_add_attr(humidity_cluster, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_TOLERANCE_ID, &zb_tolerance);
   esp_zb_cluster_list_add_humidity_meas_cluster(_cluster_list, humidity_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  _humidity_sensor = true;
 }
 
 void ZigbeeTempSensor::setHumidity(float humidity) {
@@ -163,6 +165,13 @@ void ZigbeeTempSensor::setHumidityReporting(uint16_t min_interval, uint16_t max_
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_update_reporting_info(&reporting_info);
   esp_zb_lock_release();
+}
+
+void ZigbeeTempSensor::report() {
+  reportTemperature();
+  if (_humidity_sensor) {
+    reportHumidity();
+  }
 }
 
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.h
@@ -46,8 +46,6 @@ public:
 
 private:
   bool _humidity_sensor;
-  
 };
-
 
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.h
@@ -40,6 +40,14 @@ public:
 
   // Report the humidity value
   void reportHumidity();
+
+  // Report the temperature and humidity values if humidity sensor is added
+  void report();
+
+private:
+  bool _humidity_sensor;
+  
 };
+
 
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED


### PR DESCRIPTION
## Description of Change
This PR adds 4 new endpoint types:

- Pressure sensor
- Flow sensor
- Occupancy sensor
- Carbon dioxide (CO2)

There are 3 new examples: `Pressure+Flow sensor`, `Occupancy sensor`, `Carbon dioxide sensor`

+ Some minor enhancements.

## Tests scenarios
Tested using C6 + HomeAssistant

## Related links
Closes #10684 