### PR TITLE
fix(bt): Compile error on ESP32-P4

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -25,7 +25,7 @@
 #include "esp_ota_ops.h"
 #endif  //CONFIG_APP_ROLLBACK_ENABLE
 #include "esp_private/startup_internal.h"
-#ifdef CONFIG_BT_ENABLED
+#ifdef CONFIG_BT_ENABLED && SOC_BT_SUPPORTED
 #include "esp_bt.h"
 #endif  //CONFIG_BT_ENABLED
 #include <sys/time.h>
@@ -305,7 +305,7 @@ void initArduino() {
   if (err) {
     log_e("Failed to initialize NVS! Error: %u", err);
   }
-#ifdef CONFIG_BT_ENABLED
+#ifdef CONFIG_BT_ENABLED && SOC_BT_SUPPORTED
   if (!btInUse()) {
     esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
   }

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -25,7 +25,7 @@
 #include "esp_ota_ops.h"
 #endif  //CONFIG_APP_ROLLBACK_ENABLE
 #include "esp_private/startup_internal.h"
-#ifdef CONFIG_BT_ENABLED && SOC_BT_SUPPORTED
+#if defined(CONFIG_BT_ENABLED) && SOC_BT_SUPPORTED
 #include "esp_bt.h"
 #endif  //CONFIG_BT_ENABLED
 #include <sys/time.h>
@@ -305,7 +305,7 @@ void initArduino() {
   if (err) {
     log_e("Failed to initialize NVS! Error: %u", err);
   }
-#ifdef CONFIG_BT_ENABLED && SOC_BT_SUPPORTED
+#if defined(CONFIG_BT_ENABLED) && SOC_BT_SUPPORTED
   if (!btInUse()) {
     esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
   }


### PR DESCRIPTION
## Description of Change
My project uses Arduino as an ESP-IDF component with esp-nimble-cpp to provide BLE functionality
I'm seeing compile errors when trying to build my project for the ESP32-P4 because of missing `esp_bt.h` and (as a result) not defined `esp_bt_controller_mem_release` and `ESP_BT_MODE_BTDM`.

As far as I can see `cores/esp32/esp32-hal-misc.c` is the only place where inclusion of `esp_bt.h` is not guarded by `#if SOC_BT_SUPPORTED`

This PR fixes these errors.

## Tests scenarios
I have tested compilation of my Pull Request on Arduino-esp32 core v3.1.3 with ESP32-P4 Board with this scenario

## Related links
None