### PR TITLE
feat(ble): Enable BLE for ESP32-P4 through esp-hosted

### DIFF
--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -1,0 +1,183 @@
+// Copyright 2015-2025 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sdkconfig.h"
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE) || defined(CONFIG_ESP_WIFI_REMOTE_ENABLED)
+
+#include "esp32-hal-hosted.h"
+#include "esp32-hal-log.h"
+
+#include "esp_hosted_transport_config.h"
+extern esp_err_t esp_hosted_init();
+extern esp_err_t esp_hosted_deinit();
+
+static bool hosted_initialized = false;
+static bool hosted_ble_active = false;
+static bool hosted_wifi_active = false;
+
+static sdio_pin_config_t sdio_pin_config = {
+#ifdef BOARD_HAS_SDIO_ESP_HOSTED
+  .pin_clk = BOARD_SDIO_ESP_HOSTED_CLK,
+  .pin_cmd = BOARD_SDIO_ESP_HOSTED_CMD,
+  .pin_d0 = BOARD_SDIO_ESP_HOSTED_D0,
+  .pin_d1 = BOARD_SDIO_ESP_HOSTED_D1,
+  .pin_d2 = BOARD_SDIO_ESP_HOSTED_D2,
+  .pin_d3 = BOARD_SDIO_ESP_HOSTED_D3,
+  .pin_reset = BOARD_SDIO_ESP_HOSTED_RESET
+#else
+  .pin_clk = CONFIG_ESP_SDIO_PIN_CLK,
+  .pin_cmd = CONFIG_ESP_SDIO_PIN_CMD,
+  .pin_d0 = CONFIG_ESP_SDIO_PIN_D0,
+  .pin_d1 = CONFIG_ESP_SDIO_PIN_D1,
+  .pin_d2 = CONFIG_ESP_SDIO_PIN_D2,
+  .pin_d3 = CONFIG_ESP_SDIO_PIN_D3,
+  .pin_reset = CONFIG_ESP_SDIO_GPIO_RESET_SLAVE
+#endif
+};
+
+// Forward declarations
+bool hostedInit();
+bool hostedDeinit();
+
+bool hostedInitBLE() {
+  log_i("Initializing ESP-Hosted for BLE");
+  hosted_ble_active = true;
+  return hostedInit();
+}
+
+bool hostedInitWiFi() {
+  log_i("Initializing ESP-Hosted for WiFi");
+  hosted_wifi_active = true;
+  return hostedInit();
+}
+
+bool hostedDeinitBLE() {
+  log_i("Deinitializing ESP-Hosted for BLE");
+  hosted_ble_active = false;
+  if (!hosted_wifi_active) {
+    return hostedDeinit();
+  } else {
+    log_i("ESP-Hosted is still being used by Wi-Fi. Skipping deinit.");
+    return true;
+  }
+}
+
+bool hostedDeinitWiFi() {
+  log_i("Deinitializing ESP-Hosted for WiFi");
+  hosted_wifi_active = false;
+  if (!hosted_ble_active) {
+    return hostedDeinit();
+  } else {
+    log_i("ESP-Hosted is still being used by BLE. Skipping deinit.");
+    return true;
+  }
+}
+
+bool hostedInit() {
+  if (!hosted_initialized) {
+    log_i("Initializing ESP-Hosted");
+    log_d("SDIO pins: clk=%d, cmd=%d, d0=%d, d1=%d, d2=%d, d3=%d, rst=%d", sdio_pin_config.pin_clk, sdio_pin_config.pin_cmd, sdio_pin_config.pin_d0, sdio_pin_config.pin_d1, sdio_pin_config.pin_d2, sdio_pin_config.pin_d3, sdio_pin_config.pin_reset);
+    hosted_initialized = true;
+    struct esp_hosted_sdio_config conf = INIT_DEFAULT_HOST_SDIO_CONFIG();
+    conf.pin_clk.pin = sdio_pin_config.pin_clk;
+    conf.pin_cmd.pin = sdio_pin_config.pin_cmd;
+    conf.pin_d0.pin = sdio_pin_config.pin_d0;
+    conf.pin_d1.pin = sdio_pin_config.pin_d1;
+    conf.pin_d2.pin = sdio_pin_config.pin_d2;
+    conf.pin_d3.pin = sdio_pin_config.pin_d3;
+    conf.pin_reset.pin = sdio_pin_config.pin_reset;
+    // esp_hosted_sdio_set_config() will fail on second attempt but here temporarily to not cause exception on reinit
+    if (esp_hosted_sdio_set_config(&conf) != ESP_OK || esp_hosted_init() != ESP_OK) {
+      log_e("esp_hosted_init failed!");
+      hosted_initialized = false;
+      return false;
+    }
+    log_i("ESP-Hosted initialized!");
+  }
+
+  // Attach pins to PeriMan here
+  // Slave chip model is CONFIG_IDF_SLAVE_TARGET
+  // sdio_pin_config.pin_clk
+  // sdio_pin_config.pin_cmd
+  // sdio_pin_config.pin_d0
+  // sdio_pin_config.pin_d1
+  // sdio_pin_config.pin_d2
+  // sdio_pin_config.pin_d3
+  // sdio_pin_config.pin_reset
+
+  return true;
+}
+
+bool hostedSetPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8_t d3, int8_t rst) {
+  if (clk < 0 || cmd < 0 || d0 < 0 || d1 < 0 || d2 < 0 || d3 < 0 || rst < 0) {
+    log_e("All SDIO pins must be defined");
+    return false;
+  }
+
+  if (hosted_initialized) {
+    int8_t current_clk, current_cmd, current_d0, current_d1, current_d2, current_d3, current_rst;
+    hostedGetPins(&current_clk, &current_cmd, &current_d0, &current_d1, &current_d2, &current_d3, &current_rst);
+    log_e("SDIO pins must be set before ESP-Hosted is initialized");
+    log_e("Current pins used: clk=%d, cmd=%d, d0=%d, d1=%d, d2=%d, d3=%d, rst=%d", current_clk, current_cmd, current_d0, current_d1, current_d2, current_d3, current_rst);
+    return false;
+  }
+
+  sdio_pin_config.pin_clk = clk;
+  sdio_pin_config.pin_cmd = cmd;
+  sdio_pin_config.pin_d0 = d0;
+  sdio_pin_config.pin_d1 = d1;
+  sdio_pin_config.pin_d2 = d2;
+  sdio_pin_config.pin_d3 = d3;
+  sdio_pin_config.pin_reset = rst;
+  return true;
+}
+
+void hostedGetPins(int8_t *clk, int8_t *cmd, int8_t *d0, int8_t *d1, int8_t *d2, int8_t *d3, int8_t *rst) {
+  *clk = sdio_pin_config.pin_clk;
+  *cmd = sdio_pin_config.pin_cmd;
+  *d0 = sdio_pin_config.pin_d0;
+  *d1 = sdio_pin_config.pin_d1;
+  *d2 = sdio_pin_config.pin_d2;
+  *d3 = sdio_pin_config.pin_d3;
+  *rst = sdio_pin_config.pin_reset;
+}
+
+bool hostedIsBLEActive() {
+  return hosted_ble_active;
+}
+
+bool hostedIsWiFiActive() {
+  return hosted_wifi_active;
+}
+
+bool hostedDeinit() {
+  if (!hosted_initialized) {
+    log_e("ESP-Hosted is not initialized");
+    return false;
+  }
+
+  if (esp_hosted_deinit() != ESP_OK) {
+    log_e("esp_hosted_deinit failed!");
+    return false;
+  }
+
+  hosted_initialized = false;
+  return true;
+}
+
+bool hostedIsInitialized() {
+  return hosted_initialized;
+}
+
+#endif /* defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE) || defined(CONFIG_ESP_WIFI_REMOTE_ENABLED) */

