### PR TITLE
fix: Add PSRAM Option for Geekble nano

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -449,7 +449,7 @@ esp32h2.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
 #esp32h2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 #esp32h2.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 #esp32h2.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-#esp32h2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+#esp32h2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32h2.menu.PartitionScheme.zigbee_2MB=Zigbee 2MB with spiffs
 esp32h2.menu.PartitionScheme.zigbee_2MB.build.partitions=zigbee_2MB
 esp32h2.menu.PartitionScheme.zigbee_2MB.upload.maximum_size=1310720
@@ -647,7 +647,7 @@ esp32c6.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 esp32c6.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32c6.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32c6.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32c6.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32c6.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32c6.menu.PartitionScheme.zigbee_2MB=Zigbee 2MB with spiffs
 esp32c6.menu.PartitionScheme.zigbee_2MB.build.partitions=zigbee_2MB
 esp32c6.menu.PartitionScheme.zigbee_2MB.upload.maximum_size=1310720
@@ -933,7 +933,7 @@ esp32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 esp32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32s3.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 esp32s3.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 esp32s3.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -1110,7 +1110,7 @@ esp32c3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 esp32c3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32c3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32c3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32c3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32c3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32c3.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
 esp32c3.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
 esp32c3.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
@@ -1318,7 +1318,7 @@ esp32s2.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 esp32s2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32s2.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32s2.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32s2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32s2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32s2.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
 esp32s2.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
 esp32s2.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
@@ -1501,7 +1501,7 @@ esp32.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 esp32.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
 esp32.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
 esp32.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
@@ -1681,7 +1681,7 @@ esp32da.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 esp32da.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32da.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32da.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32da.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32da.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32da.menu.PartitionScheme.custom=Custom
 esp32da.menu.PartitionScheme.custom.build.partitions=
 esp32da.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -2144,7 +2144,7 @@ esp32s3-octal.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 esp32s3-octal.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32s3-octal.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32s3-octal.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32s3-octal.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32s3-octal.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32s3-octal.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 esp32s3-octal.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 esp32s3-octal.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -2731,7 +2731,7 @@ esp32wroverkit.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB
 esp32wroverkit.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32wroverkit.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32wroverkit.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32wroverkit.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32wroverkit.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 esp32wroverkit.menu.CPUFreq.240=240MHz (WiFi/BT)
 esp32wroverkit.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -2966,7 +2966,7 @@ aventen_s3_sync.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4M
 aventen_s3_sync.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 aventen_s3_sync.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 aventen_s3_sync.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-aventen_s3_sync.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+aventen_s3_sync.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 aventen_s3_sync.menu.CPUFreq.240=240MHz (WiFi)
 aventen_s3_sync.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -3640,155 +3640,6 @@ um_bling.menu.EraseFlash.none=Disabled
 um_bling.menu.EraseFlash.none.upload.erase_cmd=
 um_bling.menu.EraseFlash.all=Enabled
 um_bling.menu.EraseFlash.all.upload.erase_cmd=-e
-
-##############################################################
-
-um_edges3_d.name=UM EdgeS3[D]
-um_edges3_d.vid.0=0x303a
-um_edges3_d.pid.0=0x82DC
-um_edges3_d.upload_port.0.vid=0x303a
-um_edges3_d.upload_port.0.pid=0x82DC
-
-um_edges3_d.bootloader.tool=esptool_py
-um_edges3_d.bootloader.tool.default=esptool_py
-
-um_edges3_d.upload.tool=esptool_py
-um_edges3_d.upload.tool.default=esptool_py
-um_edges3_d.upload.tool.network=esp_ota
-
-um_edges3_d.upload.maximum_size=1310720
-um_edges3_d.upload.maximum_data_size=327680
-um_edges3_d.upload.flags=
-um_edges3_d.upload.extra_flags=
-um_edges3_d.upload.use_1200bps_touch=false
-um_edges3_d.upload.wait_for_upload_port=false
-
-um_edges3_d.serial.disableDTR=false
-um_edges3_d.serial.disableRTS=false
-
-um_edges3_d.build.tarch=xtensa
-um_edges3_d.build.bootloader_addr=0x0
-um_edges3_d.build.target=esp32s3
-um_edges3_d.build.mcu=esp32s3
-um_edges3_d.build.core=esp32
-um_edges3_d.build.variant=um_edges3_d
-um_edges3_d.build.board=EDGES3D
-
-um_edges3_d.build.usb_mode=1
-um_edges3_d.build.cdc_on_boot=1
-um_edges3_d.build.msc_on_boot=0
-um_edges3_d.build.dfu_on_boot=0
-um_edges3_d.build.f_cpu=240000000L
-um_edges3_d.build.flash_size=8MB
-um_edges3_d.build.flash_freq=80m
-um_edges3_d.build.flash_mode=dio
-um_edges3_d.build.boot=qio
-um_edges3_d.build.partitions=default
-um_edges3_d.build.defines=
-um_edges3_d.build.loop_core=
-um_edges3_d.build.event_core=
-um_edges3_d.build.flash_type=qio
-um_edges3_d.build.psram_type=qspi
-um_edges3_d.build.memory_type=qio_qspi
-
-um_edges3_d.menu.LoopCore.1=Core 1
-um_edges3_d.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-um_edges3_d.menu.LoopCore.0=Core 0
-um_edges3_d.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-um_edges3_d.menu.EventsCore.1=Core 1
-um_edges3_d.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-um_edges3_d.menu.EventsCore.0=Core 0
-um_edges3_d.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-um_edges3_d.menu.USBMode.hwcdc=Hardware CDC and JTAG
-um_edges3_d.menu.USBMode.hwcdc.build.usb_mode=1
-um_edges3_d.menu.USBMode.default=USB-OTG (TinyUSB)
-um_edges3_d.menu.USBMode.default.build.usb_mode=0
-
-um_edges3_d.menu.CDCOnBoot.cdc=Enabled
-um_edges3_d.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-um_edges3_d.menu.CDCOnBoot.default=Disabled
-um_edges3_d.menu.CDCOnBoot.default.build.cdc_on_boot=0
-
-um_edges3_d.menu.MSCOnBoot.default=Disabled
-um_edges3_d.menu.MSCOnBoot.default.build.msc_on_boot=0
-um_edges3_d.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-um_edges3_d.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-um_edges3_d.menu.DFUOnBoot.default=Disabled
-um_edges3_d.menu.DFUOnBoot.default.build.dfu_on_boot=0
-um_edges3_d.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-um_edges3_d.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-um_edges3_d.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-um_edges3_d.menu.UploadMode.default=UART0 / Hardware CDC
-um_edges3_d.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-um_edges3_d.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-um_edges3_d.menu.UploadMode.default.upload.use_1200bps_touch=false
-um_edges3_d.menu.UploadMode.default.upload.wait_for_upload_port=false
-
-um_edges3_d.menu.PSRAM.enabled=Enabled
-um_edges3_d.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-um_edges3_d.menu.PSRAM.disabled=Disabled
-um_edges3_d.menu.PSRAM.disabled.build.defines=
-
-um_edges3_d.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
-um_edges3_d.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
-um_edges3_d.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
-
-um_edges3_d.menu.CPUFreq.240=240MHz (WiFi)
-um_edges3_d.menu.CPUFreq.240.build.f_cpu=240000000L
-um_edges3_d.menu.CPUFreq.160=160MHz (WiFi)
-um_edges3_d.menu.CPUFreq.160.build.f_cpu=160000000L
-um_edges3_d.menu.CPUFreq.80=80MHz (WiFi)
-um_edges3_d.menu.CPUFreq.80.build.f_cpu=80000000L
-um_edges3_d.menu.CPUFreq.40=40MHz
-um_edges3_d.menu.CPUFreq.40.build.f_cpu=40000000L
-um_edges3_d.menu.CPUFreq.20=20MHz
-um_edges3_d.menu.CPUFreq.20.build.f_cpu=20000000L
-um_edges3_d.menu.CPUFreq.10=10MHz
-um_edges3_d.menu.CPUFreq.10.build.f_cpu=10000000L
-
-um_edges3_d.menu.FlashMode.qio=QIO
-um_edges3_d.menu.FlashMode.qio.build.flash_mode=dio
-um_edges3_d.menu.FlashMode.qio.build.boot=qio
-um_edges3_d.menu.FlashMode.dio=DIO
-um_edges3_d.menu.FlashMode.dio.build.flash_mode=dio
-um_edges3_d.menu.FlashMode.dio.build.boot=dio
-
-um_edges3_d.menu.UploadSpeed.921600=921600
-um_edges3_d.menu.UploadSpeed.921600.upload.speed=921600
-um_edges3_d.menu.UploadSpeed.115200=115200
-um_edges3_d.menu.UploadSpeed.115200.upload.speed=115200
-um_edges3_d.menu.UploadSpeed.256000.windows=256000
-um_edges3_d.menu.UploadSpeed.256000.upload.speed=256000
-um_edges3_d.menu.UploadSpeed.230400.windows.upload.speed=256000
-um_edges3_d.menu.UploadSpeed.230400=230400
-um_edges3_d.menu.UploadSpeed.230400.upload.speed=230400
-um_edges3_d.menu.UploadSpeed.460800.linux=460800
-um_edges3_d.menu.UploadSpeed.460800.macosx=460800
-um_edges3_d.menu.UploadSpeed.460800.upload.speed=460800
-um_edges3_d.menu.UploadSpeed.512000.windows=512000
-um_edges3_d.menu.UploadSpeed.512000.upload.speed=512000
-
-um_edges3_d.menu.DebugLevel.none=None
-um_edges3_d.menu.DebugLevel.none.build.code_debug=0
-um_edges3_d.menu.DebugLevel.error=Error
-um_edges3_d.menu.DebugLevel.error.build.code_debug=1
-um_edges3_d.menu.DebugLevel.warn=Warn
-um_edges3_d.menu.DebugLevel.warn.build.code_debug=2
-um_edges3_d.menu.DebugLevel.info=Info
-um_edges3_d.menu.DebugLevel.info.build.code_debug=3
-um_edges3_d.menu.DebugLevel.debug=Debug
-um_edges3_d.menu.DebugLevel.debug.build.code_debug=4
-um_edges3_d.menu.DebugLevel.verbose=Verbose
-um_edges3_d.menu.DebugLevel.verbose.build.code_debug=5
-
-um_edges3_d.menu.EraseFlash.none=Disabled
-um_edges3_d.menu.EraseFlash.none.upload.erase_cmd=
-um_edges3_d.menu.EraseFlash.all=Enabled
-um_edges3_d.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
@@ -4884,163 +4735,6 @@ um_pros3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-um_squixl.name=UM SQUIXL
-um_squixl.vid.0=0x303a
-um_squixl.pid.0=0x82DF
-um_squixl.upload_port.0.vid=0x303a
-um_squixl.upload_port.0.pid=0x82DF
-
-um_squixl.bootloader.tool=esptool_py
-um_squixl.bootloader.tool.default=esptool_py
-
-um_squixl.upload.tool=esptool_py
-um_squixl.upload.tool.default=esptool_py
-um_squixl.upload.tool.network=esp_ota
-
-um_squixl.upload.maximum_size=1310720
-um_squixl.upload.maximum_data_size=327680
-um_squixl.upload.flags=
-um_squixl.upload.extra_flags=
-um_squixl.upload.use_1200bps_touch=false
-um_squixl.upload.wait_for_upload_port=false
-
-um_squixl.serial.disableDTR=false
-um_squixl.serial.disableRTS=false
-
-um_squixl.build.tarch=xtensa
-um_squixl.build.bootloader_addr=0x0
-um_squixl.build.target=esp32s3
-um_squixl.build.mcu=esp32s3
-um_squixl.build.core=esp32
-um_squixl.build.variant=um_squixl
-um_squixl.build.board=SQUIXL
-
-um_squixl.build.usb_mode=1
-um_squixl.build.cdc_on_boot=1
-um_squixl.build.msc_on_boot=0
-um_squixl.build.dfu_on_boot=0
-um_squixl.build.f_cpu=240000000L
-um_squixl.build.flash_size=16MB
-um_squixl.build.flash_freq=80m
-um_squixl.build.flash_mode=dio
-um_squixl.build.boot=qio
-um_squixl.build.partitions=default
-um_squixl.build.defines=
-um_squixl.build.loop_core=
-um_squixl.build.event_core=
-um_squixl.build.flash_type=qio
-um_squixl.build.psram_type=opi
-um_squixl.build.memory_type=qio_opi
-
-um_squixl.menu.LoopCore.1=Core 1
-um_squixl.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-um_squixl.menu.LoopCore.0=Core 0
-um_squixl.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-um_squixl.menu.EventsCore.1=Core 1
-um_squixl.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-um_squixl.menu.EventsCore.0=Core 0
-um_squixl.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-um_squixl.menu.USBMode.hwcdc=Hardware CDC and JTAG
-um_squixl.menu.USBMode.hwcdc.build.usb_mode=1
-um_squixl.menu.USBMode.default=USB-OTG (TinyUSB)
-um_squixl.menu.USBMode.default.build.usb_mode=0
-
-um_squixl.menu.CDCOnBoot.cdc=Enabled
-um_squixl.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-um_squixl.menu.CDCOnBoot.default=Disabled
-um_squixl.menu.CDCOnBoot.default.build.cdc_on_boot=0
-
-um_squixl.menu.MSCOnBoot.default=Disabled
-um_squixl.menu.MSCOnBoot.default.build.msc_on_boot=0
-um_squixl.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-um_squixl.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-um_squixl.menu.DFUOnBoot.default=Disabled
-um_squixl.menu.DFUOnBoot.default.build.dfu_on_boot=0
-um_squixl.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-um_squixl.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-um_squixl.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-um_squixl.menu.UploadMode.default=UART0 / Hardware CDC
-um_squixl.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-um_squixl.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-um_squixl.menu.UploadMode.default.upload.use_1200bps_touch=false
-um_squixl.menu.UploadMode.default.upload.wait_for_upload_port=false
-
-um_squixl.menu.PSRAM.opi=OPI PSRAM
-um_squixl.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
-um_squixl.menu.PSRAM.opi.build.psram_type=opi
-
-um_squixl.menu.PartitionScheme.default_16MB=Default (6.25MB APP/3.43MB SPIFFS)
-um_squixl.menu.PartitionScheme.default_16MB.build.partitions=default_16MB
-um_squixl.menu.PartitionScheme.default_16MB.upload.maximum_size=6553600
-um_squixl.menu.PartitionScheme.large_spiffs=Large SPIFFS (4.5MB APP/6.93MB SPIFFS)
-um_squixl.menu.PartitionScheme.large_spiffs.build.partitions=large_spiffs_16MB
-um_squixl.menu.PartitionScheme.large_spiffs.upload.maximum_size=4718592
-um_squixl.menu.PartitionScheme.app3M_fat9M_16MB=FFAT (3MB APP/9MB FATFS)
-um_squixl.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-um_squixl.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
-um_squixl.menu.PartitionScheme.fatflash=Large FFAT (2MB APP/12.5MB FATFS)
-um_squixl.menu.PartitionScheme.fatflash.build.partitions=ffat
-um_squixl.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
-
-um_squixl.menu.CPUFreq.240=240MHz (WiFi)
-um_squixl.menu.CPUFreq.240.build.f_cpu=240000000L
-um_squixl.menu.CPUFreq.160=160MHz (WiFi)
-um_squixl.menu.CPUFreq.160.build.f_cpu=160000000L
-um_squixl.menu.CPUFreq.80=80MHz (WiFi)
-um_squixl.menu.CPUFreq.80.build.f_cpu=80000000L
-um_squixl.menu.CPUFreq.40=40MHz
-um_squixl.menu.CPUFreq.40.build.f_cpu=40000000L
-um_squixl.menu.CPUFreq.20=20MHz
-um_squixl.menu.CPUFreq.20.build.f_cpu=20000000L
-um_squixl.menu.CPUFreq.10=10MHz
-um_squixl.menu.CPUFreq.10.build.f_cpu=10000000L
-
-um_squixl.menu.FlashMode.qio=QIO
-um_squixl.menu.FlashMode.qio.build.flash_mode=dio
-um_squixl.menu.FlashMode.qio.build.boot=qio
-um_squixl.menu.FlashMode.dio=DIO
-um_squixl.menu.FlashMode.dio.build.flash_mode=dio
-um_squixl.menu.FlashMode.dio.build.boot=dio
-
-um_squixl.menu.UploadSpeed.921600=921600
-um_squixl.menu.UploadSpeed.921600.upload.speed=921600
-um_squixl.menu.UploadSpeed.115200=115200
-um_squixl.menu.UploadSpeed.115200.upload.speed=115200
-um_squixl.menu.UploadSpeed.256000.windows=256000
-um_squixl.menu.UploadSpeed.256000.upload.speed=256000
-um_squixl.menu.UploadSpeed.230400.windows.upload.speed=256000
-um_squixl.menu.UploadSpeed.230400=230400
-um_squixl.menu.UploadSpeed.230400.upload.speed=230400
-um_squixl.menu.UploadSpeed.460800.linux=460800
-um_squixl.menu.UploadSpeed.460800.macosx=460800
-um_squixl.menu.UploadSpeed.460800.upload.speed=460800
-um_squixl.menu.UploadSpeed.512000.windows=512000
-um_squixl.menu.UploadSpeed.512000.upload.speed=512000
-
-um_squixl.menu.DebugLevel.none=None
-um_squixl.menu.DebugLevel.none.build.code_debug=0
-um_squixl.menu.DebugLevel.error=Error
-um_squixl.menu.DebugLevel.error.build.code_debug=1
-um_squixl.menu.DebugLevel.warn=Warn
-um_squixl.menu.DebugLevel.warn.build.code_debug=2
-um_squixl.menu.DebugLevel.info=Info
-um_squixl.menu.DebugLevel.info.build.code_debug=3
-um_squixl.menu.DebugLevel.debug=Debug
-um_squixl.menu.DebugLevel.debug.build.code_debug=4
-um_squixl.menu.DebugLevel.verbose=Verbose
-um_squixl.menu.DebugLevel.verbose.build.code_debug=5
-
-um_squixl.menu.EraseFlash.none=Disabled
-um_squixl.menu.EraseFlash.none.upload.erase_cmd=
-um_squixl.menu.EraseFlash.all=Enabled
-um_squixl.menu.EraseFlash.all.upload.erase_cmd=-e
-
-##############################################################
-
 um_tinypico.name=UM TinyPICO
 
 um_tinypico.bootloader.tool=esptool_py
