### PR TITLE
HTTPUpdate: Support HTTP 204

### DIFF
--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -356,6 +356,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
         log_e("Content-Length was 0 or wasn't set by Server?!\n");
       }
       break;
+    case HTTP_CODE_NO_CONTENT:
     case HTTP_CODE_NOT_MODIFIED:
       ///< Not Modified (No updates)
       ret = HTTP_UPDATE_NO_UPDATES;


### PR DESCRIPTION

## Description of Change
HTTP 204 is a successful return code which indicates No Content. While it's appropriate to return a 304 if the server has content for a device but it hasn't change, it is more accurate for a server to return a 204 if it simply doesn't have any firmware files for a particular device.

## Tests scenarios
Change is hardware independent and relies on the HTTP return code. Will work on all supported hardware. Tested on Arduino-esp32 core v3.2.0 with ESP32 Devkit C board.
