### PR TITLE
feat(zigbee): Add battery voltage attribute support

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
+++ b/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
@@ -85,9 +85,9 @@ void setup() {
   // Set tolerance for temperature measurement in °C (lowest possible value is 0.01°C)
   zbTempSensor.setTolerance(1);
 
-  // Set power source to battery and set battery percentage to measured value (now 100% for demonstration)
-  // The value can be also updated by calling zbTempSensor.setBatteryPercentage(percentage) anytime
-  zbTempSensor.setPowerSource(ZB_POWER_SOURCE_BATTERY, 100);
+  // Set power source to battery, battery percentage and battery voltage (now 100% and 3.5Vfor demonstration)
+  // The value can be also updated by calling zbTempSensor.setBatteryPercentage(percentage) or zbTempSensor.setBatteryVoltage(voltage) anytime after Zigbee.begin()
+  zbTempSensor.setPowerSource(ZB_POWER_SOURCE_BATTERY, 100, 35);
 
   // Add humidity cluster to the temperature sensor device with min, max and tolerance values
   zbTempSensor.addHumiditySensor(0, 100, 1);

--- a/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
+++ b/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
@@ -85,7 +85,7 @@ void setup() {
   // Set tolerance for temperature measurement in °C (lowest possible value is 0.01°C)
   zbTempSensor.setTolerance(1);
 
-  // Set power source to battery, battery percentage and battery voltage (now 100% and 3.5Vfor demonstration)
+  // Set power source to battery, battery percentage and battery voltage (now 100% and 3.5V for demonstration)
   // The value can be also updated by calling zbTempSensor.setBatteryPercentage(percentage) or zbTempSensor.setBatteryVoltage(voltage) anytime after Zigbee.begin()
   zbTempSensor.setPowerSource(ZB_POWER_SOURCE_BATTERY, 100, 35);
 

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -90,7 +90,7 @@ bool ZigbeeEP::setPowerSource(zb_power_source_t power_source, uint8_t battery_pe
     }
     ret = esp_zb_power_config_cluster_add_attr(power_config_cluster, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_VOLTAGE_ID, (void *)&battery_voltage);
     if (ret != ESP_OK) {
-      log_e("Failed to add battery percentage attribute: 0x%x: %s", ret, esp_err_to_name(ret));
+      log_e("Failed to add battery voltage attribute: 0x%x: %s", ret, esp_err_to_name(ret));
       return false;
     }
     ret = esp_zb_cluster_list_add_power_config_cluster(_cluster_list, power_config_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -128,7 +128,9 @@ bool ZigbeeEP::setBatteryPercentage(uint8_t percentage) {
 bool ZigbeeEP::setBatteryVoltage(uint8_t voltage) {
   esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_VOLTAGE_ID, &voltage, false);
+  ret = esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_VOLTAGE_ID, &voltage, false
+  );
   esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set battery voltage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -77,9 +77,10 @@ public:
   char *readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_addr_t ieee_addr);
 
   // Set Power source and battery percentage for battery powered devices
-  bool setPowerSource(zb_power_source_t power_source, uint8_t percentage = 255);
-  bool setBatteryPercentage(uint8_t percentage);
-  bool reportBatteryPercentage();
+  bool setPowerSource(zb_power_source_t power_source, uint8_t percentage = 0xff, uint8_t voltage = 0xff); // voltage in 100mV
+  bool setBatteryPercentage(uint8_t percentage); // 0-100 %
+  bool setBatteryVoltage(uint8_t voltage); // voltage in 100mV (example value 35 for 3.5V)
+  bool reportBatteryPercentage(); // battery voltage is not reportable attribute
 
   // Set time
   bool addTimeCluster(tm time = {}, int32_t gmt_offset = 0);  // gmt offset in seconds

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -77,10 +77,10 @@ public:
   char *readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_addr_t ieee_addr);
 
   // Set Power source and battery percentage for battery powered devices
-  bool setPowerSource(zb_power_source_t power_source, uint8_t percentage = 0xff, uint8_t voltage = 0xff); // voltage in 100mV
-  bool setBatteryPercentage(uint8_t percentage); // 0-100 %
-  bool setBatteryVoltage(uint8_t voltage); // voltage in 100mV (example value 35 for 3.5V)
-  bool reportBatteryPercentage(); // battery voltage is not reportable attribute
+  bool setPowerSource(zb_power_source_t power_source, uint8_t percentage = 0xff, uint8_t voltage = 0xff);  // voltage in 100mV
+  bool setBatteryPercentage(uint8_t percentage);                                                           // 0-100 %
+  bool setBatteryVoltage(uint8_t voltage);                                                                 // voltage in 100mV (example value 35 for 3.5V)
+  bool reportBatteryPercentage();                                                                          // battery voltage is not reportable attribute
 
   // Set time
   bool addTimeCluster(tm time = {}, int32_t gmt_offset = 0);  // gmt offset in seconds


### PR DESCRIPTION
## Description of Change

This pull request includes updates to the Zigbee Power Config Cluster adding a battery voltage functionality. The most important changes involve adding support for setting and reporting battery voltage in addition to battery percentage.

Enhancements to battery management:

* [`libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino`](diffhunk://#diff-762711ae43f701c312429d935f897759698c0a5687a95b96d8185f72aecc23b9L88-R90): Updated the `setup` function to include setting battery voltage along with battery percentage.
* [`libraries/Zigbee/src/ZigbeeEP.cpp`](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750L71-R71): Modified the `setPowerSource` method to accept battery voltage as an additional parameter and added a new method `setBatteryVoltage` to update the battery voltage attribute. [[1]](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750L71-R71) [[2]](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750R91-R95) [[3]](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750R128-R140)
* [`libraries/Zigbee/src/ZigbeeEP.h`](diffhunk://#diff-ddc8d9922531a975b3287cea342182baa7d1cac46bcc38727dfe38abd33c288cL80-R83): Updated the `ZigbeeEP` class definition to include the new battery voltage parameter in the `setPowerSource` method and added a new method `setBatteryVoltage`.

Note: Battery Voltage attribute is not reportable, that's why there is no report method for that.

## Tests scenarios
Tested using Sleepy example and HomeAssistant ZHA integration (only battery % was shown, but I was able to read the voltage value).

## Related links

Closes #11177 
