### PR TITLE
fix(esp32c5): Add proper RTC clock source to uartSetClockSource

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1157,7 +1157,11 @@ bool uartSetClockSource(uint8_t uartNum, uart_sclk_t clkSrc) {
   if (uart->num >= SOC_UART_HP_NUM) {
     switch (clkSrc) {
       case UART_SCLK_XTAL:    uart->_uart_clock_source = LP_UART_SCLK_XTAL_D2; break;
+#if CONFIG_IDF_TARGET_ESP32C5
+      case UART_SCLK_RTC:     uart->_uart_clock_source = LP_UART_SCLK_RC_FAST; break;
+#else
       case UART_SCLK_RTC:     uart->_uart_clock_source = LP_UART_SCLK_LP_FAST; break;
+#endif
       case UART_SCLK_DEFAULT:
       default:                uart->_uart_clock_source = LP_UART_SCLK_DEFAULT;
     }


### PR DESCRIPTION
C5 fails to compile when trying to build a firmware. Can't test if the fix is correct since not having a C5. If correct fix for #11254

@SuGlider 