### PR TITLE
Fix (WiFi): Do not steal scan results

### DIFF
--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -114,7 +114,7 @@ int16_t
  */
 void WiFiScanClass::_scanDone() {
   if (!(WiFiGenericClass::getStatusBits() & WIFI_SCANNING_BIT)) {
-    return; //Ignore if not scanning, scan was started by other
+    return;  //Ignore if not scanning, scan was started by other
   }
   esp_wifi_scan_get_ap_num(&(WiFiScanClass::_scanCount));
   if (WiFiScanClass::_scanResult) {

--- a/libraries/WiFi/src/WiFiScan.cpp
+++ b/libraries/WiFi/src/WiFiScan.cpp
@@ -113,6 +113,9 @@ int16_t
  * @param status STATUS
  */
 void WiFiScanClass::_scanDone() {
+  if (!(WiFiGenericClass::getStatusBits() & WIFI_SCANNING_BIT)) {
+    return; //Ignore if not scanning, scan was started by other
+  }
   esp_wifi_scan_get_ap_num(&(WiFiScanClass::_scanCount));
   if (WiFiScanClass::_scanResult) {
     free(WiFiScanClass::_scanResult);


### PR DESCRIPTION
## Description of Change
If WiFi has been started via Arduino API, but the WiFi scan is started via IDF API, `WiFiScanClass::_scanDone` is still called from 
the event callback and reads out the scan result.

## Test Scenarios
Arduino-esp32 core v 3.2.1, ESP32-C3


