### PR TITLE
feat(hosted): Add method to update the hosted slave firmware

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -49,7 +49,6 @@ extern "C" {
 #include "lwip/netif.h"
 #include "dhcpserver/dhcpserver.h"
 #include "dhcpserver/dhcpserver_options.h"
-
 }  //extern "C"
 
 #include "esp32-hal.h"
@@ -241,10 +240,10 @@ extern "C" void phy_bbpll_en_usb(bool en);
 
 #if CONFIG_ESP_WIFI_REMOTE_ENABLED
 extern "C" {
-//#include "esp_hosted.h"
-#include "esp_hosted_transport_config.h"
-extern esp_err_t esp_hosted_init();
-extern esp_err_t esp_hosted_deinit();
+#include "esp_hosted.h"
+// #include "esp_hosted_transport_config.h"
+// extern esp_err_t esp_hosted_init();
+// extern esp_err_t esp_hosted_deinit();
 };
 typedef struct {
   uint8_t pin_clk;
@@ -296,6 +295,15 @@ bool WiFiGenericClass::setPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int
   return true;
 }
 
+bool WiFiGenericClass::updateSlave(const char * url) {
+  esp_err_t err = esp_hosted_slave_ota(url);
+  if (err != ESP_OK) {
+    log_e("esp_hosted_slave_ota failed! 0x%x: %s", err, esp_err_to_name(err));
+    return false;
+  }
+  return true;
+}
+
 static bool wifiHostedInit() {
   if (!hosted_initialized) {
     hosted_initialized = true;
@@ -314,6 +322,11 @@ static bool wifiHostedInit() {
       return false;
     }
     log_v("ESP-HOSTED initialized!");
+    // // This throws heap exception when the slave has older firmware
+    // esp_hosted_coprocessor_fwver_t fwver = {0,0,0};
+    // if (esp_hosted_get_coprocessor_fwversion(&fwver) == ESP_OK) {
+    //   log_d("ESP-HOSTED Slave FW Version: %lu.%li.%lu", fwver.major1, fwver.minor1, fwver.patch1);
+    // }
   }
   // Attach pins to PeriMan here
   // Slave chip model is CONFIG_IDF_SLAVE_TARGET

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -85,6 +85,7 @@ public:
 #if CONFIG_ESP_WIFI_REMOTE_ENABLED
   // Set SDIO pins for connection to external ESP MCU
   static bool setPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8_t d3, int8_t rst);
+  static bool updateSlave(const char * url);
 #endif
 
   wifi_event_id_t onEvent(WiFiEventCb cbEvent, arduino_event_id_t event = ARDUINO_EVENT_MAX);


### PR DESCRIPTION
This pull request introduces updates to the `WiFiGeneric` module, focusing on enhancing functionality for ESP-HOSTED configurations and improving code maintainability. The most significant changes include adding a new method for updating slave firmware, modifying the inclusion of headers, and adjusting commented-out code for clarity.

### Enhancements to ESP-HOSTED functionality:
* Added a new method `WiFiGenericClass::updateSlave` in `WiFiGeneric.cpp` and declared it in `WiFiGeneric.h`. This method facilitates OTA updates for the slave firmware using the `esp_hosted_slave_ota` function. [[1]](diffhunk://#diff-0aa87997f6f48b5397f969144b34ce0ad4da8e173aee854c1cf2e1bf69ecf3aaR298-R306) [[2]](diffhunk://#diff-aef37ec58184bbd5ee4dac430dbb910ccd7b6b79815c945490410257e5879578R88)

### Code organization and cleanup:
* Adjusted the inclusion of headers in `WiFiGeneric.cpp` by uncommenting `#include "esp_hosted.h"` and commenting out unused headers and declarations, such as `esp_hosted_transport_config.h` and related functions.
* Added comments in the `wifiHostedInit` function to explain potential heap exceptions when retrieving the firmware version of older slave firmware.
* Removed an unused `extern "C"` block after the `#include` directives for better code clarity.