### PR TITLE
corrected typo in ZIGBEE_DEFAULT_PRESSURE_SENSOR_CONFIG

### DIFF
--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.h
@@ -24,8 +24,8 @@
         .pressure_meas_cfg =                                                                        \
             {                                                                                       \
                 .measured_value = ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_DEFAULT_VALUE,         \
-                .min_value = ESP_ZB_ZCL_PATTR_RESSURE_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE,          \
-                .max_value = ESP_ZB_ZCL_PATTR_RESSURE_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE,          \
+                .min_value = ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE,           \
+                .max_value = ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE,           \
             },                                                                                      \
     }
 // clang-format on


### PR DESCRIPTION
## Description of Change
Corrects misspelled macro names causing compilation errors in ZigbeePressureSensor

## Test Scenarios
n/a

## Related links
n/a
