### PR TITLE
fix: Update Pin compatibility

### DIFF
--- a/variants/Geekble_ESP32C3/pins_arduino.h
+++ b/variants/Geekble_ESP32C3/pins_arduino.h
@@ -22,6 +22,13 @@ static const uint8_t MOSI = 6;
 static const uint8_t MISO = 5;
 static const uint8_t SCK = 4;
 
+static const uint8_t D5 = 5;
+static const uint8_t D6 = 6;
+static const uint8_t D7 = 7;
+static const uint8_t D8 = 8;
+static const uint8_t D9 = 9;
+static const uint8_t D10 = 10;
+
 static const uint8_t A0 = 0;
 static const uint8_t A1 = 1;
 static const uint8_t A2 = 2;


### PR DESCRIPTION
fix: Update Pin compatibility

## Description of Change
Generally, ESP32-Arduino Users define there Arduino style pin definition like D1, D2, D3
Geekble nano didn't supported that definition for digital pins
Fixed the compatibility issues

## Tests scenarios
Geekble nano Ver.2.0 board with Arduino IDE 2.3.5, Arduino esp32 core v3.2.0

## Related links
