### PR TITLE
ci(workflows): Lock actions to commits and improve readability

### DIFF
--- a/.github/scripts/set_push_chunks.sh
+++ b/.github/scripts/set_push_chunks.sh
@@ -2,93 +2,6 @@
 
 build_all=false
 chunks_count=0
-last_check_files=""
-last_check_result=""
-gh_output=""
-
-# Define the file patterns
-core_files=(
-    '\.github/.*'
-    'cores/.*'
-    'package/.*'
-    'tools/.*'
-    'platform\.txt'
-    'programmers\.txt'
-    'variants/esp32/.*'
-    'variants/esp32c3/.*'
-    'variants/esp32c6/.*'
-    'variants/esp32h2/.*'
-    'variants/esp32p4/.*'
-    'variants/esp32s2/.*'
-    'variants/esp32s3/.*'
-)
-library_files=(
-    'libraries/.*/examples/.*'
-    'libraries/.*/src/.*'
-)
-networking_files=(
-    'libraries/Network/src/.*'
-)
-fs_files=(
-    'libraries/FS/src/.*'
-)
-static_sketches_files=(
-    'libraries/NetworkClientSecure/examples/WiFiClientSecure/WiFiClientSecure\.ino'
-    'libraries/BLE/examples/Server/Server\.ino'
-    'libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer\.ino'
-    'libraries/Insights/examples/MinimalDiagnostics/MinimalDiagnostics\.ino'
-    'libraries/NetworkClientSecure/src/.*'
-    'libraries/BLE/src/.*'
-    'libraries/Insights/src/.*'
-)
-idf_files=(
-    'idf_component\.yml'
-    'Kconfig\.projbuild'
-    'CMakeLists\.txt'
-    'variants/esp32c2/.*'
-)
-
-# Function to check if any files match the patterns
-check_files() {
-    local patterns=("$@")
-    local files_found=""
-    for pattern in "${patterns[@]}"; do
-        echo "Checking pattern: $pattern"
-        matched_files=$(echo "$gh_output" | grep -E "$pattern")
-        echo "matched_files: $matched_files"
-        files_found+="$matched_files "
-    done
-
-    last_check_files=$(echo "$files_found" | xargs)
-    if [[ -n $last_check_files ]]; then
-        last_check_result="true"
-    else
-        last_check_result="false"
-    fi
-    echo "last_check_result: $last_check_result"
-}
-
-if [[ $IS_PR != 'true' ]]; then
-    gh_output=$(gh api repos/espressif/arduino-esp32/commits/"$GITHUB_SHA" --jq '.files[].filename')
-else
-    gh_output=$(gh pr diff "$PR_NUM" --name-only)
-fi
-echo "gh_output: $gh_output"
-
-# Output the results
-check_files "${core_files[@]}"
-CORE_CHANGED=$last_check_result
-check_files "${library_files[@]}"
-LIB_CHANGED=$last_check_result
-LIB_FILES=$last_check_files
-check_files "${networking_files[@]}"
-NETWORKING_CHANGED=$last_check_result
-check_files "${fs_files[@]}"
-FS_CHANGED=$last_check_result
-check_files "${static_sketches_files[@]}"
-STATIC_SKETCHES_CHANGED=$last_check_result
-check_files "${idf_files[@]}"
-IDF_CHANGED=$last_check_result
 
 if [[ $CORE_CHANGED == 'true' ]] || [[ $IS_PR != 'true' ]]; then
     echo "Core files changed or not a PR. Building all."
@@ -163,9 +76,9 @@ chunks+="]"
 
 {
     echo "build_all=$build_all"
-    echo "build_libraries=$LIB_CHANGED"
-    echo "build_static_sketches=$STATIC_SKETCHES_CHANGED"
-    echo "build_idf=$IDF_CHANGED"
+    echo "build_libraries=$BUILD_LIBRARIES"
+    echo "build_static_sketches=$BUILD_STATIC_SKETCHES"
+    echo "build_idf=$BUILD_IDF"
     echo "chunk_count=$chunks_count"
     echo "chunks=$chunks"
 } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/allboards.yml
+++ b/.github/workflows/allboards.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.client_payload.branch }}
 
