### PR TITLE
feat(github): remove ESP32 forum from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Arduino Core for Espressif Discord Server
     url: https://discord.gg/8xY6e9crwv
     about: Community Discord server for questions and help
-  - name: ESP32 Forum - Arduino
-    url: https://esp32.com/viewforum.php?f=19
-    about: Official Forum for questions


### PR DESCRIPTION

## Description of Change
Revomed the issue template since it was redundant. As it was agreed with the team to remove it.
