### PR TITLE
feat(codeowners): Initial CODEOWNERS setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,12 +49,21 @@
 /package/ @me-no-dev
 
 # Libraries
+/libraries/ArduinoOTA/ @me-no-dev
+/libraries/AsyncUDP/ @me-no-dev
+/libraries/BLE/ @lucasssvaz @SuGlider
+/libraries/ESP_I2S/ @me-no-dev
 /libraries/ESP_NOW/ @P-R-O-C-H-Y @lucasssvaz
+/libraries/ESP_SR/ @me-no-dev
+/libraries/ESPmDNS/ @me-no-dev
 /libraries/Ethernet/ @me-no-dev
 /libraries/Matter/ @SuGlider
+/libraries/NetBIOS/ @me-no-dev
 /libraries/Network/ @me-no-dev
 /libraries/OpenThread/ @SuGlider
 /libraries/PPP/ @me-no-dev
+/libraries/SPI/ @me-no-dev
+/libraries/Update/ @me-no-dev
 /libraries/USB/ @SuGlider @me-no-dev
 /libraries/WiFi/ @me-no-dev
 /libraries/WiFiProv/ @me-no-dev


### PR DESCRIPTION
This pull request introduces a new `CODEOWNERS` file to the repository, specifying ownership rules for different parts of the ESP32 Arduino Core project. The file ensures that review requests are directed to the appropriate developers based on the file or directory being modified.

Other libraries and files can be added with time. This is only the initial setup.