@@ -32,13 +32,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.client_payload.branch }}
 
       - run: npm install
       - name: Setup jq
-        uses: dcarbone/install-jq-action@v1.0.1
+        uses: dcarbone/install-jq-action@e397bd87438d72198f81efd21f876461183d383a # v3.0.1
 
       - id: set-test-chunks
         name: Set Chunks
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.client_payload.branch }}
 
@@ -74,7 +74,7 @@ jobs:
           FQBN: ${{ toJSON(matrix.chunk) }}
 
       - name: Compile sketch
-        uses: P-R-O-C-H-Y/compile-sketches@main
+        uses: P-R-O-C-H-Y/compile-sketches@a62f069b92dc8f5053da4ac439ea6d1950cf6379 # main
         with:
           platforms: |
             ${{ env.REPOSITORY }}

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       # This step makes the contents of the repository available to the workflow
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup jq
-        uses: dcarbone/install-jq-action@v1.0.1
+        uses: dcarbone/install-jq-action@e397bd87438d72198f81efd21f876461183d383a # v3.0.1
 
       - name: Get board name
         run: bash .github/scripts/find_new_boards.sh ${{ github.repository }} ${{github.base_ref}}
@@ -47,7 +47,7 @@ jobs:
     steps:
       # This step makes the contents of the repository available to the workflow
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check if build.board is uppercase
         run: |
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Get libs cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 # v4.2.3
         with:
           key: libs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package/package_esp32_index.template.json', 'tools/get.py') }}
           path: |
@@ -73,7 +73,7 @@ jobs:
             ./tools/xtensa-*
 
       - name: Compile sketch
-        uses: P-R-O-C-H-Y/compile-sketches@main
+        uses: P-R-O-C-H-Y/compile-sketches@a62f069b92dc8f5053da4ac439ea6d1950cf6379 # main
         with:
           platforms: |
             ${{ env.REPOSITORY }}

--- a/.github/workflows/build_py_tools.yml
+++ b/.github/workflows/build_py_tools.yml
@@ -30,16 +30,16 @@ jobs:
           echo "Make sure you are using a branch inside the repository and not a fork."
 
       - name: Verify Python Tools Changed
+        uses: tj-actions/changed-files@v41
         id: verify-changed-files
-        run: |
-          CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r ^HEAD -- tools/get.py tools/espota.py tools/gen_esp32part.py tools/gen_insights_package.py | xargs)
-          echo "all_changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
-          if [ -n "$CHANGED_FILES" ]; then
-            echo "any_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "any_changed=false" >> $GITHUB_OUTPUT
-          fi
-
+        with:
+          fetch_depth: "2"
+          since_last_remote_commit: "true"
+          files: |
+            tools/get.py
+            tools/espota.py
+            tools/gen_esp32part.py
+            tools/gen_insights_package.py
       - name: List all changed files
         shell: bash
         run: |

--- a/.github/workflows/build_py_tools.yml
+++ b/.github/workflows/build_py_tools.yml
@@ -18,7 +18,7 @@ jobs:
       all_changed_files: ${{ steps.verify-changed-files.outputs.all_changed_files }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.ref }}
@@ -30,7 +30,7 @@ jobs:
           echo "Make sure you are using a branch inside the repository and not a fork."
 
       - name: Verify Python Tools Changed
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         id: verify-changed-files
         with:
           fetch_depth: "2"
@@ -40,6 +40,7 @@ jobs:
             tools/espota.py
             tools/gen_esp32part.py
             tools/gen_insights_package.py
+
       - name: List all changed files
         shell: bash
         run: |
@@ -88,25 +89,30 @@ jobs:
           for tool in ${{ env.CHANGED_TOOLS }}; do
             echo "tool $tool was changed"
           done
+
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.TOOLS_UPLOAD_PAT }}
           ref: ${{ github.event.pull_request.head.ref }}
+
       - name: Set up Python 3.8
-        uses: actions/setup-python@master
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         with:
           python-version: 3.8
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller requests
+
       - name: Build with PyInstaller
         shell: bash
         run: |
           for tool in ${{ env.CHANGED_TOOLS }}; do
             pyinstaller --distpath ./${{ env.DISTPATH }} -F --icon=.github/pytools/espressif.ico tools/$tool.py
           done
