### PR TITLE
docs(language): Enforce English on contributions and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature-request.yml
@@ -5,6 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        * Please note that we can only process feature requests reported in English to ensure effective communication and support. Feature requests written in other languages will be closed, with a request to rewrite them in English.
         * We welcome any ideas or feature requests! It is helpful if you can explain exactly why the feature would be useful.
         * There are usually some outstanding feature requests in the [existing issues list](https://github.com/espressif/arduino-esp32/issues?q=is%3Aopen+is%3Aissue+label%3A%22Type%3A+Feature+request%22), feel free to add comments to them.
         * If you would like to contribute, please read the [contributions guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html).

--- a/.github/ISSUE_TEMPLATE/Issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/Issue-report.yml
@@ -5,6 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
+        * Please note that we can only process issues reported in English to ensure effective communication and support. Issues written in other languages will be closed, with a request to rewrite them in English.
         * Before reporting a new issue please check and search in [List of existing issues](https://github.com/espressif/arduino-esp32/issues?q=is%3Aissue)
         * Please check [Online Documentation](https://docs.espressif.com/projects/arduino-esp32/en/latest/index.html)
         * Take a look on [Troubleshooting guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/troubleshooting.html)

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -15,6 +15,9 @@ Before Contributing
 
 Before sending us a Pull Request, please consider this:
 
+* All contributions must be written in English to ensure effective communication and support.
+  Pull Requests written in other languages will be closed, with a request to rewrite them in English.
+
 * Is the contribution entirely your own work, or is it already licensed under an LGPL 2.1 compatible Open Source License?
   If not, cannot accept it.
 


### PR DESCRIPTION
This pull request introduces updates to enforce English as the standard language for communication in feature requests, issue reports, and contributions. These changes aim to ensure effective communication and streamline the review process.

### Updates to communication guidelines:

* [`.github/ISSUE_TEMPLATE/Feature-request.yml`](diffhunk://#diff-3aef908cff5059f17d2d3fbd10c8c765ca45f639b1372129208b9f243c664950R8): Added a note specifying that feature requests must be written in English. Requests in other languages will be closed with a request to rewrite them in English.
* [`.github/ISSUE_TEMPLATE/Issue-report.yml`](diffhunk://#diff-fcb00a2d209e968ab371bf32541d29831b5d7fe3a070fbc9c04cd0a91b7f22d6R8): Added a similar note for issue reports, requiring them to be submitted in English for effective processing.

### Updates to contribution guidelines:

* [`docs/en/contributing.rst`](diffhunk://#diff-cf0d42bff30b139cd50ea103c575c0adcb3c2f0f2e0594fbd9caab7fd545f95bR18-R20): Introduced a new guideline stating that all contributions, including pull requests, must be written in English. Contributions in other languages will be closed with a request for re-submission in English.