### PR TITLE
feat(zigbee): Support HSV color commands for RGB light endpoint

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -6,26 +6,12 @@
 #if SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED
 
 #include <Arduino.h>
+#include <ColorFormat.h>
 
 /* Useful defines */
 #define ZB_CMD_TIMEOUT 10000  // 10 seconds
 
 #define ZB_ARRAY_LENTH(arr) (sizeof(arr) / sizeof(arr[0]))
-#define XYZ_TO_RGB(X, Y, Z, r, g, b)                                \
-  {                                                                 \
-    r = (float)(3.240479 * (X) - 1.537150 * (Y) - 0.498535 * (Z));  \
-    g = (float)(-0.969256 * (X) + 1.875992 * (Y) + 0.041556 * (Z)); \
-    b = (float)(0.055648 * (X) - 0.204043 * (Y) + 1.057311 * (Z));  \
-    if (r > 1) {                                                    \
-      r = 1;                                                        \
-    }                                                               \
-    if (g > 1) {                                                    \
-      g = 1;                                                        \
-    }                                                               \
-    if (b > 1) {                                                    \
-      b = 1;                                                        \
-    }                                                               \
-  }
 
 #define RGB_TO_XYZ(r, g, b, X, Y, Z)                               \
   {                                                                \

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -73,7 +73,7 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
       uint16_t light_color_x = (*(uint16_t *)message->attribute.data.value);
       uint16_t light_color_y = getCurrentColorY();
       //calculate RGB from XY and call setColor()
-      _current_color = espXYToRgbColor(255, light_color_x, light_color_y); //TODO: Check if level is correct
+      _current_color = espXYToRgbColor(255, light_color_x, light_color_y);  //TODO: Check if level is correct
       lightChanged();
       return;
 
@@ -81,7 +81,7 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
       uint16_t light_color_x = getCurrentColorX();
       uint16_t light_color_y = (*(uint16_t *)message->attribute.data.value);
       //calculate RGB from XY and call setColor()
-      _current_color = espXYToRgbColor(255, light_color_x, light_color_y); //TODO: Check if level is correct
+      _current_color = espXYToRgbColor(255, light_color_x, light_color_y);  //TODO: Check if level is correct
       lightChanged();
       return;
     } else if (message->attribute.id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U16) {

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -13,9 +13,7 @@ ZigbeeColorDimmableLight::ZigbeeColorDimmableLight(uint8_t endpoint) : ZigbeeEP(
   //set default values
   _current_state = false;
   _current_level = 255;
-  _current_red = 255;
-  _current_green = 255;
-  _current_blue = 255;
+  _current_color = {255, 255, 255};
 }
 
 uint16_t ZigbeeColorDimmableLight::getCurrentColorX() {
@@ -32,37 +30,18 @@ uint16_t ZigbeeColorDimmableLight::getCurrentColorY() {
              ->data_p);
 }
 
-void ZigbeeColorDimmableLight::calculateRGB(uint16_t x, uint16_t y, uint8_t &red, uint8_t &green, uint8_t &blue) {
-  float r, g, b, color_x, color_y;
-  color_x = (float)x / 65535;
-  color_y = (float)y / 65535;
-
-  float color_X = color_x / color_y;
-  float color_Z = (1 - color_x - color_y) / color_y;
-
-  XYZ_TO_RGB(color_X, 1, color_Z, r, g, b);
-
-  red = (uint8_t)(r * (float)255);
-  green = (uint8_t)(g * (float)255);
-  blue = (uint8_t)(b * (float)255);
+uint16_t ZigbeeColorDimmableLight::getCurrentColorHue() {
+  return (*(uint16_t *)esp_zb_zcl_get_attribute(
+             _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID
+  )
+             ->data_p);
 }
 
-void ZigbeeColorDimmableLight::calculateXY(uint8_t red, uint8_t green, uint8_t blue, uint16_t &x, uint16_t &y) {
-  // Convert RGB to XYZ
-  float r = (float)red / 255.0f;
-  float g = (float)green / 255.0f;
-  float b = (float)blue / 255.0f;
-
-  float X, Y, Z;
-  RGB_TO_XYZ(r, g, b, X, Y, Z);
-
-  // Convert XYZ to xy chromaticity coordinates
-  float color_x = X / (X + Y + Z);
-  float color_y = Y / (X + Y + Z);
-
-  // Convert normalized xy to 16-bit values
-  x = (uint16_t)(color_x * 65535.0f);
-  y = (uint16_t)(color_y * 65535.0f);
+uint8_t ZigbeeColorDimmableLight::getCurrentColorSaturation() {
+  return (*(uint16_t *)esp_zb_zcl_get_attribute(
+             _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID
+  )
+             ->data_p);
 }
 
 //set attribute method -> method overridden in child class
@@ -94,11 +73,7 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
       uint16_t light_color_x = (*(uint16_t *)message->attribute.data.value);
       uint16_t light_color_y = getCurrentColorY();
       //calculate RGB from XY and call setColor()
-      uint8_t red, green, blue;
-      calculateRGB(light_color_x, light_color_y, red, green, blue);
-      _current_blue = blue;
-      _current_green = green;
-      _current_red = red;
+      _current_color = espXYToRgbColor(255, light_color_x, light_color_y); //TODO: Check if level is correct
       lightChanged();
       return;
 
@@ -106,11 +81,17 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
       uint16_t light_color_x = getCurrentColorX();
       uint16_t light_color_y = (*(uint16_t *)message->attribute.data.value);
       //calculate RGB from XY and call setColor()
-      uint8_t red, green, blue;
-      calculateRGB(light_color_x, light_color_y, red, green, blue);
-      _current_blue = blue;
-      _current_green = green;
-      _current_red = red;
+      _current_color = espXYToRgbColor(255, light_color_x, light_color_y); //TODO: Check if level is correct
+      lightChanged();
+      return;
+    } else if (message->attribute.id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U16) {
+      uint16_t light_color_hue = (*(uint16_t *)message->attribute.data.value);
+      _current_color = espHsvToRgbColor(light_color_hue, getCurrentColorSaturation(), 255);
+      lightChanged();
+      return;
+    } else if (message->attribute.id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U8) {
+      uint8_t light_color_saturation = (*(uint8_t *)message->attribute.data.value);
+      _current_color = espHsvToRgbColor(getCurrentColorHue(), light_color_saturation, 255);
       lightChanged();
       return;
     } else {
@@ -123,7 +104,7 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
 
 void ZigbeeColorDimmableLight::lightChanged() {
   if (_on_light_change) {
-    _on_light_change(_current_state, _current_red, _current_green, _current_blue, _current_level);
+    _on_light_change(_current_state, _current_color.r, _current_color.g, _current_color.b, _current_level);
   }
 }
 
@@ -131,12 +112,13 @@ void ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
   //Update all attributes
   _current_state = state;
   _current_level = level;
-  _current_red = red;
-  _current_green = green;
-  _current_blue = blue;
+  _current_color = {red, green, blue};
   lightChanged();
 
-  log_v("Updating on/off light state to %d", state);
+  espXyColor_t xy_color = espRgbColorToXYColor(_current_color);
+  espHsvColor_t hsv_color = espRgbColorToHsvColor(_current_color);
+
+  log_v("Updating light state: %d, level: %d, color: %d, %d, %d", state, level, red, green, blue);
   /* Update light clusters */
   esp_zb_lock_acquire(portMAX_DELAY);
   //set on/off state
@@ -147,28 +129,42 @@ void ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
   esp_zb_zcl_set_attribute_val(
     _endpoint, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
   );
-  //set color
-  uint16_t color_x, color_y;
-  calculateXY(red, green, blue, color_x, color_y);
+  //set xy color
   esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &color_x, false
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &xy_color.x, false
   );
   esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &color_y, false
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &xy_color.y, false
+  );
+  //set hsv color
+  esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &hsv_color.h, false
+  );
+  esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &hsv_color.s, false
   );
   esp_zb_lock_release();
 }
 
 void ZigbeeColorDimmableLight::setLightState(bool state) {
-  setLight(state, _current_level, _current_red, _current_green, _current_blue);
+  setLight(state, _current_level, _current_color.r, _current_color.g, _current_color.b);
 }
 
 void ZigbeeColorDimmableLight::setLightLevel(uint8_t level) {
-  setLight(_current_state, level, _current_red, _current_green, _current_blue);
+  setLight(_current_state, level, _current_color.r, _current_color.g, _current_color.b);
 }
 
 void ZigbeeColorDimmableLight::setLightColor(uint8_t red, uint8_t green, uint8_t blue) {
   setLight(_current_state, _current_level, red, green, blue);
+}
+
+void ZigbeeColorDimmableLight::setLightColor(espRgbColor_t rgb_color) {
+  setLight(_current_state, _current_level, rgb_color.r, rgb_color.g, rgb_color.b);
+}
+
+void ZigbeeColorDimmableLight::setLightColor(espHsvColor_t hsv_color) {
+  espRgbColor_t rgb_color = espHsvColorToRgbColor(hsv_color);
+  setLight(_current_state, _current_level, rgb_color.r, rgb_color.g, rgb_color.b);
 }
 
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
@@ -9,6 +9,48 @@
 #include "ZigbeeEP.h"
 #include "ha/esp_zigbee_ha_standard.h"
 
