### PR TITLE
feat(ledc): Improve timer management with frequency/resolution matching

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -56,12 +56,10 @@ static bool find_matching_timer(uint8_t speed_mode, uint32_t freq, uint8_t resol
     peripheral_bus_type_t type = perimanGetPinBusType(i);
     if (type == ESP32_BUS_TYPE_LEDC) {
       ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(i, ESP32_BUS_TYPE_LEDC);
-      if (bus != NULL && (bus->channel / 8) == speed_mode) {
-        if (bus->freq_hz == freq && bus->channel_resolution == resolution) {
-          log_d("Found matching timer %u for freq=%u, resolution=%u", bus->timer_num, freq, resolution);
-          *timer_num = bus->timer_num;
-          return true;
-        }
+      if (bus != NULL && (bus->channel / 8) == speed_mode && bus->freq_hz == freq && bus->channel_resolution == resolution) {
+        log_d("Found matching timer %u for freq=%u, resolution=%u", bus->timer_num, freq, resolution);
+        *timer_num = bus->timer_num;
+        return true;
       }
     }
   }

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -210,7 +210,7 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
   }
 
   uint8_t group = (channel / 8);
-  uint8_t timer;
+  uint8_t timer = 0; 
   bool channel_used = ledc_handle.used_channels & (1UL << channel);
   
   if (channel_used) {

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -45,6 +45,96 @@ typedef struct {
 
 ledc_periph_t ledc_handle = {0};
 
+// Helper function to find a timer with matching frequency and resolution
+static bool find_matching_timer(uint8_t speed_mode, uint32_t freq, uint8_t resolution, uint8_t *timer_num) {
+  log_d("Searching for timer with freq=%u, resolution=%u", freq, resolution);
+  // Check all channels to find one with matching frequency and resolution
+  for (uint8_t i = 0; i < SOC_GPIO_PIN_COUNT; i++) {
+    if (!perimanPinIsValid(i)) {
+      continue;
+    }
+    peripheral_bus_type_t type = perimanGetPinBusType(i);
+    if (type == ESP32_BUS_TYPE_LEDC) {
+      ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(i, ESP32_BUS_TYPE_LEDC);
+      if (bus != NULL && (bus->channel / 8) == speed_mode) {
+        if (bus->freq_hz == freq && bus->channel_resolution == resolution) {
+          log_d("Found matching timer %u for freq=%u, resolution=%u", bus->timer_num, freq, resolution);
+          *timer_num = bus->timer_num;
+          return true;
+        }
+      }
+    }
+  }
+  log_d("No matching timer found for freq=%u, resolution=%u", freq, resolution);
+  return false;
+}
+
+// Helper function to find an unused timer
+static bool find_free_timer(uint8_t speed_mode, uint8_t *timer_num) {
+  // Check which timers are in use
+  uint8_t used_timers = 0;
+  for (uint8_t i = 0; i < SOC_GPIO_PIN_COUNT; i++) {
+    if (!perimanPinIsValid(i)) {
+      continue;
+    }
+    peripheral_bus_type_t type = perimanGetPinBusType(i);
+    if (type == ESP32_BUS_TYPE_LEDC) {
+      ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(i, ESP32_BUS_TYPE_LEDC);
+      if (bus != NULL && (bus->channel / 8) == speed_mode) {
+        log_d("Timer %u is in use by channel %u", bus->timer_num, bus->channel);
+        used_timers |= (1 << bus->timer_num);
+      }
+    }
+  }
+  
+  // Find first unused timer
+  for (uint8_t i = 0; i < SOC_LEDC_TIMER_NUM; i++) {
+    if (!(used_timers & (1 << i))) {
+      log_d("Found free timer %u", i);
+      *timer_num = i;
+      return true;
+    }
+  }
+  log_e("No free timers available");
+  return false;
+}
+
+// Helper function to remove a channel from a timer and clear timer if no channels are using it
+static void remove_channel_from_timer(uint8_t speed_mode, uint8_t timer_num, uint8_t channel) {
+  log_d("Removing channel %u from timer %u in speed_mode %u", channel, timer_num, speed_mode);
+  
+  // Check if any other channels are using this timer
+  bool timer_in_use = false;
+  for (uint8_t i = 0; i < SOC_GPIO_PIN_COUNT; i++) {
+    if (!perimanPinIsValid(i)) {
+      continue;
+    }
+    peripheral_bus_type_t type = perimanGetPinBusType(i);
+    if (type == ESP32_BUS_TYPE_LEDC) {
+      ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(i, ESP32_BUS_TYPE_LEDC);
+      if (bus != NULL && (bus->channel / 8) == speed_mode && 
+          bus->timer_num == timer_num && bus->channel != channel) {
+        log_d("Timer %u is still in use by channel %u", timer_num, bus->channel);
+        timer_in_use = true;
+        break;
+      }
+    }
+  }
+
+  if (!timer_in_use) {
+    log_d("No other channels using timer %u, deconfiguring timer", timer_num);
+    // Stop the timer
+    ledc_timer_pause(speed_mode, timer_num);
+    // Deconfigure the timer
+    ledc_timer_config_t ledc_timer;
+    memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
+    ledc_timer.speed_mode = speed_mode;
+    ledc_timer.timer_num = timer_num;
+    ledc_timer.deconfigure = true;
+    ledc_timer_config(&ledc_timer);
+  }
+}
+
 static bool fade_initialized = false;
 
 static ledc_clk_cfg_t clock_source = LEDC_DEFAULT_CLK;
@@ -81,6 +171,8 @@ static bool ledcDetachBus(void *bus) {
   }
   pinMatrixOutDetach(handle->pin, false, false);
   if (!channel_found) {
+    uint8_t group = (handle->channel / 8);
+    remove_channel_from_timer(group, handle->timer_num, handle->channel % 8);
     ledc_handle.used_channels &= ~(1UL << handle->channel);
   }
   free(handle);
@@ -117,8 +209,10 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
     return false;
   }
 
-  uint8_t group = (channel / 8), timer = ((channel / 2) % 4);
+  uint8_t group = (channel / 8);
+  uint8_t timer;
   bool channel_used = ledc_handle.used_channels & (1UL << channel);
+  
   if (channel_used) {
     log_i("Channel %u is already set up, given frequency and resolution will be ignored", channel);
     if (ledc_set_pin(pin, group, channel % 8) != ESP_OK) {
@@ -126,17 +220,26 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
       return false;
     }
   } else {
-    ledc_timer_config_t ledc_timer;
-    memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
-    ledc_timer.speed_mode = group;
-    ledc_timer.timer_num = timer;
-    ledc_timer.duty_resolution = resolution;
-    ledc_timer.freq_hz = freq;
-    ledc_timer.clk_cfg = clock_source;
+    // Find a timer with matching frequency and resolution, or a free timer
+    if (!find_matching_timer(group, freq, resolution, &timer)) {
+      if (!find_free_timer(group, &timer)) {
+        log_e("No free timers available for speed mode %u", group);
+        return false;
+      }
+      
+      // Configure the timer if we're using a new one
+      ledc_timer_config_t ledc_timer;
+      memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));
+      ledc_timer.speed_mode = group;
+      ledc_timer.timer_num = timer;
+      ledc_timer.duty_resolution = resolution;
+      ledc_timer.freq_hz = freq;
+      ledc_timer.clk_cfg = clock_source;
 
-    if (ledc_timer_config(&ledc_timer) != ESP_OK) {
-      log_e("ledc setup failed!");
-      return false;
+      if (ledc_timer_config(&ledc_timer) != ESP_OK) {
+        log_e("ledc setup failed!");
+        return false;
+      }
     }
 
     uint32_t duty = ledc_get_duty(group, (channel % 8));
@@ -157,6 +260,8 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
   ledc_channel_handle_t *handle = (ledc_channel_handle_t *)malloc(sizeof(ledc_channel_handle_t));
   handle->pin = pin;
   handle->channel = channel;
+  handle->timer_num = timer;
+  handle->freq_hz = freq;
 #ifndef SOC_LEDC_SUPPORT_FADE_STOP
   handle->lock = NULL;
 #endif

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -84,7 +84,7 @@ static bool find_free_timer(uint8_t speed_mode, uint8_t *timer_num) {
       }
     }
   }
