### PR TITLE
feat(board): add Satellite 1 CORE (rev 5.1)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -49849,3 +49849,157 @@ cyobot_v2_esp32s3.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 cyobot_v2_esp32s3.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
 
 ##############################################################
+
+# Satellite 1 CORE (rev 5.1) 
+
+sat1core_rev5_1.name=Satellite 1 CORE (rev 5.1) 
+
+sat1core_rev5_1.bootloader.tool=esptool_py
+sat1core_rev5_1.bootloader.tool.default=esptool_py
+
+sat1core_rev5_1.upload.tool=esptool_py
+sat1core_rev5_1.upload.tool.default=esptool_py
+sat1core_rev5_1.upload.tool.network=esp_ota
+
+sat1core_rev5_1.upload.maximum_size=1310720
+sat1core_rev5_1.upload.maximum_data_size=327680
+sat1core_rev5_1.upload.flags=
+sat1core_rev5_1.upload.extra_flags=
+sat1core_rev5_1.upload.use_1200bps_touch=false
+sat1core_rev5_1.upload.wait_for_upload_port=false
+
+sat1core_rev5_1.serial.disableDTR=false
+sat1core_rev5_1.serial.disableRTS=false
+
+sat1core_rev5_1.build.tarch=xtensa
+sat1core_rev5_1.build.bootloader_addr=0x0
+sat1core_rev5_1.build.target=esp32s3
+sat1core_rev5_1.build.mcu=esp32s3
+sat1core_rev5_1.build.core=esp32
+sat1core_rev5_1.build.variant=satellite1_core_rev5_1
+sat1core_rev5_1.build.board=SATELLITE1_CORE_REV5_1
+
+sat1core_rev5_1.build.usb_mode=1
+sat1core_rev5_1.build.cdc_on_boot=1
+sat1core_rev5_1.build.msc_on_boot=0
+sat1core_rev5_1.build.dfu_on_boot=0
+sat1core_rev5_1.build.f_cpu=240000000L
+sat1core_rev5_1.build.flash_size=16MB (128Mb)
+sat1core_rev5_1.build.flash_freq=80m
+sat1core_rev5_1.build.flash_mode=dio
+sat1core_rev5_1.build.boot=qio
+sat1core_rev5_1.build.boot_freq=80m
+sat1core_rev5_1.build.partitions=default
+sat1core_rev5_1.build.defines=-DBOARD_HAS_PSRAM
+sat1core_rev5_1.build.loop_core=
+sat1core_rev5_1.build.event_core=
+sat1core_rev5_1.build.psram_type=opi
+sat1core_rev5_1.build.memory_type={build.boot}_{build.psram_type}
+
+sat1core_rev5_1.menu.PSRAM.opi=Enabled
+sat1core_rev5_1.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+sat1core_rev5_1.menu.PSRAM.opi.build.psram_type=opi
+
+sat1core_rev5_1.menu.FlashMode.qio=QIO 80MHz
+sat1core_rev5_1.menu.FlashMode.qio.build.flash_mode=dio
+sat1core_rev5_1.menu.FlashMode.qio.build.boot=qio
+sat1core_rev5_1.menu.FlashMode.qio.build.boot_freq=80m
+sat1core_rev5_1.menu.FlashMode.qio.build.flash_freq=80m
+
+sat1core_rev5_1.menu.FlashSize.16M=16MB (128Mb)
+sat1core_rev5_1.menu.FlashSize.16M.build.flash_size=16MB
+
+sat1core_rev5_1.menu.LoopCore.1=Core 1
+sat1core_rev5_1.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+sat1core_rev5_1.menu.LoopCore.0=Core 0
+sat1core_rev5_1.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+sat1core_rev5_1.menu.EventsCore.1=Core 1
+sat1core_rev5_1.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+sat1core_rev5_1.menu.EventsCore.0=Core 0
+sat1core_rev5_1.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+sat1core_rev5_1.menu.USBMode.default=Hardware CDC and JTAG
+sat1core_rev5_1.menu.USBMode.default.build.usb_mode=1
+sat1core_rev5_1.menu.USBMode.hwcdc=USB-OTG (TinyUSB)
+sat1core_rev5_1.menu.USBMode.hwcdc.build.usb_mode=0
+
+sat1core_rev5_1.menu.CDCOnBoot.cdc=Enabled
+sat1core_rev5_1.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+sat1core_rev5_1.menu.CDCOnBoot.default=Disabled
+sat1core_rev5_1.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+sat1core_rev5_1.menu.MSCOnBoot.default=Disabled
+sat1core_rev5_1.menu.MSCOnBoot.default.build.msc_on_boot=0
+sat1core_rev5_1.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+sat1core_rev5_1.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+sat1core_rev5_1.menu.DFUOnBoot.default=Disabled
+sat1core_rev5_1.menu.DFUOnBoot.default.build.dfu_on_boot=0
+sat1core_rev5_1.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+sat1core_rev5_1.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+sat1core_rev5_1.menu.UploadMode.default=UART0 / Hardware CDC
+sat1core_rev5_1.menu.UploadMode.default.upload.use_1200bps_touch=false
+sat1core_rev5_1.menu.UploadMode.default.upload.wait_for_upload_port=false
+sat1core_rev5_1.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+sat1core_rev5_1.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+sat1core_rev5_1.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme1=Small App w/ OTA + Huge FS (2MB APP/2MB OTA/12MB SPIFFS)
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme1.build.custom_partitions=gen4esp32_2MBapp_2MBota_12MBspiffs
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme1.upload.maximum_size=2097152
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme2=Medium App w/ OTA + Large FS (4MB APP/4MB OTA/7MB SPIFFS)
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme2.build.custom_partitions=gen4esp32_4MBapp_4MBota_7MBspiffs
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme2.upload.maximum_size=4718592
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme3=Large App w/ OTA (8MB APP/8MB OTA)
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme3.build.custom_partitions=gen4esp32_8MBapp_8MBota
+sat1core_rev5_1.menu.PartitionScheme.gen4esp32scheme3.upload.maximum_size=8323072
+
+sat1core_rev5_1.menu.CPUFreq.240=240MHz (WiFi)
+sat1core_rev5_1.menu.CPUFreq.240.build.f_cpu=240000000L
+sat1core_rev5_1.menu.CPUFreq.160=160MHz (WiFi)
+sat1core_rev5_1.menu.CPUFreq.160.build.f_cpu=160000000L
+sat1core_rev5_1.menu.CPUFreq.80=80MHz (WiFi)
+sat1core_rev5_1.menu.CPUFreq.80.build.f_cpu=80000000L
+sat1core_rev5_1.menu.CPUFreq.40=40MHz
+sat1core_rev5_1.menu.CPUFreq.40.build.f_cpu=40000000L
+sat1core_rev5_1.menu.CPUFreq.20=20MHz
+sat1core_rev5_1.menu.CPUFreq.20.build.f_cpu=20000000L
+sat1core_rev5_1.menu.CPUFreq.10=10MHz
+sat1core_rev5_1.menu.CPUFreq.10.build.f_cpu=10000000L
+
+sat1core_rev5_1.menu.UploadSpeed.921600=921600
+sat1core_rev5_1.menu.UploadSpeed.921600.upload.speed=921600
+sat1core_rev5_1.menu.UploadSpeed.115200=115200
+sat1core_rev5_1.menu.UploadSpeed.115200.upload.speed=115200
+sat1core_rev5_1.menu.UploadSpeed.256000.windows=256000
+sat1core_rev5_1.menu.UploadSpeed.256000.upload.speed=256000
+sat1core_rev5_1.menu.UploadSpeed.230400.windows.upload.speed=256000
+sat1core_rev5_1.menu.UploadSpeed.230400=230400
+sat1core_rev5_1.menu.UploadSpeed.230400.upload.speed=230400
+sat1core_rev5_1.menu.UploadSpeed.460800.linux=460800
+sat1core_rev5_1.menu.UploadSpeed.460800.macosx=460800
+sat1core_rev5_1.menu.UploadSpeed.460800.upload.speed=460800
+sat1core_rev5_1.menu.UploadSpeed.512000.windows=512000
+sat1core_rev5_1.menu.UploadSpeed.512000.upload.speed=512000
+
+sat1core_rev5_1.menu.DebugLevel.none=None
+sat1core_rev5_1.menu.DebugLevel.none.build.code_debug=0
+sat1core_rev5_1.menu.DebugLevel.error=Error
+sat1core_rev5_1.menu.DebugLevel.error.build.code_debug=1
+sat1core_rev5_1.menu.DebugLevel.warn=Warn
+sat1core_rev5_1.menu.DebugLevel.warn.build.code_debug=2
+sat1core_rev5_1.menu.DebugLevel.info=Info
+sat1core_rev5_1.menu.DebugLevel.info.build.code_debug=3
+sat1core_rev5_1.menu.DebugLevel.debug=Debug
+sat1core_rev5_1.menu.DebugLevel.debug.build.code_debug=4
+sat1core_rev5_1.menu.DebugLevel.verbose=Verbose
+sat1core_rev5_1.menu.DebugLevel.verbose.build.code_debug=5
+
+sat1core_rev5_1.menu.EraseFlash.none=Disabled
+sat1core_rev5_1.menu.EraseFlash.none.upload.erase_cmd=
+sat1core_rev5_1.menu.EraseFlash.all=Enabled
+sat1core_rev5_1.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################

