### PR TITLE
fix(ESP_SR): crash on watchdog timeout in iddle task

### DIFF
--- a/libraries/ESP_SR/src/esp32-hal-sr.c
+++ b/libraries/ESP_SR/src/esp32-hal-sr.c
@@ -192,6 +192,7 @@ static void audio_feed_task(void *arg) {
 
     /* Feed samples of an audio stream to the AFE_SR */
     g_sr_data->afe_handle->feed(g_sr_data->afe_data, audio_buffer);
+    vTaskDelay(2);
   }
   vTaskDelete(NULL);
 }


### PR DESCRIPTION
## Description of Change
Fixing the crash that occurs after the wake-up word is recognized:
```
17:28:01.740 -> ESP-ROM:esp32s3-20210327
17:28:01.740 -> Build:Mar 27 2021
17:28:01.740 -> rst:0xc (RTC_SW_CPU_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)
17:28:01.740 -> Saved PC:0x4037706d
17:28:01.740 -> SPIWP:0xee
17:28:01.740 -> mode:DIO, clock div:1
17:28:01.740 -> load:0x3fce2820,len:0x118c
17:28:01.740 -> load:0x403c8700,len:0x4
17:28:01.740 -> load:0x403c8704,len:0xc20
17:28:01.740 -> load:0x403cb700,len:0x30e0
17:28:01.786 -> entry 0x403c88b8
17:28:02.768 -> [    16][I][esp32-hal-psram.c:102] psramAddToHeap(): PSRAM added to the heap.
17:28:02.815 -> =========== Before Setup Start ===========
17:28:02.815 -> Chip Info:
17:28:02.815 -> ------------------------------------------
17:28:02.815 ->   Model             : ESP32-S3
17:28:02.815 ->   Package           : 0
17:28:02.815 ->   Revision          : 0.01
17:28:02.815 ->   Cores             : 2
17:28:02.815 ->   CPU Frequency     : 240 MHz
17:28:02.815 ->   XTAL Frequency    : 40 MHz
17:28:02.815 ->   Features Bitfield : 0x00000012
17:28:02.815 ->   Embedded Flash    : No
17:28:02.815 ->   Embedded PSRAM    : No
17:28:02.815 ->   2.4GHz WiFi       : Yes
17:28:02.861 ->   Classic BT        : No
17:28:02.861 ->   BT Low Energy     : Yes
17:28:02.861 ->   IEEE 802.15.4     : No
17:28:02.861 -> ------------------------------------------
17:28:02.861 -> INTERNAL Memory Info:
17:28:02.861 -> ------------------------------------------
17:28:02.861 ->   Total Size        :   374656 B ( 365.9 KB)
17:28:02.861 ->   Free Bytes        :   337816 B ( 329.9 KB)
17:28:02.861 ->   Allocated Bytes   :    31808 B (  31.1 KB)
17:28:02.861 ->   Minimum Free Bytes:   332968 B ( 325.2 KB)
17:28:02.861 ->   Largest Free Block:   270324 B ( 264.0 KB)
17:28:02.861 -> ------------------------------------------
17:28:02.861 -> SPIRAM Memory Info:
17:28:02.861 -> ------------------------------------------
17:28:02.908 ->   Total Size        :  8388608 B (8192.0 KB)
17:28:02.908 ->   Free Bytes        :  8386296 B (8189.7 KB)
17:28:02.908 ->   Allocated Bytes   :        0 B (   0.0 KB)
17:28:02.908 ->   Minimum Free Bytes:  8386296 B (8189.7 KB)
17:28:02.908 ->   Largest Free Block:  8257524 B (8064.0 KB)
17:28:02.908 ->   Bus Mode          : QSPI
17:28:02.908 -> ------------------------------------------
17:28:02.908 -> Flash Info:
17:28:02.908 -> ------------------------------------------
17:28:02.908 ->   Chip Size         :  8388608 B (8 MB)
17:28:02.908 ->   Block Size        :    65536 B (  64.0 KB)
17:28:02.908 ->   Sector Size       :     4096 B (   4.0 KB)
17:28:02.908 ->   Page Size         :      256 B (   0.2 KB)
17:28:02.956 ->   Bus Speed         : 80 MHz
17:28:02.956 ->   Bus Mode          : QIO
17:28:02.956 -> ------------------------------------------
17:28:02.956 -> Partitions Info:
17:28:02.956 -> ------------------------------------------
17:28:02.956 ->                 nvs : addr: 0x00009000, size:    20.0 KB, type: DATA, subtype: NVS
17:28:02.956 ->             otadata : addr: 0x0000E000, size:     8.0 KB, type: DATA, subtype: OTA
17:28:02.956 ->                app0 : addr: 0x00010000, size:  1920.0 KB, type:  APP, subtype: OTA_0
17:28:02.956 ->                app1 : addr: 0x001F0000, size:  1920.0 KB, type:  APP, subtype: OTA_1
17:28:02.956 ->              spiffs : addr: 0x003D0000, size:   960.0 KB, type: DATA, subtype: SPIFFS
17:28:03.003 ->               model : addr: 0x004C0000, size:  3008.0 KB, type: DATA, subtype: SPIFFS
17:28:03.003 ->            coredump : addr: 0x007B0000, size:    64.0 KB, type: DATA, subtype: COREDUMP
17:28:03.003 -> ------------------------------------------
17:28:03.003 -> Software Info:
17:28:03.003 -> ------------------------------------------
17:28:03.003 ->   Compile Date/Time : May 18 2025 11:45:24
17:28:03.003 ->   Compile Host OS   : windows
17:28:03.003 ->   ESP-IDF Version   : v5.4.1-1-g2f7dcd862a-dirty
17:28:03.003 ->   Arduino Version   : 3.2.0
17:28:03.003 -> ------------------------------------------
17:28:03.049 -> Board Info:
17:28:03.049 -> ------------------------------------------
17:28:03.049 ->   Arduino Board     : ESP32S3_DEV
17:28:03.049 ->   Arduino Variant   : esp32s3
17:28:03.049 ->   Arduino FQBN      : esp32:esp32:esp32s3:JTAGAdapter=default,PSRAM=enabled,FlashMode=qio,FlashSize=8M,LoopCore=1,EventsCore=1,USBMode=hwcdc,CDCOnBoot=default,MSCOnBoot=default,DFUOnBoot=default,UploadMode=default,PartitionScheme=custom,CPUFreq=240,UploadSpeed=921600,DebugLevel=debug,EraseFlash=none,ZigbeeMode=default
17:28:03.049 -> ============ Before Setup End ============
17:28:03.189 -> [   399][D][esp32-hal-sr.c:338] sr_start(): init model
17:28:03.189 -> [   405][D][esp32-hal-sr.c:346] sr_start(): load wakenet 'wn9_hiesp'
17:28:03.329 -> MC Quantized wakenet9: wakeNet9_v1h24_Hi,ESP_3_0.63_0.635, tigger:v3, mode:2, p:0, (Nov  5 2024 16:02:49)
17:28:03.376 -> [   583][D][esp32-hal-sr.c:351] sr_start(): load multinet 'mn5q8_en'
17:28:03.376 -> [   589][D][esp32-hal-sr.c:353] sr_start(): load model_data 'mn5q8_en'
17:28:03.798 -> Quantized8 Multinet5: MN5Q8_v2_english_8_0.9_0.90, beam search:v2, (Nov  5 2024 16:02:48)
17:28:03.798 -> [  1008][I][esp32-hal-sr.c:358] sr_start(): add 7 commands
17:28:03.798 -> [  1021][I][esp32-hal-sr.c:361] sr_start():   cmd[0] phrase[0]:'Turn on the light'
17:28:03.798 -> [  1029][I][esp32-hal-sr.c:361] sr_start():   cmd[0] phrase[1]:'Switch on the light'
17:28:03.798 -> [  1036][I][esp32-hal-sr.c:361] sr_start():   cmd[1] phrase[2]:'Turn off the light'
17:28:03.798 -> [  1044][I][esp32-hal-sr.c:361] sr_start():   cmd[1] phrase[3]:'Switch off the light'
17:28:03.845 -> [  1051][I][esp32-hal-sr.c:361] sr_start():   cmd[1] phrase[4]:'Go dark'
17:28:03.845 -> [  1058][I][esp32-hal-sr.c:361] sr_start():   cmd[2] phrase[5]:'Start fan'
17:28:03.845 -> [  1065][I][esp32-hal-sr.c:361] sr_start():   cmd[3] phrase[6]:'Stop fan'
17:28:03.845 -> [  1073][D][esp32-hal-sr.c:373] sr_start(): start tasks
17:28:03.845 -> [  1078][I][esp32-hal-sr.c:142] audio_feed_task(): audio_chunksize=1024, feed_channel=3
17:28:03.845 -> [  1088][I][esp32-hal-sr.c:203] audio_detect_task(): ------------detect start------------
17:28:03.893 -> =========== After Setup Start ============
17:28:03.893 -> INTERNAL Memory Info:
17:28:03.893 -> ------------------------------------------
17:28:03.893 ->   Total Size        :   374656 B ( 365.9 KB)
17:28:03.893 ->   Free Bytes        :   273972 B ( 267.6 KB)
17:28:03.893 ->   Allocated Bytes   :    88612 B (  86.5 KB)
17:28:03.893 ->   Minimum Free Bytes:   273972 B ( 267.6 KB)
17:28:03.893 ->   Largest Free Block:   204788 B ( 200.0 KB)
17:28:03.939 -> ------------------------------------------
17:28:03.939 -> SPIRAM Memory Info:
17:28:03.939 -> ------------------------------------------
17:28:03.939 ->   Total Size        :  8388608 B (8192.0 KB)
17:28:03.939 ->   Free Bytes        :  5123552 B (5003.5 KB)
17:28:03.939 ->   Allocated Bytes   :  3256680 B (3180.4 KB)
17:28:03.939 ->   Minimum Free Bytes:  5123552 B (5003.5 KB)
17:28:03.939 ->   Largest Free Block:  5111796 B (4992.0 KB)
17:28:03.939 -> ------------------------------------------
17:28:03.985 -> GPIO Info:
17:28:03.985 -> ------------------------------------------
17:28:03.985 ->   GPIO : BUS_TYPE[bus/unit][chan]
17:28:03.985 ->   --------------------------------------  
17:28:03.985 ->      1 : GPIO
17:28:03.985 ->      3 : I2S_STD_DIN
17:28:03.985 ->      4 : I2S_STD_BCLK
17:28:03.985 ->      9 : GPIO
17:28:03.985 ->     11 : I2S_STD_WS
17:28:03.985 ->     43 : UART_TX[0]
17:28:03.985 ->     44 : UART_RX[0]
17:28:03.985 -> ============ After Setup End =============
17:28:07.221 -> [  4452][D][esp32-hal-sr.c:222] audio_detect_task(): wakeword detected
17:28:07.221 -> WakeWord Detected!
17:28:07.409 -> [  4632][D][esp32-hal-sr.c:232] audio_detect_task(): AFE_FETCH_CHANNEL_VERIFIED, channel index: 2
17:28:07.409 -> WakeWord Channel 2 Verified!
17:28:12.552 -> E (20575) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
17:28:12.552 -> E (20575) task_wdt:  - IDLE0 (CPU 0)
17:28:12.552 -> E (20575) task_wdt: Tasks currently running:
17:28:12.552 -> E (20575) task_wdt: CPU 0: SR Feed Task
17:28:12.552 -> E (20575) task_wdt: CPU 1: SR Detect Task
17:28:12.552 -> E (20575) task_wdt: Aborting.
17:28:12.598 -> E (20575) task_wdt: Print CPU 0 (current core) backtrace
17:28:12.598 -> 
17:28:12.598 -> 
17:28:12.598 -> 
17:28:12.598 -> 
17:28:12.598 -> Backtrace: 0x42062bdf:0x3fcaff80 0x4201ffd5:0x3fcaff90 0x4201d02e:0x3fcaffe0 0x4201d1d4:0x3fcb0000 0x42003ffd:0x3fcb0020 0x4037ddae:0x3fcb0060
17:28:12.645 -> 
17:28:12.645 -> 
17:28:12.645 -> 
17:28:12.645 -> 
17:28:12.645 -> ELF file SHA256: b9f0425db
17:28:12.645 -> 
17:28:12.831 -> Rebooting...
```

## Tests scenarios
Arduino Core ESP32 3.20
ESP32-S3 (ESP-S3-12k) N8R8 - ESP32S3Dev board used.
Custom partition table.
 

