### PR TITLE
 fix(zigbee): use correct carbon dioxide cluster function in setTolerance

### DIFF
--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -37,7 +37,7 @@ void ZigbeeCarbonDioxideSensor::setTolerance(float tolerance) {
   float zb_tolerance = tolerance / 1000000.0f;
   esp_zb_attribute_list_t *carbon_dioxide_measure_cluster =
     esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-  esp_zb_temperature_meas_cluster_add_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_TOLERANCE_ID, (void *)&zb_tolerance);
+  esp_zb_carbon_dioxide_measurement_cluster_add_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_TOLERANCE_ID, (void *)&zb_tolerance);
 }
 
 void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta) {

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -37,7 +37,9 @@ void ZigbeeCarbonDioxideSensor::setTolerance(float tolerance) {
   float zb_tolerance = tolerance / 1000000.0f;
   esp_zb_attribute_list_t *carbon_dioxide_measure_cluster =
     esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-  esp_zb_carbon_dioxide_measurement_cluster_add_attr(carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_TOLERANCE_ID, (void *)&zb_tolerance);
+  esp_zb_carbon_dioxide_measurement_cluster_add_attr(
+    carbon_dioxide_measure_cluster, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_TOLERANCE_ID, (void *)&zb_tolerance
+  );
 }
 
 void ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max_interval, uint16_t delta) {


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change

Fixed calling a temperature cluster function on a carbon dioxide cluster in `setTolerance`.
Same as #11008 but for carbon dioxide.

## Tests scenarios

ESP32-C6

## Related links

N/A

