### PR TITLE
feat(WebServer): Add support for JavaScript modules

### DIFF
--- a/libraries/WebServer/src/detail/mimetable.cpp
+++ b/libraries/WebServer/src/detail/mimetable.cpp
@@ -10,6 +10,7 @@ const Entry mimeTable[maxType] = {
   {".css", "text/css"},
   {".txt", "text/plain"},
   {".js", "application/javascript"},
+  {".mjs", "text/javascript"},
   {".json", "application/json"},
   {".png", "image/png"},
   {".gif", "image/gif"},

--- a/libraries/WebServer/src/detail/mimetable.h
+++ b/libraries/WebServer/src/detail/mimetable.h
@@ -9,6 +9,7 @@ enum type {
   css,
   txt,
   js,
+  mjs,
   json,
   png,
   gif,


### PR DESCRIPTION
## Description of Change
Added media type for .mjs files on the WebServer library.

Previously, they were being served with the "application/octet-stream" MIME type,  [which web browsers wouldn't accept](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#aside_%E2%80%94_.mjs_versus_.js).

I chose "text/javascript" for the media type instead of "application/javascript" (which is used by the library for .js files) because the latter was deprecated on [RFC 9239](https://www.rfc-editor.org/rfc/rfc9239).

## Test Scenarios
Tested on Arduino-esp32 core v3.2.1 using an ESP32 board.
