### PR TITLE
fix(board): Update pins_arduino.h for Geekble_ESP32C3

### DIFF
--- a/variants/Geekble_ESP32C3/pins_arduino.h
+++ b/variants/Geekble_ESP32C3/pins_arduino.h
@@ -27,6 +27,6 @@ static const uint8_t A1 = 1;
 static const uint8_t A2 = 2;
 static const uint8_t A3 = 3;
 static const uint8_t A4 = 4;
-static const uint8_t A5 = 5;
+//static const uint8_t A5 = 5;  // ADC1 no longer supported
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
Update pins_arduino.h
ADC1 no longer supported and removed from Analog pin list