### PR TITLE
ci(libs): ESP-IDF master

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
-              "size": "411886512"
+              "checksum": "SHA-256:82904a368aa6390d30a81b593a22ae6ec552bfae686864a5c45a77dc5a2071ff",
+              "size": "411886520"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
+              "size": "411930695"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:ddc1b6af9c8366dedc84903f81114241e0459e16369dc404298dc367b0479333",
-              "size": "411930695"
+              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
+              "size": "411930697"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-877057db-v1"
+              "version": "idf-master-0461e2ff-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-877057db-v1",
+          "version": "idf-master-0461e2ff-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
-              "size": "411930074"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:8c6b4c281c786d5236c96c8eee227ab7c912d9040d97c4a817d493ae1bdd72b1",
+              "size": "411886512"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:a9d94fa6bcaba685ba30566da6c624be3ce9a55c2f6b6001f88759021b586f84",
-              "size": "411930697"
+              "checksum": "SHA-256:96566d84ee95e0208aa88aca3836dea71e95c0cb19f39379ab17908d726ef3b7",
+              "size": "411930074"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 c292f95
esp-idf: master 877057db3d
arduino: release/v3.3.x 30255d7f
tinyusb: master 1cfc88dbc
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__eppp_link: 0.2.0
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp_hosted: 0.0.25
espressif__esp_modem: 1.3.0
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.5.5
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.7.0
espressif__network_provisioning: 1.0.2
joltwallet__littlefs: 1.16.4
espressif__cbor: 0.6.0~1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
espressif__esp32-camera:
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.3.0
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
```
