### PR TITLE
feat(zigbee): Add cb option for default response message

### DIFF
--- a/libraries/Zigbee/keywords.txt
+++ b/libraries/Zigbee/keywords.txt
@@ -47,6 +47,7 @@ zb_power_source_t	KEYWORD1
 ZigbeeWindowCoveringType	KEYWORD1
 ZigbeeFanMode	KEYWORD1
 ZigbeeFanModeSequence	KEYWORD1
+zb_cmd_type_t	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -96,6 +97,7 @@ getTime	KEYWORD2
 getTimezone	KEYWORD2
 addOTAClient	KEYWORD2
 clearBoundDevices	KEYWORD2
+onDefaultResponse	KEYWORD2
 
 # ZigbeeLight + ZigbeeColorDimmableLight
 onLightChange	KEYWORD2

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -608,6 +608,15 @@ void ZigbeeEP::removeBoundDevice(zb_device_params_t *device) {
   log_w("No matching device found for removal");
 }
 
+void ZigbeeEP::zbDefaultResponse(const esp_zb_zcl_cmd_default_resp_message_t *message) {
+  log_v("Default response received for endpoint %d", _endpoint);
+  log_v("Status code: %s", esp_zb_zcl_status_to_name(message->status_code));
+  log_v("Response to command: %d", message->resp_to_cmd);
+  if (_on_default_response) {
+    _on_default_response((zb_cmd_type_t)message->resp_to_cmd, message->status_code);
+  }
+}
+
 const char *ZigbeeEP::esp_zb_zcl_status_to_name(esp_zb_zcl_status_t status) {
   switch (status) {
     case ESP_ZB_ZCL_STATUS_SUCCESS:               return "Success";

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -12,6 +12,32 @@
 #define ZB_CMD_TIMEOUT             10000     // 10 seconds
 #define OTA_UPGRADE_QUERY_INTERVAL (1 * 60)  // 1 hour = 60 minutes
 
+typedef enum {
+  ZB_CMD_READ_ATTRIBUTE                = 0x00U, /*!< Read attributes command */
+  ZB_CMD_READ_ATTRIBUTE_RESPONSE       = 0x01U, /*!< Read attributes response command */
+  ZB_CMD_WRITE_ATTRIBUTE               = 0x02U, /*!< Write attributes foundation command */
+  ZB_CMD_WRITE_ATTRIBUTE_UNDIVIDED     = 0x03U, /*!< Write attributes undivided command */
+  ZB_CMD_WRITE_ATTRIBUTE_RESPONSE      = 0x04U, /*!< Write attributes response command */
+  ZB_CMD_WRITE_ATTRIBUTE_NO_RESPONSE   = 0x05U, /*!< Write attributes no response command */
+  ZB_CMD_CONFIGURE_REPORTING           = 0x06U, /*!< Configure reporting command */
+  ZB_CMD_CONFIGURE_REPORTING_RESPONSE  = 0x07U, /*!< Configure reporting response command */
+  ZB_CMD_READ_REPORTING_CONFIG         = 0x08U, /*!< Read reporting config command */
+  ZB_CMD_READ_REPORTING_CONFIG_RESPONSE= 0x09U, /*!< Read reporting config response command */
+  ZB_CMD_REPORT_ATTRIBUTE              = 0x0aU, /*!< Report attribute command */
+  ZB_CMD_DEFAULT_RESPONSE              = 0x0bU, /*!< Default response command */
+  ZB_CMD_DISCOVER_ATTRIBUTES           = 0x0cU, /*!< Discover attributes command */
+  ZB_CMD_DISCOVER_ATTRIBUTES_RESPONSE  = 0x0dU, /*!< Discover attributes response command */
+  ZB_CMD_READ_ATTRIBUTE_STRUCTURED     = 0x0eU, /*!< Read attributes structured */
+  ZB_CMD_WRITE_ATTRIBUTE_STRUCTURED    = 0x0fU, /*!< Write attributes structured */
+  ZB_CMD_WRITE_ATTRIBUTE_STRUCTURED_RESPONSE = 0x10U, /*!< Write attributes structured response */
+  ZB_CMD_DISCOVER_COMMANDS_RECEIVED    = 0x11U, /*!< Discover Commands Received command */
+  ZB_CMD_DISCOVER_COMMANDS_RECEIVED_RESPONSE = 0x12U, /*!< Discover Commands Received response command */
+  ZB_CMD_DISCOVER_COMMANDS_GENERATED   = 0x13U, /*!< Discover Commands Generated command */
+  ZB_CMD_DISCOVER_COMMANDS_GENERATED_RESPONSE = 0x14U, /*!< Discover Commands Generated response command */
+  ZB_CMD_DISCOVER_ATTRIBUTES_EXTENDED  = 0x15U, /*!< Discover attributes extended command */
+  ZB_CMD_DISCOVER_ATTRIBUTES_EXTENDED_RESPONSE = 0x16U, /*!< Discover attributes extended response command */
+} zb_cmd_type_t;
+
 #define ZB_ARRAY_LENGHT(arr) (sizeof(arr) / sizeof(arr[0]))
 
 #define RGB_TO_XYZ(r, g, b, X, Y, Z)                               \
@@ -138,6 +164,7 @@ public:
   virtual void zbReadTimeCluster(const esp_zb_zcl_attribute_t *attribute);  //already implemented
   virtual void zbIASZoneStatusChangeNotification(const esp_zb_zcl_ias_zone_status_change_notification_message_t *message) {};
   virtual void zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enroll_response_message_t *message) {};
+  virtual void zbDefaultResponse(const esp_zb_zcl_cmd_default_resp_message_t *message); //already implemented
 
   virtual void addBoundDevice(zb_device_params_t *device) {
     _bound_devices.push_back(device);
@@ -156,16 +183,22 @@ public:
     _on_identify = callback;
   }
 
+  void onDefaultResponse(void (*callback)(zb_cmd_type_t resp_to_cmd, esp_zb_zcl_status_t status)) {
+    _on_default_response = callback;
+  }
+
+  // Convert ZCL status to name
+  const char *esp_zb_zcl_status_to_name(esp_zb_zcl_status_t status);
+  
 private:
   char *_read_manufacturer;
   char *_read_model;
   void (*_on_identify)(uint16_t time);
+  void (*_on_default_response)(zb_cmd_type_t resp_to_cmd, esp_zb_zcl_status_t status);
   time_t _read_time;
   int32_t _read_timezone;
 
 protected:
-  // Convert ZCL status to name
-  const char *esp_zb_zcl_status_to_name(esp_zb_zcl_status_t status);
 
   uint8_t _endpoint;
   esp_zb_ha_standard_devices_t _device_id;

--- a/libraries/Zigbee/src/ZigbeeHandlers.cpp
+++ b/libraries/Zigbee/src/ZigbeeHandlers.cpp
@@ -398,6 +398,13 @@ static esp_err_t zb_cmd_default_resp_handler(const esp_zb_zcl_cmd_default_resp_m
     "Received default response: from address(0x%x), src_endpoint(%d) to dst_endpoint(%d), cluster(0x%x) with status 0x%x",
     message->info.src_address.u.short_addr, message->info.src_endpoint, message->info.dst_endpoint, message->info.cluster, message->status_code
   );
+
+  // List through all Zigbee EPs and call the callback function, with the message
+  for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
+    if (message->info.dst_endpoint == (*it)->getEndpoint()) {
+      (*it)->zbDefaultResponse(message);  //method zbDefaultResponse is implemented in the common EP class
+    }
+  }
   return ESP_OK;
 }
 


