### PR TITLE
fix(merge): Fix merging CN Json

### DIFF
--- a/.github/scripts/merge_packages.py
+++ b/.github/scripts/merge_packages.py
@@ -4,6 +4,7 @@
 # Usage:
 #   python merge_packages.py package_esp8266com_index.json version/new/package_esp8266com_index.json
 # Written by Ivan Grokhotkov, 2015
+# Updated by lucasssvaz to handle Chinese version sorting, 2025
 #
 
 from __future__ import print_function
@@ -36,20 +37,19 @@ def merge_objects(versions, obj):
 
 
 # Normalize ESP release version string (x.x.x) by adding '-rc<MAXINT>' (x.x.x-rc9223372036854775807)
-# to ensure having REL above any RC
+# to ensure having REL above any RC. CN version will be sorted after the official version if they happen
+# to be mixed (normally, CN and non-CN versions should not be mixed)
 # Dummy approach, functional anyway for current ESP package versioning
 # (unlike NormalizedVersion/LooseVersion/StrictVersion & similar crap)
 def pkgVersionNormalized(versionString):
-
-    verStr = str(versionString)
+    verStr = str(versionString).replace("-cn", "")
     verParts = re.split(r"\.|-rc|-alpha", verStr, flags=re.IGNORECASE)
 
     if len(verParts) == 3:
-        if sys.version_info > (3, 0):  # Python 3
-            verStr = str(versionString) + "-rc" + str(sys.maxsize)
-        else:  # Python 2
-            verStr = str(versionString) + "-rc" + str(sys.maxint)
-
+        if "-cn" in str(versionString):
+            verStr = verStr + "-rc" + str(sys.maxsize // 2)
+        else:
+            verStr = verStr + "-rc" + str(sys.maxsize)
     elif len(verParts) != 4:
         print("pkgVersionNormalized WARNING: unexpected version format: {0})".format(verStr), file=sys.stderr)
 

--- a/.github/scripts/release_append_cn.py
+++ b/.github/scripts/release_append_cn.py
@@ -17,8 +17,9 @@ import json
 
 def append_cn_to_versions(obj):
     if isinstance(obj, dict):
-        # dfu-util comes from arduino.cc and not from the Chinese mirrors, so we skip it
-        if obj.get("name") == "dfu-util":
+        # Skip tools that are not from the esp32 package
+        packager = obj.get("packager")
+        if packager is not None and packager != "esp32":
             return
 
         for key, value in obj.items():


### PR DESCRIPTION
## Description of Change

This pull request updates scripts in the `.github/scripts` directory to improve handling of Chinese version sorting and refine version appending logic for ESP packages. The changes include modifications to the version normalization logic, adjustments to filtering criteria for appending versions, and an update to the script's metadata.

### Updates to version handling:

* [`.github/scripts/merge_packages.py`](diffhunk://#diff-21f48161ad48f4a72649224c1a8aef5bf2d2b15c9f6b612e325d7ae3748c94e8L39-R52): Enhanced the `pkgVersionNormalized` function to ensure Chinese versions (`-cn`) are sorted after official versions when mixed. This is achieved by adjusting the `sys.maxsize` value used for sorting.

### Refinements to version appending logic:

* [`.github/scripts/release_append_cn.py`](diffhunk://#diff-2586b0ed70ed22159e05a71a4e9f2be52c882c800ba9a618d36a22d8ea3a65c2L20-R22): Modified the `append_cn_to_versions` function to skip tools that are not part of the `esp32` package, improving the filtering criteria for appending Chinese versions.

### Script metadata update:

* [`.github/scripts/merge_packages.py`](diffhunk://#diff-21f48161ad48f4a72649224c1a8aef5bf2d2b15c9f6b612e325d7ae3748c94e8R7): Updated the script header to reflect the new functionality for handling Chinese version sorting, with attribution to the contributor.

## Tests scenarios

Tested locally and used to fix CN JSON files.
