### PR TITLE
fix(usb): uninitilized variable warning message

### DIFF
--- a/cores/esp32/USB.cpp
+++ b/cores/esp32/USB.cpp
@@ -100,6 +100,7 @@ static bool tinyusb_device_suspended = false;
 void tud_mount_cb(void) {
   tinyusb_device_mounted = true;
   arduino_usb_event_data_t p;
+  p.suspend.remote_wakeup_en = 0;
   arduino_usb_event_post(ARDUINO_USB_EVENTS, ARDUINO_USB_STARTED_EVENT, &p, sizeof(arduino_usb_event_data_t), portMAX_DELAY);
 }
 
@@ -107,6 +108,7 @@ void tud_mount_cb(void) {
 void tud_umount_cb(void) {
   tinyusb_device_mounted = false;
   arduino_usb_event_data_t p;
+  p.suspend.remote_wakeup_en = 0;
   arduino_usb_event_post(ARDUINO_USB_EVENTS, ARDUINO_USB_STOPPED_EVENT, &p, sizeof(arduino_usb_event_data_t), portMAX_DELAY);
 }
 
@@ -123,6 +125,7 @@ void tud_suspend_cb(bool remote_wakeup_en) {
 void tud_resume_cb(void) {
   tinyusb_device_suspended = false;
   arduino_usb_event_data_t p;
+  p.suspend.remote_wakeup_en = 0;
   arduino_usb_event_post(ARDUINO_USB_EVENTS, ARDUINO_USB_RESUME_EVENT, &p, sizeof(arduino_usb_event_data_t), portMAX_DELAY);
 }
 


### PR DESCRIPTION
## Description of Change
Using ESP32-S2 with USB CDC enabled and arduino-cli with all warnings set, there is a warning message error:

```
arduino15/packages/esp32/hardware/esp32/3.1.1/cores/esp32/USB.cpp:102:28: note: 'p' declared here 102 
   arduino_usb_event_data_t p; 
   In function 'esp_err_t arduino_usb_event_post(esp_event_base_t, int32_t, void*, size_t, TickType_t)', inlined from 'void tud_umount_cb()'
```

## Tests scenarios
ESP32-S2 with Arduino CDC on Boot enbaled using Arduino CLI with all warnings activated.

`arduino-cli compile -b esp32:esp32:esp32s2:CDCOnBoot=cdc,UploadMode=cdc,PSRAM=enabled --build-path ./build --build-property upload.maximum_size=4063232 --build-property compiler.optimization_flags=-O2 --warnings all`

## Related links
Fixes #11162 