### PR TITLE
IDF master

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-ee77c489-v1"
+              "version": "idf-master-ee77c489-v2"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-ee77c489-v1",
+          "version": "idf-master-ee77c489-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
-              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
-              "size": "418535149"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
+              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
+              "size": "420022213"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-0461e2ff-v1"
+              "version": "idf-master-ee77c489-v1"
             },
             {
               "packager": "esp32",
@@ -76,7 +76,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20241016"
+              "version": "v0.12.0-esp32-20250226"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-0461e2ff-v1",
+          "version": "idf-master-ee77c489-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-0461e2ff-v1.zip",
-              "checksum": "SHA-256:e1413b7d711cbdc4efb3064d6ac25e09068d7a01db3a706bd1426b0fd992e35b",
-              "size": "411886500"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v1.zip",
+              "checksum": "SHA-256:9a434b46c019168c4a2fb6d783bcf71de5b86a2a26387d5ece5232b0ac419fc3",
+              "size": "418535149"
             }
           ]
         },
@@ -414,56 +414,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20241016",
+          "version": "v0.12.0-esp32-20250226",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:e82b0f036dc99244bead5f09a86e91bb2365cbcd1122ac68261e5647942485df",
-              "size": "2398717"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:914c726342ba5828e53f41aa454f01f317c42d8e6772d3d874593a6960fc4729",
+              "size": "2414924"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:8f8daf5bd22ec5d2fa9257b0862ec33da18ee677e023fb9a9eb17f74ce208c76",
-              "size": "2271584"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:c44ee99a9209c0234dbbcec86339fd685f5c61a763b29c33eba590bf62db2296",
+              "size": "2293923"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:bc9c020ecf20e2000f76cffa44305fd5bc44d2e688ea78cce423399d33f19767",
-              "size": "2414206"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:21ab6af3cf05f9290f4d59f1f381d5094dd2755fc528d3d2feb9334348fc0d8d",
+              "size": "2436071"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:02a2dffe801a2d005fa9e614d80ff8173395b2cb0b5d3118d0229d094a9946a7",
-              "size": "2508089"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:0b5751699e93b6d101381611c96216ddff8c7dfd16425c610993fa27993f9a0a",
+              "size": "2525387"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:c382f9e884d6565cb6089bff5f200f4810994667d885f062c3d3c5625a0fa9d6",
-              "size": "2552569"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:8bffbbb594b27a4971a3922792135f8c836fff26991f7f450094386920263531",
+              "size": "2568843"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win32-0.12.0-esp32-20241016.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20241016.zip",
-              "checksum": "SHA-256:3b5d615e0a72cc771a45dd469031312d5881c01d7b6bc9edb29b8b6bda8c2e90",
-              "size": "2946244"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win32-0.12.0-esp32-20250226.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250226.zip",
+              "checksum": "SHA-256:aaf3c955bb4eb47805a1ba108dfd07a8a56ce720cb40194a354362b5f0961230",
+              "size": "2960226"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win64-0.12.0-esp32-20241016.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20241016.zip",
-              "checksum": "SHA-256:5e7b2fd1947d3a8625f6a11db7a2340cf2f41ff4c61284c022c7d7c32b18780a",
-              "size": "2946244"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win64-0.12.0-esp32-20250226.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250226.zip",
+              "checksum": "SHA-256:79baf35325117a53093b62f6b9bee677dd12275d7066e3f8a274d2a80e986b6e",
+              "size": "2960225"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-50be9735-v1"
+              "version": "idf-master-23c73cdc-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-50be9735-v1",
+          "version": "idf-master-23c73cdc-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
-              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
-              "size": "420260446"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
+              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
+              "size": "420263536"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-ee77c489-v2"
+              "version": "idf-master-50be9735-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-ee77c489-v2",
+          "version": "idf-master-50be9735-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-ee77c489-v2.zip",
-              "checksum": "SHA-256:932534d627687fa08868554c53492f38a26ca70058dfeade66b0c3cf86e7fa50",
-              "size": "420022213"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-50be9735-v1.zip",
+              "checksum": "SHA-256:7687bc4e703edda3510b42981ac2f4aff2cc6c2a256e6b8b88806512863433fe",
+              "size": "420260446"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-23c73cdc-v1"
+              "version": "idf-master-a45d713b-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-23c73cdc-v1",
+          "version": "idf-master-a45d713b-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-23c73cdc-v1.zip",
-              "checksum": "SHA-256:cf456c0e039c10b1e829265c6251f84c4088f886093f7f822cf04c87e56caaf0",
-              "size": "420263536"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-a45d713b-v1.zip",
+              "checksum": "SHA-256:52aec557b9744e721770853c67c4ee6a391debd7bb779f654bea0e5113658786",
+              "size": "420636315"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 61b25da
esp-idf: master ee77c489e7
arduino: release/v3.3.x 7c1ac1ae
tinyusb: master 40ddf0628
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.5.2
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.1
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.19.0
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.5.5
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
```
