### PR TITLE
IDF master

### DIFF
--- a/.github/scripts/on-push.sh
+++ b/.github/scripts/on-push.sh
@@ -90,6 +90,7 @@ if [ "$BUILD_LOG" -eq 1 ]; then
 fi
 
 #build sketches for different targets
+build "esp32c5" "$CHUNK_INDEX" "$CHUNKS_CNT" "$BUILD_LOG" "$LOG_LEVEL" "$SKETCHES_FILE" "${SKETCHES_ESP32[@]}"
 build "esp32p4" "$CHUNK_INDEX" "$CHUNKS_CNT" "$BUILD_LOG" "$LOG_LEVEL" "$SKETCHES_FILE" "${SKETCHES_ESP32[@]}"
 build "esp32s3" "$CHUNK_INDEX" "$CHUNKS_CNT" "$BUILD_LOG" "$LOG_LEVEL" "$SKETCHES_FILE" "${SKETCHES_ESP32[@]}"
 build "esp32s2" "$CHUNK_INDEX" "$CHUNKS_CNT" "$BUILD_LOG" "$LOG_LEVEL" "$SKETCHES_FILE" "${SKETCHES_ESP32[@]}"

--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -156,6 +156,7 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
             esp32c6_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32h2_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32p4_opts=$(echo "PSRAM=enabled,USBMode=default,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32c5_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
 
             # Select the common part of the FQBN based on the target.  The rest will be
             # appended depending on the passed options.
@@ -190,6 +191,10 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
                 "esp32p4")
                     [ -n "${options:-$esp32p4_opts}" ] && opt=":${options:-$esp32p4_opts}"
                     fqbn="espressif:esp32:esp32p4$opt"
+                ;;
+                "esp32c5")
+                    [ -n "${options:-$esp32c5_opts}" ] && opt=":${options:-$esp32c5_opts}"
+                    fqbn="espressif:esp32:esp32c5$opt"
                 ;;
                 *)
                     echo "ERROR: Invalid chip: $target"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,6 +51,7 @@ on:
       - "variants/esp32c3/**/*"
       - "variants/esp32c6/**/*"
       - "variants/esp32h2/**/*"
+      - "variants/esp32c5/**/*"
 
 concurrency:
   group: build-${{github.event.pull_request.number || github.ref}}

--- a/boards.txt
+++ b/boards.txt
@@ -363,18 +363,12 @@ esp32c5.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api.ed -lzboss_stack.ed -l
 esp32c5.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
 esp32c5.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 esp32c5.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
-esp32c5.menu.ZigbeeMode.rcp=Zigbee RCP (radio co-processor)
-esp32c5.menu.ZigbeeMode.rcp.build.zigbee_mode=-DZIGBEE_MODE_RCP
-esp32c5.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api.rcp -lzboss_stack.rcp -lzboss_port.native
 esp32c5.menu.ZigbeeMode.ed_debug=Zigbee ED (end device) - Debug
 esp32c5.menu.ZigbeeMode.ed_debug.build.zigbee_mode=-DZIGBEE_MODE_ED
 esp32c5.menu.ZigbeeMode.ed_debug.build.zigbee_libs=-lesp_zb_api.ed.debug -lzboss_stack.ed.debug -lzboss_port.native.debug
 esp32c5.menu.ZigbeeMode.zczr_debug=Zigbee ZCZR (coordinator/router) - Debug
 esp32c5.menu.ZigbeeMode.zczr_debug.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 esp32c5.menu.ZigbeeMode.zczr_debug.build.zigbee_libs=-lesp_zb_api.zczr.debug -lzboss_stack.zczr.debug -lzboss_port.native.debug
-esp32c5.menu.ZigbeeMode.rcp_debug=Zigbee RCP (radio co-processor) - Debug
-esp32c5.menu.ZigbeeMode.rcp_debug.build.zigbee_mode=-DZIGBEE_MODE_RCP
-esp32c5.menu.ZigbeeMode.rcp_debug.build.zigbee_libs=-lesp_zb_api.rcp.debug -lzboss_stack.rcp.debug -lzboss_port.native.debug
 
 ##############################################################
 

