### PR TITLE
Use INPUT_PULLUP instead of INPUT

### DIFF
--- a/libraries/ESP32/examples/Timer/RepeatTimer/RepeatTimer.ino
+++ b/libraries/ESP32/examples/Timer/RepeatTimer/RepeatTimer.ino
@@ -33,7 +33,7 @@ void setup() {
   Serial.begin(115200);
 
   // Set BTN_STOP_ALARM to input mode
-  pinMode(BTN_STOP_ALARM, INPUT);
+  pinMode(BTN_STOP_ALARM, INPUT_PULLUP);
 
   // Create semaphore to inform us when the timer has fired
   timerSemaphore = xSemaphoreCreateBinary();


### PR DESCRIPTION
## Description of Change
The digitalRead of an INPUT pin is LOW, which stops the timer right after start. 
Setting it to INPUT_PULLUP will fix it.

It aims to make repeat timer example work out of the box on some of the popular S3 boards.

## Tests scenarios
Tested on ESP32-S3 with Arduino-esp32 core v3.0.7 using Arduino 2.3.4

## Related links
https://www.amazon.com/dp/B0C9H7Y66W