### PR TITLE
feat(netif): Allow setting interface's routing priority

### DIFF
--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -613,6 +613,15 @@ int NetworkInterface::route_prio() const {
   return esp_netif_get_route_prio(_esp_netif);
 }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+int NetworkInterface::route_prio(int prio) {
+  if (_esp_netif == NULL) {
+    return -1;
+  }
+  return esp_netif_set_route_prio(_esp_netif, prio);
+}
+#endif
+
 bool NetworkInterface::setDefault() {
   if (_esp_netif == NULL) {
     return false;

--- a/libraries/Network/src/NetworkInterface.h
+++ b/libraries/Network/src/NetworkInterface.h
@@ -58,6 +58,9 @@ public:
   String impl_name() const;
   int impl_index() const;
   int route_prio() const;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+  int route_prio(int prio);
+#endif
   bool setDefault();
   bool isDefault() const;
 


### PR DESCRIPTION
This pull request introduces a new method in the `NetworkInterface` class to set the route priority, conditionally compiled for ESP-IDF versions 5.5.0 and above. The most important changes include the addition of the `route_prio(int prio)` method and the corresponding update to the class definition.

### Additions to `NetworkInterface` functionality:
* [`libraries/Network/src/NetworkInterface.cpp`](diffhunk://#diff-b5d6011f70d313cb93bdeec5f973a759842d096bd3532cf28d6a744f204c7b42R616-R624): Added a new method `route_prio(int prio)` to set the route priority for the `_esp_netif` object, with a conditional compilation check for ESP-IDF version 5.5.0 or higher.
* [`libraries/Network/src/NetworkInterface.h`](diffhunk://#diff-2287e8edd2a9dda6fde4f484d1b084616077b4be5b643e51b3a550c5edfd9e68R61-R63): Updated the `NetworkInterface` class definition to include the declaration of the `route_prio(int prio)` method, guarded by the same ESP-IDF version check.