### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-ad6904db-v1"
+              "version": "idf-release_v5.5-a3ca8669-v1"
             },
             {
               "packager": "esp32",
@@ -104,62 +104,62 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-ad6904db-v1",
+          "version": "idf-release_v5.5-a3ca8669-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
-              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
+              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
               "size": "433176738"
             }
           ]

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-a3ca8669-v1"
+              "version": "idf-release_v5.5-02c5f2db-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-a3ca8669-v1",
+          "version": "idf-release_v5.5-02c5f2db-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-a3ca8669-v1.zip",
-              "checksum": "SHA-256:cd9c731d486694241e6f29948954de54178f7ff3e983a009368e328ebf8cc5cb",
-              "size": "433176738"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c5f2db-v1.zip",
+              "checksum": "SHA-256:66b131b37183cc3c40ba8de527930209caa33e6f8e3a6da168be10dd2b09c6d8",
+              "size": "433161863"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-b66b5448-v1"
+              "version": "idf-release_v5.5-ad6904db-v1"
             },
             {
               "packager": "esp32",
@@ -76,7 +76,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20250422"
+              "version": "v0.12.0-esp32-20250707"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-b66b5448-v1",
+          "version": "idf-release_v5.5-ad6904db-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-b66b5448-v1.zip",
-              "checksum": "SHA-256:a871d945c6bfb685ecff5e30ad759f280c841ea143071466b2e611bd1800f18f",
-              "size": "430471837"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ad6904db-v1.zip",
+              "checksum": "SHA-256:1422cf0eb6932fe7ae92493b6633e4141b3fab29c153b911cd2881993afe7083",
+              "size": "433176738"
             }
           ]
         },
@@ -414,56 +414,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20250422",
+          "version": "v0.12.0-esp32-20250707",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-amd64-0.12.0-esp32-20250422.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250422.tar.gz",
-              "checksum": "SHA-256:eb1fa9b21c65b45a2200af6dcc2914e32335d37b6dbbd181778dcc0dc025e70a",
-              "size": "2445546"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-linux-amd64-0.12.0-esp32-20250707.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250707.tar.gz",
+              "checksum": "SHA-256:766293bd7a08900d3536f87a0a7ade960f07266f16e4147f95ca5ce4e15d4c5d",
+              "size": "2489724"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-arm64-0.12.0-esp32-20250422.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250422.tar.gz",
-              "checksum": "SHA-256:f70334a9b12a75b4d943e09fa5db30973037c39dbb54d6fa9f1a7118228b3d1c",
-              "size": "2330926"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-linux-arm64-0.12.0-esp32-20250707.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250707.tar.gz",
+              "checksum": "SHA-256:34b6883c372444b49950893b2fc0101aefd10d404a88ef72c97e80199f8544d3",
+              "size": "2371243"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-armel-0.12.0-esp32-20250422.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250422.tar.gz",
-              "checksum": "SHA-256:4ac34d6fd1af86aeda87c8318732f8d691c300c285c7fd2f5037c432c63fbbb3",
-              "size": "2470732"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-linux-armel-0.12.0-esp32-20250707.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250707.tar.gz",
+              "checksum": "SHA-256:fd48492cf3ee16577c661fdccc14c349d34a9ab93aac5039ddf72332d4f4b70b",
+              "size": "2517680"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-macos-0.12.0-esp32-20250422.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250422.tar.gz",
-              "checksum": "SHA-256:9186a7a06304c6d9201cbce4ee3c7099b393bf8d329cda17a68874f92308f6ce",
-              "size": "2548730"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-macos-0.12.0-esp32-20250707.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250707.tar.gz",
+              "checksum": "SHA-256:6267be53892a76d535938a1b044b685adc7d292f090447e8a3e3d0f0996474d1",
+              "size": "2585348"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-macos-arm64-0.12.0-esp32-20250422.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250422.tar.gz",
-              "checksum": "SHA-256:2cc39318d52f393233ff1f777871aebe5b97b3fbad29556a238489263401b774",
-              "size": "2593819"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-macos-arm64-0.12.0-esp32-20250707.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250707.tar.gz",
+              "checksum": "SHA-256:150e938ac48a6ee031ddbc8b31043bc7f2073ab2ee4896b658918d35899673c3",
+              "size": "2628741"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-win32-0.12.0-esp32-20250422.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250422.zip",
-              "checksum": "SHA-256:ecb4f8533fa9098d10000f5f7e8b8eaa8591015b824b481078ddb2b37e7aa6f2",
-              "size": "2988859"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-win32-0.12.0-esp32-20250707.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250707.zip",
+              "checksum": "SHA-256:666274b04af7f36b430b6d063006051c37b8635b5175735ad5af07a1fbc6f486",
+              "size": "3034680"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-win64-0.12.0-esp32-20250422.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250422.zip",
-              "checksum": "SHA-256:e9eae8e1a8d0e030cd81dcb08394a9137cb7338a6211dfabcdbdfb37b58c5a23",
-              "size": "2988858"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-win64-0.12.0-esp32-20250707.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250707.zip",
+              "checksum": "SHA-256:5186ba3f7ee29fb6ab68a4ed7bb417211bad76ecdcdf9280a9187ebfd549a3c1",
+              "size": "3034680"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master beff445
esp-idf: release/v5.5 ad6904db25
arduino: master 9b8af64ef
tinyusb: master 5fb3c0996
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.1
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.5
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.6
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.2
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_jpeg: 1.3.1
espressif__esp_matter: 1.4.1
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.1
espressif__esp-dsp: 1.7.0
espressif__eppp_link: 1.0.1
espressif__esp_hosted: 2.2.4
espressif__esp_serial_slave_link: 1.1.0~1
espressif__esp_wifi_remote: 0.13.0
```
