### PR TITLE
fix(ci): Disable some RainMaker examples on ESP32

### DIFF
--- a/libraries/RainMaker/examples/RMakerCustomAirCooler/ci.json
+++ b/libraries/RainMaker/examples/RMakerCustomAirCooler/ci.json
@@ -1,4 +1,7 @@
 {
+  "targets": {
+    "esp32": false
+  },
   "fqbn_append": "PartitionScheme=rainmaker_4MB",
   "requires": [
     "CONFIG_ESP_RMAKER_WORK_QUEUE_TASK_STACK=[1-9][0-9]*"

--- a/libraries/RainMaker/examples/RMakerSonoffDualR3/ci.json
+++ b/libraries/RainMaker/examples/RMakerSonoffDualR3/ci.json
@@ -1,4 +1,7 @@
 {
+  "targets": {
+    "esp32": false
+  },
   "fqbn_append": "PartitionScheme=rainmaker_4MB",
   "requires": [
     "CONFIG_ESP_RMAKER_WORK_QUEUE_TASK_STACK=[1-9][0-9]*"


### PR DESCRIPTION
Examples are causing IRAM to be overrun