### PR TITLE
feat(zigbee): Add method to set/get/report analog output

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_Analog_Input_Output/Zigbee_Analog_Input_Output.ino
+++ b/libraries/Zigbee/examples/Zigbee_Analog_Input_Output/Zigbee_Analog_Input_Output.ino
@@ -26,8 +26,8 @@
  * Modified by Pat Clay
  */
 
-#ifndef ZIGBEE_MODE_ED
-#error "Zigbee end device mode is not selected in Tools->Zigbee mode"
+#ifndef ZIGBEE_MODE_ZCZR
+#error "Zigbee coordinator/router device mode is not selected in Tools->Zigbee mode"
 #endif
 
 #include "Zigbee.h"
@@ -70,6 +70,7 @@ void setup() {
   zbAnalogDevice.addAnalogOutput();
   zbAnalogDevice.setAnalogOutputApplication(ESP_ZB_ZCL_AI_RPM_OTHER);
   zbAnalogDevice.setAnalogOutputDescription("Fan Speed (RPM)");
+  zbAnalogDevice.setAnalogOutputResolution(1);
 
   // If analog output cluster is added, set callback function for analog output change
   zbAnalogDevice.onAnalogOutputChange(onAnalogOutputChange);
@@ -99,8 +100,8 @@ void setup() {
   Zigbee.addEndpoint(&zbAnalogPercent);
 
   Serial.println("Starting Zigbee...");
-  // When all EPs are registered, start Zigbee in End Device mode
-  if (!Zigbee.begin()) {
+  // When all EPs are registered, start Zigbee in Router Device mode
+  if (!Zigbee.begin(ZIGBEE_ROUTER)) {
     Serial.println("Zigbee failed to start!");
     Serial.println("Rebooting...");
     ESP.restart();
@@ -151,6 +152,9 @@ void loop() {
         Zigbee.factoryReset();
       }
     }
+    // For demonstration purposes, increment the analog output value by 100
+    zbAnalogDevice.setAnalogOutput(zbAnalogDevice.getAnalogOutput() + 100);
+    zbAnalogDevice.reportAnalogOutput();
   }
   delay(100);
 }

--- a/libraries/Zigbee/examples/Zigbee_Analog_Input_Output/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Analog_Input_Output/ci.json
@@ -1,7 +1,6 @@
 {
-  "fqbn_append": "PartitionScheme=zigbee,ZigbeeMode=ed",
+  "fqbn_append": "PartitionScheme=zigbee_zczr,ZigbeeMode=zczr",
   "requires": [
-    "CONFIG_SOC_IEEE802154_SUPPORTED=y",
     "CONFIG_ZB_ENABLED=y"
   ]
 }

--- a/libraries/Zigbee/keywords.txt
+++ b/libraries/Zigbee/keywords.txt
@@ -151,6 +151,12 @@ getAnalogOutput	KEYWORD2
 reportAnalogInput	KEYWORD2
 reportAnalogOutput	KEYWORD2
 setAnalogInputReporting	KEYWORD2
+setAnalogInputApplication	KEYWORD2
+setAnalogInputDescription	KEYWORD2
+setAnalogInputResolution	KEYWORD2
+setAnalogOutputApplication	KEYWORD2
+setAnalogOutputDescription	KEYWORD2
+setAnalogOutputResolution	KEYWORD2
 
 # ZigbeeCarbonDioxideSensor
 setCarbonDioxide	KEYWORD2

--- a/libraries/Zigbee/keywords.txt
+++ b/libraries/Zigbee/keywords.txt
@@ -142,13 +142,14 @@ setSensorType	KEYWORD2
 setCarbonDioxide	KEYWORD2
 
 # ZigbeeAnalog
-addAnalogValue	KEYWORD2
 addAnalogInput	KEYWORD2
 addAnalogOutput	KEYWORD2
 onAnalogOutputChange	KEYWORD2
-setAnalogValue	KEYWORD2
 setAnalogInput	KEYWORD2
+setAnalogOutput	KEYWORD2
+getAnalogOutput	KEYWORD2
 reportAnalogInput	KEYWORD2
+reportAnalogOutput	KEYWORD2
 setAnalogInputReporting	KEYWORD2
 
 # ZigbeeCarbonDioxideSensor

--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.h
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.h
@@ -46,11 +46,16 @@ public:
     _on_analog_output_change = callback;
   }
 
-  // Set the analog input value
+  // Set the Analog Input/Output value
   bool setAnalogInput(float analog);
+  bool setAnalogOutput(float analog);
 
-  // Report Analog Input value
+  // Get the Analog Output value
+  float getAnalogOutput() { return _output_state; }
+
+  // Report Analog Input/Output
   bool reportAnalogInput();
+  bool reportAnalogOutput();
 
   // Set reporting for Analog Input
   bool setAnalogInputReporting(uint16_t min_interval, uint16_t max_interval, float delta);
@@ -59,9 +64,10 @@ private:
   void zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message) override;
 
   void (*_on_analog_output_change)(float);
-  void analogOutputChanged(float analog_output);
+  void analogOutputChanged();
 
   uint8_t _analog_clusters;
+  float _output_state;
 };
 
 #endif  // CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.h
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.h
@@ -51,7 +51,9 @@ public:
   bool setAnalogOutput(float analog);
 
   // Get the Analog Output value
-  float getAnalogOutput() { return _output_state; }
+  float getAnalogOutput() {
+    return _output_state;
+  }
 
   // Report Analog Input/Output
   bool reportAnalogInput();


### PR DESCRIPTION
## Description of Change
This pull request introduces updates to the Zigbee library, focusing on enhancing support for analog output functionality. 
New methods added:
```cpp
bool setAnalogOutput(float analog);
float getAnalogOutput();
bool reportAnalogOutput();
```

## Tests scenarios
Tested with ESP32-C6 and the `Zigbee_Analog_Input_Output` example connecting to the HomeAssistant.

## Related links