@@ -5202,7 +4896,7 @@ um_tinyc6.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_o
 um_tinyc6.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 um_tinyc6.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 um_tinyc6.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-um_tinyc6.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+um_tinyc6.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 um_tinyc6.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
 um_tinyc6.menu.PartitionScheme.zigbee.build.partitions=zigbee
 um_tinyc6.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
@@ -5896,7 +5590,7 @@ lilygo_t_display_s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmake
 lilygo_t_display_s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 lilygo_t_display_s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 lilygo_t_display_s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-lilygo_t_display_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+lilygo_t_display_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 lilygo_t_display_s3.menu.DebugLevel.none=None
 lilygo_t_display_s3.menu.DebugLevel.none.build.code_debug=0
@@ -6018,7 +5712,7 @@ lilygo_t_eth_lite.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_
 lilygo_t_eth_lite.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 lilygo_t_eth_lite.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 lilygo_t_eth_lite.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-lilygo_t_eth_lite.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+lilygo_t_eth_lite.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 lilygo_t_eth_lite.menu.DebugLevel.none=None
 lilygo_t_eth_lite.menu.DebugLevel.none.build.code_debug=0
@@ -6313,12 +6007,12 @@ twatchs3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
 twatchs3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
 twatchs3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 
-twatchs3.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
-twatchs3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-twatchs3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
 twatchs3.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 twatchs3.menu.PartitionScheme.fatflash.build.partitions=ffat
 twatchs3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+twatchs3.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+twatchs3.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+twatchs3.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
 twatchs3.menu.PartitionScheme.rainmaker=RainMaker
 twatchs3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
 twatchs3.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
@@ -6376,16 +6070,10 @@ twatchs3.menu.EraseFlash.none.upload.erase_cmd=
 twatchs3.menu.EraseFlash.all=Enabled
 twatchs3.menu.EraseFlash.all.upload.erase_cmd=-e
 
-twatchs3.menu.Revision.Radio_SX1262=Radio-SX1262
-twatchs3.menu.Revision.Radio_SX1262.build.board=LILYGO_LORA_SX1262
 twatchs3.menu.Revision.Radio_SX1280=Radio-SX1280
 twatchs3.menu.Revision.Radio_SX1280.build.board=LILYGO_LORA_SX1280
-twatchs3.menu.Revision.Radio_CC1101=Radio-CC1101
-twatchs3.menu.Revision.Radio_CC1101.build.board=LILYGO_LORA_CC1101
-twatchs3.menu.Revision.Radio_LR1121=Radio-LR1121
-twatchs3.menu.Revision.Radio_LR1121.build.board=LILYGO_LORA_LR1121
-twatchs3.menu.Revision.Radio_SI4432=Radio-SI4432
-twatchs3.menu.Revision.Radio_SI4432.build.board=LILYGO_LORA_SI4432
+twatchs3.menu.Revision.Radio_SX1262=Radio-SX1262
+twatchs3.menu.Revision.Radio_SX1262.build.board=LILYGO_LORA_SX1262
 
 ##############################################################
 
@@ -6478,12 +6166,12 @@ twatch_ultra.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
 twatch_ultra.menu.UploadMode.cdc.upload.use_1200bps_touch=true
 twatch_ultra.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 
-twatch_ultra.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
-twatch_ultra.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-twatch_ultra.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
 twatch_ultra.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 twatch_ultra.menu.PartitionScheme.fatflash.build.partitions=ffat
 twatch_ultra.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+twatch_ultra.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+twatch_ultra.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+twatch_ultra.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
 twatch_ultra.menu.PartitionScheme.rainmaker=RainMaker
 twatch_ultra.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
 twatch_ultra.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
@@ -6541,181 +6229,11 @@ twatch_ultra.menu.EraseFlash.none.upload.erase_cmd=
 twatch_ultra.menu.EraseFlash.all=Enabled
 twatch_ultra.menu.EraseFlash.all.upload.erase_cmd=-e
 
-twatch_ultra.menu.Revision.Radio_SX1262=Radio-SX1262
-twatch_ultra.menu.Revision.Radio_SX1262.build.board=LILYGO_LORA_SX1262
 twatch_ultra.menu.Revision.Radio_SX1280=Radio-SX1280
 twatch_ultra.menu.Revision.Radio_SX1280.build.board=LILYGO_LORA_SX1280
-twatch_ultra.menu.Revision.Radio_CC1101=Radio-CC1101
-twatch_ultra.menu.Revision.Radio_CC1101.build.board=LILYGO_LORA_CC1101
-twatch_ultra.menu.Revision.Radio_LR1121=Radio-LR1121
-twatch_ultra.menu.Revision.Radio_LR1121.build.board=LILYGO_LORA_LR1121
-twatch_ultra.menu.Revision.Radio_SI4432=Radio-SI4432
-twatch_ultra.menu.Revision.Radio_SI4432.build.board=LILYGO_LORA_SI4432
+twatch_ultra.menu.Revision.Radio_SX1262=Radio-SX1262
+twatch_ultra.menu.Revision.Radio_SX1262.build.board=LILYGO_LORA_SX1262
 