+
       - name: Sign binaries
         if: matrix.os == 'windows-latest'
         env:
@@ -119,12 +125,14 @@ jobs:
           {
             ./.github/pytools/Sign-File.ps1 -Path ./${{ env.DISTPATH }}/$node.exe
           }
+
       - name: Test binaries
         shell: bash
         run: |
           for tool in ${{ env.CHANGED_TOOLS }}; do
             ./${{ env.DISTPATH }}/$tool${{ matrix.EXTEN }} -h
           done
+
       - name: Push binary to tools
         if: matrix.os == 'windows-latest'
         env:
@@ -135,8 +143,9 @@ jobs:
             cp -f ./${{ env.DISTPATH }}/$tool.exe tools/$tool.exe
           done
           bash .github/scripts/upload_py_tools.sh "${{ env.CHANGED_TOOLS }}"
+
       - name: Archive artifact
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.DISTPATH }}
           path: ${{ env.DISTPATH }}

--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: DangerJS pull request linter
-        uses: espressif/shared-github-dangerjs@v1
+        uses: espressif/shared-github-dangerjs@fb17367fd3e8ff7412603b8e946d9b19ffdb2d7f # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -21,14 +21,16 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
-      - uses: actions/setup-python@v5
+
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         with:
           cache-dependency-path: docs/requirements.txt
           cache: "pip"
           python-version: "3.10"
+
       - name: Build
         run: |
           sudo apt update
@@ -38,8 +40,9 @@ jobs:
           cd ./docs
           PATH=/home/runner/.local/bin:$PATH pip3 install -r requirements.txt --prefer-binary
           PATH=/home/runner/.local/bin:$PATH SPHINXOPTS="-W" build-docs -l en
+
       - name: Archive Docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docs
           path: docs

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -26,14 +26,17 @@ jobs:
         run: |
           echo "Release workflow failed. Exiting..."
           exit 1
-      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
-      - uses: actions/setup-python@v5
+
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         with:
           cache-dependency-path: docs/requirements.txt
           cache: "pip"
           python-version: "3.10"
+
       - name: Deploy Documentation
         env:
           # Deploy to production server

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,9 @@ jobs:
     name: Build GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Copy Files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -62,10 +62,10 @@ jobs:
     steps:
       # This step makes the contents of the repository available to the workflow
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Compile sketch
-        uses: P-R-O-C-H-Y/compile-sketches@main
+        uses: P-R-O-C-H-Y/compile-sketches@a62f069b92dc8f5053da4ac439ea6d1950cf6379 # main
         with:
           platforms: |
             ${{ env.REPOSITORY }}
@@ -80,7 +80,7 @@ jobs:
             - --warnings="all"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}-${{ matrix.target }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}
@@ -92,7 +92,7 @@ jobs:
     steps:
       # Check out repository
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ env.GITHUB_TOKEN }}
           fetch-depth: "0"
@@ -102,14 +102,14 @@ jobs:
 
       # This step is needed to get the size data produced by the compile jobs
       - name: Download sketches reports artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           pattern: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}-*
           merge-multiple: true
           path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Report results
-        uses: P-R-O-C-H-Y/report-size-deltas@main
+        uses: P-R-O-C-H-Y/report-size-deltas@4a79caa6dcc3579024293638b97156106edc588e # main
         with:
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
           destination-file: ${{ env.RESULT_LIBRARY_TEST_FILE }}
@@ -136,8 +136,9 @@ jobs:
         env:
           PR_NUM: ${{ github.event.number }}
         run: echo $PR_NUM > pr_num.txt
+
       - name: Upload PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_number
           path: ./pr_num.txt

