### PR TITLE
feat(zigbee): Support min/max setting for Analog EP

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_Analog_Input_Output/Zigbee_Analog_Input_Output.ino
+++ b/libraries/Zigbee/examples/Zigbee_Analog_Input_Output/Zigbee_Analog_Input_Output.ino
@@ -72,6 +72,9 @@ void setup() {
   zbAnalogDevice.setAnalogOutputDescription("Fan Speed (RPM)");
   zbAnalogDevice.setAnalogOutputResolution(1);
 
+  // Set the min and max values for the analog output which is used by HA to limit the range of the analog output
+  zbAnalogDevice.setAnalogOutputMinMax(-10000, 10000); //-10000 to 10000 RPM
+
   // If analog output cluster is added, set callback function for analog output change
   zbAnalogDevice.onAnalogOutputChange(onAnalogOutputChange);
 

--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
@@ -20,6 +20,8 @@ bool ZigbeeAnalog::addAnalogInput() {
                                "Analog Input";
   uint32_t application_type = 0x00000000 | (ESP_ZB_ZCL_AI_GROUP_ID << 24);
   float resolution = 0.1;  // Default resolution of 0.1
+  float min = -3.402823e+38;  // Default min value for float
+  float max = 3.402823e+38;  // Default max value for float
 
   esp_err_t ret = esp_zb_analog_input_cluster_add_attr(esp_zb_analog_input_cluster, ESP_ZB_ZCL_ATTR_ANALOG_INPUT_DESCRIPTION_ID, (void *)default_description);
   if (ret != ESP_OK) {
@@ -39,11 +41,24 @@ bool ZigbeeAnalog::addAnalogInput() {
     return false;
   }
 
+  ret = esp_zb_analog_input_cluster_add_attr(esp_zb_analog_input_cluster, ESP_ZB_ZCL_ATTR_ANALOG_INPUT_MIN_PRESENT_VALUE_ID, (void *)&min);
+  if (ret != ESP_OK) {
+    log_e("Failed to set min value: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+
+  ret = esp_zb_analog_input_cluster_add_attr(esp_zb_analog_input_cluster, ESP_ZB_ZCL_ATTR_ANALOG_INPUT_MAX_PRESENT_VALUE_ID, (void *)&max);
+  if (ret != ESP_OK) {
+    log_e("Failed to set max value: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+
   ret = esp_zb_cluster_list_add_analog_input_cluster(_cluster_list, esp_zb_analog_input_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
   if (ret != ESP_OK) {
     log_e("Failed to add Analog Input cluster: 0x%x: %s", ret, esp_err_to_name(ret));
     return false;
   }
+
   _analog_clusters |= ANALOG_INPUT;
   return true;
 }
@@ -76,6 +91,8 @@ bool ZigbeeAnalog::addAnalogOutput() {
                                "Analog Output";
   uint32_t application_type = 0x00000000 | (ESP_ZB_ZCL_AO_GROUP_ID << 24);
   float resolution = 1;  // Default resolution of 1
+  float min = -3.402823e+38;  // Default min value for float
+  float max = 3.402823e+38;  // Default max value for float
 
   esp_err_t ret =
     esp_zb_analog_output_cluster_add_attr(esp_zb_analog_output_cluster, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_DESCRIPTION_ID, (void *)default_description);
@@ -95,6 +112,19 @@ bool ZigbeeAnalog::addAnalogOutput() {
     log_e("Failed to add resolution attribute: 0x%x: %s", ret, esp_err_to_name(ret));
     return false;
   }
+
+  ret = esp_zb_analog_output_cluster_add_attr(esp_zb_analog_output_cluster, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_MIN_PRESENT_VALUE_ID, (void *)&min);
+  if (ret != ESP_OK) {
+    log_e("Failed to set min value: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+
+  ret = esp_zb_analog_output_cluster_add_attr(esp_zb_analog_output_cluster, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_MAX_PRESENT_VALUE_ID, (void *)&max);
+  if (ret != ESP_OK) {
+    log_e("Failed to set max value: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+
 
   ret = esp_zb_cluster_list_add_analog_output_cluster(_cluster_list, esp_zb_analog_output_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
   if (ret != ESP_OK) {
@@ -371,6 +401,60 @@ bool ZigbeeAnalog::setAnalogOutputResolution(float resolution) {
   esp_err_t ret = esp_zb_cluster_update_attr(analog_output_cluster, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_RESOLUTION_ID, (void *)&resolution);
   if (ret != ESP_OK) {
     log_e("Failed to set resolution: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+  return true;
+}
+
+bool ZigbeeAnalog::setAnalogOutputMinMax(float min, float max) {
+  if (!(_analog_clusters & ANALOG_OUTPUT)) {
+    log_e("Analog Output cluster not added");
+    return false;
+  }
+
+  esp_zb_attribute_list_t *analog_output_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_ANALOG_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  if (analog_output_cluster == nullptr) {
+    log_e("Failed to get analog output cluster");
+    return false;
+  }
+
+  esp_err_t ret = esp_zb_cluster_update_attr(analog_output_cluster, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_MIN_PRESENT_VALUE_ID, (void *)&min);
+  if (ret != ESP_OK) {
+    log_e("Failed to set min value: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+
+  ret = esp_zb_cluster_update_attr(analog_output_cluster, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_MAX_PRESENT_VALUE_ID, (void *)&max);
+  if (ret != ESP_OK) {
+    log_e("Failed to set max value: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+  return true;
+}
+
+bool ZigbeeAnalog::setAnalogInputMinMax(float min, float max) {
+  if (!(_analog_clusters & ANALOG_INPUT)) {
+    log_e("Analog Input cluster not added");
+    return false;
+  }
+
+  esp_zb_attribute_list_t *analog_input_cluster =
+    esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_ANALOG_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+  if (analog_input_cluster == nullptr) {
+    log_e("Failed to get analog input cluster");
+    return false;
+  }
+
+  esp_err_t ret = esp_zb_cluster_update_attr(analog_input_cluster, ESP_ZB_ZCL_ATTR_ANALOG_INPUT_MIN_PRESENT_VALUE_ID, (void *)&min);
+  if (ret != ESP_OK) {
+    log_e("Failed to set min value: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+
+  ret = esp_zb_cluster_update_attr(analog_input_cluster, ESP_ZB_ZCL_ATTR_ANALOG_INPUT_MAX_PRESENT_VALUE_ID, (void *)&max);
+  if (ret != ESP_OK) {
+    log_e("Failed to set max value: 0x%x: %s", ret, esp_err_to_name(ret));
     return false;
   }
   return true;

--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.h
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.h
@@ -41,6 +41,10 @@ public:
   bool setAnalogOutputDescription(const char *description);
   bool setAnalogOutputResolution(float resolution);
 
+  // Set the min and max values for the analog Input/Output
+  bool setAnalogOutputMinMax(float min, float max);
+  bool setAnalogInputMinMax(float min, float max);
+
   // Use to set a cb function to be called on analog output change
   void onAnalogOutputChange(void (*callback)(float analog)) {
     _on_analog_output_change = callback;


### PR DESCRIPTION
## Description of Change
This pull request introduces enhancements to the Zigbee Analog Input/Output functionality, focusing on adding support for setting minimum and maximum values for analog inputs and outputs. These changes improve configurability and enable better integration with Home Automation (HA) systems.

## Tests scenarios
Tested using the Analog Input Output example and HA on beta version 2025.6.0b5, where the Analog Output range in HA is now limited to min/max value instead of 0-1023.

## Related links
