### PR TITLE
fix(matter): removes a few matter 1.4 / IDF 5.4 compilation warning messages 

### DIFF
--- a/libraries/Matter/src/MatterEndpoints/MatterColorLight.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterColorLight.h
@@ -66,8 +66,8 @@ public:
 
 protected:
   bool started = false;
-  bool onOffState = false;       // default initial state is off, but it can be changed by begin(bool)
-  espHsvColor_t colorHSV = {0};  // default initial color HSV is black, but it can be changed by begin(bool, espHsvColor_t)
+  bool onOffState = false;             // default initial state is off, but it can be changed by begin(bool)
+  espHsvColor_t colorHSV = {0, 0, 0};  // default initial color HSV is black, but it can be changed by begin(bool, espHsvColor_t)
   EndPointOnOffCB _onChangeOnOffCB = NULL;
   EndPointRGBColorCB _onChangeColorCB = NULL;
   EndPointCB _onChangeCB = NULL;

--- a/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.h
@@ -91,7 +91,7 @@ protected:
   bool started = false;
   bool onOffState = false;             // default initial state is off, but it can be changed by begin(bool)
   uint8_t brightnessLevel = 0;         // default initial brightness is 0, but it can be changed by begin(bool, uint8_t)
-  espHsvColor_t colorHSV = {0};        // default initial color HSV is black, but it can be changed by begin(bool, uint8_t, espHsvColor_t)
+  espHsvColor_t colorHSV = {0, 0, 0};  // default initial color HSV is black, but it can be changed by begin(bool, uint8_t, espHsvColor_t)
   uint16_t colorTemperatureLevel = 0;  // default initial color temperature is 0, but it can be changed by begin(bool, uint8_t, espHsvColor_t, uint16_t)
   EndPointOnOffCB _onChangeOnOffCB = NULL;
   EndPointBrightnessCB _onChangeBrightnessCB = NULL;


### PR DESCRIPTION
## Description of Change
A Maintainance PR to remove a few compilation warning messages:

libraries\Matter\src/MatterEndpoints/MatterEnhancedColorLight.h:94:30: warning: missing initializer for member 'HsvColor_t::s' [-Wmissing-field-initializers]
libraries\Matter\src/MatterEndpoints/MatterEnhancedColorLight.h:94:30: warning: missing initializer for member 'HsvColor_t::v' [-Wmissing-field-initializers]
libraries\Matter\src/MatterEndpoints/MatterColorLight.h:70:30: warning: missing initializer for member 'HsvColor_t::s' [-Wmissing-field-initializers]
libraries\Matter\src/MatterEndpoints/MatterColorLight.h:70:30: warning: missing initializer for member 'HsvColor_t::v' [-Wmissing-field-initializers]

## Tests scenarios
CI only

## Related links
None