### PR TITLE
fix: Add PSRAM Option for Geekble nano

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -41778,6 +41778,13 @@ Geekble_Nano_ESP32S3.menu.PartitionScheme.custom=Custom
 Geekble_Nano_ESP32S3.menu.PartitionScheme.custom.build.partitions=
 Geekble_Nano_ESP32S3.menu.PartitionScheme.custom.upload.maximum_size=16777216
 
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled=Disabled
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled.build.defines=
+Geekble_Nano_ESP32S3.menu.PSRAM.disabled.build.psram_type=qspi
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled=Enabled
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+Geekble_Nano_ESP32S3.menu.PSRAM.enabled.build.psram_type=qspi
+
 Geekble_Nano_ESP32S3.menu.DebugLevel.none=None
 Geekble_Nano_ESP32S3.menu.DebugLevel.none.build.code_debug=0
 Geekble_Nano_ESP32S3.menu.DebugLevel.error=Error


### PR DESCRIPTION
fix: Add PSRAM Option for Geekble nano

Description of Change

we noticed that Geekble nano users need PSRAM option.
So enabled Geekble nano's PSRAM option in board.txt files

Tests scenarios

Tested under Arduino IDE v2.3.6, Arduino-esp32 core v3.2.0 with Geekble nano

Related links