### PR TITLE
fix(zigbee): Add lock in scanNetworks to avoid race condition

### DIFF
--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -515,8 +515,14 @@ void ZigbeeCore::scanNetworks(u_int32_t channel_mask, u_int8_t scan_duration) {
     log_e("Zigbee stack is not started, cannot scan networks");
     return;
   }
+  if (_scan_status == ZB_SCAN_RUNNING) {
+    log_w("Scan already in progress, ignoring new scan request");
+    return;
+  }
   log_v("Scanning Zigbee networks");
+  esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zdo_active_scan_request(channel_mask, scan_duration, scanCompleteCallback);
+  esp_zb_lock_release();
   _scan_status = ZB_SCAN_RUNNING;
 }
 


### PR DESCRIPTION
## Description of Change
Improvements to scan management and thread safety:

* Added a check to prevent initiating a new scan if one is already in progress, logging a warning and returning early in `ZigbeeCore::scanNetworks` (`ZigbeeCore.cpp`).
* Wrapped the scan request call with `esp_zb_lock_acquire` and `esp_zb_lock_release` to ensure thread safety when starting a Zigbee network scan (`ZigbeeCore.cpp`).

## Test Scenarios
Tested using the ScanNetworks example.

## Related links
Closes #10879 
