### PR TITLE
ci(pre-commit): Comment when fixes are needed

### DIFF
--- a/.github/workflows/pre-commit-status.yml
+++ b/.github/workflows/pre-commit-status.yml
@@ -131,3 +131,34 @@ jobs:
           gh pr edit ${{ steps.pr-info.outputs.pr_number }} --repo ${{ github.repository }} --remove-label 'Status: Pre-commit fixes required ⚠️'
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Comment on PR about pre-commit failures
+        if: |
+          steps.pr-info.outputs.artifacts_found == 'true' &&
+          steps.pr-info.outputs.pre_commit_outcome == 'failure' &&
+          steps.pr-info.outputs.pending_commit == '0'
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          pr-number: ${{ steps.pr-info.outputs.pr_number }}
+          comment-tag: pre-commit-failure
+          message: |
+            ## ⚠️ Pre-commit Hooks Failed
+
+            Some pre-commit hooks failed and require manual fixes.
+
+            **What to do:**
+            1. 🔧 Fix the issues locally in your code
+            2. 💾 Commit and push your changes
+            3. 🔄 The hooks will run again automatically
+
+            [🔗 View detailed error log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})
+
+      - name: Remove pre-commit failure comment if resolved
+        if: |
+          steps.pr-info.outputs.artifacts_found == 'true' &&
+          steps.pr-info.outputs.pre_commit_outcome == 'success'
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          pr-number: ${{ steps.pr-info.outputs.pr_number }}
+          comment-tag: pre-commit-failure
+          mode: delete


### PR DESCRIPTION
## Description of Change

This pull request improves the pre-commit workflow by providing clearer feedback to contributors when pre-commit hooks fail and automatically cleaning up comments when issues are resolved. These changes help developers quickly identify and address pre-commit issues in their pull requests.

Enhancements to pre-commit feedback:

* Added a workflow step to automatically comment on the pull request if pre-commit hooks fail and manual fixes are required, including instructions and a link to the error log.
* Added a workflow step to automatically remove the pre-commit failure comment if the issues are resolved in subsequent commits.

## Test Scenarios

Tested in Fork

