### PR TITLE
Bugfix/include order

### DIFF
--- a/cores/esp32/Arduino.h
+++ b/cores/esp32/Arduino.h
@@ -33,13 +33,16 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
-#include "esp32-hal.h"
 #include "esp8266-compat.h"
 #include "soc/gpio_reg.h"
 
 #include "stdlib_noniso.h"
 #include "binary.h"
 #include "extra_attr.h"
+
+#include "pins_arduino.h"
+#include "io_pin_remap.h"
+#include "esp32-hal.h"
 
 #define PI         3.1415926535897932384626433832795
 #define HALF_PI    1.5707963267948966192313216916398
@@ -248,8 +251,4 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);
 
 #endif /* __cplusplus */
-
-#include "pins_arduino.h"
-#include "io_pin_remap.h"
-
 #endif /* _ESP32_CORE_ARDUINO_H_ */

--- a/cores/esp32/FirmwareMSC.cpp
+++ b/cores/esp32/FirmwareMSC.cpp
@@ -19,8 +19,8 @@
 #include "esp_partition.h"
 #include "esp_ota_ops.h"
 #include "esp_image_format.h"
-#include "esp32-hal.h"
 #include "pins_arduino.h"
+#include "esp32-hal.h"
 #include "firmware_msc_fat.h"
 #include "spi_flash_mmap.h"
 

--- a/cores/esp32/esp32-hal-gpio.h
+++ b/cores/esp32/esp32-hal-gpio.h
@@ -24,9 +24,9 @@
 extern "C" {
 #endif
 
+#include "pins_arduino.h"
 #include "esp32-hal.h"
 #include "soc/soc_caps.h"
-#include "pins_arduino.h"
 #include "driver/gpio.h"
 
 #if (CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3)


### PR DESCRIPTION
## Description of Change
The PR #10128 has added `RGB_BUILTIN_LED_COLOR_ORDER` as a possible parameter for RGB LED writing function.
There is an issue with the include order.

`cores/esp32/esp32-hal-rgb-led.h` shall receive `RGB_BUILTIN_LED_COLOR_ORDER` from `variants/lolin_s3_min/pins_arduino.h` and do not modify it in case it is already defined.

But there are a few places where the include order is `esp-hal.h` first and latter `pins_arduino.h`. 
Given that `esp-hal.h` includes `esp32-hal-rgb-led.h` this cases a warning as error:
`pins_arduino.h:17: error: "RGB_BUILTIN_LED_COLOR_ORDER" redefined`

## Tests scenarios
Using Examples->ESP32->GPIO->BlinkRGB.ino  + lolin_s3_mini board

## Related links
Fixes #10822 