### PR TITLE
IDF release/v5.4

### DIFF
--- a/libraries/RainMaker/examples/RMakerCustom/ci.json
+++ b/libraries/RainMaker/examples/RMakerCustom/ci.json
@@ -1,4 +1,7 @@
 {
+  "targets": {
+    "esp32": false
+  },
   "fqbn_append": "PartitionScheme=rainmaker_4MB",
   "requires": [
     "CONFIG_ESP_RMAKER_WORK_QUEUE_TASK_STACK=[1-9][0-9]*"

--- a/libraries/RainMaker/examples/RMakerSwitch/ci.json
+++ b/libraries/RainMaker/examples/RMakerSwitch/ci.json
@@ -1,4 +1,7 @@
 {
+  "targets": {
+    "esp32": false
+  },
   "fqbn_append": "PartitionScheme=rainmaker_4MB",
   "requires": [
     "CONFIG_ESP_RMAKER_WORK_QUEUE_TASK_STACK=[1-9][0-9]*"

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-d4aa25a3-v1"
+              "version": "idf-release_v5.4-5cbd2a38-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-d4aa25a3-v1",
+          "version": "idf-release_v5.4-5cbd2a38-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-d4aa25a3-v1.zip",
-              "checksum": "SHA-256:81101d580ebafb78f71bd494f4f5162fd829279d18634282c0f8f95c9e928335",
-              "size": "350941396"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
+              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
+              "size": "351014775"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-5cbd2a38-v1"
+              "version": "idf-release_v5.4-5cbd2a38-v2"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-5cbd2a38-v1",
+          "version": "idf-release_v5.4-5cbd2a38-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v1.zip",
-              "checksum": "SHA-256:a7cc67161b62dbbd1706e9232c72181288ed6780d563b0bf49504576418303b6",
-              "size": "351014775"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-5cbd2a38-v2.zip",
+              "checksum": "SHA-256:80449d7787f05d8b082ef44914e96b33066c34d3e0df3b62097236c7c474d37a",
+              "size": "353308014"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master c12fd05
esp-idf: release/v5.4 5cbd2a3877
arduino: master e2915c48
tinyusb: master 40ddf0628
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.1
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.18.1
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
```
