### PR TITLE
fix(zigbee): Fixed Guru Meditation crash with Zigbee Analog example

### DIFF
--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
@@ -105,7 +105,7 @@ void ZigbeeAnalog::setAnalogInputReporting(uint16_t min_interval, uint16_t max_i
   memset(&reporting_info, 0, sizeof(esp_zb_zcl_reporting_info_t));
   reporting_info.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_SRV;
   reporting_info.ep = _endpoint;
-  reporting_info.cluster_id = ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT;
+  reporting_info.cluster_id = ESP_ZB_ZCL_CLUSTER_ID_ANALOG_INPUT;
   reporting_info.cluster_role = ESP_ZB_ZCL_CLUSTER_SERVER_ROLE;
   reporting_info.attr_id = ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID;
   reporting_info.u.send_info.min_interval = min_interval;


### PR DESCRIPTION
## Description of Change
Fix to a copy-paste error that causes a Guru Meditation crash with Zigbee Analog Example.

## Tests scenarios
Tested on ESP32C6 and ESP32H2, compiled using both VS Code with Arduino Community extension and Arduino IDE V1.8.19

## Related links

This will close [#11044](https://github.com/espressif/arduino-esp32/issues/11044)

