### PR TITLE
feat(zigbee): Update to esp-zigbee-sdk 1.6.5 and fix ci.json files

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -54,12 +54,12 @@ dependencies:
   espressif/esp_modem:
     version: "^1.1.0"
   espressif/esp-zboss-lib:
-    version: "==1.6.3"
+    version: "==1.6.4" # compatible with esp-zigbee-lib 1.6.5
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/esp-zigbee-lib:
-    version: "==1.6.3"
+    version: "==1.6.5"
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"

--- a/libraries/Zigbee/examples/Zigbee_On_Off_MultiSwitch/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_On_Off_MultiSwitch/ci.json
@@ -1,6 +1,6 @@
 {
   "fqbn_append": "PartitionScheme=zigbee_zczr,ZigbeeMode=zczr",
   "requires": [
-    "CONFIG_SOC_IEEE802154_SUPPORTED=y"
+    "CONFIG_ZB_ENABLED=y"
   ]
 }

--- a/libraries/Zigbee/examples/Zigbee_Power_Outlet/Zigbee_Power_Outlet.ino
+++ b/libraries/Zigbee/examples/Zigbee_Power_Outlet/Zigbee_Power_Outlet.ino
@@ -35,10 +35,10 @@
 /* Zigbee power outlet configuration */
 #define ZIGBEE_OUTLET_ENDPOINT 1
 
-#ifdef LED_BUILTIN // Use built-in LED if defined for the board
+#ifdef LED_BUILTIN  // Use built-in LED if defined for the board
 uint8_t led = LED_BUILTIN;
 #else
-uint8_t led = 2; // Use custom LED pin
+uint8_t led = 2;  // Use custom LED pin
 #endif
 
 uint8_t button = BOOT_PIN;

--- a/libraries/Zigbee/examples/Zigbee_Power_Outlet/Zigbee_Power_Outlet.ino
+++ b/libraries/Zigbee/examples/Zigbee_Power_Outlet/Zigbee_Power_Outlet.ino
@@ -34,7 +34,13 @@
 
 /* Zigbee power outlet configuration */
 #define ZIGBEE_OUTLET_ENDPOINT 1
-uint8_t led = RGB_BUILTIN;
+
+#ifdef LED_BUILTIN // Use built-in LED if defined for the board
+uint8_t led = LED_BUILTIN;
+#else
+uint8_t led = 2; // Use custom LED pin
+#endif
+
 uint8_t button = BOOT_PIN;
 
 ZigbeePowerOutlet zbOutlet = ZigbeePowerOutlet(ZIGBEE_OUTLET_ENDPOINT);

--- a/libraries/Zigbee/examples/Zigbee_Power_Outlet/ci.json
+++ b/libraries/Zigbee/examples/Zigbee_Power_Outlet/ci.json
@@ -1,7 +1,6 @@
 {
   "fqbn_append": "PartitionScheme=zigbee_zczr,ZigbeeMode=zczr",
   "requires": [
-    "CONFIG_SOC_IEEE802154_SUPPORTED=y",
     "CONFIG_ZB_ENABLED=y"
   ]
 }


### PR DESCRIPTION
## Description of Change
This pull request includes updates to Zigbee-related dependencies and configuration files to ensure compatibility with newer library versions and streamline build requirements.

### Dependency Updates:
* [`idf_component.yml`](diffhunk://#diff-1c3f4b2cdd6cc6d2fd1051a9943c18b0467e1c9790d979f5515803670e2ee490L57-R62): Updated `espressif/esp-zboss-lib` to version `1.6.4` for compatibility with `esp-zigbee-lib` version `1.6.5`. Updated `espressif/esp-zigbee-lib` to version `1.6.5`. These changes ensure compatibility between Zigbee libraries.

## Tests scenarios
Tested Zigbee compilation on ESP32-C6 and tested Analog example on ESP32-C5, that successfully connects to HA Zigbee network. 

## Related links
