### PR TITLE
fix(hash): add selective build option for Hash, WebServer dependency

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -341,6 +341,11 @@ config ARDUINO_SELECTIVE_PPP
     depends on ARDUINO_SELECTIVE_COMPILATION
     default y
 
+config ARDUINO_SELECTIVE_Hash
+    bool "Enable Hash"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
 config ARDUINO_SELECTIVE_ArduinoOTA
     bool "Enable ArduinoOTA"
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
@@ -383,6 +388,7 @@ config ARDUINO_SELECTIVE_WebServer
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
     default y
     select ARDUINO_SELECTIVE_FS
+    select ARDUINO_SELECTIVE_Hash
 
 config ARDUINO_SELECTIVE_WiFi
     bool "Enable WiFi"


### PR DESCRIPTION
The Hash library introduced in version v3.3.1 doesn't have an option to be included in a selective build, and in a selective build it defaults to not included. As the WebServer library depends on the Hash library, selective builds that include WebServer break as the dependency is not satisfied.

This PR adds an appropriate option to Kconfig, and adds the WebServer → Hash dependency.

Tested on a selective build using the Arduino core as an ESP-IDF component on an ESP32-S3. As far as I know the aren't any open issues for this.