### PR TITLE
IDF release/v5.5

### DIFF
--- a/libraries/WiFi/examples/WiFiBlueToothSwitch/WiFiBlueToothSwitch.ino
+++ b/libraries/WiFi/examples/WiFiBlueToothSwitch/WiFiBlueToothSwitch.ino
@@ -15,6 +15,11 @@
 // Sketch shows how to switch between WiFi and BlueTooth or use both
 // Button is attached between GPIO 0 and GND and modes are switched with each press
 
+#include "soc/soc_caps.h"
+#if !CONFIG_SOC_BT_SUPPORTED
+#error "This example requires native Bluetooth support"
+#endif
+
 #include "WiFi.h"
 #define STA_SSID "your-ssid"
 #define STA_PASS "your-pass"

--- a/libraries/WiFi/examples/WiFiBlueToothSwitch/ci.json
+++ b/libraries/WiFi/examples/WiFiBlueToothSwitch/ci.json
@@ -1,6 +1,6 @@
 {
   "requires": [
-    "CONFIG_BT_ENABLED=y"
+    "CONFIG_SOC_BT_SUPPORTED=y"
   ],
   "requires_any": [
     "CONFIG_SOC_WIFI_SUPPORTED=y",

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-129cd0d2-v2"
+              "version": "idf-release_v5.5-129cd0d2-v3"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-129cd0d2-v2",
+          "version": "idf-release_v5.5-129cd0d2-v3",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v2.zip",
-              "checksum": "SHA-256:9dcd284f75bb486ebcd1c86ec8a8baa7080b1e7163f63d2b3bbdbddd118eb903",
-              "size": "444179819"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-129cd0d2-v3.zip",
+              "checksum": "SHA-256:9dfe794b5bb23b5f64e92746b57349fce0656a6d03b5af6e9578e8346a2816a2",
+              "size": "446024072"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 87aa70c
esp-idf: release/v5.5 129cd0d247
arduino: master a39d1bdb9
tinyusb: master b6b22096d
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.4
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.7
espressif__esp_delta_ota: 1.1.2
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 1.4.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.6.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.2
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.1
espressif__dl_fft: 0.3.1
espressif__eppp_link: 1.1.1
espressif__esp-dsp: 1.6.0
espressif__esp-sr: 2.1.5
espressif__esp_hosted: 2.4.0
espressif__esp_serial_slave_link: 1.1.0~1
espressif__esp_wifi_remote: 0.13.0
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
```
