### PR TITLE
feat(variant): add kode dot ESP32-S3 board with QSPI LCD, SD and GPIO …

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2794,6 +2794,68 @@ esp32wroverkit.menu.EraseFlash.none.upload.erase_cmd=
 esp32wroverkit.menu.EraseFlash.all=Enabled
 esp32wroverkit.menu.EraseFlash.all.upload.erase_cmd=-e
 
+###########################################################
+
+kodedot.name=kode dot
+
+kodedot.bootloader.tool=esptool_py
+kodedot.bootloader.tool.default=esptool_py
+
+kodedot.upload.tool=esptool_py_nomerge
+kodedot.upload.tool.default=esptool_py_nomerge
+kodedot.upload.tool.network=esp_ota
+
+kodedot.upload.maximum_size=8388608
+kodedot.upload.maximum_data_size=327680
+kodedot.upload.flags=
+kodedot.upload.extra_flags=
+kodedot.upload.use_1200bps_touch=false
+kodedot.upload.wait_for_upload_port=false
+kodedot.upload.speed=921600
+
+kodedot.upload.erase_cmd=
+
+kodedot.serial.disableDTR=false
+kodedot.serial.disableRTS=false
+
+kodedot.build.tarch=xtensa
+kodedot.build.bootloader_addr=0x0
+kodedot.build.target=esp32s3
+kodedot.build.mcu=esp32s3
+kodedot.build.core=esp32
+kodedot.build.variant=kodedot
+kodedot.build.board=ESP32S3_DEV
+
+kodedot.build.usb_mode=1   
+kodedot.build.cdc_on_boot=1   
+kodedot.build.msc_on_boot=0
+kodedot.build.dfu_on_boot=0
+
+kodedot.build.f_cpu=240000000L
+
+kodedot.build.flash_offset=0x400000
+kodedot.build.flash_size=16MB
+kodedot.build.flash_freq=80m
+kodedot.build.flash_mode=dio
+
+# Menú de particiones Custom kodeOS
+kodedot.menu.PartitionScheme.kodeos=Custom kodeOS
+kodedot.menu.PartitionScheme.kodeos.build.partitions=kodedot_partitions
+
+# Particiones por defecto
+kodedot.build.partitions=kodedot_partitions
+
+kodedot.build.psram_type=qspi
+kodedot.build.defines=
+
+kodedot.build.loop_core=-DARDUINO_RUNNING_CORE=1
+kodedot.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+
+kodedot.recipe.hooks.objcopy.postobjcopy.3.pattern=
+kodedot.recipe.hooks.objcopy.postobjcopy.3.pattern_args=
+
+kodedot.recipe.output.save_file={build.project_name}.ino.bin
+
 ##############################################################
 
 aventen_s3_sync.name=Aventen S3 Sync

--- a/platform.txt
+++ b/platform.txt
@@ -330,3 +330,17 @@ tools.dfu-util.cmd=dfu-util
 tools.dfu-util.upload.params.verbose=-d
 tools.dfu-util.upload.params.quiet=
 tools.dfu-util.upload.pattern="{path}/{cmd}" --device {vid.0}:{pid.0} -D "{build.path}/{build.project_name}.bin" -Q
+
+## --------------------------------------------------------------------------
+## Custom tool for Kode Dot: esptool_py_nomerge
+## --------------------------------------------------------------------------
+tools.esptool_py_nomerge.path={runtime.tools.esptool_py.path}
+tools.esptool_py_nomerge.cmd=esptool
+tools.esptool_py_nomerge.cmd.windows=esptool.exe
+
+tools.esptool_py_nomerge.upload.protocol=serial
+tools.esptool_py_nomerge.upload.params.verbose=
+tools.esptool_py_nomerge.upload.params.quiet=
+
+tools.esptool_py_nomerge.upload.pattern_args=--chip {build.mcu} --port "{serial.port}" --baud {upload.speed} {upload.flags} --before default_reset --after hard_reset write_flash --flash_mode {build.flash_mode} --flash_freq {build.flash_freq} --flash_size {build.flash_size} {build.flash_offset} "{build.path}/{build.project_name}.bin" {upload.extra_flags}
+tools.esptool_py_nomerge.upload.pattern="{path}/{cmd}" {tools.esptool_py_nomerge.upload.pattern_args}

--- a/tools/partitions/kodedot_partitions.csv
+++ b/tools/partitions/kodedot_partitions.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     0xf000,  0x1000,
+otadata,  data, ota,     0x10000, 0x2000,
+ota_0,  app,  ota_0, 0x20000, 0x3E0000,
+ota_1,  app,  ota_1,   0x400000, 0x800000,
+storage,  data, spiffs,  0xC00000, 0x400000,