-##############################################################
-
-tlora_pager.name=LilyGo-T-LoRa-Pager
-
-tlora_pager.bootloader.tool=esptool_py
-tlora_pager.bootloader.tool.default=esptool_py
-
-tlora_pager.upload.tool=esptool_py
-tlora_pager.upload.tool.default=esptool_py
-tlora_pager.upload.tool.network=esp_ota
-
-tlora_pager.upload.maximum_size=1310720
-tlora_pager.upload.maximum_data_size=327680
-tlora_pager.upload.flags=
-tlora_pager.upload.extra_flags=
-tlora_pager.upload.use_1200bps_touch=false
-tlora_pager.upload.wait_for_upload_port=false
-
-tlora_pager.serial.disableDTR=false
-tlora_pager.serial.disableRTS=false
-
-tlora_pager.build.tarch=xtensa
-tlora_pager.build.bootloader_addr=0x0
-tlora_pager.build.target=esp32s3
-tlora_pager.build.mcu=esp32s3
-tlora_pager.build.core=esp32
-tlora_pager.build.variant=lilygo_tlora_pager
-tlora_pager.build.board=T_LORA_PAGER
-
-tlora_pager.build.usb_mode=1
-tlora_pager.build.cdc_on_boot=1
-tlora_pager.build.msc_on_boot=0
-tlora_pager.build.dfu_on_boot=0
-tlora_pager.build.f_cpu=240000000L
-tlora_pager.build.flash_size=16MB
-tlora_pager.build.flash_freq=80m
-tlora_pager.build.flash_mode=dio
-tlora_pager.build.boot=qio
-tlora_pager.build.boot_freq=80m
-tlora_pager.build.partitions=app3M_fat9M_16MB
-tlora_pager.build.defines=-DBOARD_HAS_PSRAM -DARDUINO_T_LORA_PAGER
-tlora_pager.build.loop_core=
-tlora_pager.build.event_core=
-tlora_pager.build.psram_type=qspi
-tlora_pager.build.memory_type={build.boot}_{build.psram_type}
-
-## IDE 2.0 Seems to not update the value
-tlora_pager.menu.JTAGAdapter.default=Disabled
-tlora_pager.menu.JTAGAdapter.default.build.copy_jtag_files=0
-tlora_pager.menu.JTAGAdapter.builtin=Integrated USB JTAG
-tlora_pager.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
-tlora_pager.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
-
-tlora_pager.menu.LoopCore.1=Core 1
-tlora_pager.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-tlora_pager.menu.LoopCore.0=Core 0
-tlora_pager.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-tlora_pager.menu.EventsCore.1=Core 1
-tlora_pager.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-tlora_pager.menu.EventsCore.0=Core 0
-tlora_pager.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-tlora_pager.menu.USBMode.hwcdc=Hardware CDC and JTAG
-tlora_pager.menu.USBMode.hwcdc.build.usb_mode=1
-tlora_pager.menu.USBMode.default=USB-OTG (TinyUSB)
-tlora_pager.menu.USBMode.default.build.usb_mode=0
-
-tlora_pager.menu.CDCOnBoot.default=Enabled
-tlora_pager.menu.CDCOnBoot.default.build.cdc_on_boot=1
-tlora_pager.menu.CDCOnBoot.cdc=Disabled
-tlora_pager.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
-
-tlora_pager.menu.MSCOnBoot.default=Disabled
-tlora_pager.menu.MSCOnBoot.default.build.msc_on_boot=0
-tlora_pager.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-tlora_pager.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-tlora_pager.menu.DFUOnBoot.default=Disabled
-tlora_pager.menu.DFUOnBoot.default.build.dfu_on_boot=0
-tlora_pager.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-tlora_pager.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-tlora_pager.menu.UploadMode.default=UART0 / Hardware CDC
-tlora_pager.menu.UploadMode.default.upload.use_1200bps_touch=false
-tlora_pager.menu.UploadMode.default.upload.wait_for_upload_port=false
-tlora_pager.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-tlora_pager.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-tlora_pager.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-
-tlora_pager.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
-tlora_pager.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-tlora_pager.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
-tlora_pager.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
-tlora_pager.menu.PartitionScheme.fatflash.build.partitions=ffat
-tlora_pager.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
-tlora_pager.menu.PartitionScheme.rainmaker=RainMaker
-tlora_pager.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
-tlora_pager.menu.PartitionScheme.rainmaker.upload.maximum_size=3145728
-tlora_pager.menu.PartitionScheme.esp_sr_16=ESP SR 16M (3MB APP/7MB SPIFFS/2.9MB MODEL)
-tlora_pager.menu.PartitionScheme.esp_sr_16.upload.maximum_size=3145728
-tlora_pager.menu.PartitionScheme.esp_sr_16.upload.extra_flags=0xD10000 {build.path}/srmodels.bin
-tlora_pager.menu.PartitionScheme.esp_sr_16.build.partitions=esp_sr_16
-tlora_pager.menu.PartitionScheme.custom=Custom
-tlora_pager.menu.PartitionScheme.custom.build.partitions=
-tlora_pager.menu.PartitionScheme.custom.upload.maximum_size=16777216
-
-tlora_pager.menu.CPUFreq.240=240MHz (WiFi)
-tlora_pager.menu.CPUFreq.240.build.f_cpu=240000000L
-tlora_pager.menu.CPUFreq.160=160MHz (WiFi)
-tlora_pager.menu.CPUFreq.160.build.f_cpu=160000000L
-tlora_pager.menu.CPUFreq.80=80MHz (WiFi)
-tlora_pager.menu.CPUFreq.80.build.f_cpu=80000000L
-tlora_pager.menu.CPUFreq.40=40MHz
-tlora_pager.menu.CPUFreq.40.build.f_cpu=40000000L
-tlora_pager.menu.CPUFreq.20=20MHz
-tlora_pager.menu.CPUFreq.20.build.f_cpu=20000000L
-tlora_pager.menu.CPUFreq.10=10MHz
-tlora_pager.menu.CPUFreq.10.build.f_cpu=10000000L
-
-tlora_pager.menu.UploadSpeed.921600=921600
-tlora_pager.menu.UploadSpeed.921600.upload.speed=921600
-tlora_pager.menu.UploadSpeed.115200=115200
-tlora_pager.menu.UploadSpeed.115200.upload.speed=115200
-tlora_pager.menu.UploadSpeed.256000.windows=256000
-tlora_pager.menu.UploadSpeed.256000.upload.speed=256000
-tlora_pager.menu.UploadSpeed.230400.windows.upload.speed=256000
-tlora_pager.menu.UploadSpeed.230400=230400
-tlora_pager.menu.UploadSpeed.230400.upload.speed=230400
-tlora_pager.menu.UploadSpeed.460800.linux=460800
-tlora_pager.menu.UploadSpeed.460800.macosx=460800
-tlora_pager.menu.UploadSpeed.460800.upload.speed=460800
-tlora_pager.menu.UploadSpeed.512000.windows=512000
-tlora_pager.menu.UploadSpeed.512000.upload.speed=512000
-
-tlora_pager.menu.DebugLevel.none=None
-tlora_pager.menu.DebugLevel.none.build.code_debug=0
-tlora_pager.menu.DebugLevel.error=Error
-tlora_pager.menu.DebugLevel.error.build.code_debug=1
-tlora_pager.menu.DebugLevel.warn=Warn
-tlora_pager.menu.DebugLevel.warn.build.code_debug=2
-tlora_pager.menu.DebugLevel.info=Info
-tlora_pager.menu.DebugLevel.info.build.code_debug=3
-tlora_pager.menu.DebugLevel.debug=Debug
-tlora_pager.menu.DebugLevel.debug.build.code_debug=4
-tlora_pager.menu.DebugLevel.verbose=Verbose
-tlora_pager.menu.DebugLevel.verbose.build.code_debug=5
-
-tlora_pager.menu.EraseFlash.none=Disabled
-tlora_pager.menu.EraseFlash.none.upload.erase_cmd=
-tlora_pager.menu.EraseFlash.all=Enabled
-tlora_pager.menu.EraseFlash.all.upload.erase_cmd=-e
-
-
-tlora_pager.menu.Revision.Radio_SX1262=Radio-SX1262
-tlora_pager.menu.Revision.Radio_SX1262.build.board=LILYGO_LORA_SX1262
-tlora_pager.menu.Revision.Radio_SX1280=Radio-SX1280
-tlora_pager.menu.Revision.Radio_SX1280.build.board=LILYGO_LORA_SX1280
-tlora_pager.menu.Revision.Radio_CC1101=Radio-CC1101
-tlora_pager.menu.Revision.Radio_CC1101.build.board=LILYGO_LORA_CC1101
-tlora_pager.menu.Revision.Radio_LR1121=Radio-LR1121
-tlora_pager.menu.Revision.Radio_LR1121.build.board=LILYGO_LORA_LR1121
-tlora_pager.menu.Revision.Radio_SI4432=Radio-SI4432
-tlora_pager.menu.Revision.Radio_SI4432.build.board=LILYGO_LORA_SI4432
 
 ##############################################################
 
@@ -8374,7 +7892,7 @@ sparkfun_esp32c6_thing_plus.menu.PartitionScheme.rainmaker_4MB.build.partitions=
 sparkfun_esp32c6_thing_plus.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 sparkfun_esp32c6_thing_plus.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 sparkfun_esp32c6_thing_plus.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-sparkfun_esp32c6_thing_plus.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+sparkfun_esp32c6_thing_plus.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 sparkfun_esp32c6_thing_plus.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
 sparkfun_esp32c6_thing_plus.menu.PartitionScheme.zigbee.build.partitions=zigbee
 sparkfun_esp32c6_thing_plus.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
@@ -8784,7 +8302,7 @@ sparkfun_esp32_iot_redboard.menu.PartitionScheme.rainmaker_4MB.build.partitions=
 sparkfun_esp32_iot_redboard.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 sparkfun_esp32_iot_redboard.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 sparkfun_esp32_iot_redboard.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-sparkfun_esp32_iot_redboard.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+sparkfun_esp32_iot_redboard.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 sparkfun_esp32_iot_redboard.menu.CPUFreq.240=240MHz (WiFi/BT)
 sparkfun_esp32_iot_redboard.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -8964,7 +8482,7 @@ sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker_4MB.build.partition
 sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
 sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.zigbee.build.partitions=zigbee
 sparkfun_esp32c6_qwiic_pocket.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
@@ -9298,7 +8816,7 @@ nina_w10.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ot
 nina_w10.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 nina_w10.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 nina_w10.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-nina_w10.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+nina_w10.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 nina_w10.menu.CPUFreq.240=240MHz (WiFi/BT)
 nina_w10.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -9509,7 +9027,7 @@ nora_w10.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ot
 nora_w10.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 nora_w10.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 nora_w10.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-nora_w10.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+nora_w10.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 nora_w10.menu.CPUFreq.240=240MHz (WiFi)
 nora_w10.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -10481,7 +9999,7 @@ lolin_s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ot
 lolin_s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 lolin_s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 lolin_s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-lolin_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+lolin_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 lolin_s3.menu.CPUFreq.240=240MHz (WiFi)
 lolin_s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -10981,7 +10499,7 @@ lolin_s3_pro.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_n
 lolin_s3_pro.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 lolin_s3_pro.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 lolin_s3_pro.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-lolin_s3_pro.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+lolin_s3_pro.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 lolin_s3_pro.menu.CPUFreq.240=240MHz (WiFi)
 lolin_s3_pro.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -12361,7 +11879,7 @@ dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker_4MB.build.partitions=r
 dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+dfrobot_firebeetle2_esp32e.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 dfrobot_firebeetle2_esp32e.menu.CPUFreq.240=240MHz (WiFi/BT)
 dfrobot_firebeetle2_esp32e.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -12614,7 +12132,7 @@ dfrobot_firebeetle2_esp32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=
 dfrobot_firebeetle2_esp32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 dfrobot_firebeetle2_esp32s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 dfrobot_firebeetle2_esp32s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-dfrobot_firebeetle2_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+dfrobot_firebeetle2_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 dfrobot_firebeetle2_esp32s3.menu.CPUFreq.240=240MHz (WiFi)
 dfrobot_firebeetle2_esp32s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -12975,7 +12493,7 @@ dfrobot_romeo_esp32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainma
 dfrobot_romeo_esp32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 dfrobot_romeo_esp32s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 dfrobot_romeo_esp32s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-dfrobot_romeo_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+dfrobot_romeo_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 dfrobot_romeo_esp32s3.menu.CPUFreq.240=240MHz (WiFi)
 dfrobot_romeo_esp32s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -13022,212 +12540,6 @@ dfrobot_romeo_esp32s3.menu.EraseFlash.none=Disabled
 dfrobot_romeo_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_romeo_esp32s3.menu.EraseFlash.all=Enabled
 dfrobot_romeo_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
