### PR TITLE
feat(zigbee): Add OTA client cluster support

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_OTA_Client/README.md
+++ b/libraries/Zigbee/examples/Zigbee_OTA_Client/README.md
@@ -1,0 +1,68 @@
+# Arduino-ESP32 Zigbee OTA Client + on/off light Example
+
+This example shows how to configure the Zigbee end device with OTA Client and use it as a Home Automation (HA) on/off light.
+
+# Supported Targets
+
+Currently, this example supports the following targets.
+
+| Supported Targets | ESP32-C6 | ESP32-H2 |
+| ----------------- | -------- | -------- |
+
+## Hardware Required
+
+* A USB cable for power supply and programming
+
+### Configure the Project
+
+Set the LED GPIO by changing the `LED_PIN` definition. By default, the LED_PIN is `RGB_BUILTIN`.
+By default, the `rgbLedWrite` function is used to control the LED. You can change it to digitalWrite to control a simple LED.
+
+#### Using Arduino IDE
+
+To get more information about the Espressif boards see [Espressif Development Kits](https://www.espressif.com/en/products/devkits).
+
+* Before Compile/Verify, select the correct board: `Tools -> Board`.
+* Select the End device Zigbee mode: `Tools -> Zigbee mode: Zigbee ED (end device)`
+* Select Partition Scheme for Zigbee: `Tools -> Partition Scheme: Zigbee 4MB with spiffs`
+* Select the COM port: `Tools -> Port: xxx` where the `xxx` is the detected COM port.
+* Optional: Set debug level to verbose to see all logs from Zigbee stack: `Tools -> Core Debug Level: Verbose`.
+
+## Troubleshooting
+
+If the End device flashed with this example is not connecting to the coordinator, erase the flash of the End device before flashing the example to the board. It is recommended to do this if you re-flash the coordinator.
+You can do the following:
+
+* In the Arduino IDE go to the Tools menu and set `Erase All Flash Before Sketch Upload` to `Enabled`.
+* Add to the sketch `Zigbee.factoryReset();` to reset the device and Zigbee stack.
+
+By default, the coordinator network is closed after rebooting or flashing new firmware.
+To open the network you have 2 options:
+
+* Open network after reboot by setting `Zigbee.setRebootOpenNetwork(time);` before calling `Zigbee.begin();`.
+* In application you can anytime call `Zigbee.openNetwork(time);` to open the network for devices to join.
+
+
+***Important: Make sure you are using a good quality USB cable and that you have a reliable power source***
+
+* **LED not blinking:** Check the wiring connection and the IO selection.
+* **Programming Fail:** If the programming/flash procedure fails, try reducing the serial connection speed.
+* **COM port not detected:** Check the USB cable and the USB to Serial driver installation.
+
+If the error persists, you can ask for help at the official [ESP32 forum](https://esp32.com) or see [Contribute](#contribute).
+
+## Contribute
+
+To know how to contribute to this project, see [How to contribute.](https://github.com/espressif/arduino-esp32/blob/master/CONTRIBUTING.rst)
+
+If you have any **feedback** or **issue** to report on this example/library, please open an issue or fix it by creating a new PR. Contributions are more than welcome!
+
+Before creating a new issue, be sure to try Troubleshooting and check if the same issue was already created by someone else.
+
+## Resources
+
+* Official ESP32 Forum: [Link](https://esp32.com)
+* Arduino-ESP32 Official Repository: [espressif/arduino-esp32](https://github.com/espressif/arduino-esp32)
+* ESP32-C6 Datasheet: [Link to datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf)
+* ESP32-H2 Datasheet: [Link to datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf)
+* Official ESP-IDF documentation: [ESP-IDF](https://idf.espressif.com)

--- a/libraries/Zigbee/examples/Zigbee_OTA_Client/Zigbee_OTA_Client.ino
+++ b/libraries/Zigbee/examples/Zigbee_OTA_Client/Zigbee_OTA_Client.ino
@@ -1,0 +1,112 @@
+// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @brief This example demonstrates OTA support on light bulb.
+ *
+ * The example demonstrates how to use Zigbee library to create a end device light bulb with OTA support.
+ * The light bulb is a Zigbee end device, which is controlled by a Zigbee coordinator.
+ *
+ * Proper Zigbee mode must be selected in Tools->Zigbee mode
+ * and also the correct partition scheme must be selected in Tools->Partition Scheme.
+ *
+ * Please check the README.md for instructions and more detailed description.
+ *
+ * Created by Jan Procházka (https://github.com/P-R-O-C-H-Y/)
+ */
+
+#ifndef ZIGBEE_MODE_ED
+#error "Zigbee end device mode is not selected in Tools->Zigbee mode"
+#endif
+
+#include "Zigbee.h"
+
+/* Zigbee light bulb configuration */
+#define ZIGBEE_LIGHT_ENDPOINT 1
+uint8_t led = RGB_BUILTIN;
+uint8_t button = BOOT_PIN;
+
+/* Zigbee OTA configuration */
+#define OTA_UPGRADE_RUNNING_FILE_VERSION 0x01010100 // Increment this value when the running image is updated
+#define OTA_UPGRADE_DOWNLOADED_FILE_VERSION 0x01010101 // Increment this value when the downloaded image is updated
+#define OTA_UPGRADE_HW_VERSION 0x0101 // The hardware version, this can be used to differentiate between different hardware versions
+
+ZigbeeLight zbLight = ZigbeeLight(ZIGBEE_LIGHT_ENDPOINT);
+
+/********************* RGB LED functions **************************/
+void setLED(bool value) {
+  digitalWrite(led, value);
+}
+
+/********************* Arduino functions **************************/
+void setup() {
+  Serial.begin(115200);
+
+  // Init LED and turn it OFF (if LED_PIN == RGB_BUILTIN, the rgbLedWrite() will be used under the hood)
+  pinMode(led, OUTPUT);
+  digitalWrite(led, LOW);
+
+  // Init button for factory reset
+  pinMode(button, INPUT_PULLUP);
+
+  // Optional: set Zigbee device name and model
+  zbLight.setManufacturerAndModel("Espressif", "ZBLightBulb");
+
+  // Set callback function for light change
+  zbLight.onLightChange(setLED);
+
+  // Add OTA client to the light bulb
+  zbLight.addOTAClient(OTA_UPGRADE_RUNNING_FILE_VERSION, OTA_UPGRADE_DOWNLOADED_FILE_VERSION, OTA_UPGRADE_HW_VERSION);
+
+  // Add endpoint to Zigbee Core
+  Serial.println("Adding ZigbeeLight endpoint to Zigbee Core");
+  Zigbee.addEndpoint(&zbLight);
+
+  // When all EPs are registered, start Zigbee. By default acts as ZIGBEE_END_DEVICE
+  if (!Zigbee.begin()) {
+    Serial.println("Zigbee failed to start!");
+    Serial.println("Rebooting...");
+    ESP.restart();
+  }
+  Serial.println("Connecting to network");
+  while (!Zigbee.connected()) {
+    Serial.print(".");
+    delay(100);
+  }
+  Serial.println();
+
+  // Start Zigbee OTA client query, first request is within a minute and the next requests are sent every hour automatically
+  zbLight.requestOTAUpdate();
+}
+
+void loop() {
+  // Checking button for factory reset
+  if (digitalRead(button) == LOW) {  // Push button pressed
+    // Key debounce handling
+    delay(100);
+    int startTime = millis();
+    while (digitalRead(button) == LOW) {
+      delay(50);
+      if ((millis() - startTime) > 3000) {
+        // If key pressed for more than 3secs, factory reset Zigbee and reboot
+        Serial.println("Resetting Zigbee to factory and rebooting in 1s.");
+        delay(1000);
+        Zigbee.factoryReset();
+      }
+    }
+    // Toggle light by pressing the button
+    zbLight.setLight(!zbLight.getLightState());
+  }
+  delay(100);
+}

--- a/libraries/Zigbee/examples/Zigbee_OTA_Client/Zigbee_OTA_Client.ino
+++ b/libraries/Zigbee/examples/Zigbee_OTA_Client/Zigbee_OTA_Client.ino
@@ -38,9 +38,9 @@ uint8_t led = RGB_BUILTIN;
 uint8_t button = BOOT_PIN;
 
 /* Zigbee OTA configuration */
-#define OTA_UPGRADE_RUNNING_FILE_VERSION 0x01010100 // Increment this value when the running image is updated
-#define OTA_UPGRADE_DOWNLOADED_FILE_VERSION 0x01010101 // Increment this value when the downloaded image is updated
-#define OTA_UPGRADE_HW_VERSION 0x0101 // The hardware version, this can be used to differentiate between different hardware versions
+#define OTA_UPGRADE_RUNNING_FILE_VERSION    0x01010100  // Increment this value when the running image is updated
+#define OTA_UPGRADE_DOWNLOADED_FILE_VERSION 0x01010101  // Increment this value when the downloaded image is updated
+#define OTA_UPGRADE_HW_VERSION              0x0101      // The hardware version, this can be used to differentiate between different hardware versions
 
 ZigbeeLight zbLight = ZigbeeLight(ZIGBEE_LIGHT_ENDPOINT);
 

--- a/libraries/Zigbee/examples/Zigbee_OTA_Client/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_OTA_Client/ci.json
@@ -1,0 +1,6 @@
+{
+  "fqbn_append": "PartitionScheme=zigbee,ZigbeeMode=ed",
+  "requires": [
+    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+  ]
+}

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -376,20 +376,22 @@ void ZigbeeEP::zbReadTimeCluster(const esp_zb_zcl_attribute_t *attribute) {
 //     uint8_t max_data_size; /*!< The maximum size of OTA data */
 // } esp_zb_zcl_ota_upgrade_client_variable_t;
 
-void ZigbeeEP::addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer, uint16_t image_type, uint8_t max_data_size) {
+void ZigbeeEP::addOTAClient(
+  uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer, uint16_t image_type, uint8_t max_data_size
+) {
 
   esp_zb_ota_cluster_cfg_t ota_cluster_cfg = {};
-  ota_cluster_cfg.ota_upgrade_file_version = file_version;//OTA_UPGRADE_RUNNING_FILE_VERSION;
-  ota_cluster_cfg.ota_upgrade_downloaded_file_ver = downloaded_file_ver;//OTA_UPGRADE_DOWNLOADED_FILE_VERSION;
-  ota_cluster_cfg.ota_upgrade_manufacturer = manufacturer;//OTA_UPGRADE_MANUFACTURER;
-  ota_cluster_cfg.ota_upgrade_image_type = image_type;//OTA_UPGRADE_IMAGE_TYPE;
-  
+  ota_cluster_cfg.ota_upgrade_file_version = file_version;                //OTA_UPGRADE_RUNNING_FILE_VERSION;
+  ota_cluster_cfg.ota_upgrade_downloaded_file_ver = downloaded_file_ver;  //OTA_UPGRADE_DOWNLOADED_FILE_VERSION;
+  ota_cluster_cfg.ota_upgrade_manufacturer = manufacturer;                //OTA_UPGRADE_MANUFACTURER;
+  ota_cluster_cfg.ota_upgrade_image_type = image_type;                    //OTA_UPGRADE_IMAGE_TYPE;
+
   esp_zb_attribute_list_t *ota_cluster = esp_zb_ota_cluster_create(&ota_cluster_cfg);
 
   esp_zb_zcl_ota_upgrade_client_variable_t variable_config = {};
   variable_config.timer_query = ESP_ZB_ZCL_OTA_UPGRADE_QUERY_TIMER_COUNT_DEF;
-  variable_config.hw_version = hw_version;//OTA_UPGRADE_HW_VERSION;
-  variable_config.max_data_size = max_data_size;//OTA_UPGRADE_MAX_DATA_SIZE;
+  variable_config.hw_version = hw_version;        //OTA_UPGRADE_HW_VERSION;
+  variable_config.max_data_size = max_data_size;  //OTA_UPGRADE_MAX_DATA_SIZE;
 
   uint16_t ota_upgrade_server_addr = 0xffff;
   uint8_t ota_upgrade_server_ep = 0xff;
@@ -397,36 +399,36 @@ void ZigbeeEP::addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver,
   ESP_ERROR_CHECK(esp_zb_ota_cluster_add_attr(ota_cluster, ESP_ZB_ZCL_ATTR_OTA_UPGRADE_CLIENT_DATA_ID, (void *)&variable_config));
   ESP_ERROR_CHECK(esp_zb_ota_cluster_add_attr(ota_cluster, ESP_ZB_ZCL_ATTR_OTA_UPGRADE_SERVER_ADDR_ID, (void *)&ota_upgrade_server_addr));
   ESP_ERROR_CHECK(esp_zb_ota_cluster_add_attr(ota_cluster, ESP_ZB_ZCL_ATTR_OTA_UPGRADE_SERVER_ENDPOINT_ID, (void *)&ota_upgrade_server_ep));
-  
+
   ESP_ERROR_CHECK(esp_zb_cluster_list_add_ota_cluster(_cluster_list, ota_cluster, ESP_ZB_ZCL_CLUSTER_CLIENT_ROLE));
 }
 
 static void findOTAServer(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t endpoint, void *user_ctx) {
   if (zdo_status == ESP_ZB_ZDP_STATUS_SUCCESS) {
-      esp_zb_ota_upgrade_client_query_interval_set(*((uint8_t *)user_ctx), OTA_UPGRADE_QUERY_INTERVAL);
-      esp_zb_ota_upgrade_client_query_image_req(addr, endpoint);
-      log_i("Query OTA upgrade from server endpoint: %d after %d seconds", endpoint, OTA_UPGRADE_QUERY_INTERVAL);
+    esp_zb_ota_upgrade_client_query_interval_set(*((uint8_t *)user_ctx), OTA_UPGRADE_QUERY_INTERVAL);
+    esp_zb_ota_upgrade_client_query_image_req(addr, endpoint);
+    log_i("Query OTA upgrade from server endpoint: %d after %d seconds", endpoint, OTA_UPGRADE_QUERY_INTERVAL);
   } else {
-      log_w("No OTA Server found");
+    log_w("No OTA Server found");
   }
 }
 
 void ZigbeeEP::requestOTAUpdate() {
-    esp_zb_zdo_match_desc_req_param_t req;
-    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_OTA_UPGRADE};
+  esp_zb_zdo_match_desc_req_param_t req;
+  uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_OTA_UPGRADE};
 
-    /* Match the OTA server of coordinator */
-    req.addr_of_interest = 0x0000;
-    req.dst_nwk_addr = 0x0000;
-    req.num_in_clusters = 1;
-    req.num_out_clusters = 0;
-    req.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
-    req.cluster_list = cluster_list;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    if (esp_zb_bdb_dev_joined()) {
-        esp_zb_zdo_match_cluster(&req, findOTAServer, &_endpoint);
-    }
-    esp_zb_lock_release();
+  /* Match the OTA server of coordinator */
+  req.addr_of_interest = 0x0000;
+  req.dst_nwk_addr = 0x0000;
+  req.num_in_clusters = 1;
+  req.num_out_clusters = 0;
+  req.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
+  req.cluster_list = cluster_list;
+  esp_zb_lock_acquire(portMAX_DELAY);
+  if (esp_zb_bdb_dev_joined()) {
+    esp_zb_zdo_match_cluster(&req, findOTAServer, &_endpoint);
+  }
+  esp_zb_lock_release();
 }
 
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -376,8 +376,7 @@ void ZigbeeEP::zbReadTimeCluster(const esp_zb_zcl_attribute_t *attribute) {
 //     uint8_t max_data_size; /*!< The maximum size of OTA data */
 // } esp_zb_zcl_ota_upgrade_client_variable_t;
 
-void ZigbeeEP::addOTAClient(uint32_t file_version, uint16_t manufacturer, uint16_t image_type, uint32_t downloaded_file_ver, 
-  uint16_t hw_version, uint8_t max_data_size) {
+void ZigbeeEP::addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer, uint16_t image_type, uint8_t max_data_size) {
 
   esp_zb_ota_cluster_cfg_t ota_cluster_cfg = {};
   ota_cluster_cfg.ota_upgrade_file_version = file_version;//OTA_UPGRADE_RUNNING_FILE_VERSION;

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -363,4 +363,71 @@ void ZigbeeEP::zbReadTimeCluster(const esp_zb_zcl_attribute_t *attribute) {
   }
 }
 
+// typedef struct esp_zb_ota_cluster_cfg_s {
+//     uint32_t ota_upgrade_file_version;            /*!<  The attribute indicates the file version of the running firmware image on the device */
+//     uint16_t ota_upgrade_manufacturer;            /*!<  The attribute indicates the value for the manufacturer of the device */
+//     uint16_t ota_upgrade_image_type;              /*!<  The attribute indicates the the image type of the file that the client is currently downloading */
+//     uint32_t ota_upgrade_downloaded_file_ver;     /*!<  The attribute indicates the file version of the downloaded image on the device*/
+// esp_zb_ota_cluster_cfg_t;
+
+// typedef struct esp_zb_zcl_ota_upgrade_client_variable_s {
+//     uint16_t timer_query;  /*!< The field indicates the time of querying OTA image for OTA upgrade client */
+//     uint16_t hw_version;   /*!< The hardware version */
+//     uint8_t max_data_size; /*!< The maximum size of OTA data */
+// } esp_zb_zcl_ota_upgrade_client_variable_t;
+
+void ZigbeeEP::addOTAClient(uint32_t file_version, uint16_t manufacturer, uint16_t image_type, uint32_t downloaded_file_ver, 
+  uint16_t hw_version, uint8_t max_data_size) {
+
+  esp_zb_ota_cluster_cfg_t ota_cluster_cfg = {};
+  ota_cluster_cfg.ota_upgrade_file_version = file_version;//OTA_UPGRADE_RUNNING_FILE_VERSION;
+  ota_cluster_cfg.ota_upgrade_downloaded_file_ver = downloaded_file_ver;//OTA_UPGRADE_DOWNLOADED_FILE_VERSION;
+  ota_cluster_cfg.ota_upgrade_manufacturer = manufacturer;//OTA_UPGRADE_MANUFACTURER;
+  ota_cluster_cfg.ota_upgrade_image_type = image_type;//OTA_UPGRADE_IMAGE_TYPE;
+  
+  esp_zb_attribute_list_t *ota_cluster = esp_zb_ota_cluster_create(&ota_cluster_cfg);
+
+  esp_zb_zcl_ota_upgrade_client_variable_t variable_config = {};
+  variable_config.timer_query = ESP_ZB_ZCL_OTA_UPGRADE_QUERY_TIMER_COUNT_DEF;
+  variable_config.hw_version = hw_version;//OTA_UPGRADE_HW_VERSION;
+  variable_config.max_data_size = max_data_size;//OTA_UPGRADE_MAX_DATA_SIZE;
+
+  uint16_t ota_upgrade_server_addr = 0xffff;
+  uint8_t ota_upgrade_server_ep = 0xff;
+
+  ESP_ERROR_CHECK(esp_zb_ota_cluster_add_attr(ota_cluster, ESP_ZB_ZCL_ATTR_OTA_UPGRADE_CLIENT_DATA_ID, (void *)&variable_config));
+  ESP_ERROR_CHECK(esp_zb_ota_cluster_add_attr(ota_cluster, ESP_ZB_ZCL_ATTR_OTA_UPGRADE_SERVER_ADDR_ID, (void *)&ota_upgrade_server_addr));
+  ESP_ERROR_CHECK(esp_zb_ota_cluster_add_attr(ota_cluster, ESP_ZB_ZCL_ATTR_OTA_UPGRADE_SERVER_ENDPOINT_ID, (void *)&ota_upgrade_server_ep));
+  
+  ESP_ERROR_CHECK(esp_zb_cluster_list_add_ota_cluster(_cluster_list, ota_cluster, ESP_ZB_ZCL_CLUSTER_CLIENT_ROLE));
+}
+
+static void findOTAServer(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t endpoint, void *user_ctx) {
+  if (zdo_status == ESP_ZB_ZDP_STATUS_SUCCESS) {
+      esp_zb_ota_upgrade_client_query_interval_set(*((uint8_t *)user_ctx), OTA_UPGRADE_QUERY_INTERVAL);
+      esp_zb_ota_upgrade_client_query_image_req(addr, endpoint);
+      log_i("Query OTA upgrade from server endpoint: %d after %d seconds", endpoint, OTA_UPGRADE_QUERY_INTERVAL);
+  } else {
+      log_w("No OTA Server found");
+  }
+}
+
+void ZigbeeEP::requestOTAUpdate() {
+    esp_zb_zdo_match_desc_req_param_t req;
+    uint16_t cluster_list[] = {ESP_ZB_ZCL_CLUSTER_ID_OTA_UPGRADE};
+
+    /* Match the OTA server of coordinator */
+    req.addr_of_interest = 0x0000;
+    req.dst_nwk_addr = 0x0000;
+    req.num_in_clusters = 1;
+    req.num_out_clusters = 0;
+    req.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
+    req.cluster_list = cluster_list;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    if (esp_zb_bdb_dev_joined()) {
+        esp_zb_zdo_match_cluster(&req, findOTAServer, &_endpoint);
+    }
+    esp_zb_lock_release();
+}
+
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -9,6 +9,7 @@
 
 /* Useful defines */
 #define ZB_CMD_TIMEOUT 10000  // 10 seconds
+#define OTA_UPGRADE_QUERY_INTERVAL (1 * 60) // 1 minutes
 
 #define ZB_ARRAY_LENTH(arr) (sizeof(arr) / sizeof(arr[0]))
 #define XYZ_TO_RGB(X, Y, Z, r, g, b)                                \
@@ -106,6 +107,10 @@ public:
   bool epAllowMultipleBinding() {
     return _allow_multiple_binding;
   }
+
+  void addOTAClient(uint32_t file_version = 0x01010101, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011, 
+    uint32_t downloaded_file_ver = 0x01010101, uint16_t hw_version = 0x0101, uint8_t max_data_size = 223);
+  void requestOTAUpdate();
 
   // findEndpoind may be implemented by EPs to find and bind devices
   virtual void findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req) {};

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -108,7 +108,7 @@ public:
     return _allow_multiple_binding;
   }
 
-  void addOTAClient(uint32_t file_version = 0x01010101, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011, 
+  void addOTAClient(uint32_t file_version = 0x01010100, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011, 
     uint32_t downloaded_file_ver = 0x01010101, uint16_t hw_version = 0x0101, uint8_t max_data_size = 223);
   void requestOTAUpdate();
 

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -9,7 +9,7 @@
 
 /* Useful defines */
 #define ZB_CMD_TIMEOUT 10000  // 10 seconds
-#define OTA_UPGRADE_QUERY_INTERVAL (1 * 60) // 1 minutes
+#define OTA_UPGRADE_QUERY_INTERVAL (1 * 60) // 1 hour = 60 minutes
 
 #define ZB_ARRAY_LENTH(arr) (sizeof(arr) / sizeof(arr[0]))
 #define XYZ_TO_RGB(X, Y, Z, r, g, b)                                \
@@ -108,8 +108,7 @@ public:
     return _allow_multiple_binding;
   }
 
-  void addOTAClient(uint32_t file_version = 0x01010100, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011, 
-    uint32_t downloaded_file_ver = 0x01010101, uint16_t hw_version = 0x0101, uint8_t max_data_size = 223);
+  void addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer, uint16_t image_type, uint8_t max_data_size = 223);
   void requestOTAUpdate();
 
   // findEndpoind may be implemented by EPs to find and bind devices

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -8,8 +8,8 @@
 #include <Arduino.h>
 
 /* Useful defines */
-#define ZB_CMD_TIMEOUT 10000  // 10 seconds
-#define OTA_UPGRADE_QUERY_INTERVAL (1 * 60) // 1 hour = 60 minutes
+#define ZB_CMD_TIMEOUT             10000     // 10 seconds
+#define OTA_UPGRADE_QUERY_INTERVAL (1 * 60)  // 1 hour = 60 minutes
 
 #define ZB_ARRAY_LENTH(arr) (sizeof(arr) / sizeof(arr[0]))
 #define XYZ_TO_RGB(X, Y, Z, r, g, b)                                \
@@ -119,8 +119,11 @@ public:
    * @param image_type The image type code (default: 0x1011).
    * @param max_data_size The maximum data size for OTA transfer (default and recommended: 223).
    */
-  void addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011, uint8_t max_data_size = 223);
-  /** 
+  void addOTAClient(
+    uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011,
+    uint8_t max_data_size = 223
+  );
+  /**
    * @brief Request OTA update from the server, first request is within a minute and the next requests are sent every hour automatically.
   */
   void requestOTAUpdate();

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -108,7 +108,21 @@ public:
     return _allow_multiple_binding;
   }
 
-  void addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer, uint16_t image_type, uint8_t max_data_size = 223);
+  // OTA methods
+  /**
+   * @brief Add OTA client to the Zigbee endpoint.
+   *
+   * @param file_version The current file version of the OTA client.
+   * @param downloaded_file_ver The version of the downloaded file.
+   * @param hw_version The hardware version of the device.
+   * @param manufacturer The manufacturer code (default: 0x1001).
+   * @param image_type The image type code (default: 0x1011).
+   * @param max_data_size The maximum data size for OTA transfer (default and recommended: 223).
+   */
+  void addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011, uint8_t max_data_size = 223);
+  /** 
+   * @brief Request OTA update from the server, first request is within a minute and the next requests are sent every hour automatically.
+  */
   void requestOTAUpdate();
 
   // findEndpoind may be implemented by EPs to find and bind devices

