### PR TITLE
variant lilyho_t3_s3_sx127x duplicates LORA_BUSY - deleting one of them

### DIFF
--- a/variants/lilygo_t3_s3_sx127x/pins_arduino.h
+++ b/variants/lilygo_t3_s3_sx127x/pins_arduino.h
@@ -35,7 +35,6 @@ static const uint8_t SCK = 14;
 #define LORA_CS   7  // SX1276/SX1278 CS
 #define LORA_RST  8  // SX1276/SX1278 RST
 
-#define LORA_BUSY 33
 #define LORA_DIO0 9  //IRQ
 #define LORA_DIO1 33
 #define LORA_DIO2 34


### PR DESCRIPTION
There were two definitions of LORA_BUSY generating a lot of unneccessary warnings.

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*
-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

The file contains two definitions of LORA_BUSY - one as 33, and the other as ```
#define LORA_BUSY LORA_DIO1
``` 
Where DIO1 is also defined as 33.  
This causes lots of un-useful warning messages from the duplicated definition. 

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

Tested on my Lilygo T3 S3, with this change 

## Related links
Not applicable -  no issue posted. 
