### PR TITLE
pioarduino only: fix deprecated warnings caused from esptool v5.0.0

### DIFF
--- a/tools/pioarduino-build.py
+++ b/tools/pioarduino-build.py
@@ -95,7 +95,7 @@ def generate_bootloader_image(bootloader_elf):
         env.VerboseAction(
             " ".join(
                 [
-                    '"$PYTHONEXE" "$OBJCOPY"',
+                    "$OBJCOPY",
                     "--chip",
                     build_mcu,
                     "elf2image",


### PR DESCRIPTION
esptool v5.0.0 needs to be called as esptool not anymore as esptool.py. This PR prepares this change for pioarduino.
PR needs to be merged just before https://github.com/pioarduino/platform-espressif32/pull/209 can be merged.

No changes for ArduinoIDE, the change has only impact for pioarduino

@me-no-dev 