### PR TITLE
fix(zigbee): Fix RGB color calculation

### DIFF
--- a/cores/esp32/ColorFormat.c
+++ b/cores/esp32/ColorFormat.c
@@ -119,10 +119,10 @@ espHsvColor_t espRgbColorToHsvColor(espRgbColor_t rgb) {
 }
 
 espRgbColor_t espXYColorToRgbColor(uint8_t Level, espXyColor_t xy) {
-  return espXYToRgbColor(Level, xy.x, xy.y);
+  return espXYToRgbColor(Level, xy.x, xy.y, true);
 }
 
-espRgbColor_t espXYToRgbColor(uint8_t Level, uint16_t current_X, uint16_t current_Y) {
+espRgbColor_t espXYToRgbColor(uint8_t Level, uint16_t current_X, uint16_t current_Y, bool addXYZScaling) {
   // convert xyY color space to RGB
 
   // https://www.easyrgb.com/en/math.php
@@ -156,9 +156,11 @@ espRgbColor_t espXYToRgbColor(uint8_t Level, uint16_t current_X, uint16_t curren
   // X, Y and Z input refer to a D65/2° standard illuminant.
   // sR, sG and sB (standard RGB) output range = 0 ÷ 255
   // convert XYZ to RGB - CIE XYZ to sRGB
-  X = X / 100.0f;
-  Y = Y / 100.0f;
-  Z = Z / 100.0f;
+  if (addXYZScaling) {
+    X = X / 100.0f;
+    Y = Y / 100.0f;
+    Z = Z / 100.0f;
+  }
 
   r = (X * 3.2406f) - (Y * 1.5372f) - (Z * 0.4986f);
   g = -(X * 0.9689f) + (Y * 1.8758f) + (Z * 0.0415f);

--- a/cores/esp32/ColorFormat.h
+++ b/cores/esp32/ColorFormat.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -49,7 +50,7 @@ typedef struct HsvColor_t espHsvColor_t;
 typedef struct XyColor_t espXyColor_t;
 typedef struct CtColor_t espCtColor_t;
 
-espRgbColor_t espXYToRgbColor(uint8_t Level, uint16_t current_X, uint16_t current_Y);
+espRgbColor_t espXYToRgbColor(uint8_t Level, uint16_t current_X, uint16_t current_Y, bool addXYZScaling);
 espRgbColor_t espXYColorToRgb(uint8_t Level, espXyColor_t xy);
 espXyColor_t espRgbColorToXYColor(espRgbColor_t rgb);
 espXyColor_t espRgbToXYColor(uint8_t r, uint8_t g, uint8_t b);

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -76,14 +76,13 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
       return;
     } else {
       log_w("Received message ignored. Attribute ID: %d not supported for Level Control", message->attribute.id);
-      //TODO: implement more attributes -> includes/zcl/esp_zigbee_zcl_level.h
     }
   } else if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL) {
     if (message->attribute.id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U16) {
       uint16_t light_color_x = (*(uint16_t *)message->attribute.data.value);
       uint16_t light_color_y = getCurrentColorY();
       //calculate RGB from XY and call setColor()
-      _current_color = espXYToRgbColor(255, light_color_x, light_color_y);  //TODO: Check if level is correct
+      _current_color = espXYToRgbColor(255, light_color_x, light_color_y, false);
       lightChanged();
       return;
 
@@ -91,7 +90,7 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
       uint16_t light_color_x = getCurrentColorX();
       uint16_t light_color_y = (*(uint16_t *)message->attribute.data.value);
       //calculate RGB from XY and call setColor()
-      _current_color = espXYToRgbColor(255, light_color_x, light_color_y);  //TODO: Check if level is correct
+      _current_color = espXYToRgbColor(255, light_color_x, light_color_y, false);
       lightChanged();
       return;
     } else if (message->attribute.id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U8) {


### PR DESCRIPTION
## Description of Change
This pull request introduces changes to improve color conversion functionality and refactors related code for clarity and flexibility. The most significant updates include adding an optional scaling parameter to the `espXYToRgbColor` function, modifying its usage across the codebase, and updating the header file to reflect these changes.

Before:
RED color on max level (100%) - RGB(68,0,0)

After fix:
RED color on max level (100%) - RGB(255,0,0)

## Tests scenarios
Tested using ColorDimmableLight example

## Related links
Closes #11619 
