### PR TITLE
C2: Disable network provisioning

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -68,6 +68,8 @@ dependencies:
   # RainMaker Start (Fixed versions, because Matter supports only Insights 1.0.1)
   espressif/network_provisioning:
     version: "1.0.2"
+    rules:
+      - if: "target != esp32c2"
   espressif/esp_rainmaker:
     version: "1.5.2"
     rules:


### PR DESCRIPTION
generates weird compile issues when compiling Arduino as an component of IDF when using pioarduino. No impact on Arduino Core since no C2 precompiled libs are provided.
Trying to use wifi-provisioning with the C2 is always a bad idea keeping the low resources from the C2 in mind.

@me-no-dev as discussed in Discord 