### PR TITLE
change(script): Update the issue template when version changed

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -34,6 +34,10 @@ fi
 echo "New Arduino Version: $ESP_ARDUINO_VERSION"
 echo "ESP-IDF Version: $ESP_IDF_VERSION"
 
+echo "Updating issue template..."
+cat .github/ISSUE_TEMPLATE/issue-report.yml | \
+sed "s/.*\- latest master .*/        - latest master \(checkout manually\)\\n        - v$ESP_ARDUINO_VERSION/g" > __issue-report.yml && mv __issue-report.yml .github/ISSUE_TEMPLATE/issue-report.yml
+
 echo "Updating platform.txt..."
 cat platform.txt | sed "s/version=.*/version=$ESP_ARDUINO_VERSION/g" > __platform.txt && mv __platform.txt platform.txt
 

--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -35,8 +35,8 @@ echo "New Arduino Version: $ESP_ARDUINO_VERSION"
 echo "ESP-IDF Version: $ESP_IDF_VERSION"
 
 echo "Updating issue template..."
-cat .github/ISSUE_TEMPLATE/issue-report.yml | \
-sed "s/.*\- latest master .*/        - latest master \(checkout manually\)\\n        - v$ESP_ARDUINO_VERSION/g" > __issue-report.yml && mv __issue-report.yml .github/ISSUE_TEMPLATE/issue-report.yml
+cat .github/ISSUE_TEMPLATE/Issue-report.yml | \
+sed "s/.*\- latest master .*/        - latest master \(checkout manually\)\\n        - v$ESP_ARDUINO_VERSION/g" > __issue-report.yml && mv __issue-report.yml .github/ISSUE_TEMPLATE/Issue-report.yml
 
 echo "Updating platform.txt..."
 cat platform.txt | sed "s/version=.*/version=$ESP_ARDUINO_VERSION/g" > __platform.txt && mv __platform.txt platform.txt


### PR DESCRIPTION
This pull request updates the version management script to ensure the issue template reflects the latest Arduino version. The main change is an automated update to the version listed in the issue report template, helping users report issues against the correct version.

Updates to issue template automation:

* [`.github/scripts/update-version.sh`](diffhunk://#diff-7c948b013f7ac77e61b6d313b97808fa90203751180f55e9e372e792aee386d7R37-R40): Added a step to automatically update the Arduino version in `.github/ISSUE_TEMPLATE/issue-report.yml` using `sed`, ensuring the template always references the latest version.