### PR TITLE
make BT core code execution conditional from include esp_bt.h

### DIFF
--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -15,9 +15,8 @@
 #include "esp32-hal-bt.h"
 
 #if SOC_BT_SUPPORTED
-#ifdef CONFIG_BT_BLUEDROID_ENABLED
+#if defined(CONFIG_BT_BLUEDROID_ENABLED) && __has_include("esp_bt.h")
 
-#if __has_include("esp_bt.h")
 #include "esp_bt.h"
 
 #if CONFIG_IDF_TARGET_ESP32
@@ -117,7 +116,6 @@ bool btStop() {
   return false;
 }
 
-#endif // __has_include("esp_bt.h")
 #else  // CONFIG_BT_ENABLED
 bool btStarted() {
   return false;
@@ -134,4 +132,3 @@ bool btStop() {
 #endif /* CONFIG_BT_ENABLED */
 
 #endif /* SOC_BT_SUPPORTED */
-

--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -17,6 +17,9 @@
 #if SOC_BT_SUPPORTED
 #ifdef CONFIG_BT_BLUEDROID_ENABLED
 
+#if __has_include("esp_bt.h")
+#include "esp_bt.h"
+
 #if CONFIG_IDF_TARGET_ESP32
 bool btInUse() {
   return true;
@@ -27,8 +30,6 @@ __attribute__((weak)) bool btInUse() {
   return true;
 }
 #endif
-
-#include "esp_bt.h"
 
 #ifdef CONFIG_BTDM_CONTROLLER_MODE_BTDM
 #define BT_MODE ESP_BT_MODE_BTDM
@@ -56,7 +57,7 @@ bool btStartMode(bt_mode mode) {
     case BT_MODE_BTDM:       esp_bt_mode = ESP_BT_MODE_BTDM; break;
     default:                 esp_bt_mode = BT_MODE; break;
   }
-  // esp_bt_controller_enable(MODE) This mode must be equal as the mode in “cfg” of esp_bt_controller_init().
+  // esp_bt_controller_enable(MODE) This mode must be equal as the mode in "cfg" of esp_bt_controller_init().
   cfg.mode = esp_bt_mode;
   if (cfg.mode == ESP_BT_MODE_CLASSIC_BT) {
     esp_bt_controller_mem_release(ESP_BT_MODE_BLE);
@@ -116,6 +117,7 @@ bool btStop() {
   return false;
 }
 
+#endif // __has_include("esp_bt.h")
 #else  // CONFIG_BT_ENABLED
 bool btStarted() {
   return false;
@@ -132,3 +134,4 @@ bool btStop() {
 #endif /* CONFIG_BT_ENABLED */
 
 #endif /* SOC_BT_SUPPORTED */
+

--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -17,8 +17,6 @@
 #if SOC_BT_SUPPORTED
 #if defined(CONFIG_BT_BLUEDROID_ENABLED) && __has_include("esp_bt.h")
 
-#include "esp_bt.h"
-
 #if CONFIG_IDF_TARGET_ESP32
 bool btInUse() {
   return true;
@@ -29,6 +27,8 @@ __attribute__((weak)) bool btInUse() {
   return true;
 }
 #endif
+
+#include "esp_bt.h"
 
 #ifdef CONFIG_BTDM_CONTROLLER_MODE_BTDM
 #define BT_MODE ESP_BT_MODE_BTDM
@@ -56,7 +56,7 @@ bool btStartMode(bt_mode mode) {
     case BT_MODE_BTDM:       esp_bt_mode = ESP_BT_MODE_BTDM; break;
     default:                 esp_bt_mode = BT_MODE; break;
   }
-  // esp_bt_controller_enable(MODE) This mode must be equal as the mode in "cfg" of esp_bt_controller_init().
+  // esp_bt_controller_enable(MODE) This mode must be equal as the mode in “cfg” of esp_bt_controller_init().
   cfg.mode = esp_bt_mode;
   if (cfg.mode == ESP_BT_MODE_CLASSIC_BT) {
     esp_bt_controller_mem_release(ESP_BT_MODE_BLE);


### PR DESCRIPTION
by this change it is possible to remove all not necessary BT include pathes. Why does this matter? The build system SCons which is used for pioarduino does not support @file in CPPPATH. This is a problem for Windows since command line limit is reached for big projects. The current approach to solve compile issues is to move the include files from CPPPATH to ASFLAGS and CCFLAGS and using with -iprefix. This approach generates a heavy performance decrease in compiling. To solve i am implementing a solution to keep the original correct way providing the includes via CPPPATH and remove the not needed includes. This works quiet well. Especially BT has a lot of includes, in most cases just removing this includes does solve Windows compile errors.

BUT currently removing the Bluetooth includes is not possible (even when BT is not used) because in the core file `cores/esp32/esp32-hal-bt.c` the include of `esp_bt.h` is always done. The PR changes that and only includes when the file is existing.

The PR does not change the standard behaviour and is fully backwards compatible.

Even when the change to NimBLE is done it should be checked for existing include files.
Only the compile settings are not enough to decide if the user code does use BT or not.

@me-no-dev please have a look and if possible merge for next release. All Windows pioarduino users will have a performance boost in compiling. Since the mentioned solution for removing not needed includes is ready.


