### PR TITLE
feat(tests): expand GPIO test scenarios

### DIFF
--- a/tests/validation/gpio/diagram.esp32.json
+++ b/tests/validation/gpio/diagram.esp32.json
@@ -13,16 +13,26 @@
     {
       "type": "wokwi-pushbutton",
       "id": "btn1",
-      "top": -13,
-      "left": -19.2,
+      "top": 83,
+      "left": 9.6,
       "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": -39.6,
+      "left": -41.4,
+      "rotate": 90,
+      "attrs": { "color": "red" }
     }
   ],
   "connections": [
     [ "esp32:RX", "$serialMonitor:TX", "", [] ],
     [ "esp32:TX", "$serialMonitor:RX", "", [] ],
     [ "btn1:1.l", "esp32:0", "blue", [ "h-19.2", "v48", "h-38.4" ] ],
-    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ]
+    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ],
+    [ "esp32:GND.2", "led1:C", "black", [ "v0" ] ],
+    [ "esp32:4", "led1:A", "green", [ "h0" ] ]
   ],
   "dependencies": {}
 }

--- a/tests/validation/gpio/diagram.esp32c3.json
+++ b/tests/validation/gpio/diagram.esp32c3.json
@@ -16,13 +16,23 @@
       "top": -22.6,
       "left": -19.2,
       "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": 28,
+      "left": -286.6,
+      "rotate": 270,
+      "attrs": { "color": "red" }
     }
   ],
   "connections": [
     [ "esp32:RX", "$serialMonitor:TX", "", [] ],
     [ "esp32:TX", "$serialMonitor:RX", "", [] ],
     [ "btn1:1.l", "esp32:0", "blue", [ "h-28.8", "v144", "h-144", "v-95.7" ] ],
-    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ]
+    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ],
+    [ "esp32:GND.4", "led1:C", "black", [ "h0" ] ],
+    [ "esp32:4", "led1:A", "green", [ "v0" ] ]
   ],
   "dependencies": {}
 }

--- a/tests/validation/gpio/diagram.esp32c6.json
+++ b/tests/validation/gpio/diagram.esp32c6.json
@@ -16,13 +16,23 @@
       "top": -22.6,
       "left": -19.2,
       "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": 56.8,
+      "left": -286.6,
+      "rotate": 270,
+      "attrs": { "color": "red" }
     }
   ],
   "connections": [
     [ "esp32:RX", "$serialMonitor:TX", "", [] ],
     [ "esp32:TX", "$serialMonitor:RX", "", [] ],
     [ "btn1:1.l", "esp32:0", "blue", [ "h-19.2", "v-96", "h-163.2", "v93.77" ] ],
-    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ]
+    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ],
+    [ "esp32:GND.1", "led1:C", "black", [ "h0" ] ],
+    [ "esp32:4", "led1:A", "green", [ "h0" ] ]
   ],
   "dependencies": {}
 }

--- a/tests/validation/gpio/diagram.esp32h2.json
+++ b/tests/validation/gpio/diagram.esp32h2.json
@@ -16,13 +16,23 @@
       "top": -22.6,
       "left": -19.2,
       "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": -0.8,
+      "left": -267.4,
+      "rotate": 270,
+      "attrs": { "color": "red" }
     }
   ],
   "connections": [
     [ "esp32:RX", "$serialMonitor:TX", "", [] ],
     [ "esp32:TX", "$serialMonitor:RX", "", [] ],
     [ "btn1:1.l", "esp32:0", "blue", [ "h-19.2", "v-96", "h-163.2", "v93.77" ] ],
-    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ]
+    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ],
+    [ "esp32:GND.2", "led1:C", "black", [ "h0" ] ],
+    [ "esp32:4", "led1:A", "green", [ "h-29.14", "v-26.57" ] ]
   ],
   "dependencies": {}
 }

--- a/tests/validation/gpio/diagram.esp32p4.json
+++ b/tests/validation/gpio/diagram.esp32p4.json
@@ -16,13 +16,16 @@
       "top": -128.2,
       "left": -19.2,
       "attrs": { "color": "green", "bounce": "1" }
