### PR TITLE
IDF release/v5.4

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-46909c50-v1"
+              "version": "idf-release_v5.4-f0f2980d-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-46909c50-v1",
+          "version": "idf-release_v5.4-f0f2980d-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-46909c50-v1.zip",
-              "checksum": "SHA-256:a2b0ea0a21434a501dc7ad35bc7b513412eecba132eb5a609709684374a9cece",
-              "size": "353901353"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:91b2da94a9a98d83272c326b7675c89a8908b6d69384a228252dbce0c8ac7eb8",
+              "size": "354067834"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master fdb4a87
esp-idf: release/v5.4 8497af9b77
arduino: master f3ae2a65e
tinyusb: master 2a364ca27
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.5
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.2
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.0
espressif__esp-dsp: 1.6.4
espressif__eppp_link: 0.2.0
espressif__esp_hosted: 0.0.25
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.4.1
```
