### PR TITLE
Backport for v3.1.x: feat(uart): fixes pin attach for any IDF 5.x 

### DIFF
--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -57,7 +57,7 @@ void uartWriteBuf(uart_t *uart, const uint8_t *data, size_t len);
 void uartFlush(uart_t *uart);
 void uartFlushTxOnly(uart_t *uart, bool txOnly);
 
-void uartSetBaudRate(uart_t *uart, uint32_t baud_rate);
+bool uartSetBaudRate(uart_t *uart, uint32_t baud_rate);
 uint32_t uartGetBaudRate(uart_t *uart);
 
 void uartSetRxInvert(uart_t *uart, bool invert);


### PR DESCRIPTION
Updates Arduino v3.1.x to be compatible and working with latest IDF 5.3.x

Backport of #11499 Tested with Arduino Lib Builder and resulting framework with Tasmot and provided example in #11498