### PR TITLE
fix(rmt): Fixed protocol name in RMTReadXJT examples

### DIFF
--- a/libraries/ESP32/examples/RMT/RMTReadXJT/RMTReadXJT.ino
+++ b/libraries/ESP32/examples/RMT/RMTReadXJT/RMTReadXJT.ino
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * @brief This example demonstrates usage of RMT for receiving XJT D12 data
+ * @brief This example demonstrates usage of RMT for receiving XJT LR12 data
  *
  * The output is the RMT data read and processed
  *
@@ -21,7 +21,7 @@
 
 //
 // Note: This example uses a FrSKY device communication
-//          using XJT D12 protocol
+//          using XJT LR12 protocol
 //
 // ; 0 bit = 6us low/10us high
 // ; 1 bit = 14us low/10us high


### PR DESCRIPTION
## Description of Change
I couldn't find a protocol called D12.
I found LR12 so I'll fix that.

## Tests scenarios
Find the desired protocol.

## Related links
![image](https://github.com/user-attachments/assets/e3150a1a-6246-4f86-aa1c-3f426fac16d0)
https://www.frsky-rc.com/wp-content/uploads/2017/07/Manual/XJT.pdf
manual(PDF)

https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/issues/239
Protocol information, but not open information.