### PR TITLE
fix(esp32): Add missing vflip status in esp32-cam example

### DIFF
--- a/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
+++ b/libraries/ESP32/examples/Camera/CameraWebServer/app_httpd.cpp
@@ -478,6 +478,7 @@ static esp_err_t status_handler(httpd_req_t *req) {
   p += sprintf(p, "\"raw_gma\":%u,", s->status.raw_gma);
   p += sprintf(p, "\"lenc\":%u,", s->status.lenc);
   p += sprintf(p, "\"hmirror\":%u,", s->status.hmirror);
+  p += sprintf(p, "\"vflip\":%u,", s->status.vflip);
   p += sprintf(p, "\"dcw\":%u,", s->status.dcw);
   p += sprintf(p, "\"colorbar\":%u", s->status.colorbar);
 #if CONFIG_LED_ILLUMINATOR_ENABLED


### PR DESCRIPTION
Toggle switch for V-Flip will now indicate correct status in frontend when loading the webpage

-----------
## Description of Change
PR fixes a minor bug in the webpage for the CameraWebServer example, where the toggle switch is not updated with the current status from the ESP32.

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v3.2.0 with ESP32-S (ESP32-CAM) with this scenario

## Related links