--- a/libraries/Zigbee/src/ZigbeeHandlers.cpp
+++ b/libraries/Zigbee/src/ZigbeeHandlers.cpp
@@ -5,19 +5,19 @@
 #if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
 #include "esp_ota_ops.h"
-#if CONFIG_ZB_DELTA_OTA // Delta OTA, code is prepared for this feature but not enabled by default
+#if CONFIG_ZB_DELTA_OTA  // Delta OTA, code is prepared for this feature but not enabled by default
 #include "esp_delta_ota_ops.h"
 #endif
 
 //OTA Upgrade defines and variables
-#define OTA_ELEMENT_HEADER_LEN              6       /* OTA element format header size include tag identifier and length field */
+#define OTA_ELEMENT_HEADER_LEN 6 /* OTA element format header size include tag identifier and length field */
 
 /**
  * @name Enumeration for the tag identifier denotes the type and format of the data within the element
  * @anchor esp_ota_element_tag_id_t
  */
 typedef enum esp_ota_element_tag_id_e {
-    UPGRADE_IMAGE                               = 0x0000,           /*!< Upgrade image */
+  UPGRADE_IMAGE = 0x0000, /*!< Upgrade image */
 } esp_ota_element_tag_id_t;
 
 static const esp_partition_t *s_ota_partition = NULL;
