### PR TITLE
fix(actions): Add missing permissions for workflows

### DIFF
--- a/.github/workflows/allboards.yml
+++ b/.github/workflows/allboards.yml
@@ -5,6 +5,9 @@ on:
   repository_dispatch:
     types: [test-boards]
 
+permissions:
+  contents: read
+
 jobs:
   find-boards:
     runs-on: ubuntu-latest
@@ -35,10 +38,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.client_payload.branch }}
-
-      - run: npm install
-      - name: Setup jq
-        uses: dcarbone/install-jq-action@e397bd87438d72198f81efd21f876461183d383a # v3.0.1
 
       - id: set-test-chunks
         name: Set Chunks

--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -8,6 +8,9 @@ on:
       - "libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino"
       - ".github/workflows/boards.yml"
 
+permissions:
+  contents: read
+
 env:
   # It's convenient to set variables for values used multiple times in the workflow
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -23,9 +26,6 @@ jobs:
       # This step makes the contents of the repository available to the workflow
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup jq
-        uses: dcarbone/install-jq-action@e397bd87438d72198f81efd21f876461183d383a # v3.0.1
 
       - name: Get board name
         run: bash .github/scripts/find_new_boards.sh ${{ github.repository }} ${{github.base_ref}}

--- a/.github/workflows/build_component.yml
+++ b/.github/workflows/build_component.yml
@@ -45,6 +45,9 @@ on:
       - "!*.txt"
       - "!*.properties"
 
+permissions:
+  contents: read
+
 concurrency:
   group: build-component-${{github.event.pull_request.number || github.ref}}
   cancel-in-progress: true
@@ -114,6 +117,7 @@ jobs:
           submodules: recursive
           path: components/arduino-esp32
 
+      # Need to install jq in the container to be able to use it in the script
       - name: Setup jq
         uses: dcarbone/install-jq-action@e397bd87438d72198f81efd21f876461183d383a # v3.0.1
 

--- a/.github/workflows/build_py_tools.yml
+++ b/.github/workflows/build_py_tools.yml
@@ -9,6 +9,10 @@ on:
       - "tools/gen_esp32part.py"
       - "tools/gen_insights_package.py"
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   find-changed-tools:
     name: Check if tools have been changed

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,12 @@ on:
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  security-events: write
+
 jobs:
   codeql-analysis:
     name: CodeQL ${{ matrix.language }} analysis

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -13,6 +13,9 @@ on:
       - "docs/**"
       - ".github/workflows/docs_build.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     name: Build ESP-Docs

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -13,6 +13,9 @@ on:
       - "docs/**"
       - ".github/workflows/docs_deploy.yml"
 
+permissions:
+  contents: read
+
 jobs:
   deploy-prod-docs:
     name: Deploy Documentation on Production

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,6 +10,10 @@ on:
       - ".github/scripts/on-pages.sh"
       - ".github/workflows/gh-pages.yml"
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   build-pages:
     name: Build GitHub Pages

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -13,6 +13,11 @@ concurrency:
   group: libs-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: read
+  pages: write
+
 env:
   # It's convenient to set variables for values used multiple times in the workflow
   SKETCHES_REPORTS_PATH: libraries-report

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,10 @@ concurrency:
   group: pre-commit-${{github.event.pull_request.number || github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   lint:
     if: |

--- a/.github/workflows/publishlib.yml
+++ b/.github/workflows/publishlib.yml
@@ -12,6 +12,10 @@ env:
   SKETCHES_REPORTS_PATH: artifacts/libraries-report
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lib-test-results:
     name: External Libraries Test Results

--- a/.github/workflows/publishsizes-2.x.yml
+++ b/.github/workflows/publishsizes-2.x.yml
@@ -9,6 +9,10 @@ env:
   RESULT_SIZES_TEST_FILE: SIZES_TEST.md
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sizes-test-results:
     name: Sizes Comparison Results

--- a/.github/workflows/publishsizes.yml
+++ b/.github/workflows/publishsizes.yml
@@ -12,6 +12,11 @@ env:
   SKETCHES_REPORTS_PATH: artifacts/sizes-report
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+permissions:
+  contents: read
+  pull-requests: write
+  pages: write
+
 jobs:
   sizes-test-results:
     name: Sizes Comparison Results

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,6 +56,11 @@ concurrency:
   group: build-${{github.event.pull_request.number || github.ref}}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: read
+  pages: write
+
 env:
   MAX_CHUNKS: 15
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: published
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   build:
     name: Publish Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,10 @@ concurrency:
   group: tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   push-event-file:
     name: Push event file

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -12,6 +12,9 @@ on:
         description: "Chip to build tests for"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build-tests:
     name: Build ${{ inputs.type }} tests for ${{ inputs.chip }}

--- a/.github/workflows/tests_hw.yml
+++ b/.github/workflows/tests_hw.yml
@@ -12,6 +12,9 @@ on:
         description: "Chip to run tests for"
         required: true
 
+permissions:
+  contents: read
+
 env:
   DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/tests_qemu.yml
+++ b/.github/workflows/tests_qemu.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   qemu-test:
     name: QEMU ${{ inputs.chip }} ${{ inputs.type }} tests

--- a/.github/workflows/tests_results.yml
+++ b/.github/workflows/tests_results.yml
@@ -7,7 +7,8 @@ on:
       - completed
 
 # No permissions by default
-permissions: { contents: read }
+permissions:
+  contents: read
 
 jobs:
   unit-test-results:

--- a/.github/workflows/tests_wokwi.yml
+++ b/.github/workflows/tests_wokwi.yml
@@ -7,7 +7,8 @@ on:
       - completed
 
 # No permissions by default
-permissions: { contents: read }
+permissions:
+  contents: read
 
 env:
   WOKWI_TIMEOUT: 600000 # Milliseconds


### PR DESCRIPTION
## Description of Change

This pull request updates several GitHub Actions workflow files to explicitly set the permissions key, tightening or clarifying the permissions granted to each workflow. This helps improve security and compliance with GitHub's recommended best practices. Additionally, some unused steps (such as the jq setup) have been removed from certain workflows.

These changes help ensure that each workflow only has the minimum permissions necessary, reducing potential security risks and making permission management clearer.

## Tests scenarios

CI
