### PR TITLE
ci(dangerjs): Fix and update settings

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -20,5 +20,8 @@ jobs:
         uses: espressif/shared-github-dangerjs@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          instructions-cla-link: "https://cla-assistant.io/espressif/arduino-esp32"
+          instructions-contributions-file: "docs/en/contributing.rst"
           rule-max-commits: "false"
           commit-messages-min-summary-length: "10"


### PR DESCRIPTION
## Description of Change

DangerJS options were not being applied because settings were passed as `env`. Also added links to CLA and Contribution Guides.

## Tests scenarios

Fork
