### PR TITLE
fix(ci): Process only needed files in publish sizes

### DIFF
--- a/.github/workflows/publishsizes.yml
+++ b/.github/workflows/publishsizes.yml
@@ -44,16 +44,17 @@ jobs:
           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
           do
             IFS=$'\t' read name url <<< "$artifact"
-            gh api $url > "$name.zip"
-            unzip -j "$name.zip" -d "temp_$name"
-            if [[ "$name" == "pr_number" ]]; then
-              mv "temp_$name"/* sizes-report
-            elif [[ "$name" == "pr_cli"* ]]; then
-              mv "temp_$name"/* sizes-report/pr
-            else
-              mv "temp_$name"/* sizes-report
+            # Only process pr_number and pr_cli_compile artifacts
+            if [[ "$name" == "pr_number" || "$name" =~ ^pr_cli_compile_[0-9]+$ ]]; then
+              gh api $url > "$name.zip"
+              unzip -o -j "$name.zip" -d "temp_$name"
+              if [[ "$name" == "pr_number" ]]; then
+                mv "temp_$name"/* sizes-report
+              elif [[ "$name" =~ ^pr_cli_compile_[0-9]+$ ]]; then
+                mv "temp_$name"/* sizes-report/pr
+              fi
+              rm -r "temp_$name"
             fi
-            rm -r "temp_$name"
           done
           echo "Contents of parent directory:"
           ls -R ..


### PR DESCRIPTION
## Description of Change
This pull request includes a refinement to the artifact processing logic in the `publishsizes.yml` fixing this workflow. The changes ensure that only specific artifacts (`pr_number` and `pr_cli_compile_*`) are processed.

## Tests scenarios

## Related links

