### PR TITLE
feat(boards): Add Geekble-nano-ESP32S3

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -40834,6 +40834,196 @@ Geekble_ESP32C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+Geekble_Nano_ESP32S3.name=Geekble nano ESP32-S3
+Geekble_Nano_ESP32S3.vid.0=0x303a
+Geekble_Nano_ESP32S3.pid.0= 0x82C5
+Geekble_Nano_ESP32S3.upload_port.0.vid=0x303a
+Geekble_Nano_ESP32S3.upload_port.0.pid= 0x82C5
+
+Geekble_Nano_ESP32S3.bootloader.tool=esptool_py
+Geekble_Nano_ESP32S3.bootloader.tool.default=esptool_py
+
+Geekble_Nano_ESP32S3.upload.tool=esptool_py
+Geekble_Nano_ESP32S3.upload.tool.default=esptool_py
+Geekble_Nano_ESP32S3.upload.tool.network=esp_ota
+
+Geekble_Nano_ESP32S3.upload.maximum_size=1310720
+
+Geekble_Nano_ESP32S3.upload.maximum_data_size=327680
+Geekble_Nano_ESP32S3.upload.flags=
+Geekble_Nano_ESP32S3.upload.extra_flags=
+Geekble_Nano_ESP32S3.upload.use_1200bps_touch=false
+Geekble_Nano_ESP32S3.upload.wait_for_upload_port=false
+
+Geekble_Nano_ESP32S3.serial.disableDTR=false
+Geekble_Nano_ESP32S3.serial.disableRTS=false
+
+Geekble_Nano_ESP32S3.build.tarch=xtensa
+Geekble_Nano_ESP32S3.build.bootloader_addr=0x0
+Geekble_Nano_ESP32S3.build.target=esp32s3
+Geekble_Nano_ESP32S3.build.mcu=esp32s3
+Geekble_Nano_ESP32S3.build.core=esp32
+Geekble_Nano_ESP32S3.build.variant=Geekble_Nano_ESP32S3
+Geekble_Nano_ESP32S3.build.board=GEEKBLE_NANO_ESP32S3
+
+Geekble_Nano_ESP32S3.build.usb_mode=1
+Geekble_Nano_ESP32S3.build.cdc_on_boot=1
+Geekble_Nano_ESP32S3.build.msc_on_boot=0
+Geekble_Nano_ESP32S3.build.dfu_on_boot=0
+Geekble_Nano_ESP32S3.build.f_cpu=240000000L
+Geekble_Nano_ESP32S3.build.flash_size=4MB
+Geekble_Nano_ESP32S3.build.flash_freq=80m
+Geekble_Nano_ESP32S3.build.flash_mode=dio
+Geekble_Nano_ESP32S3.build.boot=qio
+Geekble_Nano_ESP32S3.build.boot_freq=80m
+Geekble_Nano_ESP32S3.build.partitions=default
+Geekble_Nano_ESP32S3.build.defines=
+Geekble_Nano_ESP32S3.build.loop_core=
+Geekble_Nano_ESP32S3.build.event_core=
+Geekble_Nano_ESP32S3.build.psram_type=qspi
+Geekble_Nano_ESP32S3.build.memory_type={build.boot}_{build.psram_type}
+
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled=Disabled
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled.build.defines=
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled.build.psram_type=qspi
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled=Enabled
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled.build.psram_type=qspi
+
+Geekble_Nano_ESP32S3.menu.FlashMode.qio=QIO 80MHz
+Geekble_Nano_ESP32S3.menu.FlashMode.qio.build.flash_mode=dio
+Geekble_Nano_ESP32S3.menu.FlashMode.qio.build.boot=qio
+Geekble_Nano_ESP32S3.menu.FlashMode.qio.build.boot_freq=80m
+Geekble_Nano_ESP32S3.menu.FlashMode.qio.build.flash_freq=80m
+Geekble_Nano_ESP32S3.menu.FlashMode.qio120=QIO 120MHz
+Geekble_Nano_ESP32S3.menu.FlashMode.qio120.build.flash_mode=dio
+Geekble_Nano_ESP32S3.menu.FlashMode.qio120.build.boot=qio
+Geekble_Nano_ESP32S3.menu.FlashMode.qio120.build.boot_freq=120m
+Geekble_Nano_ESP32S3.menu.FlashMode.qio120.build.flash_freq=80m
+
+Geekble_Nano_ESP32S3.menu.LoopCore.1=Core 1
+Geekble_Nano_ESP32S3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+Geekble_Nano_ESP32S3.menu.LoopCore.0=Core 0
+Geekble_Nano_ESP32S3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+Geekble_Nano_ESP32S3.menu.EventsCore.1=Core 1
+Geekble_Nano_ESP32S3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+Geekble_Nano_ESP32S3.menu.EventsCore.0=Core 0
+Geekble_Nano_ESP32S3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+Geekble_Nano_ESP32S3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+Geekble_Nano_ESP32S3.menu.USBMode.hwcdc.build.usb_mode=1
+Geekble_Nano_ESP32S3.menu.USBMode.default=USB-OTG (TinyUSB)
+Geekble_Nano_ESP32S3.menu.USBMode.default.build.usb_mode=0
+
+Geekble_Nano_ESP32S3.menu.CDCOnBoot.default=Disabled
+Geekble_Nano_ESP32S3.menu.CDCOnBoot.default.build.cdc_on_boot=0
+Geekble_Nano_ESP32S3.menu.CDCOnBoot.cdc=Enabled
+Geekble_Nano_ESP32S3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+Geekble_Nano_ESP32S3.menu.MSCOnBoot.default=Disabled
+Geekble_Nano_ESP32S3.menu.MSCOnBoot.default.build.msc_on_boot=0
+Geekble_Nano_ESP32S3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+Geekble_Nano_ESP32S3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+Geekble_Nano_ESP32S3.menu.DFUOnBoot.default=Disabled
+Geekble_Nano_ESP32S3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+Geekble_Nano_ESP32S3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+Geekble_Nano_ESP32S3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+Geekble_Nano_ESP32S3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+Geekble_Nano_ESP32S3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+Geekble_Nano_ESP32S3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+Geekble_Nano_ESP32S3.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.default.build.partitions=default
+Geekble_Nano_ESP32S3.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+Geekble_Nano_ESP32S3.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.no_ota.build.partitions=no_ota
+Geekble_Nano_ESP32S3.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+Geekble_Nano_ESP32S3.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+Geekble_Nano_ESP32S3.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.huge_app.build.partitions=huge_app
+Geekble_Nano_ESP32S3.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+Geekble_Nano_ESP32S3.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+Geekble_Nano_ESP32S3.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+Geekble_Nano_ESP32S3.menu.PartitionScheme.rainmaker=RainMaker 4MB
+Geekble_Nano_ESP32S3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+Geekble_Nano_ESP32S3.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+Geekble_Nano_ESP32S3.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+Geekble_Nano_ESP32S3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+Geekble_Nano_ESP32S3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+
+Geekble_Nano_ESP32S3.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.otanofs.build.custom_partitions=ota_nofs_4MB
+Geekble_Nano_ESP32S3.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+Geekble_Nano_ESP32S3.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+Geekble_Nano_ESP32S3.menu.PartitionScheme.all_app.build.custom_partitions=max_app_4MB
+Geekble_Nano_ESP32S3.menu.PartitionScheme.all_app.upload.maximum_size=4063232
+
+Geekble_Nano_ESP32S3.menu.PartitionScheme.custom=Custom
+Geekble_Nano_ESP32S3.menu.PartitionScheme.custom.build.partitions=
+Geekble_Nano_ESP32S3.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+Geekble_Nano_ESP32S3.menu.CPUFreq.240=240MHz (WiFi)
+Geekble_Nano_ESP32S3.menu.CPUFreq.240.build.f_cpu=240000000L
+Geekble_Nano_ESP32S3.menu.CPUFreq.160=160MHz (WiFi)
+Geekble_Nano_ESP32S3.menu.CPUFreq.160.build.f_cpu=160000000L
+Geekble_Nano_ESP32S3.menu.CPUFreq.80=80MHz (WiFi)
+Geekble_Nano_ESP32S3.menu.CPUFreq.80.build.f_cpu=80000000L
+Geekble_Nano_ESP32S3.menu.CPUFreq.40=40MHz
+Geekble_Nano_ESP32S3.menu.CPUFreq.40.build.f_cpu=40000000L
+Geekble_Nano_ESP32S3.menu.CPUFreq.20=20MHz
+Geekble_Nano_ESP32S3.menu.CPUFreq.20.build.f_cpu=20000000L
+Geekble_Nano_ESP32S3.menu.CPUFreq.10=10MHz
+Geekble_Nano_ESP32S3.menu.CPUFreq.10.build.f_cpu=10000000L
+
+Geekble_Nano_ESP32S3.menu.UploadSpeed.921600=921600
+Geekble_Nano_ESP32S3.menu.UploadSpeed.921600.upload.speed=921600
+Geekble_Nano_ESP32S3.menu.UploadSpeed.115200=115200
+Geekble_Nano_ESP32S3.menu.UploadSpeed.115200.upload.speed=115200
+Geekble_Nano_ESP32S3.menu.UploadSpeed.256000.windows=256000
+Geekble_Nano_ESP32S3.menu.UploadSpeed.256000.upload.speed=256000
+Geekble_Nano_ESP32S3.menu.UploadSpeed.230400.windows.upload.speed=256000
+Geekble_Nano_ESP32S3.menu.UploadSpeed.230400=230400
+Geekble_Nano_ESP32S3.menu.UploadSpeed.230400.upload.speed=230400
+Geekble_Nano_ESP32S3.menu.UploadSpeed.460800.linux=460800
+Geekble_Nano_ESP32S3.menu.UploadSpeed.460800.macosx=460800
+Geekble_Nano_ESP32S3.menu.UploadSpeed.460800.upload.speed=460800
+Geekble_Nano_ESP32S3.menu.UploadSpeed.512000.windows=512000
+Geekble_Nano_ESP32S3.menu.UploadSpeed.512000.upload.speed=512000
+
+Geekble_Nano_ESP32S3.menu.DebugLevel.none=None
+Geekble_Nano_ESP32S3.menu.DebugLevel.none.build.code_debug=0
+Geekble_Nano_ESP32S3.menu.DebugLevel.error=Error
+Geekble_Nano_ESP32S3.menu.DebugLevel.error.build.code_debug=1
+Geekble_Nano_ESP32S3.menu.DebugLevel.warn=Warn
+Geekble_Nano_ESP32S3.menu.DebugLevel.warn.build.code_debug=2
+Geekble_Nano_ESP32S3.menu.DebugLevel.info=Info
+Geekble_Nano_ESP32S3.menu.DebugLevel.info.build.code_debug=3
+Geekble_Nano_ESP32S3.menu.DebugLevel.debug=Debug
+Geekble_Nano_ESP32S3.menu.DebugLevel.debug.build.code_debug=4
+Geekble_Nano_ESP32S3.menu.DebugLevel.verbose=Verbose
+Geekble_Nano_ESP32S3.menu.DebugLevel.verbose.build.code_debug=5
+
+Geekble_Nano_ESP32S3.menu.EraseFlash.none=Disabled
+Geekble_Nano_ESP32S3.menu.EraseFlash.none.upload.erase_cmd=
+Geekble_Nano_ESP32S3.menu.EraseFlash.all=Enabled
+Geekble_Nano_ESP32S3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+
+##############################################################
+
 waveshare_esp32_s3_zero.name=Waveshare ESP32-S3-Zero
 waveshare_esp32_s3_zero.vid.0=0x303a
 waveshare_esp32_s3_zero.pid.0=0x822B

