### PR TITLE
fix(net): Use network_event_handle_t for internal callbacks

### DIFF
--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -247,6 +247,7 @@ private:
   int8_t _pin_rmii_clock;
 #endif /* CONFIG_ETH_USE_ESP32_EMAC */
   size_t _task_stack_size;
+  network_event_handle_t _eth_connected_event_handle;
 
   static bool ethDetachBus(void *bus_pointer);
   bool beginSPI(

--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -152,7 +152,8 @@ esp_modem_dce_t *PPPClass::handle() const {
 
 PPPClass::PPPClass()
   : _dce(NULL), _pin_tx(-1), _pin_rx(-1), _pin_rts(-1), _pin_cts(-1), _flow_ctrl(ESP_MODEM_FLOW_CONTROL_NONE), _pin_rst(-1), _pin_rst_act_low(true),
-    _pin_rst_delay(200), _pin(NULL), _apn(NULL), _rx_buffer_size(4096), _tx_buffer_size(512), _mode(ESP_MODEM_MODE_COMMAND), _uart_num(UART_NUM_1) {}
+    _pin_rst_delay(200), _pin(NULL), _apn(NULL), _rx_buffer_size(4096), _tx_buffer_size(512), _mode(ESP_MODEM_MODE_COMMAND), _uart_num(UART_NUM_1),
+    _ppp_event_handle(0) {}
 
 PPPClass::~PPPClass() {}
 
@@ -360,7 +361,7 @@ bool PPPClass::begin(ppp_modem_model_t model, uint8_t uart_num, int baud_rate) {
     }
   }
 
-  Network.onSysEvent(onPppArduinoEvent);
+  _ppp_event_handle = Network.onSysEvent(onPppArduinoEvent);
 
   setStatusBits(ESP_NETIF_STARTED_BIT);
   arduino_event_t arduino_event;
@@ -402,7 +403,8 @@ void PPPClass::end(void) {
   }
   _esp_modem = NULL;
 
-  Network.removeEvent(onPppArduinoEvent);
+  Network.removeEvent(_ppp_event_handle);
+  _ppp_event_handle = 0;
 
   if (_dce != NULL) {
     esp_modem_destroy(_dce);

--- a/libraries/PPP/src/PPP.h
+++ b/libraries/PPP/src/PPP.h
@@ -108,6 +108,7 @@ private:
   int _tx_buffer_size;
   esp_modem_dce_mode_t _mode;
   uint8_t _uart_num;
+  network_event_handle_t _ppp_event_handle;
 
   static bool pppDetachBus(void *bus_pointer);
 };

--- a/libraries/WiFi/src/AP.cpp
+++ b/libraries/WiFi/src/AP.cpp
@@ -148,7 +148,7 @@ void APClass::_onApEvent(int32_t event_id, void *event_data) {
   }
 }
 
