### PR TITLE
docs(mirror): Add Chinese mirror links

### DIFF
--- a/docs/en/installing.rst
+++ b/docs/en/installing.rst
@@ -10,6 +10,11 @@ Before Installing
 We recommend you install the support using your favorite IDE, but other options are available depending on your operating system.
 To install Arduino-ESP32 support, you can use one of the following options.
 
+.. note::
+   Users in China might have troubles with connection and download speeds using GitHub. Please use our Jihulab mirror as the repository source:
+
+   ``https://jihulab.com/esp-mirror/espressif/arduino-esp32.git``
+
 Installing using Arduino IDE
 ----------------------------
 
@@ -31,6 +36,16 @@ This is the way to install Arduino-ESP32 directly from the Arduino IDE.
 
    https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json
 
+
+Users in China might have troubles with connection and download speeds using the links above. Please use our Jihulab mirror:
+
+- Stable release link::
+
+   https://jihulab.com/esp-mirror/espressif/arduino-esp32/-/raw/gh-pages/package_esp32_index_cn.json
+
+- Development release link::
+
+   https://jihulab.com/esp-mirror/espressif/arduino-esp32/-/raw/gh-pages/package_esp32_dev_index_cn.json
 
 .. note::
    Starting with the Arduino IDE version 1.6.4, Arduino allows installation of third-party platform

--- a/docs/en/troubleshooting.rst
+++ b/docs/en/troubleshooting.rst
@@ -14,6 +14,23 @@ Installing
 
 Here are the common issues during the installation.
 
+Slow or unstable downloads
+**************************
+
+Users in China might have troubles with connection and download speeds using GitHub. Please use our Jihulab mirror as the repository source:
+
+`https://jihulab.com/esp-mirror/espressif/arduino-esp32.git <https://jihulab.com/esp-mirror/espressif/arduino-esp32.git>`_
+
+JSON files for the boards manager are available here:
+
+- Stable release::
+
+   https://jihulab.com/esp-mirror/espressif/arduino-esp32/-/raw/gh-pages/package_esp32_index_cn.json
+
+- Development release::
+
+   https://jihulab.com/esp-mirror/espressif/arduino-esp32/-/raw/gh-pages/package_esp32_dev_index_cn.json
+
 Building
 --------
 


### PR DESCRIPTION
## Description of Change

This pull request updates the documentation to provide alternative download links for users in China, addressing potential issues with slow or unstable connections to GitHub. The changes include adding references to the Jihulab mirror in the installation and troubleshooting guides.

### Documentation updates for users in China:

* [`docs/en/installing.rst`](diffhunk://#diff-782bceb21b15a86ce2e11bf1c50c1fb6495417df8e671a687a56e185d166d36fR13-R17): Added a note and alternative repository link (`https://jihulab.com/esp-mirror/espressif/arduino-esp32.git`) for users in China experiencing slow download speeds. Also included stable and development release JSON file links for the Arduino IDE Boards Manager. [[1]](diffhunk://#diff-782bceb21b15a86ce2e11bf1c50c1fb6495417df8e671a687a56e185d166d36fR13-R17) [[2]](diffhunk://#diff-782bceb21b15a86ce2e11bf1c50c1fb6495417df8e671a687a56e185d166d36fR40-R49)

* [`docs/en/troubleshooting.rst`](diffhunk://#diff-bf808155282ed806fddfc0f74537e7cdac6a2def2324a267c23c858a46170f1eR17-R33): Added a new section titled "Slow or unstable downloads" with Jihulab mirror links for the repository and JSON files, providing guidance for users facing connection issues.

Requires #11288 to be consistent.