### PR TITLE
Backport: pioarduino only change for esptool v5.0.0 support

### DIFF
--- a/tools/pioarduino-build.py
+++ b/tools/pioarduino-build.py
@@ -95,15 +95,15 @@ def generate_bootloader_image(bootloader_elf):
         env.VerboseAction(
             " ".join(
                 [
-                    '"$PYTHONEXE" "$OBJCOPY"',
+                    "$OBJCOPY",
                     "--chip",
                     build_mcu,
                     "elf2image",
-                    "--flash_mode",
+                    "--flash-mode",
                     "${__get_board_flash_mode(__env__)}",
-                    "--flash_freq",
+                    "--flash-freq",
                     "${__get_board_f_image(__env__)}",
-                    "--flash_size",
+                    "--flash-size",
                     board_config.get("upload.flash_size", "4MB"),
                     "-o",
                     "$TARGET",
@@ -216,8 +216,14 @@ env.Append(
             "0x1000" if build_mcu in ["esp32", "esp32s2"] else ("0x2000" if build_mcu in ["esp32p4"] else "0x0000"),
             get_bootloader_image(variants_dir),
         ),
-        ("0x8000", join(env.subst("$BUILD_DIR"), "partitions.bin")),
-        ("0xe000", join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin")),
+        (
+            board_config.get("upload.arduino.partitions_bin", "0x8000"),
+            join(env.subst("$BUILD_DIR"), "partitions.bin"),
+        ),
+        (
+            board_config.get("upload.arduino.boot_app0", "0xe000"),
+            join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin"),
+        ),
     ]
     + [(offset, join(FRAMEWORK_DIR, img)) for offset, img in board_config.get("upload.arduino.flash_extra_images", [])],
 )


### PR DESCRIPTION
since it fixes a lot of issues. related pioarduino PR https://github.com/pioarduino/platform-espressif32/pull/212

@me-no-dev please, by merging i can keep the pioarduino build script code base the same.