-    }
+    },
+    { "type": "wokwi-led", "id": "led1", "top": -138, "left": -92.2, "attrs": { "color": "red" } }
   ],
   "connections": [
     [ "esp32:38", "$serialMonitor:TX", "", [] ],
     [ "esp32:37", "$serialMonitor:RX", "", [] ],
     [ "btn1:2.r", "esp32:GND.3", "black", [ "h19.4", "v29" ] ],
-    [ "esp32:0", "btn1:1.l", "blue", [ "h-48", "v-67.2" ] ]
+    [ "esp32:0", "btn1:1.l", "blue", [ "h-48", "v-67.2" ] ],
+    [ "esp32:GND.1", "led1:C", "black", [ "v0" ] ],
+    [ "esp32:4", "led1:A", "green", [ "v-19.2", "h-48" ] ]
   ],
   "dependencies": {}
 }

--- a/tests/validation/gpio/diagram.esp32s2.json
+++ b/tests/validation/gpio/diagram.esp32s2.json
@@ -16,13 +16,23 @@
       "top": -22.6,
       "left": -19.2,
       "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": -0.8,
+      "left": -277,
+      "rotate": 270,
+      "attrs": { "color": "red" }
     }
   ],
   "connections": [
     [ "esp32:RX", "$serialMonitor:TX", "", [] ],
     [ "esp32:TX", "$serialMonitor:RX", "", [] ],
     [ "btn1:1.l", "esp32:0", "blue", [ "h-28.8", "v-57.6", "h-144", "v42.71" ] ],
-    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ]
+    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v173", "h-269.2", "v-98.23" ] ],
+    [ "esp32:GND.1", "led1:C", "black", [ "h-67.47", "v-167.51" ] ],
+    [ "esp32:4", "led1:A", "green", [ "h0" ] ]
   ],
   "dependencies": {}
 }

--- a/tests/validation/gpio/diagram.esp32s3.json
+++ b/tests/validation/gpio/diagram.esp32s3.json
@@ -13,16 +13,26 @@
     {
       "type": "wokwi-pushbutton",
       "id": "btn1",
-      "top": -22.6,
-      "left": -19.2,
+      "top": 83,
+      "left": 9.6,
       "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": 66.4,
+      "left": -257.8,
+      "rotate": 270,
+      "attrs": { "color": "red", "flip": "" }
     }
   ],
   "connections": [
     [ "esp32:RX", "$serialMonitor:TX", "", [] ],
     [ "esp32:TX", "$serialMonitor:RX", "", [] ],
     [ "btn1:1.l", "esp32:0", "blue", [ "h-38.4", "v105.78" ] ],
-    [ "btn1:2.r", "esp32:GND.1", "black", [ "h19.4", "v221", "h-269.2", "v-57.42" ] ]
+    [ "btn1:2.r", "esp32:GND.3", "green", [ "h19.4", "v48.2", "h-144.4", "v0.18" ] ],
+    [ "esp32:4", "led1:A", "green", [ "h0" ] ],
+    [ "esp32:GND.1", "led1:C", "black", [ "h0" ] ]
   ],
   "dependencies": {}
 }

--- a/tests/validation/gpio/gpio.ino
+++ b/tests/validation/gpio/gpio.ino
@@ -1,31 +1,310 @@
 #include <Arduino.h>
 #include <unity.h>
 
-#define BTN 0
 
