### PR TITLE
feat(ledc): clear all fields added to ledc struct in IDF 5.4

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -128,7 +128,7 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
   } else {
     ledc_timer_config_t ledc_timer;
     memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
-    ledc_timer.speed_mode = group
+    ledc_timer.speed_mode = group;
     ledc_timer.timer_num = timer;
     ledc_timer.duty_resolution = resolution;
     ledc_timer.freq_hz = freq;
@@ -272,7 +272,7 @@ uint32_t ledcWriteTone(uint8_t pin, uint32_t freq) {
 
     ledc_timer_config_t ledc_timer;
     memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
-    ledc_timer.speed_mode = group
+    ledc_timer.speed_mode = group;
     ledc_timer.timer_num = timer;
     ledc_timer.duty_resolution = 10;
     ledc_timer.freq_hz = freq;
@@ -329,7 +329,7 @@ uint32_t ledcChangeFrequency(uint8_t pin, uint32_t freq, uint8_t resolution) {
 
     ledc_timer_config_t ledc_timer;
     memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
-    ledc_timer.speed_mode = group
+    ledc_timer.speed_mode = group;
     ledc_timer.timer_num = timer;
     ledc_timer.duty_resolution = resolution;
     ledc_timer.freq_hz = freq;

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -133,7 +133,7 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
     ledc_timer.duty_resolution = resolution;
     ledc_timer.freq_hz = freq;
     ledc_timer.clk_cfg = clock_source;
-    
+
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledc setup failed!");
       return false;
@@ -149,7 +149,7 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
     ledc_channel.intr_type = LEDC_INTR_DISABLE;
     ledc_channel.gpio_num = pin;
     ledc_channel.duty = duty;
-    ledc_channel.hpoint = 0; 
+    ledc_channel.hpoint = 0;
 
     ledc_channel_config(&ledc_channel);
   }

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -126,7 +126,7 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
       return false;
     }
   } else {
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source};
+    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source, .deconfigure = false};
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledc setup failed!");
       return false;
@@ -134,9 +134,16 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
 
     uint32_t duty = ledc_get_duty(group, (channel % 8));
 
-    ledc_channel_config_t ledc_channel = {
-      .speed_mode = group, .channel = (channel % 8), .timer_sel = timer, .intr_type = LEDC_INTR_DISABLE, .gpio_num = pin, .duty = duty, .hpoint = 0
-    };
+    ledc_channel_config_t ledc_channel;
+    memset((void *)&ledc_channel, 0, sizeof(ledc_channel_config_t));
+    ledc_channel.speed_mode = group;
+    ledc_channel.channel = (channel % 8);
+    ledc_channel.timer_sel = timer;
+    ledc_channel.intr_type = LEDC_INTR_DISABLE;
+    ledc_channel.gpio_num = pin;
+    ledc_channel.duty = duty;
+    ledc_channel.hpoint = 0; 
+
     ledc_channel_config(&ledc_channel);
   }
 
@@ -256,7 +263,7 @@ uint32_t ledcWriteTone(uint8_t pin, uint32_t freq) {
 
     uint8_t group = (bus->channel / 8), timer = ((bus->channel / 2) % 4);
 
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = 10, .freq_hz = freq, .clk_cfg = clock_source};
+    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = 10, .freq_hz = freq, .clk_cfg = clock_source, .deconfigure = false};
 
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledcWriteTone configuration failed!");
@@ -307,7 +314,7 @@ uint32_t ledcChangeFrequency(uint8_t pin, uint32_t freq, uint8_t resolution) {
     }
     uint8_t group = (bus->channel / 8), timer = ((bus->channel / 2) % 4);
 
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source};
+    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source, .deconfigure = false};
 
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledcChangeFrequency failed!");

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -126,7 +126,14 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
       return false;
     }
   } else {
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source, .deconfigure = false};
+    ledc_timer_config_t ledc_timer;
+    memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
+    ledc_timer.speed_mode = group
+    ledc_timer.timer_num = timer;
+    ledc_timer.duty_resolution = resolution;
+    ledc_timer.freq_hz = freq;
+    ledc_timer.clk_cfg = clock_source;
+    
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledc setup failed!");
       return false;
@@ -263,7 +270,13 @@ uint32_t ledcWriteTone(uint8_t pin, uint32_t freq) {
 
     uint8_t group = (bus->channel / 8), timer = ((bus->channel / 2) % 4);
 
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = 10, .freq_hz = freq, .clk_cfg = clock_source, .deconfigure = false};
+    ledc_timer_config_t ledc_timer;
+    memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
+    ledc_timer.speed_mode = group
+    ledc_timer.timer_num = timer;
+    ledc_timer.duty_resolution = 10;
+    ledc_timer.freq_hz = freq;
+    ledc_timer.clk_cfg = clock_source;
 
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledcWriteTone configuration failed!");
@@ -314,7 +327,13 @@ uint32_t ledcChangeFrequency(uint8_t pin, uint32_t freq, uint8_t resolution) {
     }
     uint8_t group = (bus->channel / 8), timer = ((bus->channel / 2) % 4);
 
-    ledc_timer_config_t ledc_timer = {.speed_mode = group, .timer_num = timer, .duty_resolution = resolution, .freq_hz = freq, .clk_cfg = clock_source, .deconfigure = false};
+    ledc_timer_config_t ledc_timer;
+    memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
+    ledc_timer.speed_mode = group
+    ledc_timer.timer_num = timer;
+    ledc_timer.duty_resolution = resolution;
+    ledc_timer.freq_hz = freq;
+    ledc_timer.clk_cfg = clock_source;
 
     if (ledc_timer_config(&ledc_timer) != ESP_OK) {
       log_e("ledcChangeFrequency failed!");


### PR DESCRIPTION
## Description of Change
IDF 5.3 has included a new field to `ledc_timer_config_t`, `bool deconfigure`.
IDF 5.3 included a new field to `ledc_channel_config_t`, `ledc_sleep_mode_t sleep_mode`.
IDF 5.4 included a new filed to `ledc_channel_config_t`, `unsigned int flags.output_invert`

None of those were initiated in the code. This PR set them all to `0` to make sure that these fields are correctly initiated.


## Tests scenarios
CI only

## Related links
None