### PR TITLE
IDF release/v5.4

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-fd37cd46-v1"
+              "version": "idf-release_v5.4-fe753553-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-fd37cd46-v1",
+          "version": "idf-release_v5.4-fe753553-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
-              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
-              "size": "353685651"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fe753553-v1.zip",
+              "checksum": "SHA-256:79abe0d17524dc64eccdab97bf4407127d8249e99c9b929357c10d24fe47a703",
+              "size": "353685379"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-8ad0d3d8-v1"
+              "version": "idf-release_v5.4-8ad0d3d8-v2"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-8ad0d3d8-v1",
+          "version": "idf-release_v5.4-8ad0d3d8-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v1.zip",
-              "checksum": "SHA-256:19b58817f57c5bcf06640b2e789144f44c298ad8c5c26ff95fd52e63a3be9cfb",
-              "size": "353625670"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
+              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
+              "size": "353623018"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-8ad0d3d8-v2"
+              "version": "idf-release_v5.4-fd37cd46-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-8ad0d3d8-v2",
+          "version": "idf-release_v5.4-fd37cd46-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-8ad0d3d8-v2.zip",
-              "checksum": "SHA-256:8ffa4de3df7dc6bf9c2c88b1ba54f02132020bd8275c3e4d41bf68c4fd23b351",
-              "size": "353623018"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-fd37cd46-v1.zip",
+              "checksum": "SHA-256:dcc6aff57c3fbc36667c07eeebf71a4823bb6c4f021d98bfe023509d797b662a",
+              "size": "353685651"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master ddfab9d
esp-idf: release/v5.4 8ad0d3d8f2
arduino: master 6f92b604
tinyusb: master 542e5b455
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.6.2
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.19.2
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.4.1
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