### PR DESCRIPTION
## Description of Change
Added a default response callback mechanism to ZigbeeEP that allows users to receive notifications when ZCL commands complete, eliminating the need for delays in sleepy devices.

### Main Feature: Default Response Callback
- Users can register a callback function to handle default responses
- Provides typed command identifiers (`zb_cmd_type_t`) for better error handling
- Enables confirmation of command completion without blocking delays
- **Perfect for sleepy devices**: No more `delay()` calls with unknown time

### Additional Improvements
- Added foundation command enum for type safety
- Added status name helper function for better debugging

### Usage Example
```cpp
void onResponse(zb_cmd_type_t command, esp_zb_zcl_status_t status){
  Serial.printf("Response status recieved %s", zbTempSensor.esp_zb_zcl_status_to_name(status));
  if(command == ZB_CMD_REPORT_ATTRIBUTE){ //Check the report attribute default response
    switch (status){
      case ESP_ZB_ZCL_STATUS_SUCCESS: dataToSend--; break; //data reported successfully
      case ESP_ZB_ZCL_STATUS_FAIL: resend = true; break; //data report failed 
      default: break;// can be extended by statuses like ESP_ZB_ZCL_STATUS_INVALID_VALUE, ESP_ZB_ZCL_STATUS_TIMEOUT etc.
    }
  }
}

// Register the callback
zigbee.onDefaultResponse(onResponse);
```

### Benefits for Sleepy Devices
- **No Delays**: Eliminates blocking `delay()` calls
- **Immediate Feedback**: Get notified when reporting complete
- **Better Power Management**: Device can go sleep right after data successfully reported
- **Error Handling**: Proper status checking for failed commands

## Tests scenarios
Tested using updated Temp_Hum_Sleepy example and HA. No data were lost during an 1,5 hour test with reporting data approx. every minute:
<img width="2097" height="895" alt="Screenshot 2025-07-19 at 17 34 07" src="https://github.com/user-attachments/assets/8cc4368a-c24e-41b0-ad81-33295c43aad2" />

## Related links
Closes #11038 
Closes #11597 
Maybe Related #11554 

