### PR TITLE
Fix crash when using String::move on empty string (#10938)

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -242,7 +242,7 @@ void String::move(String &rhs) {
       // Use case: When 'reserve()' was called and the first
       // assignment/append is the return value of a function.
       if (rhs.len() && rhs.buffer()) {
-        memmove(wbuffer(), rhs.buffer(), rhs.length() + 1);
+        memmove(wbuffer(), rhs.buffer(), rhs.length());
       }
       setLen(rhs.len());
       rhs.invalidate();

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -238,8 +238,12 @@ String &String::copy(const char *cstr, unsigned int length) {
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 void String::move(String &rhs) {
   if (buffer()) {
-    if (capacity() >= rhs.len() && rhs.len() && rhs.buffer()) {
-      memmove(wbuffer(), rhs.buffer(), rhs.length() + 1);
+    if (capacity() >= rhs.len()) {
+      // Use case: When 'reserve()' was called and the first
+      // assignment/append is the return value of a function.
+      if (rhs.len() && rhs.buffer()) {
+        memmove(wbuffer(), rhs.buffer(), rhs.length() + 1);
+      }
       setLen(rhs.len());
       rhs.invalidate();
       return;

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -238,16 +238,15 @@ String &String::copy(const char *cstr, unsigned int length) {
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 void String::move(String &rhs) {
   if (buffer()) {
-    if (capacity() >= rhs.len()) {
+    if (capacity() >= rhs.len() && rhs.len() && rhs.buffer()) {
       memmove(wbuffer(), rhs.buffer(), rhs.length() + 1);
       setLen(rhs.len());
       rhs.invalidate();
       return;
-    } else {
-      if (!isSSO()) {
-        free(wbuffer());
-        setBuffer(nullptr);
-      }
+    }
+    if (!isSSO()) {
+      free(wbuffer());
+      setBuffer(nullptr);
     }
   }
   if (rhs.isSSO()) {
@@ -259,10 +258,7 @@ void String::move(String &rhs) {
   }
   setCapacity(rhs.capacity());
   setLen(rhs.len());
-  rhs.setSSO(false);
-  rhs.setCapacity(0);
-  rhs.setBuffer(nullptr);
-  rhs.setLen(0);
+  rhs.init();
 }
 #endif
 


### PR DESCRIPTION
## Description of Change
`memmove` should not be called on a `nullptr` or size of `0`.
See: https://en.cppreference.com/w/cpp/string/byte/memmove

When an empty string was handed over to move, the application would crash.
The change is just adding an extra check to see if there is something to move.

## Related links
Fixes: #10938
