### PR TITLE
fix(i2s): Check if pin is used before clearing bus

### DIFF
--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -719,13 +719,13 @@ bool I2SClass::end() {
 #if SOC_I2S_SUPPORTS_TDM
     case I2S_MODE_TDM:
 #endif
-      if(_mclk >= 0) {
+      if (_mclk >= 0) {
         perimanClearPinBus(_mclk);
       }
-      if(_bclk >= 0) {
+      if (_bclk >= 0) {
         perimanClearPinBus(_bclk);
       }
-      if(_ws >= 0) {
+      if (_ws >= 0) {
         perimanClearPinBus(_ws);
       }
       if (_dout >= 0) {

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -719,9 +719,15 @@ bool I2SClass::end() {
 #if SOC_I2S_SUPPORTS_TDM
     case I2S_MODE_TDM:
 #endif
-      perimanClearPinBus(_mclk);
-      perimanClearPinBus(_bclk);
-      perimanClearPinBus(_ws);
+      if(_mclk >= 0) {
+        perimanClearPinBus(_mclk);
+      }
+      if(_bclk >= 0) {
+        perimanClearPinBus(_bclk);
+      }
+      if(_ws >= 0) {
+        perimanClearPinBus(_ws);
+      }
       if (_dout >= 0) {
         perimanClearPinBus(_dout);
       }


### PR DESCRIPTION
## Description of Change
This PR fixes error `[esp32-hal-periman.c:122] perimanSetPinBus(): Invalid pin: 255`, when some of the pins are not used (-1) but the bus clear was called anyway, so it was marked as error Invalid pin.

## Tests scenarios

## Related links

Closes #10828 