### PR TITLE
Fix(esp32) stdbool dependency in pins_arduino.h

### DIFF
--- a/variants/esp32/pins_arduino.h
+++ b/variants/esp32/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include <stdbool.h>
 
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;


### PR DESCRIPTION
esp32s3usbotg/pins_arduino.h:5:1: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
    4 | #include <stdint.h>
  +++ |+#include <stdbool.h>
    5 |

---

This is a sample error from compilation of all ESP32>USB examples when targeting the ESP32-S3 with OTG board.
Adding the dependency directly in the arduino project does not mitigate the issue :(

The only fix I managed to find is to edit it directly in the pin definitions header