### PR TITLE
fix(logging): incorrect FPS logging

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
@@ -216,8 +216,12 @@ static esp_err_t stream_handler(httpd_req_t *req) {
   size_t _jpg_buf_len = 0;
   uint8_t *_jpg_buf = NULL;
   char *part_buf[128];
+
   static int64_t last_frame = 0;
-  
+  if (!last_frame) {
+    last_frame = esp_timer_get_time();
+  }
+
   res = httpd_resp_set_type(req, _STREAM_CONTENT_TYPE);
   if (res != ESP_OK) {
     return res;
@@ -232,11 +236,6 @@ static esp_err_t stream_handler(httpd_req_t *req) {
 #endif
 
   while (true) {
-    
-    if (!last_frame) {
-    last_frame = esp_timer_get_time();
-    }
-
     fb = esp_camera_fb_get();
     if (!fb) {
       log_e("Camera capture failed");

--- a/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
@@ -216,12 +216,8 @@ static esp_err_t stream_handler(httpd_req_t *req) {
   size_t _jpg_buf_len = 0;
   uint8_t *_jpg_buf = NULL;
   char *part_buf[128];
-
   static int64_t last_frame = 0;
-  if (!last_frame) {
-    last_frame = esp_timer_get_time();
-  }
-
+  
   res = httpd_resp_set_type(req, _STREAM_CONTENT_TYPE);
   if (res != ESP_OK) {
     return res;
@@ -236,6 +232,11 @@ static esp_err_t stream_handler(httpd_req_t *req) {
 #endif
 
   while (true) {
+    
+    if (!last_frame) {
+    last_frame = esp_timer_get_time();
+    }
+
     fb = esp_camera_fb_get();
     if (!fb) {
       log_e("Camera capture failed");

--- a/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
@@ -281,6 +281,8 @@ static esp_err_t stream_handler(httpd_req_t *req) {
     int64_t fr_end = esp_timer_get_time();
 
     int64_t frame_time = fr_end - last_frame;
+    last_frame = fr_end;
+
     frame_time /= 1000;
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_INFO
     uint32_t avg_frame_time = ra_filter_run(&ra_filter, frame_time);


### PR DESCRIPTION
## Description of Change
The code provides fixes incorrect FPS calculation issue. The last_frame variable needs to be updated on each iteration, Immediately after computing the FPS of previous.

Before this commit - the last frame was being updated only once at the beginning of stream_handler function. The fps and avg_frame_time computation were completely wrong. This commit fixes the computation.

This commit - updates last_frame  variable on each iteration. results is correct fps calculation.

## Tests scenarios
I have tested my Pull Request on latest Arduino-esp32 core with ESP32-CAM (CAMERA_MODEL_AI_THINKER) with Core Debug Level - Verbose

## Related links
[Please provide links to related issue, PRs etc.](https://github.com/espressif/arduino-esp32/issues/10920)

(*eg. Closes #number of issue*)
Closes 1 issue ( #10920  )