-APClass::APClass() {
+APClass::APClass(): _wifi_ap_event_handle(0) {
   _ap_network_if = this;
 }
 
@@ -163,7 +163,7 @@ bool APClass::onEnable() {
     return false;
   }
   if (_esp_netif == NULL) {
-    Network.onSysEvent(_onApArduinoEvent);
+    _wifi_ap_event_handle = Network.onSysEvent(_onApArduinoEvent);
     _esp_netif = get_esp_interface_netif(ESP_IF_WIFI_AP);
     /* attach to receive events */
     initNetif(ESP_NETIF_ID_AP);
@@ -172,7 +172,8 @@ bool APClass::onEnable() {
 }
 
 bool APClass::onDisable() {
-  Network.removeEvent(_onApArduinoEvent);
+  Network.removeEvent(_wifi_ap_event_handle);
+  _wifi_ap_event_handle = 0;
   // we just set _esp_netif to NULL here, so destroyNetif() does not try to destroy it.
   // That would be done by WiFi.enableAP(false) if STA is not enabled, or when it gets disabled
   _esp_netif = NULL;

--- a/libraries/WiFi/src/AP.cpp
+++ b/libraries/WiFi/src/AP.cpp
@@ -148,7 +148,7 @@ void APClass::_onApEvent(int32_t event_id, void *event_data) {
   }
 }
 
-APClass::APClass(): _wifi_ap_event_handle(0) {
+APClass::APClass() : _wifi_ap_event_handle(0) {
   _ap_network_if = this;
 }
 

--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -228,7 +228,8 @@ void STAClass::_onStaEvent(int32_t event_id, void *event_data) {
 }
 
 STAClass::STAClass()
-  : _minSecurity(WIFI_AUTH_WPA2_PSK), _scanMethod(WIFI_FAST_SCAN), _sortMethod(WIFI_CONNECT_AP_BY_SIGNAL), _autoReconnect(true), _status(WL_STOPPED) {
+  : _minSecurity(WIFI_AUTH_WPA2_PSK), _scanMethod(WIFI_FAST_SCAN), _sortMethod(WIFI_CONNECT_AP_BY_SIGNAL), _autoReconnect(true), _status(WL_STOPPED),
+    _wifi_sta_event_handle(0) {
   _sta_network_if = this;
 }
 
@@ -276,14 +277,15 @@ bool STAClass::onEnable() {
       return false;
     }
     /* attach to receive events */
-    Network.onSysEvent(_onStaArduinoEvent);
+    _wifi_sta_event_handle = Network.onSysEvent(_onStaArduinoEvent);
     initNetif(ESP_NETIF_ID_STA);
   }
   return true;
 }
 
 bool STAClass::onDisable() {
-  Network.removeEvent(_onStaArduinoEvent);
+  Network.removeEvent(_wifi_sta_event_handle);
+  _wifi_sta_event_handle = 0;
   // we just set _esp_netif to NULL here, so destroyNetif() does not try to destroy it.
   // That would be done by WiFi.enableSTA(false) if AP is not enabled, or when it gets disabled
   _esp_netif = NULL;

--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -60,6 +60,8 @@ public:
   void _onApEvent(int32_t event_id, void *event_data);
 
 protected:
+  network_event_handle_t _wifi_ap_event_handle;
+
   size_t printDriverInfo(Print &out) const;
 
   friend class WiFiGenericClass;

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -95,6 +95,7 @@ protected:
   wifi_sort_method_t _sortMethod;
   bool _autoReconnect;
   wl_status_t _status;
+  network_event_handle_t _wifi_sta_event_handle;
 
   size_t printDriverInfo(Print &out) const;
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving event handling for network interfaces in the Ethernet, PPP, and WiFi libraries. The most important changes involve adding and managing event handles to ensure proper event registration and deregistration.

### Event Handling Improvements:

* `libraries/Ethernet/src/ETH.cpp` and `libraries/Ethernet/src/ETH.h`: Added `_eth_connected_event_handle` to handle Ethernet connection events. Updated methods to use this handle for event registration and removal. [[1]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94L139-R139) [[2]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94L362-R362) [[3]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94L852-R852) [[4]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94L888-R889) [[5]](diffhunk://#diff-ea9aae8e71d59244b7dfa29e0785bf5d3a82d8c8e1954f88a6ae869bcd6955ceR250)

* `libraries/PPP/src/PPP.cpp` and `libraries/PPP/src/PPP.h`: Introduced `_ppp_event_handle` to manage PPP connection events. Modified relevant methods to utilize this handle for event management. [[1]](diffhunk://#diff-364c5b65dee1a6a86c40ed47c9cf8a060bac637d8d32b18e97aba7ca0e27e673L155-R156) [[2]](diffhunk://#diff-364c5b65dee1a6a86c40ed47c9cf8a060bac637d8d32b18e97aba7ca0e27e673L363-R364) [[3]](diffhunk://#diff-364c5b65dee1a6a86c40ed47c9cf8a060bac637d8d32b18e97aba7ca0e27e673L405-R407) [[4]](diffhunk://#diff-717de1140d5005db1ceeeab2326dc99426b3764d914a831971ee27387c16f624R111)

* `libraries/WiFi/src/AP.cpp` and `libraries/WiFi/src/WiFiAP.h`: Implemented `_wifi_ap_event_handle` for handling WiFi AP events. Adjusted methods to register and remove events using this handle. [[1]](diffhunk://#diff-c06974a6b0a509d5e3b33ad8da77105fbe8affaa604c47b72a30c8d1fec7a2a7L151-R151) [[2]](diffhunk://#diff-c06974a6b0a509d5e3b33ad8da77105fbe8affaa604c47b72a30c8d1fec7a2a7L166-R166) [[3]](diffhunk://#diff-c06974a6b0a509d5e3b33ad8da77105fbe8affaa604c47b72a30c8d1fec7a2a7L175-R176) [[4]](diffhunk://#diff-1677511dd1f3c3976ff7a3ba59b87640cfb2979afe61ed4bb6f436228763a242R63-R64)

* `libraries/WiFi/src/STA.cpp` and `libraries/WiFi/src/WiFiSTA.h`: Added `_wifi_sta_event_handle` to manage WiFi STA events. Updated methods to handle event registration and removal with this handle. [[1]](diffhunk://#diff-fcf930a1c1c949e34e74528fc20ec629d3a704e97db75fadc89b8b4fb6cde7a4L231-R232) [[2]](diffhunk://#diff-fcf930a1c1c949e34e74528fc20ec629d3a704e97db75fadc89b8b4fb6cde7a4L279-R288) [[3]](diffhunk://#diff-73f4f966aef7fcba53abb38e3e279f67e10d62b495ea3932c3464f9f858eba5bR98)
