### PR TITLE
docs: Remove incorrect statement on ESP32-S3 default resolution

### DIFF
--- a/docs/en/api/adc.rst
+++ b/docs/en/api/adc.rst
@@ -52,8 +52,7 @@ This function will return analog value in millivolts (calibrated).
 analogReadResolution
 ^^^^^^^^^^^^^^^^^^^^
 
-This function is used to set the resolution of ``analogRead`` return value. Default is 12 bits (range from 0 to 4095)
-for all chips except ESP32-S3 where default is 13 bits (range from 0 to 8191).
+This function is used to set the resolution of ``analogRead`` return value. Default is 12 bits (range from 0 to 4095).
 When different resolution is set, the values read will be shifted to match the given resolution.
 
 Range is 1 - 16 .The default value will be used, if this function is not used.


### PR DESCRIPTION
## Description of Change
This PR corrects the [documentation for analogReadResolution](https://docs.espressif.com/projects/arduino-esp32/en/latest/api/adc.html#analogreadresolution) by removing an incorrect statement that the ESP32-S3 default ADC resolution is 13 bits.

As confirmed by the function's own documentation in the core header file [esp32-hal-adc.h](https://github.com/espressif/arduino-esp32/blob/c7520ccef0c343611d7f9eb0afb3576f612de2f2/cores/esp32/esp32-hal-adc.h#L49-L56), the default resolution for analogRead is 12 bits (producing a range of 0-4095). 


## Tests scenarios
Compiled and run on Seeed Studio XIAO ESP32S3 in version v3.3.0. By running the standard AnalogReadSerial example code, confirmed that the default output range is 0-4095, corresponding to 12-bit resolution.

## Related links
https://docs.espressif.com/projects/arduino-esp32/en/latest/api/adc.html#analogreadresolution

https://github.com/espressif/arduino-esp32/blob/c7520ccef0c343611d7f9eb0afb3576f612de2f2/cores/esp32/esp32-hal-adc.h#L49-L56

https://github.com/espressif/esp-idf/blob/346870a3044010f2018be0ef3b86ba650251c655/components/soc/esp32s3/include/soc/soc_caps.h#L129-L130