+#define ZIGBEE_DEFAULT_COLOR_DIMMABLE_LIGHT_CONFIG()                                                \
+    {                                                                                               \
+        .basic_cfg =                                                                                \
+            {                                                                                       \
+                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                          \
+                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                        \
+            },                                                                                      \
+        .identify_cfg =                                                                             \
+            {                                                                                       \
+                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                   \
+            },                                                                                      \
+        .groups_cfg =                                                                               \
+            {                                                                                       \
+                .groups_name_support_id = ESP_ZB_ZCL_GROUPS_NAME_SUPPORT_DEFAULT_VALUE,             \
+            },                                                                                      \
+        .scenes_cfg =                                                                               \
+            {                                                                                       \
+                .scenes_count = ESP_ZB_ZCL_SCENES_SCENE_COUNT_DEFAULT_VALUE,                        \
+                .current_scene = ESP_ZB_ZCL_SCENES_CURRENT_SCENE_DEFAULT_VALUE,                     \
+                .current_group = ESP_ZB_ZCL_SCENES_CURRENT_GROUP_DEFAULT_VALUE,                     \
+                .scene_valid = ESP_ZB_ZCL_SCENES_SCENE_VALID_DEFAULT_VALUE,                         \
+                .name_support = ESP_ZB_ZCL_SCENES_NAME_SUPPORT_DEFAULT_VALUE,                       \
+            },                                                                                      \
+        .on_off_cfg =                                                                               \
+            {                                                                                       \
+                .on_off = ESP_ZB_ZCL_ON_OFF_ON_OFF_DEFAULT_VALUE,                                   \
+            },                                                                                      \
+        .level_cfg =                                                                                \
+            {                                                                                       \
+                .current_level = ESP_ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE,              \
+            },                                                                                      \
+        .color_cfg =                                                                                \
+            {                                                                                       \
+                .current_x = ESP_ZB_ZCL_COLOR_CONTROL_CURRENT_X_DEF_VALUE,                          \
+                .current_y = ESP_ZB_ZCL_COLOR_CONTROL_CURRENT_Y_DEF_VALUE,                          \
+                .color_mode = ESP_ZB_ZCL_COLOR_CONTROL_COLOR_MODE_DEFAULT_VALUE,                    \
+                .options = ESP_ZB_ZCL_COLOR_CONTROL_OPTIONS_DEFAULT_VALUE,                          \
+                .enhanced_color_mode = ESP_ZB_ZCL_COLOR_CONTROL_ENHANCED_COLOR_MODE_DEFAULT_VALUE,  \
+                .color_capabilities = 0x0009,                                                       \
+            },                                                                                      \
+    }
+
 class ZigbeeColorDimmableLight : public ZigbeeEP {
 public:
   ZigbeeColorDimmableLight(uint8_t endpoint);
@@ -52,7 +94,7 @@ private:
 
   uint16_t getCurrentColorX();
   uint16_t getCurrentColorY();
-  uint16_t getCurrentColorHue();
+  uint8_t getCurrentColorHue();
   uint8_t getCurrentColorSaturation();
 
   void lightChanged();

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
@@ -9,47 +9,46 @@
 #include "ZigbeeEP.h"
 #include "ha/esp_zigbee_ha_standard.h"
 
-#define ZIGBEE_DEFAULT_COLOR_DIMMABLE_LIGHT_CONFIG()                                                \
-    {                                                                                               \
-        .basic_cfg =                                                                                \
-            {                                                                                       \
-                .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                          \
-                .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                        \
-            },                                                                                      \
-        .identify_cfg =                                                                             \
-            {                                                                                       \
-                .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                   \
-            },                                                                                      \
-        .groups_cfg =                                                                               \
-            {                                                                                       \
-                .groups_name_support_id = ESP_ZB_ZCL_GROUPS_NAME_SUPPORT_DEFAULT_VALUE,             \
-            },                                                                                      \
-        .scenes_cfg =                                                                               \
-            {                                                                                       \
-                .scenes_count = ESP_ZB_ZCL_SCENES_SCENE_COUNT_DEFAULT_VALUE,                        \
-                .current_scene = ESP_ZB_ZCL_SCENES_CURRENT_SCENE_DEFAULT_VALUE,                     \
-                .current_group = ESP_ZB_ZCL_SCENES_CURRENT_GROUP_DEFAULT_VALUE,                     \
-                .scene_valid = ESP_ZB_ZCL_SCENES_SCENE_VALID_DEFAULT_VALUE,                         \
-                .name_support = ESP_ZB_ZCL_SCENES_NAME_SUPPORT_DEFAULT_VALUE,                       \
-            },                                                                                      \
-        .on_off_cfg =                                                                               \
-            {                                                                                       \
-                .on_off = ESP_ZB_ZCL_ON_OFF_ON_OFF_DEFAULT_VALUE,                                   \
-            },                                                                                      \
-        .level_cfg =                                                                                \
-            {                                                                                       \
-                .current_level = ESP_ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE,              \
-            },                                                                                      \
-        .color_cfg =                                                                                \
-            {                                                                                       \
-                .current_x = ESP_ZB_ZCL_COLOR_CONTROL_CURRENT_X_DEF_VALUE,                          \
-                .current_y = ESP_ZB_ZCL_COLOR_CONTROL_CURRENT_Y_DEF_VALUE,                          \
-                .color_mode = ESP_ZB_ZCL_COLOR_CONTROL_COLOR_MODE_DEFAULT_VALUE,                    \
-                .options = ESP_ZB_ZCL_COLOR_CONTROL_OPTIONS_DEFAULT_VALUE,                          \
-                .enhanced_color_mode = ESP_ZB_ZCL_COLOR_CONTROL_ENHANCED_COLOR_MODE_DEFAULT_VALUE,  \
-                .color_capabilities = 0x0009,                                                       \
-            },                                                                                      \
-    }
+#define ZIGBEE_DEFAULT_COLOR_DIMMABLE_LIGHT_CONFIG()                                     \
+  {                                                                                      \
+    .basic_cfg =                                                                         \
+      {                                                                                  \
+        .zcl_version = ESP_ZB_ZCL_BASIC_ZCL_VERSION_DEFAULT_VALUE,                       \
+        .power_source = ESP_ZB_ZCL_BASIC_POWER_SOURCE_DEFAULT_VALUE,                     \
+      },                                                                                 \
+    .identify_cfg =                                                                      \
+      {                                                                                  \
+        .identify_time = ESP_ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE,                \
+      },                                                                                 \
+    .groups_cfg =                                                                        \
+      {                                                                                  \
+        .groups_name_support_id = ESP_ZB_ZCL_GROUPS_NAME_SUPPORT_DEFAULT_VALUE,          \
+      },                                                                                 \
+    .scenes_cfg =                                                                        \
+      {                                                                                  \
+        .scenes_count = ESP_ZB_ZCL_SCENES_SCENE_COUNT_DEFAULT_VALUE,                     \
+        .current_scene = ESP_ZB_ZCL_SCENES_CURRENT_SCENE_DEFAULT_VALUE,                  \
+        .current_group = ESP_ZB_ZCL_SCENES_CURRENT_GROUP_DEFAULT_VALUE,                  \
+        .scene_valid = ESP_ZB_ZCL_SCENES_SCENE_VALID_DEFAULT_VALUE,                      \
+        .name_support = ESP_ZB_ZCL_SCENES_NAME_SUPPORT_DEFAULT_VALUE,                    \
+      },                                                                                 \
+    .on_off_cfg =                                                                        \
+      {                                                                                  \
+        .on_off = ESP_ZB_ZCL_ON_OFF_ON_OFF_DEFAULT_VALUE,                                \
+      },                                                                                 \
+    .level_cfg =                                                                         \
+      {                                                                                  \
+        .current_level = ESP_ZB_ZCL_LEVEL_CONTROL_CURRENT_LEVEL_DEFAULT_VALUE,           \
+      },                                                                                 \
+    .color_cfg = {                                                                       \
+      .current_x = ESP_ZB_ZCL_COLOR_CONTROL_CURRENT_X_DEF_VALUE,                         \
+      .current_y = ESP_ZB_ZCL_COLOR_CONTROL_CURRENT_Y_DEF_VALUE,                         \
+      .color_mode = ESP_ZB_ZCL_COLOR_CONTROL_COLOR_MODE_DEFAULT_VALUE,                   \
+      .options = ESP_ZB_ZCL_COLOR_CONTROL_OPTIONS_DEFAULT_VALUE,                         \
+      .enhanced_color_mode = ESP_ZB_ZCL_COLOR_CONTROL_ENHANCED_COLOR_MODE_DEFAULT_VALUE, \
+      .color_capabilities = 0x0009,                                                      \
+    },                                                                                   \
+  }
 
 class ZigbeeColorDimmableLight : public ZigbeeEP {
 public:

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
@@ -24,6 +24,8 @@ public:
   void setLightState(bool state);
   void setLightLevel(uint8_t level);
   void setLightColor(uint8_t red, uint8_t green, uint8_t blue);
+  void setLightColor(espRgbColor_t rgb_color);
+  void setLightColor(espHsvColor_t hsv_color);
   void setLight(bool state, uint8_t level, uint8_t red, uint8_t green, uint8_t blue);
 
   bool getLightState() {
@@ -32,23 +34,26 @@ public:
   uint8_t getLightLevel() {
     return _current_level;
   }
+  espRgbColor_t getLightColor() {
+    return _current_color;
+  }
   uint8_t getLightRed() {
-    return _current_red;
+    return _current_color.r;
   }
   uint8_t getLightGreen() {
-    return _current_green;
+    return _current_color.g;
   }
   uint8_t getLightBlue() {
-    return _current_blue;
+    return _current_color.b;
   }
 
 private:
   void zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message) override;
-  void calculateRGB(uint16_t x, uint16_t y, uint8_t &red, uint8_t &green, uint8_t &blue);
-  void calculateXY(uint8_t red, uint8_t green, uint8_t blue, uint16_t &x, uint16_t &y);
 
   uint16_t getCurrentColorX();
   uint16_t getCurrentColorY();
+  uint16_t getCurrentColorHue();
+  uint8_t getCurrentColorSaturation();
 
   void lightChanged();
   //callback function to be called on light change (State, R, G, B, Level)
@@ -56,9 +61,7 @@ private:
 
   bool _current_state;
   uint8_t _current_level;
-  uint16_t _current_red;
-  uint16_t _current_green;
-  uint16_t _current_blue;
+  espRgbColor_t _current_color;
 };
 
 #endif  //SOC_IEEE802154_SUPPORTED && CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
@@ -16,24 +16,6 @@ ZigbeeColorDimmerSwitch::ZigbeeColorDimmerSwitch(uint8_t endpoint) : ZigbeeEP(en
   };
 }
 
