### PR TITLE
feat(board): add support for Soldered NULA Mini ESP32C6

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -52944,3 +52944,185 @@ axiometa_pixie_m1.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 axiometa_pixie_m1.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
 
 ##############################################################
+
+soldered_nula_mini_esp32c6.name=Soldered NULA Mini ESP32C6
+
+soldered_nula_mini_esp32c6.bootloader.tool=esptool_py
+soldered_nula_mini_esp32c6.bootloader.tool.default=esptool_py
+
+soldered_nula_mini_esp32c6.upload.tool=esptool_py
+soldered_nula_mini_esp32c6.upload.tool.default=esptool_py
+soldered_nula_mini_esp32c6.upload.tool.network=esp_ota
+
+soldered_nula_mini_esp32c6.upload.maximum_size=1310720
+soldered_nula_mini_esp32c6.upload.maximum_data_size=327680
+soldered_nula_mini_esp32c6.upload.flags=
+soldered_nula_mini_esp32c6.upload.extra_flags=
+soldered_nula_mini_esp32c6.upload.use_1200bps_touch=false
+soldered_nula_mini_esp32c6.upload.wait_for_upload_port=false
+
+soldered_nula_mini_esp32c6.serial.disableDTR=true
+soldered_nula_mini_esp32c6.serial.disableRTS=true
+
+soldered_nula_mini_esp32c6.build.tarch=riscv32
+soldered_nula_mini_esp32c6.build.target=esp
+soldered_nula_mini_esp32c6.build.mcu=esp32c6
+soldered_nula_mini_esp32c6.build.core=esp32
+soldered_nula_mini_esp32c6.build.variant=soldered_nula_mini_esp32c6
+soldered_nula_mini_esp32c6.build.board=SOLDERED_NULA_MINI_ESP32C6
+soldered_nula_mini_esp32c6.build.bootloader_addr=0x0
+
+soldered_nula_mini_esp32c6.build.f_cpu=160000000L
+soldered_nula_mini_esp32c6.build.flash_size=4MB
+soldered_nula_mini_esp32c6.build.flash_freq=80m
+soldered_nula_mini_esp32c6.build.flash_mode=qio
+soldered_nula_mini_esp32c6.build.boot=qio
+soldered_nula_mini_esp32c6.build.partitions=default
+soldered_nula_mini_esp32c6.build.defines=
+
+## IDE 2.0 Seems to not update the value
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.default=Disabled
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.default.build.copy_jtag_files=0
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.builtin=Integrated USB JTAG
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.builtin.build.openocdscript=esp32c6-builtin.cfg
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.external=FTDI Adapter
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.external.build.openocdscript=esp32c6-ftdi.cfg
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.external.build.copy_jtag_files=1
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.bridge=ESP USB Bridge
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.bridge.build.openocdscript=esp32c6-bridge.cfg
+soldered_nula_mini_esp32c6.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+soldered_nula_mini_esp32c6.menu.CDCOnBoot.default=Disabled
+soldered_nula_mini_esp32c6.menu.CDCOnBoot.default.build.cdc_on_boot=0
+soldered_nula_mini_esp32c6.menu.CDCOnBoot.cdc=Enabled
+soldered_nula_mini_esp32c6.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+soldered_nula_mini_esp32c6.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.default.build.partitions=default
+soldered_nula_mini_esp32c6.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+soldered_nula_mini_esp32c6.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+soldered_nula_mini_esp32c6.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+soldered_nula_mini_esp32c6.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.minimal.build.partitions=minimal
+soldered_nula_mini_esp32c6.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.no_ota.build.partitions=no_ota
+soldered_nula_mini_esp32c6.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+soldered_nula_mini_esp32c6.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+soldered_nula_mini_esp32c6.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.huge_app.build.partitions=huge_app
+soldered_nula_mini_esp32c6.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+soldered_nula_mini_esp32c6.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/190KB SPIFFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+soldered_nula_mini_esp32c6.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+soldered_nula_mini_esp32c6.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.fatflash.build.partitions=ffat
+soldered_nula_mini_esp32c6.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+soldered_nula_mini_esp32c6.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+soldered_nula_mini_esp32c6.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+soldered_nula_mini_esp32c6.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker=RainMaker 4MB
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+soldered_nula_mini_esp32c6.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+soldered_nula_mini_esp32c6.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
+soldered_nula_mini_esp32c6.menu.PartitionScheme.zigbee.build.partitions=zigbee
+soldered_nula_mini_esp32c6.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
+soldered_nula_mini_esp32c6.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+soldered_nula_mini_esp32c6.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+soldered_nula_mini_esp32c6.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+soldered_nula_mini_esp32c6.menu.PartitionScheme.custom=Custom
+soldered_nula_mini_esp32c6.menu.PartitionScheme.custom.build.partitions=
+soldered_nula_mini_esp32c6.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+soldered_nula_mini_esp32c6.menu.CPUFreq.160=160MHz (WiFi)
+soldered_nula_mini_esp32c6.menu.CPUFreq.160.build.f_cpu=160000000L
+soldered_nula_mini_esp32c6.menu.CPUFreq.80=80MHz (WiFi)
+soldered_nula_mini_esp32c6.menu.CPUFreq.80.build.f_cpu=80000000L
+soldered_nula_mini_esp32c6.menu.CPUFreq.40=40MHz
+soldered_nula_mini_esp32c6.menu.CPUFreq.40.build.f_cpu=40000000L
+soldered_nula_mini_esp32c6.menu.CPUFreq.20=20MHz
+soldered_nula_mini_esp32c6.menu.CPUFreq.20.build.f_cpu=20000000L
+soldered_nula_mini_esp32c6.menu.CPUFreq.10=10MHz
+soldered_nula_mini_esp32c6.menu.CPUFreq.10.build.f_cpu=10000000L
+
+soldered_nula_mini_esp32c6.menu.FlashMode.qio=QIO
+soldered_nula_mini_esp32c6.menu.FlashMode.qio.build.flash_mode=dio
+soldered_nula_mini_esp32c6.menu.FlashMode.qio.build.boot=qio
+soldered_nula_mini_esp32c6.menu.FlashMode.dio=DIO
+soldered_nula_mini_esp32c6.menu.FlashMode.dio.build.flash_mode=dio
+soldered_nula_mini_esp32c6.menu.FlashMode.dio.build.boot=dio
+
+soldered_nula_mini_esp32c6.menu.FlashFreq.80=80MHz
+soldered_nula_mini_esp32c6.menu.FlashFreq.80.build.flash_freq=80m
+soldered_nula_mini_esp32c6.menu.FlashFreq.40=40MHz
+soldered_nula_mini_esp32c6.menu.FlashFreq.40.build.flash_freq=40m
+
+soldered_nula_mini_esp32c6.menu.FlashSize.4M=4MB (32Mb)
+soldered_nula_mini_esp32c6.menu.FlashSize.4M.build.flash_size=4MB
+soldered_nula_mini_esp32c6.menu.FlashSize.8M=8MB (64Mb)
+soldered_nula_mini_esp32c6.menu.FlashSize.8M.build.flash_size=8MB
+soldered_nula_mini_esp32c6.menu.FlashSize.2M=2MB (16Mb)
+soldered_nula_mini_esp32c6.menu.FlashSize.2M.build.flash_size=2MB
+soldered_nula_mini_esp32c6.menu.FlashSize.16M=16MB (128Mb)
+soldered_nula_mini_esp32c6.menu.FlashSize.16M.build.flash_size=16MB
+
+soldered_nula_mini_esp32c6.menu.UploadSpeed.921600=921600
+soldered_nula_mini_esp32c6.menu.UploadSpeed.921600.upload.speed=921600
+soldered_nula_mini_esp32c6.menu.UploadSpeed.115200=115200
+soldered_nula_mini_esp32c6.menu.UploadSpeed.115200.upload.speed=115200
+soldered_nula_mini_esp32c6.menu.UploadSpeed.256000.windows=256000
+soldered_nula_mini_esp32c6.menu.UploadSpeed.256000.upload.speed=256000
+soldered_nula_mini_esp32c6.menu.UploadSpeed.230400.windows.upload.speed=256000
+soldered_nula_mini_esp32c6.menu.UploadSpeed.230400=230400
+soldered_nula_mini_esp32c6.menu.UploadSpeed.230400.upload.speed=230400
+soldered_nula_mini_esp32c6.menu.UploadSpeed.460800.linux=460800
+soldered_nula_mini_esp32c6.menu.UploadSpeed.460800.macosx=460800
+soldered_nula_mini_esp32c6.menu.UploadSpeed.460800.upload.speed=460800
+soldered_nula_mini_esp32c6.menu.UploadSpeed.512000.windows=512000
+soldered_nula_mini_esp32c6.menu.UploadSpeed.512000.upload.speed=512000
+
+soldered_nula_mini_esp32c6.menu.DebugLevel.none=None
+soldered_nula_mini_esp32c6.menu.DebugLevel.none.build.code_debug=0
+soldered_nula_mini_esp32c6.menu.DebugLevel.error=Error
+soldered_nula_mini_esp32c6.menu.DebugLevel.error.build.code_debug=1
+soldered_nula_mini_esp32c6.menu.DebugLevel.warn=Warn
+soldered_nula_mini_esp32c6.menu.DebugLevel.warn.build.code_debug=2
+soldered_nula_mini_esp32c6.menu.DebugLevel.info=Info
+soldered_nula_mini_esp32c6.menu.DebugLevel.info.build.code_debug=3
+soldered_nula_mini_esp32c6.menu.DebugLevel.debug=Debug
+soldered_nula_mini_esp32c6.menu.DebugLevel.debug.build.code_debug=4
+soldered_nula_mini_esp32c6.menu.DebugLevel.verbose=Verbose
+soldered_nula_mini_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
+
+soldered_nula_mini_esp32c6.menu.EraseFlash.none=Disabled
+soldered_nula_mini_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
+soldered_nula_mini_esp32c6.menu.EraseFlash.all=Enabled
+soldered_nula_mini_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
+
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.default=Disabled
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.default.build.zigbee_mode=
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.default.build.zigbee_libs=
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.ed=Zigbee ED (end device)
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.ed.build.zigbee_mode=-DZIGBEE_MODE_ED
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api.ed -lzboss_stack.ed -lzboss_port.native
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+soldered_nula_mini_esp32c6.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
+
+##############################################################

--- a/variants/soldered_nula_mini_esp32c6/pins_arduino.h
+++ b/variants/soldered_nula_mini_esp32c6/pins_arduino.h
@@ -1,0 +1,33 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = 23;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t USER_BTN = 9;
+
+static const uint8_t TX = 16;
+static const uint8_t RX = 17;
+
+static const uint8_t SDA = 6;
+static const uint8_t SCL = 7;
+
+static const uint8_t SS = 2;
+static const uint8_t MOSI = 3;
+static const uint8_t MISO = 4;
+static const uint8_t SCK = 5;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+static const uint8_t A6 = 6;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Add board definition for upcoming Soldered NULA Mini ESP32C6 board by Soldered Electronics
- Add board configuration to `boards.txt`
- Add pin definitions to 'variants/soldered_nula_mini_esp32c6'

-----------
## Test Scenarios
The definition was tested via Arduino IDE 2.3.5, testing Wi-FI and Bluetooth connectivity, I2C as well as the pins themselves

