### PR TITLE
ci(pre-commit): Execute codespell after formatting changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,13 +39,6 @@ repos:
               ^package\/.*$
           )
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: "v2.3.0"
-    hooks:
-      # Spell checking
-      - id: codespell
-        exclude: ^.*\.(svd|SVD)$
-
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: "v18.1.3"
     hooks:
@@ -79,6 +72,13 @@ repos:
       # YAML formatting
       - id: prettier
         types_or: [yaml]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: "v2.3.0"
+    hooks:
+      # Spell checking
+      - id: codespell
+        exclude: ^.*\.(svd|SVD)$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"


### PR DESCRIPTION
## Description of Change

Execute `codespell` after formatting changes so the warnings will actually match the line numbers in the file.

## Tests scenarios

CI and local