### PR TITLE
Fix warnings with c++23 (gcc 15.1)

### DIFF
--- a/cores/esp32/Esp.cpp
+++ b/cores/esp32/Esp.cpp
@@ -91,39 +91,39 @@ extern "C" {
  *   uint32_t = test = 10_MHz; // --> 10000000
  */
 
-unsigned long long operator"" _kHz(unsigned long long x) {
+unsigned long long operator""_kHz(unsigned long long x) {
   return x * 1000;
 }
 
-unsigned long long operator"" _MHz(unsigned long long x) {
+unsigned long long operator""_MHz(unsigned long long x) {
   return x * 1000 * 1000;
 }
 
-unsigned long long operator"" _GHz(unsigned long long x) {
+unsigned long long operator""_GHz(unsigned long long x) {
   return x * 1000 * 1000 * 1000;
 }
 
-unsigned long long operator"" _kBit(unsigned long long x) {
+unsigned long long operator""_kBit(unsigned long long x) {
   return x * 1024;
 }
 
-unsigned long long operator"" _MBit(unsigned long long x) {
+unsigned long long operator""_MBit(unsigned long long x) {
   return x * 1024 * 1024;
 }
 
-unsigned long long operator"" _GBit(unsigned long long x) {
+unsigned long long operator""_GBit(unsigned long long x) {
   return x * 1024 * 1024 * 1024;
 }
 
-unsigned long long operator"" _kB(unsigned long long x) {
+unsigned long long operator""_kB(unsigned long long x) {
   return x * 1024;
 }
 
-unsigned long long operator"" _MB(unsigned long long x) {
+unsigned long long operator""_MB(unsigned long long x) {
   return x * 1024 * 1024;
 }
 
-unsigned long long operator"" _GB(unsigned long long x) {
+unsigned long long operator""_GB(unsigned long long x) {
   return x * 1024 * 1024 * 1024;
 }
 


### PR DESCRIPTION
Using latest gcc 15.1 creates warnings in Esp.cpp The PR silence the warnings. No functional change

