### PR TITLE
IDF master

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-877057db-v1"
+              "version": "idf-master-0461e2ff-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-877057db-v1",
+          "version": "idf-master-0461e2ff-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-877057db-v1.zip",
-              "checksum": "SHA-256:fcded8de4107841bea5aaeb7bf7b53a336b3d132df29fb09ae6697b187d51920",
-              "size": "411930767"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
+              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
+              "size": "411886500"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 11f8400
esp-idf: master 0461e2ff88
arduino: release/v3.3.x 704c5ee4
tinyusb: master 1cfc88dbc
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.7.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.16.4
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.5.5
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
```
