### PR TITLE
feat(github): Update template type

### DIFF
--- a/.github/ISSUE_TEMPLATE/Issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/Issue-report.yml
@@ -80,6 +80,17 @@ body:
         - other
     validations:
       required: true
+ - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: How would you define the type of the issue? Please select from the types below.
+      options:
+        - Task
+        - Bug
+        - Question
+    validations:
+      required: true
   - type: input
     id: IDE
     attributes:


### PR DESCRIPTION
## Description of Change
To include and make the "Type" of the issue mandatory.
This way the users would need to select the type of the issue. This will allow the bot to perform more accurately in managing the backlog as well as the engineers. 

This change was discussed with the team and agreed.



