### PR TITLE
FIX [UART]: ESP32-S2 UART baud rate detection CI  test case

### DIFF
--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -399,7 +399,8 @@ void auto_baudrate_test(void) {
 
   if (TEST_UART_NUM == 1) {
     selected_serial = &Serial1;
-    uart_internal_loopback(0, RX1);
+    // UART1 pins were swapped because of ESP32-P4
+    uart_internal_loopback(0, /*RX1*/ TX1);
   } else {
 #ifdef RX2
     selected_serial = &Serial2;


### PR DESCRIPTION
-----------
## Description of Change
ESP32-S2 UART CI Baud rate test case fails.
Wrong pins were used for baud rate detection test case, therefore no data was reaching UART1 RX FIFO from UART0 TX loopback.

## Tests scenarios
Tested with all SoC (ESP32/S2/S3/C3/C6/H2/P4) using https://github.com/espressif/arduino-esp32/blob/master/tests/validation/uart/uart.ino sketch.

## Related links
None