-void test_button() {
-  Serial.println("Button test");
-  static int count = 0;
-  static int lastState = HIGH;
-  while (count < 3) {
-    int state = digitalRead(BTN);
-    if (state != lastState) {
-      if (state == LOW) {
-        count++;
-        Serial.print("Button pressed ");
-        Serial.print(count);
-        Serial.println(" times");
-      }
-      lastState = state;
-    }
-    delay(10);
+#define BTN 0
+#define LED 4
+
+volatile int interruptCounter = 0;
+volatile bool interruptFlag = false;
+volatile unsigned long lastInterruptTime = 0;
+
+// Variables for interrupt with argument test
+volatile int argInterruptCounter = 0;
+volatile bool argInterruptFlag = false;
+volatile int receivedArg = 0;
+
+void setUp(void) {
+  interruptCounter = 0;
+  interruptFlag = false;
+  lastInterruptTime = 0;
+  argInterruptCounter = 0;
+  argInterruptFlag = false;
+  receivedArg = 0;
+}
+
+void tearDown(void) {
+  detachInterrupt(digitalPinToInterrupt(BTN));
+}
+
+void IRAM_ATTR buttonISR() {
+  unsigned long currentTime = millis();
+  // Simple debouncing - ignore interrupts within 50ms
+  if (currentTime - lastInterruptTime > 50) {
+    interruptCounter = interruptCounter + 1;
+    interruptFlag = true;
+    lastInterruptTime = currentTime;
   }
 }
 
+void IRAM_ATTR buttonISRWithArg(void *arg) {
+  unsigned long currentTime = millis();
+  // Simple debouncing - ignore interrupts within 50ms
+  if (currentTime - lastInterruptTime > 50) {
+    argInterruptCounter = argInterruptCounter + 1;
+    argInterruptFlag = true;
+    receivedArg = *(int*)arg;
+    lastInterruptTime = currentTime;
+  }
+}
+
+void test_interrupt_attach_detach(void) {
+  Serial.println("GPIO interrupt - attach/detach test START");
+
+  pinMode(BTN, INPUT_PULLUP);
+  pinMode(LED, OUTPUT);
+  digitalWrite(LED, LOW);
+
+  // Reset counters
+  interruptCounter = 0;
+  interruptFlag = false;
+
+  // Attach interrupt on falling edge (button press)
+  attachInterrupt(digitalPinToInterrupt(BTN), buttonISR, FALLING);
+  Serial.println("Interrupt attached - FALLING edge");
+
+  // Wait for first button press
+  delay(1000);
+  Serial.println("Press button to trigger interrupt");
+
+  // Wait for interrupt to be triggered
+  unsigned long startTime = millis();
+  while (!interruptFlag && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(interruptFlag);
+  TEST_ASSERT_EQUAL(1, interruptCounter);
+  Serial.println("First interrupt triggered successfully");
+
+  // Reset flag for next test
+  interruptFlag = false;
+
+  // Wait for second button press
+  delay(1000);
+  Serial.println("Press button again to trigger second interrupt");
+
+  startTime = millis();
+  while (!interruptFlag && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(interruptFlag);
+  TEST_ASSERT_EQUAL(2, interruptCounter);
+  Serial.println("Second interrupt triggered successfully");
+
+  // Now detach interrupt
+  detachInterrupt(digitalPinToInterrupt(BTN));
+  Serial.println("Interrupt detached");
+
+  // Reset counters and test that interrupt no longer works
+  interruptCounter = 0;
+  interruptFlag = false;
+
+  delay(1000);
+  Serial.println("Press button - should NOT trigger interrupt");
+
+  // Wait and verify no interrupt occurs
+  delay(3000);
+  TEST_ASSERT_FALSE(interruptFlag);
+  TEST_ASSERT_EQUAL(0, interruptCounter);
+  Serial.println("No interrupt triggered after detach - SUCCESS");
+}
+
+void test_interrupt_rising_falling(void) {
+  Serial.println("GPIO interrupt - rising/falling edge test START");
+
+  pinMode(BTN, INPUT_PULLUP);
+
+  // Test FALLING edge
+  interruptCounter = 0;
+  interruptFlag = false;
+
+  attachInterrupt(digitalPinToInterrupt(BTN), buttonISR, FALLING);
+  Serial.println("Testing FALLING edge interrupt");
+
+  delay(1000);
+  Serial.println("Press button for FALLING edge test");
+
+  unsigned long startTime = millis();
+  while (!interruptFlag && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(interruptFlag);
+  Serial.println("FALLING edge interrupt worked");
+
+  detachInterrupt(digitalPinToInterrupt(BTN));
+
+  // Test RISING edge
+  interruptCounter = 0;
+  interruptFlag = false;
+
+  attachInterrupt(digitalPinToInterrupt(BTN), buttonISR, RISING);
+  Serial.println("Testing RISING edge interrupt");
+
+  delay(1000);
+  Serial.println("Release button for RISING edge test");
+
+  startTime = millis();
+  while (!interruptFlag && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(interruptFlag);
+  Serial.println("RISING edge interrupt worked");
+
+  detachInterrupt(digitalPinToInterrupt(BTN));
+}
+
+void test_interrupt_change(void) {
+  Serial.println("GPIO interrupt - CHANGE edge test START");
+
+  pinMode(BTN, INPUT_PULLUP);
+
+  interruptCounter = 0;
+  interruptFlag = false;
+
+  attachInterrupt(digitalPinToInterrupt(BTN), buttonISR, CHANGE);
+  Serial.println("Testing CHANGE edge interrupt");
+
+  delay(1000);
+  Serial.println("Press and release button for CHANGE test");
+
+  // Wait for button press (falling edge)
+  unsigned long startTime = millis();
+  while (interruptCounter < 1 && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_GREATER_OR_EQUAL(1, interruptCounter);
+  Serial.println("Button press detected");
+
+  // Wait for button release (rising edge)
+  startTime = millis();
+  while (interruptCounter < 2 && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_GREATER_OR_EQUAL(2, interruptCounter);
+  Serial.println("Button release detected - CHANGE interrupt worked");
+
+  detachInterrupt(digitalPinToInterrupt(BTN));
+}
+
+void test_interrupt_with_arg(void) {
+  Serial.println("GPIO interrupt - attachInterruptArg test START");
+
+  pinMode(BTN, INPUT_PULLUP);
+
+  // Test data to pass to interrupt
+  int testArg = 42;
+
+  // Reset counters
+  argInterruptCounter = 0;
+  argInterruptFlag = false;
+  receivedArg = 0;
+
+  // Attach interrupt with argument on falling edge (button press)
+  attachInterruptArg(digitalPinToInterrupt(BTN), buttonISRWithArg, &testArg, FALLING);
+  Serial.println("Interrupt with argument attached - FALLING edge");
+
+  delay(1000);
+  Serial.println("Press button to trigger interrupt with argument");
+
+  // Wait for interrupt to be triggered
+  unsigned long startTime = millis();
+  while (!argInterruptFlag && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(argInterruptFlag);
+  TEST_ASSERT_EQUAL(1, argInterruptCounter);
+  TEST_ASSERT_EQUAL(42, receivedArg);
+  Serial.println("Interrupt with argument triggered successfully");
+  Serial.print("Received argument value: ");
+  Serial.println(receivedArg);
+
+  // Test with different argument value
+  argInterruptFlag = false;
+  int newTestArg = 123;
+
+  // Detach and reattach with new argument
+  detachInterrupt(digitalPinToInterrupt(BTN));
+  attachInterruptArg(digitalPinToInterrupt(BTN), buttonISRWithArg, &newTestArg, FALLING);
+  Serial.println("Interrupt reattached with new argument value");
+
+  delay(1000);
+  Serial.println("Press button again to test new argument");
+
+  startTime = millis();
+  while (!argInterruptFlag && (millis() - startTime < 5000)) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(argInterruptFlag);
+  TEST_ASSERT_EQUAL(2, argInterruptCounter);
+  TEST_ASSERT_EQUAL(123, receivedArg);
+  Serial.println("Second interrupt with new argument triggered successfully");
+  Serial.print("New received argument value: ");
+  Serial.println(receivedArg);
+
+  detachInterrupt(digitalPinToInterrupt(BTN));
+  Serial.println("Interrupt with argument test completed");
+}
+
+
+void test_read_basic(void) {
+  pinMode(BTN, INPUT_PULLUP);
+  TEST_ASSERT_EQUAL(HIGH, digitalRead(BTN));
+  Serial.println("BTN read as HIGH after pinMode INPUT_PULLUP");
+
+  delay(1000);
+  TEST_ASSERT_EQUAL(LOW, digitalRead(BTN));
+  Serial.println("BTN read as LOW");
+
+  delay(1000);
+  TEST_ASSERT_EQUAL(HIGH, digitalRead(BTN));
+  Serial.println("BTN read as HIGH");
+}
+
+void test_write_basic(void) {
+  Serial.println("GPIO write - basic START");
+  pinMode(LED, OUTPUT);
+  delay(1000);
+  Serial.println("GPIO LED set to OUTPUT");
+  delay(2000);
+
+  digitalWrite(LED, HIGH);
+  delay(1000);
+  Serial.println("LED set to HIGH");
+
+  delay(3000);
+  digitalWrite(LED, LOW);
+  Serial.println("LED set to LOW");
+}
+
+
 void setup() {
   Serial.begin(115200);
-  pinMode(BTN, INPUT_PULLUP);
-  test_button();
+  while (!Serial) {}
+
+  UNITY_BEGIN();
+
+  Serial.println("GPIO interrupt test START");
+  RUN_TEST(test_interrupt_attach_detach);
+  RUN_TEST(test_interrupt_rising_falling);
+  RUN_TEST(test_interrupt_change);
+  RUN_TEST(test_interrupt_with_arg);
+  Serial.println("GPIO interrupt test END");
+
+  Serial.println("GPIO basic test START");
+  RUN_TEST(test_read_basic);
+  RUN_TEST(test_write_basic);
+  Serial.println("GPIO basic test END");
+
+  UNITY_END();
+  Serial.println("GPIO test END");
 }
 
 void loop() {}

--- a/tests/validation/gpio/scenario.yaml
+++ b/tests/validation/gpio/scenario.yaml
@@ -1,40 +1,197 @@
-name: Pushbutton counter test
+name: GPIO pheripheral test
 version: 1
-author: Jan Prochazka (jan.prochazka@espressif.com)
+author: Jan Prochazka (jan.prochazka@espressif.com) + Jakub Andrysek (jakub.andrysek@espressif.com)
 
 steps:
-  - wait-serial: "Button test"
+  ##########################################################
+  #### GPIO interrupt test
+  ##########################################################
 
-  # Need for 1s delay for scenario to run properly
-  - delay: 5000ms
+  - wait-serial: "GPIO interrupt test START"
+  #### GPIO interrupt - attach/detach test
+  - wait-serial: "GPIO interrupt - attach/detach test START"
+  - wait-serial: "Interrupt attached - FALLING edge"
+  - wait-serial: "Press button to trigger interrupt"
 
-  # Press once
+  # Simulate button press (falling edge)
   - set-control:
       part-id: btn1
       control: pressed
       value: 1
-  - delay: 2000ms
+
+  - wait-serial: "First interrupt triggered successfully"
+  - wait-serial: "Press button again to trigger second interrupt"
+
+  # Simulate button release and press again
   - set-control:
       part-id: btn1
       control: pressed
       value: 0
-  - delay: 3000ms
-
-  # Press 2nd time
+  - delay: 100ms
   - set-control:
       part-id: btn1
       control: pressed
       value: 1
-  - delay: 2000ms
+
+  - wait-serial: "Second interrupt triggered successfully"
+  - wait-serial: "Interrupt detached"
+  - wait-serial: "Press button - should NOT trigger interrupt"
+
+  # Try to trigger interrupt after detach - should not work
   - set-control:
       part-id: btn1
       control: pressed
       value: 0
-  - delay: 3000ms
-
-  # Press for the 3rd time
+  - delay: 100ms
   - set-control:
       part-id: btn1
       control: pressed
       value: 1
-  - wait-serial: "Button pressed 3 times"
+
+  - wait-serial: "No interrupt triggered after detach - SUCCESS"
+
+  #### GPIO interrupt - rising/falling edge test
+  - wait-serial: "GPIO interrupt - rising/falling edge test START"
+  - wait-serial: "Testing FALLING edge interrupt"
+  - wait-serial: "Press button for FALLING edge test"
+
+  # Ensure button starts unpressed, wait a bit, then press it (falling edge)
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 0
+  - delay: 200ms
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 1
+
+  - wait-serial: "FALLING edge interrupt worked"
+  - wait-serial: "Testing RISING edge interrupt"
+  - wait-serial: "Release button for RISING edge test"
+
+  # Test rising edge (release button) - button should already be pressed from previous test
+  - delay: 200ms
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 0
+
+  - wait-serial: "RISING edge interrupt worked"
+
+  #### GPIO interrupt - CHANGE edge test
+  - wait-serial: "GPIO interrupt - CHANGE edge test START"
+  - wait-serial: "Testing CHANGE edge interrupt"
+  - wait-serial: "Press and release button for CHANGE test"
+
+  # Ensure button starts unpressed, then press it (falling edge - first change)
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 0
+  - delay: 100ms
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 1
+
+  - wait-serial: "Button press detected"
+
+  # Release button (rising edge - second change)
+  - delay: 100ms
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 0
+
+  - wait-serial: "Button release detected - CHANGE interrupt worked"
+
+  #### GPIO interrupt - attachInterruptArg test
+  - wait-serial: "GPIO interrupt - attachInterruptArg test START"
+  - wait-serial: "Interrupt with argument attached - FALLING edge"
+  - wait-serial: "Press button to trigger interrupt with argument"
+
+  # Ensure button starts unpressed, then press it to trigger interrupt with argument
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 0
+  - delay: 100ms
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 1
+
+  - wait-serial: "Interrupt with argument triggered successfully"
+  - wait-serial: "Received argument value: 42"
+  - wait-serial: "Interrupt reattached with new argument value"
+  - wait-serial: "Press button again to test new argument"
+
+  # Press button again to test new argument value
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 0
+  - delay: 100ms
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 1
+
+  - wait-serial: "Second interrupt with new argument triggered successfully"
+  - wait-serial: "New received argument value: 123"
+  - wait-serial: "Interrupt with argument test completed"
+
+  #### GPIO interrupt test end
+  - wait-serial: "GPIO interrupt test END"
+
+
+  ##########################################################
+  #### GPIO basic test
+  ##########################################################
+
+  #### GPIO read - basic test
+  - wait-serial: "GPIO basic test START"
+
+  - wait-serial: "BTN read as HIGH after pinMode INPUT_PULLUP"
+
+  # Set the button to HIGH
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 1
+
+  - wait-serial: "BTN read as LOW"
+
+  # Set the button to LOW
+  - set-control:
+      part-id: btn1
+      control: pressed
+      value: 0
+  - wait-serial: "BTN read as HIGH"
+
+
+
+  #### GPIO write - basic test
+  - wait-serial: "GPIO write - basic START"
+  - wait-serial: "GPIO LED set to OUTPUT"
+  - expect-pin:
+      part-id: led1
+      pin: A # Anode pin
+      value: 0
+
+  - wait-serial: 'LED set to HIGH'
+  - expect-pin:
+      part-id: led1
+      pin: A # Anode pin
+      value: 1
+  - wait-serial: 'LED set to LOW'
+  - expect-pin:
+      part-id: led1
+      pin: A # Anode pin
+      value: 0
+
+  - wait-serial: "GPIO basic test END"
+
+
+  - wait-serial: "GPIO test END"

--- a/tests/validation/gpio/test_gpio.py
+++ b/tests/validation/gpio/test_gpio.py
@@ -2,15 +2,4 @@ import logging
 
 
 def test_gpio(dut):
-    LOGGER = logging.getLogger(__name__)
-
-    dut.expect_exact("Button test")
-
-    LOGGER.info("Expecting button press 1")
-    dut.expect_exact("Button pressed 1 times")
-
-    LOGGER.info("Expecting button press 2")
-    dut.expect_exact("Button pressed 2 times")
-
-    LOGGER.info("Expecting button press 3")
-    dut.expect_exact("Button pressed 3 times")
+    dut.expect_exact("GPIO test END")


### PR DESCRIPTION
# feat(tests): Enhance GPIO validation tests for ESP32

## Description of Change
Updated GPIO validation tests to provide comprehensive testing of ESP32 GPIO interrupt functionality and basic digital I/O operations.


## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v3.2.0 with Wokwi ont all available ESP32 mentioned in the test cases.
Report:
```bash
esp32:   SUCCESS
esp32c3: SUCCESS
esp32c6: SUCCESS
esp32h2: SUCCESS
esp32p4: TEST_FAILED
esp32s2: SUCCESS
esp32s3: SUCCESS
```

Code does  not work on esp32-P4 due the Wokwi issue which is reported and will be ideally fixed soon. 
