### PR TITLE
feat(board): Add onboard LED support for Waveshare ESP32-S3 Zero

### DIFF
--- a/variants/waveshare_esp32_s3_zero/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_zero/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID          0x303a
 #define USB_PID          0x822B
@@ -9,8 +10,16 @@
 #define USB_PRODUCT      "ESP32-S3-Zero"
 #define USB_SERIAL       ""  // Empty string for MAC address
 
-// Partial voltage measurement method
+// Onboard WS2812 RGB LED
 #define WS_RGB 21
+
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + WS_RGB;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 64
 
 // Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
 static const uint8_t OUTPUT_IO1 = 1;


### PR DESCRIPTION
## Description of Change
Defines the standard `LED_BUILTIN` and `RGB_BUILTIN` macros for the Waveshare ESP32-S3 Zero, allowing its onboard WS2812 RGB LED to be controlled via standard Arduino APIs.

The implementation follows the conventions established in the base ESP32-S3 variant file.

## Tests scenarios

Tested on a Waveshare ESP32-S3-ZERO board using the arduino-esp32 core v3.2.1. The standard Blink example sketch successfully controls the onboard LED after applying this change.

## Related links

https://www.waveshare.com/wiki/ESP32-S3-Zero#:~:text=ESP32%2DS3%2DZero%20uses%20GPIO21%20to%20connect%20with%20WS2812%20RGB%20LED.

https://github.com/espressif/arduino-esp32/blob/master/variants/esp32s3/pins_arduino.h