--- a/variants/satellite1_core_rev5_1/pins_arduino.h
+++ b/variants/satellite1_core_rev5_1/pins_arduino.h
@@ -1,0 +1,60 @@
+/*  Satellite 1 CORE ‒ rev 5.1  (R2025-03-18)
+ *  ESP32-S3-WROOM-1-N16R8  · 16 MB Octal-SPI flash + 8 MB Octal-SPI PSRAM
+ *  40-pin header is a one-for-one Raspberry-Pi-Zero footprint (BCM numbering).
+ */
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+/* ───────── USB descriptors (used only when USB-Mode = TinyUSB) ───────── */
+#define USB_VID          0x303A                 // Espressif Systems
+#define USB_PID          0x80F2                 // provisional, unused PID
+#define USB_MANUFACTURER "FutureProofHomes"
+#define USB_PRODUCT      "Satellite1 CORE rev5.1"
+
+/* ───────── Pi-header aliases (primary UART / I²C / I²S) ─────────────── */
+static const uint8_t TX  = 17;   // BCM14  (header pin 8)
+static const uint8_t RX  = 16;   // BCM15  (header pin 10)
+
+static const uint8_t SDA = 38;   // BCM2   (pin 3)
+static const uint8_t SCL = 39;   // BCM3   (pin 5)
+
+/* Wire0 definition expected by core */
+#define PIN_WIRE_SDA SDA
+#define PIN_WIRE_SCL SCL
+#define SDA2 SDA     // back-compat
+#define SCL2 SCL
+
+/* I²S */
+static const uint8_t I2S_BCLK  = 36;   // BCM18 (pin 12)
+static const uint8_t I2S_LRCLK = 37;   // BCM19 (pin 35)
+static const uint8_t I2S_DIN   = 35;   // BCM20 (pin 38) ← ADC
+static const uint8_t I2S_DOUT  = 34;   // BCM21 (pin 40) → DAC
+
+/* Optional default SPI (remappable via GPIO-matrix) */
+static const uint8_t SS   = 5;   // BCM8  (CE0)
+static const uint8_t MOSI = 23;  // BCM10
+static const uint8_t MISO = 22;  // BCM9
+static const uint8_t SCK  = 18;  // BCM11
+
+/* ───────── On-board user interface ───────── */
+#define LED_BUILTIN      45         // red status LED (active-HIGH)
+#define BUILTIN_LED      LED_BUILTIN
+
+#define BUTTON_BUILTIN   0          // SW2, active-LOW
+
+/* ───────── PSRAM / flash configuration ───────── */
+#define BOARD_HAS_PSRAM   1
+#define DEFAULT_PSRAM_OCT 1         // 8-bit OPI @ 120 MHz
+
+/* ───────── ADC & touch aliases ───────── */
+static const uint8_t A0 = 1;   static const uint8_t T4  = 4;
+static const uint8_t A1 = 2;   static const uint8_t T5  = 5;
+static const uint8_t A2 = 3;   static const uint8_t T6  = 6;
+static const uint8_t A3 = 4;   static const uint8_t T7  = 7;
+static const uint8_t A4 = 6;   static const uint8_t T8  = 8;
+static const uint8_t A5 = 7;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Add the [Satellite 1 CORE (rev 5.1)](https://futureproofhomes.net/products/satellite1-core-board) from FutureProofHomes.

## Tests scenarios
I have tested my Pull Request on the board itself using:

```cpp
#include <Arduino.h>

void setup() {
  Serial.begin(115200);
  while (!Serial && millis() < 3000) ;   // wait for the host (max 3 s)

  pinMode(LED_BUILTIN, OUTPUT);

  if (!psramFound()) {
    Serial.println("PSRAM not detected!");
    return;
  }

  uint32_t bytes = ESP.getPsramSize();   // 0, 2 048 000, 4 194 304, 8 388 608
  Serial.printf("PSRAM size : %u bytes\n", bytes);
  Serial.printf("PSRAM mode : %s (inferred)\n",
                bytes >= 8 * 1024 * 1024 ? "Octal" : "Quad");
}

void loop() {
  digitalWrite(LED_BUILTIN, HIGH);
  delay(500);
  digitalWrite(LED_BUILTIN, LOW);
  delay(500);
}
```

## Links
The relevant spec: https://github.com/FutureProofHomes/Satellite1-Hardware/blob/main/core/rev5.1coreSCH.pdf