### PR TITLE
Fix(esp32s3usbotg) stdbool dependency in pins_arduino.h

### DIFF
--- a/variants/esp32s3usbotg/pins_arduino.h
+++ b/variants/esp32s3usbotg/pins_arduino.h
@@ -2,7 +2,6 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
-// Prevents fatal compilation failure in Arduino for ESP32 board with OTG
 #include <stdbool.h>
 
 #define USB_VID 0x303a

--- a/variants/esp32s3usbotg/pins_arduino.h
+++ b/variants/esp32s3usbotg/pins_arduino.h
@@ -2,6 +2,8 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+// Prevents fatal compilation failure in Arduino for ESP32 board with OTG
+#include <stdbool.h>
 
 #define USB_VID 0x303a
 #define USB_PID 0x1001


### PR DESCRIPTION
esp32s3usbotg/pins_arduino.h:5:1: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
4 | #include <stdint.h>
+++ |+#include <stdbool.h>
5 |

This is a sample error from compilation of all ESP32>USB examples when targeting the ESP32-S3 with OTG board.
Adding the dependency directly in the arduino project does not mitigate the issue :(

The only fix I managed to find is to edit it directly in the pin definitions header

P.S.: a previous pull was created for the base esp32 board, but it was suggested to be requested for merge on the variant itself