### PR TITLE
refactor(rmt): refactored RMT loopback example

### DIFF
--- a/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
+++ b/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
@@ -57,10 +57,10 @@ void setup() {
 
   // create multiple pulses with different width to be sent
   for (int i = 0; i < 255; i++) {
-    data[i].level0 = 1; // HIGH
-    data[i].duration0 = 1 + 13 - (i % 13); // number of Tick on High
-    data[i].level1 = 0; // LOW
-    data[i].duration1 = 1 + (i % 13); // number of Ticks on Low
+    data[i].level0 = 1;                     // HIGH
+    data[i].duration0 = 1 + 13 - (i % 13);  // number of Tick on High
+    data[i].level1 = 0;                     // LOW
+    data[i].duration1 = 1 + (i % 13);       // number of Ticks on Low
     my_data[i].val = 0;
   }
   data[255].val = 0;
@@ -69,9 +69,7 @@ void setup() {
   Serial.println("Preloaded Data that will sent (time in 0.1us):");
   // Printout the received data plus the original values
   for (int i = 0; i < RMT_NUM_EXCHANGED_DATA; i++) {
-    Serial.printf("%08lx=[%c 0x%02x|%c 0x%02x] ", data[i].val,
-                  data[i].level0 ? 'H' : 'L', data[i].duration0,
-                  data[i].level1 ? 'H' : 'L', data[i].duration1);
+    Serial.printf("%08lx=[%c 0x%02x|%c 0x%02x] ", data[i].val, data[i].level0 ? 'H' : 'L', data[i].duration0, data[i].level1 ? 'H' : 'L', data[i].duration1);
 
     if (!((i + 1) % 4)) {
       Serial.println();

--- a/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
+++ b/libraries/ESP32/examples/RMT/RMTLoopback/RMTLoopback.ino
@@ -1,4 +1,4 @@
-// Copyright 2023 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,14 +35,11 @@
 rmt_data_t my_data[256];
 rmt_data_t data[256];
 
-static EventGroupHandle_t events;
-
 #define RMT_FREQ               10000000  // tick time is 100ns
-#define RMT_NUM_EXCHANGED_DATA 30
+#define RMT_NUM_EXCHANGED_DATA 32
 
 void setup() {
   Serial.begin(115200);
-  events = xEventGroupCreate();
 
   if (!rmtInit(RMT_TX_PIN, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, RMT_FREQ)) {
     Serial.println("init sender failed\n");
@@ -50,25 +47,43 @@ void setup() {
   if (!rmtInit(RMT_RX_PIN, RMT_RX_MODE, RMT_MEM_RX, RMT_FREQ)) {
     Serial.println("init receiver failed\n");
   }
+  Serial.println();
+  Serial.println("RMT tick set to: 100ns");
 
   // End of transmission shall be detected when line is idle for 2us = 20*100ns
   rmtSetRxMaxThreshold(RMT_RX_PIN, 20);
   // Disable Glitch  filter
   rmtSetRxMinThreshold(RMT_RX_PIN, 0);
 
-  Serial.println("real tick set to: 100ns");
-  Serial.printf("\nPlease connect GPIO %d to GPIO %d, now.\n", RMT_TX_PIN, RMT_RX_PIN);
-}
-
-void loop() {
-  // Init data
-  int i;
-  for (i = 0; i < 255; i++) {
-    data[i].val = 0x80010001 + ((i % 13) << 16) + 13 - (i % 13);
+  // create multiple pulses with different width to be sent
+  for (int i = 0; i < 255; i++) {
+    data[i].level0 = 1; // HIGH
+    data[i].duration0 = 1 + 13 - (i % 13); // number of Tick on High
+    data[i].level1 = 0; // LOW
+    data[i].duration1 = 1 + (i % 13); // number of Ticks on Low
     my_data[i].val = 0;
   }
   data[255].val = 0;
+  Serial.println();
+  Serial.println("====================================================================================================");
+  Serial.println("Preloaded Data that will sent (time in 0.1us):");
+  // Printout the received data plus the original values
+  for (int i = 0; i < RMT_NUM_EXCHANGED_DATA; i++) {
+    Serial.printf("%08lx=[%c 0x%02x|%c 0x%02x] ", data[i].val,
+                  data[i].level0 ? 'H' : 'L', data[i].duration0,
+                  data[i].level1 ? 'H' : 'L', data[i].duration1);
 
+    if (!((i + 1) % 4)) {
+      Serial.println();
+    }
+  }
+  Serial.println("====================================================================================================");
+  Serial.printf("Please connect GPIO %d to GPIO %d, now.", RMT_TX_PIN, RMT_RX_PIN);
+  Serial.println();
+  Serial.println();
+}
+
+void loop() {
   // Start an async data read
   size_t rx_num_symbols = RMT_NUM_EXCHANGED_DATA;
   rmtReadAsync(RMT_RX_PIN, my_data, &rx_num_symbols);
@@ -84,13 +99,13 @@ void loop() {
   Serial.printf("Got %d RMT symbols\n", rx_num_symbols);
 
   // Printout the received data plus the original values
-  for (i = 0; i < 60; i++) {
+  for (int i = 0; i < RMT_NUM_EXCHANGED_DATA; i++) {
     Serial.printf("%08lx=%08lx ", my_data[i].val, data[i].val);
     if (!((i + 1) % 4)) {
-      Serial.println("");
+      Serial.println();
     }
   }
-  Serial.println("\n");
+  Serial.println();
 
-  delay(500);
+  delay(2000);
 }


### PR DESCRIPTION
## Description of Change
The way RMT loopback example was done, it had a sync problem that caused the result to do not match.
Low level signal was sent first and then the high level, therefore, it would only detect the second signal (high) after a delay in nanoseconds. This delay would cause the received signal to be shifted by one RMT symbol.

Output of the original example:
```
Got 30 RMT symbols
000e8001=8001000e 000d8001=8002000d 000b8002=8003000c 000a8004=8004000b 
00098005=8005000a 00088006=80060009 00078007=80070008 00068008=80080007 
```

With this refactoring/fix, RMT symbols start with High Level and the output matches the received RMT symbols.
This PR makes the example easier for understanding as well as the RMT symbol will better match.

```
Got 32 RMT symbols
0001800e=0001800e 0002800d=0002800d 0003800c=0003800c 0004800b=0004800b 
0005800a=0005800a 00068009=00068009 00078008=00078008 00088007=00088007 
```


## Tests scenarios
Tested with ESP32, ESP32-C3 and ESP32-S3 using the provided example.

## Related links
Related to #11200 