--- a/variants/kodedot/custom_ota_override.cpp
+++ b/variants/kodedot/custom_ota_override.cpp
@@ -1,0 +1,14 @@
+// custom_ota_override.cpp
+// This function overrides the weak definition of `verifyRollbackLater()` in the kode dot board.
+
+extern "C" {
+    // Declare the weak function symbol to override it
+    bool verifyRollbackLater() __attribute__((weak));
+}
+
+// Custom implementation of verifyRollbackLater()
+// Returning `true` prevents the OTA image from being automatically marked as valid.
+// This ensures that the system will roll back to the previous image unless it is explicitly validated later.
+bool verifyRollbackLater() {
+    return true;
+}

--- a/variants/kodedot/pins_arduino.h
+++ b/variants/kodedot/pins_arduino.h
@@ -1,0 +1,107 @@
+/*
+  ────────────────────────────────────────────────────────────────────────
+  KodeDot – ESP32-S3R8  Variant
+  Pin definition file for the Arduino-ESP32 core
+  ────────────────────────────────────────────────────────────────────────
+  * External 2 × 10 connector → simple aliases  PIN1 … PIN20
+  * On-board QSPI LCD 410×502 @40 MHz  (SPI3_HOST)
+  * micro-SD on SPI2_HOST
+  * Dual-I²C:  external (GPIO37/36)  +  internal-sensors (GPIO48/47)
+  * USB VID/PID 0x303A:0x1001
+*/
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*──────────────── USB device descriptor ────────────────*/
+#define USB_VID 0x303A         // Espressif Systems VID
+#define USB_PID 0x1001         // Product ID: KodeDot-S3
+
+/*──────────────── UART0 (Arduino Serial) ────────────────*/
+static const uint8_t TX = 43;  // U0TXD – PIN16 on the 2×10 header
+static const uint8_t RX = 44;  // U0RXD – PIN18 on the 2×10 header
+
+/*──────────────── I²C buses ─────────────────────────────*/
+/* External expansion bus → header pins 11/13 */
+static const uint8_t SCL = 37; // GPIO37 – PIN12
+static const uint8_t SDA = 36; // GPIO36 – PIN14
+
+/* Internal sensor/touch bus (not on header) */
+#define INT_I2C_SCL 47         // GPIO47
+#define INT_I2C_SDA 48         // GPIO48
+
+/*──────────────── SPI2 – micro-SD ───────────────────────*/
+static const uint8_t SS   = 15; // SD_CS
+static const uint8_t MOSI = 16; // SD_MOSI
+static const uint8_t MISO = 18; // SD_MISO
+static const uint8_t SCK  = 17; // SD_CLK
+#define BOARD_HAS_SD_SPI
+#define SD_CS SS
+
+/*──────────────── QSPI LCD (SPI3_HOST) ─────────────────–
+ * Controller: ST7789 / 4-line SPI (no D/C pin)
+ * Resolution: 410×502 px, 16 bpp, RGB color-space
+ * Clock:      40 MHz
+ */
+#define BOARD_HAS_SPI_LCD
+#define LCD_MODEL             ST7789
+#define LCD_WIDTH             410
+#define LCD_HEIGHT            502
+
+#define LCD_HOST              SPI3_HOST
+#define LCD_SCK               35  // GPIO35  • QSPI_CLK
+#define LCD_MOSI              33  // GPIO33  • QSPI_IO0 (D0)
+#define LCD_IO1               34  // GPIO34  • QSPI_IO1 (D1)
+#define LCD_IO2               37  // GPIO37  • QSPI_IO2 (D2)
+#define LCD_IO3               36  // GPIO36  • QSPI_IO3 (D3)
+#define LCD_CS                10  // GPIO10
+#define LCD_RST                9  // GPIO09
+#define LCD_DC               -1   // not used in 4-line SPI
+/* Optional: back-light enable shares the NeoPixel pin */
+#define LCD_BL                 5  // GPIO05 (same as NEOPIXEL)
+
+/*──────────────── Analogue / Touch pads ────────────────*/
+static const uint8_t A0 = 11;  // PIN4  – GPIO11 / TOUCH11 / ADC2_CH0
+static const uint8_t A1 = 12;  // PIN6  – GPIO12 / TOUCH12 / ADC2_CH1
+static const uint8_t A2 = 13;  // PIN8  – GPIO13 / TOUCH13 / ADC2_CH2
+static const uint8_t A3 = 14;  // PIN10 – GPIO14 / TOUCH14 / ADC2_CH3
+static const uint8_t T0 = A0, T1 = A1, T2 = A2, T3 = A3;
+
+/*──────────────── On-board controls & indicator ─────────*/
+#define BUTTON_TOP        0      // GPIO00 – BOOT    • active-LOW
+#define BUTTON_BOTTOM     6      // GPIO06           • active-LOW
+#define NEOPIXEL_PIN      5      // GPIO05 – WS2812
+#define LED_BUILTIN       NEOPIXEL_PIN
+
+/*──────────────── JTAG (also on connector) ──────────────*/
+#define MTCK 39   // PIN11 – GPIO39
+#define MTDO 40   // PIN13 – GPIO40
+#define MTDI 41   // PIN15 – GPIO41
+#define MTMS 42   // PIN17 – GPIO42
+
+/*──────────────── 2×10 header: simple aliases ───────────
+   NOTE: power pins (1 = 5 V, 2 = 3 V3, 19/20 = GND) are **not**
+         exposed as GPIO numbers – they remain undefined here. */
+#define PIN3   1   // GPIO01 / TOUCH1 / ADC1_CH0
+#define PIN4  11   // GPIO11 / TOUCH11 / ADC2_CH0
+#define PIN5   2   // GPIO02 / TOUCH2 / ADC1_CH1
+#define PIN6  12   // GPIO12 / TOUCH12 / ADC2_CH1
+#define PIN7   3   // GPIO03 / TOUCH3 / ADC1_CH2
+#define PIN8  13   // GPIO13 / TOUCH13 / ADC2_CH2
+#define PIN9   4   // GPIO04 / TOUCH4 / ADC1_CH3
+#define PIN10 14   // GPIO14 / TOUCH14 / ADC2_CH3
+#define PIN11 39   // MTCK
+#define PIN12 37   // SCL  (external I²C)
+#define PIN13 40   // MTDO
+#define PIN14 36   // SDA  (external I²C)
+#define PIN15 41   // MTDI
+#define PIN16 43   // TX  (U0TXD)
+#define PIN17 42   // MTMS
+#define PIN18 44   // RX  (U0RXD)
+/* PIN1, PIN2, PIN19, PIN20 are power/ground and deliberately
+   left undefined – they are **not** usable as GPIO. */
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Add kode dot esp32-s3 board variant