-void ZigbeeColorDimmerSwitch::calculateXY(uint8_t red, uint8_t green, uint8_t blue, uint16_t &x, uint16_t &y) {
-  // Convert RGB to XYZ
-  float r = (float)red / 255.0f;
-  float g = (float)green / 255.0f;
-  float b = (float)blue / 255.0f;
-
-  float X, Y, Z;
-  RGB_TO_XYZ(r, g, b, X, Y, Z);
-
-  // Convert XYZ to xy chromaticity coordinates
-  float color_x = X / (X + Y + Z);
-  float color_y = Y / (X + Y + Z);
-
-  // Convert normalized xy to 16-bit values
-  x = (uint16_t)(color_x * 65535.0f);
-  y = (uint16_t)(color_y * 65535.0f);
-}
-
 void ZigbeeColorDimmerSwitch::bindCb(esp_zb_zdp_status_t zdo_status, void *user_ctx) {
   if (zdo_status == ESP_ZB_ZDP_STATUS_SUCCESS) {
     log_i("Bound successfully!");
@@ -417,15 +399,13 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, esp
 
 void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t blue) {
   if (_is_bound) {
-    //Convert RGB to XY
-    uint16_t color_x, color_y;
-    calculateXY(red, green, blue, color_x, color_y);
+    espXyColor_t xy_color = espRgbToXYColor(red, green, blue);
 
     esp_zb_zcl_color_move_to_color_cmd_t cmd_req;
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
-    cmd_req.color_x = color_x;
-    cmd_req.color_y = color_y;
+    cmd_req.color_x = xy_color.x;
+    cmd_req.color_y = xy_color.y;
     cmd_req.transition_time = 0;
     log_v("Sending 'set light color' command");
     esp_zb_lock_acquire(portMAX_DELAY);
@@ -438,16 +418,14 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
 
 void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint16_t group_addr) {
   if (_is_bound) {
-    //Convert RGB to XY
-    uint16_t color_x, color_y;
-    calculateXY(red, green, blue, color_x, color_y);
+    espXyColor_t xy_color = espRgbToXYColor(red, green, blue);
 
     esp_zb_zcl_color_move_to_color_cmd_t cmd_req;
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
-    cmd_req.color_x = color_x;
-    cmd_req.color_y = color_y;
+    cmd_req.color_x = xy_color.x;
+    cmd_req.color_y = xy_color.y;
     cmd_req.transition_time = 0;
     log_v("Sending 'set light color' command to group address 0x%x", group_addr);
     esp_zb_lock_acquire(portMAX_DELAY);
@@ -460,17 +438,15 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
 
 void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t endpoint, uint16_t short_addr) {
   if (_is_bound) {
-    //Convert RGB to XY
-    uint16_t color_x, color_y;
-    calculateXY(red, green, blue, color_x, color_y);
+    espXyColor_t xy_color = espRgbToXYColor(red, green, blue);
 
     esp_zb_zcl_color_move_to_color_cmd_t cmd_req;
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
     cmd_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
-    cmd_req.color_x = color_x;
-    cmd_req.color_y = color_y;
+    cmd_req.color_x = xy_color.x;
+    cmd_req.color_y = xy_color.y;
     cmd_req.transition_time = 0;
     log_v("Sending 'set light color' command to endpoint %d, address 0x%x", endpoint, short_addr);
     esp_zb_lock_acquire(portMAX_DELAY);
@@ -483,17 +459,15 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
 
 void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
   if (_is_bound) {
-    //Convert RGB to XY
-    uint16_t color_x, color_y;
-    calculateXY(red, green, blue, color_x, color_y);
+    espXyColor_t xy_color = espRgbToXYColor(red, green, blue);
 
     esp_zb_zcl_color_move_to_color_cmd_t cmd_req;
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.zcl_basic_cmd.dst_endpoint = endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
     memcpy(cmd_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
-    cmd_req.color_x = color_x;
-    cmd_req.color_y = color_y;
+    cmd_req.color_x = xy_color.x;
+    cmd_req.color_y = xy_color.y;
     cmd_req.transition_time = 0;
     log_v(
       "Sending 'set light color' command to endpoint %d,  ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],


### PR DESCRIPTION
## Description of Change
This PR adds support for HSV color commands.

## Tests scenarios
Tested XY color, please @ilker-aktuna test the HSV colors.

## Related links
Closes #10669 
