### PR TITLE
fix(uart): idf 5.5 new gpio_iomux_* functions

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1287,11 +1287,11 @@ bool uartSetClockSource(uint8_t uartNum, uart_sclk_t clkSrc) {
 #if SOC_UART_LP_NUM >= 1
   if (uart->num >= SOC_UART_HP_NUM) {
     switch (clkSrc) {
-      case UART_SCLK_XTAL:    uart->_uart_clock_source = LP_UART_SCLK_XTAL_D2; break;
+      case UART_SCLK_XTAL: uart->_uart_clock_source = LP_UART_SCLK_XTAL_D2; break;
 #if CONFIG_IDF_TARGET_ESP32C5
-      case UART_SCLK_RTC:     uart->_uart_clock_source = LP_UART_SCLK_RC_FAST; break;
+      case UART_SCLK_RTC: uart->_uart_clock_source = LP_UART_SCLK_RC_FAST; break;
 #else
-      case UART_SCLK_RTC:     uart->_uart_clock_source = LP_UART_SCLK_LP_FAST; break;
+      case UART_SCLK_RTC: uart->_uart_clock_source = LP_UART_SCLK_LP_FAST; break;
 #endif
       case UART_SCLK_DEFAULT:
       default:                uart->_uart_clock_source = LP_UART_SCLK_DEFAULT;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -325,15 +325,15 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
     }
   }
 #if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
-    else {
-      if (upin->input) {
-        rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_INPUT_ONLY);
-      } else {
-        rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_OUTPUT_ONLY);
-      }
-      rtc_gpio_init(io_num);
-      rtc_gpio_iomux_func_sel(io_num, upin->iomux_func);
+  else {
+    if (upin->input) {
+      rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_INPUT_ONLY);
+    } else {
+      rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_OUTPUT_ONLY);
     }
+    rtc_gpio_init(io_num);
+    rtc_gpio_iomux_func_sel(io_num, upin->iomux_func);
+  }
 #endif
   return true;
 }

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -316,7 +316,7 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
     return false;
   }
 
-    // Assign the correct function to the GPIO.
+  // Assign the correct function to the GPIO.
   assert(upin->iomux_func != -1);
   if (uart_num < SOC_UART_HP_NUM) {
     if (upin->input) {

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -319,11 +319,19 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
   // Assign the correct function to the GPIO.
   assert(upin->iomux_func != -1);
   if (uart_num < SOC_UART_HP_NUM) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
     if (upin->input) {
       gpio_iomux_input(io_num, upin->iomux_func, upin->signal);
     } else {
       gpio_iomux_output(io_num, upin->iomux_func);
     }
+#else
+    gpio_iomux_out(io_num, upin->iomux_func, false);
+    // If the pin is input, we also have to redirect the signal, in order to bypass the GPIO matrix.
+    if (upin->input) {
+      gpio_iomux_in(io_num, upin->signal);
+    }
+#endif
   }
 #if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
   else {

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -315,26 +315,25 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
   if (upin->iomux_func == -1 || upin->default_gpio == -1 || upin->default_gpio != io_num) {
     return false;
   }
-
   // Assign the correct function to the GPIO.
   assert(upin->iomux_func != -1);
   if (uart_num < SOC_UART_HP_NUM) {
-    gpio_iomux_out(io_num, upin->iomux_func, false);
-    // If the pin is input, we also have to redirect the signal, in order to bypass the GPIO matrix.
     if (upin->input) {
-      gpio_iomux_in(io_num, upin->signal);
+      gpio_iomux_input(io_num, upin->iomux_func, upin->signal);
+    } else {
+      gpio_iomux_output(io_num, upin->iomux_func);
     }
   }
 #if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
-  else {
-    if (upin->input) {
-      rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_INPUT_ONLY);
-    } else {
-      rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_OUTPUT_ONLY);
+    else {
+        if (upin->input) {
+            rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_INPUT_ONLY);
+        } else {
+            rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_OUTPUT_ONLY);
+        }
+        rtc_gpio_init(io_num);
+        rtc_gpio_iomux_func_sel(io_num, upin->iomux_func);
     }
-    rtc_gpio_init(io_num);
-    rtc_gpio_iomux_func_sel(io_num, upin->iomux_func);
-  }
 #endif
   return true;
 }

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -317,7 +317,10 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
   }
 
   // Assign the correct function to the GPIO.
-  assert(upin->iomux_func != -1);
+  if (upin->iomux_func == -1) {
+    log_e("IO#%d has bad IOMUX internal information. Switching to GPIO Matrix UART function.", io_num);
+    return false;
+  }
   if (uart_num < SOC_UART_HP_NUM) {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
     if (upin->input) {

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -326,13 +326,13 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
   }
 #if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
     else {
-        if (upin->input) {
-            rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_INPUT_ONLY);
-        } else {
-            rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_OUTPUT_ONLY);
-        }
-        rtc_gpio_init(io_num);
-        rtc_gpio_iomux_func_sel(io_num, upin->iomux_func);
+      if (upin->input) {
+        rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_INPUT_ONLY);
+      } else {
+        rtc_gpio_set_direction(io_num, RTC_GPIO_MODE_OUTPUT_ONLY);
+      }
+      rtc_gpio_init(io_num);
+      rtc_gpio_iomux_func_sel(io_num, upin->iomux_func);
     }
 #endif
   return true;

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -315,7 +315,8 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
   if (upin->iomux_func == -1 || upin->default_gpio == -1 || upin->default_gpio != io_num) {
     return false;
   }
-  // Assign the correct function to the GPIO.
+
+    // Assign the correct function to the GPIO.
   assert(upin->iomux_func != -1);
   if (uart_num < SOC_UART_HP_NUM) {
     if (upin->input) {


### PR DESCRIPTION
## Description of Change
IDF 5.5 has deprecated `gpio_iomux_in()` and `gpio_iomux_ou()` functions.
Therefore it is necessary to update the UART `_uartTrySetIomuxPin()` function to follow the new API.


## Tests scenarios
CI Only

## Related links
None - Internal.