### PR TITLE
feat(matter): adds esp_matter:: namespace to attribute_t

### DIFF
--- a/libraries/Matter/src/MatterEndPoint.h
+++ b/libraries/Matter/src/MatterEndPoint.h
@@ -38,7 +38,7 @@ public:
   }
 
   // helper functions for attribute manipulation
-  attribute_t *getAttribute(uint32_t cluster_id, uint32_t attribute_id) {
+  esp_matter::attribute_t *getAttribute(uint32_t cluster_id, uint32_t attribute_id) {
     if (endpoint_id == 0) {
       log_e("Endpoint ID is not set");
       return NULL;
@@ -53,7 +53,7 @@ public:
       log_e("Cluster [%d] not found", cluster_id);
       return NULL;
     }
-    attribute_t *attribute = attribute::get(cluster, attribute_id);
+    esp_matter::attribute_t *attribute = attribute::get(cluster, attribute_id);
     if (attribute == NULL) {
       log_e("Attribute [%d] not found", attribute_id);
       return NULL;
@@ -63,7 +63,7 @@ public:
 
   // get the value of an attribute from its cluster id and attribute it
   bool getAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
-    attribute_t *attribute = getAttribute(cluster_id, attribute_id);
+    esp_matter::attribute_t *attribute = getAttribute(cluster_id, attribute_id);
     if (attribute == NULL) {
       return false;
     }
@@ -77,7 +77,7 @@ public:
 
   // set the value of an attribute from its cluster id and attribute it
   bool setAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
-    attribute_t *attribute = getAttribute(cluster_id, attribute_id);
+    esp_matter::attribute_t *attribute = getAttribute(cluster_id, attribute_id);
     if (attribute == NULL) {
       return false;
     }

--- a/libraries/Matter/src/MatterEndpoints/MatterColorLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterColorLight.cpp
@@ -194,7 +194,7 @@ bool MatterColorLight::begin(bool initialState, espHsvColor_t _colorHSV) {
 
   /* Mark deferred persistence for some attributes that might be changed rapidly */
   cluster_t *level_control_cluster = cluster::get(endpoint, LevelControl::Id);
-  attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
+  esp_matter::attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
   attribute::set_deferred_persistence(current_level_attribute);
 
   started = true;
@@ -220,7 +220,7 @@ bool MatterColorLight::setOnOff(bool newState) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, OnOff::Id);
-  attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
@@ -271,7 +271,7 @@ bool MatterColorLight::setColorHSV(espHsvColor_t _hsvColor) {
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, ColorControl::Id);
   // update hue
-  attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::CurrentHue::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::CurrentHue::Id);
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
   if (val.val.u8 != colorHSV.h) {

--- a/libraries/Matter/src/MatterEndpoints/MatterColorTemperatureLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterColorTemperatureLight.cpp
@@ -122,11 +122,11 @@ bool MatterColorTemperatureLight::begin(bool initialState, uint8_t brightness, u
 
   /* Mark deferred persistence for some attributes that might be changed rapidly */
   cluster_t *level_control_cluster = cluster::get(endpoint, LevelControl::Id);
-  attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
+  esp_matter::attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
   attribute::set_deferred_persistence(current_level_attribute);
 
   cluster_t *color_control_cluster = cluster::get(endpoint, ColorControl::Id);
-  attribute_t *color_temp_attribute = attribute::get(color_control_cluster, ColorControl::Attributes::ColorTemperatureMireds::Id);
+  esp_matter::attribute_t *color_temp_attribute = attribute::get(color_control_cluster, ColorControl::Attributes::ColorTemperatureMireds::Id);
   attribute::set_deferred_persistence(color_temp_attribute);
 
   started = true;
@@ -152,7 +152,7 @@ bool MatterColorTemperatureLight::setOnOff(bool newState) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, OnOff::Id);
-  attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
@@ -193,7 +193,7 @@ bool MatterColorTemperatureLight::setBrightness(uint8_t newBrightness) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, LevelControl::Id);
-  attribute_t *attribute = attribute::get(cluster, LevelControl::Attributes::CurrentLevel::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, LevelControl::Attributes::CurrentLevel::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
@@ -224,7 +224,7 @@ bool MatterColorTemperatureLight::setColorTemperature(uint16_t newTemperature) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, ColorControl::Id);
-  attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::ColorTemperatureMireds::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::ColorTemperatureMireds::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);

--- a/libraries/Matter/src/MatterEndpoints/MatterDimmableLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterDimmableLight.cpp
@@ -101,7 +101,7 @@ bool MatterDimmableLight::begin(bool initialState, uint8_t brightness) {
 
   /* Mark deferred persistence for some attributes that might be changed rapidly */
   cluster_t *level_control_cluster = cluster::get(endpoint, LevelControl::Id);
-  attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
+  esp_matter::attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
   attribute::set_deferred_persistence(current_level_attribute);
 
   started = true;
@@ -127,7 +127,7 @@ bool MatterDimmableLight::setOnOff(bool newState) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, OnOff::Id);
-  attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
@@ -168,7 +168,7 @@ bool MatterDimmableLight::setBrightness(uint8_t newBrightness) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, LevelControl::Id);
-  attribute_t *attribute = attribute::get(cluster, LevelControl::Attributes::CurrentLevel::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, LevelControl::Attributes::CurrentLevel::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);