@@ -35,7 +35,6 @@ static esp_err_t zb_cmd_default_resp_handler(const esp_zb_zcl_cmd_default_resp_m
 static esp_err_t zb_window_covering_movement_resp_handler(const esp_zb_zcl_window_covering_movement_message_t *message);
 static esp_err_t zb_ota_upgrade_status_handler(const esp_zb_zcl_ota_upgrade_value_message_t *message);
 static esp_err_t zb_ota_upgrade_query_image_resp_handler(const esp_zb_zcl_ota_upgrade_query_image_resp_message_t *message);
-
 
 // Zigbee action handlers
 [[maybe_unused]]
@@ -55,9 +54,7 @@ static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id,
     case ESP_ZB_CORE_WINDOW_COVERING_MOVEMENT_CB_ID:
       ret = zb_window_covering_movement_resp_handler((esp_zb_zcl_window_covering_movement_message_t *)message);
       break;
-    case ESP_ZB_CORE_OTA_UPGRADE_VALUE_CB_ID:
-      ret = zb_ota_upgrade_status_handler((esp_zb_zcl_ota_upgrade_value_message_t *)message);
-      break;
+    case ESP_ZB_CORE_OTA_UPGRADE_VALUE_CB_ID: ret = zb_ota_upgrade_status_handler((esp_zb_zcl_ota_upgrade_value_message_t *)message); break;
     case ESP_ZB_CORE_OTA_UPGRADE_QUERY_IMAGE_RESP_CB_ID:
       ret = zb_ota_upgrade_query_image_resp_handler((esp_zb_zcl_ota_upgrade_query_image_resp_message_t *)message);
       break;
@@ -237,8 +234,7 @@ static esp_err_t zb_window_covering_movement_resp_handler(const esp_zb_zcl_windo
   return ESP_OK;
 }
 
-static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, uint16_t payload_size, void **outbuf, uint16_t *outlen)
-{
+static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, uint16_t payload_size, void **outbuf, uint16_t *outlen) {
   static uint16_t tagid = 0;
   void *data_buf = NULL;
   uint16_t data_len;
@@ -246,12 +242,12 @@ static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, 
   if (!s_tagid_received) {
     uint32_t length = 0;
     if (!payload || payload_size <= OTA_ELEMENT_HEADER_LEN) {
-        log_e("Invalid element format");
-        return ESP_ERR_INVALID_ARG;
+      log_e("Invalid element format");
+      return ESP_ERR_INVALID_ARG;
     }
 
     const uint8_t *payload_ptr = (const uint8_t *)payload;
-    tagid  = *(const uint16_t *)payload_ptr;
+    tagid = *(const uint16_t *)payload_ptr;
     length = *(const uint32_t *)(payload_ptr + sizeof(tagid));
     if ((length + OTA_ELEMENT_HEADER_LEN) != total_size) {
       log_e("Invalid element length [%ld/%ld]", length, total_size);
@@ -281,8 +277,7 @@ static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, 
   return ESP_OK;
 }
 
-static esp_err_t zb_ota_upgrade_status_handler(const esp_zb_zcl_ota_upgrade_value_message_t *message)
-{
+static esp_err_t zb_ota_upgrade_status_handler(const esp_zb_zcl_ota_upgrade_value_message_t *message) {
   static uint32_t total_size = 0;
   static uint32_t offset = 0;
   [[maybe_unused]]
@@ -291,94 +286,91 @@ static esp_err_t zb_ota_upgrade_status_handler(const esp_zb_zcl_ota_upgrade_valu
 
   if (message->info.status == ESP_ZB_ZCL_STATUS_SUCCESS) {
     switch (message->upgrade_status) {
-    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_START:
-      log_i("Zigbee - OTA upgrade start");
-      start_time = esp_timer_get_time();
-      s_ota_partition = esp_ota_get_next_update_partition(NULL);
-      assert(s_ota_partition);
+      case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_START:
+        log_i("Zigbee - OTA upgrade start");
+        start_time = esp_timer_get_time();
+        s_ota_partition = esp_ota_get_next_update_partition(NULL);
+        assert(s_ota_partition);
 #if CONFIG_ZB_DELTA_OTA
-      ret = esp_delta_ota_begin(s_ota_partition, 0, &s_ota_handle);
+        ret = esp_delta_ota_begin(s_ota_partition, 0, &s_ota_handle);
 #else
-      ret = esp_ota_begin(s_ota_partition, 0, &s_ota_handle);
+        ret = esp_ota_begin(s_ota_partition, 0, &s_ota_handle);
 #endif
-      if(ret != ESP_OK) {
-        log_e("Zigbee - Failed to begin OTA partition, status: %s", esp_err_to_name(ret));
-        return ret;
-      }
-      break;
-    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_RECEIVE:
-      total_size = message->ota_header.image_size;
-      offset += message->payload_size;
-      log_i("Zigbee - OTA Client receives data: progress [%ld/%ld]", offset, total_size);
-      if (message->payload_size && message->payload) {
-        uint16_t payload_size = 0;
-        void    *payload = NULL;
-        ret = esp_element_ota_data(total_size, message->payload, message->payload_size, &payload, &payload_size);
-        if(ret != ESP_OK) {
-          log_e("Zigbee - Failed to element OTA data, status: %s", esp_err_to_name(ret));
+        if (ret != ESP_OK) {
+          log_e("Zigbee - Failed to begin OTA partition, status: %s", esp_err_to_name(ret));
           return ret;
         }
+        break;
+      case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_RECEIVE:
+        total_size = message->ota_header.image_size;
+        offset += message->payload_size;
+        log_i("Zigbee - OTA Client receives data: progress [%ld/%ld]", offset, total_size);
+        if (message->payload_size && message->payload) {
+          uint16_t payload_size = 0;
+          void *payload = NULL;
+          ret = esp_element_ota_data(total_size, message->payload, message->payload_size, &payload, &payload_size);
+          if (ret != ESP_OK) {
+            log_e("Zigbee - Failed to element OTA data, status: %s", esp_err_to_name(ret));
+            return ret;
+          }
 #if CONFIG_ZB_DELTA_OTA
-        ret = esp_delta_ota_write(s_ota_handle, payload, payload_size);
+          ret = esp_delta_ota_write(s_ota_handle, payload, payload_size);
 #else
-        ret = esp_ota_write(s_ota_handle, (const void *)payload, payload_size);
+          ret = esp_ota_write(s_ota_handle, (const void *)payload, payload_size);
 #endif
-        if(ret != ESP_OK) {
-          log_e("Zigbee - Failed to write OTA data to partition, status: %s", esp_err_to_name(ret));
+          if (ret != ESP_OK) {
+            log_e("Zigbee - Failed to write OTA data to partition, status: %s", esp_err_to_name(ret));
+            return ret;
+          }
+        }
+        break;
+      case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_APPLY: log_i("Zigbee - OTA upgrade apply"); break;
+      case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_CHECK:
+        ret = offset == total_size ? ESP_OK : ESP_FAIL;
+        offset = 0;
+        total_size = 0;
+        s_tagid_received = false;
+        log_i("Zigbee - OTA upgrade check status: %s", esp_err_to_name(ret));
+        break;
+      case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_FINISH:
+        log_i("Zigbee - OTA Finish");
+        log_i(
+          "Zigbee - OTA Information: version: 0x%lx, manufacturer code: 0x%x, image type: 0x%x, total size: %ld bytes, cost time: %lld ms,",
+          message->ota_header.file_version, message->ota_header.manufacturer_code, message->ota_header.image_type, message->ota_header.image_size,
+          (esp_timer_get_time() - start_time) / 1000
+        );
+#if CONFIG_ZB_DELTA_OTA
+        ret = esp_delta_ota_end(s_ota_handle);
+#else
+        ret = esp_ota_end(s_ota_handle);
+#endif
+        if (ret != ESP_OK) {
+          log_e("Zigbee - Failed to end OTA partition, status: %s", esp_err_to_name(ret));
           return ret;
         }
-      }
-      break;
-    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_APPLY:
-      log_i("Zigbee - OTA upgrade apply");
-      break;
-    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_CHECK:
-      ret = offset == total_size ? ESP_OK : ESP_FAIL;
-      offset = 0;
-      total_size = 0;
-      s_tagid_received = false;
-      log_i("Zigbee - OTA upgrade check status: %s", esp_err_to_name(ret));
-      break;
-    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_FINISH:
-      log_i("Zigbee - OTA Finish");
-      log_i("Zigbee - OTA Information: version: 0x%lx, manufacturer code: 0x%x, image type: 0x%x, total size: %ld bytes, cost time: %lld ms,",
-                message->ota_header.file_version, message->ota_header.manufacturer_code, message->ota_header.image_type,
-                message->ota_header.image_size, (esp_timer_get_time() - start_time) / 1000);
-#if CONFIG_ZB_DELTA_OTA
-      ret = esp_delta_ota_end(s_ota_handle);
-#else
-      ret = esp_ota_end(s_ota_handle);
-#endif
-      if(ret != ESP_OK) {
-        log_e("Zigbee - Failed to end OTA partition, status: %s", esp_err_to_name(ret));
-        return ret;
-      }
-      ret = esp_ota_set_boot_partition(s_ota_partition);
-      if(ret != ESP_OK) {
-        log_e("Zigbee - Failed to set OTA boot partition, status: %s", esp_err_to_name(ret));
-        return ret;
-      }
-      log_w("Zigbee - Prepare to restart system");
-      esp_restart();
-      break;
-    default:
-      log_i("Zigbee - OTA status: %d", message->upgrade_status);
-      break;
+        ret = esp_ota_set_boot_partition(s_ota_partition);
+        if (ret != ESP_OK) {
+          log_e("Zigbee - Failed to set OTA boot partition, status: %s", esp_err_to_name(ret));
+          return ret;
+        }
+        log_w("Zigbee - Prepare to restart system");
+        esp_restart();
+        break;
+      default: log_i("Zigbee - OTA status: %d", message->upgrade_status); break;
     }
   }
   return ret;
 }
 
-static esp_err_t zb_ota_upgrade_query_image_resp_handler(const esp_zb_zcl_ota_upgrade_query_image_resp_message_t *message)
-{
+static esp_err_t zb_ota_upgrade_query_image_resp_handler(const esp_zb_zcl_ota_upgrade_query_image_resp_message_t *message) {
   if (message->info.status == ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_i("Zigbee - Queried OTA image from address: 0x%04hx, endpoint: %d", message->server_addr.u.short_addr, message->server_endpoint);
     log_i("Zigbee - Image version: 0x%lx, manufacturer code: 0x%x, image size: %ld", message->file_version, message->manufacturer_code, message->image_size);
-    if(message->image_size == 0) {
+    if (message->image_size == 0) {
       log_i("Zigbee - Rejecting OTA image upgrade, image size is 0");
       return ESP_FAIL;
     }
-    if(message->file_version == 0) {
+    if (message->file_version == 0) {
       log_i("Zigbee - Rejecting OTA image upgrade, file version is 0");
       return ESP_FAIL;
     }

--- a/libraries/Zigbee/src/ZigbeeHandlers.cpp
+++ b/libraries/Zigbee/src/ZigbeeHandlers.cpp
@@ -301,6 +301,15 @@ static esp_err_t zb_ota_upgrade_query_image_resp_handler(const esp_zb_zcl_ota_up
     log_i("Zigbee - Queried OTA image from address: 0x%04hx, endpoint: %d", message->server_addr.u.short_addr, message->server_endpoint);
     log_i("Zigbee - Image version: 0x%lx, manufacturer code: 0x%x, image size: %ld", message->file_version, message->manufacturer_code,
               message->image_size);
+    //TODO: add more contidions to reject OTA image upgrade
+    if(message->image_size == 0) {
+      log_i("Zigbee - Rejecting OTA image upgrade, image size is 0");
+      return ESP_FAIL;
+    }
+    if(message->file_version == 0) {
+      log_i("Zigbee - Rejecting OTA image upgrade, file version is 0");
+      return ESP_FAIL;
+    }
     log_i("Zigbee - Approving OTA image upgrade");
   } else {
     log_i("Zigbee - OTA image upgrade response status: 0x%x", message->info.status);

--- a/libraries/Zigbee/src/ZigbeeHandlers.cpp
+++ b/libraries/Zigbee/src/ZigbeeHandlers.cpp
@@ -5,6 +5,24 @@
 #if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
 #include "esp_ota_ops.h"
+#if CONFIG_ZB_DELTA_OTA // Delta OTA, code is prepared for this feature but not enabled by default
+#include "esp_delta_ota_ops.h"
+#endif
+
+//OTA Upgrade defines and variables
+#define OTA_ELEMENT_HEADER_LEN              6       /* OTA element format header size include tag identifier and length field */
+
+/**
+ * @name Enumeration for the tag identifier denotes the type and format of the data within the element
+ * @anchor esp_ota_element_tag_id_t
+ */
+typedef enum esp_ota_element_tag_id_e {
+    UPGRADE_IMAGE                               = 0x0000,           /*!< Upgrade image */
+} esp_ota_element_tag_id_t;
+
+static const esp_partition_t *s_ota_partition = NULL;
+static esp_ota_handle_t s_ota_handle = 0;
+static bool s_tagid_received = false;
 
 // forward declaration of all implemented handlers
 static esp_err_t zb_attribute_set_handler(const esp_zb_zcl_set_attr_value_message_t *message);
@@ -219,21 +237,6 @@ static esp_err_t zb_window_covering_movement_resp_handler(const esp_zb_zcl_windo
   return ESP_OK;
 }
 
-//OTA Upgrade
-#define OTA_ELEMENT_HEADER_LEN              6       /* OTA element format header size include tag identifier and length field */
-
-/**
- * @name Enumeration for the tag identifier denotes the type and format of the data within the element
- * @anchor esp_ota_element_tag_id_t
- */
-typedef enum esp_ota_element_tag_id_e {
-    UPGRADE_IMAGE                               = 0x0000,           /*!< Upgrade image */
-} esp_ota_element_tag_id_t;
-
-static const esp_partition_t *s_ota_partition = NULL;
-static esp_ota_handle_t s_ota_handle = 0;
-static bool s_tagid_received = false;
-
 static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, uint16_t payload_size, void **outbuf, uint16_t *outlen)
 {
   static uint16_t tagid = 0;
@@ -247,8 +250,9 @@ static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, 
         return ESP_ERR_INVALID_ARG;
     }
 
-    tagid  = *(const uint16_t *)payload;
-    length = *(const uint32_t *)(payload + sizeof(tagid));
+    const uint8_t *payload_ptr = (const uint8_t *)payload;
+    tagid  = *(const uint16_t *)payload_ptr;
+    length = *(const uint32_t *)(payload_ptr + sizeof(tagid));
     if ((length + OTA_ELEMENT_HEADER_LEN) != total_size) {
       log_e("Invalid element length [%ld/%ld]", length, total_size);
       return ESP_ERR_INVALID_ARG;
@@ -256,7 +260,7 @@ static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, 
 
     s_tagid_received = true;
 
-    data_buf = (void *)(payload + OTA_ELEMENT_HEADER_LEN);
+    data_buf = (void *)(payload_ptr + OTA_ELEMENT_HEADER_LEN);
     data_len = payload_size - OTA_ELEMENT_HEADER_LEN;
   } else {
     data_buf = (void *)payload;
@@ -279,98 +283,97 @@ static esp_err_t esp_element_ota_data(uint32_t total_size, const void *payload, 
 
 static esp_err_t zb_ota_upgrade_status_handler(const esp_zb_zcl_ota_upgrade_value_message_t *message)
 {
-    static uint32_t total_size = 0;
-    static uint32_t offset = 0;
-    static int64_t start_time = 0;
-    esp_err_t ret = ESP_OK;
+  static uint32_t total_size = 0;
+  static uint32_t offset = 0;
+  [[maybe_unused]]
+  static int64_t start_time = 0;
+  esp_err_t ret = ESP_OK;
 
-    if (message->info.status == ESP_ZB_ZCL_STATUS_SUCCESS) {
-        switch (message->upgrade_status) {
-        case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_START:
-            log_i("Zigbee - OTA upgrade start");
-            start_time = esp_timer_get_time();
-            s_ota_partition = esp_ota_get_next_update_partition(NULL);
-            assert(s_ota_partition);
+  if (message->info.status == ESP_ZB_ZCL_STATUS_SUCCESS) {
+    switch (message->upgrade_status) {
+    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_START:
+      log_i("Zigbee - OTA upgrade start");
+      start_time = esp_timer_get_time();
+      s_ota_partition = esp_ota_get_next_update_partition(NULL);
+      assert(s_ota_partition);
 #if CONFIG_ZB_DELTA_OTA
-            ret = esp_delta_ota_begin(s_ota_partition, 0, &s_ota_handle);
+      ret = esp_delta_ota_begin(s_ota_partition, 0, &s_ota_handle);
 #else
-            ret = esp_ota_begin(s_ota_partition, 0, &s_ota_handle);
+      ret = esp_ota_begin(s_ota_partition, 0, &s_ota_handle);
 #endif
-            if(ret != ESP_OK) {
-              log_e("Zigbee - Failed to begin OTA partition, status: %s", esp_err_to_name(ret));
-              return ret;
-            }
-            break;
-        case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_RECEIVE:
-            total_size = message->ota_header.image_size;
-            offset += message->payload_size;
-            log_i("Zigbee - OTA Client receives data: progress [%ld/%ld]", offset, total_size);
-            if (message->payload_size && message->payload) {
-                uint16_t payload_size = 0;
-                void    *payload = NULL;
-                ret = esp_element_ota_data(total_size, message->payload, message->payload_size, &payload, &payload_size);
-                if(ret != ESP_OK) {
-                  log_e("Zigbee - Failed to element OTA data, status: %s", esp_err_to_name(ret));
-                  return ret;
-                }
-#if CONFIG_ZB_DELTA_OTA
-                ret = esp_delta_ota_write(s_ota_handle, payload, payload_size);
-#else
-                ret = esp_ota_write(s_ota_handle, (const void *)payload, payload_size);
-#endif
-                if(ret != ESP_OK) {
-                  log_e("Zigbee - Failed to write OTA data to partition, status: %s", esp_err_to_name(ret));
-                  return ret;
-                }
-            }
-            break;
-        case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_APPLY:
-            log_i("Zigbee - OTA upgrade apply");
-            break;
-        case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_CHECK:
-            ret = offset == total_size ? ESP_OK : ESP_FAIL;
-            offset = 0;
-            total_size = 0;
-            s_tagid_received = false;
-            log_i("Zigbee - OTA upgrade check status: %s", esp_err_to_name(ret));
-            break;
-        case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_FINISH:
-            log_i("Zigbee - OTA Finish");
-            log_i("Zigbee - OTA Information: version: 0x%lx, manufacturer code: 0x%x, image type: 0x%x, total size: %ld bytes, cost time: %lld ms,",
-                     message->ota_header.file_version, message->ota_header.manufacturer_code, message->ota_header.image_type,
-                     message->ota_header.image_size, (esp_timer_get_time() - start_time) / 1000);
-#if CONFIG_ZB_DELTA_OTA
-            ret = esp_delta_ota_end(s_ota_handle);
-#else
-            ret = esp_ota_end(s_ota_handle);
-#endif
-            if(ret != ESP_OK) {
-              log_e("Zigbee - Failed to end OTA partition, status: %s", esp_err_to_name(ret));
-              return ret;
-            }
-            ret = esp_ota_set_boot_partition(s_ota_partition);
-            if(ret != ESP_OK) {
-              log_e("Zigbee - Failed to set OTA boot partition, status: %s", esp_err_to_name(ret));
-              return ret;
-            }
-            log_w("Zigbee - Prepare to restart system");
-            esp_restart();
-            break;
-        default:
-            log_i("Zigbee - OTA status: %d", message->upgrade_status);
-            break;
+      if(ret != ESP_OK) {
+        log_e("Zigbee - Failed to begin OTA partition, status: %s", esp_err_to_name(ret));
+        return ret;
+      }
+      break;
+    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_RECEIVE:
+      total_size = message->ota_header.image_size;
+      offset += message->payload_size;
+      log_i("Zigbee - OTA Client receives data: progress [%ld/%ld]", offset, total_size);
+      if (message->payload_size && message->payload) {
+        uint16_t payload_size = 0;
+        void    *payload = NULL;
+        ret = esp_element_ota_data(total_size, message->payload, message->payload_size, &payload, &payload_size);
+        if(ret != ESP_OK) {
+          log_e("Zigbee - Failed to element OTA data, status: %s", esp_err_to_name(ret));
+          return ret;
         }
+#if CONFIG_ZB_DELTA_OTA
+        ret = esp_delta_ota_write(s_ota_handle, payload, payload_size);
+#else
+        ret = esp_ota_write(s_ota_handle, (const void *)payload, payload_size);
+#endif
+        if(ret != ESP_OK) {
+          log_e("Zigbee - Failed to write OTA data to partition, status: %s", esp_err_to_name(ret));
+          return ret;
+        }
+      }
+      break;
+    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_APPLY:
+      log_i("Zigbee - OTA upgrade apply");
+      break;
+    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_CHECK:
+      ret = offset == total_size ? ESP_OK : ESP_FAIL;
+      offset = 0;
+      total_size = 0;
+      s_tagid_received = false;
+      log_i("Zigbee - OTA upgrade check status: %s", esp_err_to_name(ret));
+      break;
+    case ESP_ZB_ZCL_OTA_UPGRADE_STATUS_FINISH:
+      log_i("Zigbee - OTA Finish");
+      log_i("Zigbee - OTA Information: version: 0x%lx, manufacturer code: 0x%x, image type: 0x%x, total size: %ld bytes, cost time: %lld ms,",
+                message->ota_header.file_version, message->ota_header.manufacturer_code, message->ota_header.image_type,
+                message->ota_header.image_size, (esp_timer_get_time() - start_time) / 1000);
+#if CONFIG_ZB_DELTA_OTA
+      ret = esp_delta_ota_end(s_ota_handle);
+#else
+      ret = esp_ota_end(s_ota_handle);
+#endif
+      if(ret != ESP_OK) {
+        log_e("Zigbee - Failed to end OTA partition, status: %s", esp_err_to_name(ret));
+        return ret;
+      }
+      ret = esp_ota_set_boot_partition(s_ota_partition);
+      if(ret != ESP_OK) {
+        log_e("Zigbee - Failed to set OTA boot partition, status: %s", esp_err_to_name(ret));
+        return ret;
+      }
+      log_w("Zigbee - Prepare to restart system");
+      esp_restart();
+      break;
+    default:
+      log_i("Zigbee - OTA status: %d", message->upgrade_status);
+      break;
     }
-    return ret;
+  }
+  return ret;
 }
 
 static esp_err_t zb_ota_upgrade_query_image_resp_handler(const esp_zb_zcl_ota_upgrade_query_image_resp_message_t *message)
 {
   if (message->info.status == ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_i("Zigbee - Queried OTA image from address: 0x%04hx, endpoint: %d", message->server_addr.u.short_addr, message->server_endpoint);
-    log_i("Zigbee - Image version: 0x%lx, manufacturer code: 0x%x, image size: %ld", message->file_version, message->manufacturer_code,
-              message->image_size);
-    //TODO: add more contidions to reject OTA image upgrade
+    log_i("Zigbee - Image version: 0x%lx, manufacturer code: 0x%x, image size: %ld", message->file_version, message->manufacturer_code, message->image_size);
     if(message->image_size == 0) {
       log_i("Zigbee - Rejecting OTA image upgrade, image size is 0");
       return ESP_FAIL;


### PR DESCRIPTION
## Description of Change
This PR adds support for Zigbee OTA Client cluster.

To add Client cluster to the endpoint, add `zbDevice.addOTAClient()` before adding the endpoint to the Zigbee Class.
The first 3 parameters are required and should be defined in your application, so you can control them when releasing a new updated version.

```cpp
addOTAClient(uint32_t file_version, uint32_t downloaded_file_ver, uint16_t hw_version, uint16_t manufacturer = 0x1001, uint16_t image_type = 0x1011, uint8_t max_data_size = 223);
```

Added an simple OTA Client example to demonstrate how to use the OTA update.

For creating the OTA binary file (update file), you will need to get a [python script from the esp-zigbee-sdk](https://github.com/espressif/esp-zigbee-sdk/blob/main/tools/image_builder_tool/image_builder_tool.py).

## Tests scenarios
The OTA update was tested using the HomeAssistant, with specific configuration to allow the OTA updates for custom devices.

Thanks @lhespress for this tutorial: [ZHA.OTA.Instructions.pdf](https://github.com/user-attachments/files/18772161/ZHA.OTA.Instructions.pdf)
Link to the OTA creating process and how to use the image_builder_tool:
https://docs.espressif.com/projects/esp-zigbee-sdk/en/latest/esp32/user-guide/zcl_ota_upgrade.html#generate-and-apply-ota-upgrade-image

## Related links
Related #10871 
Related #10135 