### PR TITLE
feat(matter): enables BLE Matter commissioning with NimBLE

### DIFF
--- a/libraries/Matter/examples/MatterColorLight/MatterColorLight.ino
+++ b/libraries/Matter/examples/MatterColorLight/MatterColorLight.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,22 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 #include <Preferences.h>
 
 // List of Matter Endpoints for this Node
 // Color Light Endpoint
 MatterColorLight ColorLight;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // it will keep last OnOff & HSV Color state stored, using Preferences
 Preferences matterPref;
@@ -81,6 +87,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -95,6 +103,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize Matter EndPoint
   matterPref.begin("MatterPrefs", false);
@@ -121,7 +130,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
     Serial.printf(
       "Initial state: %s | RGB Color: (%d,%d,%d) \r\n", ColorLight ? "ON" : "OFF", ColorLight.getColorRGB().r, ColorLight.getColorRGB().g,
       ColorLight.getColorRGB().b
@@ -154,7 +163,7 @@ void loop() {
     );
     // configure the Light based on initial on-off state and its color
     ColorLight.updateAccessory();
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // A button is also used to control the light

--- a/libraries/Matter/examples/MatterCommissionTest/MatterCommissionTest.ino
+++ b/libraries/Matter/examples/MatterCommissionTest/MatterCommissionTest.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,27 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // On/Off Light Endpoint
 MatterOnOffLight OnOffLight;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 void setup() {
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -41,6 +49,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize at least one Matter EndPoint
   OnOffLight.begin();
@@ -64,7 +73,7 @@ void loop() {
       Serial.println("Matter Fabric not commissioned yet. Waiting for commissioning.");
     }
   }
-  Serial.println("Matter Node is commissioned and connected to Wi-Fi.");
+  Serial.println("Matter Node is commissioned and connected to the network.");
   Serial.println("====> Decommissioning in 30 seconds. <====");
   delay(30000);
   Matter.decommission();

--- a/libraries/Matter/examples/MatterComposedLights/MatterComposedLights.ino
+++ b/libraries/Matter/examples/MatterComposedLights/MatterComposedLights.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // There will be 3 On/Off Light Endpoints in the same Node
@@ -22,9 +25,12 @@ MatterOnOffLight Light1;
 MatterDimmableLight Light2;
 MatterColorLight Light3;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here -  USED to decommission the Matter Node
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -56,6 +62,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -71,6 +79,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize all 3 Matter EndPoints
   Light1.begin();
@@ -103,7 +112,7 @@ void loop() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   //displays the Light state every 5 seconds

--- a/libraries/Matter/examples/MatterContactSensor/MatterContactSensor.ino
+++ b/libraries/Matter/examples/MatterContactSensor/MatterContactSensor.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,15 +30,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Matter Contact Sensor Endpoint
 MatterContactSensor ContactSensor;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // LED will be used to indicate the Contact Sensor state
 // set your board RGB LED pin here
@@ -67,6 +73,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -75,6 +83,7 @@ void setup() {
     Serial.print(".");
   }
   Serial.println();
+#endif
 
   // set initial contact sensor state as false (default)
   ContactSensor.begin();
@@ -99,7 +108,7 @@ void setup() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 

--- a/libraries/Matter/examples/MatterDimmableLight/MatterDimmableLight.ino
+++ b/libraries/Matter/examples/MatterDimmableLight/MatterDimmableLight.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,22 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 #include <Preferences.h>
 
 // List of Matter Endpoints for this Node
 // Dimmable Light Endpoint
 MatterDimmableLight DimmableLight;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // it will keep last OnOff & Brightness state stored, using Preferences
 Preferences matterPref;
@@ -77,6 +83,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -91,6 +99,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize Matter EndPoint
   matterPref.begin("MatterPrefs", false);
@@ -116,7 +125,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
     Serial.printf("Initial state: %s | brightness: %d\r\n", DimmableLight ? "ON" : "OFF", DimmableLight.getBrightness());
     // configure the Light based on initial on-off state and brightness
     DimmableLight.updateAccessory();
@@ -143,7 +152,7 @@ void loop() {
     Serial.printf("Initial state: %s | brightness: %d\r\n", DimmableLight ? "ON" : "OFF", DimmableLight.getBrightness());
     // configure the Light based on initial on-off state and brightness
     DimmableLight.updateAccessory();
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // A button is also used to control the light

--- a/libraries/Matter/examples/MatterEnhancedColorLight/MatterEnhancedColorLight.ino
+++ b/libraries/Matter/examples/MatterEnhancedColorLight/MatterEnhancedColorLight.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,22 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 #include <Preferences.h>
 
 // List of Matter Endpoints for this Node
 // Color Light Endpoint
 MatterEnhancedColorLight EnhancedColorLight;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // It will use HSV color to control all Matter Attribute Changes
 HsvColor_t currentHSVColor = {0, 0, 0};
@@ -85,6 +91,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -99,6 +107,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize Matter EndPoint
   matterPref.begin("MatterPrefs", false);
@@ -143,7 +152,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
     Serial.printf(
       "Initial state: %s | RGB Color: (%d,%d,%d) \r\n", EnhancedColorLight ? "ON" : "OFF", EnhancedColorLight.getColorRGB().r,
       EnhancedColorLight.getColorRGB().g, EnhancedColorLight.getColorRGB().b
@@ -176,7 +185,7 @@ void loop() {
     );
     // configure the Light based on initial on-off state and its color
     EnhancedColorLight.updateAccessory();
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // A button is also used to control the light

--- a/libraries/Matter/examples/MatterEvents/MatterEvents.ino
+++ b/libraries/Matter/examples/MatterEvents/MatterEvents.ino
@@ -14,11 +14,17 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // List of Matter Endpoints for this Node
 // On/Off Light Endpoint
@@ -119,6 +125,8 @@ void setup() {
     delay(10);  // Wait for Serial to initialize
   }
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -134,6 +142,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize at least one Matter EndPoint
   OnOffLight.begin();

--- a/libraries/Matter/examples/MatterFan/MatterFan.ino
+++ b/libraries/Matter/examples/MatterFan/MatterFan.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +14,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Fan Endpoint - On/Off control + Speed Percent Control + Fan Modes
 MatterFan Fan;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here - used for toggling On/Off and decommission the Matter Node
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -76,6 +82,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -90,6 +98,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // On Boot or Reset, Fan is set at 0% speed, OFF, changing between OFF, ON, SMART and HIGH
   Fan.begin(0, MatterFan::FAN_MODE_OFF, MatterFan::FAN_MODE_SEQ_OFF_HIGH);
@@ -141,7 +150,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 
@@ -162,7 +171,7 @@ void loop() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // A builtin button is used to trigger and send a command to the Matter Controller

--- a/libraries/Matter/examples/MatterHumiditySensor/MatterHumiditySensor.ino
+++ b/libraries/Matter/examples/MatterHumiditySensor/MatterHumiditySensor.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,15 +21,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Matter Humidity Sensor Endpoint
 MatterHumiditySensor SimulatedHumiditySensor;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here - decommissioning button
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -60,6 +66,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -68,6 +76,7 @@ void setup() {
     Serial.print(".");
   }
   Serial.println();
+#endif
 
   // set initial humidity sensor measurement
   // Simulated Sensor - it shall initially print 95% and then move to the 10% to 30% humidity range
@@ -92,7 +101,7 @@ void setup() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 

--- a/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
+++ b/libraries/Matter/examples/MatterMinimum/MatterMinimum.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,15 +22,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Single On/Off Light Endpoint - at least one per node
 MatterOnOffLight OnOffLight;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // Light GPIO that can be controlled by Matter APP
 #ifdef LED_BUILTIN
@@ -62,6 +68,8 @@ void setup() {
   // Initialize the LED GPIO
   pinMode(ledPin, OUTPUT);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -73,6 +81,7 @@ void setup() {
     delay(500);
   }
   Serial.println();
+#endif
 
   // Initialize at least one Matter EndPoint
   OnOffLight.begin();

--- a/libraries/Matter/examples/MatterOccupancySensor/MatterOccupancySensor.ino
+++ b/libraries/Matter/examples/MatterOccupancySensor/MatterOccupancySensor.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,15 +28,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Matter Occupancy Sensor Endpoint
 MatterOccupancySensor OccupancySensor;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here - decommissioning only
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -52,6 +58,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -60,6 +68,7 @@ void setup() {
     Serial.print(".");
   }
   Serial.println();
+#endif
 
   // set initial occupancy sensor state as false and connected to a PIR sensor type (default)
   OccupancySensor.begin();
@@ -83,7 +92,7 @@ void setup() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 

--- a/libraries/Matter/examples/MatterOnIdentify/MatterOnIdentify.ino
+++ b/libraries/Matter/examples/MatterOnIdentify/MatterOnIdentify.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,15 +26,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Single On/Off Light Endpoint - at least one per node
 MatterOnOffLight OnOffLight;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // Light GPIO that can be controlled by Matter APP
 #ifdef LED_BUILTIN
@@ -88,6 +94,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -96,6 +104,7 @@ void setup() {
     Serial.print(".");
   }
   Serial.println();
+#endif
 
   // Initialize at least one Matter EndPoint
   OnOffLight.begin();
@@ -125,7 +134,7 @@ void setup() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 

--- a/libraries/Matter/examples/MatterOnOffLight/MatterOnOffLight.ino
+++ b/libraries/Matter/examples/MatterOnOffLight/MatterOnOffLight.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,12 +14,18 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 #include <Preferences.h>
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // List of Matter Endpoints for this Node
 // On/Off Light Endpoint
@@ -68,6 +74,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -82,6 +90,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize Matter EndPoint
   matterPref.begin("MatterPrefs", false);
@@ -93,7 +102,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
     Serial.printf("Initial state: %s\r\n", OnOffLight.getOnOff() ? "ON" : "OFF");
     OnOffLight.updateAccessory();  // configure the Light based on initial state
   }
@@ -118,7 +127,7 @@ void loop() {
     }
     Serial.printf("Initial state: %s\r\n", OnOffLight.getOnOff() ? "ON" : "OFF");
     OnOffLight.updateAccessory();  // configure the Light based on initial state
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // A button is also used to control the light

--- a/libraries/Matter/examples/MatterOnOffPlugin/MatterOnOffPlugin.ino
+++ b/libraries/Matter/examples/MatterOnOffPlugin/MatterOnOffPlugin.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,22 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 #include <Preferences.h>
 
 // List of Matter Endpoints for this Node
 // On/Off Plugin Endpoint
 MatterOnOffPlugin OnOffPlugin;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // it will keep last OnOff state stored, using Preferences
 Preferences matterPref;
@@ -67,6 +73,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -80,6 +88,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize Matter EndPoint
   matterPref.begin("MatterPrefs", false);
@@ -91,7 +100,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
     Serial.printf("Initial state: %s\r\n", OnOffPlugin.getOnOff() ? "ON" : "OFF");
     OnOffPlugin.updateAccessory();  // configure the Plugin based on initial state
   }
@@ -116,7 +125,7 @@ void loop() {
     }
     Serial.printf("Initial state: %s\r\n", OnOffPlugin.getOnOff() ? "ON" : "OFF");
     OnOffPlugin.updateAccessory();  // configure the Plugin based on initial state
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // Check if the button has been pressed

--- a/libraries/Matter/examples/MatterPressureSensor/MatterPressureSensor.ino
+++ b/libraries/Matter/examples/MatterPressureSensor/MatterPressureSensor.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,15 +21,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Matter Pressure Sensor Endpoint
 MatterPressureSensor SimulatedPressureSensor;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here - decommissioning button
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -60,6 +66,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -68,6 +76,7 @@ void setup() {
     Serial.print(".");
   }
   Serial.println();
+#endif
 
   // set initial pressure sensor measurement
   // Simulated Sensor - it shall initially print 900hPa and then move to the 950 to 1100 hPa as pressure range
@@ -92,7 +101,7 @@ void setup() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 

--- a/libraries/Matter/examples/MatterSmartButon/MatterSmartButon.ino
+++ b/libraries/Matter/examples/MatterSmartButon/MatterSmartButon.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +14,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Generic Switch Endpoint - works as a smart button with a single click
 MatterGenericSwitch SmartButton;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -43,6 +49,8 @@ void setup() {
   Serial.print("Connecting to ");
   Serial.println(ssid);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -54,6 +62,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize the Matter EndPoint
   SmartButton.begin();
@@ -62,7 +71,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 
@@ -83,7 +92,7 @@ void loop() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // A builtin button is used to trigger a command to the Matter Controller

--- a/libraries/Matter/examples/MatterTemperatureLight/MatterTemperatureLight.ino
+++ b/libraries/Matter/examples/MatterTemperatureLight/MatterTemperatureLight.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,22 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 #include <Preferences.h>
 
 // List of Matter Endpoints for this Node
 // Color Temperature CW/WW Light Endpoint
 MatterColorTemperatureLight CW_WW_Light;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // it will keep last OnOff & Brightness state stored, using Preferences
 Preferences matterPref;
@@ -88,6 +94,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
@@ -102,6 +110,7 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   delay(500);
+#endif
 
   // Initialize Matter EndPoint
   matterPref.begin("MatterPrefs", false);
@@ -133,7 +142,7 @@ void setup() {
   Matter.begin();
   // This may be a restart of a already commissioned Matter accessory
   if (Matter.isDeviceCommissioned()) {
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
     Serial.printf(
       "Initial state: %s | brightness: %d | Color Temperature: %d mireds \r\n", CW_WW_Light ? "ON" : "OFF", CW_WW_Light.getBrightness(),
       CW_WW_Light.getColorTemperature()
@@ -166,7 +175,7 @@ void loop() {
     );
     // configure the Light based on initial on-off state and brightness
     CW_WW_Light.updateAccessory();
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 
   // A button is also used to control the light

--- a/libraries/Matter/examples/MatterTemperatureSensor/MatterTemperatureSensor.ino
+++ b/libraries/Matter/examples/MatterTemperatureSensor/MatterTemperatureSensor.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,15 +21,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Matter Temperature Sensor Endpoint
 MatterTemperatureSensor SimulatedTemperatureSensor;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here - decommissioning button
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -60,6 +66,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -68,6 +76,7 @@ void setup() {
     Serial.print(".");
   }
   Serial.println();
+#endif
 
   // set initial temperature sensor measurement
   // Simulated Sensor - it shall initially print -25C and then move to the -10C to 10C range
@@ -92,7 +101,7 @@ void setup() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
   }
 }
 

--- a/libraries/Matter/examples/MatterThermostat/MatterThermostat.ino
+++ b/libraries/Matter/examples/MatterThermostat/MatterThermostat.ino
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,15 +21,21 @@
 
 // Matter Manager
 #include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the decive can be commissioned using BLE, WiFi is not used - save flash space
 #include <WiFi.h>
+#endif
 
 // List of Matter Endpoints for this Node
 // Matter Thermostat Endpoint
 MatterThermostat SimulatedThermostat;
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
 // WiFi is manually set and started
 const char *ssid = "your-ssid";          // Change this to your WiFi SSID
 const char *password = "your-password";  // Change this to your WiFi password
+#endif
 
 // set your board USER BUTTON pin here - decommissioning button
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
@@ -62,6 +68,8 @@ void setup() {
 
   Serial.begin(115200);
 
+// CONFIG_ENABLE_CHIPOBLE is enbaled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
   // Manually connect to WiFi
   WiFi.begin(ssid, password);
   // Wait for connection
@@ -70,6 +78,7 @@ void setup() {
     Serial.print(".");
   }
   Serial.println();
+#endif
 
   // Simulated Thermostat in COOLING and HEATING mode with Auto Mode to keep the temperature between setpoints
   // Auto Mode can only be used when the control sequence of operation is Cooling & Heating
@@ -94,7 +103,7 @@ void setup() {
         Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
       }
     }
-    Serial.println("Matter Node is commissioned and connected to Wi-Fi. Ready for use.");
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
 
     // after commissioning, set initial thermostat parameters
     // start the thermostat in AUTO mode

--- a/libraries/Matter/src/Matter.cpp
+++ b/libraries/Matter/src/Matter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@
 
 #include <Matter.h>
 #include <app/server/Server.h>
+#if CONFIG_ENABLE_MATTER_OVER_THREAD
+#include "esp_openthread_types.h"
+#include "platform/ESP32/OpenthreadLauncher.h"
+#endif
 
 using namespace esp_matter;
 using namespace esp_matter::attribute;
@@ -150,6 +154,18 @@ void ArduinoMatter::begin() {
     log_e("No Matter endpoint has been created. Please create an endpoint first.");
     return;
   }
+
+#if CONFIG_ENABLE_MATTER_OVER_THREAD
+  // Set OpenThread platform config
+  esp_openthread_platform_config_t config;
+  memset(&config, 0, sizeof(esp_openthread_platform_config_t));
+  config.radio_config.radio_mode = RADIO_MODE_NATIVE;
+  config.host_config.host_connection_mode = HOST_CONNECTION_MODE_NONE;
+  config.port_config.storage_partition_name = "nvs";
+  config.port_config.netif_queue_size = 10;
+  config.port_config.task_queue_size = 10;
+  set_openthread_platform_config(&config);
+#endif
 
   /* Matter start */
   esp_err_t err = esp_matter::start(app_event_cb);

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndPoint.cpp
+++ b/libraries/Matter/src/MatterEndPoint.cpp
@@ -1,0 +1,139 @@
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sdkconfig.h>
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <MatterEndPoint.h>
+
+uint16_t MatterEndPoint::secondary_network_endpoint_id = 0;
+
+// This function is called to create a secondary network interface endpoint.
+// It can be used for devices that support multiple network interfaces,
+// such as Ethernet, Thread and Wi-Fi.
+bool MatterEndPoint::createSecondaryNetworkInterface() {
+  if (secondary_network_endpoint_id != 0) {
+    log_v("Secondary network interface endpoint already exists with ID %d", secondary_network_endpoint_id);
+    return false;
+  }
+  // Create a secondary network interface endpoint
+  endpoint::secondary_network_interface::config_t secondary_network_interface_config;
+  secondary_network_interface_config.network_commissioning.feature_map = chip::to_underlying(
+    //chip::app::Clusters::NetworkCommissioning::Feature::kWiFiNetworkInterface) |
+    chip::app::Clusters::NetworkCommissioning::Feature::kThreadNetworkInterface
+  );
+  endpoint_t *endpoint = endpoint::secondary_network_interface::create(node::get(), &secondary_network_interface_config, ENDPOINT_FLAG_NONE, nullptr);
+  if (endpoint == nullptr) {
+    log_e("Failed to create secondary network interface endpoint");
+    return false;
+  }
+  secondary_network_endpoint_id = endpoint::get_id(endpoint);
+  log_i("Secondary Network Interface created with endpoint_id %d", secondary_network_endpoint_id);
+  return true;
+}
+
+uint16_t MatterEndPoint::getSecondaryNetworkEndPointId() {
+  return secondary_network_endpoint_id;
+}
+
+uint16_t MatterEndPoint::getEndPointId() {
+  return endpoint_id;
+}
+
+void MatterEndPoint::setEndPointId(uint16_t ep) {
+ if (ep == 0) {   
+    log_e("Invalid endpoint ID");
+    return;
+  }
+  log_v("Endpoint ID set to %d", ep);
+
+  endpoint_id = ep;
+}
+
+// helper functions for attribute manipulation
+esp_matter::attribute_t *MatterEndPoint::getAttribute(uint32_t cluster_id, uint32_t attribute_id) {
+  if (endpoint_id == 0) {
+    log_e("Endpoint ID is not set");
+    return nullptr;
+  }
+  endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
+  if (endpoint == nullptr) {
+    log_e("Endpoint [%d] not found", endpoint_id);
+    return nullptr;
+  }
+  cluster_t *cluster = cluster::get(endpoint, cluster_id);
+  if (cluster == nullptr) {
+    log_e("Cluster [%d] not found", cluster_id);
+    return nullptr;
+  }
+  esp_matter::attribute_t *attribute = attribute::get(cluster, attribute_id);
+  if (attribute == nullptr) {
+    log_e("Attribute [%d] not found", attribute_id);
+    return nullptr;
+  }
+  return attribute;
+}
+
+// get the value of an attribute from its cluster id and attribute it
+bool MatterEndPoint::getAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
+  esp_matter::attribute_t *attribute = getAttribute(cluster_id, attribute_id);
+  if (attribute == nullptr) {
+    return false;
+  }
+  if (attribute::get_val(attribute, attrVal) == ESP_OK) {
+    log_v("GET_VAL Success for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
+    return true;
+  }
+  log_e("GET_VAL FAILED! for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
+  return false;
+}
+
+// set the value of an attribute from its cluster id and attribute it
+bool MatterEndPoint::setAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
+  esp_matter::attribute_t *attribute = getAttribute(cluster_id, attribute_id);
+  if (attribute == nullptr) {
+    return false;
+  }
+  if (attribute::set_val(attribute, attrVal) == ESP_OK) {
+    log_v("SET_VAL Success for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
+    return true;
+  }
+  log_e("SET_VAL FAILED! for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
+  return false;
+}
+
+// update the value of an attribute from its cluster id and attribute it
+bool MatterEndPoint::updateAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
+  if (attribute::update(endpoint_id, cluster_id, attribute_id, attrVal) == ESP_OK) {
+    log_v("Update Success for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
+    return true;
+  }
+  log_e("Update FAILED! for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
+  return false;
+}
+
+// This callback is invoked when clients interact with the Identify Cluster of an specific endpoint.
+bool MatterEndPoint::endpointIdentifyCB(uint16_t endpoint_id, bool identifyIsEnabled) {
+  if (_onEndPointIdentifyCB) {
+    return _onEndPointIdentifyCB(identifyIsEnabled);
+  }
+  return true;
+}
+
+// User callback for the Identify Cluster functionality
+void MatterEndPoint::onIdentify(EndPointIdentifyCB onEndPointIdentifyCB) {
+  _onEndPointIdentifyCB = onEndPointIdentifyCB;
+}
+
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterEndPoint.h
+++ b/libraries/Matter/src/MatterEndPoint.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 #include <sdkconfig.h>
 #ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
 
-#include <Matter.h>
+#include <Arduino.h>
+#include <esp_matter.h>
 #include <functional>
 
 using namespace esp_matter;
@@ -29,93 +30,47 @@ public:
     ATTR_UPDATE = true
   };
 
-  uint16_t getEndPointId() {
-    return endpoint_id;
-  }
-
-  void setEndPointId(uint16_t ep) {
-    endpoint_id = ep;
-  }
-
-  // helper functions for attribute manipulation
-  esp_matter::attribute_t *getAttribute(uint32_t cluster_id, uint32_t attribute_id) {
-    if (endpoint_id == 0) {
-      log_e("Endpoint ID is not set");
-      return nullptr;
-    }
-    endpoint_t *endpoint = endpoint::get(node::get(), endpoint_id);
-    if (endpoint == nullptr) {
-      log_e("Endpoint [%d] not found", endpoint_id);
-      return nullptr;
-    }
-    cluster_t *cluster = cluster::get(endpoint, cluster_id);
-    if (cluster == nullptr) {
-      log_e("Cluster [%d] not found", cluster_id);
-      return nullptr;
-    }
-    esp_matter::attribute_t *attribute = attribute::get(cluster, attribute_id);
-    if (attribute == nullptr) {
-      log_e("Attribute [%d] not found", attribute_id);
-      return nullptr;
-    }
-    return attribute;
-  }
-
-  // get the value of an attribute from its cluster id and attribute it
-  bool getAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
-    esp_matter::attribute_t *attribute = getAttribute(cluster_id, attribute_id);
-    if (attribute == nullptr) {
-      return false;
-    }
-    if (attribute::get_val(attribute, attrVal) == ESP_OK) {
-      log_v("GET_VAL Success for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
-      return true;
-    }
-    log_e("GET_VAL FAILED! for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
-    return false;
-  }
-
-  // set the value of an attribute from its cluster id and attribute it
-  bool setAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
-    esp_matter::attribute_t *attribute = getAttribute(cluster_id, attribute_id);
-    if (attribute == nullptr) {
-      return false;
-    }
-    if (attribute::set_val(attribute, attrVal) == ESP_OK) {
-      log_v("SET_VAL Success for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
-      return true;
-    }
-    log_e("SET_VAL FAILED! for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
-    return false;
-  }
-
-  // update the value of an attribute from its cluster id and attribute it
-  bool updateAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal) {
-    if (attribute::update(endpoint_id, cluster_id, attribute_id, attrVal) == ESP_OK) {
-      log_v("Update Success for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
-      return true;
-    }
-    log_e("Update FAILED! for cluster %d, attribute %d with value %d", cluster_id, attribute_id, attrVal->val.u32);
-    return false;
-  }
+  using EndPointIdentifyCB = std::function<bool(bool)>;
 
   // this function is called by Matter internal event processor. It could be overwritten by the application, if necessary.
   virtual bool attributeChangeCB(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *val) = 0;
 
+  // This function is called to create a secondary network interface endpoint.
+  // It can be used for devices that support multiple network interfaces,
+  // such as Ethernet, Thread and Wi-Fi.
+  bool createSecondaryNetworkInterface();
+
+  // This function is called to get the secondary network interface endpoint ID.
+  uint16_t getSecondaryNetworkEndPointId();
+
+  // This function is called to get the current Matter Accessory endpoint ID.
+  uint16_t getEndPointId();
+
+  // This function is called to set the current Matter Accessory endpoint ID.
+  void setEndPointId(uint16_t ep);
+
+  // helper functions for attribute manipulation
+  esp_matter::attribute_t *getAttribute(uint32_t cluster_id, uint32_t attribute_id);
+
+  // get the value of an attribute from its cluster id and
+  bool getAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal);
+
+  // set the value of an attribute from its cluster id and
+  bool setAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal);
+
+  // update the value of an attribute from its cluster id
+  bool updateAttributeVal(uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *attrVal);
+
   // This callback is invoked when clients interact with the Identify Cluster of an specific endpoint.
-  bool endpointIdentifyCB(uint16_t endpoint_id, bool identifyIsEnabled) {
-    if (_onEndPointIdentifyCB) {
-      return _onEndPointIdentifyCB(identifyIsEnabled);
-    }
-    return true;
-  }
+  bool endpointIdentifyCB(uint16_t endpoint_id, bool identifyIsEnabled);
+
   // User callaback for the Identify Cluster functionality
-  using EndPointIdentifyCB = std::function<bool(bool)>;
-  void onIdentify(EndPointIdentifyCB onEndPointIdentifyCB) {
-    _onEndPointIdentifyCB = onEndPointIdentifyCB;
-  }
+  void onIdentify(EndPointIdentifyCB onEndPointIdentifyCB);
 
 protected:
+  // used for secondary network interface endpoints
+  static uint16_t secondary_network_endpoint_id;
+  // main endpoint ID
   uint16_t endpoint_id = 0;
   EndPointIdentifyCB _onEndPointIdentifyCB = nullptr;
 };

--- a/libraries/Matter/src/MatterEndpoints/MatterColorLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterColorLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -196,6 +196,11 @@ bool MatterColorLight::begin(bool initialState, espHsvColor_t _colorHSV) {
   cluster_t *level_control_cluster = cluster::get(endpoint, LevelControl::Id);
   esp_matter::attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
   attribute::set_deferred_persistence(current_level_attribute);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
 
   started = true;
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterColorLight.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterColorLight.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterColorTemperatureLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterColorTemperatureLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,10 @@ bool MatterColorTemperatureLight::begin(bool initialState, uint8_t brightness, u
   cluster_t *color_control_cluster = cluster::get(endpoint, ColorControl::Id);
   esp_matter::attribute_t *color_temp_attribute = attribute::get(color_control_cluster, ColorControl::Attributes::ColorTemperatureMireds::Id);
   attribute::set_deferred_persistence(color_temp_attribute);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
 
   started = true;
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterColorTemperatureLight.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterColorTemperatureLight.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterContactSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterContactSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,6 +60,11 @@ bool MatterContactSensor::begin(bool _contactState) {
   contactState = _contactState;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Contact Sensor created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterContactSensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterContactSensor.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterDimmableLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterDimmableLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,6 +103,10 @@ bool MatterDimmableLight::begin(bool initialState, uint8_t brightness) {
   cluster_t *level_control_cluster = cluster::get(endpoint, LevelControl::Id);
   esp_matter::attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
   attribute::set_deferred_persistence(current_level_attribute);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
 
   started = true;
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterDimmableLight.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterDimmableLight.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -216,6 +216,10 @@ bool MatterEnhancedColorLight::begin(bool initialState, espHsvColor_t _colorHSV,
   cluster_t *level_control_cluster = cluster::get(endpoint, LevelControl::Id);
   esp_matter::attribute_t *current_level_attribute = attribute::get(level_control_cluster, LevelControl::Attributes::CurrentLevel::Id);
   attribute::set_deferred_persistence(current_level_attribute);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
 
   started = true;
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterFan.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterFan.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,6 +110,11 @@ bool MatterFan::begin(uint8_t percent, FanMode_t fanMode, FanModeSequence_t fanM
 
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Fan created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterFan.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterFan.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterGenericSwitch.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterGenericSwitch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,6 +79,11 @@ bool MatterGenericSwitch::begin() {
 
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Generic Switch created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterGenericSwitch.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterGenericSwitch.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterHumiditySensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterHumiditySensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,6 +68,11 @@ bool MatterHumiditySensor::begin(uint16_t _rawHumidity) {
   rawHumidity = _rawHumidity;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Humidity Sensor created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+  
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterHumiditySensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterHumiditySensor.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterOccupancySensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterOccupancySensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,6 +71,11 @@ bool MatterOccupancySensor::begin(bool _occupancyState, OccupancySensorType_t _o
   occupancyState = _occupancyState;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Occupancy Sensor created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterOccupancySensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterOccupancySensor.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterOnOffLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterOnOffLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,6 +79,11 @@ bool MatterOnOffLight::begin(bool initialState) {
 
   setEndPointId(endpoint::get_id(endpoint));
   log_i("On-Off Light created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterOnOffLight.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterOnOffLight.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterOnOffPlugin.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterOnOffPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,6 +78,11 @@ bool MatterOnOffPlugin::begin(bool initialState) {
   onOffState = initialState;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("On-Off Plugin created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterOnOffPlugin.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterOnOffPlugin.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,6 +61,11 @@ bool MatterPressureSensor::begin(int16_t _rawPressure) {
   rawPressure = _rawPressure;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Pressure Sensor created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterPressureSensor.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterTemperatureSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterTemperatureSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,6 +61,11 @@ bool MatterTemperatureSensor::begin(int16_t _rawTemperature) {
   rawTemperature = _rawTemperature;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Temperature Sensor created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterTemperatureSensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterTemperatureSensor.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libraries/Matter/src/MatterEndpoints/MatterThermostat.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterThermostat.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -202,6 +202,11 @@ bool MatterThermostat::begin(ControlSequenceOfOperation_t _controlSequence, Ther
 
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Thermostat created with endpoint_id %d", getEndPointId());
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+  createSecondaryNetworkInterface();
+#endif
+
   started = true;
   return true;
 }

--- a/libraries/Matter/src/MatterEndpoints/MatterThermostat.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterThermostat.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description of Change

Given that Arduino Core 3.3.x will support NimBLE, it is now possible to enable Matter network commissioning using BLE.
This PR changes examples and Matter Library code in order to make it work.

This must be done case by case because each SoC has certain limitations:

CONFIG_ENABLE_CHIPOBLE=n
- ESP32: uses Bluedroid, therefore it can't use NimBLE, neither CHIPOBLE
- ESP32S2: has no BLE, therefore it can't use NimBLE, neither CHIPOBLE

CONFIG_ENABLE_CHIPOBLE=y
- ESP32-S3: has NimBLE and shall use CHIPOBLE for commissioning WiFi only
- ESP32-C3: has NimBLE and shall use CHIPOBLE for commissioning WiFi only
- ESP32-C5: has NimBLE and shall use CHIPOBLE for commissioning WiFi or Thread(*)
- ESP32-C6: has NimBLE and shall use CHIPOBLE for commissioning WiFi or Thread(*)
- ESP32-H2: has NimBLE and shall use CHIPOBLE for commissioning Thread only

(*) some extra chnages are necessary in order to make Matter run the commissioning for a Thread Network.

No Matter Support with Arduino:
- ESP32-P4: No Wireless interface. Possible to get it done a C6/H2 wireless Slave configuration for WiFi/Thread.
- ESP32-C2: Problems building it within Arduino standard configuration.

## Tests scenarios
USing the examples with ESP32, S2, S3, C3, C5, C6, and H2.

## Related links
https://github.com/espressif/arduino-esp32/pull/11531