--- a/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.cpp
@@ -214,7 +214,7 @@ bool MatterEnhancedColorLight::begin(bool initialState, espHsvColor_t _colorHSV,
 
   /* Mark deferred persistence for some attributes that might be changed rapidly */
   cluster_t *level_control_cluster = cluster::get(endpoint, LevelControl::Id);
-  attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
+  esp_matter::attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
   attribute::set_deferred_persistence(current_level_attribute);
 
   started = true;
@@ -240,7 +240,7 @@ bool MatterEnhancedColorLight::setOnOff(bool newState) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, OnOff::Id);
-  attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
@@ -281,7 +281,7 @@ bool MatterEnhancedColorLight::setBrightness(uint8_t newBrightness) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, LevelControl::Id);
-  attribute_t *attribute = attribute::get(cluster, LevelControl::Attributes::CurrentLevel::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, LevelControl::Attributes::CurrentLevel::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
@@ -312,7 +312,7 @@ bool MatterEnhancedColorLight::setColorTemperature(uint16_t newTemperature) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, ColorControl::Id);
-  attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::ColorTemperatureMireds::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::ColorTemperatureMireds::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
@@ -353,7 +353,7 @@ bool MatterEnhancedColorLight::setColorHSV(espHsvColor_t _hsvColor) {
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, ColorControl::Id);
   // update hue
-  attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::CurrentHue::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, ColorControl::Attributes::CurrentHue::Id);
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);
   if (val.val.u8 != colorHSV.h) {

--- a/libraries/Matter/src/MatterEndpoints/MatterOnOffLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterOnOffLight.cpp
@@ -108,7 +108,7 @@ bool MatterOnOffLight::setOnOff(bool newState) {
 
   endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
   cluster_t *cluster = cluster::get(endpoint, OnOff::Id);
-  attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
+  esp_matter::attribute_t *attribute = attribute::get(cluster, OnOff::Attributes::OnOff::Id);
 
   esp_matter_attr_val_t val = esp_matter_invalid(NULL);
   attribute::get_val(attribute, &val);


### PR DESCRIPTION
## Description of Change

When compiling an Arduino project that uses the Matter library (v3.1.0) together with M5Unified (v0.2.2) on M5Stack Atom, I encounter a compilation error caused by an ambiguous reference to attribute_t. It appears that the Matter library defines attribute_t in esp_matter_core.h, and M5Unified (via M5GFX) also declares attribute_t as an enum in enum.hpp.

This PR fixes this issue by forcing the namespace `esp_matter::` into `attribute_t` matter type name.

## Tests scenarios
Using M5Stack Libraries:

``` cpp
#include <M5Unified.h>
#include <Matter.h>

void setup() {
  M5.begin();
  Matter.begin();

  // ...
}

void loop() {
  M5.update();
  // ...
}
```



## Related links
Fixes #10804 
