### PR TITLE
fix(wifi_scan): Fix some edge cases where WiFi Scan may fail

### DIFF
--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -92,9 +92,6 @@ int16_t
   }
   if (esp_wifi_scan_start(&config, false) == ESP_OK) {
     _scanStarted = millis();
-    if (!_scanStarted) {  //Prevent 0 from millis overflow
-      ++_scanStarted;
-    }
 
     WiFiGenericClass::clearStatusBits(WIFI_SCAN_DONE_BIT);
     WiFiGenericClass::setStatusBits(WIFI_SCANNING_BIT);
@@ -118,21 +115,20 @@ int16_t
 void WiFiScanClass::_scanDone() {
   esp_wifi_scan_get_ap_num(&(WiFiScanClass::_scanCount));
   if (WiFiScanClass::_scanResult) {
-    delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
-    WiFiScanClass::_scanResult = nullptr;
+    free(WiFiScanClass::_scanResult);
+    WiFiScanClass::_scanResult = NULL;
   }
 
   if (WiFiScanClass::_scanCount) {
-    WiFiScanClass::_scanResult = new (std::nothrow) wifi_ap_record_t[WiFiScanClass::_scanCount];
+    WiFiScanClass::_scanResult = calloc(WiFiScanClass::_scanCount, sizeof(wifi_ap_record_t));
     if (!WiFiScanClass::_scanResult) {
       WiFiScanClass::_scanCount = 0;
     } else if (esp_wifi_scan_get_ap_records(&(WiFiScanClass::_scanCount), (wifi_ap_record_t *)_scanResult) != ESP_OK) {
-      delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
-      WiFiScanClass::_scanResult = nullptr;
+      free(WiFiScanClass::_scanResult);
+      WiFiScanClass::_scanResult = NULL;
       WiFiScanClass::_scanCount = 0;
     }
   }
-  WiFiScanClass::_scanStarted = 0;  //Reset after a scan is completed for normal behavior
   WiFiGenericClass::setStatusBits(WIFI_SCAN_DONE_BIT);
   WiFiGenericClass::clearStatusBits(WIFI_SCANNING_BIT);
 }
@@ -161,14 +157,12 @@ int16_t WiFiScanClass::scanComplete() {
   }
 
   if (WiFiGenericClass::getStatusBits() & WIFI_SCANNING_BIT) {
+    // Check if the delay expired, return WIFI_SCAN_FAILED in this case
+    if ((millis() - WiFiScanClass::_scanStarted) > WiFiScanClass::_scanTimeout) {
+      WiFiGenericClass::clearStatusBits(WIFI_SCANNING_BIT);
+      return WIFI_SCAN_FAILED;
+    }
     return WIFI_SCAN_RUNNING;
-  }
-  // last one to avoid time affecting Async mode
-  if (WiFiScanClass::_scanStarted
-      && (millis() - WiFiScanClass::_scanStarted)
-           > WiFiScanClass::_scanTimeout) {  //Check is scan was started and if the delay expired, return WIFI_SCAN_FAILED in this case
-    WiFiGenericClass::clearStatusBits(WIFI_SCANNING_BIT);
-    return WIFI_SCAN_FAILED;
   }
 
   return WIFI_SCAN_FAILED;
@@ -179,11 +173,12 @@ int16_t WiFiScanClass::scanComplete() {
  */
 void WiFiScanClass::scanDelete() {
   WiFiGenericClass::clearStatusBits(WIFI_SCAN_DONE_BIT);
+  WiFiGenericClass::clearStatusBits(WIFI_SCANNING_BIT);
   if (WiFiScanClass::_scanResult) {
-    delete[] reinterpret_cast<wifi_ap_record_t *>(WiFiScanClass::_scanResult);
-    WiFiScanClass::_scanResult = nullptr;
-    WiFiScanClass::_scanCount = 0;
+    free(WiFiScanClass::_scanResult);
+    WiFiScanClass::_scanResult = NULL;
   }
+  WiFiScanClass::_scanCount = 0;
 }
 
 /**


### PR DESCRIPTION
Rework of https://github.com/espressif/arduino-esp32/pull/11075

This pull request focuses on memory management improvements and code simplification in the `WiFiScan.cpp` file. The most important changes include replacing `delete[]` with `free()`, using `calloc()` instead of `new`, and simplifying the scan completion check.

Memory management improvements:

* Replaced `delete[]` with `free()` and set the pointer to `NULL` in the `_scanDone` and `scanDelete` methods to prevent potential memory leaks. [[1]](diffhunk://#diff-bace60178f098d80f1b271ad8ffff33f935644dfad66894478bf3a5969dc7b57L121-L135) [[2]](diffhunk://#diff-bace60178f098d80f1b271ad8ffff33f935644dfad66894478bf3a5969dc7b57R176-R181)
* Replaced `new` with `calloc()` for allocating memory for `WiFiScanClass::_scanResult` to ensure the allocated memory is zero-initialized.

Code simplification:

* Simplified the scan completion check in the `scanComplete` method by removing unnecessary conditions and comments.

Other changes:

* Removed unnecessary increment of `_scanStarted` to prevent `0` from millis overflow.

Closes: https://github.com/espressif/arduino-esp32/pull/11075