--- a/.github/workflows/pre-commit-status.yml
+++ b/.github/workflows/pre-commit-status.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report success
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const owner = '${{ github.repository_owner }}';
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report pending
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const owner = '${{ github.repository_owner }}';

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -58,22 +58,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-          IS_PR: ${{ github.event_name == 'pull_request' }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          if [[ $IS_PR != 'true' ]]; then
-              files_changed=$(gh api repos/espressif/arduino-esp32/commits/"$GITHUB_SHA" --jq '.files[].filename' | xargs)
-          else
-              files_changed=$(gh pr diff "$PR_NUM" --name-only | xargs)
-          fi
-          echo "all_changed_files=$files_changed" >> $GITHUB_OUTPUT
-          echo "Changed files:"
-          for file in $files_changed; do
-              echo "  $file"
-          done
+        uses: tj-actions/changed-files@v42.0.2
 
       - name: Run pre-commit hooks in changed files
         run: pre-commit run --color=always --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
 
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Set up Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         with:
           cache-dependency-path: tools/pre-commit/requirements.txt
           cache: "pip"
@@ -46,7 +46,7 @@ jobs:
           echo "PY_HASH=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: Restore pre-commit cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: restore-cache
         with:
           path: |
@@ -58,13 +58,13 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42.0.2
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
 
       - name: Run pre-commit hooks in changed files
         run: pre-commit run --color=always --show-diff-on-failure --files ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Save pre-commit cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: ${{ always() && steps.restore-cache.outputs.cache-hit != 'true' }}
         continue-on-error: true
         with:
@@ -73,7 +73,7 @@ jobs:
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       - name: Push changes using pre-commit-ci-lite
-        uses: pre-commit-ci/lite-action@v1.1.0
+        uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
         # Only push changes in PRs
         if: ${{ always() && github.event_name == 'pull_request' }}
         with:

--- a/.github/workflows/publishlib.yml
+++ b/.github/workflows/publishlib.yml
@@ -44,12 +44,12 @@ jobs:
 
       - name: Read the pr_num file
         id: pr_num_reader
-        uses: juliangruber/read-file-action@v1
+        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1.1.7
         with:
           path: ./artifacts/workflows/pr_num.txt
 
       - name: Report results
-        uses: P-R-O-C-H-Y/report-size-deltas@libs
+        uses: P-R-O-C-H-Y/report-size-deltas@256d1f13e4195cd7fd436d2f959e6dc4d5e4b406 # libs
         with:
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
           github-token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/publishsizes-2.x.yml
+++ b/.github/workflows/publishsizes-2.x.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # This step checks out the repository's code at gh-pages branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 # This step checks out the repository's code at gh-pages branch
         with:
           ref: gh-pages
 
@@ -34,7 +34,7 @@ jobs:
           mv v2.x_cli_compile/*.json artifacts/sizes-report/master/
 
       - name: Report results
-        uses: P-R-O-C-H-Y/report-size-deltas@sizes_v2
+        uses: P-R-O-C-H-Y/report-size-deltas@df83fc5a7b5e1e06ea334c27d1f1776f77b266dd # sizes_v2
         with:
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
           github-token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/publishsizes.yml
+++ b/.github/workflows/publishsizes.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # This step checks out the repository's code at gh-pages branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 # This step checks out the repository's code at gh-pages branch
         with:
           ref: gh-pages
 
@@ -60,12 +60,12 @@ jobs:
 
       - name: Read the pr_num file
         id: pr_num_reader
-        uses: juliangruber/read-file-action@v1
+        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1.1.7
         with:
           path: ./artifacts/sizes-report/pr_num.txt
 
       - name: Report results
-        uses: P-R-O-C-H-Y/report-size-deltas@sizes_v2
+        uses: P-R-O-C-H-Y/report-size-deltas@df83fc5a7b5e1e06ea334c27d1f1776f77b266dd # sizes_v2
         with:
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}
           github-token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,13 +45,12 @@ on:
       - "!.github/scripts/tests_*"
       - "!.github/scripts/upload_*"
       - "variants/esp32/**/*"
+      - "variants/esp32s2/**/*"
+      - "variants/esp32s3/**/*"
       - "variants/esp32c2/**/*"
       - "variants/esp32c3/**/*"
       - "variants/esp32c6/**/*"
       - "variants/esp32h2/**/*"
-      - "variants/esp32p4/**/*"
-      - "variants/esp32s2/**/*"
-      - "variants/esp32s3/**/*"
 
 concurrency:
   group: build-${{github.event.pull_request.number || github.ref}}
@@ -86,13 +85,58 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files_yaml: |
+            core:
+              - '.github/**'
+              - 'cores/**'
+              - 'package/**'
+              - 'tools/**'
+              - 'platform.txt'
+              - 'programmers.txt'
+              - "variants/esp32/**/*"
+              - "variants/esp32s2/**/*"
+              - "variants/esp32s3/**/*"
+              - "variants/esp32c3/**/*"
+              - "variants/esp32c6/**/*"
+              - "variants/esp32h2/**/*"
+            libraries:
+              - 'libraries/**/examples/**'
+              - 'libraries/**/src/**'
+            networking:
+              - 'libraries/Network/src/**'
+            fs:
+              - 'libraries/FS/src/**'
+            static_sketeches:
+              - 'libraries/NetworkClientSecure/examples/WiFiClientSecure/WiFiClientSecure.ino'
+              - 'libraries/BLE/examples/Server/Server.ino'
+              - 'libraries/ESP32/examples/Camera/CameraWebServer/CameraWebServer.ino'
+              - 'libraries/Insights/examples/MinimalDiagnostics/MinimalDiagnostics.ino'
+              - 'libraries/NetworkClientSecure/src/**'
+              - 'libraries/BLE/src/**'
+              - 'libraries/Insights/src/**'
+            idf:
+              - 'idf_component.yml'
+              - 'Kconfig.projbuild'
+              - 'CMakeLists.txt'
+              - "variants/esp32c2/**/*"
+
       - name: Set chunks
         id: set-chunks
         env:
+          LIB_FILES: ${{ steps.changed-files.outputs.libraries_all_changed_files }}
           IS_PR: ${{ github.event_name == 'pull_request' }}
-          PR_NUM: ${{ github.event.pull_request.number }}
           MAX_CHUNKS: ${{ env.MAX_CHUNKS }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_IDF: ${{ steps.changed-files.outputs.idf_any_changed == 'true' }}
+          BUILD_LIBRARIES: ${{ steps.changed-files.outputs.libraries_any_changed == 'true' }}
+          BUILD_STATIC_SKETCHES: ${{ steps.changed-files.outputs.static_sketeches_any_changed == 'true' }}
+          FS_CHANGED: ${{ steps.changed-files.outputs.fs_any_changed == 'true' }}
+          NETWORKING_CHANGED: ${{ steps.changed-files.outputs.networking_any_changed == 'true' }}
+          CORE_CHANGED: ${{ steps.changed-files.outputs.core_any_changed == 'true' }}
+          LIB_CHANGED: ${{ steps.changed-files.outputs.libraries_any_changed == 'true' }}
         run: |
           bash ./.github/scripts/set_push_chunks.sh
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,12 +45,13 @@ on:
       - "!.github/scripts/tests_*"
       - "!.github/scripts/upload_*"
       - "variants/esp32/**/*"
-      - "variants/esp32s2/**/*"
-      - "variants/esp32s3/**/*"
       - "variants/esp32c2/**/*"
       - "variants/esp32c3/**/*"
       - "variants/esp32c6/**/*"
       - "variants/esp32h2/**/*"
+      - "variants/esp32p4/**/*"
+      - "variants/esp32s2/**/*"
+      - "variants/esp32s3/**/*"
 
 concurrency:
   group: build-${{github.event.pull_request.number || github.ref}}
@@ -65,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: bash ./.github/scripts/check-cmakelists.sh
 
   gen-chunks:
@@ -81,13 +82,13 @@ jobs:
       chunks: ${{ steps.set-chunks.outputs.chunks }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files_yaml: |
             core:
@@ -98,11 +99,12 @@ jobs:
               - 'platform.txt'
               - 'programmers.txt'
               - "variants/esp32/**/*"
-              - "variants/esp32s2/**/*"
-              - "variants/esp32s3/**/*"
               - "variants/esp32c3/**/*"
               - "variants/esp32c6/**/*"
               - "variants/esp32h2/**/*"
+              - "variants/esp32p4/**/*"
+              - "variants/esp32s2/**/*"
+              - "variants/esp32s3/**/*"
             libraries:
               - 'libraries/**/examples/**'
               - 'libraries/**/src/**'
@@ -142,7 +144,7 @@ jobs:
 
       - name: Upload sketches found
         if: ${{ steps.set-chunks.outputs.build_all == 'false' && steps.set-chunks.outputs.build_libraries == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sketches_found
           path: sketches_found.txt
@@ -161,13 +163,13 @@ jobs:
         chunk: ${{ fromJson(needs.gen-chunks.outputs.chunks) }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         with:
           python-version: "3.x"
 
       - name: Get libs cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 # v4.2.3
         with:
           key: libs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package/package_esp32_index.template.json', 'tools/get.py') }}
           path: |
@@ -195,7 +197,7 @@ jobs:
 
       - name: Download sketches found
         if: ${{ needs.gen-chunks.outputs.build_all == 'false' && needs.gen-chunks.outputs.build_libraries == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: sketches_found
 
@@ -205,7 +207,7 @@ jobs:
 
       #Upload cli compile json as artifact
       - name: Upload cli compile json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_cli_compile_${{ matrix.chunk }}
           path: cli_compile_${{ matrix.chunk }}.json
@@ -223,8 +225,8 @@ jobs:
         os: [windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         with:
           python-version: "3.x"
       - name: Build Sketches
@@ -260,10 +262,11 @@ jobs:
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
       - name: Check out arduino-esp32 as a component
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
           path: components/arduino-esp32
+
       - name: Build
         env:
           IDF_TARGET: ${{ matrix.idf_target }}
@@ -283,7 +286,7 @@ jobs:
     steps:
       # Check out repository
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           fetch-depth: "0"
@@ -292,7 +295,7 @@ jobs:
         run: git checkout remotes/origin/gh-pages
 
       - name: Download sketches reports artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           pattern: pr_cli_compile_*
           merge-multiple: true
@@ -322,8 +325,9 @@ jobs:
         env:
           PR_NUM: ${{ github.event.number }}
         run: echo $PR_NUM > pr_num.txt
+
       - name: Upload PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_number
           path: ./pr_num.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         with:
           python-version: "3.x"
-      - run: pip install packaging
-      - run: pip install pyserial
+
+      - name: Install packaging
+        run: pip install packaging
+
+      - name: Install pyserial
+        run: pip install pyserial
+
       - name: Build Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: event_file
           path: ${{ github.event_path }}
@@ -62,7 +62,7 @@ jobs:
       PERFORMANCE_ENABLED: ${{ contains(github.event.pull_request.labels.*.name, 'perf_test') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: .github/scripts/tests_matrix.sh
 
@@ -71,7 +71,7 @@ jobs:
         run: bash .github/scripts/tests_matrix.sh
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: matrix_info
           path: info/*

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check if already built
         id: cache-build-binaries
         if: github.event.pull_request.number != null
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: tests-${{ env.id }}-bin
           path: |
@@ -46,10 +46,10 @@ jobs:
 
       - name: Checkout user repository
         if: ${{ steps.check-build.outputs.enabled == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get libs cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 # v4.2.3
         if: ${{ steps.check-build.outputs.enabled == 'true' }}
         with:
           key: libs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package/package_esp32_index.template.json', 'tools/get.py') }}
@@ -68,7 +68,7 @@ jobs:
           bash .github/scripts/tests_build.sh -c -type ${{ inputs.type }} -t ${{ inputs.chip }}
 
       - name: Upload ${{ inputs.chip }} ${{ inputs.type }} binaries as cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: steps.check-build.outputs.enabled == 'true' && github.event.pull_request.number != null
         with:
           key: tests-${{ env.id }}-bin
@@ -79,7 +79,7 @@ jobs:
             ~/.arduino/tests/${{ inputs.chip }}/**/build*.tmp/sdkconfig
 
       - name: Upload ${{ inputs.chip }} ${{ inputs.type }} binaries as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tests-bin-${{ inputs.chip }}-${{ inputs.type }}
           overwrite: true

--- a/.github/workflows/tests_hw.yml
+++ b/.github/workflows/tests_hw.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check if already passed
         id: cache-results
         if: github.event.pull_request.number != null
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: tests-${{ env.id }}-results-hw
           path: |
@@ -59,13 +59,13 @@ jobs:
 
       - name: Checkout user repository
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: |
             *
 
       # setup-python currently only works on ubuntu images
-      # - uses: actions/setup-python@v5
+      # - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
       #   if: ${{ steps.check-tests.outputs.enabled == 'true' }}
       #   with:
       #     cache-dependency-path: tests/requirements.txt
@@ -82,7 +82,7 @@ jobs:
 
       - name: Get binaries
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: tests-bin-${{ inputs.chip }}-${{ inputs.type }}
           path: |
@@ -99,7 +99,7 @@ jobs:
           bash .github/scripts/tests_run.sh -c -type ${{ inputs.type }} -t ${{ inputs.chip }} -i 0 -m 1 -e
 
       - name: Upload ${{ inputs.chip }} ${{ inputs.type }} hardware results as cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: steps.check-tests.outputs.enabled == 'true' && github.event.pull_request.number != null
         with:
           key: tests-${{ env.id }}-results-hw
@@ -108,7 +108,7 @@ jobs:
             tests/**/result_*.json
 
       - name: Upload ${{ inputs.chip }} ${{ inputs.type }} hardware results as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: tests-results-hw-${{ inputs.chip }}-${{ inputs.type }}

--- a/.github/workflows/tests_qemu.yml
+++ b/.github/workflows/tests_qemu.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check if already passed
         id: get-cache-results
         if: github.event.pull_request.number != null
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: tests-${{ env.id }}-results-qemu
           path: |
@@ -43,7 +43,7 @@ jobs:
 
       - name: Checkout user repository
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -60,7 +60,7 @@ jobs:
           cd .github
           curl https://codeload.github.com/${{ github.repository }}/tar.gz/master | tar -xz --strip=2 arduino-esp32-master/.github
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         with:
           cache-dependency-path: tests/requirements.txt
@@ -74,14 +74,14 @@ jobs:
           pip install -r tests/requirements.txt --extra-index-url https://dl.espressif.com/pypi
 
       - name: Install APT dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         with:
           packages: libpixman-1-0 libnuma1 libglib2.0-0 libslirp0 libsdl2-2.0-0
           version: 1.0
 
       - name: Get QEMU version
-        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        uses: pozetroninc/github-action-get-latest-release@2a61c339ea7ef0a336d1daa35ef0cb1418e7676c # v0.8.0
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         id: get-qemu-version
         with:
@@ -92,7 +92,7 @@ jobs:
 
       - name: Cache QEMU
         id: cache-qemu
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3 # v4.2.3
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         with:
           path: |
@@ -113,7 +113,7 @@ jobs:
 
       - name: Get binaries
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: tests-bin-${{ inputs.chip }}-${{ inputs.type }}
           path: |
@@ -124,7 +124,7 @@ jobs:
         run: QEMU_PATH="${{ env.QEMU_INSTALL_PATH }}" bash .github/scripts/tests_run.sh -c -type ${{inputs.type}} -t ${{inputs.chip}} -i 0 -m 1 -Q
 
       - name: Upload ${{ inputs.chip }} ${{ inputs.type }} QEMU results as cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: steps.check-tests.outputs.enabled == 'true' && github.event.pull_request.number != null
         with:
           key: tests-${{ env.id }}-results-qemu
@@ -133,7 +133,7 @@ jobs:
             tests/**/result_*.json
 
       - name: Upload ${{ inputs.chip }} ${{ inputs.type }} QEMU results as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: tests-results-qemu-${{ inputs.chip }}-${{ inputs.type }}

--- a/.github/workflows/tests_results.yml
+++ b/.github/workflows/tests_results.yml
@@ -24,12 +24,12 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: gh-pages
 
       - name: Download and Extract Artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: ./artifacts
@@ -83,7 +83,7 @@ jobs:
           echo "Wokwi tests: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}"
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           commit: ${{ env.original_sha }}
           event_file: ./artifacts/parent-artifacts/event_file/event.json
@@ -95,7 +95,7 @@ jobs:
           json_suite_details: true
 
       - name: Upload JSON
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() }}
         with:
           name: unity_results
@@ -109,7 +109,7 @@ jobs:
 
       - name: Clean up caches
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const ref = process.env.original_ref;
@@ -139,7 +139,7 @@ jobs:
             });
 
       - name: Report conclusion
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: always()
         with:
           script: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: Generate badge
         if: ${{ !cancelled() && (env.original_event == 'schedule' || env.original_event == 'workflow_dispatch') }} # codespell:ignore cancelled
-        uses: jaywcjlove/generated-badges@v1.0.13
+        uses: jaywcjlove/generated-badges@0e078ae4d4bab3777ea4f137de496ab44688f5ad # v1.0.13
         with:
           label: Runtime Tests
           status: ${{ job.status == 'success' && 'passing' || 'failing' }}

--- a/.github/workflows/tests_wokwi.yml
+++ b/.github/workflows/tests_wokwi.yml
@@ -27,7 +27,7 @@ jobs:
       types: ${{ steps.set-ref.outputs.types }}
     steps:
       - name: Report pending
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const owner = '${{ github.repository_owner }}';
@@ -47,7 +47,7 @@ jobs:
             core.info(`${name} is ${state}`);
 
       - name: Download and extract event file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -55,7 +55,7 @@ jobs:
           path: artifacts/event_file
 
       - name: Download and extract matrix info
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -130,7 +130,7 @@ jobs:
           echo "ref=$ref" >> $GITHUB_OUTPUT
 
       - name: Download and extract parent hardware results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -140,7 +140,7 @@ jobs:
           path: artifacts/results/hw
 
       - name: Download and extract parent QEMU results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -150,14 +150,14 @@ jobs:
           path: artifacts/results/qemu
 
       - name: Upload parent artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: parent-artifacts
           path: artifacts
           if-no-files-found: error
 
       - name: Report conclusion
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: always()
         with:
           script: |
@@ -197,7 +197,7 @@ jobs:
         chip: ${{ fromJson(needs.get-artifacts.outputs.targets) }}
     steps:
       - name: Report pending
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const owner = '${{ github.repository_owner }}';
@@ -219,7 +219,7 @@ jobs:
       - name: Check if already passed
         id: get-cache-results
         if: needs.get-artifacts.outputs.pr_num
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           key: tests-${{ env.id }}-results-wokwi
           path: |
@@ -243,11 +243,11 @@ jobs:
       # DO NOT CHECKOUT THE USER'S REPOSITORY IN THIS WORKFLOW. IT HAS HIGH SECURITY RISKS.
       - name: Checkout repository
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.get-artifacts.outputs.base || github.ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         with:
           cache-dependency-path: tests/requirements.txt
@@ -266,11 +266,11 @@ jobs:
 
       - name: Wokwi CI Server
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        uses: wokwi/wokwi-ci-server-action@v1
+        uses: wokwi/wokwi-ci-server-action@a6fabb5a49e080158c7a1d121ea5b789536a82c3 # v1
 
       - name: Get binaries
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -286,7 +286,7 @@ jobs:
           bash .github/scripts/tests_run.sh -c -type ${{ matrix.type }} -t ${{ matrix.chip }} -i 0 -m 1 -W ${{ env.WOKWI_TIMEOUT }}
 
       - name: Upload ${{ matrix.chip }} ${{ matrix.type }} Wokwi results as cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: steps.check-tests.outputs.enabled == 'true' && needs.get-artifacts.outputs.pr_num
         with:
           key: tests-${{ env.id }}-results-wokwi
@@ -295,7 +295,7 @@ jobs:
             tests/**/result_*.json
 
       - name: Upload ${{ matrix.chip }} ${{ matrix.type }} Wokwi results as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: tests-results-wokwi-${{ matrix.chip }}-${{ matrix.type }}
@@ -305,7 +305,7 @@ jobs:
             tests/**/result_*.json
 
       - name: Report conclusion
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: always()
         with:
           script: |

--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -45,13 +45,13 @@ jobs:
           echo "Tag: $tag"
           echo "RELEASE_TAG=$tag" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.git_ref || env.RELEASE_TAG }}
           submodules: "recursive"
 
       - name: Upload components to the component registry
-        uses: espressif/upload-components-ci-action@v1
+        uses: espressif/upload-components-ci-action@b78a19fa5424714997596d3ecffa634aef8ae20b # v1.0.5
         with:
           name: arduino-esp32
           version: ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
## Description of Change

To avoid supply chain attacks, lock actions used in workflows to commit hash rather than tag.
Also improve readability of files.