### PR TITLE
pioarduino only: make adresses for partitions.bin and boot_app0.bin configureable

### DIFF
--- a/tools/pioarduino-build.py
+++ b/tools/pioarduino-build.py
@@ -216,8 +216,14 @@ env.Append(
             "0x1000" if build_mcu in ["esp32", "esp32s2"] else ("0x2000" if build_mcu in ["esp32p4"] else "0x0000"),
             get_bootloader_image(variants_dir),
         ),
-        ("0x8000", join(env.subst("$BUILD_DIR"), "partitions.bin")),
-        ("0xe000", join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin")),
+        (
+            board_config.get("upload.arduino.partitions_bin", "0x8000"),
+            join(env.subst("$BUILD_DIR"), "partitions.bin"),
+        ),
+        (
+            board_config.get("upload.arduino.boot_app0", "0xe000"),
+            join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin"),
+        ),
     ]
     + [(offset, join(FRAMEWORK_DIR, img)) for offset, img in board_config.get("upload.arduino.flash_extra_images", [])],
 )


### PR DESCRIPTION
by doing this it is possible to use custom bootloader which does not fit in the fixed (too small) partition.

Fixes question https://community.platformio.org/t/modify-esp32s3-partition-table-offset-in-a-simple-way-using-framework-arduino/47909

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request
