### PR TITLE
feat(zigbee): Update ESP-ZIGBEE-SDK to 1.6.6

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -54,12 +54,12 @@ dependencies:
   espressif/esp_modem:
     version: "^1.1.0"
   espressif/esp-zboss-lib:
-    version: "==1.6.4" # compatible with esp-zigbee-lib 1.6.5
+    version: "==1.6.4" # compatible with esp-zigbee-lib 1.6.6
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/esp-zigbee-lib:
-    version: "==1.6.5"
+    version: "==1.6.6"
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"


### PR DESCRIPTION
## Description of Change
New version of `esp-zigbee-sdk` 1.6.6 got released today. This PR updates the version in `idf_component.yml` so it will be picked for next libs build. This version brings the Binary and Multistate support and more.

## Tests scenarios

## Related links
Related #11609 
Related #11560 
