### PR TITLE
fix(zigbeeEP): review of names and memory allocation

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -251,7 +251,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MANUFACTURER_NAME_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
     char *_read_manufacturer = (char *) malloc(zbstr->len + 1);
-    if (_read_manufacturer == nullptr) {
+    if (_read_manufacturer == NULL) {
       log_e("Failed to allocate memory for manufacturer data");
       xSemaphoreGive(lock);
       return;
@@ -264,7 +264,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
     char *_read_model = (char *) malloc(zbstr->len + 1);
-    if (_read_model == nullptr) {
+    if (_read_model == NULL) {
       log_e("Failed to allocate memory for model data");
       xSemaphoreGive(lock);
       return;

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -19,8 +19,8 @@ ZigbeeEP::ZigbeeEP(uint8_t endpoint) {
   _ep_config.endpoint = 0;
   _cluster_list = nullptr;
   _on_identify = nullptr;
-  _read_model = nullptr;
-  _read_manufacturer = nullptr;  
+  _read_model[0] = '\0';
+  _read_manufacturer[0] = '\0';  
   _time_status = 0;
   if (!lock) {
     lock = xSemaphoreCreateBinary();
@@ -38,7 +38,7 @@ bool ZigbeeEP::setManufacturerAndModel(const char *name, const char *model) {
   // Convert manufacturer to ZCL string
   size_t name_length = strlen(name);
   size_t model_length = strlen(model);
-  if (name_length > 32 || model_length > 32) {
+  if (name_length > ZB_MAX_NAME_LENGTH || model_length > ZB_MAX_NAME_LENGTH) {
     log_e("Manufacturer or model name is too long");
     return false;
   }
@@ -49,15 +49,8 @@ bool ZigbeeEP::setManufacturerAndModel(const char *name, const char *model) {
     return false;
   }  
   // Allocate a new array of size length + 2 (1 for the length, 1 for null terminator)
-  char *zb_name = (char *) malloc(name_length + 2);
-  char *zb_model = (char *) malloc(model_length + 2);
-  if (zb_name == nullptr || zb_model == nullptr) {
-    log_e("Failed to allocate memory for name and model data");
-    // make sure any allocated memory is returned to heap
-    free(zb_name);
-    free(zb_model);
-    return false;
-  }
+  char zb_name[ZB_MAX_NAME_LENGTH + 2];
+  char zb_model[ZB_MAX_NAME_LENGTH + 2];
   // Store the length as the first element
   zb_name[0] = static_cast<char>(name_length);  // Cast size_t to char
   zb_model[0] = static_cast<char>(model_length);
@@ -76,8 +69,6 @@ bool ZigbeeEP::setManufacturerAndModel(const char *name, const char *model) {
   if (ret_model != ESP_OK) {
     log_e("Failed to set model: 0x%x: %s", ret_model, esp_err_to_name(ret_model));
   }
-  free(zb_model);
-  free(zb_name);
   return ret_name == ESP_OK && ret_model == ESP_OK;
 }
 
@@ -176,8 +167,7 @@ char *ZigbeeEP::readManufacturer(uint8_t endpoint, uint16_t short_addr, esp_zb_i
   read_req.attr_number = ZB_ARRAY_LENTH(attributes);
   read_req.attr_field = attributes;
 
-  free(_read_manufacturer);
-  _read_manufacturer = nullptr;
+  _read_manufacturer[0] = '\0';
 
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_read_attr_cmd_req(&read_req);
@@ -212,8 +202,7 @@ char *ZigbeeEP::readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_add
   read_req.attr_number = ZB_ARRAY_LENTH(attributes);
   read_req.attr_field = attributes;
 
-  free(_read_model);
-  _read_model = nullptr;
+  _read_model[0] = '\0';
 
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_read_attr_cmd_req(&read_req);
@@ -254,30 +243,16 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   /* Basic cluster attributes */
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MANUFACTURER_NAME_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
-    char *zb_manufacturer = (char *)malloc(zbstr->len + 1);
-    if (zb_manufacturer == nullptr) {
-      log_e("Failed to allocate memory for manufacturer data");
-      xSemaphoreGive(lock);
-      return;
-    } 
-    memcpy(zb_manufacturer, zbstr->data, zbstr->len);
-    zb_manufacturer[zbstr->len] = '\0';
+    memcpy(_read_manufacturer, zbstr->data, zbstr->len);
+    _read_manufacturer[zbstr->len] = '\0';
     log_i("Peer Manufacturer is \"%s\"", zb_manufacturer);
-    _read_manufacturer = zb_manufacturer;
     xSemaphoreGive(lock);
   }
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
-    char *zb_model = (char *)malloc(zbstr->len + 1);
-    if (zb_model == nullptr) {
-      log_e("Failed to allocate memory for model data");
-      xSemaphoreGive(lock);
-      return;
-    } 
-    memcpy(zb_model, zbstr->data, zbstr->len);
-    zb_model[zbstr->len] = '\0';
+    memcpy(_read_model, zbstr->data, zbstr->len);
+    _read_model[zbstr->len] = '\0';
     log_i("Peer Model is \"%s\"", zb_model);
-    _read_model = zb_model;
     xSemaphoreGive(lock);
   }
 }

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -36,9 +36,8 @@ void ZigbeeEP::setVersion(uint8_t version) {
 
 bool ZigbeeEP::setManufacturerAndModel(const char *name, const char *model) {
   // Allocate a new array of size length + 2 (1 for the length, 1 for null terminator)
-  // This memory space can't be deleted or overwritten, therefore using static
-  static char zb_name[ZB_MAX_NAME_LENGTH + 2];
-  static char zb_model[ZB_MAX_NAME_LENGTH + 2];
+  char zb_name[ZB_MAX_NAME_LENGTH + 2];
+  char zb_model[ZB_MAX_NAME_LENGTH + 2];
 
   // Convert manufacturer to ZCL string
   size_t name_length = strlen(name);

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -250,7 +250,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   /* Basic cluster attributes */
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MANUFACTURER_NAME_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
-    char *_read_manufacturer = (char *)malloc(zbstr->len + 1);
+    _read_manufacturer = (char *)malloc(zbstr->len + 1);
     if (_read_manufacturer == NULL) {
       log_e("Failed to allocate memory for manufacturer data");
       xSemaphoreGive(lock);

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -261,7 +261,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
       return;
     } 
     memcpy(zb_manufacturer, zbstr->data, zbstr->len);
-    string[zbstr->len] = '\0';
+    zb_manufacturer[zbstr->len] = '\0';
     log_i("Peer Manufacturer is \"%s\"", zb_manufacturer);
     _read_manufacturer = zb_manufacturer;
     xSemaphoreGive(lock);
@@ -275,7 +275,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
       return;
     } 
     memcpy(zb_model, zbstr->data, zbstr->len);
-    string[zbstr->len] = '\0';
+    zb_model[zbstr->len] = '\0';
     log_i("Peer Model is \"%s\"", zb_model);
     _read_model = zb_model;
     xSemaphoreGive(lock);

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -20,7 +20,7 @@ ZigbeeEP::ZigbeeEP(uint8_t endpoint) {
   _cluster_list = nullptr;
   _on_identify = nullptr;
   _read_model = NULL;
-  _read_manufacturer = NULL;  
+  _read_manufacturer = NULL;
   _time_status = 0;
   if (!lock) {
     lock = xSemaphoreCreateBinary();
@@ -51,7 +51,7 @@ bool ZigbeeEP::setManufacturerAndModel(const char *name, const char *model) {
   if (basic_cluster == nullptr) {
     log_e("Failed to get basic cluster");
     return false;
-  }  
+  }
   // Store the length as the first element
   zb_name[0] = static_cast<char>(name_length);  // Cast size_t to char
   zb_model[0] = static_cast<char>(model_length);
@@ -172,7 +172,7 @@ char *ZigbeeEP::readManufacturer(uint8_t endpoint, uint16_t short_addr, esp_zb_i
     free(_read_manufacturer);
   }
   _read_manufacturer = NULL;
-  
+
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_read_attr_cmd_req(&read_req);
   esp_zb_lock_release();
@@ -206,7 +206,7 @@ char *ZigbeeEP::readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_add
   read_req.attr_number = ZB_ARRAY_LENTH(attributes);
   read_req.attr_field = attributes;
 
- if (_read_model != NULL) {
+  if (_read_model != NULL) {
     free(_read_model);
   }
   _read_model = NULL;
@@ -250,7 +250,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   /* Basic cluster attributes */
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MANUFACTURER_NAME_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
-    char *_read_manufacturer = (char *) malloc(zbstr->len + 1);
+    char *_read_manufacturer = (char *)malloc(zbstr->len + 1);
     if (_read_manufacturer == NULL) {
       log_e("Failed to allocate memory for manufacturer data");
       xSemaphoreGive(lock);
@@ -263,7 +263,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   }
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
-    char *_read_model = (char *) malloc(zbstr->len + 1);
+    char *_read_model = (char *)malloc(zbstr->len + 1);
     if (_read_model == NULL) {
       log_e("Failed to allocate memory for model data");
       xSemaphoreGive(lock);

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -263,7 +263,7 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   }
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
-    char *_read_model = (char *)malloc(zbstr->len + 1);
+    _read_model = (char *)malloc(zbstr->len + 1);
     if (_read_model == NULL) {
       log_e("Failed to allocate memory for model data");
       xSemaphoreGive(lock);

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -35,6 +35,11 @@ void ZigbeeEP::setVersion(uint8_t version) {
 }
 
 bool ZigbeeEP::setManufacturerAndModel(const char *name, const char *model) {
+  // Allocate a new array of size length + 2 (1 for the length, 1 for null terminator)
+  // This memory space can't be deleted or overwritten, therefore using static
+  static char zb_name[ZB_MAX_NAME_LENGTH + 2];
+  static char zb_model[ZB_MAX_NAME_LENGTH + 2];
+
   // Convert manufacturer to ZCL string
   size_t name_length = strlen(name);
   size_t model_length = strlen(model);
@@ -48,9 +53,6 @@ bool ZigbeeEP::setManufacturerAndModel(const char *name, const char *model) {
     log_e("Failed to get basic cluster");
     return false;
   }  
-  // Allocate a new array of size length + 2 (1 for the length, 1 for null terminator)
-  char zb_name[ZB_MAX_NAME_LENGTH + 2];
-  char zb_model[ZB_MAX_NAME_LENGTH + 2];
   // Store the length as the first element
   zb_name[0] = static_cast<char>(name_length);  // Cast size_t to char
   zb_model[0] = static_cast<char>(model_length);
@@ -245,14 +247,14 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
     memcpy(_read_manufacturer, zbstr->data, zbstr->len);
     _read_manufacturer[zbstr->len] = '\0';
-    log_i("Peer Manufacturer is \"%s\"", zb_manufacturer);
+    log_i("Peer Manufacturer is \"%s\"", _read_manufacturer);
     xSemaphoreGive(lock);
   }
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
     memcpy(_read_model, zbstr->data, zbstr->len);
     _read_model[zbstr->len] = '\0';
-    log_i("Peer Model is \"%s\"", zb_model);
+    log_i("Peer Model is \"%s\"", _read_model);
     xSemaphoreGive(lock);
   }
 }

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -251,6 +251,11 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MANUFACTURER_NAME_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
     char *_read_manufacturer = (char *) malloc(zbstr->len + 1);
+    if (_read_manufacturer == nullptr) {
+      log_e("Failed to allocate memory for manufacturer data");
+      xSemaphoreGive(lock);
+      return;
+    }
     memcpy(_read_manufacturer, zbstr->data, zbstr->len);
     _read_manufacturer[zbstr->len] = '\0';
     log_i("Peer Manufacturer is \"%s\"", _read_manufacturer);
@@ -259,6 +264,11 @@ void ZigbeeEP::zbReadBasicCluster(const esp_zb_zcl_attribute_t *attribute) {
   if (attribute->id == ESP_ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_CHAR_STRING && attribute->data.value) {
     zbstring_t *zbstr = (zbstring_t *)attribute->data.value;
     char *_read_model = (char *) malloc(zbstr->len + 1);
+    if (_read_model == nullptr) {
+      log_e("Failed to allocate memory for model data");
+      xSemaphoreGive(lock);
+      return;
+    }
     memcpy(_read_model, zbstr->data, zbstr->len);
     _read_model[zbstr->len] = '\0';
     log_i("Peer Model is \"%s\"", _read_model);

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -42,7 +42,10 @@ typedef enum {
 class ZigbeeEP {
 public:
   ZigbeeEP(uint8_t endpoint = 10);
-  ~ZigbeeEP() {}
+  ~ZigbeeEP() {
+    free(_read_manufacturer);
+    free(_read_model);
+  }
 
   // Set ep config and cluster list
   void setEpConfig(esp_zb_endpoint_config_t ep_config, esp_zb_cluster_list_t *cluster_list) {

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -142,8 +142,8 @@ public:
   }
 
 private:
-  char _read_manufacturer[ZB_MAX_NAME_LENGTH + 1];  // + 1 for the extra '\0'
-  char _read_model[ZB_MAX_NAME_LENGTH + 1];  // + 1 for the extra '\0'
+  char *_read_manufacturer;
+  char *_read_model;
   void (*_on_identify)(uint16_t time);
   time_t _read_time;
   int32_t _read_timezone;

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -41,11 +41,12 @@ typedef enum {
 /* Zigbee End Device Class */
 class ZigbeeEP {
 public:
+  // constants and limits
+  static constexpr size_t ZB_MAX_NAME_LENGTH = 32;
+
+  // constructors and destructor
   ZigbeeEP(uint8_t endpoint = 10);
-  ~ZigbeeEP() {
-    free(_read_manufacturer);
-    free(_read_model);
-  }
+  ~ZigbeeEP() {}
 
   // Set ep config and cluster list
   void setEpConfig(esp_zb_endpoint_config_t ep_config, esp_zb_cluster_list_t *cluster_list) {
@@ -141,8 +142,8 @@ public:
   }
 
 private:
-  char *_read_manufacturer;
-  char *_read_model;
+  char _read_manufacturer[ZB_MAX_NAME_LENGTH + 1];  // + 1 for the extra '\0'
+  char _read_model[ZB_MAX_NAME_LENGTH + 1];  // + 1 for the extra '\0'
   void (*_on_identify)(uint16_t time);
   time_t _read_time;
   int32_t _read_timezone;


### PR DESCRIPTION
## Description of Change
Just a general review of memory allocation routines and changing `string` variable name to avoid using reserved words.

## Tests scenarios
CI only

## Related links
https://github.com/espressif/arduino-esp32/pull/11196