### PR TITLE
Changed setTimeout() to setConnectionTimeout() in WebServer

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -430,7 +430,7 @@ void WebServer::handleClient() {
       case HC_WAIT_READ:
         // Wait for data from client to become available
         if (_currentClient.available()) {
-          _currentClient.setTimeout(HTTP_MAX_SEND_WAIT); /* / 1000 removed, WifiClient setTimeout changed to ms */
+          _currentClient.setConnectionTimeout(HTTP_MAX_SEND_WAIT);
           if (_parseRequest(_currentClient)) {
             _contentLength = CONTENT_LENGTH_NOT_SET;
             _responseCode = 0;


### PR DESCRIPTION

## Description of Change
In WebServer setTimeout() was being used instead of the new method of NetworkClient setConnectionTimeout() 

