### PR TITLE
fix: Use correct category for ESP_NOW

### DIFF
--- a/libraries/ESP_NOW/library.properties
+++ b/libraries/ESP_NOW/library.properties
@@ -4,6 +4,6 @@ author=me-no-dev
 maintainer=P-R-O-C-H-Y
 sentence=Library for ESP_NOW
 paragraph=Supports ESP32 Arduino platforms.
-category=Sensor
+category=Communication
 url=https://github.com/espressif/arduino-esp32/
 architectures=esp32


### PR DESCRIPTION
## Description of Change

Change category of ESP_NOW from "Sensor", which is not a valid category, to "Communication", since ESP_NOW enables communications.

here are the valid categories
  + Display
  + Communication
  + Signal Input/Output
  + Sensors
  + Device Control
  + Timing
  + Data Storage
  + Data Processing
  + Other

## Test Scenarios
In the arduino app, to use a category,

  1.  Sketch
  2. Include Library
  3. Manage Libraries
  4. Topic dropdown menu
  5. select a category

## Related links

see here for valid categories at the time of this commit

https://github.com/arduino/arduino-cli/blob/b6ddb5ad8397309b1c37745344b455406f085d0d/internal/arduino/libraries/libraries.go#L38

