### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-master-7cf5dacd-v2"
+              "version": "idf-release_v5.5-719b1b2b-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-master-7cf5dacd-v2",
+          "version": "idf-release_v5.5-719b1b2b-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-master/esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-master-7cf5dacd-v2.zip",
-              "checksum": "SHA-256:91f74810c5bee0fa4463f7df73f1f6b5e4a08a6c2094014b9a4c0fac61eb43de",
-              "size": "405095217"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-719b1b2b-v1.zip",
+              "checksum": "SHA-256:9fa690303a09dd0e082a0223a4f11ae6c95b80c458e583422fdd01626984e815",
+              "size": "404843846"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 8db32ca
esp-idf: release/v5.5 719b1b2be0
arduino: release/v3.3.x 5540afa1e
tinyusb: master 5428b8794
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.6.2
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.19.2
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_matter: 1.4.1
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 2.0.2
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.9.2
```
