### PR TITLE
fix(docs): correct code block indentation in core_compatibility.rst

### DIFF
--- a/docs/en/guides/core_compatibility.rst
+++ b/docs/en/guides/core_compatibility.rst
@@ -9,7 +9,7 @@ Welcome to the compatibility guide for library developers aiming to support mult
 Code Adaptations
 ----------------
 
-To ensure compatibility with both versions of the ESP32 Arduino core, developers should utilize conditional compilation directives in their code. Below is an example of how to conditionally include code based on the ESP32 Arduino core version::
+To ensure compatibility with both versions of the ESP32 Arduino core, developers should utilize conditional compilation directives in their code. Below is an example of how to conditionally include code based on the ESP32 Arduino core version:
 
 .. code-block:: cpp
 
@@ -26,7 +26,7 @@ To ensure compatibility with both versions of the ESP32 Arduino core, developers
 Version Print
 -------------
 
-To easily print the ESP32 Arduino core version at runtime, developers can use the `ESP_ARDUINO_VERSION_STR` macro. Below is an example of how to print the ESP32 Arduino core version::
+To easily print the ESP32 Arduino core version at runtime, developers can use the `ESP_ARDUINO_VERSION_STR` macro. Below is an example of how to print the ESP32 Arduino core version:
 
 .. code-block:: cpp
 

--- a/docs/en/guides/core_compatibility.rst
+++ b/docs/en/guides/core_compatibility.rst
@@ -11,26 +11,26 @@ Code Adaptations
 
 To ensure compatibility with both versions of the ESP32 Arduino core, developers should utilize conditional compilation directives in their code. Below is an example of how to conditionally include code based on the ESP32 Arduino core version::
 
-    .. code-block:: cpp
+.. code-block:: cpp
 
-      #ifdef ESP_ARDUINO_VERSION_MAJOR
-      #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
-          // Code for version 3.x
-      #else
-          // Code for version 2.x
-      #endif
-      #else
-          // Code for version 1.x
-      #endif
+   #ifdef ESP_ARDUINO_VERSION_MAJOR
+   #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+       // Code for version 3.x
+   #else
+       // Code for version 2.x
+   #endif
+   #else
+       // Code for version 1.x
+   #endif
 
 Version Print
 -------------
 
 To easily print the ESP32 Arduino core version at runtime, developers can use the `ESP_ARDUINO_VERSION_STR` macro. Below is an example of how to print the ESP32 Arduino core version::
 
-    .. code-block:: cpp
+.. code-block:: cpp
 
-      Serial.printf(" ESP32 Arduino core version: %s\n", ESP_ARDUINO_VERSION_STR);
+   Serial.printf(" ESP32 Arduino core version: %s\n", ESP_ARDUINO_VERSION_STR);
 
 API Differences
 ---------------


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
https://docs.espressif.com/projects/arduino-esp32/en/latest/guides/core_compatibility.html
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change

This Pull Request fixes indentation issues in the `core_compatibility.rst` documentation file, specifically within `.. code-block:: cpp` sections. These formatting issues previously caused the code blocks to be rendered incorrectly in the generated documentation.

No functionality or logic is changed — this is a documentation-only fix.
