### PR TITLE
fix(freertos_stats): remove volatile c++ 20 deprecated warning

### DIFF
--- a/cores/esp32/freertos_stats.cpp
+++ b/cores/esp32/freertos_stats.cpp
@@ -31,7 +31,8 @@ void printRunningTasks(Print &printer) {
 #endif
   configRUN_TIME_COUNTER_TYPE ulTotalRunTime = 0;
   TaskStatus_t *pxTaskStatusArray = NULL;
-  volatile UBaseType_t uxArraySize = 0, x = 0;
+  volatile UBaseType_t uxArraySize = 0;
+  uint32_t x = 0;
   const char *taskStates[] = {"Running", "Ready", "Blocked", "Suspended", "Deleted", "Invalid"};
 
   // Take a snapshot of the number of tasks in case it changes while this function is executing.


### PR DESCRIPTION
## Description of Change
Moving ESP32 Arduino codebase to C++ 20/2a has introduced a warning when compiling the Arduino Core due to CPP 20 deprecation of operations using volatile variables. This PR fixes the warning by removing `volatile` in a simple index variable.

```
\Arduino\hardware\espressif\esp32\cores\esp32\freertos_stats.cpp: In function 'void printRunningTasks(Print&)':
\Arduino\hardware\espressif\esp32\cores\esp32\freertos_stats.cpp:72:34: warning: '++' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
   72 |     for (x = 0; x < uxArraySize; x++) {
      |                                  ^
```

## Tests scenarios
Compilation of any sketch using Arduino. Message is gone.
`/freertos/portmacro.h` defines:
``` cpp
#define portBASE_TYPE               int
typedef unsigned portBASE_TYPE      UBaseType_t;
```

Therefore, `UBaseType_t` is just a `unsigned int`.

## Related links
None