### PR TITLE
feat(core): Add wait time before setup

### DIFF
--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -44,10 +44,15 @@ __attribute__((weak)) bool shouldPrintChipDebugReport(void) {
   return false;
 }
 
+__attribute__((weak)) uint64_t getArduinoSetupWaitTick(void) {
+  return 0;
+}
+
 void loopTask(void *pvParameters) {
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
   // sets UART0 (default console) RX/TX pins as already configured in boot or as defined in variants/pins_arduino.h
   Serial0.setPins(gpioNumberToDigitalPin(SOC_RX0), gpioNumberToDigitalPin(SOC_TX0));
+  vTaskDelay(getArduinoSetupWaitTick());
 #endif
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
   printBeforeSetupInfo();


### PR DESCRIPTION
## Description of Change
Added initialization time for UART, etc.
Default value is 0.

## Tests scenarios
Arduino-esp32 core v3.2.0 with M5STACK_STICKC_PLUS2 Board

### now or default
```c
void setup() {
}

void loop() {
}
```

#### output
```
------------------------------
  Total Size        :   378124 B ( 369.3 KB)
  Free Bytes        :   336868 B ( 329.0 KB)
  Allocated Bytes   :    33972 B (  33.2 KB)
  Minimum Free Bytes:   330908 B ( 323.2 KB)
  Largest Free Block:   110580 B ( 108.0 KB)
------------------------------------------
SPIRAM Memory Info:
------------------------------------------
  Total Size        :  2097152 B (2048.0 KB)
  Free Bytes        :  2095104 B (2046.0 KB)
  Allocated Bytes   :        0 B (   0.0 KB)
  Minimum Free Bytes:  2095104 B (2046.0 KB)
  Largest Free Block:  2064372 B (2016.0 KB)
------------------------------------------
GPIO Info:
------------------------------------------
  GPIO : BUS_TYPE[bus/unit][chan]
  --------------------------------------  
     1 : UART_TX[0]
     3 : UART_RX[0]
============ After Setup End =============
```
Output is cut off because UART is not yet initialized.

### set wait
```c
uint64_t getArduinoSetupWaitTick(void) {
  return 1000;
}

void setup() {
}

void loop() {
}
```

#### output
```
=========== Before Setup Start ===========
Chip Info:
------------------------------------------
  Model             : ESP32
  Package           : PICO-V3-02
  Revision          : 3.00
  Cores             : 2
  CPU Frequency     : 240 MHz
  XTAL Frequency    : 40 MHz
  Features Bitfield : 0x000000b3
  Embedded Flash    : Yes
  Embedded PSRAM    : Yes
  2.4GHz WiFi       : Yes
  Classic BT        : Yes
  BT Low Energy     : Yes
  IEEE 802.15.4     : No
------------------------------------------
INTERNAL Memory Info:
------------------------------------------
  Total Size        :   378124 B ( 369.3 KB)
  Free Bytes        :   336956 B ( 329.1 KB)
  Allocated Bytes   :    33916 B (  33.1 KB)
  Minimum Free Bytes:   331256 B ( 323.5 KB)
  Largest Free Block:   110580 B ( 108.0 KB)
------------------------------------------
SPIRAM Memory Info:
------------------------------------------
  Total Size        :  2097152 B (2048.0 KB)
  Free Bytes        :  2095104 B (2046.0 KB)
  Allocated Bytes   :        0 B (   0.0 KB)
  Minimum Free Bytes:  2095104 B (2046.0 KB)
  Largest Free Block:  2064372 B (2016.0 KB)
  Bus Mode          : QSPI
------------------------------------------
Flash Info:
------------------------------------------
  Chip Size         :  8388608 B (8 MB)
  Block Size        :    65536 B (  64.0 KB)
  Sector Size       :     4096 B (   4.0 KB)
  Page Size         :      256 B (   0.2 KB)
  Bus Speed         : 80 MHz
  Bus Mode          : QIO
------------------------------------------
Partitions Info:
------------------------------------------
                nvs : addr: 0x00009000, size:    20.0 KB, type: DATA, subtype: NVS
            otadata : addr: 0x0000E000, size:     8.0 KB, type: DATA, subtype: OTA
               app0 : addr: 0x00010000, size:  3264.0 KB, type:  APP, subtype: OTA_0
               app1 : addr: 0x00340000, size:  3264.0 KB, type:  APP, subtype: OTA_1
             spiffs : addr: 0x00670000, size:  1536.0 KB, type: DATA, subtype: SPIFFS
           coredump : addr: 0x007F0000, size:    64.0 KB, type: DATA, subtype: COREDUMP
------------------------------------------
Software Info:
------------------------------------------
  Compile Date/Time : May 15 2025 12:17:22
  Compile Host OS   : windows
  ESP-IDF Version   : v5.4.1-1-g2f7dcd862a-dirty
  Arduino Version   : 3.2.0
------------------------------------------
Board Info:
------------------------------------------
  Arduino Board     : M5STACK_STICKC_PLUS2
  Arduino Variant   : m5stack_stickc_plus2
  Arduino FQBN      : esp32:esp32:m5stack_stickc_plus2:UploadSpeed=1500000,CPUFreq=240,FlashFreq=80,FlashMode=qio,FlashSize=8M,PartitionScheme=default_8MB,DebugLevel=verbose,PSRAM=enabled,LoopCore=1,EventsCore=1,EraseFlash=none
============ Before Setup End ============
=========== After Setup Start ============
INTERNAL Memory Info:
------------------------------------------
  Total Size        :   378124 B ( 369.3 KB)
  Free Bytes        :   336868 B ( 329.0 KB)
  Allocated Bytes   :    33972 B (  33.2 KB)
  Minimum Free Bytes:   330908 B ( 323.2 KB)
  Largest Free Block:   110580 B ( 108.0 KB)
------------------------------------------
SPIRAM Memory Info:
------------------------------------------
  Total Size        :  2097152 B (2048.0 KB)
  Free Bytes        :  2095104 B (2046.0 KB)
  Allocated Bytes   :        0 B (   0.0 KB)
  Minimum Free Bytes:  2095104 B (2046.0 KB)
  Largest Free Block:  2064372 B (2016.0 KB)
------------------------------------------
GPIO Info:
------------------------------------------
  GPIO : BUS_TYPE[bus/unit][chan]
  --------------------------------------  
     1 : UART_TX[0]
     3 : UART_RX[0]
============ After Setup End =============
```

All output.