### PR TITLE
feat(wifi): Add support for 2.4GHz and 5GHz band switching

### DIFF
--- a/libraries/WiFi/examples/WiFiScan/WiFiScan.ino
+++ b/libraries/WiFi/examples/WiFiScan/WiFiScan.ino
@@ -1,5 +1,5 @@
 /*
- *  This sketch demonstrates how to scan WiFi networks.
+ *  This sketch demonstrates how to scan WiFi networks. For chips that support 5GHz band, separate scans are done for all bands.
  *  The API is based on the Arduino WiFi Shield library, but has significant changes as newer WiFi functions are supported.
  *  E.g. the return value of `encryptionType()` different because more modern encryption is supported.
  */
@@ -7,18 +7,13 @@
 
 void setup() {
   Serial.begin(115200);
-
-  // Set WiFi to station mode and disconnect from an AP if it was previously connected.
-  WiFi.mode(WIFI_STA);
-  WiFi.disconnect();
-  delay(100);
-
+  // Enable Station Interface
+  WiFi.STA.begin();
   Serial.println("Setup done");
 }
 
-void loop() {
+void ScanWiFi() {
   Serial.println("Scan start");
-
   // WiFi.scanNetworks will return the number of networks found.
   int n = WiFi.scanNetworks();
   Serial.println("Scan done");
@@ -54,11 +49,33 @@ void loop() {
       delay(10);
     }
   }
-  Serial.println("");
 
   // Delete the scan result to free memory for code below.
   WiFi.scanDelete();
-
+  Serial.println("-------------------------------------");
+}
+void loop() {
+  Serial.println("-------------------------------------");
+  Serial.println("Default wifi band mode scan:");
+  Serial.println("-------------------------------------");
+  WiFi.setBandMode(WIFI_BAND_MODE_AUTO);
+  ScanWiFi();
+#if CONFIG_SOC_WIFI_SUPPORT_5G
   // Wait a bit before scanning again.
-  delay(5000);
+  delay(1000);
+  Serial.println("-------------------------------------");
+  Serial.println("2.4 Ghz wifi band mode scan:");
+  Serial.println("-------------------------------------");
+  WiFi.setBandMode(WIFI_BAND_MODE_2G_ONLY);
+  ScanWiFi();
+  // Wait a bit before scanning again.
+  delay(1000);
+  Serial.println("-------------------------------------");
+  Serial.println("5 Ghz wifi band mode scan:");
+  Serial.println("-------------------------------------");
+  WiFi.setBandMode(WIFI_BAND_MODE_5G_ONLY);
+  ScanWiFi();
+#endif
+  // Wait a bit before scanning again.
+  delay(10000);
 }

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -740,7 +740,7 @@ bool WiFiGenericClass::setBandMode(wifi_band_mode_t band_mode) {
   delay(100);
   return true;
 #else
-  if (band_mode == WIFI_BAND_MODE_5G_ONLY){
+  if (band_mode == WIFI_BAND_MODE_5G_ONLY) {
     log_e("This chip supports only 2.4GHz WiFi");
   }
   return band_mode != WIFI_BAND_MODE_5G_ONLY;

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -111,6 +111,10 @@ public:
   bool setTxPower(wifi_power_t power);
   wifi_power_t getTxPower();
 
+  bool setBandMode(wifi_band_mode_t band_mode);
+  wifi_band_mode_t getBandMode();
+  wifi_band_t getBand();
+
   bool initiateFTM(uint8_t frm_count = 16, uint16_t burst_period = 2, uint8_t channel = 1, const uint8_t *mac = NULL);
 
   static bool setDualAntennaConfig(uint8_t gpio_ant1, uint8_t gpio_ant2, wifi_rx_ant_t rx_mode, wifi_tx_ant_t tx_mode);


### PR DESCRIPTION
This pull request includes changes to the WiFi library to add support for scanning WiFi networks in both 2.4GHz and 5GHz bands. The most important changes include updating the example sketch to demonstrate scanning for both bands, adding new methods to control WiFi band modes, and ensuring compatibility with chips that support 5GHz WiFi.

Enhancements to WiFi scanning:

* [`libraries/WiFi/examples/WiFiScan/WiFiScan.ino`](diffhunk://#diff-afcdb9d9488c384bf9f65155df1a3fe577e93dab466a11211246e3d7c46b4268L2-L21): Updated the example sketch to perform separate scans for 2.4GHz and 5GHz bands if supported by the chip. [[1]](diffhunk://#diff-afcdb9d9488c384bf9f65155df1a3fe577e93dab466a11211246e3d7c46b4268L2-L21) [[2]](diffhunk://#diff-afcdb9d9488c384bf9f65155df1a3fe577e93dab466a11211246e3d7c46b4268L57-R80)

New methods for WiFi band control:

* [`libraries/WiFi/src/WiFiGeneric.cpp`](diffhunk://#diff-0aa87997f6f48b5397f969144b34ce0ad4da8e173aee854c1cf2e1bf69ecf3aaR708-R791): Added methods `setBandMode`, `getBandMode`, and `getBand` to control and retrieve the current WiFi band mode and active band. These methods ensure compatibility with chips supporting 5GHz WiFi.
* [`libraries/WiFi/src/WiFiGeneric.h`](diffhunk://#diff-aef37ec58184bbd5ee4dac430dbb910ccd7b6b79815c945490410257e5879578R114-R117): Declared the new methods `setBandMode`, `getBandMode`, and `getBand` in the `WiFiGenericClass`.

Initialization improvements:

* [`libraries/WiFi/src/WiFiGeneric.cpp`](diffhunk://#diff-0aa87997f6f48b5397f969144b34ce0ad4da8e173aee854c1cf2e1bf69ecf3aaR381-R384): Set the default band mode to AUTO during WiFi initialization if the chip supports 5GHz WiFi.
