### PR TITLE
feat(ssl): Do not check if client is connected if already disconnected

### DIFF
--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
@@ -315,9 +315,10 @@ int NetworkClientSecure::available() {
 }
 
 uint8_t NetworkClientSecure::connected() {
-  uint8_t dummy = 0;
-  read(&dummy, 0);
-
+  if (_connected) {
+    uint8_t dummy = 0;
+    read(&dummy, 0);
+  }
   return _connected;
 }
 


### PR DESCRIPTION
This pull request makes a small fix to the `NetworkClientSecure::connected()` method in `NetworkClientSecure.cpp` to ensure the `_connected` flag is checked before attempting to read data.

* [`libraries/NetworkClientSecure/src/NetworkClientSecure.cpp`](diffhunk://#diff-bbbbbb0d6d927e0fde3606b5b7ed30e801815a588d73167f3994b5e4f28bf0e7R318-R321): Added a conditional check for `_connected` in the `connected()` method to prevent unnecessary or invalid read operations.

Fixes: https://github.com/espressif/arduino-esp32/issues/11325