### PR TITLE
fix(NetworkUDP): flush network UDP - reset tx len to zero

### DIFF
--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -292,6 +292,7 @@ size_t NetworkUDP::write(const uint8_t *buffer, size_t size) {
 
 void NetworkUDP::flush() {
     clear();
+    /* Reset tx buffer length */
     tx_buffer_len = 0;
 }
 

--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -291,7 +291,8 @@ size_t NetworkUDP::write(const uint8_t *buffer, size_t size) {
 }
 
 void NetworkUDP::flush() {
-  clear();
+    clear();
+    tx_buffer_len = 0;
 }
 
 int NetworkUDP::parsePacket() {


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [X] Please **update relevant Documentation** if applicable
4. [X] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [X] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Fix flush network UDP method

## Tests scenarios

 I have tested my Pull Request on Arduino-esp32 core 3.1.3 +IDF 5.3.2 with ESP32 and ESP32-S2 Board and ESP32-CAM with this scenario