-
-##############################################################
-dfrobot_lorawan_esp32s3.name=DFRobot LoRaWAN ESP32-S3
-#dfrobot_lorawan_esp32s3.vid.0=0x303a
-#dfrobot_lorawan_esp32s3.pid.0=0x1001
-
-dfrobot_lorawan_esp32s3.bootloader.tool=esptool_py
-dfrobot_lorawan_esp32s3.bootloader.tool.default=esptool_py
-
-dfrobot_lorawan_esp32s3.upload.tool=esptool_py
-dfrobot_lorawan_esp32s3.upload.tool.default=esptool_py
-dfrobot_lorawan_esp32s3.upload.tool.network=esp_ota
-
-dfrobot_lorawan_esp32s3.upload.speed=921600
-dfrobot_lorawan_esp32s3.upload.erase_cmd=
-dfrobot_lorawan_esp32s3.upload.maximum_size=1310720
-dfrobot_lorawan_esp32s3.upload.maximum_data_size=327680
-dfrobot_lorawan_esp32s3.upload.flags=
-dfrobot_lorawan_esp32s3.upload.extra_flags=
-dfrobot_lorawan_esp32s3.upload.use_1200bps_touch=false
-dfrobot_lorawan_esp32s3.upload.wait_for_upload_port=false
-
-dfrobot_lorawan_esp32s3.serial.disableDTR=false
-dfrobot_lorawan_esp32s3.serial.disableRTS=false
-
-dfrobot_lorawan_esp32s3.build.tarch=xtensa
-dfrobot_lorawan_esp32s3.build.bootloader_addr=0x0
-dfrobot_lorawan_esp32s3.build.target=esp32s3
-dfrobot_lorawan_esp32s3.build.mcu=esp32s3
-dfrobot_lorawan_esp32s3.build.core=esp32
-dfrobot_lorawan_esp32s3.build.variant=dfrobot_lorawan_esp32s3
-dfrobot_lorawan_esp32s3.build.board=DFROBOT_LORAWAN_ESP32S3
-dfrobot_lorawan_esp32s3.build.usb_mode=1
-dfrobot_lorawan_esp32s3.build.cdc_on_boot=1
-dfrobot_lorawan_esp32s3.build.msc_on_boot=0
-dfrobot_lorawan_esp32s3.build.dfu_on_boot=0
-dfrobot_lorawan_esp32s3.build.f_cpu=240000000L
-dfrobot_lorawan_esp32s3.build.flash_size=4MB
-dfrobot_lorawan_esp32s3.build.flash_freq=80m
-dfrobot_lorawan_esp32s3.build.flash_mode=dio
-dfrobot_lorawan_esp32s3.build.boot=qio
-dfrobot_lorawan_esp32s3.build.boot_freq=80m
-dfrobot_lorawan_esp32s3.build.partitions=default
-dfrobot_lorawan_esp32s3.build.defines=-D{build.band}
-dfrobot_lorawan_esp32s3.build.loop_core=
-dfrobot_lorawan_esp32s3.build.event_core=
-dfrobot_lorawan_esp32s3.build.psram_type=qspi
-dfrobot_lorawan_esp32s3.build.memory_type={build.flash_type}_{build.psram_type}
-dfrobot_lorawan_esp32s3.build.region=
-
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio=QIO 80MHz
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio.build.flash_mode=dio
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio.build.boot=qio
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio.build.boot_freq=80m
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio.build.flash_freq=80m
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio.build.flash_type=qio
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio120=QIO 120MHz
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio120.build.flash_mode=dio
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio120.build.boot=qio
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio120.build.boot_freq=120m
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio120.build.flash_freq=80m
-dfrobot_lorawan_esp32s3.menu.FlashMode.qio120.build.flash_type=qio
-dfrobot_lorawan_esp32s3.menu.FlashMode.dio=DIO 80MHz
-dfrobot_lorawan_esp32s3.menu.FlashMode.dio.build.flash_mode=dio
-dfrobot_lorawan_esp32s3.menu.FlashMode.dio.build.boot=dio
-dfrobot_lorawan_esp32s3.menu.FlashMode.dio.build.boot_freq=80m
-dfrobot_lorawan_esp32s3.menu.FlashMode.dio.build.flash_freq=80m
-dfrobot_lorawan_esp32s3.menu.FlashMode.dio.build.flash_type=qio
-
-dfrobot_lorawan_esp32s3.menu.FlashSize.4M=4MB (32Mb)
-dfrobot_lorawan_esp32s3.menu.FlashSize.4M.build.flash_size=4MB
-
-dfrobot_lorawan_esp32s3.menu.LoopCore.1=Core 1
-dfrobot_lorawan_esp32s3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-dfrobot_lorawan_esp32s3.menu.LoopCore.0=Core 0
-dfrobot_lorawan_esp32s3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-dfrobot_lorawan_esp32s3.menu.EventsCore.1=Core 1
-dfrobot_lorawan_esp32s3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-dfrobot_lorawan_esp32s3.menu.EventsCore.0=Core 0
-dfrobot_lorawan_esp32s3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-dfrobot_lorawan_esp32s3.menu.USBMode.hwcdc=Hardware CDC and JTAG
-dfrobot_lorawan_esp32s3.menu.USBMode.hwcdc.build.usb_mode=1
-dfrobot_lorawan_esp32s3.menu.USBMode.default=USB-OTG (TinyUSB)
-dfrobot_lorawan_esp32s3.menu.USBMode.default.build.usb_mode=0
-
-dfrobot_lorawan_esp32s3.menu.CDCOnBoot.default=Disabled
-dfrobot_lorawan_esp32s3.menu.CDCOnBoot.default.build.cdc_on_boot=0
-dfrobot_lorawan_esp32s3.menu.CDCOnBoot.cdc=Enabled
-dfrobot_lorawan_esp32s3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-
-dfrobot_lorawan_esp32s3.menu.MSCOnBoot.default=Disabled
-dfrobot_lorawan_esp32s3.menu.MSCOnBoot.default.build.msc_on_boot=0
-dfrobot_lorawan_esp32s3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-dfrobot_lorawan_esp32s3.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-dfrobot_lorawan_esp32s3.menu.DFUOnBoot.default=Disabled
-dfrobot_lorawan_esp32s3.menu.DFUOnBoot.default.build.dfu_on_boot=0
-dfrobot_lorawan_esp32s3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-dfrobot_lorawan_esp32s3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-dfrobot_lorawan_esp32s3.menu.UploadMode.default=UART0 / Hardware CDC
-dfrobot_lorawan_esp32s3.menu.UploadMode.default.upload.use_1200bps_touch=false
-dfrobot_lorawan_esp32s3.menu.UploadMode.default.upload.wait_for_upload_port=false
-dfrobot_lorawan_esp32s3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-dfrobot_lorawan_esp32s3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-dfrobot_lorawan_esp32s3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.default.build.partitions=default
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.minimal.build.partitions=minimal
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.no_ota.build.partitions=no_ota
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.huge_app.build.partitions=huge_app
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.rainmaker=RainMaker 4MB
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
-dfrobot_lorawan_esp32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
-
-
-dfrobot_lorawan_esp32s3.menu.CPUFreq.240=240MHz (WiFi)
-dfrobot_lorawan_esp32s3.menu.CPUFreq.240.build.f_cpu=240000000L
-dfrobot_lorawan_esp32s3.menu.CPUFreq.160=160MHz (WiFi)
-dfrobot_lorawan_esp32s3.menu.CPUFreq.160.build.f_cpu=160000000L
-dfrobot_lorawan_esp32s3.menu.CPUFreq.80=80MHz (WiFi)
-dfrobot_lorawan_esp32s3.menu.CPUFreq.80.build.f_cpu=80000000L
-dfrobot_lorawan_esp32s3.menu.CPUFreq.40=40MHz
-dfrobot_lorawan_esp32s3.menu.CPUFreq.40.build.f_cpu=40000000L
-dfrobot_lorawan_esp32s3.menu.CPUFreq.20=20MHz
-dfrobot_lorawan_esp32s3.menu.CPUFreq.20.build.f_cpu=20000000L
-dfrobot_lorawan_esp32s3.menu.CPUFreq.10=10MHz
-dfrobot_lorawan_esp32s3.menu.CPUFreq.10.build.f_cpu=10000000L
-
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.921600=921600
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.921600.upload.speed=921600
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.115200=115200
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.115200.upload.speed=115200
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.256000.windows=256000
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.256000.upload.speed=256000
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.230400.windows.upload.speed=256000
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.230400=230400
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.230400.upload.speed=230400
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.460800.linux=460800
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.460800.macosx=460800
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.460800.upload.speed=460800
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.512000.windows=512000
-dfrobot_lorawan_esp32s3.menu.UploadSpeed.512000.upload.speed=512000
-
-dfrobot_lorawan_esp32s3.menu.DebugLevel.none=None
-dfrobot_lorawan_esp32s3.menu.DebugLevel.none.build.code_debug=0
-dfrobot_lorawan_esp32s3.menu.DebugLevel.error=Error
-dfrobot_lorawan_esp32s3.menu.DebugLevel.error.build.code_debug=1
-dfrobot_lorawan_esp32s3.menu.DebugLevel.warn=Warn
-dfrobot_lorawan_esp32s3.menu.DebugLevel.warn.build.code_debug=2
-dfrobot_lorawan_esp32s3.menu.DebugLevel.info=Info
-dfrobot_lorawan_esp32s3.menu.DebugLevel.info.build.code_debug=3
-dfrobot_lorawan_esp32s3.menu.DebugLevel.debug=Debug
-dfrobot_lorawan_esp32s3.menu.DebugLevel.debug.build.code_debug=4
-dfrobot_lorawan_esp32s3.menu.DebugLevel.verbose=Verbose
-dfrobot_lorawan_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
-
-dfrobot_lorawan_esp32s3.menu.EraseFlash.none=Disabled
-dfrobot_lorawan_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
-dfrobot_lorawan_esp32s3.menu.EraseFlash.all=Enabled
-dfrobot_lorawan_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
-
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.0=REGION_EU868
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.0.build.band=REGION_EU868
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.1=REGION_EU433
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.1.build.band=REGION_EU433
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.2=REGION_CN470
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.2.build.band=REGION_CN470
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.3=REGION_US915
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.3.build.band=REGION_US915
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.4=REGION_AU915
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.4.build.band=REGION_AU915
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.5=REGION_CN779
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.5.build.band=REGION_CN779
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.6=REGION_AS923
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.6.build.band=REGION_AS923
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.7=REGION_KR920
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.7.build.band=REGION_KR920
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.8=REGION_IN865
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.8.build.band=REGION_IN865
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.9=REGION_US915_HYBRID
-dfrobot_lorawan_esp32s3.menu.LORAWAN_REGION.9.build.band=REGION_US915_HYBRID
 
 ##############################################################
 
@@ -17866,140 +17178,6 @@ sparklemotionmini.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 sparklemotionmini.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
 
 ##############################################################