--- a/variants/Geekble_Nano_ESP32S3/pins_arduino.h
+++ b/variants/Geekble_Nano_ESP32S3/pins_arduino.h
@@ -36,6 +36,9 @@ static const uint8_t A7 = 14;
 // alternate pin functions
 
 static const uint8_t LED_BUILTIN = D13;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
 static const uint8_t SW_BUILTIN = 0;
 
 static const uint8_t TX = D1;

--- a/variants/Geekble_Nano_ESP32S3/pins_arduino.h
+++ b/variants/Geekble_Nano_ESP32S3/pins_arduino.h
@@ -1,0 +1,71 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID          0x303a
+#define USB_PID          0x82C5
+#define USB_MANUFACTURER "Geekble"
+#define USB_PRODUCT      "Geekble nano ESP32-S3"
+#define USB_SERIAL       ""  // Empty string for MAC address
+
+static const uint8_t D0 = 44;  // also RX
+static const uint8_t D1 = 43;  // also TX
+static const uint8_t D2 = 5;
+static const uint8_t D3 = 6;  // also CTS
+static const uint8_t D4 = 7;  // also DSR
+static const uint8_t D5 = 8;
+static const uint8_t D6 = 9;
+static const uint8_t D7 = 10;
+static const uint8_t D8 = 17;
+static const uint8_t D9 = 18;
+static const uint8_t D10 = 21;  // also SS
+static const uint8_t D11 = 38;  // also MOSI
+static const uint8_t D12 = 47;  // also MISO
+static const uint8_t D13 = 48;  // also SCK, LED_BUILTIN
+
+static const uint8_t A0 = 1;  // also DTR
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 11;  // also SDA
+static const uint8_t A5 = 12;  // also SCL
+static const uint8_t A6 = 13;
+static const uint8_t A7 = 14;
+
+// alternate pin functions
+
+static const uint8_t LED_BUILTIN = D13;
+static const uint8_t SW_BUILTIN = 0;
+
+static const uint8_t TX = D1;
+static const uint8_t RX = D0;
+static const uint8_t RTS = 45;
+static const uint8_t CTS = D3;
+static const uint8_t DTR = A0;
+static const uint8_t DSR = D4;
+
+static const uint8_t SS = D10;
+static const uint8_t MOSI = D11;
+static const uint8_t MISO = D12;
+static const uint8_t SCK = D13;
+
+static const uint8_t SDA = A4;
+static const uint8_t SCL = A5;
+
+// Touch input capable pins on the header
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+
+#define PIN_I2S_SCK    D7
+#define PIN_I2S_FS     D8
+#define PIN_I2S_SD     D9
+#define PIN_I2S_SD_OUT D9  // same as bidir
+#define PIN_I2S_SD_IN  D10
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
1. add new board
2. https://cafe.naver.com/geekbleofficial/18197
3. https://github.com/SooDragon/Geekble-nano-ESP32S3

## Description of Change
A new Dev board for ESP32-S3
It's simple,Easy to use, comparable with Arduino Nano and Arduino Nano ESP32
It's targeted South Korean market to introduce ESP32-S3 to Korean makers

## Tests scenarios
Tested with 
- Arduino IDE 2.3.4 
- Arduino IDE 1.8.19
- Arduino-esp32 core 3.1.1
- Arduino dev boards with ESP32-S3

## Related links
https://github.com/SooDragon/Geekble-nano-ESP32S3