### PR TITLE
feat(sr): Update ESP-SR to 2.x and enable it for ESP32-P4

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -103,9 +103,9 @@ dependencies:
       - if: "target not in [esp32c2, esp32p4]"
   # RainMaker End
   espressif/esp-sr:
-    version: "^1.4.2"
+    version: "^2.1.5"
     rules:
-      - if: "target in [esp32s3]"
+      - if: "target in [esp32s3, esp32p4]"
   espressif/esp_hosted:
     version: "^2.0.12"
     rules:

--- a/libraries/ESP_SR/src/ESP_SR.cpp
+++ b/libraries/ESP_SR/src/ESP_SR.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
 #include "sdkconfig.h"
-#if CONFIG_IDF_TARGET_ESP32S3 && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
+#if (CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4) && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
 #include "ESP_SR.h"
 
 static esp_err_t on_sr_fill(void *arg, void *out, size_t len, size_t *bytes_read, uint32_t timeout_ms) {

--- a/libraries/ESP_SR/src/ESP_SR.h
+++ b/libraries/ESP_SR/src/ESP_SR.h
@@ -6,7 +6,7 @@
 
 #pragma once
 #include "sdkconfig.h"
-#if CONFIG_IDF_TARGET_ESP32S3 && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
+#if (CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4) && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
 
 #include "ESP_I2S.h"
 #include "esp32-hal-sr.h"

--- a/libraries/ESP_SR/src/esp32-hal-sr.c
+++ b/libraries/ESP_SR/src/esp32-hal-sr.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Unlicense OR CC0-1.0
  */
 #include "sdkconfig.h"
-#if CONFIG_IDF_TARGET_ESP32S3 && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
+#if (CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4) && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
 
 #if !defined(ARDUINO_PARTITION_esp_sr_32) && !defined(ARDUINO_PARTITION_esp_sr_16) && !defined(ARDUINO_PARTITION_esp_sr_8)
 #warning Compatible partition must be selected for ESP_SR to work

--- a/libraries/ESP_SR/src/esp32-hal-sr.h
+++ b/libraries/ESP_SR/src/esp32-hal-sr.h
@@ -6,7 +6,7 @@
 
 #pragma once
 #include "sdkconfig.h"
-#if CONFIG_IDF_TARGET_ESP32S3 && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
+#if (CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4) && (CONFIG_USE_WAKENET || CONFIG_USE_MULTINET)
 
 #include "driver/i2s_types.h"
 #include "esp_err.h"


### PR DESCRIPTION
This pull request updates the ESP Speech Recognition (`ESP_SR`) component to support the ESP32P4 target and upgrades the underlying `esp-sr` dependency version. The main changes ensure that speech recognition features are now available for both ESP32S3 and ESP32P4 platforms when WakeNet or MultiNet are enabled.

**Platform and Dependency Updates:**

* Updated the `espressif/esp-sr` dependency version from `^1.4.2` to `^2.1.5` in `idf_component.yml`, and expanded its rules to include the ESP32P4 target.

**Platform Support Expansion:**

* Modified preprocessor conditionals in `ESP_SR.cpp`, `ESP_SR.h`, `esp32-hal-sr.c`, and `esp32-hal-sr.h` to include both `CONFIG_IDF_TARGET_ESP32S3` and `CONFIG_IDF_TARGET_ESP32P4`, enabling speech recognition features for ESP32P4. [[1]](diffhunk://#diff-851eb004e9e5540eb0d33084a734d7f07956c639ed63fbf3f32c83adda0dcea7L7-R7) [[2]](diffhunk://#diff-efb824d4c780e58795dee415cbab84d430f99b418f44088e3dfc97f529138072L9-R9) [[3]](diffhunk://#diff-6da5946afd887fbb04d73d89bb98e7e730b5bcfdd418b4f127e77e51f3c4a531L7-R7) [[4]](diffhunk://#diff-d18a2c477df37df25ec2ad2c701b722f95093da4bd862dcfd1410b279b752a9aL9-R9)

Fixes: https://github.com/espressif/arduino-esp32/issues/11783