-# Adafruit Sparkle Motion Stick w/ESP32
-
-sparklemotionstick.name=Adafruit Sparkle Motion Stick (ESP32)
-
-sparklemotionstick.bootloader.tool=esptool_py
-sparklemotionstick.bootloader.tool.default=esptool_py
-
-sparklemotionstick.upload.tool=esptool_py
-sparklemotionstick.upload.tool.default=esptool_py
-sparklemotionstick.upload.tool.network=esp_ota
-
-sparklemotionstick.upload.maximum_size=1310720
-sparklemotionstick.upload.maximum_data_size=327680
-sparklemotionstick.upload.flags=
-sparklemotionstick.upload.extra_flags=
-
-sparklemotionstick.serial.disableDTR=true
-sparklemotionstick.serial.disableRTS=true
-
-sparklemotionstick.build.tarch=xtensa
-sparklemotionstick.build.bootloader_addr=0x1000
-sparklemotionstick.build.target=esp32
-sparklemotionstick.build.mcu=esp32
-sparklemotionstick.build.core=esp32
-sparklemotionstick.build.variant=adafruit_sparklemotionstick_esp32
-sparklemotionstick.build.board=SPARKLEMOTIONSTICK_ESP32
-
-sparklemotionstick.build.f_cpu=240000000L
-sparklemotionstick.build.flash_size=4MB
-sparklemotionstick.build.flash_freq=80m
-sparklemotionstick.build.flash_mode=dio
-sparklemotionstick.build.boot=dio
-sparklemotionstick.build.partitions=default
-sparklemotionstick.build.defines=
-sparklemotionstick.build.loop_core=
-sparklemotionstick.build.event_core=
-
-sparklemotionstick.menu.LoopCore.1=Core 1
-sparklemotionstick.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-sparklemotionstick.menu.LoopCore.0=Core 0
-sparklemotionstick.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-sparklemotionstick.menu.EventsCore.1=Core 1
-sparklemotionstick.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-sparklemotionstick.menu.EventsCore.0=Core 0
-sparklemotionstick.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-sparklemotionstick.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-sparklemotionstick.menu.PartitionScheme.default.build.partitions=default
-sparklemotionstick.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-sparklemotionstick.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-sparklemotionstick.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-sparklemotionstick.menu.PartitionScheme.minimal.build.partitions=minimal
-sparklemotionstick.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-sparklemotionstick.menu.PartitionScheme.no_ota.build.partitions=no_ota
-sparklemotionstick.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-sparklemotionstick.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-sparklemotionstick.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-sparklemotionstick.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-sparklemotionstick.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-sparklemotionstick.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-sparklemotionstick.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-sparklemotionstick.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-sparklemotionstick.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-sparklemotionstick.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-sparklemotionstick.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-sparklemotionstick.menu.PartitionScheme.huge_app.build.partitions=huge_app
-sparklemotionstick.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-sparklemotionstick.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-sparklemotionstick.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-sparklemotionstick.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-
-sparklemotionstick.menu.CPUFreq.240=240MHz (WiFi/BT)
-sparklemotionstick.menu.CPUFreq.240.build.f_cpu=240000000L
-sparklemotionstick.menu.CPUFreq.160=160MHz (WiFi/BT)
-sparklemotionstick.menu.CPUFreq.160.build.f_cpu=160000000L
-sparklemotionstick.menu.CPUFreq.80=80MHz (WiFi/BT)
-sparklemotionstick.menu.CPUFreq.80.build.f_cpu=80000000L
-sparklemotionstick.menu.CPUFreq.40=40MHz
-sparklemotionstick.menu.CPUFreq.40.build.f_cpu=40000000L
-sparklemotionstick.menu.CPUFreq.20=20MHz
-sparklemotionstick.menu.CPUFreq.20.build.f_cpu=20000000L
-sparklemotionstick.menu.CPUFreq.10=10MHz
-sparklemotionstick.menu.CPUFreq.10.build.f_cpu=10000000L
-
-sparklemotionstick.menu.FlashFreq.80=80MHz
-sparklemotionstick.menu.FlashFreq.80.build.flash_freq=80m
-sparklemotionstick.menu.FlashFreq.40=40MHz
-sparklemotionstick.menu.FlashFreq.40.build.flash_freq=40m
-
-sparklemotionstick.menu.FlashSize.4M=4MB (32Mb)
-sparklemotionstick.menu.FlashSize.4M.build.flash_size=4MB
-
-sparklemotionstick.menu.UploadSpeed.921600=921600
-sparklemotionstick.menu.UploadSpeed.921600.upload.speed=921600
-sparklemotionstick.menu.UploadSpeed.115200=115200
-sparklemotionstick.menu.UploadSpeed.115200.upload.speed=115200
-sparklemotionstick.menu.UploadSpeed.256000.windows=256000
-sparklemotionstick.menu.UploadSpeed.256000.upload.speed=256000
-sparklemotionstick.menu.UploadSpeed.230400.windows.upload.speed=256000
-sparklemotionstick.menu.UploadSpeed.230400=230400
-sparklemotionstick.menu.UploadSpeed.230400.upload.speed=230400
-sparklemotionstick.menu.UploadSpeed.460800.linux=460800
-sparklemotionstick.menu.UploadSpeed.460800.macosx=460800
-sparklemotionstick.menu.UploadSpeed.460800.upload.speed=460800
-sparklemotionstick.menu.UploadSpeed.512000.windows=512000
-sparklemotionstick.menu.UploadSpeed.512000.upload.speed=512000
-
-sparklemotionstick.menu.DebugLevel.none=None
-sparklemotionstick.menu.DebugLevel.none.build.code_debug=0
-sparklemotionstick.menu.DebugLevel.error=Error
-sparklemotionstick.menu.DebugLevel.error.build.code_debug=1
-sparklemotionstick.menu.DebugLevel.warn=Warn
-sparklemotionstick.menu.DebugLevel.warn.build.code_debug=2
-sparklemotionstick.menu.DebugLevel.info=Info
-sparklemotionstick.menu.DebugLevel.info.build.code_debug=3
-sparklemotionstick.menu.DebugLevel.debug=Debug
-sparklemotionstick.menu.DebugLevel.debug.build.code_debug=4
-sparklemotionstick.menu.DebugLevel.verbose=Verbose
-sparklemotionstick.menu.DebugLevel.verbose.build.code_debug=5
-
-sparklemotionstick.menu.EraseFlash.none=Disabled
-sparklemotionstick.menu.EraseFlash.none.upload.erase_cmd=
-sparklemotionstick.menu.EraseFlash.all=Enabled
-sparklemotionstick.menu.EraseFlash.all.upload.erase_cmd=-e
-
-sparklemotionstick.menu.ZigbeeMode.default=Disabled
-sparklemotionstick.menu.ZigbeeMode.default.build.zigbee_mode=
-sparklemotionstick.menu.ZigbeeMode.default.build.zigbee_libs=
-sparklemotionstick.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
-sparklemotionstick.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
-sparklemotionstick.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
-
-##############################################################
 
 nodemcu-32s.name=NodeMCU-32S
 
@@ -18382,7 +17560,7 @@ nologo_esp32s3_pico.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmake
 nologo_esp32s3_pico.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 nologo_esp32s3_pico.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 nologo_esp32s3_pico.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-nologo_esp32s3_pico.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+nologo_esp32s3_pico.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 nologo_esp32s3_pico.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 nologo_esp32s3_pico.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 nologo_esp32s3_pico.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -19101,7 +18279,7 @@ esp32-poe.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_o
 esp32-poe.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32-poe.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32-poe.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32-poe.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32-poe.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32-poe.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
 esp32-poe.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
 esp32-poe.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
@@ -19244,7 +18422,7 @@ esp32-poe-iso.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 esp32-poe-iso.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32-poe-iso.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32-poe-iso.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32-poe-iso.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32-poe-iso.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32-poe-iso.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
 esp32-poe-iso.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
 esp32-poe-iso.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
@@ -19522,7 +18700,7 @@ esp32s2-devkitlipo.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker
 esp32s2-devkitlipo.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32s2-devkitlipo.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32s2-devkitlipo.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32s2-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32s2-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32s2-devkitlipo.menu.PartitionScheme.custom=Custom
 esp32s2-devkitlipo.menu.PartitionScheme.custom.build.partitions=
 esp32s2-devkitlipo.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -19717,7 +18895,7 @@ esp32s2-devkitlipo-usb.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainm
 esp32s2-devkitlipo-usb.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32s2-devkitlipo-usb.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32s2-devkitlipo-usb.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32s2-devkitlipo-usb.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32s2-devkitlipo-usb.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32s2-devkitlipo-usb.menu.PartitionScheme.custom=Custom
 esp32s2-devkitlipo-usb.menu.PartitionScheme.custom.build.partitions=
 esp32s2-devkitlipo-usb.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -19972,7 +19150,7 @@ esp32s3-devkitlipo.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker
 esp32s3-devkitlipo.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32s3-devkitlipo.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32s3-devkitlipo.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32s3-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32s3-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32s3-devkitlipo.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 esp32s3-devkitlipo.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 esp32s3-devkitlipo.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -20130,7 +19308,7 @@ esp32c3-devkitlipo.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker
 esp32c3-devkitlipo.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32c3-devkitlipo.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32c3-devkitlipo.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32c3-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32c3-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32c3-devkitlipo.menu.PartitionScheme.custom=Custom
 esp32c3-devkitlipo.menu.PartitionScheme.custom.build.partitions=
 esp32c3-devkitlipo.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -20303,7 +19481,7 @@ esp32c6-evb.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no
 esp32c6-evb.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32c6-evb.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32c6-evb.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32c6-evb.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32c6-evb.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32c6-evb.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
 esp32c6-evb.menu.PartitionScheme.zigbee.build.partitions=zigbee
 esp32c6-evb.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
@@ -20486,7 +19664,7 @@ esp32h2-devkitlipo.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=314
 #esp32h2-devkitlipo.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 #esp32h2-devkitlipo.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 #esp32h2-devkitlipo.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-#esp32h2-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+#esp32h2-devkitlipo.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32h2-devkitlipo.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
 esp32h2-devkitlipo.menu.PartitionScheme.zigbee.build.partitions=zigbee
 esp32h2-devkitlipo.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
@@ -20661,7 +19839,7 @@ esp32-sbc-fabgl.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4M
 esp32-sbc-fabgl.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 esp32-sbc-fabgl.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 esp32-sbc-fabgl.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-esp32-sbc-fabgl.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32-sbc-fabgl.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 esp32-sbc-fabgl.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
 esp32-sbc-fabgl.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
 esp32-sbc-fabgl.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
@@ -20904,7 +20082,7 @@ m5stack_core.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_n
 m5stack_core.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_core.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_core.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_core.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_core.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_core.menu.PartitionScheme.custom=Custom
 m5stack_core.menu.PartitionScheme.custom.build.partitions=
 m5stack_core.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -21080,7 +20258,7 @@ m5stack_fire.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_n
 m5stack_fire.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_fire.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_fire.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_fire.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_fire.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_fire.menu.PartitionScheme.custom=Custom
 m5stack_fire.menu.PartitionScheme.custom.build.partitions=
 m5stack_fire.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -21254,7 +20432,7 @@ m5stack_core2.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 m5stack_core2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_core2.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_core2.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_core2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_core2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_core2.menu.PartitionScheme.custom=Custom
 m5stack_core2.menu.PartitionScheme.custom.build.partitions=
 m5stack_core2.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -21428,7 +20606,7 @@ m5stack_tough.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 m5stack_tough.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_tough.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_tough.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_tough.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_tough.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_tough.menu.PartitionScheme.custom=Custom
 m5stack_tough.menu.PartitionScheme.custom.build.partitions=
 m5stack_tough.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -21595,7 +20773,7 @@ m5stack_station.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4M
 m5stack_station.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_station.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_station.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_station.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_station.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_station.menu.PartitionScheme.custom=Custom
 m5stack_station.menu.PartitionScheme.custom.build.partitions=
 m5stack_station.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -22074,7 +21252,7 @@ m5stack_stickc_plus2.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmak
 m5stack_stickc_plus2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_stickc_plus2.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_stickc_plus2.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_stickc_plus2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_stickc_plus2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_stickc_plus2.menu.PartitionScheme.custom=Custom
 m5stack_stickc_plus2.menu.PartitionScheme.custom.build.partitions=
 m5stack_stickc_plus2.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -22481,7 +21659,7 @@ m5stack_atoms3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB
 m5stack_atoms3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_atoms3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_atoms3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_atoms3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_atoms3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_atoms3.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_atoms3.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_atoms3.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -22714,7 +21892,7 @@ m5stack_cores3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB
 m5stack_cores3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_cores3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_cores3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_cores3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_cores3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_cores3.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_cores3.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_cores3.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -23256,7 +22434,7 @@ m5stack_unit_cams3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker
 m5stack_unit_cams3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_unit_cams3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_unit_cams3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_unit_cams3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_unit_cams3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_unit_cams3.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_unit_cams3.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_unit_cams3.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -23553,7 +22731,7 @@ m5stack_paper.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 m5stack_paper.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_paper.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_paper.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_paper.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_paper.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_paper.menu.PartitionScheme.custom=Custom
 m5stack_paper.menu.PartitionScheme.custom.build.partitions=
 m5stack_paper.menu.PartitionScheme.custom.upload.maximum_size=16777216
