### PR TITLE
fix(ledc): Allow setting AnalogWrite frequency and resolution before calling analogWrite

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -785,7 +785,7 @@ void analogWrite(uint8_t pin, int value) {
 
 void analogWriteFrequency(uint8_t pin, uint32_t freq) {
   ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(pin, ESP32_BUS_TYPE_LEDC);
-  if (bus != NULL) { // if pin is attached to LEDC change frequency, otherwise update the global frequency
+  if (bus != NULL) {  // if pin is attached to LEDC change frequency, otherwise update the global frequency
     if (ledcChangeFrequency(pin, freq, analog_resolution) == 0) {
       log_e("analogWrite frequency cant be set due to selected resolution! Try to adjust resolution first");
       return;
@@ -796,7 +796,7 @@ void analogWriteFrequency(uint8_t pin, uint32_t freq) {
 
 void analogWriteResolution(uint8_t pin, uint8_t resolution) {
   ledc_channel_handle_t *bus = (ledc_channel_handle_t *)perimanGetPinBus(pin, ESP32_BUS_TYPE_LEDC);
-  if (bus != NULL) { // if pin is attached to LEDC change resolution, otherwise update the global resolution
+  if (bus != NULL) {  // if pin is attached to LEDC change resolution, otherwise update the global resolution
     if (ledcChangeFrequency(pin, analog_frequency, resolution) == 0) {
       log_e("analogWrite resolution cant be set due to selected frequency! Try to adjust frequency first");
       return;


### PR DESCRIPTION
## Description of Change
This pull request improves the behavior of `analogWriteFrequency` and `analogWriteResolution` functions in the `esp32-hal-ledc.c` file. The changes ensure that when a pin is not yet attached to the LEDC bus, frequency and resolution updates are applied to the global settings that are later used when calling `analogWrite`.

Improvements to pin-specific configuration:

* Updated `analogWriteFrequency` to check if the pin is attached to the LEDC bus and apply the frequency change to the pin, falling back to updating the global frequency if not attached.
* Updated `analogWriteResolution` to check if the pin is attached to the LEDC bus and apply the resolution change to the pin, falling back to updating the global resolution if not attached.

## Test Scenarios
Tested using simple sketch on ESP32.

```cpp
void setup() {
  analogWriteFrequency(5,1000);
  analogWriteResolution(5, 10);
  analogWrite(5,1000);
}

void loop() {
  // put your main code here, to run repeatedly:
}
```

Before:
```
[   733][E][esp32-hal-ledc.c:788] analogWriteFrequency(): analogWrite frequency cant be set due to selected resolution! Try to adjust resolution first
[   746][E][esp32-hal-ledc.c:796] analogWriteResolution(): analogWrite resolution cant be set due to selected frequency! Try to adjust frequency first
[   762][V][esp32-hal-periman.c:235] perimanSetBusDeinit(): Deinit function for type LEDC (12) successfully set to 0x400d17b0
[   775][D][esp32-hal-ledc.c:53] find_matching_timer(): Searching for timer with freq=1000, resolution=8
[   786][D][esp32-hal-ledc.c:69] find_matching_timer(): No matching timer found for freq=1000, resolution=8
[   798][D][esp32-hal-ledc.c:97] find_free_timer(): Found free timer 0
[   807][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 5 successfully set to type LEDC (12) with bus 0x3ffb8524
[   819][I][esp32-hal-ledc.c:288] ledcAttachChannel(): LEDC attached to pin 5 (channel 0, resolution 8)

```
After:
```
[   733][V][esp32-hal-periman.c:235] perimanSetBusDeinit(): Deinit function for type LEDC (12) successfully set to 0x400d17bc
[   744][D][esp32-hal-ledc.c:53] find_matching_timer(): Searching for timer with freq=1000, resolution=10
[   756][D][esp32-hal-ledc.c:69] find_matching_timer(): No matching timer found for freq=1000, resolution=10
[   767][D][esp32-hal-ledc.c:97] find_free_timer(): Found free timer 0
[   776][V][esp32-hal-periman.c:160] perimanSetPinBus(): Pin 5 successfully set to type LEDC (12) with bus 0x3ffb8524
[   788][I][esp32-hal-ledc.c:288] ledcAttachChannel(): LEDC attached to pin 5 (channel 0, resolution 10)

```
## Related links
Closes #11670 
