### PR TITLE
IDF release/v5.4

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -252,13 +252,23 @@ static bool wifiHostedInit() {
   if (!hosted_initialized) {
     hosted_initialized = true;
     struct esp_hosted_sdio_config conf = INIT_DEFAULT_HOST_SDIO_CONFIG();
+#ifdef BOARD_HAS_SDIO_ESP_HOSTED
+    conf.pin_clk.pin = BOARD_SDIO_ESP_HOSTED_CLK;
+    conf.pin_cmd.pin = BOARD_SDIO_ESP_HOSTED_CMD;
+    conf.pin_d0.pin = BOARD_SDIO_ESP_HOSTED_D0;
+    conf.pin_d1.pin = BOARD_SDIO_ESP_HOSTED_D1;
+    conf.pin_d2.pin = BOARD_SDIO_ESP_HOSTED_D2;
+    conf.pin_d3.pin = BOARD_SDIO_ESP_HOSTED_D3;
+    conf.pin_reset.pin = BOARD_SDIO_ESP_HOSTED_RESET;
+#else
     conf.pin_clk.pin = CONFIG_ESP_SDIO_PIN_CLK;
     conf.pin_cmd.pin = CONFIG_ESP_SDIO_PIN_CMD;
     conf.pin_d0.pin = CONFIG_ESP_SDIO_PIN_D0;
     conf.pin_d1.pin = CONFIG_ESP_SDIO_PIN_D1;
     conf.pin_d2.pin = CONFIG_ESP_SDIO_PIN_D2;
     conf.pin_d3.pin = CONFIG_ESP_SDIO_PIN_D3;
-    //conf.pin_rst.pin = CONFIG_ESP_SDIO_GPIO_RESET_SLAVE;
+    conf.pin_reset.pin = CONFIG_ESP_SDIO_GPIO_RESET_SLAVE;
+#endif
     // esp_hosted_sdio_set_config() will fail on second attempt but here temporarily to not cause exception on reinit
     if (esp_hosted_sdio_set_config(&conf) != ESP_OK || esp_hosted_init() != ESP_OK) {
       log_e("esp_hosted_init failed!");

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-aed8bdc8-v1"
+              "version": "idf-release_v5.4-f0f2980d-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-aed8bdc8-v1",
+          "version": "idf-release_v5.4-f0f2980d-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-aed8bdc8-v1.zip",
-              "checksum": "SHA-256:448691c3171f79b2136e4ab8006e9c78bd1627156dab1365fff8f8867a6a7e5b",
-              "size": "353758763"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-f0f2980d-v1.zip",
+              "checksum": "SHA-256:b1a77c83634111d78a356f1d1756dc815eeeb91605c5d8714a0db7cccbd0bede",
+              "size": "353978504"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master ac45e2d
esp-idf: release/v5.4 f0f2980d05
arduino: master 882ef25a3
tinyusb: master e95973d34
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.2
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.0
espressif__eppp_link: 0.3.1
espressif__esp_hosted: 2.0.13
espressif__esp_serial_slave_link: 1.1.0
espressif__esp_wifi_remote: 0.13.0
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
```
