### PR TITLE
fix(zigbee): Fixes in handlers, destructors and co2 sensor delta reporting

### DIFF
--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -29,7 +29,6 @@ ZigbeeCore::ZigbeeCore() {
     }
   }
 }
-ZigbeeCore::~ZigbeeCore() {}
 
 //forward declaration
 static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id, const void *message);

--- a/libraries/Zigbee/src/ZigbeeCore.h
+++ b/libraries/Zigbee/src/ZigbeeCore.h
@@ -86,7 +86,7 @@ private:
 
 public:
   ZigbeeCore();
-  ~ZigbeeCore();
+  ~ZigbeeCore() {}
 
   std::list<ZigbeeEP *> ep_objects;
 

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -27,8 +27,6 @@ ZigbeeEP::ZigbeeEP(uint8_t endpoint) {
   }
 }
 
-ZigbeeEP::~ZigbeeEP() {}
-
 void ZigbeeEP::setVersion(uint8_t version) {
   _ep_config.app_device_version = version;
 }

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -55,7 +55,7 @@ typedef enum {
 class ZigbeeEP {
 public:
   ZigbeeEP(uint8_t endpoint = 10);
-  ~ZigbeeEP();
+  ~ZigbeeEP() {}
 
   // Set ep config and cluster list
   void setEpConfig(esp_zb_endpoint_config_t ep_config, esp_zb_cluster_list_t *cluster_list) {

--- a/libraries/Zigbee/src/ZigbeeHandlers.cpp
+++ b/libraries/Zigbee/src/ZigbeeHandlers.cpp
@@ -29,9 +29,11 @@ static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id,
 static esp_err_t zb_attribute_set_handler(const esp_zb_zcl_set_attr_value_message_t *message) {
   if (!message) {
     log_e("Empty message");
+    return ESP_FAIL;
   }
   if (message->info.status != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Received message: error status(%d)", message->info.status);
+    return ESP_ERR_INVALID_ARG;
   }
 
   log_v(
@@ -55,9 +57,11 @@ static esp_err_t zb_attribute_set_handler(const esp_zb_zcl_set_attr_value_messag
 static esp_err_t zb_attribute_reporting_handler(const esp_zb_zcl_report_attr_message_t *message) {
   if (!message) {
     log_e("Empty message");
+    return ESP_FAIL;
   }
   if (message->status != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Received message: error status(%d)", message->status);
+    return ESP_ERR_INVALID_ARG;
   }
   log_v(
     "Received report from address(0x%x) src endpoint(%d) to dst endpoint(%d) cluster(0x%x)", message->src_address.u.short_addr, message->src_endpoint,
@@ -75,9 +79,11 @@ static esp_err_t zb_attribute_reporting_handler(const esp_zb_zcl_report_attr_mes
 static esp_err_t zb_cmd_read_attr_resp_handler(const esp_zb_zcl_cmd_read_attr_resp_message_t *message) {
   if (!message) {
     log_e("Empty message");
+    return ESP_FAIL;
   }
   if (message->info.status != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Received message: error status(%d)", message->info.status);
+    return ESP_ERR_INVALID_ARG;
   }
   log_v(
     "Read attribute response: from address(0x%x) src endpoint(%d) to dst endpoint(%d) cluster(0x%x)", message->info.src_address.u.short_addr,
@@ -109,9 +115,11 @@ static esp_err_t zb_cmd_read_attr_resp_handler(const esp_zb_zcl_cmd_read_attr_re
 static esp_err_t zb_configure_report_resp_handler(const esp_zb_zcl_cmd_config_report_resp_message_t *message) {
   if (!message) {
     log_e("Empty message");
+    return ESP_FAIL;
   }
   if (message->info.status != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Received message: error status(%d)", message->info.status);
+    return ESP_ERR_INVALID_ARG;
   }
   esp_zb_zcl_config_report_resp_variable_t *variable = message->variables;
   while (variable) {
@@ -127,9 +135,11 @@ static esp_err_t zb_configure_report_resp_handler(const esp_zb_zcl_cmd_config_re
 static esp_err_t zb_cmd_default_resp_handler(const esp_zb_zcl_cmd_default_resp_message_t *message) {
   if (!message) {
     log_e("Empty message");
+    return ESP_FAIL;
   }
   if (message->info.status != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Received message: error status(%d)", message->info.status);
+    return ESP_ERR_INVALID_ARG;
   }
   log_v(
     "Received default response: from address(0x%x), src_endpoint(%d) to dst_endpoint(%d), cluster(0x%x) with status 0x%x",

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -56,9 +56,11 @@ void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max
   reporting_info.u.send_info.max_interval = max_interval;
   reporting_info.u.send_info.def_min_interval = min_interval;
   reporting_info.u.send_info.def_max_interval = max_interval;
-  reporting_info.u.send_info.delta.u16 = delta;
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
+  float delta_f = delta / 1000000.0f;
+  memcpy(&reporting_info.u.send_info.delta.s32, &delta_f, sizeof(float));
+
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_update_reporting_info(&reporting_info);
   esp_zb_lock_release();

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.h
@@ -39,7 +39,7 @@ typedef struct zigbee_carbon_dioxide_sensor_cfg_s {
 class ZigbeeCarbonDioxideSensor : public ZigbeeEP {
 public:
   ZigbeeCarbonDioxideSensor(uint8_t endpoint);
-  ~ZigbeeCarbonDioxideSensor();
+  ~ZigbeeCarbonDioxideSensor() {}
 
   // Set the carbon dioxide value in ppm
   void setCarbonDioxide(float carbon_dioxide);

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
@@ -12,7 +12,7 @@
 class ZigbeeColorDimmableLight : public ZigbeeEP {
 public:
   ZigbeeColorDimmableLight(uint8_t endpoint);
-  ~ZigbeeColorDimmableLight();
+  ~ZigbeeColorDimmableLight() {}
 
   void onLightChange(void (*callback)(bool, uint8_t, uint8_t, uint8_t, uint8_t)) {
     _on_light_change = callback;

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.h
@@ -12,7 +12,7 @@
 class ZigbeeColorDimmerSwitch : public ZigbeeEP {
 public:
   ZigbeeColorDimmerSwitch(uint8_t endpoint);
-  ~ZigbeeColorDimmerSwitch();
+  ~ZigbeeColorDimmerSwitch() {}
 
   // methods to control the color dimmable light
   void lightToggle();

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.h
@@ -67,7 +67,7 @@ typedef struct zigbee_dimmable_light_cfg_s {
 class ZigbeeDimmableLight : public ZigbeeEP {
 public:
   ZigbeeDimmableLight(uint8_t endpoint);
-  ~ZigbeeDimmableLight();
+  ~ZigbeeDimmableLight() {}
 
   void onLightChange(void (*callback)(bool, uint8_t)) {
     _on_light_change = callback;

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.h
@@ -39,7 +39,7 @@ typedef struct zigbee_flow_sensor_cfg_s {
 class ZigbeeFlowSensor : public ZigbeeEP {
 public:
   ZigbeeFlowSensor(uint8_t endpoint);
-  ~ZigbeeFlowSensor();
+  ~ZigbeeFlowSensor() {}
 
   // Set the flow value in 0,1 m3/h
   void setFlow(float value);

--- a/libraries/Zigbee/src/ep/ZigbeeLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeLight.h
@@ -12,7 +12,7 @@
 class ZigbeeLight : public ZigbeeEP {
 public:
   ZigbeeLight(uint8_t endpoint);
-  ~ZigbeeLight();
+  ~ZigbeeLight() {}
 
   // Use to set a cb function to be called on light change
   void onLightChange(void (*callback)(bool)) {

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.h
@@ -39,7 +39,7 @@ typedef struct zigbee_occupancy_sensor_cfg_s {
 class ZigbeeOccupancySensor : public ZigbeeEP {
 public:
   ZigbeeOccupancySensor(uint8_t endpoint);
-  ~ZigbeeOccupancySensor();
+  ~ZigbeeOccupancySensor() {}
 
   // Set the occupancy value. True for occupied, false for unoccupied
   void setOccupancy(bool occupied);

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
@@ -39,7 +39,7 @@ typedef struct zigbee_pressure_sensor_cfg_s {
 class ZigbeePressureSensor : public ZigbeeEP {
 public:
   ZigbeePressureSensor(uint8_t endpoint);
-  ~ZigbeePressureSensor();
+  ~ZigbeePressureSensor() {}
 
   // Set the pressure value in 1 hPa
   void setPressure(int16_t value);

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.h
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.h
@@ -12,7 +12,7 @@
 class ZigbeeSwitch : public ZigbeeEP {
 public:
   ZigbeeSwitch(uint8_t endpoint);
-  ~ZigbeeSwitch();
+  ~ZigbeeSwitch() {}
 
   // methods to control the on/off light
   void lightToggle();

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.h
@@ -12,7 +12,7 @@
 class ZigbeeTempSensor : public ZigbeeEP {
 public:
   ZigbeeTempSensor(uint8_t endpoint);
-  ~ZigbeeTempSensor();
+  ~ZigbeeTempSensor() {}
 
   // Set the temperature value in 0,01°C
   void setTemperature(float value);

--- a/libraries/Zigbee/src/ep/ZigbeeThermostat.h
+++ b/libraries/Zigbee/src/ep/ZigbeeThermostat.h
@@ -32,7 +32,7 @@
 class ZigbeeThermostat : public ZigbeeEP {
 public:
   ZigbeeThermostat(uint8_t endpoint);
-  ~ZigbeeThermostat();
+  ~ZigbeeThermostat() {}
 
   void onTempRecieve(void (*callback)(float)) {
     _on_temp_recieve = callback;


### PR DESCRIPTION
## Description of Change
This PR fixes:

- CO2 sensor delta value in reporting to be correct. (float deltas will be supported in upcoming esp-zigbee-sdk version 1.6.2)
- Fixed undeclared destructors for all EPs -> declared empty destructors as they are not used.
- Added returns in Zigbee Handlers to avoid processing empty or failed messages.

## Tests scenarios
Tested locally.

## Related links