-  
+
   // Find first unused timer
   for (uint8_t i = 0; i < SOC_LEDC_TIMER_NUM; i++) {
     if (!(used_timers & (1 << i))) {
@@ -100,7 +100,7 @@ static bool find_free_timer(uint8_t speed_mode, uint8_t *timer_num) {
 // Helper function to remove a channel from a timer and clear timer if no channels are using it
 static void remove_channel_from_timer(uint8_t speed_mode, uint8_t timer_num, uint8_t channel) {
   log_d("Removing channel %u from timer %u in speed_mode %u", channel, timer_num, speed_mode);
-  
+
   // Check if any other channels are using this timer
   bool timer_in_use = false;
   for (uint8_t i = 0; i < SOC_GPIO_PIN_COUNT; i++) {
@@ -110,8 +110,7 @@ static void remove_channel_from_timer(uint8_t speed_mode, uint8_t timer_num, uin
     peripheral_bus_type_t type = perimanGetPinBusType(i);
     if (type == ESP32_BUS_TYPE_LEDC) {
       ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(i, ESP32_BUS_TYPE_LEDC);
-      if (bus != NULL && (bus->channel / 8) == speed_mode && 
-          bus->timer_num == timer_num && bus->channel != channel) {
+      if (bus != NULL && (bus->channel / 8) == speed_mode && bus->timer_num == timer_num && bus->channel != channel) {
         log_d("Timer %u is still in use by channel %u", timer_num, bus->channel);
         timer_in_use = true;
         break;
@@ -208,9 +207,9 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
   }
 
   uint8_t group = (channel / 8);
-  uint8_t timer = 0; 
+  uint8_t timer = 0;
   bool channel_used = ledc_handle.used_channels & (1UL << channel);
-  
+
   if (channel_used) {
     log_i("Channel %u is already set up, given frequency and resolution will be ignored", channel);
     if (ledc_set_pin(pin, group, channel % 8) != ESP_OK) {
@@ -224,7 +223,7 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, uint8_t c
         log_e("No free timers available for speed mode %u", group);
         return false;
       }
-      
+
       // Configure the timer if we're using a new one
       ledc_timer_config_t ledc_timer;
       memset((void *)&ledc_timer, 0, sizeof(ledc_timer_config_t));

--- a/cores/esp32/esp32-hal-ledc.h
+++ b/cores/esp32/esp32-hal-ledc.h
@@ -51,6 +51,8 @@ typedef struct {
   uint8_t pin;                 // Pin assigned to channel
   uint8_t channel;             // Channel number
   uint8_t channel_resolution;  // Resolution of channel
+  uint8_t timer_num;          // Timer number used by this channel
+  uint32_t freq_hz;           // Frequency configured for this channel
   voidFuncPtr fn;
   void *arg;
 #ifndef SOC_LEDC_SUPPORT_FADE_STOP

--- a/cores/esp32/esp32-hal-ledc.h
+++ b/cores/esp32/esp32-hal-ledc.h
@@ -51,8 +51,8 @@ typedef struct {
   uint8_t pin;                 // Pin assigned to channel
   uint8_t channel;             // Channel number
   uint8_t channel_resolution;  // Resolution of channel
-  uint8_t timer_num;          // Timer number used by this channel
-  uint32_t freq_hz;           // Frequency configured for this channel
+  uint8_t timer_num;           // Timer number used by this channel
+  uint32_t freq_hz;            // Frequency configured for this channel
   voidFuncPtr fn;
   void *arg;
 #ifndef SOC_LEDC_SUPPORT_FADE_STOP


### PR DESCRIPTION
## Description of Change
This pull request introduces enhancements to the LEDC (LED Controller) functionality by adding helper functions for timer management, improving channel attachment logic, and extending the `ledc_channel_handle_t` structure. The changes aim to streamline timer allocation and deconfiguration, improve frequency and resolution matching, and provide better resource management.

## Tests scenarios
Tested using customized ledc example on C6 -> 4 LEDC Timers and checked on oscilloscope.

```
int brightness = 0;  // how bright the LED is
int fadeAmount = 5;  // how many points to fade the LED by

void setup() {
  // 2 pins same channel - same timer
  ledcAttachChannel(4, 5000, 8, 0);
  ledcAttachChannel(5, 5000, 8, 0);
  // 3 pins with new timer
  ledcAttach(0, 10000, 10);
  ledcAttach(1, 50000, 8);
  ledcAttach(2, 5000, 10);
  // reused timer that uses pin 0
  ledcAttach(3, 10000, 10);
  // no more free timers
  ledcAttach(6, 8000, 8);
  // detach pin and deconfigure unused timer
  ledcDetach(1);
  // use the new free timer
  ledcAttach(6, 8000, 8);
}

void loop() {
  // set the brightness on LEDC channel 0
  ledcWrite(0, brightness);
  ledcWrite(2, brightness);
  ledcWrite(3, brightness);
  ledcWrite(4, brightness);
  ledcWrite(5, brightness);
  ledcWrite(6, brightness);

  // change the brightness for next time through the loop:
  brightness = brightness + fadeAmount;

  // reverse the direction of the fading at the ends of the fade:
  if (brightness <= 0 || brightness >= 255) {
    fadeAmount = -fadeAmount;
  }
  // wait for 30 milliseconds to see the dimming effect
  delay(30);
}
```

## Related links
Closes #11373 
