### PR TITLE
ci(ext_lib): Skip P4 in ArduinoBLE test

### DIFF
--- a/.github/workflows/lib.json
+++ b/.github/workflows/lib.json
@@ -9,7 +9,8 @@
     {
         "name": "ArduinoBLE",
         "exclude_targets": [
-            "esp32s2"
+            "esp32s2",
+            "esp32p4"
         ],
         "sketch_path": [
             "~/Arduino/libraries/ArduinoBLE/examples/Central/Scan/Scan.ino"


### PR DESCRIPTION
This pull request updates the `.github/workflows/lib.json` file to expand the list of excluded targets for the `ArduinoBLE` library.

* [`.github/workflows/lib.json`](diffhunk://#diff-23000dfd440105a884f18235455e3f3a6fee21b598c7f7411f37a0eec4ae9fa3L12-R13): Added `esp32p4` to the `exclude_targets` list for the `ArduinoBLE` library. As it does not have Bluetooth.