@@ -24271,7 +23449,7 @@ m5stack_stamp_s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4
 m5stack_stamp_s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_stamp_s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_stamp_s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_stamp_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_stamp_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_stamp_s3.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_stamp_s3.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_stamp_s3.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -24508,7 +23686,7 @@ m5stack_capsule.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4M
 m5stack_capsule.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_capsule.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_capsule.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_capsule.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_capsule.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_capsule.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_capsule.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_capsule.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -24748,7 +23926,7 @@ m5stack_cardputer.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_
 m5stack_cardputer.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_cardputer.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_cardputer.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_cardputer.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_cardputer.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_cardputer.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_cardputer.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_cardputer.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -24985,7 +24163,7 @@ m5stack_dial.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_n
 m5stack_dial.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_dial.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_dial.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_dial.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_dial.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_dial.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_dial.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_dial.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -25222,7 +24400,7 @@ m5stack_dinmeter.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4
 m5stack_dinmeter.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 m5stack_dinmeter.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 m5stack_dinmeter.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-m5stack_dinmeter.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+m5stack_dinmeter.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 m5stack_dinmeter.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 m5stack_dinmeter.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 m5stack_dinmeter.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
@@ -29047,7 +28225,7 @@ bpi_leaf_s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no
 bpi_leaf_s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 bpi_leaf_s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 bpi_leaf_s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-bpi_leaf_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+bpi_leaf_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 bpi_leaf_s3.menu.CPUFreq.240=240MHz (WiFi)
 bpi_leaf_s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -29804,7 +28982,7 @@ fri3d_2024_esp32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker
 fri3d_2024_esp32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 fri3d_2024_esp32s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 fri3d_2024_esp32s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-fri3d_2024_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+fri3d_2024_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 fri3d_2024_esp32s3.menu.CPUFreq.240=240MHz (WiFi)
 fri3d_2024_esp32s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -31571,7 +30749,7 @@ wifiduino32c3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 wifiduino32c3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 wifiduino32c3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 wifiduino32c3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-wifiduino32c3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+wifiduino32c3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 wifiduino32c3.menu.CPUFreq.160=160MHz (WiFi)
 wifiduino32c3.menu.CPUFreq.160.build.f_cpu=160000000L
@@ -31802,7 +30980,7 @@ wifiduino32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 wifiduino32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 wifiduino32s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 wifiduino32s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-wifiduino32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+wifiduino32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 wifiduino32s3.menu.CPUFreq.240=240MHz (WiFi)
 wifiduino32s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -33015,7 +32193,7 @@ kb32.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 kb32.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 kb32.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 kb32.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-kb32.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+kb32.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 kb32.menu.CPUFreq.240=240MHz (WiFi/BT)
 kb32.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -33193,7 +32371,7 @@ deneyapkart.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no
 deneyapkart.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 deneyapkart.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 deneyapkart.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-deneyapkart.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+deneyapkart.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 deneyapkart.menu.CPUFreq.240=240MHz (WiFi/BT)
 deneyapkart.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -33371,7 +32549,7 @@ deneyapkart1A.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 deneyapkart1A.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 deneyapkart1A.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 deneyapkart1A.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-deneyapkart1A.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+deneyapkart1A.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 deneyapkart1A.menu.CPUFreq.240=240MHz (WiFi/BT)
 deneyapkart1A.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -33634,7 +32812,7 @@ deneyapkart1Av2.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4M
 deneyapkart1Av2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 deneyapkart1Av2.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 deneyapkart1Av2.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-deneyapkart1Av2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+deneyapkart1Av2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 deneyapkart1Av2.menu.CPUFreq.240=240MHz (WiFi)
 deneyapkart1Av2.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -33803,7 +32981,7 @@ deneyapmini.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no
 deneyapmini.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 deneyapmini.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 deneyapmini.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-deneyapmini.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+deneyapmini.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 deneyapmini.menu.CPUFreq.240=240MHz (WiFi)
 deneyapmini.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -33993,7 +33171,7 @@ deneyapminiv2.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_
 deneyapminiv2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 deneyapminiv2.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 deneyapminiv2.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-deneyapminiv2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+deneyapminiv2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 deneyapminiv2.menu.CPUFreq.240=240MHz (WiFi)
 deneyapminiv2.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -34162,7 +33340,7 @@ deneyapkartg.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_n
 deneyapkartg.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 deneyapkartg.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 deneyapkartg.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-deneyapkartg.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+deneyapkartg.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 deneyapkartg.menu.CPUFreq.160=160MHz (WiFi)
 deneyapkartg.menu.CPUFreq.160.build.f_cpu=160000000L
@@ -34910,7 +34088,7 @@ tamc_termod_s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB
 tamc_termod_s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 tamc_termod_s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 tamc_termod_s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-tamc_termod_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+tamc_termod_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 tamc_termod_s3.menu.CPUFreq.240=240MHz (WiFi)
 tamc_termod_s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -35608,7 +34786,7 @@ XIAO_ESP32C3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_n
 XIAO_ESP32C3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 XIAO_ESP32C3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 XIAO_ESP32C3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-XIAO_ESP32C3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+XIAO_ESP32C3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 XIAO_ESP32C3.menu.CPUFreq.160=160MHz (WiFi)
 XIAO_ESP32C3.menu.CPUFreq.160.build.f_cpu=160000000L
@@ -37344,7 +36522,7 @@ unphone8.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ot
 unphone8.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 unphone8.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 unphone8.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-unphone8.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+unphone8.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 unphone8.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
 unphone8.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
 
@@ -37500,7 +36678,7 @@ unphone9.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ot
 unphone9.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 unphone9.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 unphone9.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-unphone9.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+unphone9.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 unphone9.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
 unphone9.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
 
@@ -38229,7 +37407,7 @@ VALTRACK_V4_VTS_ESP32_C3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rai
 VALTRACK_V4_VTS_ESP32_C3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 VALTRACK_V4_VTS_ESP32_C3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 VALTRACK_V4_VTS_ESP32_C3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-VALTRACK_V4_VTS_ESP32_C3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+VALTRACK_V4_VTS_ESP32_C3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 VALTRACK_V4_VTS_ESP32_C3.menu.CPUFreq.160=160MHz (WiFi)
 VALTRACK_V4_VTS_ESP32_C3.menu.CPUFreq.160.build.f_cpu=160000000L
@@ -38380,7 +37558,7 @@ VALTRACK_V4_MFW_ESP32_C3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rai
 VALTRACK_V4_MFW_ESP32_C3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 VALTRACK_V4_MFW_ESP32_C3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 VALTRACK_V4_MFW_ESP32_C3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-VALTRACK_V4_MFW_ESP32_C3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+VALTRACK_V4_MFW_ESP32_C3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 VALTRACK_V4_MFW_ESP32_C3.menu.CPUFreq.160=160MHz (WiFi)
 VALTRACK_V4_MFW_ESP32_C3.menu.CPUFreq.160.build.f_cpu=160000000L
@@ -38611,7 +37789,7 @@ Edgebox-ESP-100.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4M
 Edgebox-ESP-100.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 Edgebox-ESP-100.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 Edgebox-ESP-100.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-Edgebox-ESP-100.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+Edgebox-ESP-100.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 Edgebox-ESP-100.menu.CPUFreq.240=240MHz (WiFi)
 Edgebox-ESP-100.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -38981,7 +38159,7 @@ nebulas3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ot
 nebulas3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 nebulas3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 nebulas3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-nebulas3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+nebulas3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 nebulas3.menu.CPUFreq.240=240MHz (WiFi)
 nebulas3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -39207,7 +38385,7 @@ lionbits3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_o
 lionbits3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 lionbits3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 lionbits3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-lionbits3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+lionbits3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 lionbits3.menu.CPUFreq.240=240MHz (WiFi)
 lionbits3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -40505,7 +39683,7 @@ atd147_s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_o
 atd147_s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 atd147_s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 atd147_s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-atd147_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+atd147_s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 atd147_s3.menu.CPUFreq.240=240MHz (WiFi)
 atd147_s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -40688,7 +39866,7 @@ atd35s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
 atd35s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 atd35s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 atd35s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-atd35s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+atd35s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 atd35s3.menu.CPUFreq.240=240MHz (WiFi)
 atd35s3.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -41778,6 +40956,13 @@ Geekble_Nano_ESP32S3.menu.PartitionScheme.custom=Custom
 Geekble_Nano_ESP32S3.menu.PartitionScheme.custom.build.partitions=
 Geekble_Nano_ESP32S3.menu.PartitionScheme.custom.upload.maximum_size=16777216
 
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled=Disabled
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled.build.defines=
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled.build.psram_type=qspi
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled=Enabled
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled.build.psram_type=qspi
+
 Geekble_Nano_ESP32S3.menu.DebugLevel.none=None
 Geekble_Nano_ESP32S3.menu.DebugLevel.none.build.code_debug=0
 Geekble_Nano_ESP32S3.menu.DebugLevel.error=Error
@@ -42317,7 +41502,7 @@ waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker.build.partitions
 waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_lcd_169.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -42516,7 +41701,7 @@ waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.rainmaker.build.partitio
 waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_amoled_18.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -42715,7 +41900,7 @@ waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker.build.partitions=rainm
 waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_lcd_169.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_lcd_169.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_lcd_169.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_lcd_169.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -43228,7 +42413,7 @@ aslcanx2.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ot
 aslcanx2.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 aslcanx2.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 aslcanx2.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-aslcanx2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+aslcanx2.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 
 aslcanx2.menu.CPUFreq.240=240MHz (WiFi)
 aslcanx2.menu.CPUFreq.240.build.f_cpu=240000000L
@@ -43777,8 +42962,8 @@ alfredo-nou3.upload.maximum_size=3342336
 alfredo-nou3.upload.maximum_data_size=327680
 alfredo-nou3.upload.flags=
 alfredo-nou3.upload.extra_flags=
-alfredo-nou3.upload.use_1200bps_touch=true
-alfredo-nou3.upload.wait_for_upload_port=true
+alfredo-nou3.upload.use_1200bps_touch=false
+alfredo-nou3.upload.wait_for_upload_port=false
 
 alfredo-nou3.serial.disableDTR=false
 alfredo-nou3.serial.disableRTS=false
@@ -43791,7 +42976,7 @@ alfredo-nou3.build.core=esp32
 alfredo-nou3.build.variant=alfredo-nou3
 alfredo-nou3.build.board=ALFREDO_NOU3
 
-alfredo-nou3.build.usb_mode=0
+alfredo-nou3.build.usb_mode=1
 alfredo-nou3.build.cdc_on_boot=1
 alfredo-nou3.build.msc_on_boot=0
 alfredo-nou3.build.dfu_on_boot=0
@@ -43818,10 +43003,10 @@ alfredo-nou3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
 alfredo-nou3.menu.EventsCore.0=Core 0
 alfredo-nou3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
-alfredo-nou3.menu.USBMode.default=USB-OTG (TinyUSB)
-alfredo-nou3.menu.USBMode.default.build.usb_mode=0
-alfredo-nou3.menu.USBMode.hwcdc=Hardware CDC and JTAG
-alfredo-nou3.menu.USBMode.hwcdc.build.usb_mode=1
+alfredo-nou3.menu.USBMode.default=Hardware CDC and JTAG
+alfredo-nou3.menu.USBMode.default.build.usb_mode=1
+alfredo-nou3.menu.USBMode.usbotg=USB-OTG (TinyUSB)
+alfredo-nou3.menu.USBMode.usbotg.build.usb_mode=0
 
 alfredo-nou3.menu.CDCOnBoot.cdc=Enabled
 alfredo-nou3.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
@@ -43838,12 +43023,12 @@ alfredo-nou3.menu.DFUOnBoot.default.build.dfu_on_boot=0
 alfredo-nou3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
 alfredo-nou3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
 
-alfredo-nou3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-alfredo-nou3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-alfredo-nou3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 alfredo-nou3.menu.UploadMode.default=UART0 / Hardware CDC
 alfredo-nou3.menu.UploadMode.default.upload.use_1200bps_touch=false
 alfredo-nou3.menu.UploadMode.default.upload.wait_for_upload_port=false
+alfredo-nou3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+alfredo-nou3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+alfredo-nou3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
 
 alfredo-nou3.menu.PartitionScheme.default_8MB=Default (3MB APP/1.5MB SPIFFS)
 alfredo-nou3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
