### PR TITLE
fix(dangerjs): Disable target branch rule

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -24,4 +24,5 @@ jobs:
           instructions-cla-link: "https://cla-assistant.io/espressif/arduino-esp32"
           instructions-contributions-file: "docs/en/contributing.rst"
           rule-max-commits: "false"
+          rule-target-branch: "false"
           commit-messages-min-summary-length: "10"


### PR DESCRIPTION
## Description of Change

This pull request introduces a minor update to the DangerJS workflow configuration. The change adds a new rule to disable enforcement of `master` as the target branch (as not all PRs target master).

* [`.github/workflows/dangerjs.yml`](diffhunk://#diff-e878c7efb136c2bdcc5ffdc181348b2597cb408c5f8349f67355b8c47b442521R27): Added `rule-target-branch: "false"` to the DangerJS workflow configuration to disable the target branch rule.