## Description of Change

This PR adds full support for the **kode dot** esp32-s3 board variant to the Arduino-ESP32 core:

- **New variant directory** `variants/kodedot/` containing:  
  - `pins_arduino.h` with pin mappings for the 2×10 header, QSPI-LCD, SD, I²C buses, buttons, NeoPixel, JTAG, USB power pins, etc.  
  - `kodedot_partitions.csv` defining the custom flash layout (OTA, SPIFFS, app slots).  
  - **`custom_ota_override.cpp`** to override the weak `verifyRollbackLater()` hook, forcing OTA images to remain un-validated until explicitly approved, thus protecting against faulty updates.
- **Platform configuration** in `platform.txt`:  
  - **Custom upload tool** `esptool_py_nomerge` that writes firmware at the partition offset defined in `kodedot_partitions.csv` without manual flags.
- **Documentation** updated in:  
  - `boards.txt` (board entry for KodeDot)  
  - `platform.txt` (custom tool declaration)  

With these additions, users can select **kode dot**, compile and upload their sketch (or OTA) directly into the correct partition, and rely on the `custom_ota_override.cpp` behavior to guard against bad firmware rolls.

## Test scenarios

I have tested and debugged this PR on real **kode dot** hardware using:  
- **Arduino-ESP32 core v3.2.0**  
- **macOS 14.5** with **Arduino IDE 2.3.2** (custom tool)  
- **Examples run**:  
  - Blink / NeoPixel (`LED_BUILTIN`)  
  - I²C scan (external header & internal sensor bus)  
  - SPI to micro-SD (SPI2_HOST)  
  - QSPI-LCD fill screen @40 MHz (SPI3_HOST)  
  - **Firmware upload** lands at correct offset via `esptool_py_nomerge`  
  - USB-Serial enumeration (VID/PID 0x303A:0x1001)  
  - Button presses & JTAG debug  
  - OTA update behavior: new images remain un-validated until manual confirmation, and rollback works as intended.

All tests passed, including OTA rollback verification.

## Related links

- **Website:** https://kode.diy/es  
- **GitHub org:** https://github.com/kodediy  
- **Issue:** N/A  
- **Documentation updated:** `boards.txt`, `platform.txt`