### PR TITLE
fix(wifi): Workaround bug in esp_wifi_get_protocol()

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -604,7 +604,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m) {
 #endif
     uint32_t current_protocol = 0;
     if (m & WIFI_MODE_STA) {
-      err = esp_wifi_get_protocol(WIFI_IF_STA, (uint8_t*)&current_protocol);
+      err = esp_wifi_get_protocol(WIFI_IF_STA, (uint8_t *)&current_protocol);
       if (err == ESP_OK && current_protocol == WIFI_PROTOCOL_LR) {
         log_v("Disabling long range on STA");
         err = esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_DEFAULT);
@@ -614,7 +614,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m) {
       }
     }
     if (m & WIFI_MODE_AP) {
-      err = esp_wifi_get_protocol(WIFI_IF_AP, (uint8_t*)&current_protocol);
+      err = esp_wifi_get_protocol(WIFI_IF_AP, (uint8_t *)&current_protocol);
       if (err == ESP_OK && current_protocol == WIFI_PROTOCOL_LR) {
         log_v("Disabling long range on AP");
         err = esp_wifi_set_protocol(WIFI_IF_AP, WIFI_PROTOCOL_DEFAULT);

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -602,9 +602,9 @@ bool WiFiGenericClass::mode(wifi_mode_t m) {
 #else
 #define WIFI_PROTOCOL_DEFAULT (WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N)
 #endif
-    uint8_t current_protocol = 0;
+    uint32_t current_protocol = 0;
     if (m & WIFI_MODE_STA) {
-      err = esp_wifi_get_protocol(WIFI_IF_STA, &current_protocol);
+      err = esp_wifi_get_protocol(WIFI_IF_STA, (uint8_t*)&current_protocol);
       if (err == ESP_OK && current_protocol == WIFI_PROTOCOL_LR) {
         log_v("Disabling long range on STA");
         err = esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_DEFAULT);
@@ -614,7 +614,7 @@ bool WiFiGenericClass::mode(wifi_mode_t m) {
       }
     }
     if (m & WIFI_MODE_AP) {
-      err = esp_wifi_get_protocol(WIFI_IF_AP, &current_protocol);
+      err = esp_wifi_get_protocol(WIFI_IF_AP, (uint8_t*)&current_protocol);
       if (err == ESP_OK && current_protocol == WIFI_PROTOCOL_LR) {
         log_v("Disabling long range on AP");
         err = esp_wifi_set_protocol(WIFI_IF_AP, WIFI_PROTOCOL_DEFAULT);


### PR DESCRIPTION
This pull request includes changes to the `WiFiGenericClass::mode` method in the `WiFiGeneric.cpp` file. The changes involve updating the data type of the `current_protocol` variable and modifying the way its address is passed to the `esp_wifi_get_protocol` function. This is required, because `esp_wifi_get_protocol` sets more than one byte in the provided return mask.

Data type and casting updates:

* Changed the data type of `current_protocol` from `uint8_t` to `uint32_t` to accommodate a wider range of values.
* Updated the `esp_wifi_get_protocol` function calls to cast the address of `current_protocol` to `uint8_t*` to match the expected parameter type. [[1]](diffhunk://#diff-0aa87997f6f48b5397f969144b34ce0ad4da8e173aee854c1cf2e1bf69ecf3aaL605-R607) [[2]](diffhunk://#diff-0aa87997f6f48b5397f969144b34ce0ad4da8e173aee854c1cf2e1bf69ecf3aaL617-R617)

Fixes: https://github.com/espressif/arduino-esp32/issues/11218