### PR TITLE
Add function to handle library installation from ci.json

### DIFF
--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -425,6 +425,10 @@ The ``ci.json`` file is used to specify how the test suite and sketches will han
 * ``fqbn``: A dictionary that specifies the FQBNs that will be used to compile the sketch. The key is the target name and the value is a list
   of FQBNs. The `default FQBNs <https://github.com/espressif/arduino-esp32/blob/a31a5fca1739993173caba995f7785b8eed6b30e/.github/scripts/sketch_utils.sh#L86-L91>`_
   are used if this field is not specified. This overrides the default FQBNs and the ``fqbn_append`` field.
+* ``libs``: A list of libraries that are required to run the test suite. The libraries will be installed automatically if they are not already present.
+  Libraries are installed using the ``arduino-cli lib install`` command, so you can specify libraries by name + version (e.g., ``AudioZero@1.0.0``)
+  or by URL (e.g., ``https://github.com/arduino-libraries/WiFi101.git``).
+  More information can be found in the `Arduino CLI documentation <https://arduino.github.io/arduino-cli/1.3/commands/arduino-cli_lib_install/>`_.
 
 The ``wifi`` test suite is a good example of how to use the ``ci.json`` file:
 


### PR DESCRIPTION
## Description of Change
This pull request enhances the automation for building Arduino sketches by introducing support for installing required libraries specified in a `ci.json` file. It adds a new `install_libs` function to the build scripts, ensures libraries are installed before building sketches, and updates the documentation to describe this new feature.

## Test Scenarios
I have tested multiple scenarios of library installations from `ci.json` files on various ESP32 boards in CI.
Link to my GitHub Actions workflow: [link](https://github.com/JakubAndrysek/arduino-esp32/actions/runs/17262216498/job/48986151555?pr=6)

## Related links
<img width="1151" height="160" alt="image" src="https://github.com/user-attachments/assets/f0cc234e-61ee-40fc-aa4f-f237f7a66610" />


<img width="1221" height="784" alt="image" src="https://github.com/user-attachments/assets/8a31b729-7dbe-4d2f-9377-f35d1927d74e" />