### PR TITLE
ci(release): Add package JSON with chinese mirrors

### DIFF
--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -346,7 +346,7 @@ sed '0,/github\.com\/espressif\//!s|github\.com/espressif/|dl.espressif.cn/githu
 if [ "$RELEASE_PRE" == "false" ]; then
     echo "Generating $PACKAGE_JSON_REL ..."
     cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$OUTPUT_DIR/$PACKAGE_JSON_REL"
-    # On MacOS the sed command won't behave as expected. Use gsed instead.
+    # On MacOS the sed command won't skip the first match. Use gsed instead.
     sed '0,/github\.com\/espressif\//!s|github\.com/espressif/|dl.espressif.cn/github_assets/espressif/|g' "$OUTPUT_DIR/$PACKAGE_JSON_REL" > "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
 fi
 


### PR DESCRIPTION
## Description of Change

This pull request enhances the release script (`.github/scripts/on-release.sh`) to support generating and handling package JSON files for a Chinese mirror (`dl.espressif.cn`). The changes ensure compatibility with the Chinese mirror by adding new JSON files, modifying commands, and updating upload logic.

### Support for Chinese mirror:

* Added new variables `PACKAGE_JSON_DEV_CN` and `PACKAGE_JSON_REL_CN` to handle Chinese mirror-specific package JSON files.
* Updated the `sed` command to replace URLs for the Chinese mirror (`github.com` → `dl.espressif.cn/github_assets`) while generating the Chinese-specific JSON files.
* Modified the `merge_package_json` logic to include merging of Chinese mirror-specific JSON files during release preparation.
* Added a note that package JSONs for the Chinese mirror are not tested during the release process, as the mirror might not yet be updated.
* Enhanced the upload steps to include uploading the Chinese mirror-specific JSON files to both GitHub assets and GitHub Pages.