### PR TITLE
Add FED4 board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -50789,4 +50789,3 @@ fed4.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 fed4.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
 
 ##############################################################
-

--- a/variants/fed4/pins_arduino.h
+++ b/variants/fed4/pins_arduino.h
@@ -22,9 +22,8 @@ static const uint8_t SS = 47;
 static const uint8_t MOSI = 11;
 static const uint8_t MISO = 13;
 static const uint8_t SCK = 12;
-static const uint8_t SDCS = 10; // sd cs pin
-static const uint8_t DSCS = 14; //display cs pin
-
+static const uint8_t SDCS = 10;  // sd cs pin
+static const uint8_t DSCS = 14;  //display cs pin
 
 static const uint8_t A1 = 1;
 static const uint8_t A2 = 2;
@@ -43,7 +42,6 @@ static const uint8_t D8 = 8;
 static const uint8_t D13 = 13;
 static const uint8_t D9 = 9;
 
-
 static const uint8_t T1 = 1;
 static const uint8_t T2 = 2;
 static const uint8_t T3 = 3;
@@ -51,13 +49,12 @@ static const uint8_t T4 = 4;
 static const uint8_t T5 = 5;
 static const uint8_t T6 = 6;
 
-
 static const uint8_t BOOT_BTN = 0;
 static const uint8_t VBAT_VOLTAGE = 7;
 static const uint8_t LDO2 = 47;
 static const uint8_t STATUS_RGB = 35;
 static const uint8_t RGB_STRIP = 36;
-static const uint8_t INTERRUPT_PIN  = 18;
+static const uint8_t INTERRUPT_PIN = 18;
 static const uint8_t USER_BTN_1 = 14;
 static const uint8_t USER_BTN_2 = 39;
 static const uint8_t USER_BTN_3 = 40;
@@ -69,9 +66,6 @@ static const uint8_t MSBY = 15;
 static const uint8_t TRRS_1 = 4;
 static const uint8_t TRRS_2 = 2;
 static const uint8_t TRRS_3 = 3;
-
-
-
 
 #define PIN_RGB_LED STATUS_RGB
 // BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino


### PR DESCRIPTION
Adding the FED4 board 

## Description of Change
Adding the FED4 board pin definitions and to boards.txt. 

the FED4 is a small commercial product that university labs can use monitor feeding behaviors of mice.
Designed by my company Smart Bee Designs LLC

![FED4](https://github.com/user-attachments/assets/1e96e09b-535d-4d47-850b-cf4769f5c745)
![image001](https://github.com/user-attachments/assets/66b60a03-9074-41f8-ae2c-8b8206d908ec) 

The Fed4 is the next installment in the FED line (replacing the FED3) https://kravitzlab.com/research & https://open-ephys.org/fed3/fed3

## Tests scenarios
Tested on 3.2.0 on Windows running through several sketches that functionally test the device.

