### PR TITLE
fix(gpio): Fix GPIO warning message

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -185,7 +185,7 @@ extern int ARDUINO_ISR_ATTR __digitalRead(uint8_t pin) {
 #endif  // RGB_BUILTIN
   // This work when the pin is set as GPIO and in INPUT mode. For all other pin functions, it may return inconsistent response
   if (perimanGetPinBus(pin, ESP32_BUS_TYPE_GPIO) == NULL) {
-    log_w("IO %i is not set as GPIO. digitalRead() may return an inconsistent value.");
+    log_w("IO %i is not set as GPIO. digitalRead() may return an inconsistent value.", pin);
   }
   return gpio_get_level((gpio_num_t)pin);
 }


### PR DESCRIPTION
## Description of Change

This pull request includes a minor fix to the `__digitalRead` function in the `esp32-hal-gpio.c` file. The change ensures that the `log_w` warning message properly includes the pin number in its output.

* [`cores/esp32/esp32-hal-gpio.c`](diffhunk://#diff-cc07ee5f3d34f8f2648dff856f751f53c9b84477993e8e6adb0f8291d897cc09L188-R188): Updated the `log_w` function call in `__digitalRead` to include the `pin` parameter, ensuring the warning message displays the pin number correctly.

## Related links

Closes #11265

