### PR TITLE
Add header check for esp_bt.h in esp32-hal-misc.c

### DIFF
--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -308,7 +308,7 @@ void initArduino() {
   if (err) {
     log_e("Failed to initialize NVS! Error: %u", err);
   }
-#if (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && SOC_BT_SUPPORTED
+#if (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && SOC_BT_SUPPORTED && __has_include("esp_bt.h")
   if (!btInUse()) {
     esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
   }


### PR DESCRIPTION
@me-no-dev 
to fix error in pioarduino compile when `lib_ignore = BLE` is used. Furthermore this aligns with check in line 28.
No functional change in Arduino code.

The setting `lib_ignore` can be used to speed up build compile times, since only libs which are really used are compiled
and all not needed include paths are removed (helps Windows users, with path length limit)

RMT Blink Example with `lib_ignore` set for BLE and Wifi (manually added this patch)
```
Converting RMTWriteNeoPixel.ino
[ComponentManager] Ignored library: esp_wifi (4 entries)
[ComponentManager] Ignored library: bt (37 entries)
[ComponentManager] Updated build file (41 total removals)
[ComponentManager] Processed 2 ignored libraries
[ComponentManager] Session completed with 4 changes
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 25 compatible libraries
Scanning dependencies...
No dependencies
Building in release mode
```
