### PR TITLE
feat(modem): execution of AT command in raw mode

### DIFF
--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -747,6 +747,18 @@ String PPPClass::cmd(const char *at_command, int timeout) {
   return String(out);
 }
 
+String PPPClass::cmd_raw(const char *at_command, int timeout) {
+  PPP_CMD_MODE_CHECK(String());
+
+  char out[CONFIG_ESP_MODEM_C_API_STR_MAX] = {0};
+  esp_err_t err = _esp_modem_at_raw(_dce, at_command, out, "OK", "ERROR", timeout);
+  if (err != ESP_OK) {
+    log_e("esp_modem_at failed %d %s", err, esp_err_to_name(err));
+    return String();
+  }
+  return String(out);
+}
+
 size_t PPPClass::printDriverInfo(Print &out) const {
   size_t bytes = 0;
   if (_dce == NULL || _mode == ESP_MODEM_MODE_DATA) {

--- a/libraries/PPP/src/PPP.h
+++ b/libraries/PPP/src/PPP.h
@@ -78,6 +78,12 @@ public:
     return cmd(at_command.c_str(), timeout);
   }
 
+  // Send AT command in raw mode (doesn’t append ‘\r’ to command, returns everything) with timeout in milliseconds
+  String cmd_raw(const char *at_command, int timeout);
+  String cmd_raw(String at_command, int timeout) {
+    return cmd_raw(at_command.c_str(), timeout);
+  }
+
   // untested
   bool powerDown();
   bool reset();


### PR DESCRIPTION
## Description of Change

Regular `cmd` function does not return the entire reply of the given AT command that is problematic for some use cases, e.g., quering GNSS data in CMUX mode. So, lets introduce `cmd_raw` call that, assuming correct CMUX behaviour, returns entire reply of the given AT command.

## Tests scenarios

Tested with `Waveshare ESP32-S3 SIM7670G 4G Development Board` using B05 modem firmware.