@@ -43923,22 +43108,20 @@ alfredo-nou3.menu.EraseFlash.all=Enabled
 alfredo-nou3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
-codecell.name=CodeCell C3
+codecell.name=CodeCell
+codecell.vid.0=0x303a
+codecell.pid.0=0x1002
+codecell.upload_port.0.vid=0x303a
+codecell.upload_port.0.pid=0x1002
 
 codecell.bootloader.tool=esptool_py
-codecell.bootloader.tool.default=esptool_py
-
 codecell.upload.tool=esptool_py
-codecell.upload.tool.default=esptool_py
-codecell.upload.tool.network=esp_ota
-
-codecell.upload.maximum_size=1310720
+codecell.upload.maximum_size=4194304
 codecell.upload.maximum_data_size=327680
-codecell.upload.flags=
-codecell.upload.extra_flags=
 codecell.upload.use_1200bps_touch=false
 codecell.upload.wait_for_upload_port=false
 
+codecell.upload.speed=921600
 codecell.serial.disableDTR=false
 codecell.serial.disableRTS=false
 
@@ -43947,9 +43130,8 @@ codecell.build.target=esp
 codecell.build.mcu=esp32c3
 codecell.build.core=esp32
 codecell.build.variant=codecell
-codecell.build.board=CODECELLC3
+codecell.build.board=ESP32C3_DEV
 codecell.build.bootloader_addr=0x0
-
 codecell.build.cdc_on_boot=1
 codecell.build.f_cpu=160000000L
 codecell.build.flash_size=4MB
@@ -43957,118 +43139,13 @@ codecell.build.flash_freq=80m
 codecell.build.flash_mode=qio
 codecell.build.boot=qio
 codecell.build.partitions=default
-codecell.build.defines=
-
-
-codecell.menu.JTAGAdapter.default=Disabled
-codecell.menu.JTAGAdapter.default.build.copy_jtag_files=0
-codecell.menu.JTAGAdapter.builtin=Integrated USB JTAG
-codecell.menu.JTAGAdapter.builtin.build.openocdscript=esp32c3-builtin.cfg
-codecell.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
-codecell.menu.JTAGAdapter.external=FTDI Adapter
-codecell.menu.JTAGAdapter.external.build.openocdscript=esp32c3-ftdi.cfg
-codecell.menu.JTAGAdapter.external.build.copy_jtag_files=1
-codecell.menu.JTAGAdapter.bridge=ESP USB Bridge
-codecell.menu.JTAGAdapter.bridge.build.openocdscript=esp32c3-bridge.cfg
-codecell.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
-
-codecell.menu.CDCOnBoot.default=Enabled
-codecell.menu.CDCOnBoot.default.build.cdc_on_boot=0
-codecell.menu.CDCOnBoot.cdc=Enabled
-codecell.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
 
 codecell.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-codecell.menu.PartitionScheme.default.build.partitions=default
-codecell.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-codecell.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-codecell.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-codecell.menu.PartitionScheme.minimal.build.partitions=minimal
-codecell.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
-codecell.menu.PartitionScheme.no_fs.build.partitions=no_fs
-codecell.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
-codecell.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-codecell.menu.PartitionScheme.no_ota.build.partitions=no_ota
-codecell.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-codecell.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-codecell.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-codecell.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-codecell.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-codecell.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-codecell.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-codecell.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-codecell.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-codecell.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-codecell.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-codecell.menu.PartitionScheme.huge_app.build.partitions=huge_app
-codecell.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-codecell.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-codecell.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-codecell.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-codecell.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
-codecell.menu.PartitionScheme.fatflash.build.partitions=ffat
-codecell.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
-codecell.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
-codecell.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
-codecell.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
-codecell.menu.PartitionScheme.rainmaker=RainMaker 4MB
-codecell.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
-codecell.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
-codecell.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
-codecell.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
-codecell.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
-codecell.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
-codecell.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-codecell.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
-codecell.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
-codecell.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
-codecell.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
-codecell.menu.PartitionScheme.zigbee_zczr_8MB=Zigbee ZCZR 8MB with spiffs
-codecell.menu.PartitionScheme.zigbee_zczr_8MB.build.partitions=zigbee_zczr_8MB
-codecell.menu.PartitionScheme.zigbee_zczr_8MB.upload.maximum_size=3407872
-codecell.menu.PartitionScheme.custom=Custom
-codecell.menu.PartitionScheme.custom.build.partitions=
-codecell.menu.PartitionScheme.custom.upload.maximum_size=16777216
-
-codecell.menu.CPUFreq.160=160MHz (WiFi)
-codecell.menu.CPUFreq.160.build.f_cpu=160000000L
-codecell.menu.CPUFreq.80=80MHz (WiFi)
-codecell.menu.CPUFreq.80.build.f_cpu=80000000L
-codecell.menu.CPUFreq.40=40MHz
-codecell.menu.CPUFreq.40.build.f_cpu=40000000L
-codecell.menu.CPUFreq.20=20MHz
-codecell.menu.CPUFreq.20.build.f_cpu=20000000L
-codecell.menu.CPUFreq.10=10MHz
-codecell.menu.CPUFreq.10.build.f_cpu=10000000L
-
+codecell.menu.CPUFreq.160=160MHz
 codecell.menu.FlashMode.qio=QIO
-codecell.menu.FlashMode.qio.build.flash_mode=dio
-codecell.menu.FlashMode.qio.build.boot=qio
-codecell.menu.FlashMode.dio=DIO
-codecell.menu.FlashMode.dio.build.flash_mode=dio
-codecell.menu.FlashMode.dio.build.boot=dio
-
 codecell.menu.FlashFreq.80=80MHz
-codecell.menu.FlashFreq.80.build.flash_freq=80m
-codecell.menu.FlashFreq.40=40MHz
-codecell.menu.FlashFreq.40.build.flash_freq=40m
-
 codecell.menu.FlashSize.4M=4MB (32Mb)
-codecell.menu.FlashSize.4M.build.flash_size=4MB
-
 codecell.menu.UploadSpeed.921600=921600
-codecell.menu.UploadSpeed.921600.upload.speed=921600
-codecell.menu.UploadSpeed.115200=115200
-codecell.menu.UploadSpeed.115200.upload.speed=115200
-codecell.menu.UploadSpeed.256000.windows=256000
-codecell.menu.UploadSpeed.256000.upload.speed=256000
-codecell.menu.UploadSpeed.230400.windows.upload.speed=256000
-codecell.menu.UploadSpeed.230400=230400
-codecell.menu.UploadSpeed.230400.upload.speed=230400
-codecell.menu.UploadSpeed.460800.linux=460800
-codecell.menu.UploadSpeed.460800.macosx=460800
-codecell.menu.UploadSpeed.460800.upload.speed=460800
-codecell.menu.UploadSpeed.512000.windows=512000
-codecell.menu.UploadSpeed.512000.upload.speed=512000
 
 codecell.menu.DebugLevel.none=None
 codecell.menu.DebugLevel.none.build.code_debug=0
@@ -44088,12 +43165,6 @@ codecell.menu.EraseFlash.none.upload.erase_cmd=
 codecell.menu.EraseFlash.all=Enabled
 codecell.menu.EraseFlash.all.upload.erase_cmd=-e
 
-codecell.menu.ZigbeeMode.default=Disabled
-codecell.menu.ZigbeeMode.default.build.zigbee_mode=
-codecell.menu.ZigbeeMode.default.build.zigbee_libs=
-codecell.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
-codecell.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
-codecell.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
 ##############################################################
 
 jczn_2432s028r.name=ESP32-2432S028R CYD
@@ -44395,7 +43466,7 @@ waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.rainmaker.build.partiti
 waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_amoled_241.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -44600,7 +43671,7 @@ waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker.build.partitions=
 waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_lcd_43.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -44799,7 +43870,7 @@ waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker.build.partitions
 waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_lcd_43B.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -45003,7 +44074,7 @@ waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker.build.partitions=r
 waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_lcd_7.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -45202,7 +44273,7 @@ waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker.build.partitions=r
 waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_lcd_5.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -45401,7 +44472,7 @@ waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker.build.partitions=
 waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_lcd_5B.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -45600,7 +44671,7 @@ waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker.build.partitions=r
 waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_lcd_4.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -45808,7 +44879,7 @@ waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.default_8MB.build.partitio
 waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_touch_lcd_185.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -46385,7 +45456,7 @@ waveshare_esp32_s3_lcd_185.menu.PartitionScheme.default_8MB.build.partitions=def
 waveshare_esp32_s3_lcd_185.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_lcd_185.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_lcd_185.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_lcd_185.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_lcd_185.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_lcd_185.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_lcd_185.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_lcd_185.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -46622,7 +45693,7 @@ waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.default_8MB.build.partitio
 waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_touch_lcd_146.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -46859,7 +45930,7 @@ waveshare_esp32_s3_lcd_146.menu.PartitionScheme.default_8MB.build.partitions=def
 waveshare_esp32_s3_lcd_146.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_lcd_146.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_lcd_146.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_lcd_146.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_lcd_146.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_lcd_146.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_lcd_146.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_lcd_146.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -47096,7 +46167,7 @@ waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.default_8MB.build.part
 waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_touch_lcd_185_box.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -47329,7 +46400,7 @@ waveshare_esp32_s3_lcd_147.menu.PartitionScheme.default_8MB.build.partitions=def
 waveshare_esp32_s3_lcd_147.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_lcd_147.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_lcd_147.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_lcd_147.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_lcd_147.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_lcd_147.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_lcd_147.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_lcd_147.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -47566,7 +46637,7 @@ waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.default_8MB.build.partition
 waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_touch_lcd_21.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -47803,7 +46874,7 @@ waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.default_8MB.build.partition
 waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
 waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.default.build.partitions=default
 waveshare_esp32_s3_touch_lcd_28.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
@@ -48037,7 +47108,7 @@ waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.default_8MB.build.partitions=d
 waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
 waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
 waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
 waveshare_esp32_s3_relay_6ch.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
@@ -48277,7 +47348,7 @@ waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.rainmaker.build.partiti
 waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_amoled_164.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -48479,7 +47550,7 @@ waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.rainmaker.build.partiti
 waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_amoled_143.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -48681,7 +47752,7 @@ waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.rainmaker.build.partiti
 waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
 waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
 waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.fatflash.build.partitions=ffat
 waveshare_esp32_s3_touch_amoled_191.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
@@ -49831,216 +48902,6 @@ yb_esp32s3_eth.menu.EraseFlash.all=Enabled
 yb_esp32s3_eth.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
