### PR TITLE
fix(i2c): Use new init API

### DIFF
--- a/cores/esp32/esp32-hal-i2c-slave.c
+++ b/cores/esp32/esp32-hal-i2c-slave.c
@@ -43,6 +43,7 @@
 #include "soc/i2c_struct.h"
 #include "soc/periph_defs.h"
 #include "hal/i2c_ll.h"
+#include "hal/i2c_types.h"
 #ifndef CONFIG_IDF_TARGET_ESP32C5
 #include "hal/clk_gate_ll.h"
 #endif
@@ -337,7 +338,13 @@ esp_err_t i2cSlaveInit(uint8_t num, int sda, int scl, uint16_t slaveID, uint32_t
   }
 #endif  // !defined(CONFIG_IDF_TARGET_ESP32P4)
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+  i2c_ll_set_mode(i2c->dev, I2C_BUS_MODE_SLAVE);
+  i2c_ll_enable_pins_open_drain(i2c->dev, false);
+#else
   i2c_ll_slave_init(i2c->dev);
+#endif
+
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
   i2c_ll_enable_fifo_mode(i2c->dev, true);
 #else


### PR DESCRIPTION
## Description of Change

This pull request updates the I2C slave initialization logic in `cores/esp32/esp32-hal-i2c-slave.c` to improve compatibility with newer versions of the ESP-IDF framework. The changes include conditional compilation adjustments and updates to the initialization process for I2C slave mode.

### Compatibility updates for ESP-IDF versions:

* Added a conditional check for ESP-IDF version 5.5.0 or higher to use `i2c_ll_set_mode` and `i2c_ll_enable_pins_open_drain` for initializing the I2C slave mode. This ensures compatibility with the latest ESP-IDF APIs.