### PR TITLE
fix(eth): Set the ETH properties at the correct time

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -124,8 +124,8 @@ void ETHClass::_onEthEvent(int32_t event_id, void *event_data) {
 }
 
 ETHClass::ETHClass(uint8_t eth_index)
-  : _eth_handle(NULL), _eth_index(eth_index), _phy_type(ETH_PHY_MAX), _glue_handle(NULL), _mac(NULL), _phy(NULL),
-    _eth_started(false), _link_speed(100), _full_duplex(true), _auto_negotiation(true)
+  : _eth_handle(NULL), _eth_index(eth_index), _phy_type(ETH_PHY_MAX), _glue_handle(NULL), _mac(NULL), _phy(NULL), _eth_started(false), _link_speed(100),
+    _full_duplex(true), _auto_negotiation(true)
 #if ETH_SPI_SUPPORTS_CUSTOM
     ,
     _spi(NULL)

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -229,6 +229,10 @@ private:
   esp_eth_netif_glue_handle_t _glue_handle;
   esp_eth_mac_t *_mac;
   esp_eth_phy_t *_phy;
+  bool _eth_started;
+  uint16_t _link_speed;
+  bool _full_duplex;
+  bool _auto_negotiation;
 #if ETH_SPI_SUPPORTS_CUSTOM
   SPIClass *_spi;
   char _cs_str[10];
@@ -256,6 +260,9 @@ private:
 #endif
     int sck, int miso, int mosi, spi_host_device_t spi_host, uint8_t spi_freq_mhz
   );
+  bool _setFullDuplex(bool on);
+  bool _setLinkSpeed(uint16_t speed);
+  bool _setAutoNegotiation(bool on);
 
   friend class EthernetClass;  // to access beginSPI
 };


### PR DESCRIPTION
This pull request includes several changes to the `ETHClass` in the `libraries/Ethernet/src/ETH.cpp` and `libraries/Ethernet/src/ETH.h` files. The changes primarily focus on adding support for configuring Ethernet settings such as full duplex mode, link speed, and auto-negotiation, as well as ensuring these settings are properly managed during the Ethernet initialization and shutdown processes.

### Enhancements to Ethernet Configuration:

* Added new member variables `_eth_started`, `_link_speed`, `_full_duplex`, and `_auto_negotiation` to the `ETHClass` to store Ethernet configuration settings.
* Implemented new methods `setFullDuplex`, `setLinkSpeed`, and `setAutoNegotiation` to allow configuration of Ethernet settings before calling `ETH.begin()`. Each method includes validation to ensure settings are applied correctly. [[1]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94L1012-R1046) [[2]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R1090-R1098) [[3]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R1129-R1144)
* Added private methods `_setFullDuplex`, `_setLinkSpeed`, and `_setAutoNegotiation` to apply the settings to the Ethernet hardware.

### Initialization and Shutdown Process:

* Modified the `ETHClass::begin` and `ETHClass::beginSPI` methods to apply the Ethernet configuration settings (full duplex, link speed, and auto-negotiation) during the initialization process if auto-negotiation is disabled. [[1]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R355-R367) [[2]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R807-R819)
* Updated the `ETHClass::end` method to reset the `_eth_started` flag when shutting down the Ethernet interface.

### Code Refactoring:

* Refactored the `ETHClass` constructor to initialize the new member variables.
* Ensured that the `_eth_started` flag is set to true after successful initialization and set to false during shutdown. [[1]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R384-R385) [[2]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R835-R836) [[3]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R930-R932)

Reference: https://github.com/espressif/arduino-esp32/issues/10923
