### PR TITLE
IDF master

### DIFF
--- a/cores/esp32/esp32-hal-i2c-slave.c
+++ b/cores/esp32/esp32-hal-i2c-slave.c
@@ -43,6 +43,7 @@
 #include "soc/i2c_struct.h"
 #include "soc/periph_defs.h"
 #include "hal/i2c_ll.h"
+#include "hal/i2c_types.h"
 #ifndef CONFIG_IDF_TARGET_ESP32C5
 #include "hal/clk_gate_ll.h"
 #endif
@@ -337,7 +338,13 @@ esp_err_t i2cSlaveInit(uint8_t num, int sda, int scl, uint16_t slaveID, uint32_t
   }
 #endif  // !defined(CONFIG_IDF_TARGET_ESP32P4)
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+  i2c_ll_set_mode(i2c->dev, I2C_BUS_MODE_SLAVE);
+  i2c_ll_enable_pins_open_drain(i2c->dev, true);
+#else
   i2c_ll_slave_init(i2c->dev);
+#endif
+
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
   i2c_ll_enable_fifo_mode(i2c->dev, true);
 #else

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -57,12 +57,12 @@ dependencies:
     version: "==1.6.3"
     require: public
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   espressif/esp-zigbee-lib:
     version: "==1.6.3"
     require: public
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   espressif/esp-dsp:
     version: "^1.3.4"
     rules:
@@ -73,32 +73,32 @@ dependencies:
   espressif/esp_rainmaker:
     version: "1.5.2"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   espressif/rmaker_common:
     version: "1.4.6"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   espressif/esp_insights:
     version: "1.2.2"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   # New version breaks esp_insights 1.0.1
   espressif/esp_diag_data_store:
     version: "1.0.2"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   espressif/esp_diagnostics:
     version: "1.2.1"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   espressif/cbor:
     version: "0.6.0~1"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   espressif/qrcode:
     version: "0.1.0~2"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target not in [esp32c2, esp32p4, esp32c5]"
   # RainMaker End
   espressif/esp-sr:
     version: "^1.4.2"

--- a/libraries/BluetoothSerial/src/BTAddress.cpp
+++ b/libraries/BluetoothSerial/src/BTAddress.cpp
@@ -7,7 +7,9 @@
  *      Author: Thomas M. (ArcticSnowSky)
  */
 #include "sdkconfig.h"
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#include "soc/soc_caps.h"
+
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 #include "BTAddress.h"
 #include <string>

--- a/libraries/BluetoothSerial/src/BTAddress.h
+++ b/libraries/BluetoothSerial/src/BTAddress.h
@@ -10,7 +10,9 @@
 #ifndef COMPONENTS_CPP_UTILS_BTADDRESS_H_
 #define COMPONENTS_CPP_UTILS_BTADDRESS_H_
 #include "sdkconfig.h"
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#include "soc/soc_caps.h"
+
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 #include <esp_gap_bt_api.h>  // ESP32 BT
 #include <Arduino.h>
 

--- a/libraries/BluetoothSerial/src/BTAdvertisedDevice.h
+++ b/libraries/BluetoothSerial/src/BTAdvertisedDevice.h
@@ -5,9 +5,11 @@
  *      Author: Thomas M. (ArcticSnowSky)
  */
 
-#ifndef __BTADVERTISEDDEVICE_H__
-#define __BTADVERTISEDDEVICE_H__
+#pragma once
+#include "sdkconfig.h"
+#include "soc/soc_caps.h"
 
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 #include "BTAddress.h"
 #include <string>
 

--- a/libraries/BluetoothSerial/src/BTAdvertisedDeviceSet.cpp
+++ b/libraries/BluetoothSerial/src/BTAdvertisedDeviceSet.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "sdkconfig.h"
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#include "soc/soc_caps.h"
+
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 //#include <map>
 

--- a/libraries/BluetoothSerial/src/BTScan.h
+++ b/libraries/BluetoothSerial/src/BTScan.h
@@ -5,8 +5,11 @@
  *      Author: Thomas M. (ArcticSnowSky)
  */
 
-#ifndef __BTSCAN_H__
-#define __BTSCAN_H__
+#pragma once
+#include "sdkconfig.h"
+#include "soc/soc_caps.h"
+
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 #include <map>
 #include <string>

--- a/libraries/BluetoothSerial/src/BTScanResultsSet.cpp
+++ b/libraries/BluetoothSerial/src/BTScanResultsSet.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "sdkconfig.h"
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#include "soc/soc_caps.h"
+
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 #include <esp_err.h>
 

--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -19,8 +19,9 @@
 #include <cstring>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "soc/soc_caps.h"
 
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 #ifdef ARDUINO_ARCH_ESP32
 #include "esp32-hal-log.h"

--- a/libraries/BluetoothSerial/src/BluetoothSerial.h
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.h
@@ -16,8 +16,9 @@
 #define _BLUETOOTH_SERIAL_H_
 
 #include "sdkconfig.h"
+#include "soc/soc_caps.h"
 
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 #include "Arduino.h"
 #include "Stream.h"

--- a/libraries/SimpleBLE/examples/SimpleBleDevice/ci.json
+++ b/libraries/SimpleBLE/examples/SimpleBleDevice/ci.json
@@ -1,5 +1,6 @@
 {
   "requires": [
+    "CONFIG_SOC_BLE_SUPPORTED=y",
     "CONFIG_BT_ENABLED=y",
     "CONFIG_BLUEDROID_ENABLED=y"
   ]

--- a/libraries/SimpleBLE/src/SimpleBLE.cpp
+++ b/libraries/SimpleBLE/src/SimpleBLE.cpp
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 #include "sdkconfig.h"
+#include "soc/soc_caps.h"
 
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 #include "SimpleBLE.h"
 #include "esp32-hal-log.h"

--- a/libraries/SimpleBLE/src/SimpleBLE.h
+++ b/libraries/SimpleBLE/src/SimpleBLE.h
@@ -16,8 +16,9 @@
 #define _SIMPLE_BLE_H_
 
 #include "sdkconfig.h"
+#include "soc/soc_caps.h"
 
-#if defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
+#if SOC_BT_SUPPORTED && defined(CONFIG_BT_ENABLED) && defined(CONFIG_BLUEDROID_ENABLED)
 
 #include <cstdint>
 #include <cstdio>

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-465b159c-v1"
+              "version": "idf-master-38628f98-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-465b159c-v1",
+          "version": "idf-master-38628f98-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
-              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
-              "size": "398162223"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
+              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
+              "size": "398323971"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-d930a386-v1"
+              "version": "idf-master-465b159c-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-d930a386-v1",
+          "version": "idf-master-465b159c-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-d930a386-v1.zip",
-              "checksum": "SHA-256:0310daa4f08f807f2bf3babd2587c2694df64c70e367863eadf5020636b717ae",
-              "size": "422376381"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-465b159c-v1.zip",
+              "checksum": "SHA-256:2619d697406076b03990a9b475ba512a0db297e3cf82dd5bade0d58aceafc10c",
+              "size": "398162223"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 69d504b
esp-idf: master 465b159cd8
arduino: idf-master 67fa6d25
tinyusb: master 8b3c55888
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.6.1
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.19.1
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.4.0
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.5.5
```
