### PR TITLE
feat(openthread): Add RLOC16 in otPrintNetworkInformation()

### DIFF
--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -335,7 +335,7 @@ void OpenThread::otPrintNetworkInformation(Stream &output) {
 
   output.printf("Role: %s", otGetStringDeviceRole());
   output.println();
-  output.printf("RLOC16: 0x%04x", otThreadGetRloc16(mInstance)); // RLOC16
+  output.printf("RLOC16: 0x%04x", otThreadGetRloc16(mInstance));  // RLOC16
   output.println();
   output.printf("Network Name: %s", otThreadGetNetworkName(mInstance));
   output.println();

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -335,6 +335,8 @@ void OpenThread::otPrintNetworkInformation(Stream &output) {
 
   output.printf("Role: %s", otGetStringDeviceRole());
   output.println();
+  output.printf("RLOC16: 0x%04x", otThreadGetRloc16(mInstance)); // RLOC16
+  output.println();
   output.printf("Network Name: %s", otThreadGetNetworkName(mInstance));
   output.println();
   output.printf("Channel: %d", otLinkGetChannel(mInstance));


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [X] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [X] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Add RLOC16 in otPrintNetworkInformation(). RLOC16, which represents the last 16 bits of the RLOC.
https://openthread.io/guides/thread-primer/ipv6-addressing#how_a_routing_locator_is_generated

## Tests scenarios
Tested with ESP32-C6 DevKit. I got the RLOC16
```
09:19:59.609 -> ==============================================
09:19:59.609 -> Role: Router
09:19:59.609 -> RLOC16: 0x3c00
09:19:59.609 -> Network Name: MyHome
09:19:59.609 -> Channel: 25
09:19:59.609 -> PAN ID: 0x1234
09:19:59.609 -> Extended PAN ID: a748dbb0ecc9****
09:19:59.609 -> Network Key: 7226b9ec8288c183a90c8ee53f******
```

## Related links
Closes #11479 

