### PR TITLE
fix(pins_arduino): Fixes te mask for the Watchy Device pins

### DIFF
--- a/variants/watchy/pins_arduino.h
+++ b/variants/watchy/pins_arduino.h
@@ -29,15 +29,15 @@ static const uint8_t RTC_INT_PIN = 27;
 #if defined(ARDUINO_WATCHY_V10)
 static const uint8_t UP_BTN_PIN = 32;
 static const uint8_t BATT_ADC_PIN = 33;
-#define RTC_TYPE    1  //DS3231
+#define RTC_TYPE 1  //DS3231
 #elif defined(ARDUINO_WATCHY_V15)
 static const uint8_t UP_BTN_PIN = 32;
 static const uint8_t BATT_ADC_PIN = 35;
-#define RTC_TYPE    2  //PCF8563
+#define RTC_TYPE 2  //PCF8563
 #elif defined(ARDUINO_WATCHY_V20)
 static const uint8_t UP_BTN_PIN = 35;
 static const uint8_t BATT_ADC_PIN = 34;
-#define RTC_TYPE    2  //PCF8563
+#define RTC_TYPE 2  //PCF8563
 #endif
 
 #define UP_BTN_MASK   (BIT64(UP_BTN_PIN))


### PR DESCRIPTION
## Description of Change
Based on user report, the Watchy `pins-arduino.h` causes compilation error.
It shall follow https://github.com/sqfmi/Watchy/blob/master/src/config.h 

## Test Scenarios
Select Watchy board and try to compile a basic sketch
The board revision will default to "Watchy 2.0". Leave it that way.

#### Open Arduino IDE Examples -> Watchy -> WatchFaces -> Basic.ino

``` cpp
#include <Watchy.h>
#include "settings.h"

Watchy watchy(settings);

void setup() {
  watchy.init();
}

void loop() {}
```

#### Error Message that shall be fixed with this PR:
``` 
In file included from C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\cores\esp32/Arduino.h:43,
                 from C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.h:4,
                 from C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:1:
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp: In member function 'void Watchy::deepSleep()':
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:46:23: error: 'GPIO_SEL_26' was not declared in this scope; did you mean 'GPIO_NUM_26'?
   46 | #define MENU_BTN_MASK GPIO_SEL_26
      |                       ^~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:50:23: note: in expansion of macro 'MENU_BTN_MASK'
   50 | #define BTN_PIN_MASK  MENU_BTN_MASK | BACK_BTN_MASK | UP_BTN_MASK | DOWN_BTN_MASK
      |                       ^~~~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:129:7: note: in expansion of macro 'BTN_PIN_MASK'
  129 |       BTN_PIN_MASK,
      |       ^~~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:47:23: error: 'GPIO_SEL_25' was not declared in this scope; did you mean 'GPIO_NUM_25'?
   47 | #define BACK_BTN_MASK GPIO_SEL_25
      |                       ^~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:50:39: note: in expansion of macro 'BACK_BTN_MASK'
   50 | #define BTN_PIN_MASK  MENU_BTN_MASK | BACK_BTN_MASK | UP_BTN_MASK | DOWN_BTN_MASK
      |                                       ^~~~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:129:7: note: in expansion of macro 'BTN_PIN_MASK'
  129 |       BTN_PIN_MASK,
      |       ^~~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:42:21: error: 'GPIO_SEL_35' was not declared in this scope; did you mean 'GPIO_NUM_35'?
   42 | #define UP_BTN_MASK GPIO_SEL_35
      |                     ^~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:50:55: note: in expansion of macro 'UP_BTN_MASK'
   50 | #define BTN_PIN_MASK  MENU_BTN_MASK | BACK_BTN_MASK | UP_BTN_MASK | DOWN_BTN_MASK
      |                                                       ^~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:129:7: note: in expansion of macro 'BTN_PIN_MASK'
  129 |       BTN_PIN_MASK,
      |       ^~~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:48:23: error: 'GPIO_SEL_4' was not declared in this scope; did you mean 'GPIO_NUM_4'?
   48 | #define DOWN_BTN_MASK GPIO_SEL_4
      |                       ^~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:50:69: note: in expansion of macro 'DOWN_BTN_MASK'
   50 | #define BTN_PIN_MASK  MENU_BTN_MASK | BACK_BTN_MASK | UP_BTN_MASK | DOWN_BTN_MASK
      |                                                                     ^~~~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:129:7: note: in expansion of macro 'BTN_PIN_MASK'
  129 |       BTN_PIN_MASK,
      |       ^~~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp: In member function 'virtual void Watchy::handleButtonPress()':
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:46:23: error: 'GPIO_SEL_26' was not declared in this scope; did you mean 'GPIO_NUM_26'?
   46 | #define MENU_BTN_MASK GPIO_SEL_26
      |                       ^~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:138:19: note: in expansion of macro 'MENU_BTN_MASK'
  138 |   if (wakeupBit & MENU_BTN_MASK) {
      |                   ^~~~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:47:23: error: 'GPIO_SEL_25' was not declared in this scope; did you mean 'GPIO_NUM_25'?
   47 | #define BACK_BTN_MASK GPIO_SEL_25
      |                       ^~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:174:24: note: in expansion of macro 'BACK_BTN_MASK'
  174 |   else if (wakeupBit & BACK_BTN_MASK) {
      |                        ^~~~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:42:21: error: 'GPIO_SEL_35' was not declared in this scope; did you mean 'GPIO_NUM_35'?
   42 | #define UP_BTN_MASK GPIO_SEL_35
      |                     ^~~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:187:24: note: in expansion of macro 'UP_BTN_MASK'
  187 |   else if (wakeupBit & UP_BTN_MASK) {
      |                        ^~~~~~~~~~~
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.0\variants\watchy/pins_arduino.h:48:23: error: 'GPIO_SEL_4' was not declared in this scope; did you mean 'GPIO_NUM_4'?
   48 | #define DOWN_BTN_MASK GPIO_SEL_4
      |                       ^~~~~~~~~~
C:\Users\esp\Documents\Arduino\libraries\Watchy\src\Watchy.cpp:199:24: note: in expansion of macro 'DOWN_BTN_MASK'
  199 |   else if (wakeupBit & DOWN_BTN_MASK) {
      |                        ^~~~~~~~~~~~~

```


## Related links
Closes #11737 