### PR TITLE
ci(gitlab): Initial GitLab setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,25 @@
+workflow:
+  rules:
+    # Disable those non-protected push triggered pipelines
+    - if: '$CI_COMMIT_REF_NAME != "master" && $CI_COMMIT_BRANCH !~ /^release\/v/ && $CI_COMMIT_TAG !~ /^\d+\.\d+(\.\d+)?($|-)/ && $CI_PIPELINE_SOURCE == "push"'
+      when: never
+    # when running merged result pipelines, CI_COMMIT_SHA represents the temp commit it created.
+    # Please use PIPELINE_COMMIT_SHA at all places that require a commit sha of the original commit.
+    - if: $CI_OPEN_MERGE_REQUESTS != null
+      variables:
+        PIPELINE_COMMIT_SHA: $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+        IS_MR_PIPELINE: 1
+    - if: $CI_OPEN_MERGE_REQUESTS == null
+      variables:
+        PIPELINE_COMMIT_SHA: $CI_COMMIT_SHA
+        IS_MR_PIPELINE: 0
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      variables:
+        IS_SCHEDULED_RUN: "true"
+    - when: always
+
+# Place the default settings in `.gitlab/workflows/common.yml` instead
+
+include:
+  - '.gitlab/workflows/common.yml'
+  - '.gitlab/workflows/sample.yml'

--- a/.gitlab/workflows/common.yml
+++ b/.gitlab/workflows/common.yml
@@ -1,0 +1,26 @@
+#####################
+# Default Variables #
+#####################
+
+stages:
+  - pre_check
+  - build
+  - test
+  - result
+
+variables:
+  ESP_IDF_VERSION: "5.4"
+  ESP_ARDUINO_VERSION: "3.2.1"
+
+#############
+# `default` #
+#############
+
+default:
+  retry:
+    max: 2
+    when:
+      # In case of a runner failure we could hop to another one, or a network error could go away.
+      - runner_system_failure
+      # Job execution timeout may be caused by a network issue.
+      - job_execution_timeout

--- a/.gitlab/workflows/sample.yml
+++ b/.gitlab/workflows/sample.yml
@@ -1,0 +1,6 @@
+hello-world:
+  stage: test
+  script:
+    - echo "Hello, World from GitLab CI!"
+  rules:
+    - when: always


### PR DESCRIPTION
This pull request introduces enhancements to the GitLab CI/CD pipeline configuration by adding new workflow rules, default settings, and a sample job. These changes aim to improve pipeline behavior, provide default configurations, and include a simple example for demonstration purposes.

### Workflow Rules Enhancements:
* [`.gitlab-ci.yml`](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R1-R25): Added rules to handle non-protected branches, merge request pipelines, and scheduled runs. Default settings are now included from external files.

### Default Pipeline Settings:
* [`.gitlab/workflows/common.yml`](diffhunk://#diff-b3c839b55be0d62c88fabbeb6d33bbb1d234cd98188c23d2808f225a2e2f5563R1-R26): Defined default stages (`pre_check`, `build`, `test`, `result`), variables (`ESP_IDF_VERSION`, `ESP_ARDUINO_VERSION`), and retry policies for jobs.

### Example Job:
* [`.gitlab/workflows/sample.yml`](diffhunk://#diff-2795a745884632e07172a4af387416c505d127fbf85e52b4027a13bd20b30459R1-R6): Added a sample job (`hello-world`) that echoes "Hello, World from GitLab CI!" as a simple demonstration.