### PR TITLE
Potential fix for code scanning alert no. 71: Use of potentially dangerous function

### DIFF
--- a/cores/esp32/esp32-hal-time.c
+++ b/cores/esp32/esp32-hal-time.c
@@ -27,19 +27,19 @@ static void setTimeZone(long offset, int daylight) {
   char tz[33] = {0};
 
   if (offset % 3600) {
-    sprintf(cst, "UTC%ld:%02u:%02u", offset / 3600, abs((offset % 3600) / 60), abs(offset % 60));
+    snprintf(cst, sizeof(cst), "UTC%ld:%02u:%02u", offset / 3600, abs((offset % 3600) / 60), abs(offset % 60));
   } else {
-    sprintf(cst, "UTC%ld", offset / 3600);
+    snprintf(cst, sizeof(cst), "UTC%ld", offset / 3600);
   }
   if (daylight != 3600) {
     long tz_dst = offset - daylight;
     if (tz_dst % 3600) {
-      sprintf(cdt, "DST%ld:%02u:%02u", tz_dst / 3600, abs((tz_dst % 3600) / 60), abs(tz_dst % 60));
+      snprintf(cdt, sizeof(cdt), "DST%ld:%02u:%02u", tz_dst / 3600, abs((tz_dst % 3600) / 60), abs(tz_dst % 60));
     } else {
-      sprintf(cdt, "DST%ld", tz_dst / 3600);
+      snprintf(cdt, sizeof(cdt), "DST%ld", tz_dst / 3600);
     }
   }
-  sprintf(tz, "%s%s", cst, cdt);
+  snprintf(tz, sizeof(tz), "%s%s", cst, cdt);
   setenv("TZ", tz, 1);
   tzset();
 }

--- a/libraries/AsyncUDP/src/AsyncUDP.cpp
+++ b/libraries/AsyncUDP/src/AsyncUDP.cpp
@@ -317,6 +317,33 @@ AsyncUDPPacket::AsyncUDPPacket(AsyncUDPPacket &packet) {
   pbuf_ref(_pb);
 }
 