-
-yb_esp32s3_drv.name=YelloByte YB-ESP32-S3-DRV
-
-yb_esp32s3_drv.bootloader.tool=esptool_py
-yb_esp32s3_drv.bootloader.tool.default=esptool_py
-
-yb_esp32s3_drv.upload.tool=esptool_py
-yb_esp32s3_drv.upload.tool.default=esptool_py
-yb_esp32s3_drv.upload.tool.network=esp_ota
-
-yb_esp32s3_drv.upload.maximum_size=1310720
-yb_esp32s3_drv.upload.maximum_data_size=327680
-yb_esp32s3_drv.upload.flags=
-yb_esp32s3_drv.upload.extra_flags=
-yb_esp32s3_drv.upload.use_1200bps_touch=false
-yb_esp32s3_drv.upload.wait_for_upload_port=false
-
-yb_esp32s3_drv.serial.disableDTR=false
-yb_esp32s3_drv.serial.disableRTS=false
-
-yb_esp32s3_drv.build.tarch=xtensa
-yb_esp32s3_drv.build.bootloader_addr=0x0
-yb_esp32s3_drv.build.target=esp32s3
-yb_esp32s3_drv.build.mcu=esp32s3
-yb_esp32s3_drv.build.core=esp32
-yb_esp32s3_drv.build.variant=yb_esp32s3_drv
-yb_esp32s3_drv.build.board=YB_ESP32S3_DRV
-
-yb_esp32s3_drv.build.usb_mode=1
-yb_esp32s3_drv.build.cdc_on_boot=1
-yb_esp32s3_drv.build.msc_on_boot=0
-yb_esp32s3_drv.build.dfu_on_boot=0
-yb_esp32s3_drv.build.f_cpu=240000000L
-yb_esp32s3_drv.build.flash_size=8MB
-yb_esp32s3_drv.build.flash_freq=80m
-yb_esp32s3_drv.build.flash_mode=dio
-yb_esp32s3_drv.build.boot=qio
-yb_esp32s3_drv.build.partitions=default
-yb_esp32s3_drv.build.defines=
-yb_esp32s3_drv.build.loop_core=
-yb_esp32s3_drv.build.event_core=
-yb_esp32s3_drv.build.flash_type=qio
-yb_esp32s3_drv.build.psram_type=qspi
-yb_esp32s3_drv.build.memory_type={build.flash_type}_{build.psram_type}
-
-yb_esp32s3_drv.menu.JTAGAdapter.default=Disabled
-yb_esp32s3_drv.menu.JTAGAdapter.default.build.copy_jtag_files=0
-yb_esp32s3_drv.menu.JTAGAdapter.builtin=Integrated USB JTAG
-yb_esp32s3_drv.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
-yb_esp32s3_drv.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
-yb_esp32s3_drv.menu.JTAGAdapter.external=FTDI Adapter
-yb_esp32s3_drv.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
-yb_esp32s3_drv.menu.JTAGAdapter.external.build.copy_jtag_files=1
-yb_esp32s3_drv.menu.JTAGAdapter.bridge=ESP USB Bridge
-yb_esp32s3_drv.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
-yb_esp32s3_drv.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
-
-yb_esp32s3_drv.menu.LoopCore.1=Core 1
-yb_esp32s3_drv.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-yb_esp32s3_drv.menu.LoopCore.0=Core 0
-yb_esp32s3_drv.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-yb_esp32s3_drv.menu.EventsCore.1=Core 1
-yb_esp32s3_drv.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-yb_esp32s3_drv.menu.EventsCore.0=Core 0
-yb_esp32s3_drv.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-yb_esp32s3_drv.menu.USBMode.hwcdc=Hardware CDC and JTAG
-yb_esp32s3_drv.menu.USBMode.hwcdc.build.usb_mode=1
-yb_esp32s3_drv.menu.USBMode.default=USB-OTG (TinyUSB)
-yb_esp32s3_drv.menu.USBMode.default.build.usb_mode=0
-
-yb_esp32s3_drv.menu.CDCOnBoot.cdc=Enabled
-yb_esp32s3_drv.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
-yb_esp32s3_drv.menu.CDCOnBoot.default=Disabled
-yb_esp32s3_drv.menu.CDCOnBoot.default.build.cdc_on_boot=0
-
-yb_esp32s3_drv.menu.MSCOnBoot.default=Disabled
-yb_esp32s3_drv.menu.MSCOnBoot.default.build.msc_on_boot=0
-yb_esp32s3_drv.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-yb_esp32s3_drv.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-yb_esp32s3_drv.menu.DFUOnBoot.default=Disabled
-yb_esp32s3_drv.menu.DFUOnBoot.default.build.dfu_on_boot=0
-yb_esp32s3_drv.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-yb_esp32s3_drv.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-yb_esp32s3_drv.menu.UploadMode.default=UART0 / Hardware CDC
-yb_esp32s3_drv.menu.UploadMode.default.upload.use_1200bps_touch=false
-yb_esp32s3_drv.menu.UploadMode.default.upload.wait_for_upload_port=false
-yb_esp32s3_drv.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-yb_esp32s3_drv.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-yb_esp32s3_drv.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-
-yb_esp32s3_drv.menu.PSRAM.enabled=QSPI PSRAM
-yb_esp32s3_drv.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
-yb_esp32s3_drv.menu.PSRAM.enabled.build.psram_type=qspi
-yb_esp32s3_drv.menu.PSRAM.disabled=Disabled
-yb_esp32s3_drv.menu.PSRAM.disabled.build.defines=
-yb_esp32s3_drv.menu.PSRAM.disabled.build.psram_type=qspi
-yb_esp32s3_drv.menu.PSRAM.opi=OPI PSRAM
-yb_esp32s3_drv.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
-yb_esp32s3_drv.menu.PSRAM.opi.build.psram_type=opi
-
-yb_esp32s3_drv.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
-yb_esp32s3_drv.menu.PartitionScheme.default.build.partitions=default
-yb_esp32s3_drv.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
-yb_esp32s3_drv.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
-yb_esp32s3_drv.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
-yb_esp32s3_drv.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-yb_esp32s3_drv.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-yb_esp32s3_drv.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-yb_esp32s3_drv.menu.PartitionScheme.minimal.build.partitions=minimal
-yb_esp32s3_drv.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-yb_esp32s3_drv.menu.PartitionScheme.no_ota.build.partitions=no_ota
-yb_esp32s3_drv.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-yb_esp32s3_drv.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-yb_esp32s3_drv.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-yb_esp32s3_drv.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-yb_esp32s3_drv.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-yb_esp32s3_drv.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-yb_esp32s3_drv.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-yb_esp32s3_drv.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-yb_esp32s3_drv.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-yb_esp32s3_drv.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-yb_esp32s3_drv.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-yb_esp32s3_drv.menu.PartitionScheme.huge_app.build.partitions=huge_app
-yb_esp32s3_drv.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-yb_esp32s3_drv.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
-yb_esp32s3_drv.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-yb_esp32s3_drv.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-yb_esp32s3_drv.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
-yb_esp32s3_drv.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
-yb_esp32s3_drv.menu.PartitionScheme.max_app_8MB.upload.maximum_size=8257536
-
-yb_esp32s3_drv.menu.CPUFreq.240=240MHz (WiFi)
-yb_esp32s3_drv.menu.CPUFreq.240.build.f_cpu=240000000L
-yb_esp32s3_drv.menu.CPUFreq.160=160MHz (WiFi)
-yb_esp32s3_drv.menu.CPUFreq.160.build.f_cpu=160000000L
-yb_esp32s3_drv.menu.CPUFreq.80=80MHz (WiFi)
-yb_esp32s3_drv.menu.CPUFreq.80.build.f_cpu=80000000L
-yb_esp32s3_drv.menu.CPUFreq.40=40MHz
-yb_esp32s3_drv.menu.CPUFreq.40.build.f_cpu=40000000L
-yb_esp32s3_drv.menu.CPUFreq.20=20MHz
-yb_esp32s3_drv.menu.CPUFreq.20.build.f_cpu=20000000L
-yb_esp32s3_drv.menu.CPUFreq.10=10MHz
-yb_esp32s3_drv.menu.CPUFreq.10.build.f_cpu=10000000L
-
-yb_esp32s3_drv.menu.FlashMode.qio=QIO 80MHz
-yb_esp32s3_drv.menu.FlashMode.qio.build.flash_mode=dio
-yb_esp32s3_drv.menu.FlashMode.qio.build.boot=qio
-yb_esp32s3_drv.menu.FlashMode.qio.build.boot_freq=80m
-yb_esp32s3_drv.menu.FlashMode.qio.build.flash_freq=80m
-yb_esp32s3_drv.menu.FlashMode.qio120=QIO 120MHz
-yb_esp32s3_drv.menu.FlashMode.qio120.build.flash_mode=dio
-yb_esp32s3_drv.menu.FlashMode.qio120.build.boot=qio
-yb_esp32s3_drv.menu.FlashMode.qio120.build.boot_freq=120m
-yb_esp32s3_drv.menu.FlashMode.qio120.build.flash_freq=80m
-yb_esp32s3_drv.menu.FlashMode.dio=DIO 80MHz
-yb_esp32s3_drv.menu.FlashMode.dio.build.flash_mode=dio
-yb_esp32s3_drv.menu.FlashMode.dio.build.boot=dio
-yb_esp32s3_drv.menu.FlashMode.dio.build.boot_freq=80m
-yb_esp32s3_drv.menu.FlashMode.dio.build.flash_freq=80m
-yb_esp32s3_drv.menu.FlashMode.opi=OPI 80MHz
-yb_esp32s3_drv.menu.FlashMode.opi.build.flash_mode=dout
-yb_esp32s3_drv.menu.FlashMode.opi.build.boot=opi
-yb_esp32s3_drv.menu.FlashMode.opi.build.boot_freq=80m
-yb_esp32s3_drv.menu.FlashMode.opi.build.flash_freq=80m
-
-yb_esp32s3_drv.menu.FlashSize.4M=4MB (32Mb)
-yb_esp32s3_drv.menu.FlashSize.4M.build.flash_size=4MB
-yb_esp32s3_drv.menu.FlashSize.8M=8MB (64Mb)
-yb_esp32s3_drv.menu.FlashSize.8M.build.flash_size=8MB
-yb_esp32s3_drv.menu.FlashSize.16M=16MB (128Mb)
-yb_esp32s3_drv.menu.FlashSize.16M.build.flash_size=16MB
-
-yb_esp32s3_drv.menu.UploadSpeed.921600=921600
-yb_esp32s3_drv.menu.UploadSpeed.921600.upload.speed=921600
-yb_esp32s3_drv.menu.UploadSpeed.115200=115200
-yb_esp32s3_drv.menu.UploadSpeed.115200.upload.speed=115200
-yb_esp32s3_drv.menu.UploadSpeed.256000.windows=256000
-yb_esp32s3_drv.menu.UploadSpeed.256000.upload.speed=256000
-yb_esp32s3_drv.menu.UploadSpeed.230400.windows.upload.speed=256000
-yb_esp32s3_drv.menu.UploadSpeed.230400=230400
-yb_esp32s3_drv.menu.UploadSpeed.230400.upload.speed=230400
-yb_esp32s3_drv.menu.UploadSpeed.460800.linux=460800
-yb_esp32s3_drv.menu.UploadSpeed.460800.macosx=460800
-yb_esp32s3_drv.menu.UploadSpeed.460800.upload.speed=460800
-yb_esp32s3_drv.menu.UploadSpeed.512000.windows=512000
-yb_esp32s3_drv.menu.UploadSpeed.512000.upload.speed=512000
-
-yb_esp32s3_drv.menu.DebugLevel.none=None
-yb_esp32s3_drv.menu.DebugLevel.none.build.code_debug=0
-yb_esp32s3_drv.menu.DebugLevel.error=Error
-yb_esp32s3_drv.menu.DebugLevel.error.build.code_debug=1
-yb_esp32s3_drv.menu.DebugLevel.warn=Warn
-yb_esp32s3_drv.menu.DebugLevel.warn.build.code_debug=2
-yb_esp32s3_drv.menu.DebugLevel.info=Info
-yb_esp32s3_drv.menu.DebugLevel.info.build.code_debug=3
-yb_esp32s3_drv.menu.DebugLevel.debug=Debug
-yb_esp32s3_drv.menu.DebugLevel.debug.build.code_debug=4
-yb_esp32s3_drv.menu.DebugLevel.verbose=Verbose
-yb_esp32s3_drv.menu.DebugLevel.verbose.build.code_debug=5
-
-yb_esp32s3_drv.menu.EraseFlash.none=Disabled
-yb_esp32s3_drv.menu.EraseFlash.none.upload.erase_cmd=
-yb_esp32s3_drv.menu.EraseFlash.all=Enabled
-yb_esp32s3_drv.menu.EraseFlash.all.upload.erase_cmd=-e
-
-##############################################################
 # Huidu HD-WF2 - esp32-s3 HUB75 driver board
 # https://www.hdwell.com/Product/index46.html
 
@@ -50499,7 +49360,7 @@ cyobot_v2_esp32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_
 cyobot_v2_esp32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
 cyobot_v2_esp32s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
 cyobot_v2_esp32s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-cyobot_v2_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+cyobot_v2_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4116480
 cyobot_v2_esp32s3.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
 cyobot_v2_esp32s3.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
 cyobot_v2_esp32s3.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592


### PR DESCRIPTION
fix: Add PSRAM Option for Geekble nano

## Description of Change
we noticed that Geekble nano users need PSRAM option.
So enabled Geekble nano's PSRAM option in board.txt files

## Tests scenarios
Tested under Arduino IDE v2.3.6, Arduino-esp32 core v3.2.0 with Geekble nano

## Related links