### PR TITLE
fix(esp32): float conversion warning in String::toFloat

### DIFF
--- a/cores/esp32/WString.cpp
+++ b/cores/esp32/WString.cpp
@@ -910,7 +910,7 @@ long String::toInt(void) const {
 
 float String::toFloat(void) const {
   if (buffer()) {
-    return atof(buffer());
+    return static_cast<float>(atof(buffer()));
   }
   return 0;
 }


### PR DESCRIPTION
Function `float String::toFloat(void) const` returns a `double`.

This causes the warning:
`warning: conversion from 'double' to 'float' may change value [-Wfloat-conversion]`
when compiled with option `-Wfloat-conversion`

## Description of Change

Statically cast return value to `float`.

## Test Scenarios

Code compiles without warning when change made.

## Related links

None
