### PR TITLE
docs(discord): Replace Gitter links with Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Arduino ESP32 Gitter Channel
-    url: https://gitter.im/espressif/arduino-esp32
-    about: Community channel for questions and help
+  - name: Arduino Core for Espressif Discord Server
+    url: https://discord.gg/8xY6e9crwv
+    about: Community Discord server for questions and help
   - name: ESP32 Forum - Arduino
     url: https://esp32.com/viewforum.php?f=19
     about: Official Forum for questions

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![External Libraries Test](https://img.shields.io/github/actions/workflow/status/espressif/arduino-esp32/lib.yml?branch=master&event=schedule&label=External%20Libraries%20Test)](https://github.com/espressif/arduino-esp32/blob/gh-pages/LIBRARIES_TEST.md)
 [![Runtime Tests](https://github.com/espressif/arduino-esp32/blob/gh-pages/runtime-tests-results/badge.svg)](https://github.com/espressif/arduino-esp32/actions/workflows/tests_results.yml)
 
-### Need help or have a question? Join the chat at [Gitter](https://gitter.im/espressif/arduino-esp32) or [open a new Discussion](https://github.com/espressif/arduino-esp32/discussions)
+### Need help or have a question? Join the chat at [Discord](https://discord.gg/8xY6e9crwv) or [open a new Discussion](https://github.com/espressif/arduino-esp32/discussions)
+
+[![Discord invite](https://img.shields.io/discord/1327272229427216425?logo=discord&logoColor=white&logoSize=auto&label=Discord)](https://discord.gg/8xY6e9crwv)
 
 ## Contents
 

--- a/docs/en/getting_started.rst
+++ b/docs/en/getting_started.rst
@@ -102,7 +102,7 @@ Here are some community channels where you may find information and ask for some
 - `ESP32 Forum`_: Official Espressif Forum.
 - `ESP32 Forum - Arduino`_: Official Espressif Forum for Arduino related discussions.
 - `ESP32 Forum - Hardware`_: Official Espressif Forum for Hardware related discussions.
-- `Gitter`_
+- `Arduino Core for Espressif (Discord)`_: Official Espressif Discord channel for the Arduino Core.
 - `Espressif MCUs (Discord)`_
 - `ESP32 on Reddit`_
 
@@ -153,7 +153,7 @@ Resources
 .. _ESP32 Forum: https://esp32.com
 .. _ESP32 Forum - Arduino: https://esp32.com/viewforum.php?f=19
 .. _ESP32 Forum - Hardware: https://esp32.com/viewforum.php?f=12
-.. _Gitter: https://gitter.im/espressif/arduino-esp32
+.. _Arduino Core for Espressif (Discord): https://discord.gg/8xY6e9crwv
 .. _Adafruit (Discord): https://discord.gg/adafruit
-.. _Espressif MCUs (Discord): https://discord.gg/nKxMTnkD
+.. _Espressif MCUs (Discord): https://discord.com/invite/XqnZPbF
 .. _ESP32 on Reddit: https://www.reddit.com/r/esp32


### PR DESCRIPTION
## Description of Change

Replace Gitter with Discord in documentation.

