### PR TITLE
fix(spi): Correct SPI mapping for ESP32S2

### DIFF
--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -79,16 +79,15 @@ struct spi_struct_t {
 
 #if CONFIG_IDF_TARGET_ESP32S2
 // ESP32S2
-#define SPI_COUNT (3)
+#define SPI_COUNT (2)
 
-#define SPI_CLK_IDX(p)  ((p == 0) ? SPICLK_OUT_MUX_IDX : ((p == 1) ? FSPICLK_OUT_MUX_IDX : ((p == 2) ? SPI3_CLK_OUT_MUX_IDX : 0)))
-#define SPI_MISO_IDX(p) ((p == 0) ? SPIQ_OUT_IDX : ((p == 1) ? FSPIQ_OUT_IDX : ((p == 2) ? SPI3_Q_OUT_IDX : 0)))
-#define SPI_MOSI_IDX(p) ((p == 0) ? SPID_IN_IDX : ((p == 1) ? FSPID_IN_IDX : ((p == 2) ? SPI3_D_IN_IDX : 0)))
+#define SPI_CLK_IDX(p)  ((p == 0) ? FSPICLK_OUT_MUX_IDX : ((p == 1) ? SPI3_CLK_OUT_MUX_IDX : 0))
+#define SPI_MISO_IDX(p) ((p == 0) ? FSPIQ_OUT_IDX : ((p == 1) ? SPI3_Q_OUT_IDX : 0))
+#define SPI_MOSI_IDX(p) ((p == 0) ? FSPID_IN_IDX : ((p == 1) ? SPI3_D_IN_IDX : 0))
 
-#define SPI_SPI_SS_IDX(n)  ((n == 0) ? SPICS0_OUT_IDX : ((n == 1) ? SPICS1_OUT_IDX : 0))
-#define SPI_HSPI_SS_IDX(n) ((n == 0) ? SPI3_CS0_OUT_IDX : ((n == 1) ? SPI3_CS1_OUT_IDX : ((n == 2) ? SPI3_CS2_OUT_IDX : SPI3_CS0_OUT_IDX)))
-#define SPI_FSPI_SS_IDX(n) ((n == 0) ? FSPICS0_OUT_IDX : ((n == 1) ? FSPICS1_OUT_IDX : ((n == 2) ? FSPICS2_OUT_IDX : FSPICS0_OUT_IDX)))
-#define SPI_SS_IDX(p, n)   ((p == 0) ? SPI_SPI_SS_IDX(n) : ((p == 1) ? SPI_SPI_SS_IDX(n) : ((p == 2) ? SPI_HSPI_SS_IDX(n) : 0)))
+#define SPI_HSPI_SS_IDX(n) ((n == 0) ? SPI3_CS0_OUT_IDX : ((n == 1) ? SPI3_CS1_OUT_IDX : ((n == 2) ? SPI3_CS2_OUT_IDX : 0)))
+#define SPI_FSPI_SS_IDX(n) ((n == 0) ? FSPICS0_OUT_IDX : ((n == 1) ? FSPICS1_OUT_IDX : ((n == 2) ? FSPICS2_OUT_IDX : 0)))
+#define SPI_SS_IDX(p, n)   ((p == 0) ? SPI_FSPI_SS_IDX(n) : ((p == 1) ? SPI_HSPI_SS_IDX(n) : 0))
 
 #elif CONFIG_IDF_TARGET_ESP32S3
 // ESP32S3
@@ -98,8 +97,8 @@ struct spi_struct_t {
 #define SPI_MISO_IDX(p) ((p == 0) ? FSPIQ_OUT_IDX : ((p == 1) ? SPI3_Q_OUT_IDX : 0))
 #define SPI_MOSI_IDX(p) ((p == 0) ? FSPID_IN_IDX : ((p == 1) ? SPI3_D_IN_IDX : 0))
 
-#define SPI_HSPI_SS_IDX(n) ((n == 0) ? SPI3_CS0_OUT_IDX : ((n == 1) ? SPI3_CS1_OUT_IDX : 0))
-#define SPI_FSPI_SS_IDX(n) ((n == 0) ? FSPICS0_OUT_IDX : ((n == 1) ? FSPICS1_OUT_IDX : 0))
+#define SPI_HSPI_SS_IDX(n) ((n == 0) ? SPI3_CS0_OUT_IDX : ((n == 1) ? SPI3_CS1_OUT_IDX : ((n == 2) ? SPI3_CS2_OUT_IDX : 0)))
+#define SPI_FSPI_SS_IDX(n) ((n == 0) ? FSPICS0_OUT_IDX : ((n == 1) ? FSPICS1_OUT_IDX : ((n == 2) ? FSPICS2_OUT_IDX : 0)))
 #define SPI_SS_IDX(p, n)   ((p == 0) ? SPI_FSPI_SS_IDX(n) : ((p == 1) ? SPI_HSPI_SS_IDX(n) : 0))
 
 #elif CONFIG_IDF_TARGET_ESP32P4
@@ -151,11 +150,7 @@ struct spi_struct_t {
 #define SPI_MUTEX_UNLOCK()
 // clang-format off
 static spi_t _spi_bus_array[] = {
-#if CONFIG_IDF_TARGET_ESP32S2
-  {(volatile spi_dev_t *)(DR_REG_SPI1_BASE), 0, -1, -1, -1, -1, false},
-  {(volatile spi_dev_t *)(DR_REG_SPI2_BASE), 1, -1, -1, -1, -1, false},
-  {(volatile spi_dev_t *)(DR_REG_SPI3_BASE), 2, -1, -1, -1, -1, false}
-#elif CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4
+#if CONFIG_IDF_TARGET_ESP32S2 ||CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4
   {(volatile spi_dev_t *)(DR_REG_SPI2_BASE), 0, -1, -1, -1, -1, false},
   {(volatile spi_dev_t *)(DR_REG_SPI3_BASE), 1, -1, -1, -1, -1, false}
 #elif CONFIG_IDF_TARGET_ESP32C2
@@ -179,11 +174,7 @@ static spi_t _spi_bus_array[] = {
 #define SPI_MUTEX_UNLOCK() xSemaphoreGive(spi->lock)
 
 static spi_t _spi_bus_array[] = {
-#if CONFIG_IDF_TARGET_ESP32S2
-  {(volatile spi_dev_t *)(DR_REG_SPI1_BASE), NULL, 0, -1, -1, -1, -1, false},
-  {(volatile spi_dev_t *)(DR_REG_SPI2_BASE), NULL, 1, -1, -1, -1, -1, false},
-  {(volatile spi_dev_t *)(DR_REG_SPI3_BASE), NULL, 2, -1, -1, -1, -1, false}
-#elif CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4
+#if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4
   {(volatile spi_dev_t *)(DR_REG_SPI2_BASE), NULL, 0, -1, -1, -1, -1, false}, {(volatile spi_dev_t *)(DR_REG_SPI3_BASE), NULL, 1, -1, -1, -1, -1, false}
 #elif CONFIG_IDF_TARGET_ESP32C2
   {(volatile spi_dev_t *)(DR_REG_SPI2_BASE), NULL, 0, -1, -1, -1, -1, false}
@@ -621,6 +612,7 @@ void spiStopBus(spi_t *spi) {
 
 spi_t *spiStartBus(uint8_t spi_num, uint32_t clockDiv, uint8_t dataMode, uint8_t bitOrder) {
   if (spi_num >= SPI_COUNT) {
+    log_e("SPI bus index %d is out of range", spi_num);
     return NULL;
   }
 

--- a/cores/esp32/esp32-hal-spi.h
+++ b/cores/esp32/esp32-hal-spi.h
@@ -27,19 +27,13 @@ extern "C" {
 #include <stdbool.h>
 
 #define SPI_HAS_TRANSACTION
-
-#ifdef CONFIG_IDF_TARGET_ESP32S2
-#define FSPI 1  //SPI 1 bus. ESP32S2: for external memory only (can use the same data lines but different SS)
-#define HSPI 2  //SPI 2 bus. ESP32S2: external memory or device  - it can be matrixed to any pins
-#define SPI2 2  // Another name for ESP32S2 SPI 2
-#define SPI3 3  //SPI 3 bus. ESP32S2: device only - it can be matrixed to any pins
-#elif CONFIG_IDF_TARGET_ESP32
+#ifdef CONFIG_IDF_TARGET_ESP32
 #define FSPI 1  //SPI 1 bus attached to the flash (can use the same data lines but different SS)
 #define HSPI 2  //SPI 2 bus normally mapped to pins 12 - 15, but can be matrixed to any pins
 #define VSPI 3  //SPI 3 bus normally attached to pins 5, 18, 19 and 23, but can be matrixed to any pins
 #else
-#define FSPI 0  // ESP32C2, C3, C6, H2, S3, P4 - SPI 2 bus
-#define HSPI 1  // ESP32S3, P4 - SPI 3 bus
+#define FSPI 0  // ESP32C2, C3, C6, H2, S2, S3, P4 - SPI 2 bus
+#define HSPI 1  // ESP32S2, S3, P4 - SPI 3 bus
 #endif
 
 // This defines are not representing the real Divider of the ESP32

--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -27,7 +27,9 @@ bool SDFS::begin(uint8_t ssPin, SPIClass &spi, uint32_t frequency, const char *m
     return true;
   }
 
-  spi.begin();
+  if (!spi.begin()) {
+    return false;
+  }
 
   _pdrv = sdcard_init(ssPin, &spi, frequency);
   if (_pdrv == 0xFF) {

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -74,6 +74,7 @@ bool SPIClass::begin(int8_t sck, int8_t miso, int8_t mosi, int8_t ss) {
 
   _spi = spiStartBus(_spi_num, _div, SPI_MODE0, SPI_MSBFIRST);
   if (!_spi) {
+    log_e("SPI bus %d start failed.", _spi_num);
     return false;
   }
 


### PR DESCRIPTION
## Description of Change
This pull request refines SPI bus handling for ESP32S2 by correcting SPI bus mappings, and adds error handling for SPI initialization failures.

### Updates to SPI bus definitions and mappings:
* [`cores/esp32/esp32-hal-spi.c`](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL82-R90): Adjusted SPI bus mappings for ESP32S2, reducing `SPI_COUNT` from 3 to 2 and updating index definitions for clock, MISO, MOSI, and SS pins. [[1]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL82-R90) [[2]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL101-R101)
* [`cores/esp32/esp32-hal-spi.h`](diffhunk://#diff-5935efca13e11582e45cc53a8bf12d03f51d4970e97c1a22fc7f8a6a9619fbfcL30-R36): Revised SPI bus definitions for ESP32S2 and other targets, aligning bus identifiers (`FSPI`, `HSPI`) with their intended functionality.

### Error handling improvements:
* [`cores/esp32/esp32-hal-spi.c`](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR615): Added error logging for invalid SPI bus index in `spiStartBus`.
* [`libraries/SPI/src/SPI.cpp`](diffhunk://#diff-622bbeef9fa9d6ba8af6dc3d28e4d5171c697731b6da352e7a18c8e9fddb687eR77): Enhanced error handling in `SPIClass::begin` by logging failures when SPI bus initialization fails.

### Initialization logic improvements:
* [`libraries/SD/src/SD.cpp`](diffhunk://#diff-5d6741398fa5d3717504dcd70fefeb4e92dfbc9e8c2b4a2367e5dbcf02955fb5L30-R32): Added a check to ensure `spi.begin()` succeeds before proceeding with SD card initialization. Returns `false` if SPI initialization fails.

## Tests scenarios
Tested with SD SPI example, using SPI 0 (FSPI) and SPI 1 (HSPI) with PSRAM enabled/disabled.

## Related links
Closes #10079 
