### PR TITLE
fix(arduino_pins): fixes Lolin-C3-Pico and C3-Mini RGB LED pin + C3-Pico SPI SCK pin definition

### DIFF
--- a/variants/lolin_c3_mini/pins_arduino.h
+++ b/variants/lolin_c3_mini/pins_arduino.h
@@ -2,10 +2,18 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
-static const uint8_t LED_BUILTIN = 7;
+// based on https://www.wemos.cc/en/latest/c3/c3_mini.html
+// WS2812 RGB LED on pin 7
+#define PIN_RGB_LED 7
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
 #define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;

--- a/variants/lolin_c3_pico/pins_arduino.h
+++ b/variants/lolin_c3_pico/pins_arduino.h
@@ -4,10 +4,18 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
-static const uint8_t LED_BUILTIN = 7;
+// based on https://www.wemos.cc/en/latest/c3/c3_pico.html
+// WS2812 RGB LED on pin 7
+#define PIN_RGB_LED 7
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
 #define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;
@@ -17,7 +25,7 @@ static const uint8_t SCL = 10;
 
 static const uint8_t VBAT = 3;
 
-static const uint8_t SCK = 2;
+static const uint8_t SCK = 1;
 static const uint8_t MISO = 0;
 static const uint8_t MOSI = 4;
 static const uint8_t SS = 5;


### PR DESCRIPTION
## Description of Change
Based on https://www.wemos.cc/en/latest/c3/c3_pico.html there were a few pin setting errors for the Lolin-C3-Pico board.
It also fixes the RGB Pin of the Lolin-C3-Mini board, as defned in https://www.wemos.cc/en/latest/c3/c3_mini.html

## Tests scenarios
CI only

## Related links
https://github.com/espressif/arduino-esp32/discussions/11184