### PR TITLE
feat(eth): Add setters for negotiation, speed and duplex modes

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -1014,7 +1014,7 @@ bool ETHClass::setFullDuplex(bool on) {
   if (_eth_handle == NULL) {
     return false;
   }
-  eth_duplex_t link_duplex = on?ETH_DUPLEX_FULL:ETH_DUPLEX_HALF;
+  eth_duplex_t link_duplex = on ? ETH_DUPLEX_FULL : ETH_DUPLEX_HALF;
   esp_err_t err = esp_eth_ioctl(_eth_handle, ETH_CMD_S_DUPLEX_MODE, &link_duplex);
   if (err != ESP_OK) {
     log_e("Failed to set duplex mode: 0x%x: %s", err, esp_err_to_name(err));
@@ -1064,7 +1064,7 @@ bool ETHClass::setLinkSpeed(uint16_t speed) {
   if (_eth_handle == NULL) {
     return false;
   }
-  eth_speed_t link_speed = (speed == 10)?ETH_SPEED_10M:ETH_SPEED_100M;
+  eth_speed_t link_speed = (speed == 10) ? ETH_SPEED_10M : ETH_SPEED_100M;
   esp_err_t err = esp_eth_ioctl(_eth_handle, ETH_CMD_S_SPEED, &link_speed);
   if (err != ESP_OK) {
     log_e("Failed to set link speed: 0x%x: %s", err, esp_err_to_name(err));

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -1010,6 +1010,18 @@ bool ETHClass::fullDuplex() const {
   return (link_duplex == ETH_DUPLEX_FULL);
 }
 
+bool ETHClass::setFullDuplex(bool on) {
+  if (_eth_handle == NULL) {
+    return false;
+  }
+  eth_duplex_t link_duplex = on?ETH_DUPLEX_FULL:ETH_DUPLEX_HALF;
+  esp_err_t err = esp_eth_ioctl(_eth_handle, ETH_CMD_S_DUPLEX_MODE, &link_duplex);
+  if (err != ESP_OK) {
+    log_e("Failed to set duplex mode: 0x%x: %s", err, esp_err_to_name(err));
+  }
+  return err == ESP_OK;
+}
+
 bool ETHClass::autoNegotiation() const {
   if (_eth_handle == NULL) {
     return false;
@@ -1017,6 +1029,17 @@ bool ETHClass::autoNegotiation() const {
   bool auto_nego;
   esp_eth_ioctl(_eth_handle, ETH_CMD_G_AUTONEGO, &auto_nego);
   return auto_nego;
+}
+
+bool ETHClass::setAutoNegotiation(bool on) {
+  if (_eth_handle == NULL) {
+    return false;
+  }
+  esp_err_t err = esp_eth_ioctl(_eth_handle, ETH_CMD_S_AUTONEGO, &on);
+  if (err != ESP_OK) {
+    log_e("Failed to set auto negotiation: 0x%x: %s", err, esp_err_to_name(err));
+  }
+  return err == ESP_OK;
 }
 
 uint32_t ETHClass::phyAddr() const {
@@ -1028,13 +1051,25 @@ uint32_t ETHClass::phyAddr() const {
   return phy_addr;
 }
 
-uint8_t ETHClass::linkSpeed() const {
+uint16_t ETHClass::linkSpeed() const {
   if (_eth_handle == NULL) {
     return 0;
   }
   eth_speed_t link_speed;
   esp_eth_ioctl(_eth_handle, ETH_CMD_G_SPEED, &link_speed);
   return (link_speed == ETH_SPEED_10M) ? 10 : 100;
+}
+
+bool ETHClass::setLinkSpeed(uint16_t speed) {
+  if (_eth_handle == NULL) {
+    return false;
+  }
+  eth_speed_t link_speed = (speed == 10)?ETH_SPEED_10M:ETH_SPEED_100M;
+  esp_err_t err = esp_eth_ioctl(_eth_handle, ETH_CMD_S_SPEED, &link_speed);
+  if (err != ESP_OK) {
+    log_e("Failed to set link speed: 0x%x: %s", err, esp_err_to_name(err));
+  }
+  return err == ESP_OK;
 }
 
 // void ETHClass::getMac(uint8_t* mac)

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -192,8 +192,14 @@ public:
 
   // ETH Handle APIs
   bool fullDuplex() const;
-  uint8_t linkSpeed() const;
+  bool setFullDuplex(bool on);
+  
+  uint16_t linkSpeed() const;
+  bool setLinkSpeed(uint16_t speed);//10 or 100
+
   bool autoNegotiation() const;
+  bool setAutoNegotiation(bool on);
+
   uint32_t phyAddr() const;
 
   esp_eth_handle_t handle() const;

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -193,9 +193,9 @@ public:
   // ETH Handle APIs
   bool fullDuplex() const;
   bool setFullDuplex(bool on);
-  
+
   uint16_t linkSpeed() const;
-  bool setLinkSpeed(uint16_t speed);//10 or 100
+  bool setLinkSpeed(uint16_t speed);  //10 or 100
 
   bool autoNegotiation() const;
   bool setAutoNegotiation(bool on);


### PR DESCRIPTION
This pull request introduces several new methods and modifications to the `ETHClass` in the Ethernet library to enhance its functionality. The primary changes include adding methods to set duplex mode, auto-negotiation, and link speed, as well as updating the return type of the `linkSpeed` method.

### Enhancements to `ETHClass`:

* Added `setFullDuplex` method to allow setting the duplex mode of the Ethernet connection.
* Added `setAutoNegotiation` method to enable or disable auto-negotiation on the Ethernet connection.
* Added `setLinkSpeed` method to set the link speed of the Ethernet connection.
* Updated `linkSpeed` method to return `uint16_t` instead of `uint8_t` for better compatibility with link speed values.

### Header file updates:

* Updated `ETH.h` to declare the new methods and modify the return type of `linkSpeed`.

fixes: https://github.com/espressif/arduino-esp32/issues/10923