### PR TITLE
fix(platform): Improve firmware size calculation

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -185,8 +185,8 @@ recipe.output.save_file={build.project_name}.{build.variant}.bin
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
-recipe.size.regex=^(?:\.iram0\.text|\.iram0\.vectors|\.dram0\.data|\.flash\.text|\.flash\.rodata|)\s+([0-9]+).*
-recipe.size.regex.data=^(?:\.dram0\.data|\.dram0\.bss|\.noinit)\s+([0-9]+).*
+recipe.size.regex=^(?:\.iram0\.text|\.iram0\.vectors|\.dram0\.data|\.dram1\.data|\.flash\.text|\.flash\.rodata|\.flash\.appdesc|\.flash\.init_array|\.eh_frame|)\s+([0-9]+).*
+recipe.size.regex.data=^(?:\.dram0\.data|\.dram0\.bss|\.dram1\.data|\.dram1\.bss|\.noinit)\s+([0-9]+).*
 
 ## Required discoveries and monitors
 ## ---------------------------------


### PR DESCRIPTION
It will still have a couple of hundred of bytes difference, which will have to be fixed in another way, but that is much better than having a couple of hundreds of KB difference. Actual fix will be to write out own size tool and report the actual file size and better calculate the RAM usage by using `esp-idf-size` or similar.
