### PR TITLE
remove weak function declaration of tud_msc_is_writable_cb to fix simultaneous CDC and MSC

### DIFF
--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -466,9 +466,6 @@ __attribute__((weak)) int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint
 __attribute__((weak)) int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void *buffer, uint16_t bufsize) {
   return -1;
 }
-__attribute__((weak)) bool tud_msc_is_writable_cb(uint8_t lun) {
-  return false;
-}
 #endif
 #if CFG_TUD_NCM
 __attribute__((weak)) bool tud_network_recv_cb(const uint8_t *src, uint16_t size) {


### PR DESCRIPTION
## Description of Change
Solves issue #11245 through the [workaround suggested by nitz](https://github.com/espressif/arduino-esp32/issues/11245#issuecomment-2842952196).

## Tests scenarios
I have tested the proposed changes with a [senseBox MCU ESP32S2](https://github.com/espressif/arduino-esp32/tree/master/variants/sensebox_mcu_esp32s2) and another microcontroller with an ESP32S3 with the following script:
```cpp
void setup() {
  Serial.begin(115200);
}

void loop() {
  Serial.println("hello");
  delay(500);
}
```

## Related links
Closes #11245.