### PR TITLE
Cap size of last chunk in raw read in WebServer

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -186,8 +186,12 @@ bool WebServer::_parseRequest(NetworkClient &client) {
       _currentHandler->raw(*this, _currentUri, *_currentRaw);
       _currentRaw->status = RAW_WRITE;
 
-      while (_currentRaw->totalSize < _clientContentLength) {
-        _currentRaw->currentSize = client.readBytes(_currentRaw->buf, HTTP_RAW_BUFLEN);
+      while (1) {
+        size_t read_len = std::min(_clientContentLength - _currentRaw->totalSize, (size_t) HTTP_RAW_BUFLEN);
+        if (read_len == 0) {
+          break;
+        }
+        _currentRaw->currentSize = client.readBytes(_currentRaw->buf, read_len);
         _currentRaw->totalSize += _currentRaw->currentSize;
         if (_currentRaw->currentSize == 0) {
           _currentRaw->status = RAW_ABORTED;

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -187,7 +187,7 @@ bool WebServer::_parseRequest(NetworkClient &client) {
       _currentRaw->status = RAW_WRITE;
 
       while (_currentRaw->totalSize < _clientContentLength) {
-        size_t read_len = std::min(_clientContentLength - _currentRaw->totalSize, (size_t) HTTP_RAW_BUFLEN);
+        size_t read_len = std::min(_clientContentLength - _currentRaw->totalSize, (size_t)HTTP_RAW_BUFLEN);
         _currentRaw->currentSize = client.readBytes(_currentRaw->buf, read_len);
         _currentRaw->totalSize += _currentRaw->currentSize;
         if (_currentRaw->currentSize == 0) {

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -186,11 +186,8 @@ bool WebServer::_parseRequest(NetworkClient &client) {
       _currentHandler->raw(*this, _currentUri, *_currentRaw);
       _currentRaw->status = RAW_WRITE;
 
-      while (1) {
+      while (_currentRaw->totalSize < _clientContentLength) {
         size_t read_len = std::min(_clientContentLength - _currentRaw->totalSize, (size_t) HTTP_RAW_BUFLEN);
-        if (read_len == 0) {
-          break;
-        }
         _currentRaw->currentSize = client.readBytes(_currentRaw->buf, read_len);
         _currentRaw->totalSize += _currentRaw->currentSize;
         if (_currentRaw->currentSize == 0) {


### PR DESCRIPTION
## Description of Change

Cap size of last chunk in raw read in WebServer

Currently, the raw read would time out if the content length is not a multiple of HTTP_RAW_BUFLEN, as it tries to read HTTP_RAW_BUFLEN bytes even if the last chunk should actually contain less.

That introduces a five second delay before the final raw call to the handler is performed.

By capping the size to the amount of remaining bytes, this delay is removed.

## Tests scenarios

Tested on an ESP32C3 using a modified [UploadHugeFile example](https://github.com/espressif/arduino-esp32/tree/fb6e977aa8437e0a487a629c3ecad97f794f5508/libraries/WebServer/examples/UploadHugeFile), and curl uploading any file with a size not multiple of 1436.

## Related links
None