### PR TITLE
Zigbee: Add dimmable light endpoint class 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ set(ARDUINO_LIBRARY_Zigbee_SRCS
   libraries/Zigbee/src/ZigbeeHandlers.cpp
   libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
   libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+  libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
   libraries/Zigbee/src/ep/ZigbeeLight.cpp
   libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
   libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp

--- a/libraries/Zigbee/examples/Zigbee_Dimmable_Light/README.md
+++ b/libraries/Zigbee/examples/Zigbee_Dimmable_Light/README.md
@@ -1,0 +1,68 @@
+# Arduino-ESP32 Zigbee Dimmable Light Example
+
+This example shows how to configure the Zigbee end device and use it as a Home Automation (HA) dimmable light.
+
+# Supported Targets
+
+Currently, this example supports the following targets.
+
+| Supported Targets | ESP32-C6 | ESP32-H2 |
+| ----------------- | -------- | -------- |
+
+## Hardware Required
+
+* A USB cable for power supply and programming
+* Board (ESP32-H2 or ESP32-C6) as Zigbee end device and upload the Zigbee_Dimmable_Light example
+* Zigbee network / coordinator (Other board with switch examples or Zigbee2mqtt or ZigbeeHomeAssistant like application)
+
+### Configure the Project
+
+Set the LED GPIO by changing the `LED_PIN` definition. By default, the LED_PIN is `RGB_BUILTIN`.
+
+#### Using Arduino IDE
+
+To get more information about the Espressif boards see [Espressif Development Kits](https://www.espressif.com/en/products/devkits).
+
+* Before Compile/Verify, select the correct board: `Tools -> Board`.
+* Select the End device Zigbee mode: `Tools -> Zigbee mode: Zigbee ED (end device)`
+* Select Partition Scheme for Zigbee: `Tools -> Partition Scheme: Zigbee 4MB with spiffs`
+* Select the COM port: `Tools -> Port: xxx` where the `xxx` is the detected COM port.
+* Optional: Set debug level to verbose to see all logs from Zigbee stack: `Tools -> Core Debug Level: Verbose`.
+
+## Troubleshooting
+
+If the End device flashed with this example is not connecting to the coordinator, erase the flash of the End device before flashing the example to the board. It is recommended to do this if you re-flash the coordinator.
+You can do the following:
+
+* In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`.
+* Add to the sketch `Zigbee.factoryReset();` to reset the device and Zigbee stack.
+
+By default, the coordinator network is closed after rebooting or flashing new firmware.
+To open the network you have 2 options:
+
+* Open network after reboot by setting `Zigbee.setRebootOpenNetwork(time);` before calling `Zigbee.begin();`.
+* In application you can anytime call `Zigbee.openNetwork(time);` to open the network for devices to join.
+
+***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***
+
+* **LED not blinking:** Check the wiring connection and the IO selection.
+* **Programming Fail:** If the programming/flash procedure fails, try reducing the serial connection speed.
+* **COM port not detected:** Check the USB cable and the USB to Serial driver installation.
+
+If the error persists, you can ask for help at the official [ESP32 forum](https://esp32.com) or see [Contribute](#contribute).
+
+## Contribute
+
+To know how to contribute to this project, see [How to contribute.](https://github.com/espressif/arduino-esp32/blob/master/CONTRIBUTING.rst)
+
+If you have any **feedback** or **issue** to report on this example/library, please open an issue or fix it by creating a new PR. Contributions are more than welcome!
+
+Before creating a new issue, be sure to try Troubleshooting and check if the same issue was already created by someone else.
+
+## Resources
+
+* Official ESP32 Forum: [Link](https://esp32.com)
+* Arduino-ESP32 Official Repository: [espressif/arduino-esp32](https://github.com/espressif/arduino-esp32)
+* ESP32-C6 Datasheet: [Link to datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf)
+* ESP32-H2 Datasheet: [Link to datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf)
+* Official ESP-IDF documentation: [ESP-IDF](https://idf.espressif.com)

--- a/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
@@ -41,10 +41,8 @@ uint8_t button = BOOT_PIN;
 ZigbeeDimmableLight zbDimmableLight = ZigbeeDimmableLight(ZIGBEE_LIGHT_ENDPOINT);
 
 /********************* RGB LED functions **************************/
-void setLight(bool state, uint8_t level)
-{
-  if (!state)
-  {
+void setLight(bool state, uint8_t level) {
+  if (!state) {
     rgbLedWrite(led, 0, 0, 0);
     return;
   }
@@ -52,12 +50,10 @@ void setLight(bool state, uint8_t level)
 }
 
 // Create a task on identify call to handle the identify function
-void identify(uint16_t time)
-{
+void identify(uint16_t time) {
   static uint8_t blink = 1;
   log_d("Identify called for %d seconds", time);
-  if (time == 0)
-  {
+  if (time == 0) {
     // If identify time is 0, stop blinking and restore light as it was used for identify
     zbDimmableLight.restoreLight();
     return;
@@ -67,8 +63,7 @@ void identify(uint16_t time)
 }
 
 /********************* Arduino functions **************************/
-void setup()
-{
+void setup() {
   Serial.begin(115200);
 
   // Init RMT and leave light OFF
@@ -91,34 +86,28 @@ void setup()
   Zigbee.addEndpoint(&zbDimmableLight);
 
   // When all EPs are registered, start Zigbee in End Device mode
-  if (!Zigbee.begin())
-  {
+  if (!Zigbee.begin()) {
     Serial.println("Zigbee failed to start!");
     Serial.println("Rebooting...");
     ESP.restart();
   }
   Serial.println("Connecting to network");
-  while (!Zigbee.connected())
-  {
+  while (!Zigbee.connected()) {
     Serial.print(".");
     delay(100);
   }
   Serial.println();
 }
 
-void loop()
-{
+void loop() {
   // Checking button for factory reset
-  if (digitalRead(button) == LOW)
-  { // Push button pressed
+  if (digitalRead(button) == LOW) {  // Push button pressed
     // Key debounce handling
     delay(100);
     int startTime = millis();
-    while (digitalRead(button) == LOW)
-    {
+    while (digitalRead(button) == LOW) {
       delay(50);
-      if ((millis() - startTime) > 3000)
-      {
+      if ((millis() - startTime) > 3000) {
         // If key pressed for more than 3secs, factory reset Zigbee and reboot
         Serial.println("Resetting Zigbee to factory and rebooting in 1s.");
         delay(1000);

--- a/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
@@ -33,16 +33,22 @@
 
 #include "Zigbee.h"
 
-#define LED_PIN RGB_BUILTIN
-#define BUTTON_PIN 9 // C6/H2 Boot button
+/* Zigbee dimmable light configuration */
 #define ZIGBEE_LIGHT_ENDPOINT 10
+uint8_t led = RGB_BUILTIN;
+uint8_t button = BOOT_PIN;
 
 ZigbeeDimmableLight zbDimmableLight = ZigbeeDimmableLight(ZIGBEE_LIGHT_ENDPOINT);
 
-/********************* LED functions **************************/
+/********************* RGB LED functions **************************/
 void setLight(bool state, uint8_t level)
 {
-  rgbLedWrite(LED_PIN, level, level, level);
+  if (!state)
+  {
+    rgbLedWrite(led, 0, 0, 0);
+    return;
+  }
+  rgbLedWrite(led, level, level, level);
 }
 
 // Create a task on identify call to handle the identify function
@@ -56,18 +62,20 @@ void identify(uint16_t time)
     zbDimmableLight.restoreLight();
     return;
   }
-  rgbLedWrite(LED_PIN, 255 * blink, 255 * blink, 255 * blink);
+  rgbLedWrite(led, 255 * blink, 255 * blink, 255 * blink);
   blink = !blink;
 }
 
 /********************* Arduino functions **************************/
 void setup()
 {
+  Serial.begin(115200);
+
   // Init RMT and leave light OFF
-  rgbLedWrite(LED_PIN, 0, 0, 0);
+  rgbLedWrite(led, 0, 0, 0);
 
   // Init button for factory reset
-  pinMode(BUTTON_PIN, INPUT_PULLUP);
+  pinMode(button, INPUT_PULLUP);
 
   // Set callback function for light change
   zbDimmableLight.onLightChange(setLight);
@@ -79,32 +87,46 @@ void setup()
   zbDimmableLight.setManufacturerAndModel("Espressif", "ZBLightBulb");
 
   // Add endpoint to Zigbee Core
-  log_d("Adding ZigbeeLight endpoint to Zigbee Core");
+  Serial.println("Adding ZigbeeLight endpoint to Zigbee Core");
   Zigbee.addEndpoint(&zbDimmableLight);
 
-  // When all EPs are registered, start Zigbee. By default acts as ZIGBEE_END_DEVICE
-  log_d("Calling Zigbee.begin()");
-  Zigbee.begin();
+  // When all EPs are registered, start Zigbee in End Device mode
+  if (!Zigbee.begin())
+  {
+    Serial.println("Zigbee failed to start!");
+    Serial.println("Rebooting...");
+    ESP.restart();
+  }
+  Serial.println("Connecting to network");
+  while (!Zigbee.connected())
+  {
+    Serial.print(".");
+    delay(100);
+  }
+  Serial.println();
 }
 
 void loop()
 {
   // Checking button for factory reset
-  if (digitalRead(BUTTON_PIN) == LOW)
+  if (digitalRead(button) == LOW)
   { // Push button pressed
     // Key debounce handling
     delay(100);
     int startTime = millis();
-    while (digitalRead(BUTTON_PIN) == LOW)
+    while (digitalRead(button) == LOW)
     {
       delay(50);
       if ((millis() - startTime) > 3000)
       {
         // If key pressed for more than 3secs, factory reset Zigbee and reboot
-        Serial.printf("Resetting Zigbee to factory settings, reboot.\n");
+        Serial.println("Resetting Zigbee to factory and rebooting in 1s.");
+        delay(1000);
         Zigbee.factoryReset();
       }
     }
+    // Increase blightness by 50 every time the button is pressed
+    zbDimmableLight.setLightLevel(zbDimmableLight.getLightLevel() + 50);
   }
   delay(100);
 }

--- a/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
@@ -24,7 +24,7 @@
  *
  * Please check the README.md for instructions and more detailed description.
  *
- * Created by Jan Procházka (https://github.com/P-R-O-C-H-Y/)
+ * Created by [FaBjE](https://github.com/FaBjE) based on examples by [Jan Procházka](https://github.com/P-R-O-C-H-Y/)
  */
 
 #ifndef ZIGBEE_MODE_ED

--- a/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
+++ b/libraries/Zigbee/examples/Zigbee_Dimmable_Light/Zigbee_Dimmable_Light.ino
@@ -1,0 +1,110 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @brief This example demonstrates Zigbee Dimmable light bulb.
+ *
+ * The example demonstrates how to use Zigbee library to create an end device with
+ * dimmable light end point.
+ * The light bulb is a Zigbee end device, which is controlled by a Zigbee coordinator.
+ *
+ * Proper Zigbee mode must be selected in Tools->Zigbee mode
+ * and also the correct partition scheme must be selected in Tools->Partition Scheme.
+ *
+ * Please check the README.md for instructions and more detailed description.
+ *
+ * Created by Jan Procházka (https://github.com/P-R-O-C-H-Y/)
+ */
+
+#ifndef ZIGBEE_MODE_ED
+#error "Zigbee end device mode is not selected in Tools->Zigbee mode"
+#endif
+
+#include "Zigbee.h"
+
+#define LED_PIN RGB_BUILTIN
+#define BUTTON_PIN 9 // C6/H2 Boot button
+#define ZIGBEE_LIGHT_ENDPOINT 10
+
+ZigbeeDimmableLight zbDimmableLight = ZigbeeDimmableLight(ZIGBEE_LIGHT_ENDPOINT);
+
+/********************* LED functions **************************/
+void setLight(bool state, uint8_t level)
+{
+  rgbLedWrite(LED_PIN, level, level, level);
+}
+
+// Create a task on identify call to handle the identify function
+void identify(uint16_t time)
+{
+  static uint8_t blink = 1;
+  log_d("Identify called for %d seconds", time);
+  if (time == 0)
+  {
+    // If identify time is 0, stop blinking and restore light as it was used for identify
+    zbDimmableLight.restoreLight();
+    return;
+  }
+  rgbLedWrite(LED_PIN, 255 * blink, 255 * blink, 255 * blink);
+  blink = !blink;
+}
+
+/********************* Arduino functions **************************/
+void setup()
+{
+  // Init RMT and leave light OFF
+  rgbLedWrite(LED_PIN, 0, 0, 0);
+
+  // Init button for factory reset
+  pinMode(BUTTON_PIN, INPUT_PULLUP);
+
+  // Set callback function for light change
+  zbDimmableLight.onLightChange(setLight);
+
+  // Optional: Set callback function for device identify
+  zbDimmableLight.onIdentify(identify);
+
+  // Optional: Set Zigbee device name and model
+  zbDimmableLight.setManufacturerAndModel("Espressif", "ZBLightBulb");
+
+  // Add endpoint to Zigbee Core
+  log_d("Adding ZigbeeLight endpoint to Zigbee Core");
+  Zigbee.addEndpoint(&zbDimmableLight);
+
+  // When all EPs are registered, start Zigbee. By default acts as ZIGBEE_END_DEVICE
+  log_d("Calling Zigbee.begin()");
+  Zigbee.begin();
+}
+
+void loop()
+{
+  // Checking button for factory reset
+  if (digitalRead(BUTTON_PIN) == LOW)
+  { // Push button pressed
+    // Key debounce handling
+    delay(100);
+    int startTime = millis();
+    while (digitalRead(BUTTON_PIN) == LOW)
+    {
+      delay(50);
+      if ((millis() - startTime) > 3000)
+      {
+        // If key pressed for more than 3secs, factory reset Zigbee and reboot
+        Serial.printf("Resetting Zigbee to factory settings, reboot.\n");
+        Zigbee.factoryReset();
+      }
+    }
+  }
+  delay(100);
+}

--- a/libraries/Zigbee/examples/Zigbee_Dimmable_Light/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Dimmable_Light/ci.json
@@ -1,0 +1,6 @@
+{
+  "fqbn_append": "PartitionScheme=zigbee,ZigbeeMode=ed",
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
+}

--- a/libraries/Zigbee/src/Zigbee.h
+++ b/libraries/Zigbee/src/Zigbee.h
@@ -9,6 +9,7 @@
 // Endpoints
 #include "ep/ZigbeeLight.h"
 #include "ep/ZigbeeSwitch.h"
+#include "ep/ZigbeeDimmableLight.h"
 #include "ep/ZigbeeColorDimmableLight.h"
 #include "ep/ZigbeeColorDimmerSwitch.h"
 #include "ep/ZigbeeTempSensor.h"

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
@@ -1,6 +1,6 @@
 
 #include "ZigbeeDimmableLight.h"
-#if SOC_IEEE802154_SUPPORTED
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
 #include "esp_zigbee_cluster.h"
 

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
@@ -8,7 +8,7 @@ ZigbeeDimmableLight::ZigbeeDimmableLight(uint8_t endpoint) : ZigbeeEP(endpoint) 
   _device_id = ESP_ZB_HA_DIMMABLE_LIGHT_DEVICE_ID;
 
   zigbee_dimmable_light_cfg_t light_cfg = ZIGBEE_DEFAULT_DIMMABLE_LIGHT_CONFIG();
-  _cluster_list = esp_zb_dimmable_light_clusters_create(&light_cfg);
+  _cluster_list = zigbee_dimmable_light_clusters_create(&light_cfg);
 
   _ep_config = {.endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_DIMMABLE_LIGHT_DEVICE_ID, .app_device_version = 0};
 
@@ -80,7 +80,7 @@ void ZigbeeDimmableLight::setLightLevel(uint8_t level) {
   setLight(_current_state, level);
 }
 
-esp_zb_cluster_list_t *ZigbeeDimmableLight::esp_zb_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg) {
+esp_zb_cluster_list_t *ZigbeeDimmableLight::zigbee_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg) {
   esp_zb_attribute_list_t *esp_zb_basic_cluster = esp_zb_basic_cluster_create(&light_cfg->basic_cfg);
   esp_zb_attribute_list_t *esp_zb_identify_cluster = esp_zb_identify_cluster_create(&light_cfg->identify_cfg);
   esp_zb_attribute_list_t *esp_zb_groups_cluster = esp_zb_groups_cluster_create(&light_cfg->groups_cfg);

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
@@ -4,8 +4,7 @@
 
 #include "esp_zigbee_cluster.h"
 
-ZigbeeDimmableLight::ZigbeeDimmableLight(uint8_t endpoint) : ZigbeeEP(endpoint)
-{
+ZigbeeDimmableLight::ZigbeeDimmableLight(uint8_t endpoint) : ZigbeeEP(endpoint) {
   _device_id = ESP_ZB_HA_DIMMABLE_LIGHT_DEVICE_ID;
 
   zigbee_dimmable_light_cfg_t light_cfg = ZIGBEE_DEFAULT_DIMMABLE_LIGHT_CONFIG();
@@ -19,58 +18,41 @@ ZigbeeDimmableLight::ZigbeeDimmableLight(uint8_t endpoint) : ZigbeeEP(endpoint)
 }
 
 // set attribute method -> method overridden in child class
-void ZigbeeDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message)
-{
+void ZigbeeDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message) {
   // check the data and call right method
-  if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF)
-  {
-    if (message->attribute.id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL)
-    {
-      if (_current_state != *(bool *)message->attribute.data.value)
-      {
+  if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF) {
+    if (message->attribute.id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL) {
+      if (_current_state != *(bool *)message->attribute.data.value) {
         _current_state = *(bool *)message->attribute.data.value;
         lightChanged();
       }
       return;
-    }
-    else
-    {
+    } else {
       log_w("Received message ignored. Attribute ID: %d not supported for On/Off Light", message->attribute.id);
     }
-  }
-  else if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL)
-  {
-    if (message->attribute.id == ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U8)
-    {
-      if (_current_level != *(uint8_t *)message->attribute.data.value)
-      {
+  } else if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL) {
+    if (message->attribute.id == ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U8) {
+      if (_current_level != *(uint8_t *)message->attribute.data.value) {
         _current_level = *(uint8_t *)message->attribute.data.value;
         lightChanged();
       }
       return;
-    }
-    else
-    {
+    } else {
       log_w("Received message ignored. Attribute ID: %d not supported for Level Control", message->attribute.id);
       // TODO: implement more attributes -> includes/zcl/esp_zigbee_zcl_level.h
     }
-  }
-  else
-  {
+  } else {
     log_w("Received message ignored. Cluster ID: %d not supported for dimmable Light", message->info.cluster);
   }
 }
 
-void ZigbeeDimmableLight::lightChanged()
-{
-  if (_on_light_change)
-  {
+void ZigbeeDimmableLight::lightChanged() {
+  if (_on_light_change) {
     _on_light_change(_current_state, _current_level);
   }
 }
 
-void ZigbeeDimmableLight::setLight(bool state, uint8_t level)
-{
+void ZigbeeDimmableLight::setLight(bool state, uint8_t level) {
   // Update all attributes
   _current_state = state;
   _current_level = level;
@@ -81,25 +63,24 @@ void ZigbeeDimmableLight::setLight(bool state, uint8_t level)
   esp_zb_lock_acquire(portMAX_DELAY);
   // set on/off state
   esp_zb_zcl_set_attribute_val(
-      _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false
+  );
   // set level
   esp_zb_zcl_set_attribute_val(
-      _endpoint, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
+  );
   esp_zb_lock_release();
 }
 
-void ZigbeeDimmableLight::setLightState(bool state)
-{
+void ZigbeeDimmableLight::setLightState(bool state) {
   setLight(state, _current_level);
 }
 
-void ZigbeeDimmableLight::setLightLevel(uint8_t level)
-{
+void ZigbeeDimmableLight::setLightLevel(uint8_t level) {
   setLight(_current_state, level);
 }
 
-esp_zb_cluster_list_t *ZigbeeDimmableLight::esp_zb_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg)
-{
+esp_zb_cluster_list_t *ZigbeeDimmableLight::esp_zb_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg) {
   esp_zb_attribute_list_t *esp_zb_basic_cluster = esp_zb_basic_cluster_create(&light_cfg->basic_cfg);
   esp_zb_attribute_list_t *esp_zb_identify_cluster = esp_zb_identify_cluster_create(&light_cfg->identify_cfg);
   esp_zb_attribute_list_t *esp_zb_groups_cluster = esp_zb_groups_cluster_create(&light_cfg->groups_cfg);
@@ -119,4 +100,4 @@ esp_zb_cluster_list_t *ZigbeeDimmableLight::esp_zb_dimmable_light_clusters_creat
   return esp_zb_cluster_list;
 }
 
-#endif // SOC_IEEE802154_SUPPORTED
+#endif  // SOC_IEEE802154_SUPPORTED

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
@@ -1,0 +1,93 @@
+
+#include "ZigbeeDimmableLight.h"
+#if SOC_IEEE802154_SUPPORTED
+
+#include "esp_zigbee_cluster.h"
+
+ZigbeeDimmableLight::ZigbeeDimmableLight(uint8_t endpoint) : ZigbeeEP(endpoint)
+{
+  _device_id = ESP_ZB_HA_DIMMABLE_LIGHT_DEVICE_ID;
+
+  esp_zb_dimmable_light_cfg_t light_cfg = ESP_ZB_DEFAULT_DIMMABLE_LIGHT_CONFIG();
+  _cluster_list = esp_zb_dimmable_light_clusters_create(&light_cfg);
+
+  _ep_config = {.endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_DIMMABLE_LIGHT_DEVICE_ID, .app_device_version = 0};
+
+  // set default values
+  _current_state = false;
+  _current_level = 255;
+}
+
+// set attribute method -> method overridden in child class
+void ZigbeeDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message)
+{
+  // check the data and call right method
+  if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF)
+  {
+    if (message->attribute.id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL)
+    {
+      if (_current_state != *(bool *)message->attribute.data.value)
+      {
+        _current_state = *(bool *)message->attribute.data.value;
+        lightChanged();
+      }
+      return;
+    }
+    else
+    {
+      log_w("Received message ignored. Attribute ID: %d not supported for On/Off Light", message->attribute.id);
+    }
+  }
+  else if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL)
+  {
+    if (message->attribute.id == ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U8)
+    {
+      if (_current_level != *(uint8_t *)message->attribute.data.value)
+      {
+        _current_level = *(uint8_t *)message->attribute.data.value;
+        lightChanged();
+      }
+      return;
+    }
+    else
+    {
+      log_w("Received message ignored. Attribute ID: %d not supported for Level Control", message->attribute.id);
+      // TODO: implement more attributes -> includes/zcl/esp_zigbee_zcl_level.h
+    }
+  }
+  else
+  {
+    log_w("Received message ignored. Cluster ID: %d not supported for Color dimmable Light", message->info.cluster);
+  }
+}
+
+void ZigbeeDimmableLight::lightChanged()
+{
+  if (_on_light_change)
+  {
+    _on_light_change(_current_state, _current_level);
+  }
+}
+
+esp_zb_cluster_list_t *ZigbeeDimmableLight::esp_zb_dimmable_light_clusters_create(esp_zb_dimmable_light_cfg_t *light_cfg)
+{
+  esp_zb_attribute_list_t *esp_zb_basic_cluster = esp_zb_basic_cluster_create(&light_cfg->basic_cfg);
+  esp_zb_attribute_list_t *esp_zb_identify_cluster = esp_zb_identify_cluster_create(&light_cfg->identify_cfg);
+  esp_zb_attribute_list_t *esp_zb_groups_cluster = esp_zb_groups_cluster_create(&light_cfg->groups_cfg);
+  esp_zb_attribute_list_t *esp_zb_scenes_cluster = esp_zb_scenes_cluster_create(&light_cfg->scenes_cfg);
+  esp_zb_attribute_list_t *esp_zb_on_off_cluster = esp_zb_on_off_cluster_create(&light_cfg->on_off_cfg);
+  esp_zb_attribute_list_t *esp_zb_level_cluster = esp_zb_level_cluster_create(&light_cfg->level_cfg);
+
+  // ------------------------------ Create cluster list ------------------------------
+  esp_zb_cluster_list_t *esp_zb_cluster_list = esp_zb_zcl_cluster_list_create();
+  esp_zb_cluster_list_add_basic_cluster(esp_zb_cluster_list, esp_zb_basic_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_identify_cluster(esp_zb_cluster_list, esp_zb_identify_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_groups_cluster(esp_zb_cluster_list, esp_zb_groups_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_scenes_cluster(esp_zb_cluster_list, esp_zb_scenes_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_on_off_cluster(esp_zb_cluster_list, esp_zb_on_off_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  esp_zb_cluster_list_add_level_cluster(esp_zb_cluster_list, esp_zb_level_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+
+  return esp_zb_cluster_list;
+}
+
+#endif // SOC_IEEE802154_SUPPORTED

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
@@ -8,7 +8,7 @@ ZigbeeDimmableLight::ZigbeeDimmableLight(uint8_t endpoint) : ZigbeeEP(endpoint)
 {
   _device_id = ESP_ZB_HA_DIMMABLE_LIGHT_DEVICE_ID;
 
-  esp_zb_dimmable_light_cfg_t light_cfg = ESP_ZB_DEFAULT_DIMMABLE_LIGHT_CONFIG();
+  zigbee_dimmable_light_cfg_t light_cfg = ZIGBEE_DEFAULT_DIMMABLE_LIGHT_CONFIG();
   _cluster_list = esp_zb_dimmable_light_clusters_create(&light_cfg);
 
   _ep_config = {.endpoint = _endpoint, .app_profile_id = ESP_ZB_AF_HA_PROFILE_ID, .app_device_id = ESP_ZB_HA_DIMMABLE_LIGHT_DEVICE_ID, .app_device_version = 0};
@@ -98,7 +98,7 @@ void ZigbeeDimmableLight::setLightLevel(uint8_t level)
   setLight(_current_state, level);
 }
 
-esp_zb_cluster_list_t *ZigbeeDimmableLight::esp_zb_dimmable_light_clusters_create(esp_zb_dimmable_light_cfg_t *light_cfg)
+esp_zb_cluster_list_t *ZigbeeDimmableLight::esp_zb_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg)
 {
   esp_zb_attribute_list_t *esp_zb_basic_cluster = esp_zb_basic_cluster_create(&light_cfg->basic_cfg);
   esp_zb_attribute_list_t *esp_zb_identify_cluster = esp_zb_identify_cluster_create(&light_cfg->identify_cfg);

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
@@ -15,8 +15,7 @@
  *
  *
  */
-typedef struct zigbee_dimmable_light_cfg_s
-{
+typedef struct zigbee_dimmable_light_cfg_s {
   esp_zb_basic_cluster_cfg_t basic_cfg;       /*!<  Basic cluster configuration, @ref esp_zb_basic_cluster_cfg_s */
   esp_zb_identify_cluster_cfg_t identify_cfg; /*!<  Identify cluster configuration, @ref esp_zb_identify_cluster_cfg_s */
   esp_zb_groups_cluster_cfg_t groups_cfg;     /*!<  Groups cluster configuration, @ref esp_zb_groups_cluster_cfg_s */
@@ -65,18 +64,15 @@ typedef struct zigbee_dimmable_light_cfg_s
   }
 // clang-format on
 
-class ZigbeeDimmableLight : public ZigbeeEP
-{
+class ZigbeeDimmableLight : public ZigbeeEP {
 public:
   ZigbeeDimmableLight(uint8_t endpoint);
   ~ZigbeeDimmableLight();
 
-  void onLightChange(void (*callback)(bool, uint8_t))
-  {
+  void onLightChange(void (*callback)(bool, uint8_t)) {
     _on_light_change = callback;
   }
-  void restoreLight()
-  {
+  void restoreLight() {
     lightChanged();
   }
 
@@ -84,12 +80,10 @@ public:
   void setLightLevel(uint8_t level);
   void setLight(bool state, uint8_t level);
 
-  bool getLightState()
-  {
+  bool getLightState() {
     return _current_state;
   }
-  uint8_t getLightLevel()
-  {
+  uint8_t getLightLevel() {
     return _current_level;
   }
 
@@ -116,4 +110,4 @@ private:
   uint8_t _current_level;
 };
 
-#endif // SOC_IEEE802154_SUPPORTED
+#endif  // SOC_IEEE802154_SUPPORTED

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
@@ -15,7 +15,8 @@
  *
  *
  */
-typedef struct zigbee_dimmable_light_cfg_s {
+typedef struct zigbee_dimmable_light_cfg_s
+{
   esp_zb_basic_cluster_cfg_t basic_cfg;       /*!<  Basic cluster configuration, @ref esp_zb_basic_cluster_cfg_s */
   esp_zb_identify_cluster_cfg_t identify_cfg; /*!<  Identify cluster configuration, @ref esp_zb_identify_cluster_cfg_s */
   esp_zb_groups_cluster_cfg_t groups_cfg;     /*!<  Groups cluster configuration, @ref esp_zb_groups_cluster_cfg_s */
@@ -29,6 +30,7 @@ typedef struct zigbee_dimmable_light_cfg_s {
  *        Added here as not supported by ESP Zigbee library.
  *
  */
+// clang-format off
 #define ZIGBEE_DEFAULT_DIMMABLE_LIGHT_CONFIG()                                  \
   {                                                                             \
     .basic_cfg =                                                                \
@@ -61,16 +63,20 @@ typedef struct zigbee_dimmable_light_cfg_s {
         .current_level = ESP_ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE,  \
       },                                                                        \
   }
+// clang-format on
 
-class ZigbeeDimmableLight : public ZigbeeEP {
+class ZigbeeDimmableLight : public ZigbeeEP
+{
 public:
   ZigbeeDimmableLight(uint8_t endpoint);
   ~ZigbeeDimmableLight();
 
-  void onLightChange(void (*callback)(bool, uint8_t)) {
+  void onLightChange(void (*callback)(bool, uint8_t))
+  {
     _on_light_change = callback;
   }
-  void restoreLight() {
+  void restoreLight()
+  {
     lightChanged();
   }
 
@@ -78,10 +84,12 @@ public:
   void setLightLevel(uint8_t level);
   void setLight(bool state, uint8_t level);
 
-  bool getLightState() {
+  bool getLightState()
+  {
     return _current_state;
   }
-  uint8_t getLightLevel() {
+  uint8_t getLightLevel()
+  {
     return _current_level;
   }
 
@@ -108,4 +116,4 @@ private:
   uint8_t _current_level;
 };
 
-#endif  // SOC_IEEE802154_SUPPORTED
+#endif // SOC_IEEE802154_SUPPORTED

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
@@ -1,0 +1,103 @@
+/* Class of Zigbee On/Off Light endpoint inherited from common EP class */
+
+#pragma once
+
+#include "soc/soc_caps.h"
+#if SOC_IEEE802154_SUPPORTED
+
+#include "ZigbeeEP.h"
+#include "ha/esp_zigbee_ha_standard.h"
+
+/**
+ * @brief Zigbee HA standard dimmable light device clusters.
+ *        Added here as not supported by ESP Zigbee library.
+ *
+ *
+ */
+typedef struct esp_zb_dimmable_light_cfg_s
+{
+  esp_zb_basic_cluster_cfg_t basic_cfg;       /*!<  Basic cluster configuration, @ref esp_zb_basic_cluster_cfg_s */
+  esp_zb_identify_cluster_cfg_t identify_cfg; /*!<  Identify cluster configuration, @ref esp_zb_identify_cluster_cfg_s */
+  esp_zb_groups_cluster_cfg_t groups_cfg;     /*!<  Groups cluster configuration, @ref esp_zb_groups_cluster_cfg_s */
+  esp_zb_scenes_cluster_cfg_t scenes_cfg;     /*!<  Scenes cluster configuration, @ref esp_zb_scenes_cluster_cfg_s */
+  esp_zb_on_off_cluster_cfg_t on_off_cfg;     /*!<  On off cluster configuration, @ref esp_zb_on_off_cluster_cfg_s */
+  esp_zb_level_cluster_cfg_t level_cfg;       /*!<  Level cluster configuration, @ref esp_zb_level_cluster_cfg_s */
+} esp_zb_dimmable_light_cfg_t;
+
+/**
+ * @brief Zigbee HA standard dimmable light device default config value.
+ *        Added here as not supported by ESP Zigbee library.
+ *
+ */
+#define ESP_ZB_DEFAULT_DIMMABLE_LIGHT_CONFIG()                                        \
+  {                                                                                   \
+      .basic_cfg =                                                                    \
+          {                                                                           \
+              .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,              \
+              .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,            \
+          },                                                                          \
+      .identify_cfg =                                                                 \
+          {                                                                           \
+              .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,       \
+          },                                                                          \
+      .groups_cfg =                                                                   \
+          {                                                                           \
+              .groups_name_support_id = ESP_ZB_ZCL_GROUPS_NAME_SUPPORT_DEFAULT_VALUE, \
+          },                                                                          \
+      .scenes_cfg =                                                                   \
+          {                                                                           \
+              .scenes_count = ESP_ZB_ZCL_SCENES_SCENE_COUNT_DEFAULT_VALUE,            \
+              .current_scene = ESP_ZB_ZCL_SCENES_CURRENT_SCENE_DEFAULT_VALUE,         \
+              .current_group = ESP_ZB_ZCL_SCENES_CURRENT_GROUP_DEFAULT_VALUE,         \
+              .scene_valid = ESP_ZB_ZCL_SCENES_SCENE_VALID_DEFAULT_VALUE,             \
+              .name_support = ESP_ZB_ZCL_SCENES_NAME_SUPPORT_DEFAULT_VALUE,           \
+          },                                                                          \
+      .on_off_cfg =                                                                   \
+          {                                                                           \
+              .on_off = ESP_ZB_ZCL_ON_OFF_ON_OFF_DEFAULT_VALUE,                       \
+          },                                                                          \
+      .level_cfg =                                                                    \
+          {                                                                           \
+              .current_level = ESP_ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE,  \
+          },                                                                          \
+  }
+
+class ZigbeeDimmableLight : public ZigbeeEP
+{
+public:
+  ZigbeeDimmableLight(uint8_t endpoint);
+  ~ZigbeeDimmableLight();
+
+  void onLightChange(void (*callback)(bool, uint8_t))
+  {
+    _on_light_change = callback;
+  }
+  void restoreLight()
+  {
+    lightChanged();
+  }
+
+private:
+  void zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message) override;
+
+  void lightChanged();
+  // callback function to be called on light change (State, Level)
+  void (*_on_light_change)(bool, uint8_t);
+
+  /**
+   * @brief  Create a standard HA dimmable light cluster list.
+   *        Added here as not supported by ESP Zigbee library.
+   *
+   * @note This contains basic, identify, groups, scenes, on-off, level, as server side.
+   * @param[in] light_cfg  Configuration parameters for this cluster lists defined by @ref esp_zb_dimmable_light_cfg_t
+   *
+   * @return Pointer to cluster list  @ref esp_zb_cluster_list_s
+   *
+   */
+  esp_zb_cluster_list_t *esp_zb_dimmable_light_clusters_create(esp_zb_dimmable_light_cfg_t *light_cfg);
+
+  bool _current_state;
+  uint8_t _current_level;
+};
+
+#endif // SOC_IEEE802154_SUPPORTED

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
@@ -15,66 +15,62 @@
  *
  *
  */
-typedef struct esp_zb_dimmable_light_cfg_s
-{
+typedef struct zigbee_dimmable_light_cfg_s {
   esp_zb_basic_cluster_cfg_t basic_cfg;       /*!<  Basic cluster configuration, @ref esp_zb_basic_cluster_cfg_s */
   esp_zb_identify_cluster_cfg_t identify_cfg; /*!<  Identify cluster configuration, @ref esp_zb_identify_cluster_cfg_s */
   esp_zb_groups_cluster_cfg_t groups_cfg;     /*!<  Groups cluster configuration, @ref esp_zb_groups_cluster_cfg_s */
   esp_zb_scenes_cluster_cfg_t scenes_cfg;     /*!<  Scenes cluster configuration, @ref esp_zb_scenes_cluster_cfg_s */
   esp_zb_on_off_cluster_cfg_t on_off_cfg;     /*!<  On off cluster configuration, @ref esp_zb_on_off_cluster_cfg_s */
   esp_zb_level_cluster_cfg_t level_cfg;       /*!<  Level cluster configuration, @ref esp_zb_level_cluster_cfg_s */
-} esp_zb_dimmable_light_cfg_t;
+} zigbee_dimmable_light_cfg_t;
 
 /**
  * @brief Zigbee HA standard dimmable light device default config value.
  *        Added here as not supported by ESP Zigbee library.
  *
  */
-#define ESP_ZB_DEFAULT_DIMMABLE_LIGHT_CONFIG()                                        \
-  {                                                                                   \
-      .basic_cfg =                                                                    \
-          {                                                                           \
-              .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,              \
-              .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,            \
-          },                                                                          \
-      .identify_cfg =                                                                 \
-          {                                                                           \
-              .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,       \
-          },                                                                          \
-      .groups_cfg =                                                                   \
-          {                                                                           \
-              .groups_name_support_id = ESP_ZB_ZCL_GROUPS_NAME_SUPPORT_DEFAULT_VALUE, \
-          },                                                                          \
-      .scenes_cfg =                                                                   \
-          {                                                                           \
-              .scenes_count = ESP_ZB_ZCL_SCENES_SCENE_COUNT_DEFAULT_VALUE,            \
-              .current_scene = ESP_ZB_ZCL_SCENES_CURRENT_SCENE_DEFAULT_VALUE,         \
-              .current_group = ESP_ZB_ZCL_SCENES_CURRENT_GROUP_DEFAULT_VALUE,         \
-              .scene_valid = ESP_ZB_ZCL_SCENES_SCENE_VALID_DEFAULT_VALUE,             \
-              .name_support = ESP_ZB_ZCL_SCENES_NAME_SUPPORT_DEFAULT_VALUE,           \
-          },                                                                          \
-      .on_off_cfg =                                                                   \
-          {                                                                           \
-              .on_off = ESP_ZB_ZCL_ON_OFF_ON_OFF_DEFAULT_VALUE,                       \
-          },                                                                          \
-      .level_cfg =                                                                    \
-          {                                                                           \
-              .current_level = ESP_ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE,  \
-          },                                                                          \
+#define ZIGBEE_DEFAULT_DIMMABLE_LIGHT_CONFIG()                                  \
+  {                                                                             \
+    .basic_cfg =                                                                \
+      {                                                                         \
+        .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,              \
+        .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,            \
+      },                                                                        \
+    .identify_cfg =                                                             \
+      {                                                                         \
+        .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,       \
+      },                                                                        \
+    .groups_cfg =                                                               \
+      {                                                                         \
+        .groups_name_support_id = ESP_ZB_ZCL_GROUPS_NAME_SUPPORT_DEFAULT_VALUE, \
+      },                                                                        \
+    .scenes_cfg =                                                               \
+      {                                                                         \
+        .scenes_count = ESP_ZB_ZCL_SCENES_SCENE_COUNT_DEFAULT_VALUE,            \
+        .current_scene = ESP_ZB_ZCL_SCENES_CURRENT_SCENE_DEFAULT_VALUE,         \
+        .current_group = ESP_ZB_ZCL_SCENES_CURRENT_GROUP_DEFAULT_VALUE,         \
+        .scene_valid = ESP_ZB_ZCL_SCENES_SCENE_VALID_DEFAULT_VALUE,             \
+        .name_support = ESP_ZB_ZCL_SCENES_NAME_SUPPORT_DEFAULT_VALUE,           \
+      },                                                                        \
+    .on_off_cfg =                                                               \
+      {                                                                         \
+        .on_off = ESP_ZB_ZCL_ON_OFF_ON_OFF_DEFAULT_VALUE,                       \
+      },                                                                        \
+    .level_cfg =                                                                \
+      {                                                                         \
+        .current_level = ESP_ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE,  \
+      },                                                                        \
   }
 
-class ZigbeeDimmableLight : public ZigbeeEP
-{
+class ZigbeeDimmableLight : public ZigbeeEP {
 public:
   ZigbeeDimmableLight(uint8_t endpoint);
   ~ZigbeeDimmableLight();
 
-  void onLightChange(void (*callback)(bool, uint8_t))
-  {
+  void onLightChange(void (*callback)(bool, uint8_t)) {
     _on_light_change = callback;
   }
-  void restoreLight()
-  {
+  void restoreLight() {
     lightChanged();
   }
 
@@ -82,12 +78,10 @@ public:
   void setLightLevel(uint8_t level);
   void setLight(bool state, uint8_t level);
 
-  bool getLightState()
-  {
+  bool getLightState() {
     return _current_state;
   }
-  uint8_t getLightLevel()
-  {
+  uint8_t getLightLevel() {
     return _current_level;
   }
 
@@ -103,15 +97,15 @@ private:
    *        Added here as not supported by ESP Zigbee library.
    *
    * @note This contains basic, identify, groups, scenes, on-off, level, as server side.
-   * @param[in] light_cfg  Configuration parameters for this cluster lists defined by @ref esp_zb_dimmable_light_cfg_t
+   * @param[in] light_cfg  Configuration parameters for this cluster lists defined by @ref zigbee_dimmable_light_cfg_t
    *
    * @return Pointer to cluster list  @ref esp_zb_cluster_list_s
    *
    */
-  esp_zb_cluster_list_t *esp_zb_dimmable_light_clusters_create(esp_zb_dimmable_light_cfg_t *light_cfg);
+  esp_zb_cluster_list_t *esp_zb_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg);
 
   bool _current_state;
   uint8_t _current_level;
 };
 
-#endif // SOC_IEEE802154_SUPPORTED
+#endif  // SOC_IEEE802154_SUPPORTED

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
@@ -104,7 +104,7 @@ private:
    * @return Pointer to cluster list  @ref esp_zb_cluster_list_s
    *
    */
-  esp_zb_cluster_list_t *esp_zb_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg);
+  esp_zb_cluster_list_t *zigbee_dimmable_light_clusters_create(zigbee_dimmable_light_cfg_t *light_cfg);
 
   bool _current_state;
   uint8_t _current_level;

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
@@ -3,7 +3,8 @@
 #pragma once
 
 #include "soc/soc_caps.h"
-#if SOC_IEEE802154_SUPPORTED
+#include "sdkconfig.h"
+#if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
 #include "ZigbeeEP.h"
 #include "ha/esp_zigbee_ha_standard.h"
@@ -75,6 +76,19 @@ public:
   void restoreLight()
   {
     lightChanged();
+  }
+
+  void setLightState(bool state);
+  void setLightLevel(uint8_t level);
+  void setLight(bool state, uint8_t level);
+
+  bool getLightState()
+  {
+    return _current_state;
+  }
+  uint8_t getLightLevel()
+  {
+    return _current_level;
   }
 
 private:


### PR DESCRIPTION
## Description of Change
This PR adds a Zigbee endpoint for a normal dimmable light. (So no colors or white-temperature change)
I based it on the "color dimmable light" example.

Unfortunately this endpoint type is not in the ESP Zigbee library by default.
So I had to make my own "esp_zb_dimmable_light_clusters_create" function.
It appears to be functioning good, but please do a proper check if I figured it out correctly.

## Tests scenarios
I've tested this with Home Assistant.
The Arduino applications runs on a ESP32-C6 with Arduino-esp32 core on "master" branch.

I'm looking forward to your feedback 😃 