### PR TITLE
IDF release/v5.3

### DIFF
--- a/libraries/RainMaker/examples/RMakerCustomAirCooler/ci.json
+++ b/libraries/RainMaker/examples/RMakerCustomAirCooler/ci.json
@@ -1,4 +1,7 @@
 {
+  "targets": {
+    "esp32": false
+  },
   "fqbn_append": "PartitionScheme=rainmaker_4MB",
   "requires": [
     "CONFIG_ESP_RMAKER_WORK_QUEUE_TASK_STACK=[1-9][0-9]*"

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-cfea4f7c-v1"
+              "version": "idf-release_v5.3-d7d3eb3f-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-cfea4f7c-v1",
+          "version": "idf-release_v5.3-d7d3eb3f-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-cfea4f7c-v1.zip",
-              "checksum": "SHA-256:1099291229a9be453c771c5867b8487a0266db9246b672417337b8f511d7f820",
-              "size": "341118284"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
+              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
+              "size": "341173802"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-d7d3eb3f-v1"
+              "version": "idf-release_v5.3-adf53196-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-d7d3eb3f-v1",
+          "version": "idf-release_v5.3-adf53196-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d7d3eb3f-v1.zip",
-              "checksum": "SHA-256:0bd88ab3601e8473b8afcc0178598f455da6c8666bcc8e31f15451d6a02972de",
-              "size": "341173802"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-adf53196-v1.zip",
+              "checksum": "SHA-256:e89326897786646a8e05fce9a1ae9bd2be5c7bc9e88877ffbd9b60fabbbda9f9",
+              "size": "340711238"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 2f061cb
esp-idf: release/v5.3 d7d3eb3f0a
arduino: master c23c7867
tinyusb: master 249556360
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.5
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.16.1
espressif__eppp_link: 0.2.0
espressif__esp-dsp: 1.5.2
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
