### PR TITLE
fix: Delete 8M flash option for xiao_esp32_s3_plus.

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -36051,12 +36051,12 @@ XIAO_ESP32S3_Plus.build.cdc_on_boot=1
 XIAO_ESP32S3_Plus.build.msc_on_boot=0
 XIAO_ESP32S3_Plus.build.dfu_on_boot=0
 XIAO_ESP32S3_Plus.build.f_cpu=240000000L
-XIAO_ESP32S3_Plus.build.flash_size=8MB
+XIAO_ESP32S3_Plus.build.flash_size=16MB
 XIAO_ESP32S3_Plus.build.flash_freq=80m
 XIAO_ESP32S3_Plus.build.flash_mode=dio
 XIAO_ESP32S3_Plus.build.boot=qio
 XIAO_ESP32S3_Plus.build.boot_freq=80m
-XIAO_ESP32S3_Plus.build.partitions=default_8MB
+XIAO_ESP32S3_Plus.build.partitions=ffat
 XIAO_ESP32S3_Plus.build.defines=
 XIAO_ESP32S3_Plus.build.loop_core=
 XIAO_ESP32S3_Plus.build.event_core=
@@ -36093,8 +36093,6 @@ XIAO_ESP32S3_Plus.menu.FlashMode.dio.build.boot=dio
 XIAO_ESP32S3_Plus.menu.FlashMode.dio.build.boot_freq=80m
 XIAO_ESP32S3_Plus.menu.FlashMode.dio.build.flash_freq=80m
 
-XIAO_ESP32S3_Plus.menu.FlashSize.8M=8MB (64Mb)
-XIAO_ESP32S3_Plus.menu.FlashSize.8M.build.flash_size=8MB
 XIAO_ESP32S3_Plus.menu.FlashSize.16M=16MB (128Mb)
 XIAO_ESP32S3_Plus.menu.FlashSize.16M.build.flash_size=16MB
 

--- a/variants/XIAO_ESP32S3_Plus/pins_arduino.h
+++ b/variants/XIAO_ESP32S3_Plus/pins_arduino.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #define USB_VID 0x2886
-#define USB_PID 0x0056
+#define USB_PID 0x0063
 
 static const uint8_t LED_BUILTIN = 21;
 #define BUILTIN_LED LED_BUILTIN  // backward compatibility


### PR DESCRIPTION
Firstly, the xiao_esp32_s3_plus does not support 8M flash. When the 8M flash is selected by default, the PartitionScheme uses the 16M flash configuration by default, which causes program errors.