### PR TITLE
Fix error #8176: simple_ble_start enable controller failed 259

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -305,11 +305,11 @@ void initArduino() {
   if (err) {
     log_e("Failed to initialize NVS! Error: %u", err);
   }
-#if defined(CONFIG_BT_ENABLED) && SOC_BT_SUPPORTED
-  if (!btInUse()) {
-    esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
-  }
-#endif
+//#if defined(CONFIG_BT_ENABLED) && SOC_BT_SUPPORTED
+//  if (!btInUse()) {
+//    esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
+//  }
+//#endif
   init();
   initVariant();
 }


### PR DESCRIPTION
which happens when example https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFiProv/examples/WiFiProv is compiled with pioarduino. The full pioarduino example is here https://github.com/pioarduino/test-rainmaker/tree/wifiprov

This PR fixes this bug by comment out the call to `esp_bt_controller_mem_release` since, once you release that memory, it cannot be reclaimed per the docs. 




