### PR TITLE
IDF release/v5.4

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-bcb3c32d-v1"
+              "version": "idf-release_v5.4-0ba53566-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-bcb3c32d-v1",
+          "version": "idf-release_v5.4-0ba53566-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-bcb3c32d-v1.zip",
-              "checksum": "SHA-256:2ab7a8565d4eadd805c1d00c9a1550292d3287dc43efa166d7ad3ba5322344bb",
-              "size": "345570903"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
+              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
+              "size": "345893035"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-0ba53566-v1"
+              "version": "idf-release_v5.4-57d976b7-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-0ba53566-v1",
+          "version": "idf-release_v5.4-57d976b7-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-0ba53566-v1.zip",
-              "checksum": "SHA-256:d98c887a2ba60a0b47bad24293f3f106c645d8e8ec5c1c7b5b0b956cbdb0a132",
-              "size": "345893035"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
+              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
+              "size": "345898632"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-57d976b7-v1"
+              "version": "idf-release_v5.4-d4aa25a3-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-57d976b7-v1",
+          "version": "idf-release_v5.4-d4aa25a3-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-57d976b7-v1.zip",
-              "checksum": "SHA-256:7c94fd1859dc83a6c3cd4ba08437455a8e532aeb14b84181d0b0387f8c20e65b",
-              "size": "345898632"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
+              "checksum": "SHA-256:6fa3e72f397de66fcc8a9ab828314db5026db11293b067c0ef5b7857771fd479",
+              "size": "345898572"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 16a6e09
esp-idf: release/v5.4 0ba53566fa
arduino: master 7575fa0c
tinyusb: master 1cfc88dbc
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_insights: 1.0.1
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.7.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.16.4
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.3.0
espressif__esp32-camera:
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
