### PR TITLE
Fix crash in String when using nullptr (#10971)

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -290,7 +290,8 @@ String &String::operator=(StringSumHelper &&rval) {
 #endif
 
 String &String::operator=(const char *cstr) {
-  return copy(cstr, strlen(cstr));
+  const uint32_t length = cstr ? strlen(cstr) : 0u;
+  return copy(cstr, length);
 }
 
 /*********************************************/


### PR DESCRIPTION
## Description of Change
See: https://github.com/espressif/arduino-esp32/issues/10971#issuecomment-2660859418


## Related links

Fixes: #10971
