### PR TITLE
fix(zigbee): Replace assert with error log to solve immediate crash

### DIFF
--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -237,7 +237,7 @@ void ZigbeeCore::closeNetwork() {
 }
 
 static void bdb_start_top_level_commissioning_cb(uint8_t mode_mask) {
-  if(esp_zb_bdb_start_top_level_commissioning(mode_mask) != ESP_OK){
+  if (esp_zb_bdb_start_top_level_commissioning(mode_mask) != ESP_OK) {
     log_e("Failed to start Zigbee commissioning");
   }
 }

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -237,7 +237,9 @@ void ZigbeeCore::closeNetwork() {
 }
 
 static void bdb_start_top_level_commissioning_cb(uint8_t mode_mask) {
-  ESP_ERROR_CHECK(esp_zb_bdb_start_top_level_commissioning(mode_mask));
+  if(esp_zb_bdb_start_top_level_commissioning(mode_mask) != ESP_OK){
+    log_e("Failed to start Zigbee commissioning");
+  }
 }
 
 void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {


### PR DESCRIPTION
## Description of Change
Replace `ESP_ERROR_CHECK` with proper error handling to prevent system crashes when `esp_zb_bdb_start_top_level_commissioning()` returns `ESP_FAIL` due to invalid commissioning state (can be in progress). This allows the existing retry mechanism to continue working while providing better error logging instead of assertion failures.

Same way its now done in esp-zigbee-sdk examples:
```cpp
static void bdb_start_top_level_commissioning_cb(uint8_t mode_mask)
{
    ESP_RETURN_ON_FALSE(esp_zb_bdb_start_top_level_commissioning(mode_mask) == ESP_OK, , TAG, "Failed to start Zigbee commissioning");
}
```
## Tests scenarios
Tested using some Zigbee example with rebooting many times.

## Related links
Closes #11554 