### PR TITLE
ci(component): Enable ESP32-C5 for component testing

### DIFF
--- a/.github/scripts/on-push-idf.sh
+++ b/.github/scripts/on-push-idf.sh
@@ -26,7 +26,7 @@ for example in $affected_examples; do
         fi
     fi
 
-    idf.py -C "$example_path" set-target "$IDF_TARGET"
+    idf.py --preview -C "$example_path" set-target "$IDF_TARGET"
 
     has_requirements=$(${CHECK_REQUIREMENTS} "$example_path" "$example_path/sdkconfig")
     if [ "$has_requirements" -eq 0 ]; then
@@ -35,5 +35,5 @@ for example in $affected_examples; do
     fi
 
     printf "\n\033[95mBuilding %s\033[0m\n\n" "$example"
-    idf.py -C "$example_path" -DEXTRA_COMPONENT_DIRS="$PWD/components" build
+    idf.py --preview -C "$example_path" -DEXTRA_COMPONENT_DIRS="$PWD/components" build
 done

--- a/.github/workflows/build_component.yml
+++ b/.github/workflows/build_component.yml
@@ -67,8 +67,6 @@ jobs:
     if: ${{ !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')) }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      idf_ver: ${{ steps.set-matrix.outputs.idf_ver }}
-      idf_target: ${{ steps.set-matrix.outputs.idf_target }}
       should_build: ${{ steps.affected-examples.outputs.should_build }}
     steps:
       - name: Install universal-ctags


### PR DESCRIPTION
## Description of Change

This pull request updates the matrix generation for the Arduino as ESP-IDF component tests and includes the ESP32-C5 in the tests.

## Test Scenarios

CI