### PR TITLE
test(i2c): Do not use delta as Wokwi timing can be inconsistent

### DIFF
--- a/tests/validation/i2c_master/i2c_master.ino
+++ b/tests/validation/i2c_master/i2c_master.ino
@@ -162,7 +162,7 @@ void rtc_run_clock() {
   ds1307_get_time(&read_sec, &read_min, &read_hour, &read_day, &read_month, &read_year);
 
   //Check time
-  TEST_ASSERT_UINT8_WITHIN(2, start_sec + 5, read_sec);
+  TEST_ASSERT_NOT_EQUAL(start_sec, read_sec); //Seconds should have changed
   TEST_ASSERT_EQUAL(start_min, read_min);
   TEST_ASSERT_EQUAL(start_hour, read_hour);
   TEST_ASSERT_EQUAL(start_day, read_day);

--- a/tests/validation/i2c_master/i2c_master.ino
+++ b/tests/validation/i2c_master/i2c_master.ino
@@ -162,7 +162,7 @@ void rtc_run_clock() {
   ds1307_get_time(&read_sec, &read_min, &read_hour, &read_day, &read_month, &read_year);
 
   //Check time
-  TEST_ASSERT_NOT_EQUAL(start_sec, read_sec); //Seconds should have changed
+  TEST_ASSERT_NOT_EQUAL(start_sec, read_sec);  //Seconds should have changed
   TEST_ASSERT_EQUAL(start_min, read_min);
   TEST_ASSERT_EQUAL(start_hour, read_hour);
   TEST_ASSERT_EQUAL(start_day, read_day);


### PR DESCRIPTION
## Description of Change

Check for changed values rather than a specific range to avoid tests failing due to inconsistent Wokwi timing.

## Tests scenarios

CI