### PR TITLE
feat(ap): Add support for DHCP Captive Portal (opt 114)

### DIFF
--- a/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
+++ b/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
@@ -34,8 +34,9 @@ void handleNotFound() {
 
 void setup() {
   Serial.begin(115200);
-  WiFi.mode(WIFI_AP);
-  WiFi.softAP("ESP32-DNSServer");
+  WiFi.AP.begin();
+  WiFi.AP.create("ESP32-DNSServer");
+  WiFi.AP.enableDhcpCaptivePortal();
 
   // by default DNSServer is started serving any "*" domain name. It will reply
   // AccessPoint's IP to all DNS request (this is required for Captive Portal detection)

--- a/libraries/WiFi/src/WiFiAP.h
+++ b/libraries/WiFi/src/WiFiAP.h
@@ -53,6 +53,7 @@ public:
 
   bool bandwidth(wifi_bandwidth_t bandwidth);
   bool enableNAPT(bool enable = true);
+  bool enableDhcpCaptivePortal();
 
   String SSID(void) const;
   uint8_t stationCount();


### PR DESCRIPTION
This pull request introduces functionality to enable a DHCP-based captive portal for WiFi access points, along with updates to simplify the setup process in the Captive Portal example. The most significant changes include adding the new `enableDhcpCaptivePortal` method to the `APClass`, modifying the example code to utilize this new feature, and updating the `WiFiAP.h` header file to declare the new method.

### Enhancements to WiFi Access Point functionality:

* **Added `enableDhcpCaptivePortal` method to `APClass`:** This method enables a DHCP-based captive portal by configuring the DHCP server to redirect clients to a specific captive portal URI. It includes error handling for stopping and starting the DHCP server and checks if the access point is started before enabling the feature.
* **Declared `enableDhcpCaptivePortal` in `WiFiAP.h`:** The new method is added to the `APClass` interface, making it accessible for users of the library.

### Updates to the Captive Portal example:

* **Simplified WiFi setup in `CaptivePortal.ino`:** Replaced the manual configuration of the access point with the new `WiFi.AP.create` and `WiFi.AP.enableDhcpCaptivePortal` methods, streamlining the setup process for users.