--- a/boards.txt
+++ b/boards.txt
@@ -359,22 +359,22 @@ esp32c5.menu.ZigbeeMode.default.build.zigbee_mode=
 esp32c5.menu.ZigbeeMode.default.build.zigbee_libs=
 esp32c5.menu.ZigbeeMode.ed=Zigbee ED (end device)
 esp32c5.menu.ZigbeeMode.ed.build.zigbee_mode=-DZIGBEE_MODE_ED
-esp32c5.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api_ed -lesp_zb_cli_command -lzboss_stack.ed -lzboss_port
+esp32c5.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api.ed -lzboss_stack.ed -lzboss_port.native
 esp32c5.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
 esp32c5.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
-esp32c5.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api_zczr -lesp_zb_cli_command -lzboss_stack.zczr -lzboss_port
+esp32c5.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
 esp32c5.menu.ZigbeeMode.rcp=Zigbee RCP (radio co-processor)
 esp32c5.menu.ZigbeeMode.rcp.build.zigbee_mode=-DZIGBEE_MODE_RCP
-esp32c5.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api_rcp -lesp_zb_cli_command -lzboss_stack.rcp -lzboss_port
+esp32c5.menu.ZigbeeMode.rcp.build.zigbee_libs=-lesp_zb_api.rcp -lzboss_stack.rcp -lzboss_port.native
 esp32c5.menu.ZigbeeMode.ed_debug=Zigbee ED (end device) - Debug
 esp32c5.menu.ZigbeeMode.ed_debug.build.zigbee_mode=-DZIGBEE_MODE_ED
-esp32c5.menu.ZigbeeMode.ed_debug.build.zigbee_libs=-lesp_zb_api_ed.debug -lesp_zb_cli_command -lzboss_stack.ed.debug -lzboss_port.debug
+esp32c5.menu.ZigbeeMode.ed_debug.build.zigbee_libs=-lesp_zb_api.ed.debug -lzboss_stack.ed.debug -lzboss_port.native.debug
 esp32c5.menu.ZigbeeMode.zczr_debug=Zigbee ZCZR (coordinator/router) - Debug
 esp32c5.menu.ZigbeeMode.zczr_debug.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
-esp32c5.menu.ZigbeeMode.zczr_debug.build.zigbee_libs=-lesp_zb_api_zczr.debug -lesp_zb_cli_command -lzboss_stack.zczr.debug -lzboss_port.debug
+esp32c5.menu.ZigbeeMode.zczr_debug.build.zigbee_libs=-lesp_zb_api.zczr.debug -lzboss_stack.zczr.debug -lzboss_port.native.debug
 esp32c5.menu.ZigbeeMode.rcp_debug=Zigbee RCP (radio co-processor) - Debug
 esp32c5.menu.ZigbeeMode.rcp_debug.build.zigbee_mode=-DZIGBEE_MODE_RCP