+AsyncUDPPacket& AsyncUDPPacket::operator=(const AsyncUDPPacket& packet) {
+  if (this != &packet) {
+    if (_pb) {
+      // Free existing pbuf reference
+      pbuf_free(_pb);
+    }
+
+    // Copy all members
+    _udp = packet._udp;
+    _pb = packet._pb;
+    _if = packet._if;
+    _data = packet._data;
+    _len = packet._len;
+    _index = 0;
+
+    memcpy(&_remoteIp, &packet._remoteIp, sizeof(ip_addr_t));
+    memcpy(&_localIp, &packet._localIp, sizeof(ip_addr_t));
+    _localPort = packet._localPort;
+    _remotePort = packet._remotePort;
+    memcpy(_remoteMac, packet._remoteMac, 6);
+
+    // Increment reference count for the new pbuf
+    pbuf_ref(_pb);
+  }
+  return *this;
+}
+
 AsyncUDPPacket::AsyncUDPPacket(AsyncUDP *udp, pbuf *pb, const ip_addr_t *raddr, uint16_t rport, struct netif *ntif) {
   _udp = udp;
   _pb = pb;

--- a/libraries/AsyncUDP/src/AsyncUDP.h
+++ b/libraries/AsyncUDP/src/AsyncUDP.h
@@ -100,6 +100,9 @@ public:
 
   size_t write(const uint8_t *data, size_t len);
   size_t write(uint8_t data);
+
+  // Copy assignment operator
+  AsyncUDPPacket& operator=(const AsyncUDPPacket& packet);
 };
 
 class AsyncUDP : public Print {

--- a/libraries/ESP32/examples/FreeRTOS/Mutex/Mutex.ino
+++ b/libraries/ESP32/examples/FreeRTOS/Mutex/Mutex.ino
@@ -72,16 +72,16 @@ void Task(void *pvParameters) {  // This is a task.
         int new_value = random(1000);
 
         char str0[32];
-        sprintf(str0, " %d <- %d      |", shared_variable, new_value);
+        snprintf(str0, sizeof(str0), " %d <- %d      |", shared_variable, new_value);
         char str1[32];
-        sprintf(str1, "                 | %d <- %d", shared_variable, new_value);
+        snprintf(str1, sizeof(str1), "                 | %d <- %d", shared_variable, new_value);
         Serial.printf("%s\n", task_num ? str0 : str1);
 
         shared_variable = new_value;
         delay(random(100));  // wait random time of max 100 ms - simulating some computation
 
-        sprintf(str0, " R: %d          |", shared_variable);
-        sprintf(str1, "                 | R: %d", shared_variable);
+        snprintf(str0, sizeof(str0), " R: %d          |", shared_variable);
+        snprintf(str1, sizeof(str1), "                 | R: %d", shared_variable);
         Serial.printf("%s\n", task_num ? str0 : str1);
         //Serial.printf("Task %d after write: reading %d\n", task_num, shared_variable);
 

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1593,8 +1593,9 @@ void HTTPClient::setCookie(String date, String headerValue) {
 
   // overwrite or delete cookie in/from cookie jar
   time_t now_local = time(NULL);
-  time_t now_gmt = mktime(gmtime(&now_local));
-
+  struct tm tm_gmt;
+  gmtime_r(&now_local, &tm_gmt);
+  time_t now_gmt = mktime(&tm_gmt);
   bool found = false;
 
   for (auto c = _cookieJar->begin(); c != _cookieJar->end(); ++c) {
@@ -1619,8 +1620,9 @@ void HTTPClient::setCookie(String date, String headerValue) {
 
 bool HTTPClient::generateCookieString(String *cookieString) {
   time_t now_local = time(NULL);
-  time_t now_gmt = mktime(gmtime(&now_local));
-
+  struct tm tm_gmt;
+  gmtime_r(&now_local, &tm_gmt);
+  time_t now_gmt = mktime(&tm_gmt);
   *cookieString = "";
   bool found = false;
 

--- a/libraries/LittleFS/examples/LITTLEFS_time/LITTLEFS_time.ino
+++ b/libraries/LittleFS/examples/LITTLEFS_time/LITTLEFS_time.ino
@@ -40,10 +40,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  DIR : ");
       Serial.print(file.name());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
       if (levels) {
         listDir(fs, file.path(), levels - 1);
@@ -54,10 +55,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  SIZE: ");
       Serial.print(file.size());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
     }
     file = root.openNextFile();

--- a/libraries/SD/examples/SD_time/SD_time.ino
+++ b/libraries/SD/examples/SD_time/SD_time.ino
@@ -78,10 +78,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  DIR : ");
       Serial.print(file.name());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
       if (levels) {
         listDir(fs, file.path(), levels - 1);
@@ -92,10 +93,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  SIZE: ");
       Serial.print(file.size());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
     }
     file = root.openNextFile();

--- a/libraries/SD/src/sd_diskio.cpp
+++ b/libraries/SD/src/sd_diskio.cpp
@@ -462,18 +462,34 @@ private:
  * FATFS API
  * */
 
+/**
+ * @brief Initialize the SD card and prepare it for use with the FATFS filesystem.
+ *
+ * This function performs the low-level initialization sequence for an SD card
+ * over SPI, following the SD card protocol. It sends the required commands to
+ * bring the card out of idle state, checks for card type (SDv1, SDv2, SDHC, MMC),
+ * and configures the card for block access. The function also handles error
+ * conditions and sets the card status accordingly.
+ *
+ * @param pdrv Physical drive number (index into s_cards array).
+ * @return DSTATUS Status of the disk after initialization.
+ */
 DSTATUS ff_sd_initialize(uint8_t pdrv) {
   char token;
   unsigned int resp;
   unsigned int start;
+  // Get the card structure for the given drive number
   ardu_sdcard_t *card = s_cards[pdrv];
 
+  // If the card is already initialized, return its status
   if (!(card->status & STA_NOINIT)) {
     return card->status;
   }
 
+  // Lock the SPI bus and set it to a low frequency (400kHz) for initialization
   AcquireSPI card_locked(card, 400000);
 
+  // Send at least 74 clock cycles with CS high and MOSI high (send 0xFF)
   digitalWrite(card->ssPin, HIGH);
   for (uint8_t i = 0; i < 20; i++) {
     card->spi->transfer(0XFF);

--- a/libraries/SD_MMC/examples/SDMMC_time/SDMMC_time.ino
+++ b/libraries/SD_MMC/examples/SDMMC_time/SDMMC_time.ino
@@ -83,10 +83,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  DIR : ");
       Serial.print(file.name());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
       if (levels) {
         listDir(fs, file.path(), levels - 1);
@@ -97,10 +98,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  SIZE: ");
       Serial.print(file.size());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
     }
     file = root.openNextFile();

--- a/libraries/SPIFFS/examples/SPIFFS_time/SPIFFS_time.ino
+++ b/libraries/SPIFFS/examples/SPIFFS_time/SPIFFS_time.ino
@@ -28,10 +28,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  DIR : ");
       Serial.print(file.name());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
       if (levels) {
         listDir(fs, file.path(), levels - 1);
@@ -42,10 +43,11 @@ void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
       Serial.print("  SIZE: ");
       Serial.print(file.size());
       time_t t = file.getLastWrite();
-      struct tm *tmstruct = localtime(&t);
+      struct tm tmstruct;
+      localtime_r(&t, &tmstruct);
       Serial.printf(
-        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour,
-        tmstruct->tm_min, tmstruct->tm_sec
+        "  LAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour,
+        tmstruct.tm_min, tmstruct.tm_sec
       );
     }
     file = root.openNextFile();


### PR DESCRIPTION
Potential fix for [https://github.com/espressif/arduino-esp32/security/code-scanning/71](https://github.com/espressif/arduino-esp32/security/code-scanning/71)

To fix the problem, replace the use of `gmtime` with `gmtime_r`, which requires the caller to provide a `struct tm` to store the result. Specifically, in `libraries/HTTPClient/src/HTTPClient.cpp`, on line 1596 and 1622, change:

```cpp
time_t now_gmt = mktime(gmtime(&now_local));
```

to:

```cpp
struct tm tm_gmt;
gmtime_r(&now_local, &tm_gmt);
time_t now_gmt = mktime(&tm_gmt);
```

This change should be made in both places where `gmtime` is used (lines 1596 and 1622). No new imports are needed, as `<time.h>` is already included.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
