### PR TITLE
feat(uart): sets correct ESP32/S2 clock source for the example

### DIFF
--- a/libraries/ESP32/examples/Serial/RxTimeout_Demo/RxTimeout_Demo.ino
+++ b/libraries/ESP32/examples/Serial/RxTimeout_Demo/RxTimeout_Demo.ino
@@ -22,8 +22,8 @@
    then copy the data from the FIFO to the Arduino internal buffer, making it available to the Arduino API.
 
    There is an important detail about how HardwareSerial works using ESP32 and ESP32-S2:
-   If the baud rate is lower than 250,000, it will select REF_TICK as clock source in order to avoid that 
-   the baud rate may change when the CPU Frequency is changed. Default UART clock source is APB, which changes 
+   If the baud rate is lower than 250,000, it will select REF_TICK as clock source in order to avoid that
+   the baud rate may change when the CPU Frequency is changed. Default UART clock source is APB, which changes
    when CPU clock source is also changed. But when it selects REF_TICK as UART clock source, RX Timeout is limited to 1.
    Therefore, in order to change the ESP32/ESP32-S2 RX Timeout it is necessary to fix the UART Clock Source to APB.
 

--- a/libraries/ESP32/examples/Serial/RxTimeout_Demo/RxTimeout_Demo.ino
+++ b/libraries/ESP32/examples/Serial/RxTimeout_Demo/RxTimeout_Demo.ino
@@ -21,6 +21,15 @@
    If UART receives less than 120 bytes, it will wait RX Timeout to understand that the bus is IDLE and
    then copy the data from the FIFO to the Arduino internal buffer, making it available to the Arduino API.
 
+   There is an important detail about how HardwareSerial works using ESP32 and ESP32-S2:
+   If the baud rate is lower than 250,000, it will select REF_TICK as clock source in order to avoid that 
+   the baud rate may change when the CPU Frequency is changed. Default UART clock source is APB, which changes 
+   when CPU clock source is also changed. But when it selects REF_TICK as UART clock source, RX Timeout is limited to 1.
+   Therefore, in order to change the ESP32/ESP32-S2 RX Timeout it is necessary to fix the UART Clock Source to APB.
+
+   In the case of the other SoC, such as ESP32-S3, C3, C6, H2 and P4, there is no such RX Timeout limitation.
+   Those will set the UART Source Clock as XTAL, which allows the baud rate to be high and it is steady, not
+   changing with the CPU Frequency.
 */
 
 #include <Arduino.h>
@@ -45,6 +54,12 @@ void setup() {
 
   // UART1 will have its RX<->TX cross connected
   // GPIO4 <--> GPIO5 using external wire
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+  // UART_CLK_SRC_APB will allow higher values of RX Timeout
+  // default for ESP32 and ESP32-S2 is REF_TICK which limits the RX Timeout to 1
+  // setClockSource() must be called before begin()
+  Serial1.setClockSource(UART_CLK_SRC_APB);
+#endif
   Serial1.begin(BAUD, SERIAL_8N1, RXPIN, TXPIN);  // Rx = 4, Tx = 5 will work for ESP32, S2, S3 and C3
 #if USE_INTERNAL_PIN_LOOPBACK
   uart_internal_loopback(TEST_UART, RXPIN);


### PR DESCRIPTION
## Description of Change
Rx Timeout example was not working correctly using ESP32 and ESP32-S2 due to default selection of REF_TICK as UART Clock Source. REF_TICK limits RX Timeout to 1.

This PR adds the necessary call to `HardwareSerial::setClockSource()` in order to make it work properly. 

## Tests scenarios
Tested using the example code of this PR.
ESP32 | ESP32-S2 | ESP32-C3 | ESP32-C6 | ESP32-S3 | ESP32-H2

#### Expect output (see the time it takes to read 10 bytes):
```
ets Jul 29 2019 12:21:46

rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:1
load:0x3fff0030,len:4888
load:0x40078000,len:16516
load:0x40080400,len:4
load:0x40080404,len:3476
entry 0x400805b4
[     8][I][esp32-hal-psram.c:102] psramAddToHeap(): PSRAM added to the heap.


================================
Test Case #1
================================
Testing the time for receiving 10 bytes at 9600 baud, using RX Timeout = 50:
It has sent 10 bytes from Serial1 TX to Serial1 RX
It took 62 milliseconds to read 10 bytes
Received data: [0123456789]
========================
Finished!


================================
Test Case #2
================================
Testing the time for receiving 10 bytes at 9600 baud, using RX Timeout = 20:
It has sent 10 bytes from Serial1 TX to Serial1 RX
It took 31 milliseconds to read 10 bytes
Received data: [0123456789]
========================
Finished!


================================
Test Case #3
================================
Testing the time for receiving 10 bytes at 9600 baud, using RX Timeout = 10:
It has sent 10 bytes from Serial1 TX to Serial1 RX
It took 21 milliseconds to read 10 bytes
Received data: [0123456789]
========================
Finished!


================================
Test Case #4
================================
Testing the time for receiving 10 bytes at 9600 baud, using RX Timeout = 5:
It has sent 10 bytes from Serial1 TX to Serial1 RX
It took 16 milliseconds to read 10 bytes
Received data: [0123456789]
========================
Finished!


================================
Test Case #5
================================
Testing the time for receiving 10 bytes at 9600 baud, using RX Timeout = 1:
It has sent 10 bytes from Serial1 TX to Serial1 RX
It took 11 milliseconds to read 10 bytes
Received data: [0123456789]
========================
Finished!
```

## Related links
None