### PR TITLE
IDF master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hi
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThread)
   #if(CONFIG_SOC_IEEE802154_SUPPORTED) # Does not work!
   #if(CONFIG_OPENTHREAD_ENABLED) # Does not work!
-  if(IDF_TARGET STREQUAL "esp32c6" OR IDF_TARGET STREQUAL "esp32h2") # Sadly only this works
+  if(IDF_TARGET STREQUAL "esp32c6" OR IDF_TARGET STREQUAL "esp32h2" OR IDF_TARGET STREQUAL "esp32c5") # Sadly only this works
     list(APPEND requires openthread)
   endif()
 endif()

--- a/cores/esp32/chip-debug-report.cpp
+++ b/cores/esp32/chip-debug-report.cpp
@@ -69,7 +69,7 @@ static void printPkgVersion(void) {
   chip_report_printf("%lu", pkg_ver);
 #elif CONFIG_IDF_TARGET_ESP32C5
   // ToDo: Update this line when EFUSE_PKG_VERSION is available again for ESP32-C5
-  uint32_t pkg_ver = 0; //REG_GET_FIELD(EFUSE_RD_MAC_SYS2_REG, EFUSE_PKG_VERSION);
+  uint32_t pkg_ver = 0;  //REG_GET_FIELD(EFUSE_RD_MAC_SYS2_REG, EFUSE_PKG_VERSION);
   chip_report_printf("%lu", pkg_ver);
 #else
   chip_report_printf("Unknown");
@@ -93,11 +93,11 @@ static void printChipInfo(void) {
     case CHIP_ESP32H2: chip_report_printf("ESP32-H2\n"); break;
     case CHIP_ESP32P4: chip_report_printf("ESP32-P4\n"); break;
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
-    case CHIP_ESP32C5: chip_report_printf("ESP32-C5\n"); break;
+    case CHIP_ESP32C5:  chip_report_printf("ESP32-C5\n"); break;
     case CHIP_ESP32C61: chip_report_printf("ESP32-C61\n"); break;
     case CHIP_ESP32H21: chip_report_printf("ESP32-H21\n"); break;
 #endif
-    default:           chip_report_printf("Unknown %d\n", info.model); break;
+    default: chip_report_printf("Unknown %d\n", info.model); break;
   }
   printPkgVersion();
   chip_report_printf("  Revision          : %.2f\n", (float)(info.revision) / 100.0);

--- a/cores/esp32/chip-debug-report.cpp
+++ b/cores/esp32/chip-debug-report.cpp
@@ -68,7 +68,8 @@ static void printPkgVersion(void) {
   uint32_t pkg_ver = REG_GET_FIELD(EFUSE_RD_MAC_SYS_2_REG, EFUSE_PKG_VERSION);
   chip_report_printf("%lu", pkg_ver);
 #elif CONFIG_IDF_TARGET_ESP32C5
-  uint32_t pkg_ver = REG_GET_FIELD(EFUSE_RD_MAC_SYS2_REG, EFUSE_PKG_VERSION);
+  // ToDo: Update this line when EFUSE_PKG_VERSION is available again for ESP32-C5
+  uint32_t pkg_ver = 0; //REG_GET_FIELD(EFUSE_RD_MAC_SYS2_REG, EFUSE_PKG_VERSION);
   chip_report_printf("%lu", pkg_ver);
 #else
   chip_report_printf("Unknown");

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -105,7 +105,7 @@ dependencies:
     rules:
       - if: "target in [esp32s3]"
   espressif/esp_hosted:
-    version: "^0.0.25"
+    version: "^2.0.0"
     rules:
       - if: "target == esp32p4"
   espressif/esp_wifi_remote:

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -252,13 +252,23 @@ static bool wifiHostedInit() {
   if (!hosted_initialized) {
     hosted_initialized = true;
     struct esp_hosted_sdio_config conf = INIT_DEFAULT_HOST_SDIO_CONFIG();
+#ifdef BOARD_HAS_SDIO_ESP_HOSTED
+    conf.pin_clk.pin = BOARD_SDIO_ESP_HOSTED_CLK;
+    conf.pin_cmd.pin = BOARD_SDIO_ESP_HOSTED_CMD;
+    conf.pin_d0.pin = BOARD_SDIO_ESP_HOSTED_D0;
+    conf.pin_d1.pin = BOARD_SDIO_ESP_HOSTED_D1;
+    conf.pin_d2.pin = BOARD_SDIO_ESP_HOSTED_D2;
+    conf.pin_d3.pin = BOARD_SDIO_ESP_HOSTED_D3;
+    conf.pin_reset.pin = BOARD_SDIO_ESP_HOSTED_RESET;
+#else
     conf.pin_clk.pin = CONFIG_ESP_SDIO_PIN_CLK;
     conf.pin_cmd.pin = CONFIG_ESP_SDIO_PIN_CMD;
     conf.pin_d0.pin = CONFIG_ESP_SDIO_PIN_D0;
     conf.pin_d1.pin = CONFIG_ESP_SDIO_PIN_D1;
     conf.pin_d2.pin = CONFIG_ESP_SDIO_PIN_D2;
     conf.pin_d3.pin = CONFIG_ESP_SDIO_PIN_D3;
-    //conf.pin_rst.pin = CONFIG_ESP_SDIO_GPIO_RESET_SLAVE;
+    conf.pin_reset.pin = CONFIG_ESP_SDIO_GPIO_RESET_SLAVE;
+#endif
     // esp_hosted_sdio_set_config() will fail on second attempt but here temporarily to not cause exception on reinit
     if (esp_hosted_sdio_set_config(&conf) != ESP_OK || esp_hosted_init() != ESP_OK) {
       log_e("esp_hosted_init failed!");

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-38628f98-v1"
+              "version": "idf-master-aaebc374-v1"
             },
             {
               "packager": "esp32",
@@ -76,7 +76,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20250226"
+              "version": "v0.12.0-esp32-20250422"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-38628f98-v1",
+          "version": "idf-master-aaebc374-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-38628f98-v1.zip",
-              "checksum": "SHA-256:efc30a38cccff38c36a86fd3db78aeb13594da60ccf49bc7971b7a9f849abcdf",
-              "size": "398323971"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-master-aaebc374-v1.zip",
+              "checksum": "SHA-256:5baa0bbeae58973fd6bd4004332eb554b723a1e67f1af389840fac8081c2e21e",
+              "size": "404569749"
             }
           ]
         },
@@ -414,56 +414,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20250226",
+          "version": "v0.12.0-esp32-20250422",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:914c726342ba5828e53f41aa454f01f317c42d8e6772d3d874593a6960fc4729",
-              "size": "2414924"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-amd64-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:eb1fa9b21c65b45a2200af6dcc2914e32335d37b6dbbd181778dcc0dc025e70a",
+              "size": "2445546"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:c44ee99a9209c0234dbbcec86339fd685f5c61a763b29c33eba590bf62db2296",
-              "size": "2293923"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-arm64-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:f70334a9b12a75b4d943e09fa5db30973037c39dbb54d6fa9f1a7118228b3d1c",
+              "size": "2330926"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:21ab6af3cf05f9290f4d59f1f381d5094dd2755fc528d3d2feb9334348fc0d8d",
-              "size": "2436071"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-armel-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:4ac34d6fd1af86aeda87c8318732f8d691c300c285c7fd2f5037c432c63fbbb3",
+              "size": "2470732"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:0b5751699e93b6d101381611c96216ddff8c7dfd16425c610993fa27993f9a0a",
-              "size": "2525387"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-macos-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:9186a7a06304c6d9201cbce4ee3c7099b393bf8d329cda17a68874f92308f6ce",
+              "size": "2548730"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:8bffbbb594b27a4971a3922792135f8c836fff26991f7f450094386920263531",
-              "size": "2568843"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-macos-arm64-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:2cc39318d52f393233ff1f777871aebe5b97b3fbad29556a238489263401b774",
+              "size": "2593819"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win32-0.12.0-esp32-20250226.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250226.zip",
-              "checksum": "SHA-256:aaf3c955bb4eb47805a1ba108dfd07a8a56ce720cb40194a354362b5f0961230",
-              "size": "2960226"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-win32-0.12.0-esp32-20250422.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250422.zip",
+              "checksum": "SHA-256:ecb4f8533fa9098d10000f5f7e8b8eaa8591015b824b481078ddb2b37e7aa6f2",
+              "size": "2988859"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win64-0.12.0-esp32-20250226.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250226.zip",
-              "checksum": "SHA-256:79baf35325117a53093b62f6b9bee677dd12275d7066e3f8a274d2a80e986b6e",
-              "size": "2960225"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-win64-0.12.0-esp32-20250422.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250422.zip",
+              "checksum": "SHA-256:e9eae8e1a8d0e030cd81dcb08394a9137cb7338a6211dfabcdbdfb37b58c5a23",
+              "size": "2988858"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 69d504b
esp-idf: master aaebc37467
arduino: idf-master 05610aa2
tinyusb: master 542e5b455
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.6.2
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.1
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.0
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.19.2
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 2.0.1
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.5.5
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
```