-esp32c5.menu.ZigbeeMode.rcp_debug.build.zigbee_libs=-lesp_zb_api_rcp.debug -lesp_zb_cli_command -lzboss_stack.rcp.debug -lzboss_port.debug
+esp32c5.menu.ZigbeeMode.rcp_debug.build.zigbee_libs=-lesp_zb_api.rcp.debug -lzboss_stack.rcp.debug -lzboss_port.native.debug
 
 ##############################################################
 

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-0d6099ec-v1"
+              "version": "idf-master-472792eb-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-0d6099ec-v1",
+          "version": "idf-master-472792eb-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
-              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
-              "size": "405662253"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
+              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
+              "size": "405817403"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-c5865270-v4"
+              "version": "idf-master-0d6099ec-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-c5865270-v4",
+          "version": "idf-master-0d6099ec-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
-              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
-              "size": "405118469"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0d6099ec-v1.zip",
+              "checksum": "SHA-256:ff8fc228c98e9b8ff936a572b78d7d98f394355ee81c28ce8d047705f8d5d4a6",
+              "size": "405662253"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-d30e4d99-v1"
+              "version": "idf-master-5950be0d-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-d30e4d99-v1",
+          "version": "idf-master-5950be0d-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
-              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
-              "size": "408571055"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
+              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
+              "size": "408679818"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-0f0068ff-v1"
+              "version": "idf-master-d30e4d99-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-0f0068ff-v1",
+          "version": "idf-master-d30e4d99-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
-              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
-              "size": "408284906"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-d30e4d99-v1.zip",
+              "checksum": "SHA-256:cc170c8b1415dc02b0f4e4ec13c587d49a3beaf50e60051f802b5697240f95d7",
+              "size": "408571055"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-472792eb-v1"
+              "version": "idf-master-1160a86b-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-472792eb-v1",
+          "version": "idf-master-1160a86b-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-472792eb-v1.zip",
-              "checksum": "SHA-256:b319ccb826ad1e52e637d10c910ecd901474bd5cb5bf06b10d31a8eed55cf443",
-              "size": "405817403"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-1160a86b-v1.zip",
+              "checksum": "SHA-256:ab71bb61b12ad109750d4d39200c2aeaa826395f65a2c95c2012d969eb5f76a2",
+              "size": "405894668"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-5950be0d-v1"
+              "version": "idf-master-c5865270-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-5950be0d-v1",
+          "version": "idf-master-c5865270-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-5950be0d-v1.zip",
-              "checksum": "SHA-256:6124d3cc98cc2b379dafb6088c4457edf5ccc92c7b0314844d65920d1da6eae9",
-              "size": "408679818"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
+              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
+              "size": "408755498"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,27 +42,27 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-489d7a2b-v1"
+              "version": "idf-master-0f0068ff-v1"
             },
             {
               "packager": "esp32",
               "name": "xtensa-esp-elf-gcc",
-              "version": "esp-13.2.0_20240530"
+              "version": "esp-14.2.0_20241119"
             },
             {
               "packager": "esp32",
               "name": "xtensa-esp-elf-gdb",
-              "version": "14.2_20240403"
+              "version": "15.2_20241112"
             },
             {
               "packager": "esp32",
               "name": "riscv32-esp-elf-gcc",
-              "version": "esp-13.2.0_20240530"
+              "version": "esp-14.2.0_20241119"
             },
             {
               "packager": "esp32",
               "name": "riscv32-esp-elf-gdb",
-              "version": "14.2_20240403"
+              "version": "15.2_20241112"
             },
             {
               "packager": "esp32",
@@ -95,311 +95,311 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-489d7a2b-v1",
+          "version": "idf-master-0f0068ff-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-489d7a2b-v1.zip",
-              "checksum": "SHA-256:489012502218a7d30f6c312764bc8d10830a51e1db29558f15181c68373d0095",
-              "size": "341414090"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0f0068ff-v1.zip",
+              "checksum": "SHA-256:abfbca04b43be21413778dfe406ab1420357104c8c67067ce198900926075425",
+              "size": "408284906"
             }
           ]
         },
         {
           "name": "xtensa-esp-elf-gcc",
-          "version": "esp-13.2.0_20240530",
+          "version": "esp-14.2.0_20241119",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:bce77e8480701d5a90545369d1b5848f6048eb39c0022d2446d1e33a8e127490",
-              "size": "208911713"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:b1859df334a85541ae746e1b86439f59180d87f8cf1cc04c2e770fadf9f006e9",
+              "size": "323678089"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:7c9e3c1adc733d042ed87b92daa1d6396e1b441c1755f1fa14cb88855719ba88",
-              "size": "202519931"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:7ff023033a5c00e55b9fc0a0b26d18fb0e476c24e24c5b0459bcb2e05a3729f1",
+              "size": "320064691"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:d6955e8ea6af91574bf9213b92f32ca09eb8640103446b7fa19a63cfeeec5421",
-              "size": "202206516"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:bb11dbf3ed25d4e0cc9e938749519e8236cfa2609e85742d311f1d869111805a",
+              "size": "319454139"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:3666ee74ecb693ee6488f11469802630a7b0d32608184045a4f35cb413f59e3d",
-              "size": "213304863"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:5ac611dca62ec791d413d1f417d566c444b006d2a4f97bd749b15f782d87249b",
+              "size": "328335914"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
-              "checksum": "SHA-256:948cf57b6eecc898b5f70e06ad08ba88c08b627be570ec631dfcd72f6295194a",
-              "size": "221357024"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
+              "checksum": "SHA-256:15b3e60362028eaeff9156dc82dac3f1436b4aeef3920b28d7650974d8c34751",
+              "size": "336215844"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
-              "checksum": "SHA-256:6f03fdf0cc14a7f3900ee59977f62e8626d8b7c208506e52f1fd883ac223427a",
-              "size": "199689745"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
+              "checksum": "SHA-256:45c475518735133789bacccad31f872318b7ecc0b31cc9b7924aad880034f0bf",
+              "size": "318797396"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-i686-w64-mingw32_hotfix.zip",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-i686-w64-mingw32_hotfix.zip",
-              "checksum": "SHA-256:d6b227c50e3c8e21d62502b3140e5ab74a4cb502c2b4169c36238b9858a8fb88",
-              "size": "266042967"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:b30e450e0af279783c54a9ae77c3b367dd556b78eda930a92ec7b784a74c28c8",
+              "size": "382457717"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-w64-mingw32_hotfix.zip",
-              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-x86_64-w64-mingw32_hotfix.zip",
-              "checksum": "SHA-256:155ee97b531236e6a7c763395c68ca793e55e74d2cb4d38a23057a153e01e7d0",
-              "size": "269831985"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:62ae704777d73c30689efff6e81178632a1ca44d1a2d60f4621eb997e040e028",
+              "size": "386316009"
             }
           ]
         },
         {
           "name": "xtensa-esp-elf-gdb",
-          "version": "14.2_20240403",
+          "version": "15.2_20241112",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:9d68472d4cba5cf8c2b79d94f86f92c828e76a632bd1e6be5e7706e5b304d36e",
-              "size": "31010320"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:18774349d2b1c7d7f5ba984563f7022aef4a3df4b706ed8821c53266f599343d",
+              "size": "35179121"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:bdabc3217994815fc311c4e16e588b78f6596b5ad4ffa46c80b40e982cfb1e66",
-              "size": "30954580"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:77cb3b2c85d6cfbb40b7f99eebbc2b1c3f4fe13eba20b3da798bdbbc6eb8e87c",
+              "size": "34295046"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:d54b8d703ba897b28c627da3d27106a3906dd01ba298778a67064710bc33c76d",
-              "size": "28697281"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:b87af0539de118eb9d43a4a89c8c1b0a6ab2557560015155104c44f91b5c4aa0",
+              "size": "30338727"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-i586-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:64d3bc992ed8fdec383d49e8b803ac494605a38117c8293db8da055037de96b0",
-              "size": "29890994"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-i586-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:2c7531bd390928fed479999ac9089b39a25f56ca4f4cc330db7d7a633a37405b",
+              "size": "33906121"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
-              "checksum": "SHA-256:023e74b3fda793da4bc0509b02de776ee0dad6efaaac17bef5916fb7dc9c26b9",
-              "size": "44446611"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-x86_64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-x86_64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:ba2907be9a4c22c4e418f42ec84cf57401570a71dabbe69425227114ebf351a7",
+              "size": "52502302"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
-              "checksum": "SHA-256:ea757c6bf8c25238f6d2fdcc6bbab25a1b00608a0f9e19b7ddd2f37ddbdc3fb1",
-              "size": "37021423"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-aarch64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-aarch64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:893500d6de354a6870820b9398531d8cd37d1cd85f3ae9b1f8a4c070b8048707",
+              "size": "41892363"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-i686-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:322e8d9b700dc32d8158e3dc55fb85ec55de48d0bb7789375ee39a28d5d655e2",
-              "size": "26302466"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-i686-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:328181380fccb252105c51a86071edbc5ef63e0114540edc4f8b2d62acf44916",
+              "size": "31307770"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-x86_64-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-14.2_20240403-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:a27a2fe20f192f8e0a51b8936428b4e1cf8935cfe008ee445cc49f6fc7f6db2e",
-              "size": "28366035"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/xtensa-esp-elf-gdb-15.2_20241112-x86_64-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-15.2_20241112-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:9c1949058d7aa1fa6f6f2d03173659b9f54e3c3940cbeebc1d56ae169c604ab2",
+              "size": "31420687"
             }
           ]
         },
         {
           "name": "riscv32-esp-elf-gcc",
-          "version": "esp-13.2.0_20240530",
+          "version": "esp-14.2.0_20241119",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:e7fbfffbb19dcd3764a9848a141bf44e19ad0b48e0bd1515912345c26fe52fba",
-              "size": "294346758"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:a16942465d33c7f0334c16e83bc6feb62e06eeb79cf19099293480bb8d48c0cd",
+              "size": "593721156"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:a178a895b807ed2e87d5d62153c36a6aae048581f527c0eb152f0a02b8de9571",
-              "size": "288374597"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:22486233d0e0fd58a54ae453b701f195f1432fc6f2e17085b9d6c8d5d9acefb7",
+              "size": "587879927"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:4a2f176d0f5bc8a70645975e2a08ea94145fb69b7225c5cdcbd6024a4836aaf5",
-              "size": "287737495"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:27a72d5d96cdb56dae2a1da5dfde1717c18a8c1f9a1454c8e34a8bd34abe662d",
+              "size": "586531522"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:7a6f02f1b2effafb18600bbf602818f6923fd320f000fb8659f34acbfda8812f",
-              "size": "299138540"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:b7bd6e4cd53a4c55831d48e96a3d500bfffb091bec84a30bc8c3ad687e3eb3a2",
+              "size": "597070471"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
-              "checksum": "SHA-256:a193b4f025d0d836b0a9d9cbe760af1c53e53af66fc332fe98952bc4c456dd9a",
-              "size": "305025700"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
+              "checksum": "SHA-256:5f8b571e1aedbe9f856f3bdeca6600cd5510ccff1ca102c4f001421eda560585",
+              "size": "602343061"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
-              "checksum": "SHA-256:7082dd2e2123dea5609a24092d19ac6612ae7e219df1d298de6b2f64cb4af0df",
-              "size": "285458443"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
+              "checksum": "SHA-256:a7276042a7eb2d33c2dff7167539e445c32c07d43a2c6827e86d035642503e0b",
+              "size": "578521565"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-i686-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:590bfb10576702639825581cc00c445da6e577012840a787137417e80d15f46d",
-              "size": "366573064"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:54193a97bd75205678ead8d11f00b351cfa3c2a6e5ab5d966341358b9f9422d7",
+              "size": "672055172"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:413eb9f6adf8fdaf25544d014c850fc09eb38bb93a2fc5ebd107ab1b0de1bb3a",
-              "size": "369820297"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:24c8407fa467448d394e0639436a5ede31caf1838e35e8435e19df58ebed438c",
+              "size": "677812937"
             }
           ]
         },
         {
           "name": "riscv32-esp-elf-gdb",
-          "version": "14.2_20240403",
+          "version": "15.2_20241112",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:ce004bc0bbd71b246800d2d13b239218b272a38bd528e316f21f1af2db8a4b13",
-              "size": "30707431"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:bfca245b3d84244ad3b6156496728d916ac5ccc0d7f8e048194b7eba5cdbe047",
+              "size": "35297398"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:ba10f2866c61410b88c65957274280b1a62e3bed05131654ed9b6758efe18e55",
-              "size": "30824065"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:8536da9e3093b8f25e0b5204b04ed4afea432d1fd262f2abb466016d3d750ea6",
+              "size": "34455317"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:88539db5d987f28827efac7e26080a2803b9b539342ccd2963ccfdd56d7f08f7",
-              "size": "29000575"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:33a80d5e6604bb7d08b15492b8ec84c9176245e066d0bf8aad7570786ca44081",
+              "size": "31188203"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-i586-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:0e628ee37438ab6ba05eb889a76d09e50cb98e0020a16b8e2b935c5cf19b4ed2",
-              "size": "29947521"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-i586-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:ba448ecf2c80064013eaacb0e7be514a5ef17516f49ff3e50bc41c5578b8d88e",
+              "size": "34211289"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-x86_64-apple-darwin14.tar.gz",
-              "checksum": "SHA-256:8f6bda832d70dad5860a639d55aba4237bd10cbac9f4822db1eece97357b34a9",
-              "size": "44196117"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-x86_64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-x86_64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:bdd07c54fe3216eb5c34f92cac514eb4af777c951573f186c33408c75f56bb4b",
+              "size": "52831957"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-aarch64-apple-darwin21.1.tar.gz",
-              "checksum": "SHA-256:d88b6116e86456c8480ce9bc95aed375a35c0d091f1da0a53b86be0e6ef3d320",
-              "size": "36794404"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-aarch64-apple-darwin21.1.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-aarch64-apple-darwin21.1.tar.gz",
+              "checksum": "SHA-256:9924f439ae77c3346e532a48a0d56330466c33ce1abd8d72b77f9f7f5c3b1196",
+              "size": "42227631"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-i686-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:d6e7ce05805b0d8d4dd138ad239b98a1adf8da98941867d60760eb1ae5361730",
-              "size": "26486295"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-i686-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:dcdafd30854b092671f555d844d94b0733e2ffcac8c026b4fb7b8a72ebef0016",
+              "size": "31971712"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-x86_64-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-14.2_20240403-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:5c9f211dc46daf6b96fad09d709284a0f0186fef8947d9f6edd6bca5b5ad4317",
-              "size": "27942579"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v15.2_20241112/riscv32-esp-elf-gdb-15.2_20241112-x86_64-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-15.2_20241112-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:6ec8b3a073f2c5835321b4b560f8fc56180458204d071da139ff983436ea45e5",
+              "size": "31759225"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-c5865270-v1"
+              "version": "idf-master-c5865270-v2"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-c5865270-v1",
+          "version": "idf-master-c5865270-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v1.zip",
-              "checksum": "SHA-256:9d6953fb301706541fd628399f68439c080884ede1e091fd162f57f7abfacd3a",
-              "size": "408755498"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
+              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
+              "size": "404665311"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-c5865270-v3"
+              "version": "idf-master-c5865270-v4"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-c5865270-v3",
+          "version": "idf-master-c5865270-v4",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
-              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
-              "size": "405118620"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v4.zip",
+              "checksum": "SHA-256:a864b2c7362c59907928e5559b0508f2cf3242682f7610c44dbf4c64e46019ef",
+              "size": "405118469"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-c5865270-v2"
+              "version": "idf-master-c5865270-v3"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-c5865270-v2",
+          "version": "idf-master-c5865270-v3",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v2.zip",
-              "checksum": "SHA-256:31d13acd47a8b15d26985f3b88ce6f9e55066f6dc135f704782ea32d85086c24",
-              "size": "404665311"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-c5865270-v3.zip",
+              "checksum": "SHA-256:d61e4000a92f7df55033f69cc3857dbb102f7d990e75ab39a6f4abd48d71601a",
+              "size": "405118620"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 47c4ca4
esp-idf: master 0f0068fff3
arduino: release/v3.3.x f46725e8
tinyusb: master 2d7d1070f
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.5.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.16.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.3.0
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
espressif__esp32-camera:
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.5.4
```
