### PR TITLE
feat(eth): Add support for LAN867X ETH PHY

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -125,6 +125,10 @@ dependencies:
   chmorgan/esp-libhelix-mp3:
     version: "1.0.3"
     require: public
+  espressif/lan867x:
+    version: "^2.0.0"
+    rules:
+      - if: "target in [esp32, esp32p4]"
 examples:
   - path: ./idf_component_examples/hello_world
   - path: ./idf_component_examples/hw_cdc_hello_world

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -34,6 +34,9 @@
 #if defined __has_include && __has_include("soc/emac_ext_struct.h")
 #include "soc/emac_ext_struct.h"
 #endif /* __has_include("soc/emac_ext_struct.h" */
+#if ETH_PHY_LAN867X_SUPPORTED
+#include "esp_eth_phy_lan867x.h"
+#endif
 #include "soc/rtc.h"
 #endif /* CONFIG_ETH_USE_ESP32_EMAC */
 #include "esp32-hal-periman.h"
@@ -292,6 +295,9 @@ bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int mdc, int mdio, i
     case ETH_PHY_DP83848: _phy = esp_eth_phy_new_dp83848(&phy_config); break;
     case ETH_PHY_KSZ8041: _phy = esp_eth_phy_new_ksz80xx(&phy_config); break;
     case ETH_PHY_KSZ8081: _phy = esp_eth_phy_new_ksz80xx(&phy_config); break;
+#if ETH_PHY_LAN867X_SUPPORTED
+    case ETH_PHY_LAN867X: _phy = esp_eth_phy_new_lan867x(&phy_config); break;
+#endif
     default:              log_e("Unsupported PHY %d", type); break;
   }
   if (_phy == NULL) {

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -298,7 +298,7 @@ bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int mdc, int mdio, i
 #if ETH_PHY_LAN867X_SUPPORTED
     case ETH_PHY_LAN867X: _phy = esp_eth_phy_new_lan867x(&phy_config); break;
 #endif
-    default:              log_e("Unsupported PHY %d", type); break;
+    default: log_e("Unsupported PHY %d", type); break;
   }
   if (_phy == NULL) {
     log_e("esp_eth_phy_new failed");

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -78,6 +78,9 @@
 #include "esp_netif.h"
 
 #if CONFIG_ETH_USE_ESP32_EMAC
+#if defined __has_include && __has_include("esp_eth_phy_lan867x.h")
+#define ETH_PHY_LAN867X_SUPPORTED 1
+#endif
 #define ETH_PHY_IP101 ETH_PHY_TLK110
 #if CONFIG_IDF_TARGET_ESP32
 typedef enum {
@@ -138,6 +141,9 @@ typedef enum {
   ETH_PHY_DP83848,
   ETH_PHY_KSZ8041,
   ETH_PHY_KSZ8081,
+#if ETH_PHY_LAN867X_SUPPORTED
+  ETH_PHY_LAN867X,
+#endif
 #endif /* CONFIG_ETH_USE_ESP32_EMAC */
 #if CONFIG_ETH_SPI_ETHERNET_DM9051
   ETH_PHY_DM9051,


### PR DESCRIPTION
This pull request adds support for the LAN867x Ethernet PHY to the ESP32 platform. The changes include updating dependencies, conditionally enabling code for the new PHY, and integrating it into the Ethernet library's initialization and configuration logic.

**LAN867x PHY Support Integration:**

* Added `espressif/lan867x` as a dependency in `idf_component.yml`, limited to ESP32 and ESP32P4 targets.
* Defined `ETH_PHY_LAN867X_SUPPORTED` macro in `ETH.h` when `esp_eth_phy_lan867x.h` is available, enabling conditional compilation for LAN867x support.
* Added `ETH_PHY_LAN867X` to the `eth_phy_type_t` enum, making it selectable as a PHY type.
* Included `esp_eth_phy_lan867x.h` and added case handling for `ETH_PHY_LAN867X` in the Ethernet initialization logic, allowing the library to instantiate and use the LAN867x PHY. [[1]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R37-R39) [[2]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R298-R300)

Closes: https://github.com/espressif/esp32-arduino-lib-builder/pull/319