### PR TITLE
fix(board): Update PSRAM configuration for RAK3112 to fix PSRAM error

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -50809,8 +50809,10 @@ rakwireless_rak3112.build.flash_mode=dio
 rakwireless_rak3112.build.boot=dio
 rakwireless_rak3112.build.partitions=default
 rakwireless_rak3112.build.defines=
+rakwireless_rak3112.build.psram_type=opi
+rakwireless_rak3112.build.memory_type={build.boot}_{build.psram_type}
 
-rakwireless_rak3112.menu.PSRAM.enabled=Enabled
+rakwireless_rak3112.menu.PSRAM.enabled=OPI PSRAM
 rakwireless_rak3112.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 rakwireless_rak3112.menu.PSRAM.enabled.build.psram_type=opi
 rakwireless_rak3112.menu.PSRAM.disabled=Disabled

--- a/boards.txt
+++ b/boards.txt
@@ -50805,14 +50805,14 @@ rakwireless_rak3112.build.dfu_on_boot=0
 rakwireless_rak3112.build.f_cpu=240000000L
 rakwireless_rak3112.build.flash_size=16MB
 rakwireless_rak3112.build.flash_freq=80m
-rakwireless_rak3112.build.flash_mode=dio
-rakwireless_rak3112.build.boot=dio
+rakwireless_rak3112.build.flash_mode=qio
+rakwireless_rak3112.build.boot=qio
 rakwireless_rak3112.build.partitions=default
 rakwireless_rak3112.build.defines=
 rakwireless_rak3112.build.psram_type=opi
 rakwireless_rak3112.build.memory_type={build.boot}_{build.psram_type}
 
-rakwireless_rak3112.menu.PSRAM.enabled=OPI PSRAM
+rakwireless_rak3112.menu.PSRAM.enabled=Enabled
 rakwireless_rak3112.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
 rakwireless_rak3112.menu.PSRAM.enabled.build.psram_type=opi
 rakwireless_rak3112.menu.PSRAM.disabled=Disabled

--- a/variants/rakwireless_rak3112/pins_arduino.h
+++ b/variants/rakwireless_rak3112/pins_arduino.h
@@ -48,15 +48,15 @@ static const uint8_t SCK = 13;
 #define LORA_IRQ  LORA_DIO1
 
 // For WisBlock modules, see: https://docs.rakwireless.com/Product-Categories/WisBlock/
-#define WB_IO1 21
-#define WB_IO2 14
-#define WB_IO3 41
-#define WB_IO4 42
-#define WB_IO5 38
-#define WB_IO6 39
-#define WB_A0 1
-#define WB_A1 2
-#define WB_CS 12
+#define WB_IO1  21
+#define WB_IO2  14
+#define WB_IO3  41
+#define WB_IO4  42
+#define WB_IO5  38
+#define WB_IO6  39
+#define WB_A0   1
+#define WB_A1   2
+#define WB_CS   12
 #define WB_LED1 46
 #define WB_LED2 45
 

--- a/variants/rakwireless_rak3112/pins_arduino.h
+++ b/variants/rakwireless_rak3112/pins_arduino.h
@@ -47,4 +47,17 @@ static const uint8_t SCK = 13;
 #define LORA_BUSY 48
 #define LORA_IRQ  LORA_DIO1
 
+// For WisBlock modules, see: https://docs.rakwireless.com/Product-Categories/WisBlock/
+#define WB_IO1 21
+#define WB_IO2 14
+#define WB_IO3 41
+#define WB_IO4 42
+#define WB_IO5 38
+#define WB_IO6 39
+#define WB_A0 1
+#define WB_A1 2
+#define WB_CS 12
+#define WB_LED1 46
+#define WB_LED2 45
+
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
fix : quad_psram: psram id read error: 0x00ffffff, psram chip not found or not supported, or wrong psram line mode arduino

Configuration updates for `rakwireless_rak3112`:
* Added a new `psram_type` property with the value `opi` to specify the type of PSRAM used.
* Introduced a `memory_type` property that dynamically combines `build.boot` and `build.psram_type` for better memory type management.
* Updated the `menu.PSRAM.enabled` description to "OPI PSRAM" for clarity.
* Add wisblock pin define