### PR TITLE
feat(uart): fixes loopback function after IDF changes

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1399,10 +1399,10 @@ void uart_internal_loopback(uint8_t uartNum, int8_t rxPin) {
     return;
   }
   // forces rxPin to use GPIO Matrix and setup the pin to receive UART TX Signal - IDF 5.4.1 Change with uart_release_pin()
-  gpio_func_sel((gpio_num_t) rxPin, PIN_FUNC_GPIO);
-  gpio_pullup_en((gpio_num_t) rxPin);
-  gpio_input_enable((gpio_num_t) rxPin);
-  esp_rom_gpio_connect_in_signal(rxPin, uart_periph_signal[uartNum].pins[SOC_UART_RX_PIN_IDX].signal, false);  
+  gpio_func_sel((gpio_num_t)rxPin, PIN_FUNC_GPIO);
+  gpio_pullup_en((gpio_num_t)rxPin);
+  gpio_input_enable((gpio_num_t)rxPin);
+  esp_rom_gpio_connect_in_signal(rxPin, uart_periph_signal[uartNum].pins[SOC_UART_RX_PIN_IDX].signal, false);
   esp_rom_gpio_connect_out_signal(rxPin, uart_periph_signal[uartNum].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
 }
 

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -32,6 +32,7 @@
 #include "driver/gpio.h"
 #include "hal/gpio_hal.h"
 #include "esp_rom_gpio.h"
+#include "esp_private/gpio.h"
 
 #include "driver/rtc_io.h"
 #include "driver/lp_io.h"

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1383,10 +1383,10 @@ unsigned long uartDetectBaudrate(uart_t *uart) {
 #endif
 }
 
-///////////////////////////
-// These functions are for testing purpose only and can be used in Arduino Sketches
-// Those are used in the UART examples and CI
-///////////////////////////
+/*
+ * These functions are for testing purposes only and can be used in Arduino Sketches.
+ * They are utilized in the UART examples and CI.
+ */
 
 /*
    This function internally binds defined UARTs TX signal with defined RX pin of any UART (same or different).

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1383,41 +1383,10 @@ unsigned long uartDetectBaudrate(uart_t *uart) {
 #endif
 }
 
-/*
-    These functions are for testing purpose only and can be used in Arduino Sketches
-    Those are used in the UART examples
-*/
-
-/*
-    This is intended to make an internal loopback connection using IOMUX
-    The function uart_internal_loopback() shall be used right after Arduino Serial.begin(...)
-    This code "replaces" the physical wiring for connecting TX <--> RX in a loopback
-
-
-// gets the right TX or RX SIGNAL, based on the UART number from gpio_sig_map.h
-#ifdef CONFIG_IDF_TARGET_ESP32P4
-#define UART_TX_SIGNAL(uartNumber) \
-  (uartNumber == UART_NUM_0        \
-     ? UART0_TXD_PAD_OUT_IDX       \
-     : (uartNumber == UART_NUM_1   \
-          ? UART1_TXD_PAD_OUT_IDX  \
-          : (uartNumber == UART_NUM_2 ? UART2_TXD_PAD_OUT_IDX : (uartNumber == UART_NUM_3 ? UART3_TXD_PAD_OUT_IDX : UART4_TXD_PAD_OUT_IDX))))
-#define UART_RX_SIGNAL(uartNumber) \
-  (uartNumber == UART_NUM_0        \
-     ? UART0_RXD_PAD_IN_IDX        \
-     : (uartNumber == UART_NUM_1   \
-          ? UART1_RXD_PAD_IN_IDX   \
-          : (uartNumber == UART_NUM_2 ? UART2_RXD_PAD_IN_IDX : (uartNumber == UART_NUM_3 ? UART3_RXD_PAD_IN_IDX : UART4_RXD_PAD_IN_IDX))))
-#else
-#if SOC_UART_HP_NUM > 2
-#define UART_TX_SIGNAL(uartNumber) (uartNumber == UART_NUM_0 ? U0TXD_OUT_IDX : (uartNumber == UART_NUM_1 ? U1TXD_OUT_IDX : U2TXD_OUT_IDX))
-#define UART_RX_SIGNAL(uartNumber) (uartNumber == UART_NUM_0 ? U0RXD_IN_IDX : (uartNumber == UART_NUM_1 ? U1RXD_IN_IDX : U2RXD_IN_IDX))
-#else
-#define UART_TX_SIGNAL(uartNumber) (uartNumber == UART_NUM_0 ? U0TXD_OUT_IDX : U1TXD_OUT_IDX)
-#define UART_RX_SIGNAL(uartNumber) (uartNumber == UART_NUM_0 ? U0RXD_IN_IDX : U1RXD_IN_IDX)
-#endif
-#endif  // ifdef CONFIG_IDF_TARGET_ESP32P4
-*/
+///////////////////////////
+// These functions are for testing purpose only and can be used in Arduino Sketches
+// Those are used in the UART examples and CI
+///////////////////////////
 
 /*
    This function internally binds defined UARTs TX signal with defined RX pin of any UART (same or different).


### PR DESCRIPTION
## Description of Change
IDF 5.4.1 has added a new function called uart_release_pin() that is called whenever new pins are set or when uart driver is deleted.

This has a side effect that causes RX pin to never work again with the loopback function. Other changes also have removed some GPIO setup that was necessary for the GPIO loopback mode work.

This PR forces a full RX Pin setup in order to make it work in GPIO Matrix with Loopback TX Signal

## Tests scenarios
CI Only

## Related links
CI error 