### PR TITLE
feat(zigbee): Update esp-zigbee-lib to 1.6.7

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -54,12 +54,12 @@ dependencies:
   espressif/esp_modem:
     version: "^1.1.0"
   espressif/esp-zboss-lib:
-    version: "==1.6.4" # compatible with esp-zigbee-lib 1.6.6
+    version: "==1.6.4" # compatible with esp-zigbee-lib 1.6.7
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/esp-zigbee-lib:
-    version: "==1.6.6"
+    version: "==1.6.7"
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"


### PR DESCRIPTION
## Description of Change
This pull request updates the Zigbee-related dependencies to newer versions for improved compatibility. The changes ensure that `esp-zboss-lib` and `esp-zigbee-lib` are aligned with their latest compatible releases.

Dependency updates:

* Updated `esp-zboss-lib` version requirement to be compatible with `esp-zigbee-lib` 1.6.7 in `idf_component.yml`.
* Updated `esp-zigbee-lib` version from 1.6.6 to 1.6.7 in `idf_component.yml`.

## Test Scenarios
Will be tested with new libs when build.

## Related links