### PR TITLE
Update pins_arduino.h for lolin_c3_pico to define LED as RGB rather than the default GRB

### DIFF
--- a/variants/lolin_c3_pico/pins_arduino.h
+++ b/variants/lolin_c3_pico/pins_arduino.h
@@ -16,6 +16,7 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
 #define RGB_BUILTIN    LED_BUILTIN
 #define RGB_BRIGHTNESS 64
+#define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;


### PR DESCRIPTION
## Description of Change
Please describe your proposed Pull Request and it's impact.

On the lolin_c3_pico the LED is RGB, but RGB_BUILTIN_LED_COLOR_ORDER defaults to GRB which is correct for many Neopixel LEDs

## Test Scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

Tested on Lolin C3 Pico - with Frugal_IoT system, looked carefully at call to rgbLedWrite which was correctly sending rgb in that order, BUT the LED was coming up the wrong color because of the default to presume the actual write to LED should be GRB.

I'm using PlatformIO with specific config
```
[env:sht30_lolin_c3_pico]
platform = espressif32
board = lolin_c3_mini 
board_build.variant = lolin_c3_pico
build_flags = 
    ${common.build_flags}
    -D ARDUINO_LOLIN_C3_PICO ; if using C3_PICO use lolin_c3_mini as board and define here
lib_compat_mode = strict
board_build.partitions = huge_app.csv
lib_deps = 
    ${common.lib_deps}
```


## Related links
Please provide links to related issue, PRs etc.
N/A
(*eg. Closes #number of issue*)
