### PR TITLE
fix(release): Replace all assets with chinese mirrors

### DIFF
--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -343,11 +343,13 @@ echo "Generating $PACKAGE_JSON_DEV ..."
 cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$OUTPUT_DIR/$PACKAGE_JSON_DEV"
 # On MacOS the sed command won't skip the first match. Use gsed instead.
 sed '0,/github\.com\//!s|github\.com/|dl.espressif.cn/github_assets/|g' "$OUTPUT_DIR/$PACKAGE_JSON_DEV" > "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN"
+python "$SCRIPTS_DIR/release_append_cn.py" "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN"
 if [ "$RELEASE_PRE" == "false" ]; then
     echo "Generating $PACKAGE_JSON_REL ..."
     cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$OUTPUT_DIR/$PACKAGE_JSON_REL"
     # On MacOS the sed command won't skip the first match. Use gsed instead.
     sed '0,/github\.com\//!s|github\.com/|dl.espressif.cn/github_assets/|g' "$OUTPUT_DIR/$PACKAGE_JSON_REL" > "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
+    python "$SCRIPTS_DIR/release_append_cn.py" "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
 fi
 
 # Figure out the last release or pre-release

--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -342,12 +342,12 @@ jq_arg=".packages[0].platforms[0].version = \"$RELEASE_TAG\" | \
 echo "Generating $PACKAGE_JSON_DEV ..."
 cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$OUTPUT_DIR/$PACKAGE_JSON_DEV"
 # On MacOS the sed command won't skip the first match. Use gsed instead.
-sed '0,/github\.com\/espressif\//!s|github\.com/espressif/|dl.espressif.cn/github_assets/espressif/|g' "$OUTPUT_DIR/$PACKAGE_JSON_DEV" > "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN"
+sed '0,/github\.com\//!s|github\.com/|dl.espressif.cn/github_assets/|g' "$OUTPUT_DIR/$PACKAGE_JSON_DEV" > "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN"
 if [ "$RELEASE_PRE" == "false" ]; then
     echo "Generating $PACKAGE_JSON_REL ..."
     cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$OUTPUT_DIR/$PACKAGE_JSON_REL"
     # On MacOS the sed command won't skip the first match. Use gsed instead.
-    sed '0,/github\.com\/espressif\//!s|github\.com/espressif/|dl.espressif.cn/github_assets/espressif/|g' "$OUTPUT_DIR/$PACKAGE_JSON_REL" > "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
+    sed '0,/github\.com\//!s|github\.com/|dl.espressif.cn/github_assets/|g' "$OUTPUT_DIR/$PACKAGE_JSON_REL" > "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
 fi
 
 # Figure out the last release or pre-release
@@ -456,14 +456,14 @@ echo "Uploading $PACKAGE_JSON_DEV ..."
 echo "Download URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV")"
 echo "Pages URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_DEV" "$OUTPUT_DIR/$PACKAGE_JSON_DEV")"
 echo "Download CN URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN")"
-echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_DEV" "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN")"
+echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_DEV_CN" "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN")"
 echo
 if [ "$RELEASE_PRE" == "false" ]; then
     echo "Uploading $PACKAGE_JSON_REL ..."
     echo "Download URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL")"
     echo "Pages URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL")"
     echo "Download CN URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN")"
-    echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN")"
+    echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_REL_CN" "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN")"
     echo
 fi
 

--- a/.github/scripts/release_append_cn.py
+++ b/.github/scripts/release_append_cn.py
@@ -1,0 +1,56 @@
+
+#!/usr/bin/env python3
+
+# Arduino IDE provides by default a package file for the ESP32. This causes version conflicts
+# when the user tries to use the JSON file with the Chinese mirrors.
+#
+# The downside is that the Arduino IDE will always warn the user that updates are available as it
+# will consider the version from the Chinese mirrors as a pre-release version.
+#
+# This script is used to append "-cn" to all versions in the package_esp32_index_cn.json file so that
+# the user can select the Chinese mirrors without conflicts.
+#
+# If Arduino ever stops providing the package_esp32_index.json file by default,
+# this script can be removed and the tags reverted.
+
+import json
+
+def append_cn_to_versions(obj):
+    if isinstance(obj, dict):
+        # dfu-util comes from arduino.cc and not from the Chinese mirrors, so we skip it
+        if obj.get("name") == "dfu-util":
+            return
+
+        for key, value in obj.items():
+            if key == "version" and isinstance(value, str):
+                if not value.endswith("-cn"):
+                    obj[key] = value + "-cn"
+            else:
+                append_cn_to_versions(value)
+
+    elif isinstance(obj, list):
+        for item in obj:
+            append_cn_to_versions(item)
+
+def process_json_file(input_path, output_path=None):
+    with open(input_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    append_cn_to_versions(data)
+
+    if output_path is None:
+        output_path = input_path
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+    print(f"Updated JSON written to {output_path}")
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python release_append_cn.py input.json [output.json]")
+    else:
+        input_file = sys.argv[1]
+        output_file = sys.argv[2] if len(sys.argv) > 2 else None
+        process_json_file(input_file, output_file)

--- a/docs/en/installing.rst
+++ b/docs/en/installing.rst
@@ -70,6 +70,8 @@ To start the installation process using the Boards Manager, follow these steps:
    :figclass: align-center
 
 -  Open Boards Manager from Tools > Board menu and install *esp32* platform (and do not forget to select your ESP32 board from Tools > Board menu after installation).
+   Users in China must select the package version with the "-cn" suffix and perform updates manually.
+   Automatic updates are not supported in this region, as they target the default package without the "-cn" suffix, resulting in download failures.
 
 .. figure:: ../_static/install_guide_boards_manager_esp32.png
    :align: center


### PR DESCRIPTION
## Description of Change

This pull request makes updates to the `.github/scripts/on-release.sh` script to improve consistency in URL handling and correct an issue in the upload logic for Chinese-specific pages. These changes ensure proper substitution of URLs and accurate references during the upload process.

Keeping it as draft until assets like this are available:
https://dl.espressif.cn/github_assets/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu12/aarch64-linux-gnu.mklittlefs-c41e51a.200706.tar.gz

### URL handling improvements:

* Updated the `sed` command to simplify and generalize the substitution of `github.com` URLs with `dl.espressif.cn/github_assets` by removing the hardcoded `espressif` path segment. This change applies to both development and release package JSON files. ([.github/scripts/on-release.shL345-R350](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL345-R350))

### Upload logic corrections:

* Fixed the `git_safe_upload_to_pages` calls for Chinese-specific pages (`$PACKAGE_JSON_DEV_CN` and `$PACKAGE_JSON_REL_CN`) to use the correct file references, ensuring that the appropriate content is uploaded. ([.github/scripts/on-release.shL459-R466](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL459-R466))
