### PR TITLE
fix(network): fixes a macro name conflict warning

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -23,7 +23,11 @@
 #include <lwip/netdb.h>
 #include <errno.h>
 
-#define _IN6_IS_ADDR_V4MAPPED(a) ((((__const uint32_t *)(a))[0] == 0) && (((__const uint32_t *)(a))[1] == 0) && (((__const uint32_t *)(a))[2] == htonl(0xffff)))
+// It is already defined in IDF as:
+//#define IN6_IS_ADDR_V4MAPPED(a)     ip6_addr_isipv4mappedipv6((ip6_addr_t*)(a))
+//#define ip6_addr_isipv4mappedipv6(ip6addr) (((ip6addr)->addr[0] == 0) && ((ip6addr)->addr[1] == 0) && (((ip6addr)->addr[2]) == PP_HTONL(0x0000FFFFUL)))
+// Keeping as a memory of the change.
+//#define _IN6_IS_ADDR_V4MAPPED(a) ((((__const uint32_t *)(a))[0] == 0) && (((__const uint32_t *)(a))[1] == 0) && (((__const uint32_t *)(a))[2] == htonl(0xffff)))
 
 #define WIFI_CLIENT_DEF_CONN_TIMEOUT_MS (3000)
 #define WIFI_CLIENT_MAX_WRITE_RETRY     (10)
@@ -598,7 +602,7 @@ IPAddress NetworkClient::remoteIP(int fd) const {
   // IPv6, but it might be IPv4 mapped address
   if (((struct sockaddr *)&addr)->sa_family == AF_INET6) {
     struct sockaddr_in6 *saddr6 = (struct sockaddr_in6 *)&addr;
-    if (_IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
+    if (IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
       return IPAddress(IPv4, (uint8_t *)saddr6->sin6_addr.s6_addr + IPADDRESS_V4_BYTES_INDEX);
     } else {
       return IPAddress(IPv6, (uint8_t *)(saddr6->sin6_addr.s6_addr), saddr6->sin6_scope_id);
@@ -640,7 +644,7 @@ IPAddress NetworkClient::localIP(int fd) const {
   // IPv6, but it might be IPv4 mapped address
   if (((struct sockaddr *)&addr)->sa_family == AF_INET6) {
     struct sockaddr_in6 *saddr6 = (struct sockaddr_in6 *)&addr;
-    if (_IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
+    if (IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
       return IPAddress(IPv4, (uint8_t *)saddr6->sin6_addr.s6_addr + IPADDRESS_V4_BYTES_INDEX);
     } else {
       return IPAddress(IPv6, (uint8_t *)(saddr6->sin6_addr.s6_addr), saddr6->sin6_scope_id);

--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -23,7 +23,7 @@
 #include <lwip/netdb.h>
 #include <errno.h>
 
-#define IN6_IS_ADDR_V4MAPPED(a) ((((__const uint32_t *)(a))[0] == 0) && (((__const uint32_t *)(a))[1] == 0) && (((__const uint32_t *)(a))[2] == htonl(0xffff)))
+#define _IN6_IS_ADDR_V4MAPPED(a) ((((__const uint32_t *)(a))[0] == 0) && (((__const uint32_t *)(a))[1] == 0) && (((__const uint32_t *)(a))[2] == htonl(0xffff)))
 
 #define WIFI_CLIENT_DEF_CONN_TIMEOUT_MS (3000)
 #define WIFI_CLIENT_MAX_WRITE_RETRY     (10)
@@ -598,7 +598,7 @@ IPAddress NetworkClient::remoteIP(int fd) const {
   // IPv6, but it might be IPv4 mapped address
   if (((struct sockaddr *)&addr)->sa_family == AF_INET6) {
     struct sockaddr_in6 *saddr6 = (struct sockaddr_in6 *)&addr;
-    if (IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
+    if (_IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
       return IPAddress(IPv4, (uint8_t *)saddr6->sin6_addr.s6_addr + IPADDRESS_V4_BYTES_INDEX);
     } else {
       return IPAddress(IPv6, (uint8_t *)(saddr6->sin6_addr.s6_addr), saddr6->sin6_scope_id);
@@ -640,7 +640,7 @@ IPAddress NetworkClient::localIP(int fd) const {
   // IPv6, but it might be IPv4 mapped address
   if (((struct sockaddr *)&addr)->sa_family == AF_INET6) {
     struct sockaddr_in6 *saddr6 = (struct sockaddr_in6 *)&addr;
-    if (IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
+    if (_IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
       return IPAddress(IPv4, (uint8_t *)saddr6->sin6_addr.s6_addr + IPADDRESS_V4_BYTES_INDEX);
     } else {
       return IPAddress(IPv6, (uint8_t *)(saddr6->sin6_addr.s6_addr), saddr6->sin6_scope_id);


### PR DESCRIPTION
## Description of Change
Fixes a simple macro name conflict warning message:

IDF 5.3+ declares:
``` cpp
#define IN6_IS_ADDR_V4MAPPED(a)     ip6_addr_isipv4mappedipv6((ip6_addr_t*)(a))
#define ip6_addr_isipv4mappedipv6(ip6addr) (((ip6addr)->addr[0] == 0) && ((ip6addr)->addr[1] == 0) && (((ip6addr)->addr[2]) == PP_HTONL(0x0000FFFFUL)))
```
 
`libraries/Network/src/NetworkClient.cpp` declares:
``` cpp
#define _IN6_IS_ADDR_V4MAPPED(a) ((((__const uint32_t *)(a))[0] == 0) && (((__const uint32_t *)(a))[1] == 0) && (((__const uint32_t *)(a))[2] == htonl(0xffff)))
```

Therefore, both should be the same.

#### Warning message:

```
\libraries\Network\src\NetworkClient.cpp:26:9: warning: "IN6_IS_ADDR_V4MAPPED" redefined
   26 | #define IN6_IS_ADDR_V4MAPPED(a) ((((__const uint32_t *)(a))[0] == 0) && (((__const uint32_t *)(a))[1] == 0) && (((__const uint32_t *)(a))[2] == htonl(0xffff)))
      |         ^~~~~~~~~~~~~~~~~~~~
In file included from \tools\esp32-arduino-libs\esp32/include/lwip/lwip/src/include/lwip/sockets.h:53,
                 from \tools\esp32-arduino-libs\esp32/include/lwip/include/lwip/sockets.h:8,
                 from \libraries\Network\src\NetworkClient.cpp:22:
\tools\esp32-arduino-libs\esp32/include/lwip/lwip/src/include/lwip/inet.h:133:9: note: this is the location of the previous definition
  133 | #define IN6_IS_ADDR_V4MAPPED(a)     ip6_addr_isipv4mappedipv6((ip6_addr_t*)(a))
      |         ^~~~~~~~~~~~~~~~~~~~
``` 
## Tests scenarios
CI only

## Related links
None