### PR TITLE
fix(esp32): Compiler warning - loop variable `a` shadows previous instance of `a` in function `i2c_slave_gpio_mode`

### DIFF
--- a/cores/esp32/esp32-hal-i2c-slave.c
+++ b/cores/esp32/esp32-hal-i2c-slave.c
@@ -618,7 +618,7 @@ static bool i2c_slave_check_line_state(int8_t sda, int8_t scl) {
         log_w("Recovered after %d Cycles", a);
         gpio_set_level(sda, 0);  // start
         i2c_slave_delay_us(5);
-        for (uint8_t a = 0; a < 9; a++) {
+        for (uint8_t b = 0; b < 9; b++) {
           gpio_set_level(scl, 1);
           i2c_slave_delay_us(5);
           gpio_set_level(scl, 0);


### PR DESCRIPTION
In function `i2c_slave_gpio_mode` an inner loop variable `a` shadows an outer loop variable `a`.

This causes the warning:
`warning: declaration of 'a' shadows a previous local [-Wshadow]`
when compiled with option`-Wshadow`.

## Description of Change

Renamed variable `a` in inner loop to `b`.

## Test Scenarios

Code compiles without warning when change made.

## Related links

None
