### PR TITLE
feat(rmt): adds new function to send specific number of loops

### DIFF
--- a/cores/esp32/esp32-hal-rmt.h
+++ b/cores/esp32/esp32-hal-rmt.h
@@ -124,7 +124,9 @@ bool rmtWrite(int pin, rmt_data_t *data, size_t num_rmt_symbols, uint32_t timeou
 bool rmtWriteAsync(int pin, rmt_data_t *data, size_t num_rmt_symbols);
 
 /**
-     Writing data up to the reserved memsize, looping continuously
+     Writing data up to the reserved memsize, looping continuously (rmtWriteLooping) or fixed 
+     number of times (rmtWriteLoopingCount())
+     
      <rmt_symbol> is a 32 bits structure as defined by rmt_data_t type.
      It is possible to use the macro RMT_SYMBOLS_OF(data), if data is an array of rmt_data_t
 
@@ -136,6 +138,7 @@ bool rmtWriteAsync(int pin, rmt_data_t *data, size_t num_rmt_symbols);
      <bool rmtTransmitCompleted(int pin)> will return always <true> while it is looping.
 */
 bool rmtWriteLooping(int pin, rmt_data_t *data, size_t num_rmt_symbols);
+bool rmtWriteLoopingCount(int pin, rmt_data_t *data, size_t num_rmt_symbols, uint32_t loop_count);
 
 /**
      Checks if transmission is completed and the rmtChannel ready for transmitting new data.


### PR DESCRIPTION
## Description of Change
Adds a new function `rmtWriteLoopingCount()` to send a specific number of times, repeating the same RMT Symbols.

## Test Scenarios


## Related links
Closes #11731