### PR TITLE
fix(ppp): Detach PPP RST pin from periman on end

### DIFF
--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -432,6 +432,11 @@ void PPPClass::end(void) {
     _pin_cts = -1;
     perimanClearPinBus(pin);
   }
+  if (_pin_rst != -1) {
+    pin = _pin_rst;
+    _pin_rst = -1;
+    perimanClearPinBus(pin);
+  }
 
   _mode = ESP_MODEM_MODE_COMMAND;
 }


### PR DESCRIPTION
This pull request updates the `PPPClass::end` method in `libraries/PPP/src/PPP.cpp` to ensure proper cleanup of the `_pin_rst` pin during the method execution.

### Cleanup improvements:
* [`libraries/PPP/src/PPP.cpp`](diffhunk://#diff-364c5b65dee1a6a86c40ed47c9cf8a060bac637d8d32b18e97aba7ca0e27e673R435-R439): Added logic to check if `_pin_rst` is set (not equal to `-1`) and clear it using `perimanClearPinBus`, ensuring consistent resource cleanup.