### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-adb3f2a5-v1"
+              "version": "idf-release_v5.5-cf8dad07-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-adb3f2a5-v1",
+          "version": "idf-release_v5.5-cf8dad07-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-adb3f2a5-v1.zip",
-              "checksum": "SHA-256:c7bdda06e7ddae51880fc0e1c76114a8e766a9d682e3645e7794f7126b895a94",
-              "size": "430508851"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-cf8dad07-v1.zip",
+              "checksum": "SHA-256:1029d278d27676bd67432257d637bb308a05883dface477c5ef283680babbac8",
+              "size": "430419361"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.5 df8c4c0
esp-idf: release/v5.5 cf8dad0746
arduino: release/v3.3.x 1426927c8
tinyusb: master ea64300a9
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.5
espressif__esp_delta_ota: 1.1.2
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.1
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.0
espressif__esp-dsp: 1.4.12
espressif__esp-sr: 1.9.5
espressif__eppp_link: 0.3.1
espressif__esp_hosted: 2.0.13
espressif__esp_serial_slave_link: 1.1.0~1
espressif__esp_wifi_remote: 0.13.0
```