--- a/cores/esp32/esp32-hal-hosted.h
+++ b/cores/esp32/esp32-hal-hosted.h
@@ -1,0 +1,53 @@
+// Copyright 2015-2025 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MAIN_ESP32_HAL_HOSTED_H_
+#define MAIN_ESP32_HAL_HOSTED_H_
+
+#include "sdkconfig.h"
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE) || defined(CONFIG_ESP_WIFI_REMOTE_ENABLED)
+
+#include "stdint.h"
+#include "stdbool.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  uint8_t pin_clk;
+  uint8_t pin_cmd;
+  uint8_t pin_d0;
+  uint8_t pin_d1;
+  uint8_t pin_d2;
+  uint8_t pin_d3;
+  uint8_t pin_reset;
+} sdio_pin_config_t;
+
+bool hostedInitBLE();
+bool hostedInitWiFi();
+bool hostedDeinitBLE();
+bool hostedDeinitWiFi();
+bool hostedIsInitialized();
+bool hostedIsBLEActive();
+bool hostedIsWiFiActive();
+bool hostedSetPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8_t d3, int8_t rst);
+void hostedGetPins(int8_t *clk, int8_t *cmd, int8_t *d0, int8_t *d1, int8_t *d2, int8_t *d3, int8_t *rst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE) || defined(CONFIG_ESP_WIFI_REMOTE_ENABLED) */
+#endif /* MAIN_ESP32_HAL_HOSTED_H_ */

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -100,6 +100,7 @@ void yield(void);
 #include "esp32-hal-psram.h"
 #include "esp32-hal-rgb-led.h"
 #include "esp32-hal-cpu.h"
+#include "esp32-hal-hosted.h"
 
 void analogWrite(uint8_t pin, int value);
 void analogWriteFrequency(uint8_t pin, uint32_t freq);

--- a/libraries/BLE/src/BLE2901.cpp
+++ b/libraries/BLE/src/BLE2901.cpp
@@ -16,9 +16,8 @@
 */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -56,4 +55,4 @@ void BLE2901::setDescription(const String &userDesc) {
 }
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLE2901.h
+++ b/libraries/BLE/src/BLE2901.h
@@ -19,9 +19,8 @@
 #define COMPONENTS_CPP_UTILS_BLE2901_H_
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -44,5 +43,6 @@ public:
 };  // BLE2901
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLE2901_H_ */

