### PR TITLE
fix(docs): Correct list indentation for analogWrite parameter

### DIFF
--- a/docs/en/api/ledc.rst
+++ b/docs/en/api/ledc.rst
@@ -296,6 +296,7 @@ It is compatible with Arduinos analogWrite function.
 
 * ``pin`` select the GPIO pin.
 * ``value`` select the duty cycle of pwm.
+
   * range is from 0 (always off) to 255 (always on).
 
 analogWriteResolution


### PR DESCRIPTION
## Description of Change

This pull request fixes a minor formatting issue in the analogWrite function documentation. The description for the value parameter's valid range (0 to 255) was incorrectly indented. This change corrects the indentation to ensure proper rendering and improved readability. This is a purely stylistic fix with no impact on code functionality.

Before fix: 
<img width="927" height="325" alt="Snipaste_2025-08-14_22-10-44" src="https://github.com/user-attachments/assets/645ea3ca-915e-4244-8e56-f3663bd2d6a3" />

After fix: 
<img width="920" height="357" alt="Snipaste_2025-08-14_22-11-39" src="https://github.com/user-attachments/assets/6c0b5cf4-b361-42e7-a3db-673822cc88c6" />


## Test Scenarios
This is a documentation-only change.

## Related links

https://docs.espressif.com/projects/arduino-esp32/en/latest/api/ledc.html#analogwrite