### PR TITLE
ci(libs): ESP-IDF release/v5.4

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
-              "size": "345893666"
+              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
+              "size": "345893708"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
-              "size": "345893703"
+              "checksum": "SHA-256:ae265b008c5bf2ecfdbfdbc61360c2d70b6852bc4b77bf560b2cfa235dd571c4",
+              "size": "345893053"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
-              "size": "345893659"
+              "checksum": "SHA-256:4eb1d014aab4d331b2f8d09b56af0972708628b80a7ff33769117acb2e1dec6c",
+              "size": "345893666"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-bcb3c32d-v1"
+              "version": "idf-release_v5.4-0ba53566-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-bcb3c32d-v1",
+          "version": "idf-release_v5.4-0ba53566-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:86c15df2aef46f0fb0507c680dd5f782502442ff38fbc87a08967bf800cbea2e",
+              "size": "345893659"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:fff29855631fd102800636bc9116898ac2347a9cfc7516cbe260fa7cc270af41",
-              "size": "345893708"
+              "checksum": "SHA-256:63255d8b15aa729a45cc9991fd435d48a3c63960b3d42f0580077ac346ce405f",
+              "size": "345893703"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 5db5d9a
esp-idf: release/v5.4 0ba53566fa
arduino: master 1467d874
tinyusb: master 1cfc88dbc
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.7.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.16.4
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
espressif__esp32-camera:
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
