### PR TITLE
Update ZigbeeColorDimmableLight to clamp color hue and saturation to 0-254 (Fixes #11527)

### DIFF
--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -127,7 +127,8 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
 
   espXyColor_t xy_color = espRgbColorToXYColor(_current_color);
   espHsvColor_t hsv_color = espRgbColorToHsvColor(_current_color);
-  uint8_t hue = (uint8_t)hsv_color.h;
+  uint8_t hue = (uint8_t)hsv_color.h; // Recast from uint16 to uint8
+  hue = (hue > 254) ? 254 : hue;  // Clamp to 0-254 (per the Zigbee standard)
   uint8_t saturation = (hsv_color.s > 254) ? 254 : (uint8_t)hsv_color.s;  // Clamp to 0-254 (per the Zigbee standard)
 
   log_v("Updating light state: %d, level: %d, color: %d, %d, %d", state, level, red, green, blue);

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -128,6 +128,7 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
   espXyColor_t xy_color = espRgbColorToXYColor(_current_color);
   espHsvColor_t hsv_color = espRgbColorToHsvColor(_current_color);
   uint8_t hue = (uint8_t)hsv_color.h;
+  uint8_t saturation = (hsv_color.s > 254) ? 254 : (uint8_t)hsv_color.s;  // Clamp to 0-254 (per the Zigbee standard)
 
   log_v("Updating light state: %d, level: %d, color: %d, %d, %d", state, level, red, green, blue);
   /* Update light clusters */
@@ -174,7 +175,7 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
   }
   //set saturation
   ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &hsv_color.s, false
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light saturation: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "ZigbeeColorDimmableLight.h"
 #if CONFIG_ZB_ENABLED
 
@@ -127,9 +128,8 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
 
   espXyColor_t xy_color = espRgbColorToXYColor(_current_color);
   espHsvColor_t hsv_color = espRgbColorToHsvColor(_current_color);
-  uint8_t hue = (uint8_t)hsv_color.h; // Recast from uint16 to uint8
-  hue = (hue > 254) ? 254 : hue;  // Clamp to 0-254 (per the Zigbee standard)
-  uint8_t saturation = (hsv_color.s > 254) ? 254 : (uint8_t)hsv_color.s;  // Clamp to 0-254 (per the Zigbee standard)
+  uint8_t hue = std::min((uint8_t)hsv_color.h, (uint8_t)254); // Clamp to 0-254
+  uint8_t saturation = std::min((uint8_t)hsv_color.s, (uint8_t)254); // Clamp to 0-254
 
   log_v("Updating light state: %d, level: %d, color: %d, %d, %d", state, level, red, green, blue);
   /* Update light clusters */

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -128,8 +128,8 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
 
   espXyColor_t xy_color = espRgbColorToXYColor(_current_color);
   espHsvColor_t hsv_color = espRgbColorToHsvColor(_current_color);
-  uint8_t hue = std::min((uint8_t)hsv_color.h, (uint8_t)254); // Clamp to 0-254
-  uint8_t saturation = std::min((uint8_t)hsv_color.s, (uint8_t)254); // Clamp to 0-254
+  uint8_t hue = std::min((uint8_t)hsv_color.h, (uint8_t)254);         // Clamp to 0-254
+  uint8_t saturation = std::min((uint8_t)hsv_color.s, (uint8_t)254);  // Clamp to 0-254
 
   log_v("Updating light state: %d, level: %d, color: %d, %d, %d", state, level, red, green, blue);
   /* Update light clusters */


### PR DESCRIPTION
## Description of Change
The Zigbee standard requires color saturation in the range of 0-254, but `espRgbColorToHsvColor` returns saturations in the range of 0-255. As referenced in #11527 when a full saturation color is set, the following error is received:

```
[  6303][E][ZigbeeColorDimmableLight.cpp:180] setLight(): Failed to set light saturation: 0x87: Invalid value
```

This PR clamps the range of the saturation used in `setLight()` to 0-254 (reducing it to 254 from 255 when full saturation is set), eliminating the "Invalid value" error.

## Tests scenarios
I have tested this change on my XIAO ESP32-C6 


## Related links
Fixes #11527 