### PR TITLE
feat(matter): necessary changes to insights version for esp_matter

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -69,7 +69,7 @@ dependencies:
   espressif/network_provisioning:
     version: "1.0.2"
   espressif/esp_rainmaker:
-    version: "1.5.0"
+    version: "1.5.2"
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/rmaker_common:

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -77,16 +77,16 @@ dependencies:
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/esp_insights:
-    version: "1.0.1"
+    version: "1.2.2"
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   # New version breaks esp_insights 1.0.1
   espressif/esp_diag_data_store:
-    version: "1.0.1"
+    version: "1.0.2"
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/esp_diagnostics:
-    version: "1.0.2"
+    version: "1.2.1"
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/cbor:


### PR DESCRIPTION
## Description of Change
Recent version of ESP MATTER v1.4 needs newer versions of ESP INSIGHTS and DIAGNOTICS.
This PR updates the Managed Components version.

## Tests scenarios
Using ESP LIB BUILDER

## Related links
Related to https://github.com/espressif/esp32-arduino-lib-builder/pull/280