### PR TITLE
fix(esp32:m5stack_atoms3) : Update pins_arduino.h of variant m5stack_atoms3 with correct LED_BUILTIN value matching GPIO #35

### DIFF
--- a/variants/m5stack_atoms3/pins_arduino.h
+++ b/variants/m5stack_atoms3/pins_arduino.h
@@ -7,10 +7,10 @@
 #define USB_VID 0x303a
 #define USB_PID 0x1001
 
-// Some boards have too low voltage on this pin (board design bug)
-// Use different pin with 3V and connect with 48
-// and change this setup for the chosen pin (for example 38)
-static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + 48;
+// The board RGB led is connected to GPIO #35
+#define PIN_RGB_LED 35
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
 #define BUILTIN_LED    LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN    LED_BUILTIN
 #define RGB_BUILTIN    LED_BUILTIN


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [X] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [X] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [X] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Setting the proper RGB led pin in the header code to GPIO35

## Tests scenarios
I have tested my pull request on an AtomS3-Lite with Blink.ino and BlinkRGB.ino (Exemples>ESP32>GPIO>BlinkRGB)
The schematics of the AtomS3 (non-lite) shows the LED also connected to GPIO35

## Related links
Fixes [#11688 ](https://github.com/espressif/arduino-esp32/issues/11688)
[HW Doc for AtomS3 ](https://docs.m5stack.com/en/core/AtomS3)
[HW Doc for AtomS3-Lite](https://docs.m5stack.com/en/core/AtomS3-lite)

