### PR TITLE
fix(package_index): Use HTTPS URL for online help link

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -6,7 +6,7 @@
       "websiteURL": "https://github.com/espressif/arduino-esp32",
       "email": "hristo@espressif.com",
       "help": {
-        "online": "http://esp32.com"
+        "online": "https://esp32.com"
       },
       "platforms": [
         {


### PR DESCRIPTION
## Description of Change
The generated package index uses secure HTTPS links to all resources, but still uses an obsolete HTTP link for the online help URL in the package metadata. Fix this tiny issue in the package template.