### PR TITLE
fix(sntp): Lock / Unlock LWIP if CONFIG_LWIP_TCPIP_CORE_LOCKING is set

### DIFF
--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -51,15 +51,16 @@ static void setTimeZone(long offset, int daylight) {
 void configTime(long gmtOffset_sec, int daylightOffset_sec, const char *server1, const char *server2, const char *server3) {
   //tcpip_adapter_init();  // Should not hurt anything if already inited
   esp_netif_init();
-  if (sntp_enabled()) {
-    sntp_stop();
-  }
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
   if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
     LOCK_TCPIP_CORE();
   }
 #endif
+
+  if (sntp_enabled()) {
+    sntp_stop();
+  }
 
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
   sntp_setservername(0, (char *)server1);
@@ -83,15 +84,16 @@ void configTime(long gmtOffset_sec, int daylightOffset_sec, const char *server1,
 void configTzTime(const char *tz, const char *server1, const char *server2, const char *server3) {
   //tcpip_adapter_init();  // Should not hurt anything if already inited
   esp_netif_init();
-  if (sntp_enabled()) {
-    sntp_stop();
-  }
 
 #ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
   if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
     LOCK_TCPIP_CORE();
   }
 #endif
+
+  if (sntp_enabled()) {
+    sntp_stop();
+  }
 
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
   sntp_setservername(0, (char *)server1);


### PR DESCRIPTION
- Complete fix for: #10526
- Complete fix for PR #10529

The previous PR didn't lock around 

```c++
if (sntp_enabled()) {
    sntp_stop();
  }
```

... which causes the ESP to crash if SNTP is used, then the ESP is disconnected rom WiFi (WiFi down for example), then ESP reconnects when WiFi is up again, and a sntp call is made.