### PR TITLE
fix(matter): examples must set pin to Digital Mode after analogWrite() and before digitalWrite()

### DIFF
--- a/libraries/Matter/examples/MatterColorLight/MatterColorLight.ino
+++ b/libraries/Matter/examples/MatterColorLight/MatterColorLight.ino
@@ -60,6 +60,10 @@ bool setLightState(bool state, espHsvColor_t colorHSV) {
     analogWrite(ledPin, colorHSV.v);
 #endif
   } else {
+#ifndef RGB_BUILTIN
+    // after analogWrite(), it is necessary to set the GPIO to digital mode first
+    pinMode(ledPin, OUTPUT);
+#endif
     digitalWrite(ledPin, LOW);
   }
   // store last HSV Color and OnOff state for when the Light is restarted / power goes off

--- a/libraries/Matter/examples/MatterDimmableLight/MatterDimmableLight.ino
+++ b/libraries/Matter/examples/MatterDimmableLight/MatterDimmableLight.ino
@@ -56,6 +56,10 @@ bool setLightState(bool state, uint8_t brightness) {
     analogWrite(ledPin, brightness);
 #endif
   } else {
+#ifndef RGB_BUILTIN
+    // after analogWrite(), it is necessary to set the GPIO to digital mode first
+    pinMode(ledPin, OUTPUT);
+#endif
     digitalWrite(ledPin, LOW);
   }
   // store last Brightness and OnOff state for when the Light is restarted / power goes off

--- a/libraries/Matter/examples/MatterEnhancedColorLight/MatterEnhancedColorLight.ino
+++ b/libraries/Matter/examples/MatterEnhancedColorLight/MatterEnhancedColorLight.ino
@@ -64,6 +64,10 @@ bool setLightState(bool state, espHsvColor_t colorHSV, uint8_t brighteness, uint
     analogWrite(ledPin, colorHSV.v);
 #endif
   } else {
+#ifndef RGB_BUILTIN
+    // after analogWrite(), it is necessary to set the GPIO to digital mode first
+    pinMode(ledPin, OUTPUT);
+#endif    
     digitalWrite(ledPin, LOW);
   }
   // store last HSV Color and OnOff state for when the Light is restarted / power goes off

--- a/libraries/Matter/examples/MatterEnhancedColorLight/MatterEnhancedColorLight.ino
+++ b/libraries/Matter/examples/MatterEnhancedColorLight/MatterEnhancedColorLight.ino
@@ -67,7 +67,7 @@ bool setLightState(bool state, espHsvColor_t colorHSV, uint8_t brighteness, uint
 #ifndef RGB_BUILTIN
     // after analogWrite(), it is necessary to set the GPIO to digital mode first
     pinMode(ledPin, OUTPUT);
-#endif    
+#endif
     digitalWrite(ledPin, LOW);
   }
   // store last HSV Color and OnOff state for when the Light is restarted / power goes off

--- a/libraries/Matter/examples/MatterFan/MatterFan.ino
+++ b/libraries/Matter/examples/MatterFan/MatterFan.ino
@@ -49,11 +49,11 @@ void fanDCMotorDrive(bool fanState, uint8_t speedPercent) {
   // drive the Fan DC motor
   if (fanState == false) {
     // turn off the Fan
- #ifndef RGB_BUILTIN
+#ifndef RGB_BUILTIN
     // after analogWrite(), it is necessary to set the GPIO to digital mode first
     pinMode(dcMotorPin, OUTPUT);
 #endif
-   digitalWrite(dcMotorPin, LOW);
+    digitalWrite(dcMotorPin, LOW);
   } else {
     // set the Fan speed
     uint8_t fanDCMotorPWM = map(speedPercent, 0, 100, 0, 255);

--- a/libraries/Matter/examples/MatterFan/MatterFan.ino
+++ b/libraries/Matter/examples/MatterFan/MatterFan.ino
@@ -49,7 +49,11 @@ void fanDCMotorDrive(bool fanState, uint8_t speedPercent) {
   // drive the Fan DC motor
   if (fanState == false) {
     // turn off the Fan
-    digitalWrite(dcMotorPin, LOW);
+ #ifndef RGB_BUILTIN
+    // after analogWrite(), it is necessary to set the GPIO to digital mode first
+    pinMode(ledPin, OUTPUT);
+#endif
+   digitalWrite(dcMotorPin, LOW);
   } else {
     // set the Fan speed
     uint8_t fanDCMotorPWM = map(speedPercent, 0, 100, 0, 255);

--- a/libraries/Matter/examples/MatterFan/MatterFan.ino
+++ b/libraries/Matter/examples/MatterFan/MatterFan.ino
@@ -51,7 +51,7 @@ void fanDCMotorDrive(bool fanState, uint8_t speedPercent) {
     // turn off the Fan
  #ifndef RGB_BUILTIN
     // after analogWrite(), it is necessary to set the GPIO to digital mode first
-    pinMode(ledPin, OUTPUT);
+    pinMode(dcMotorPin, OUTPUT);
 #endif
    digitalWrite(dcMotorPin, LOW);
   } else {

--- a/libraries/Matter/examples/MatterTemperatureLight/MatterTemperatureLight.ino
+++ b/libraries/Matter/examples/MatterTemperatureLight/MatterTemperatureLight.ino
@@ -66,6 +66,10 @@ bool setLightState(bool state, uint8_t brightness, uint16_t temperature_Mireds) 
     analogWrite(ledPin, brightness);
 #endif
   } else {
+#ifndef RGB_BUILTIN
+    // after analogWrite(), it is necessary to set the GPIO to digital mode first
+    pinMode(ledPin, OUTPUT);
+#endif
     digitalWrite(ledPin, LOW);
   }
   // store last Brightness and OnOff state for when the Light is restarted / power goes off


### PR DESCRIPTION
## Description of Change
When no RGB LED is used, a regular LED is used, in the examples, to demonstrate Light Brightness or the Fan Motor Power. 

The regular LED is driven with `analogWrite()` and set OFF with `digitalWrite(pin, LOW)`. In order to set it OFF, it is necessary to set the pin to Digital Mode OUTPUT, otherwise an error will be displayed in the UART console. 

## Tests scenarios
Using ESP32.

None