### PR TITLE
RFQ: make TimedRead and TimedPeek virtual

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -558,23 +558,23 @@ int HWCDC::available(void) {
   return uxQueueMessagesWaiting(rx_queue);
 }
 
-int HWCDC::peek(void) {
+int HWCDC::_peek(TickType_t timeout) {
   if (rx_queue == NULL) {
     return -1;
   }
   uint8_t c;
-  if (xQueuePeek(rx_queue, &c, 0)) {
+  if (xQueuePeek(rx_queue, &c, timeout)) {
     return c;
   }
   return -1;
 }
 
-int HWCDC::read(void) {
+int HWCDC::_read(TickType_t timeout) {
   if (rx_queue == NULL) {
     return -1;
   }
   uint8_t c = 0;
-  if (xQueueReceive(rx_queue, &c, 0)) {
+  if (xQueueReceive(rx_queue, &c, timeout)) {
     return c;
   }
   return -1;

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -48,6 +48,17 @@ private:
   static bool deinit(void *busptr);
   static bool isCDC_Connected();
 
+protected:
+  int _peek(TickType_t timeout);
+  int _read(TickType_t timeout);
+
+  virtual int timedRead() override {
+    return _read(pdMS_TO_TICKS(_timeout));
+  }
+  virtual int timedPeek() override {
+    return _peek(pdMS_TO_TICKS(_timeout));
+  }
+
 public:
   HWCDC();
   ~HWCDC();
@@ -63,8 +74,12 @@ public:
 
   int available(void);
   int availableForWrite(void);
-  int peek(void);
-  int read(void);
+  int peek(void){
+    return _peek(0);
+  }
+  int read(void){
+    return _read(0);
+  }
   size_t read(uint8_t *buffer, size_t size);
   size_t write(uint8_t);
   size_t write(const uint8_t *buffer, size_t size);

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -527,14 +527,15 @@ int HardwareSerial::peek(void) {
   return -1;
 }
 
-int HardwareSerial::read(void) {
+int HardwareSerial::_read(uint32_t timeout) {
   uint8_t c = 0;
-  if (uartReadBytes(_uart, &c, 1, 0) == 1) {
+  if (uartReadBytes(_uart, &c, 1, timeout) == 1) {
     return c;
   } else {
     return -1;
   }
 }
+
 
 // read characters into buffer
 // terminates if size characters have been read, or no further are pending
@@ -661,4 +662,14 @@ size_t HardwareSerial::setTxBufferSize(size_t new_size) {
   // if new_size is higher than SOC_UART_FIFO_LEN, TX Ringbuffer will be active and it will be used to report back "availableToWrite()"
   _txBufferSize = new_size;
   return new_size;
+}
+
+int HardwareSerial::timedPeek(void) {
+
+  uint8_t out;
+  if(uartTimedPeek(_uart, &out, _timeout)){
+    return out;
+  }
+
+  return -1;
 }

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -311,7 +311,9 @@ public:
   int available(void);
   int availableForWrite(void);
   int peek(void);
-  int read(void);
+  int read(void){
+    return _read(0);
+  }
   size_t read(uint8_t *buffer, size_t size);
   inline size_t read(char *buffer, size_t size) {
     return read((uint8_t *)buffer, size);
@@ -399,6 +401,14 @@ protected:
   void _createEventTask(void *args);
   void _destroyEventTask(void);
   static void _uartEventTask(void *args);
+
+  int _read(uint32_t timeout);
+
+  virtual int timedRead() override {
+    return _read(_timeout);
+  }
+
+  virtual int timedPeek() override;
 };
 
 extern void serialEventRun(void) __attribute__((weak));

--- a/cores/esp32/Stream.h
+++ b/cores/esp32/Stream.h
@@ -49,8 +49,8 @@ class Stream : public Print {
 protected:
   unsigned long _timeout;                                          // number of milliseconds to wait for the next char before aborting timed read
   unsigned long _startMillis;                                      // used for timeout measurement
-  int timedRead();                                                 // private method to read stream with timeout
-  int timedPeek();                                                 // private method to peek stream with timeout
+  virtual int timedRead();                                         // private method to read stream with timeout
+  virtual int timedPeek();                                         // private method to peek stream with timeout
   int peekNextDigit(LookaheadMode lookahead, bool detectDecimal);  // returns the next numeric digit in the stream or -1 if timeout
 
 public:

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -51,6 +51,7 @@ uint32_t uartAvailableForWrite(uart_t *uart);
 size_t uartReadBytes(uart_t *uart, uint8_t *buffer, size_t size, uint32_t timeout_ms);
 uint8_t uartRead(uart_t *uart);
 uint8_t uartPeek(uart_t *uart);
+bool uartTimedPeek(uart_t *uart, uint8_t * out, uint32_t timeout_ms);
 
 void uartWrite(uart_t *uart, uint8_t c);
 void uartWriteBuf(uart_t *uart, const uint8_t *data, size_t len);


### PR DESCRIPTION
This is a request for comment / proof of concept

Right now `Stream::TimedRead()` and `Stream::TimedPeek()` are concrete functions inside `Stream`

This mean that when a function that can wait up to a **timeout** (like `Stream::readBytes`, `Stream::readBytesUntil`, `Stream::readStringUntil` ecc) and there is nothing in the **RX** buffer the default implementation simply keep spinning in a tight/busy loop calling either `ChildClass::read()` or `ChildClass::peek()`

This PR keep the default implementation of the two function but add virtual to it so each concrete child class (like `HardwareSerial`, `HWCDC`) can implement an optimised version that relay on the FreeRTOS scheduler and not on busy-polling the interface

In this PR there is implementation for two interfaces


