### PR TITLE
feat(uart): fixes pin attach for any IDF 5.x

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -308,7 +308,7 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
   assert(upin->iomux_func != -1);
   if (uart_num < SOC_UART_HP_NUM) {
     gpio_iomux_out(io_num, upin->iomux_func, false);
-    // If the pin is input, we also have to redirect the signal, in order to bypasse the GPIO matrix.
+    // If the pin is input, we also have to redirect the signal, in order to bypass the GPIO matrix.
     if (upin->input) {
       gpio_iomux_in(io_num, upin->signal);
     }

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -332,7 +332,7 @@ static esp_err_t _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx
   // if tx and rx share the same IO, both signals need to be routed to IOs through GPIO matrix
   bool tx_rx_same_io = (tx_io_num == rx_io_num);
 
-  /* In the following statements, if the io_num is negative, no need to configure anything. */
+  // In the following statements, if the io_num is negative, no need to configure anything.
   if (tx_io_num >= 0) {
 #if CONFIG_ESP_SLEEP_GPIO_RESET_WORKAROUND || CONFIG_PM_SLP_DISABLE_GPIO
     // In such case, IOs are going to switch to sleep configuration (isolate) when entering sleep for power saving reason

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -304,7 +304,7 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
     return false;
   }
 
-  // Assign the correct funct to the GPIO.
+  // Assign the correct function to the GPIO.
   assert(upin->iomux_func != -1);
   if (uart_num < SOC_UART_HP_NUM) {
     gpio_iomux_out(io_num, upin->iomux_func, false);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -349,7 +349,7 @@ static esp_err_t _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx
       }
 #if SOC_LP_GPIO_MATRIX_SUPPORTED
       else {
-        rtc_gpio_init(tx_io_num); // set as a LP_GPIO pin
+        rtc_gpio_init(tx_io_num);  // set as a LP_GPIO pin
         lp_gpio_connect_out_signal(tx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_TX_PIN_IDX), 0, 0);
         // output enable is set inside lp_gpio_connect_out_signal func after the signal is connected
       }
@@ -368,13 +368,13 @@ static esp_err_t _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx
       if (uart_num < SOC_UART_HP_NUM) {
         gpio_input_enable(rx_io_num);
         esp_rom_gpio_connect_in_signal(rx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), 0);
-       }
+      }
 #if SOC_LP_GPIO_MATRIX_SUPPORTED
       else {
         rtc_gpio_mode_t mode = (tx_rx_same_io ? RTC_GPIO_MODE_INPUT_OUTPUT : RTC_GPIO_MODE_INPUT_ONLY);
         rtc_gpio_set_direction(rx_io_num, mode);
-        if (!tx_rx_same_io) { // set the same pin again as a LP_GPIO will overwrite connected out_signal, not desired, so skip
-          rtc_gpio_init(rx_io_num); // set as a LP_GPIO pin
+        if (!tx_rx_same_io) {        // set the same pin again as a LP_GPIO will overwrite connected out_signal, not desired, so skip
+          rtc_gpio_init(rx_io_num);  // set as a LP_GPIO pin
         }
         lp_gpio_connect_in_signal(rx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), 0);
       }
@@ -390,14 +390,14 @@ static esp_err_t _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx
     }
 #if SOC_LP_GPIO_MATRIX_SUPPORTED
     else {
-      rtc_gpio_init(rts_io_num); // set as a LP_GPIO pin
+      rtc_gpio_init(rts_io_num);  // set as a LP_GPIO pin
       lp_gpio_connect_out_signal(rts_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RTS_PIN_IDX), 0, 0);
       // output enable is set inside lp_gpio_connect_out_signal func after the signal is connected
     }
 #endif
   }
 
-  if (cts_io_num >= 0  && !_uartTrySetIomuxPin(uart_num, cts_io_num, SOC_UART_CTS_PIN_IDX)) {
+  if (cts_io_num >= 0 && !_uartTrySetIomuxPin(uart_num, cts_io_num, SOC_UART_CTS_PIN_IDX)) {
     if (uart_num < SOC_UART_HP_NUM) {
       gpio_pullup_en(cts_io_num);
       gpio_input_enable(cts_io_num);
@@ -406,7 +406,7 @@ static esp_err_t _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx
 #if SOC_LP_GPIO_MATRIX_SUPPORTED
     else {
       rtc_gpio_set_direction(cts_io_num, RTC_GPIO_MODE_INPUT_ONLY);
-      rtc_gpio_init(cts_io_num); // set as a LP_GPIO pin
+      rtc_gpio_init(cts_io_num);  // set as a LP_GPIO pin
       lp_gpio_connect_in_signal(cts_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_CTS_PIN_IDX), 0);
     }
 #endif
@@ -1517,7 +1517,7 @@ void uart_internal_loopback(uint8_t uartNum, int8_t rxPin) {
     log_e("UART%d is not supported for loopback or RX pin %d is invalid.", uartNum, rxPin);
     return;
   }
-#if 0 // leave this code here for future reference and need
+#if 0  // leave this code here for future reference and need
   // forces rxPin to use GPIO Matrix and setup the pin to receive UART TX Signal - IDF 5.4.1 Change with uart_release_pin()
   gpio_func_sel((gpio_num_t)rxPin, PIN_FUNC_GPIO);
   gpio_pullup_en((gpio_num_t)rxPin);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -329,7 +329,7 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
 
 static esp_err_t _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx_io_num, int rts_io_num, int cts_io_num) {
   // Since an IO cannot route peripheral signals via IOMUX and GPIO matrix at the same time,
-  // if tx and rx share the same IO, both signals need to be route to IOs through GPIO matrix
+  // if tx and rx share the same IO, both signals need to be routed to IOs through GPIO matrix
   bool tx_rx_same_io = (tx_io_num == rx_io_num);
 
   /* In the following statements, if the io_num is negative, no need to configure anything. */


### PR DESCRIPTION
## Description of Change

This PR fixes the effect of the IDF 5.4  commit https://github.com/espressif/esp-idf/commit/60f5828a4a790d4481aaf7c69eac72e3af1079fe that breaks any Arduino sketch that fails reading UART
 
Nothing is printed into Serial Monitor, event when data is sent.

Sketch
``` cpp
void setup() {
  Serial.begin(115200); // using UART0 - open Serial Monitor to send data to Serial
}

void loop() {
  // just echo back what is sent to Serial
  if (Serial.available()) {
    Serial.write((char) Serial.read());
  }
}
```
## Tests scenarios
Tested using CI and UART test Cases.


## Related links
Closes #11498 