### PR TITLE
fix(zigbee): Add default destructor to Window Covering and fix initialization of tm struct

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -95,7 +95,7 @@ public:
   void reportBatteryPercentage();
 
   // Set time
-  void addTimeCluster(tm time = {0}, int32_t gmt_offset = 0);  // gmt offset in seconds
+  void addTimeCluster(tm time = {}, int32_t gmt_offset = 0);  // gmt offset in seconds
   void setTime(tm time);
   void setTimezone(int32_t gmt_offset);
 

--- a/libraries/Zigbee/src/ep/ZigbeeWindowCovering.h
+++ b/libraries/Zigbee/src/ep/ZigbeeWindowCovering.h
@@ -67,7 +67,7 @@ typedef struct zigbee_window_covering_cfg_s {
 class ZigbeeWindowCovering : public ZigbeeEP {
 public:
   ZigbeeWindowCovering(uint8_t endpoint);
-  ~ZigbeeWindowCovering();
+  ~ZigbeeWindowCovering() {}
 
   // Set the callback functions for the window covering commands
   void onOpen(void (*callback)()) {


### PR DESCRIPTION
## Description of Change
This PR add a quick fix that adds a default empty destructor + fixing a warning of uninitialized members of tm structure in `addTimeCluster();` method

## Tests scenarios
Compiled without any errors and warnings

## Related links

