### PR TITLE
New SPI invert hardware SS function in hall-spi and SPI library

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -74,7 +74,7 @@ struct spi_struct_t {
   int8_t miso;
   int8_t mosi;
   int8_t ss;
-  bool invert_out;
+  bool ss_invert;
 };
 
 #if CONFIG_IDF_TARGET_ESP32S2
@@ -368,7 +368,7 @@ bool spiAttachSS(spi_t *spi, uint8_t ss_num, int8_t ss) {
     return false;
   }
   pinMode(ss, OUTPUT);
-  pinMatrixOutAttach(ss, SPI_SS_IDX(spi->num, ss_num), spi->invert_out, false);
+  pinMatrixOutAttach(ss, SPI_SS_IDX(spi->num, ss_num), spi->ss_invert, false);
   spiEnableSSPins(spi, (1 << ss_num));
   spi->ss = ss;
   if (!perimanSetPinBus(ss, ESP32_BUS_TYPE_SPI_MASTER_SS, (void *)(spi->num + 1), spi->num, -1)) {
@@ -440,7 +440,7 @@ void spiSSDisable(spi_t *spi) {
 
 void spiSSInvertout(spi_t *spi, bool invert) {
   if (spi) {
-    spi->invert_out = invert;
+    spi->ss_invert = invert;
   }
 }
 

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -438,7 +438,7 @@ void spiSSDisable(spi_t *spi) {
   SPI_MUTEX_UNLOCK();
 }
 
-void spiSSInvertout(spi_t *spi, bool invert) {
+void spiSSInvert(spi_t *spi, bool invert) {
   if (spi) {
     spi->ss_invert = invert;
   }

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -74,6 +74,7 @@ struct spi_struct_t {
   int8_t miso;
   int8_t mosi;
   int8_t ss;
+  bool invert_out;
 };
 
 #if CONFIG_IDF_TARGET_ESP32S2
@@ -356,6 +357,8 @@ bool spiDetachMOSI(spi_t *spi) {
   return true;
 }
 
+
+
 bool spiAttachSS(spi_t *spi, uint8_t ss_num, int8_t ss) {
   if (!spi || ss < 0 || ss_num > 2) {
     return false;
@@ -365,7 +368,7 @@ bool spiAttachSS(spi_t *spi, uint8_t ss_num, int8_t ss) {
     return false;
   }
   pinMode(ss, OUTPUT);
-  pinMatrixOutAttach(ss, SPI_SS_IDX(spi->num, ss_num), false, false);
+  pinMatrixOutAttach(ss, SPI_SS_IDX(spi->num, ss_num), spi->invert_out, false);
   spiEnableSSPins(spi, (1 << ss_num));
   spi->ss = ss;
   if (!perimanSetPinBus(ss, ESP32_BUS_TYPE_SPI_MASTER_SS, (void *)(spi->num + 1), spi->num, -1)) {
@@ -433,6 +436,12 @@ void spiSSDisable(spi_t *spi) {
   spi->dev->user.cs_setup = 0;
   spi->dev->user.cs_hold = 0;
   SPI_MUTEX_UNLOCK();
+}
+
+void spiSSInvertout(spi_t *spi, bool invert) {
+  if (spi) {
+    spi->invert_out = invert;
+  }
 }
 
 void spiSSSet(spi_t *spi) {

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -357,8 +357,6 @@ bool spiDetachMOSI(spi_t *spi) {
   return true;
 }
 
-
-
 bool spiAttachSS(spi_t *spi, uint8_t ss_num, int8_t ss) {
   if (!spi || ss < 0 || ss_num > 2) {
     return false;

--- a/cores/esp32/esp32-hal-spi.h
+++ b/cores/esp32/esp32-hal-spi.h
@@ -97,6 +97,8 @@ void spiSSSet(spi_t *spi);
 void spiSSClear(spi_t *spi);
 
 void spiWaitReady(spi_t *spi);
+//invert hardware SS
+void spiSSInvertout(spi_t *spi, bool invert);
 
 uint32_t spiGetClockDiv(spi_t *spi);
 uint8_t spiGetDataMode(spi_t *spi);

--- a/cores/esp32/esp32-hal-spi.h
+++ b/cores/esp32/esp32-hal-spi.h
@@ -98,7 +98,7 @@ void spiSSClear(spi_t *spi);
 
 void spiWaitReady(spi_t *spi);
 //invert hardware SS
-void spiSSInvertout(spi_t *spi, bool invert);
+void spiSSInvert(spi_t *spi, bool invert);
 
 uint32_t spiGetClockDiv(spi_t *spi);
 uint8_t spiGetDataMode(spi_t *spi);

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -144,6 +144,12 @@ void SPIClass::setHwCs(bool use) {
   _use_hw_ss = use;
 }
 
+void SPIClass::setSSInvert(bool invert) {
+  if (_spi) {
+    spiSSInvertout(_spi, invert);
+  }
+}
+
 void SPIClass::setFrequency(uint32_t freq) {
   SPI_PARAM_LOCK();
   //check if last freq changed

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -146,7 +146,7 @@ void SPIClass::setHwCs(bool use) {
 
 void SPIClass::setSSInvert(bool invert) {
   if (_spi) {
-    spiSSInvertout(_spi, invert);
+    spiSSInvert(_spi, invert);
   }
 }
 

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -65,7 +65,7 @@ public:
   void end();
   
   void setHwCs(bool use);
-  void setSSInvert(bool invert);
+  void setSSInvert(bool invert);  //use before setHwCS for change to be used by setHwCs
   void setBitOrder(uint8_t bitOrder);
   void setDataMode(uint8_t dataMode);
   void setFrequency(uint32_t freq);

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -63,8 +63,9 @@ public:
   ~SPIClass();
   void begin(int8_t sck = -1, int8_t miso = -1, int8_t mosi = -1, int8_t ss = -1);
   void end();
-
+  
   void setHwCs(bool use);
+  void setSSInvert(bool invert);
   void setBitOrder(uint8_t bitOrder);
   void setDataMode(uint8_t dataMode);
   void setFrequency(uint32_t freq);

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -63,7 +63,7 @@ public:
   ~SPIClass();
   void begin(int8_t sck = -1, int8_t miso = -1, int8_t mosi = -1, int8_t ss = -1);
   void end();
-  
+
   void setHwCs(bool use);
   void setSSInvert(bool invert);  //use before setHwCS for change to be used by setHwCs
   void setBitOrder(uint8_t bitOrder);


### PR DESCRIPTION

This PR adds the ability to invert the logic level of the Hardware Slave Select (SS) pin for ESP32 SPI buses (HSPI/VSPI). This is critical for compatibility with hardware that expects active-high SS signals.

Backward Compatibility:
No breaking changes: Existing code using setHwCs() will default to invert_out=false (original behavior)
No Software SS Impact: Only affects hardware-controlled SS pins.
Isolation: Changes to one SPI bus (e.g., HSPI) do not affect others (e.g., VSPI).

Usage Example:
SPIClass *hspi = NULL;
setup(){
hspi = new SPIClass(HSPI);
hspi->begin();
hspi->setSSInvert(true);  // Set before setHwCs();
hspi->setHwCs(true); 
hspi->beginTransaction(SPISettings(SPI_CLOCK, MSBFIRST, SPI_MODE2));
}

I have tested my Pull Request on Arduino-esp32 core v3.1.3 with ESP32-S3 Board.



## Related links
Some people have the same issue but with espidf. I use arduino ide so I fixed it for myself.
https://esp32.com/viewtopic.php?t=16057
https://esp32.com/viewtopic.php?t=16057