--- a/libraries/BLE/src/BLE2902.cpp
+++ b/libraries/BLE/src/BLE2902.cpp
@@ -15,9 +15,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -126,4 +125,4 @@ void BLE2902::setNotifications(bool flag) {
 }
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLE2902.h
+++ b/libraries/BLE/src/BLE2902.h
@@ -13,9 +13,8 @@
 #define COMPONENTS_CPP_UTILS_BLE2902_H_
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -62,5 +61,6 @@ This class will be removed in a future version.")]] BLE2902 : public BLEDescript
   };  // BLE2902
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLE2902_H_ */

--- a/libraries/BLE/src/BLE2904.cpp
+++ b/libraries/BLE/src/BLE2904.cpp
@@ -13,10 +13,10 @@
  * See also:
  * https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.descriptor.gatt.characteristic_presentation_format.xml
  */
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -85,4 +85,4 @@ void BLE2904::setUnit(uint16_t unit) {
 }
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLE2904.h
+++ b/libraries/BLE/src/BLE2904.h
@@ -13,9 +13,8 @@
 #define COMPONENTS_CPP_UTILS_BLE2904_H_
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -105,5 +104,6 @@ private:
 };  // BLE2904
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLE2904_H_ */

--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -227,4 +226,4 @@ BLEAddress::BLEAddress(String stringAddress, uint8_t type) {
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEAddress.h
+++ b/libraries/BLE/src/BLEAddress.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEADDRESS_H_
 #define COMPONENTS_CPP_UTILS_BLEADDRESS_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -22,7 +22,9 @@
  ***************************************************************************/
 
 #include "WString.h"
+#if SOC_BLE_SUPPORTED
 #include <esp_bt.h>
+#endif
 #include <string>
 
 /***************************************************************************
@@ -109,5 +111,6 @@ private:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEADDRESS_H_ */

--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -659,4 +659,4 @@ uint8_t BLEAdvertisedDevice::getAdvType() {
 }
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEAdvertisedDevice.h
+++ b/libraries/BLE/src/BLEAdvertisedDevice.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEADVERTISEDDEVICE_H_
 #define COMPONENTS_CPP_UTILS_BLEADVERTISEDDEVICE_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -230,5 +230,6 @@ public:
 #endif  // SOC_BLE_50_SUPPORTED && CONFIG_BLUEDROID_ENABLED
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEADVERTISEDDEVICE_H_ */

--- a/libraries/BLE/src/BLEAdvertising.cpp
+++ b/libraries/BLE/src/BLEAdvertising.cpp
@@ -22,9 +22,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -1425,4 +1424,4 @@ bool BLEAdvertising::stop() {
 #endif /* CONFIG_NIMBLE_ENABLED */
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEAdvertising.h
+++ b/libraries/BLE/src/BLEAdvertising.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEADVERTISING_H_
 #define COMPONENTS_CPP_UTILS_BLEADVERTISING_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -253,5 +253,6 @@ private:
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEADVERTISING_H_ */

--- a/libraries/BLE/src/BLEBeacon.cpp
+++ b/libraries/BLE/src/BLEBeacon.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -96,4 +95,4 @@ void BLEBeacon::setProximityUUID(BLEUUID uuid) {
 }
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEBeacon.h
+++ b/libraries/BLE/src/BLEBeacon.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEBEACON_H_
 #define COMPONENTS_CPP_UTILS_BLEBEACON_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -64,5 +64,6 @@ public:
 };  // BLEBeacon
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEBEACON_H_ */

--- a/libraries/BLE/src/BLECharacteristic.cpp
+++ b/libraries/BLE/src/BLECharacteristic.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -1172,4 +1171,4 @@ void BLECharacteristicCallbacks::onSubscribe(BLECharacteristic *pCharacteristic,
 #endif /* CONFIG_NIMBLE_ENABLED */
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLECharacteristic.h
+++ b/libraries/BLE/src/BLECharacteristic.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLECHARACTERISTIC_H_
 #define COMPONENTS_CPP_UTILS_BLECHARACTERISTIC_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -330,5 +330,6 @@ public:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLECHARACTERISTIC_H_ */

--- a/libraries/BLE/src/BLECharacteristicMap.cpp
+++ b/libraries/BLE/src/BLECharacteristicMap.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -183,4 +182,4 @@ void BLECharacteristicMap::handleGATTServerEvent(uint16_t conn_handle, uint16_t 
 #endif  // CONFIG_NIMBLE_ENABLED
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -20,7 +19,9 @@
  ***************************************************************************/
 
 #include "Arduino.h"
+#if SOC_BLE_SUPPORTED
 #include <esp_bt.h>
+#endif
 #include "BLEClient.h"
 #include "BLEUtils.h"
 #include "BLEService.h"
@@ -1298,4 +1299,4 @@ bool BLEClientCallbacks::onConnParamsUpdateRequest(BLEClient *pClient, const ble
 #endif  // CONFIG_NIMBLE_ENABLED
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEClient.h
+++ b/libraries/BLE/src/BLEClient.h
@@ -13,9 +13,8 @@
 #define MAIN_BLECLIENT_H_
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -213,5 +212,6 @@ public:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* MAIN_BLECLIENT_H_ */

--- a/libraries/BLE/src/BLEDescriptor.cpp
+++ b/libraries/BLE/src/BLEDescriptor.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -406,4 +405,4 @@ int BLEDescriptor::handleGATTServerEvent(uint16_t conn_handle, uint16_t attr_han
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEDescriptor.h
+++ b/libraries/BLE/src/BLEDescriptor.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEDESCRIPTOR_H_
 #define COMPONENTS_CPP_UTILS_BLEDESCRIPTOR_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -182,5 +182,6 @@ public:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEDESCRIPTOR_H_ */

--- a/libraries/BLE/src/BLEDescriptorMap.cpp
+++ b/libraries/BLE/src/BLEDescriptorMap.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -213,4 +212,4 @@ void BLEDescriptorMap::handleGATTServerEvent(uint16_t conn_handle, uint16_t attr
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -24,7 +23,15 @@
 #include <freertos/task.h>
 #include <esp_err.h>
 #include <nvs_flash.h>
+#if SOC_BLE_SUPPORTED
 #include <esp_bt.h>
+#else
+// For ESP32-P4 and other chips without native BLE support
+// Define minimal types needed for interface compatibility
+typedef int esp_power_level_t;
+typedef int esp_ble_power_type_t;
+#define ESP_BLE_PWR_TYPE_DEFAULT 0
+#endif
 
 #include <esp_err.h>
 #include <map>
@@ -73,6 +80,10 @@
 #include "host/util/util.h"
 #include "services/gap/ble_svc_gap.h"
 #include "services/gatt/ble_svc_gatt.h"
+#endif
+
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
+#include "esp32-hal-hosted.h"
 #endif
 
 /***************************************************************************
@@ -341,6 +352,16 @@ void BLEDevice::init(String deviceName) {
 #endif  // CONFIG_BLE_SMP_ENABLE
 #endif  // CONFIG_BLUEDROID_ENABLED
 
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
+    // Initialize esp-hosted transport for BLE HCI when explicitly enabled
+    if (!hostedInitBLE()) {
+      log_e("Failed to initialize ESP-Hosted for BLE");
+      return;
+    }
+
+    // Hosted HCI driver will be initialized automatically by NimBLE transport layer
+#endif
+
 #if defined(CONFIG_NIMBLE_ENABLED)
     errRc = nimble_port_init();
     if (errRc != ESP_OK) {
@@ -412,10 +433,14 @@ void BLEDevice::init(String deviceName) {
  */
 void BLEDevice::setPower(esp_power_level_t powerLevel, esp_ble_power_type_t powerType) {
   log_v(">> setPower: %d (type: %d)", powerLevel, powerType);
+#if defined(SOC_BLE_SUPPORTED)
   esp_err_t errRc = ::esp_ble_tx_power_set(powerType, powerLevel);
   if (errRc != ESP_OK) {
     log_e("esp_ble_tx_power_set: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
   };
+#else
+  log_w("setPower not supported with hosted HCI - power controlled by co-processor");
+#endif
   log_v("<< setPower");
 }  // setPower
 
@@ -438,6 +463,7 @@ void BLEDevice::setPower(esp_power_level_t powerLevel, esp_ble_power_type_t powe
  */
 
 int BLEDevice::getPower(esp_ble_power_type_t powerType) {
+#if SOC_BLE_SUPPORTED
   switch (esp_ble_tx_power_get(powerType)) {
     case ESP_PWR_LVL_N12: return -12;
     case ESP_PWR_LVL_N9:  return -9;
@@ -449,6 +475,10 @@ int BLEDevice::getPower(esp_ble_power_type_t powerType) {
     case ESP_PWR_LVL_P9:  return 9;
     default:              return -128;
   }
+#else
+  log_w("getPower not supported with hosted HCI - power controlled by co-processor");
+  return 0; // Return default power level
+#endif
 }  // getPower
 
 /**
@@ -683,13 +713,21 @@ void BLEDevice::deinit(bool release_memory) {
   nimble_port_deinit();
 #endif
 
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
+  hostedDeinitBLE();
+#endif
+
+#if CONFIG_BT_CONTROLLER_ENABLED
   esp_bt_controller_disable();
   esp_bt_controller_deinit();
+#endif
 
 #ifdef ARDUINO_ARCH_ESP32
   if (release_memory) {
     // Require tests because we released classic BT memory and this can cause crash (most likely not, esp-idf takes care of it)
+#if CONFIG_BT_CONTROLLER_ENABLED
     esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
+#endif
   } else {
 #ifdef CONFIG_NIMBLE_ENABLED
     m_synced = false;
@@ -728,6 +766,14 @@ String BLEDevice::getBLEStackString() {
     case BLEStack::UNKNOWN:
     default:                  return "Unknown";
   }
+}
+
+bool BLEDevice::isHostedBLE() {
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
+  return true;
+#else
+  return false;
+#endif
 }
 
 /***************************************************************************
@@ -1113,4 +1159,4 @@ int BLEDeviceCallbacks::onStoreStatus(struct ble_store_status_event *event, void
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEDevice.h
+++ b/libraries/BLE/src/BLEDevice.h
@@ -11,10 +11,10 @@
 
 #ifndef MAIN_BLEDevice_H_
 #define MAIN_BLEDevice_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -22,7 +22,15 @@
  ***************************************************************************/
 
 #include <map>
+#if defined(SOC_BLE_SUPPORTED)
 #include <esp_bt.h>
+#else
+// For ESP32-P4 and other chips without native BLE support
+// Define minimal types needed for interface compatibility
+typedef int esp_power_level_t;
+typedef int esp_ble_power_type_t;
+#define ESP_BLE_PWR_TYPE_DEFAULT 0
+#endif
 #include "WString.h"
 #include "BLEServer.h"
 #include "BLEClient.h"
@@ -32,6 +40,8 @@
 #include "BLESecurity.h"
 #include "BLEAddress.h"
 #include "BLEUtils.h"
+#include "BLEUUID.h"
+#include "BLEAdvertisedDevice.h"
 
 /***************************************************************************
  *                           Common definitions                            *
@@ -60,6 +70,9 @@ enum class BLEStack {
 #if defined(CONFIG_NIMBLE_ENABLED)
 #include <host/ble_gap.h>
 #define ESP_GATT_IF_NONE BLE_HS_CONN_HANDLE_NONE
+
+// Hosted HCI transport implementation is provided in BLEHostedHCI.cpp
+// and is automatically linked when building for ESP32-P4
 
 // NimBLE configuration compatibility macros
 #if defined(CONFIG_SCAN_DUPLICATE_BY_DEVICE_ADDR) && !defined(CONFIG_BTDM_SCAN_DUPL_TYPE_DEVICE)
@@ -190,6 +203,7 @@ public:
   static void deinit(bool release_memory = false);
   static BLEStack getBLEStack();
   static String getBLEStackString();
+  static bool isHostedBLE();
 
   /***************************************************************************
    *                       Bluedroid public declarations                    *
@@ -272,5 +286,6 @@ public:
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* MAIN_BLEDevice_H_ */

--- a/libraries/BLE/src/BLEEddystoneTLM.cpp
+++ b/libraries/BLE/src/BLEEddystoneTLM.cpp
@@ -14,10 +14,10 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
+
 #include <string.h>
 #include <stdio.h>
 #include "esp32-hal-log.h"
@@ -181,4 +181,4 @@ void BLEEddystoneTLM::setTime(uint32_t tmil) {
 }  // setTime
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEEddystoneTLM.h
+++ b/libraries/BLE/src/BLEEddystoneTLM.h
@@ -11,10 +11,10 @@
 
 #ifndef _BLEEddystoneTLM_H_
 #define _BLEEddystoneTLM_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 #include "BLEUUID.h"
@@ -65,5 +65,6 @@ private:
 };  // BLEEddystoneTLM
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* _BLEEddystoneTLM_H_ */

--- a/libraries/BLE/src/BLEEddystoneURL.cpp
+++ b/libraries/BLE/src/BLEEddystoneURL.cpp
@@ -13,10 +13,10 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
+
 #include <string.h>
 #include "esp32-hal-log.h"
 #include "BLEEddystoneURL.h"
@@ -174,34 +174,22 @@ void BLEEddystoneURL::setUUID(BLEUUID l_uuid) {
 }  // setUUID
 
 void BLEEddystoneURL::setPower(esp_power_level_t advertisedTxPower) {
-  int tx_power;
+  int tx_power = 0;
+  #if SOC_BLE_SUPPORTED
   switch (advertisedTxPower) {
-    case ESP_PWR_LVL_N12:  // 12dbm
-      tx_power = -12;
-      break;
-    case ESP_PWR_LVL_N9:  // -9dbm
-      tx_power = -9;
-      break;
-    case ESP_PWR_LVL_N6:  // -6dbm
-      tx_power = -6;
-      break;
-    case ESP_PWR_LVL_N3:  // -3dbm
-      tx_power = -3;
-      break;
-    case ESP_PWR_LVL_N0:  //  0dbm
-      tx_power = 0;
-      break;
-    case ESP_PWR_LVL_P3:  // +3dbm
-      tx_power = +3;
-      break;
-    case ESP_PWR_LVL_P6:  // +6dbm
-      tx_power = +6;
-      break;
-    case ESP_PWR_LVL_P9:  // +9dbm
-      tx_power = +9;
-      break;
-    default: tx_power = 0;
+    case ESP_PWR_LVL_N12:  tx_power = -12; break;
+    case ESP_PWR_LVL_N9:   tx_power = -9;  break;
+    case ESP_PWR_LVL_N6:   tx_power = -6;  break;
+    case ESP_PWR_LVL_N3:   tx_power = -3;  break;
+    case ESP_PWR_LVL_N0:   tx_power = 0;   break;
+    case ESP_PWR_LVL_P3:   tx_power = +3;  break;
+    case ESP_PWR_LVL_P6:   tx_power = +6;  break;
+    case ESP_PWR_LVL_P9:   tx_power = +9;  break;
+    default:               tx_power = 0;   break;
   }
+  #else
+  log_w("setPower not supported with hosted HCI - power controlled by co-processor");
+  #endif
   m_eddystoneData.advertisedTxPower = int8_t((tx_power - -100) / 2);
 }  // setPower
 
@@ -300,4 +288,4 @@ void BLEEddystoneURL::_initHeadder() {
 }
 
 #endif
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEEddystoneURL.h
+++ b/libraries/BLE/src/BLEEddystoneURL.h
@@ -14,15 +14,17 @@
 
 #ifndef _BLEEddystoneURL_H_
 #define _BLEEddystoneURL_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 #include "BLEUUID.h"
 #include <BLEAdvertisedDevice.h>
-#include "esp_bt.h"
+#if SOC_BLE_SUPPORTED
+#include <esp_bt.h>
+#endif
 
 #define EDDYSTONE_URL_FRAME_TYPE 0x10
 
@@ -65,5 +67,6 @@ private:
 };  // BLEEddystoneURL
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* _BLEEddystoneURL_H_ */

--- a/libraries/BLE/src/BLEExceptions.cpp
+++ b/libraries/BLE/src/BLEExceptions.cpp
@@ -6,8 +6,9 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
+#include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 
 //#include "BLEExceptions.h"
 
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEExceptions.h
+++ b/libraries/BLE/src/BLEExceptions.h
@@ -7,10 +7,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEEXCEPTIONS_H_
 #define COMPONENTS_CPP_UTILS_BLEEXCEPTIONS_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 
 #if CONFIG_CXX_EXCEPTIONS != 1
 #error "C++ exception handling must be enabled within make menuconfig. See Compiler Options > Enable C++ Exceptions."
@@ -30,5 +30,6 @@ class BLEUuidNotFoundException : public std::exception {
   }
 };
 
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEEXCEPTIONS_H_ */

--- a/libraries/BLE/src/BLEHIDDevice.cpp
+++ b/libraries/BLE/src/BLEHIDDevice.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -282,4 +281,4 @@ BLEService *BLEHIDDevice::batteryService() {
 }
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEHIDDevice.h
+++ b/libraries/BLE/src/BLEHIDDevice.h
@@ -13,9 +13,8 @@
 #define _BLEHIDDEVICE_H_
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 #include "BLECharacteristic.h"
@@ -80,5 +79,6 @@ private:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* _BLEHIDDEVICE_H_ */

--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -999,4 +998,4 @@ bool BLERemoteCharacteristic::unsubscribe(bool response) {
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLERemoteCharacteristic.h
+++ b/libraries/BLE/src/BLERemoteCharacteristic.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEREMOTECHARACTERISTIC_H_
 #define COMPONENTS_CPP_UTILS_BLEREMOTECHARACTERISTIC_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -193,5 +193,6 @@ private:
 };  // BLERemoteCharacteristic
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEREMOTECHARACTERISTIC_H_ */

--- a/libraries/BLE/src/BLERemoteDescriptor.cpp
+++ b/libraries/BLE/src/BLERemoteDescriptor.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -480,4 +479,4 @@ exit:
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLERemoteDescriptor.h
+++ b/libraries/BLE/src/BLERemoteDescriptor.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEREMOTEDESCRIPTOR_H_
 #define COMPONENTS_CPP_UTILS_BLEREMOTEDESCRIPTOR_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -103,5 +103,6 @@ private:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEREMOTEDESCRIPTOR_H_ */

--- a/libraries/BLE/src/BLERemoteService.cpp
+++ b/libraries/BLE/src/BLERemoteService.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -424,4 +423,4 @@ int BLERemoteService::characteristicDiscCB(uint16_t conn_handle, const struct bl
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLERemoteService.h
+++ b/libraries/BLE/src/BLERemoteService.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEREMOTESERVICE_H_
 #define COMPONENTS_CPP_UTILS_BLEREMOTESERVICE_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -128,5 +128,6 @@ private:
 };  // BLERemoteService
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEREMOTESERVICE_H_ */

--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -13,9 +13,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -860,4 +859,4 @@ void BLEScan::onHostSync() {
 #endif  // CONFIG_NIMBLE_ENABLED
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEScan.h
+++ b/libraries/BLE/src/BLEScan.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLESCAN_H_
 #define COMPONENTS_CPP_UTILS_BLESCAN_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -233,5 +233,6 @@ public:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLESCAN_H_ */

--- a/libraries/BLE/src/BLESecurity.cpp
+++ b/libraries/BLE/src/BLESecurity.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -368,4 +367,4 @@ void BLESecurityCallbacks::onAuthenticationComplete(ble_gap_conn_desc *desc) {
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLESecurity.h
+++ b/libraries/BLE/src/BLESecurity.h
@@ -13,9 +13,8 @@
 #define COMPONENTS_CPP_UTILS_BLESECURITY_H_
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
@@ -217,5 +216,6 @@ public:
 };  // BLESecurityCallbacks
 
 #endif  /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif  /* SOC_BLE_SUPPORTED */
+#endif  /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif  // COMPONENTS_CPP_UTILS_BLESECURITY_H_

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -10,16 +10,17 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /***************************************************************************
  *                       Common includes                                   *
  ***************************************************************************/
 
+#if SOC_BLE_SUPPORTED
 #include <esp_bt.h>
+#endif
 #include "GeneralUtils.h"
 #include "BLEDevice.h"
 #include "BLEServer.h"
@@ -1041,4 +1042,4 @@ void BLEServerCallbacks::onMtuChanged(BLEServer *pServer, ble_gap_conn_desc *des
 #endif  // CONFIG_NIMBLE_ENABLED
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEServer.h
+++ b/libraries/BLE/src/BLEServer.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLESERVER_H_
 #define COMPONENTS_CPP_UTILS_BLESERVER_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -271,5 +271,6 @@ public:
 };  // BLEServerCallbacks
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLESERVER_H_ */

--- a/libraries/BLE/src/BLEService.cpp
+++ b/libraries/BLE/src/BLEService.cpp
@@ -12,9 +12,8 @@
 // A service is identified by a UUID.  A service is also the container for one or more characteristics.
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -650,4 +649,4 @@ bool BLEService::start() {
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEService.h
+++ b/libraries/BLE/src/BLEService.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLESERVICE_H_
 #define COMPONENTS_CPP_UTILS_BLESERVICE_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -197,5 +197,6 @@ private:
 };  // BLEService
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLESERVICE_H_ */

--- a/libraries/BLE/src/BLEServiceMap.cpp
+++ b/libraries/BLE/src/BLEServiceMap.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -154,4 +153,4 @@ void BLEServiceMap::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_i
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEUUID.cpp
+++ b/libraries/BLE/src/BLEUUID.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -333,4 +332,4 @@ const ble_uuid_any_t *BLEUUID::getNative() const {
 #endif
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEUUID.h
+++ b/libraries/BLE/src/BLEUUID.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEUUID_H_
 #define COMPONENTS_CPP_UTILS_BLEUUID_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -123,5 +123,6 @@ private:
 };  // BLEUUID
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEUUID_H_ */

--- a/libraries/BLE/src/BLEUtils.cpp
+++ b/libraries/BLE/src/BLEUtils.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -27,7 +26,9 @@
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
+#if SOC_BLE_SUPPORTED
 #include <esp_bt.h>
+#endif
 
 #include <esp_err.h>
 #include <map>
@@ -2253,4 +2254,4 @@ void BLEUtils::taskRelease(const BLETaskData &taskData, int flags) {
 #endif  // CONFIG_NIMBLE_ENABLED
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEUtils.h
+++ b/libraries/BLE/src/BLEUtils.h
@@ -11,10 +11,10 @@
 
 #ifndef COMPONENTS_CPP_UTILS_BLEUTILS_H_
 #define COMPONENTS_CPP_UTILS_BLEUTILS_H_
-#include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
 
+#include "soc/soc_caps.h"
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -148,5 +148,6 @@ public:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEUTILS_H_ */

--- a/libraries/BLE/src/BLEValue.cpp
+++ b/libraries/BLE/src/BLEValue.cpp
@@ -10,9 +10,8 @@
  */
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -135,4 +134,4 @@ void BLEValue::setValue(const uint8_t *pData, size_t length) {
 }  // setValue
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */

--- a/libraries/BLE/src/BLEValue.h
+++ b/libraries/BLE/src/BLEValue.h
@@ -13,9 +13,8 @@
 #define COMPONENTS_CPP_UTILS_BLEVALUE_H_
 
 #include "soc/soc_caps.h"
-#if SOC_BLE_SUPPORTED
-
 #include "sdkconfig.h"
+#if defined(SOC_BLE_SUPPORTED) || defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE)
 #if defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)
 
 /*****************************************************************************
@@ -57,5 +56,6 @@ private:
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */
-#endif /* SOC_BLE_SUPPORTED */
+#endif /* SOC_BLE_SUPPORTED || CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE */
+
 #endif /* COMPONENTS_CPP_UTILS_BLEVALUE_H_ */

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -240,100 +240,18 @@ extern "C" void phy_bbpll_en_usb(bool en);
 #endif
 
 #if CONFIG_ESP_WIFI_REMOTE_ENABLED
-extern "C" {
-//#include "esp_hosted.h"
-#include "esp_hosted_transport_config.h"
-extern esp_err_t esp_hosted_init();
-extern esp_err_t esp_hosted_deinit();
-};
-typedef struct {
-  uint8_t pin_clk;
-  uint8_t pin_cmd;
-  uint8_t pin_d0;
-  uint8_t pin_d1;
-  uint8_t pin_d2;
-  uint8_t pin_d3;
-  uint8_t pin_reset;
-} sdio_pin_config_t;
-
-static bool hosted_initialized = false;
-static sdio_pin_config_t sdio_pin_config = {
-#ifdef BOARD_HAS_SDIO_ESP_HOSTED
-  .pin_clk = BOARD_SDIO_ESP_HOSTED_CLK,
-  .pin_cmd = BOARD_SDIO_ESP_HOSTED_CMD,
-  .pin_d0 = BOARD_SDIO_ESP_HOSTED_D0,
-  .pin_d1 = BOARD_SDIO_ESP_HOSTED_D1,
-  .pin_d2 = BOARD_SDIO_ESP_HOSTED_D2,
-  .pin_d3 = BOARD_SDIO_ESP_HOSTED_D3,
-  .pin_reset = BOARD_SDIO_ESP_HOSTED_RESET
-#else
-  .pin_clk = CONFIG_ESP_SDIO_PIN_CLK,
-  .pin_cmd = CONFIG_ESP_SDIO_PIN_CMD,
-  .pin_d0 = CONFIG_ESP_SDIO_PIN_D0,
-  .pin_d1 = CONFIG_ESP_SDIO_PIN_D1,
-  .pin_d2 = CONFIG_ESP_SDIO_PIN_D2,
-  .pin_d3 = CONFIG_ESP_SDIO_PIN_D3,
-  .pin_reset = CONFIG_ESP_SDIO_GPIO_RESET_SLAVE
-#endif
-};
 
 bool WiFiGenericClass::setPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8_t d3, int8_t rst) {
-  if (clk < 0 || cmd < 0 || d0 < 0 || d1 < 0 || d2 < 0 || d3 < 0 || rst < 0) {
-    log_e("All SDIO pins must be defined");
-    return false;
-  }
-  if (hosted_initialized) {
-    log_e("SDIO pins must be set before WiFi is initialized");
-    return false;
-  }
-  sdio_pin_config.pin_clk = clk;
-  sdio_pin_config.pin_cmd = cmd;
-  sdio_pin_config.pin_d0 = d0;
-  sdio_pin_config.pin_d1 = d1;
-  sdio_pin_config.pin_d2 = d2;
-  sdio_pin_config.pin_d3 = d3;
-  sdio_pin_config.pin_reset = rst;
-  return true;
+  return hostedSetPins(clk, cmd, d0, d1, d2, d3, rst);
 }
 
-static bool wifiHostedInit() {
-  if (!hosted_initialized) {
-    hosted_initialized = true;
-    struct esp_hosted_sdio_config conf = INIT_DEFAULT_HOST_SDIO_CONFIG();
-    conf.pin_clk.pin = sdio_pin_config.pin_clk;
-    conf.pin_cmd.pin = sdio_pin_config.pin_cmd;
-    conf.pin_d0.pin = sdio_pin_config.pin_d0;
-    conf.pin_d1.pin = sdio_pin_config.pin_d1;
-    conf.pin_d2.pin = sdio_pin_config.pin_d2;
-    conf.pin_d3.pin = sdio_pin_config.pin_d3;
-    conf.pin_reset.pin = sdio_pin_config.pin_reset;
-    // esp_hosted_sdio_set_config() will fail on second attempt but here temporarily to not cause exception on reinit
-    if (esp_hosted_sdio_set_config(&conf) != ESP_OK || esp_hosted_init() != ESP_OK) {
-      log_e("esp_hosted_init failed!");
-      hosted_initialized = false;
-      return false;
-    }
-    log_v("ESP-HOSTED initialized!");
-  }
-  // Attach pins to PeriMan here
-  // Slave chip model is CONFIG_IDF_SLAVE_TARGET
-  // sdio_pin_config.pin_clk
-  // sdio_pin_config.pin_cmd
-  // sdio_pin_config.pin_d0
-  // sdio_pin_config.pin_d1
-  // sdio_pin_config.pin_d2
-  // sdio_pin_config.pin_d3
-  // sdio_pin_config.pin_reset
-
-  return true;
-}
 #endif
 
 bool wifiLowLevelInit(bool persistent) {
   if (!lowLevelInitDone) {
     lowLevelInitDone = true;
 #if CONFIG_ESP_WIFI_REMOTE_ENABLED
-    if (!wifiHostedInit()) {
+    if (!hostedInitWiFi()) {
       lowLevelInitDone = false;
       return lowLevelInitDone;
     }
@@ -402,11 +320,7 @@ static bool wifiLowLevelDeinit() {
       arduino_event.event_id = ARDUINO_EVENT_WIFI_OFF;
       Network.postEvent(&arduino_event);
 #if CONFIG_ESP_WIFI_REMOTE_ENABLED
-      if (hosted_initialized && esp_hosted_deinit() == ESP_OK) {
-        hosted_initialized = false;
-        log_v("ESP-HOSTED uninitialized!");
-        // detach SDIO pins from PeriMan
-      }
+      hostedDeinitWiFi();
 #endif
     }
   }


### PR DESCRIPTION
## Description of Change

Added support for BLE on ESP32-P4 via esp-hosted. Also moved esp-hosted related functions to a generic file that can be used by both Wi-Fi and BLE.

Requires https://github.com/espressif/esp32-arduino-lib-builder/pull/318

## Test Scenarios

Tested locally

## Related links

Closes https://github.com/espressif/arduino-esp32/issues/11788
https://github.com/espressif/arduino-esp32/issues/10278
