### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-12938e51-v1"
+              "version": "idf-release_v5.3-cfea4f7c-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-12938e51-v1",
+          "version": "idf-release_v5.3-cfea4f7c-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
-              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
-              "size": "341111000"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
+              "checksum": "SHA-256:95e63417398d9a7d00d10c8059b3868fc6db9b861fef95c5b5416df377436e70",
+              "size": "341118280"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-083aad99-v2"
+              "version": "idf-release_v5.3-12938e51-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-083aad99-v2",
+          "version": "idf-release_v5.3-12938e51-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-083aad99-v2.zip",
-              "checksum": "SHA-256:4c6cae2e34df7e85a149615a6c18169777faf9460f708fc51d93616a117973c2",
-              "size": "341175680"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-12938e51-v1.zip",
+              "checksum": "SHA-256:d96d3b1a52c3a23dcc41ba7c72a8beadf05933ef2f533866189c59440b3c56b5",
+              "size": "341111000"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 2f061cb
esp-idf: release/v5.3 12938e511e
arduino: master 9eb7dc6f
tinyusb: master 7c1afa837
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.16.0
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
espressif__esp32-camera:
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
```
