### PR TITLE
Backport: changes to compile v3.1.x as component of IDF branch release/v5.3

### DIFF
--- a/.github/workflows/build_py_tools.yml
+++ b/.github/workflows/build_py_tools.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   find-changed-tools:
     name: Check if tools have been changed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       any_changed: ${{ steps.verify-changed-files.outputs.any_changed }}
       all_changed_files: ${{ steps.verify-changed-files.outputs.all_changed_files }}
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-20.04, ARM]
+        os: [windows-latest, macos-latest, ubuntu-latest, ARM]
         include:
           - os: windows-latest
             TARGET: win64
@@ -64,7 +64,7 @@ jobs:
           - os: macos-latest
             TARGET: macos
             SEPARATOR: ":"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             TARGET: linux-amd64
             SEPARATOR: ":"
           - os: ARM

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -237,7 +237,7 @@ jobs:
       needs.gen-chunks.outputs.build_all == 'true' ||
       needs.gen-chunks.outputs.build_libraries == 'true' ||
       needs.gen-chunks.outputs.build_idf == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/cores/esp32/esp32-hal-i2c-slave.c
+++ b/cores/esp32/esp32-hal-i2c-slave.c
@@ -338,11 +338,10 @@ esp_err_t i2cSlaveInit(uint8_t num, int sda, int scl, uint16_t slaveID, uint32_t
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 3)
   i2c_ll_set_mode(i2c->dev, I2C_BUS_MODE_SLAVE);
   i2c_ll_enable_pins_open_drain(i2c->dev, true);
-  i2c_ll_enable_fifo_mode(i2c->dev, true);
 #else
   i2c_ll_slave_init(i2c->dev);
-  i2c_ll_slave_set_fifo_mode(i2c->dev, true);
 #endif
+  i2c_ll_slave_set_fifo_mode(i2c->dev, true);
   i2c_ll_set_slave_addr(i2c->dev, slaveID, false);
   i2c_ll_set_tout(i2c->dev, I2C_LL_MAX_TIMEOUT);
   i2c_slave_set_frequency(i2c, frequency);
@@ -363,11 +362,7 @@ esp_err_t i2cSlaveInit(uint8_t num, int sda, int scl, uint16_t slaveID, uint32_t
 
   i2c_ll_disable_intr_mask(i2c->dev, I2C_LL_INTR_MASK);
   i2c_ll_clear_intr_mask(i2c->dev, I2C_LL_INTR_MASK);
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 3)
-  i2c_ll_enable_fifo_mode(i2c->dev, true);
-#else
   i2c_ll_slave_set_fifo_mode(i2c->dev, true);
-#endif
 
   if (!i2c->intr_handle) {
     uint32_t flags = ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_SHARED;

--- a/cores/esp32/esp32-hal-i2c-slave.c
+++ b/cores/esp32/esp32-hal-i2c-slave.c
@@ -335,8 +335,14 @@ esp_err_t i2cSlaveInit(uint8_t num, int sda, int scl, uint16_t slaveID, uint32_t
   }
 #endif  // !defined(CONFIG_IDF_TARGET_ESP32P4)
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 3)
+  i2c_ll_set_mode(i2c->dev, I2C_BUS_MODE_SLAVE);
+  i2c_ll_enable_pins_open_drain(i2c->dev, true);
+  i2c_ll_enable_fifo_mode(i2c->dev, true);
+#else
   i2c_ll_slave_init(i2c->dev);
   i2c_ll_slave_set_fifo_mode(i2c->dev, true);
+#endif
   i2c_ll_set_slave_addr(i2c->dev, slaveID, false);
   i2c_ll_set_tout(i2c->dev, I2C_LL_MAX_TIMEOUT);
   i2c_slave_set_frequency(i2c, frequency);
@@ -357,7 +363,11 @@ esp_err_t i2cSlaveInit(uint8_t num, int sda, int scl, uint16_t slaveID, uint32_t
 
   i2c_ll_disable_intr_mask(i2c->dev, I2C_LL_INTR_MASK);
   i2c_ll_clear_intr_mask(i2c->dev, I2C_LL_INTR_MASK);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 3)
+  i2c_ll_enable_fifo_mode(i2c->dev, true);
+#else
   i2c_ll_slave_set_fifo_mode(i2c->dev, true);
+#endif
 
   if (!i2c->intr_handle) {
     uint32_t flags = ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_SHARED;


### PR DESCRIPTION
the change allows to compile Arduino branch release/v3.1.x as an component of IDF 5.3. with actual branch release/v5.3.
The change is backwards compatible to the released version since there is IDF < 5.3.3 used