### PR TITLE
ci: Allow push to the component registry from a given git ref

### DIFF
--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to push to the component registry'
+        description: 'Version to push to the component registry'
+        required: true
+      git_ref:
+        description: 'Git ref with the source to push to the component registry'
         required: true
   workflow_run:
     workflows: ["ESP32 Arduino Release"]
@@ -44,7 +47,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ inputs.git_ref || env.RELEASE_TAG }}
           submodules: "recursive"
 
       - name: Upload components to the component registry


### PR DESCRIPTION
This is meant to provide us a way to re-release a component if issue is found.
