### PR TITLE
Add #ifndef for USB_VID and USB_PID for esp32s3 board variant

### DIFF
--- a/variants/esp32s3/pins_arduino.h
+++ b/variants/esp32s3/pins_arduino.h
@@ -4,8 +4,12 @@
 #include <stdint.h>
 #include "soc/soc_caps.h"
 
+#ifndef USB_VID
 #define USB_VID 0x303a
+#endif
+#ifndef USB_PID
 #define USB_PID 0x1001
+#endif
 
 // Some boards have too low voltage on this pin (board design bug)
 // Use different pin with 3V and connect with 48


### PR DESCRIPTION
## Description of Change
This adds `#ifndef`s for the `USB_VID` and `USB_PID` `#define`s for the `esp32s3` board variant. By adding `#ifndef`s, this allows the end user to customize the Vendor ID and Product ID that the device shows up as.

Tangentially: Should this be added to other variants? To all variants? Some of the variants also define `USB_MANUFACTURER`, `USB_PRODUCT` and/or `USB_SERIAL` with no way to override them. Should those also get `#ifndef`s?

## Tests scenarios
I tested this with an ESP32-S3 (supermini) by including/excluding different combinations of `-DUSB_VID=0x1234` and `-DUSB_PID=0x5678` build flags