### PR TITLE
fix(idf_component): Add USB HOST component

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -121,6 +121,76 @@ dependencies:
   chmorgan/esp-libhelix-mp3:
     version: "1.0.3"
     require: public
+  # https://components.espressif.com/components/espressif/esp_modem_usb_dte
+  espressif/esp_modem_usb_dte:
+    version: "^1.2.1"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_cdc_acm
+  espressif/usb_host_cdc_acm:
+    version: "^2.0.6"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_ch34x_vcp
+  espressif/usb_host_ch34x_vcp:
+    version: "^2.0.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_cp210x_vcp
+  espressif/usb_host_cp210x_vcp:
+    version: "^2.0.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_ftdi_vcp
+  espressif/usb_host_ftdi_vcp:
+    version: "^2.0.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_vcp
+  espressif/usb_host_vcp:
+    version: "^1.0.0~5"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_hid
+  espressif/usb_host_hid:
+    version: "^1.0.3"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_msc
+  espressif/usb_host_msc:
+    version: "^1.1.3"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_uac
+  espressif/usb_host_uac:
+    version: "^1.2.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_host_uvc
+  espressif/usb_host_uvc:
+    version: "^2.1.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/usb_stream
+  espressif/usb_stream:
+    version: "^1.5.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/iot_usbh_modem
+  espressif/iot_usbh_modem:
+    version: "^1.1.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/espressif/iot_usbh_cdc
+  espressif/iot_usbh_cdc:
+    version: "^1.0.0"
+    rules:
+      - if: "target in [esp32s3]"
+  # https://components.espressif.com/components/chmorgan/esp-audio-player
+  chmorgan/esp-audio-player:
+    version: "^1.0.7"
+    rules:
+      - if: "target in [esp32s3]"
 examples:
   - path: ./idf_component_examples/hello_world
   - path: ./idf_component_examples/hw_cdc_hello_world

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -132,25 +132,25 @@ dependencies:
     rules:
       - if: "target in [esp32s3]"
   # https://components.espressif.com/components/espressif/usb_host_ch34x_vcp
-  espressif/usb_host_ch34x_vcp:
-    version: "^2.0.0"
-    rules:
-      - if: "target in [esp32s3]"
+  #espressif/usb_host_ch34x_vcp:
+  #  version: "^2.0.0"
+  #  rules:
+  #    - if: "target in [esp32s3]"
   # https://components.espressif.com/components/espressif/usb_host_cp210x_vcp
-  espressif/usb_host_cp210x_vcp:
-    version: "^2.0.0"
-    rules:
-      - if: "target in [esp32s3]"
+  #espressif/usb_host_cp210x_vcp:
+  #  version: "^2.0.0"
+  #  rules:
+  #    - if: "target in [esp32s3]"
   # https://components.espressif.com/components/espressif/usb_host_ftdi_vcp
-  espressif/usb_host_ftdi_vcp:
-    version: "^2.0.0"
-    rules:
-      - if: "target in [esp32s3]"
+  #espressif/usb_host_ftdi_vcp:
+  #  version: "^2.0.0"
+  #  rules:
+  #    - if: "target in [esp32s3]"
   # https://components.espressif.com/components/espressif/usb_host_vcp
-  espressif/usb_host_vcp:
-    version: "^1.0.0~5"
-    rules:
-      - if: "target in [esp32s3]"
+  #espressif/usb_host_vcp:
+  #  version: "^1.0.0~5"
+  #  rules:
+  #    - if: "target in [esp32s3]"
   # https://components.espressif.com/components/espressif/usb_host_hid
   espressif/usb_host_hid:
     version: "^1.0.3"


### PR DESCRIPTION
Add USB HOST component

-----------
## Description of Change
```
idf.py add-dependency "espressif/esp_modem_usb_dte"
idf.py add-dependency "espressif/usb_host_cdc_acm"
idf.py add-dependency "espressif/usb_host_ch34x_vcp"
idf.py add-dependency "espressif/usb_host_cp210x_vcp"
idf.py add-dependency "espressif/usb_host_ftdi_vcp"
idf.py add-dependency "espressif/usb_host_vcp"
idf.py add-dependency "espressif/usb_host_hid"
idf.py add-dependency "espressif/usb_host_msc"
idf.py add-dependency "espressif/usb_host_uac"
idf.py add-dependency "espressif/usb_host_uvc"
idf.py add-dependency "espressif/usb_stream"
idf.py add-dependency "espressif/iot_usbh_modem"
idf.py add-dependency "espressif/iot_usbh_cdc"
idf.py add-dependency "chmorgan/esp-audio-player"
```

There is no need to build it with esp32-arduino-lib-builder.

https://github.com/espressif/esp-iot-solution/tree/master/examples/usb/host
Add the components used here.

## Tests scenarios
```
./build.sh -A release/v3.3.x -I release/v5.3 -t esp32s3 -b idf-libs
```
Confirm that you can build it with esp32-arduino-lib-builder.

## Related links
https://github.com/espressif/arduino-esp32/issues/10978
https://github.com/hathach/tinyusb/issues/2634