### PR TITLE
Simplify calls to String::copy

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -230,7 +230,7 @@ String &String::copy(const char *cstr, unsigned int length) {
     invalidate();
     return *this;
   }
-  memmove(wbuffer(), cstr, length + 1);
+  memmove(wbuffer(), cstr, length);
   setLen(length);
   return *this;
 }

--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -226,7 +226,7 @@ bool String::changeBuffer(unsigned int maxStrLen) {
 /*********************************************/
 
 String &String::copy(const char *cstr, unsigned int length) {
-  if (!reserve(length)) {
+  if (cstr == nullptr || !reserve(length)) {
     invalidate();
     return *this;
   }
@@ -270,12 +270,7 @@ String &String::operator=(const String &rhs) {
   if (this == &rhs) {
     return *this;
   }
-  if (rhs.buffer()) {
-    copy(rhs.buffer(), rhs.len());
-  } else {
-    invalidate();
-  }
-  return *this;
+  return copy(rhs.buffer(), rhs.len());
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
@@ -295,12 +290,7 @@ String &String::operator=(StringSumHelper &&rval) {
 #endif
 
 String &String::operator=(const char *cstr) {
-  if (cstr) {
-    copy(cstr, strlen(cstr));
-  } else {
-    invalidate();
-  }
-  return *this;
+  return copy(cstr, strlen(cstr));
 }
 
 /*********************************************/


### PR DESCRIPTION
## Description of Change

A number of the same checks were done before calling `copy()` which should be done in the `copy()` function itself.

This also makes it less likely some of these checks or follow-up calls to `invalidate()` may be forgotten in future code changes.


N.B. I did not remove the pointer checks in 2 constructors where `copy()` is called, as this does save an extra call to `init()`.