### PR TITLE
feat(update): Allow updating any type of file system

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -182,7 +182,7 @@ String ArduinoOTAClass::readStringUntil(char end) {
 void ArduinoOTAClass::_onRx() {
   if (_state == OTA_IDLE) {
     int cmd = parseInt();
-    if (cmd != U_FLASH && cmd != U_SPIFFS) {
+    if (cmd != U_FLASH && cmd != U_FLASHFS) {
       return;
     }
     _cmd = cmd;

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -52,11 +52,31 @@ HTTPUpdateResult HTTPUpdate::update(NetworkClient &client, const String &url, co
   if (!http.begin(client, url)) {
     return HTTP_UPDATE_FAILED;
   }
-  return handleUpdate(http, currentVersion, false, requestCB);
+  return handleUpdate(http, currentVersion, U_FLASH, requestCB);
+}
+
+HTTPUpdateResult HTTPUpdate::updateFs(HTTPClient &httpClient, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
+  return handleUpdate(httpClient, currentVersion, U_FLASHFS, requestCB);
 }
 
 HTTPUpdateResult HTTPUpdate::updateSpiffs(HTTPClient &httpClient, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
-  return handleUpdate(httpClient, currentVersion, true, requestCB);
+  return handleUpdate(httpClient, currentVersion, U_SPIFFS, requestCB);
+}
+
+HTTPUpdateResult HTTPUpdate::updateFatfs(HTTPClient &httpClient, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
+  return handleUpdate(httpClient, currentVersion, U_FATFS, requestCB);
+}
+
+HTTPUpdateResult HTTPUpdate::updateLittlefs(HTTPClient &httpClient, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
+  return handleUpdate(httpClient, currentVersion, U_LITTLEFS, requestCB);
+}
+
+HTTPUpdateResult HTTPUpdate::updateFs(NetworkClient &client, const String &url, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    return HTTP_UPDATE_FAILED;
+  }
+  return handleUpdate(http, currentVersion, U_FLASHFS, requestCB);
 }
 
 HTTPUpdateResult HTTPUpdate::updateSpiffs(NetworkClient &client, const String &url, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
@@ -64,11 +84,27 @@ HTTPUpdateResult HTTPUpdate::updateSpiffs(NetworkClient &client, const String &u
   if (!http.begin(client, url)) {
     return HTTP_UPDATE_FAILED;
   }
-  return handleUpdate(http, currentVersion, true, requestCB);
+  return handleUpdate(http, currentVersion, U_SPIFFS, requestCB);
+}
+
+HTTPUpdateResult HTTPUpdate::updateFatfs(NetworkClient &client, const String &url, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    return HTTP_UPDATE_FAILED;
+  }
+  return handleUpdate(http, currentVersion, U_FATFS, requestCB);
+}
+
+HTTPUpdateResult HTTPUpdate::updateLittlefs(NetworkClient &client, const String &url, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    return HTTP_UPDATE_FAILED;
+  }
+  return handleUpdate(http, currentVersion, U_LITTLEFS, requestCB);
 }
 
 HTTPUpdateResult HTTPUpdate::update(HTTPClient &httpClient, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
-  return handleUpdate(httpClient, currentVersion, false, requestCB);
+  return handleUpdate(httpClient, currentVersion, U_FLASH, requestCB);
 }
 
 HTTPUpdateResult
@@ -77,7 +113,7 @@ HTTPUpdateResult
   if (!http.begin(client, host, port, uri)) {
     return HTTP_UPDATE_FAILED;
   }
-  return handleUpdate(http, currentVersion, false, requestCB);
+  return handleUpdate(http, currentVersion, U_FLASH, requestCB);
 }
 
 /**
@@ -158,7 +194,7 @@ String getSketchSHA256() {
  * @param currentVersion const char *
  * @return HTTPUpdateResult
  */
-HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &currentVersion, bool spiffs, HTTPUpdateRequestCB requestCB) {
+HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &currentVersion, uint8_t type, HTTPUpdateRequestCB requestCB) {
 
   HTTPUpdateResult ret = HTTP_UPDATE_FAILED;
 
@@ -187,8 +223,14 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
   http.addHeader("x-ESP32-chip-size", String(ESP.getFlashChipSize()));
   http.addHeader("x-ESP32-sdk-version", ESP.getSdkVersion());
 
-  if (spiffs) {
+  if (type == U_SPIFFS) {
     http.addHeader("x-ESP32-mode", "spiffs");
+  } else if (type == U_FATFS) {
+    http.addHeader("x-ESP32-mode", "fatfs");
+  } else if (type == U_LITTLEFS) {
+    http.addHeader("x-ESP32-mode", "littlefs");
+  } else if (type == U_FLASHFS) {
+    http.addHeader("x-ESP32-mode", "flashfs");
   } else {
     http.addHeader("x-ESP32-mode", "sketch");
   }
@@ -251,8 +293,24 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
     case HTTP_CODE_OK:  ///< OK (Start Update)
       if (len > 0) {
         bool startUpdate = true;
-        if (spiffs) {
-          const esp_partition_t *_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, NULL);
+        if (type != U_FLASH) {
+          const esp_partition_t *_partition = NULL;
+          if (type == U_SPIFFS) {
+            _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, NULL);
+          } else if (type == U_FATFS) {
+            _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_FAT, NULL);
+          } else if (type == U_LITTLEFS) {
+            _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_LITTLEFS, NULL);
+          } else if (type == U_FLASHFS) {
+            _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, NULL);
+            if (!_partition) {
+              _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_FAT, NULL);
+            }
+            if (!_partition) {
+              _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_LITTLEFS, NULL);
+            }
+          }
+          
           if (!_partition) {
             _lastError = HTTP_UE_NO_PARTITION;
             return HTTP_UPDATE_FAILED;
@@ -291,17 +349,15 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
 
           delay(100);
 
-          int command;
+          int command =  type;
 
-          if (spiffs) {
-            command = U_SPIFFS;
-            log_d("runUpdate spiffs...\n");
-          } else {
-            command = U_FLASH;
+          if (type == U_FLASH) {
             log_d("runUpdate flash...\n");
+          } else {
+            log_d("runUpdate file system...\n");
           }
 
-          if (!spiffs) {
+          if (type == U_FLASH) {
             /* To do
                     uint8_t buf[4];
                     if(tcp->peekBytes(&buf[0], 4) != 4) {
@@ -341,7 +397,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
               _cbEnd();
             }
 
-            if (_rebootOnUpdate && !spiffs) {
+            if (_rebootOnUpdate && type == U_FLASH) {
               ESP.restart();
             }
 

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -98,11 +98,17 @@ public:
     NetworkClient &client, const String &host, uint16_t port, const String &uri = "/", const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL
   );
 
+  t_httpUpdate_return updateFs(NetworkClient &client, const String &url, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
   t_httpUpdate_return updateSpiffs(NetworkClient &client, const String &url, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
+  t_httpUpdate_return updateFatfs(NetworkClient &client, const String &url, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
+  t_httpUpdate_return updateLittlefs(NetworkClient &client, const String &url, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
 
   t_httpUpdate_return update(HTTPClient &httpClient, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
 
+  t_httpUpdate_return updateFs(HTTPClient &httpClient, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
   t_httpUpdate_return updateSpiffs(HTTPClient &httpClient, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
+  t_httpUpdate_return updateFatfs(HTTPClient &httpClient, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
+  t_httpUpdate_return updateLittlefs(HTTPClient &httpClient, const String &currentVersion = "", HTTPUpdateRequestCB requestCB = NULL);
 
   // Notification callbacks
   void onStart(HTTPUpdateStartCB cbOnStart) {
@@ -122,7 +128,7 @@ public:
   String getLastErrorString(void);
 
 protected:
-  t_httpUpdate_return handleUpdate(HTTPClient &http, const String &currentVersion, bool spiffs = false, HTTPUpdateRequestCB requestCB = NULL);
+  t_httpUpdate_return handleUpdate(HTTPClient &http, const String &currentVersion, uint8_t type = U_FLASH, HTTPUpdateRequestCB requestCB = NULL);
   bool runUpdate(Stream &in, uint32_t size, String md5, int command = U_FLASH);
 
   // Set the error and potentially use a CB to notify the application

--- a/libraries/HTTPUpdateServer/src/HTTPUpdateServer.h
+++ b/libraries/HTTPUpdateServer/src/HTTPUpdateServer.h
@@ -122,7 +122,7 @@ public:
             Serial.printf("Update: %s\n", upload.filename.c_str());
           }
           if (upload.name == "filesystem") {
-            if (!Update.begin(UPDATE_SIZE_UNKNOWN, U_SPIFFS)) {  //Instead of SPIFFS.totalBytes(). Fix https://github.com/espressif/arduino-esp32/issues/9967
+            if (!Update.begin(UPDATE_SIZE_UNKNOWN, U_FLASHFS)) {  //Instead of SPIFFS.totalBytes(). Fix https://github.com/espressif/arduino-esp32/issues/9967
               if (_serial_output) {
                 Update.printError(Serial);
               }

--- a/libraries/Update/examples/HTTP_Server_AES_OTA_Update/HTTP_Server_AES_OTA_Update.ino
+++ b/libraries/Update/examples/HTTP_Server_AES_OTA_Update/HTTP_Server_AES_OTA_Update.ino
@@ -18,7 +18,7 @@ defaults:- {if not set ie. "Update.setupCrypt();" }
 
 OTA_MODE options:-
   U_AES_DECRYPT_NONE       decryption disabled, loads OTA image files as sent(plain)
-  U_AES_DECRYPT_AUTO       auto loads both plain & encrypted OTA FLASH image files, and plain OTA SPIFFS image files
+  U_AES_DECRYPT_AUTO       auto loads both plain & encrypted OTA FLASH image files, and plain OTA File System image files
   U_AES_DECRYPT_ON         decrypts OTA image files
 
 https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/
@@ -36,7 +36,6 @@ espsecure.py encrypt_flash_data  = runs the idf encryption function to make a en
 
 #include <WiFi.h>
 #include <NetworkClient.h>
-#include <SPIFFS.h>
 #include <Update.h>
 #include <WebServer.h>
 #include <ESPmDNS.h>
@@ -145,7 +144,7 @@ void setupHttpUpdateServer() {
       if (upload.status == UPLOAD_FILE_START) {
         Serial.printf("Update: %s\n", upload.filename.c_str());
         if (upload.name == "filesystem") {
-          if (!Update.begin(SPIFFS.totalBytes(), U_SPIFFS)) {  //start with max available size
+          if (!Update.begin(UPDATE_SIZE_UNKNOWN, U_FLASHFS)) {  //start with max available size
             Update.printError(Serial);
           }
         } else {

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -29,9 +29,12 @@
 
 #define UPDATE_SIZE_UNKNOWN 0xFFFFFFFF
 
-#define U_FLASH  0
-#define U_SPIFFS 100
-#define U_AUTH   200
+#define U_FLASH    0
+#define U_FLASHFS  100
+#define U_SPIFFS   101
+#define U_FATFS    102
+#define U_LITTLEFS 103
+#define U_AUTH     200
 
 #define ENCRYPTED_BLOCK_SIZE       16
 #define ENCRYPTED_TWEAK_BLOCK_SIZE 32
@@ -267,7 +270,6 @@ private:
   size_t _size;
   THandlerFunction_Progress _progress_callback;
   uint32_t _progress;
-  uint32_t _paroffset;
   uint32_t _command;
   const esp_partition_t *_partition;
 

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -75,7 +75,7 @@ UpdateClass::UpdateClass()
 #ifndef UPDATE_NOCRYPT
     _cryptKey(0), _cryptBuffer(0),
 #endif /* UPDATE_NOCRYPT */
-    _buffer(0), _skipBuffer(0), _bufferLen(0), _size(0), _progress_callback(NULL), _progress(0), _paroffset(0), _command(U_FLASH), _partition(NULL)
+    _buffer(0), _skipBuffer(0), _bufferLen(0), _size(0), _progress_callback(NULL), _progress(0), _command(U_FLASH), _partition(NULL)
 #ifndef UPDATE_NOCRYPT
     ,
     _cryptMode(U_AES_DECRYPT_AUTO), _cryptAddress(0), _cryptCfg(0xf)
@@ -154,16 +154,39 @@ bool UpdateClass::begin(size_t size, int command, int ledPin, uint8_t ledOn, con
     }
     log_d("OTA Partition: %s", _partition->label);
   } else if (command == U_SPIFFS) {
-    _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, label);
-    _paroffset = 0;
+    _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, NULL);
+    if (!_partition) {
+      _error = UPDATE_ERROR_NO_PARTITION;
+      return false;
+    }
+    log_d("SPIFFS Partition: %s", _partition->label);
+  } else if (command == U_FATFS) {
+    _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_FAT, NULL);
+    if (!_partition) {
+      _error = UPDATE_ERROR_NO_PARTITION;
+      return false;
+    }
+    log_d("FATFS Partition: %s", _partition->label);
+  } else if (command == U_LITTLEFS) {
+    _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_LITTLEFS, NULL);
+    if (!_partition) {
+      _error = UPDATE_ERROR_NO_PARTITION;
+      return false;
+    }
+    log_d("LittleFS Partition: %s", _partition->label);
+  } else if (command == U_FLASHFS) {
+    _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, NULL);
     if (!_partition) {
       _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_FAT, NULL);
-      _paroffset = 0x1000;  //Offset for ffat, assuming size is already corrected
-      if (!_partition) {
-        _error = UPDATE_ERROR_NO_PARTITION;
-        return false;
-      }
     }
+    if (!_partition) {
+      _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_LITTLEFS, NULL);
+    }
+    if (!_partition) {
+      _error = UPDATE_ERROR_NO_PARTITION;
+      return false;
+    }
+    log_d("FS Partition: %s", _partition->label);
   } else {
     _error = UPDATE_ERROR_BAD_ARGUMENT;
     log_e("bad command %u", command);
@@ -452,7 +475,7 @@ bool UpdateClass::_verifyHeader(uint8_t data) {
       return false;
     }
     return true;
-  } else if (_command == U_SPIFFS) {
+  } else {
     return true;
   }
   return false;
@@ -471,7 +494,7 @@ bool UpdateClass::_verifyEnd() {
     }
     _reset();
     return true;
-  } else if (_command == U_SPIFFS) {
+  } else {
     _reset();
     return true;
   }


### PR DESCRIPTION
This pull request adds support for updating multiple file system types via OTA (Over-The-Air) updates, refactors the update logic to generalize file system handling, and introduces new update methods for various file systems. The changes improve flexibility and maintainability by replacing the previous SPIFFS-only logic with support for SPIFFS, FATFS, LittleFS, and a generic file system mode. Additionally, several code cleanups and refactorings are included.

**File System OTA Update Support:**

* Added new constants (`U_FLASHFS`, `U_FATFS`, `U_LITTLEFS`) to `Update.h` to represent different file system OTA update modes, and refactored code to use these instead of only `U_SPIFFS`.
* Updated the `UpdateClass::begin` method and OTA partition selection logic to support SPIFFS, FATFS, LittleFS, and a generic file system mode (`U_FLASHFS`), including fallback logic for partition selection.
* Refactored the `handleUpdate` method in `HTTPUpdate.cpp` to accept a file system type parameter instead of a boolean, and to set appropriate HTTP headers and select the correct partition for each file system type. [[1]](diffhunk://#diff-4d0647a7b73978609ab64831ed08a0d31399831fdba3562006fe9a4ec3be48ffL161-R197) [[2]](diffhunk://#diff-4d0647a7b73978609ab64831ed08a0d31399831fdba3562006fe9a4ec3be48ffL190-R233) [[3]](diffhunk://#diff-4d0647a7b73978609ab64831ed08a0d31399831fdba3562006fe9a4ec3be48ffL254-R313) [[4]](diffhunk://#diff-4d0647a7b73978609ab64831ed08a0d31399831fdba3562006fe9a4ec3be48ffL294-R360) [[5]](diffhunk://#diff-4d0647a7b73978609ab64831ed08a0d31399831fdba3562006fe9a4ec3be48ffL344-R400)

**API Additions and Refactoring:**

* Added new update methods for file systems (`updateFs`, `updateFatfs`, `updateLittlefs`) to both `HTTPUpdate.h` and `HTTPUpdate.cpp`, for both `NetworkClient` and `HTTPClient` usage. [[1]](diffhunk://#diff-5bd9bf2518c0a81dc81416b522031f56070468aea1553f2683ddc174b0492e0bR101-R111) [[2]](diffhunk://#diff-4d0647a7b73978609ab64831ed08a0d31399831fdba3562006fe9a4ec3be48ffL55-R107)
* Updated function signatures and internal logic to use the new file system type constants, replacing previous boolean flags and simplifying the API. [[1]](diffhunk://#diff-5bd9bf2518c0a81dc81416b522031f56070468aea1553f2683ddc174b0492e0bL125-R131) [[2]](diffhunk://#diff-4d0647a7b73978609ab64831ed08a0d31399831fdba3562006fe9a4ec3be48ffL80-R116)

**Code Cleanup and Documentation:**

* Removed the unused `_paroffset` member from `UpdateClass` and related logic, simplifying partition offset handling. [[1]](diffhunk://#diff-77720a0e454e87b623476427db59992ebde686b09b57a5a97dfd2c6571c2a6f5L270) [[2]](diffhunk://#diff-d191305f68623de65611bd3810671941f2ef29ef0137bd3106553201f1a3e66fL78-R78)
* Updated documentation and comments to clarify that OTA file system updates now support multiple types, not just SPIFFS. [[1]](diffhunk://#diff-ceac58bc755e68838243164c8030bfa4d344b42ac9d39d275405c4b9c5706f50L21-R21) [[2]](diffhunk://#diff-ceac58bc755e68838243164c8030bfa4d344b42ac9d39d275405c4b9c5706f50L148-R147)
* Updated example code and server logic to use the new generic file system mode (`U_FLASHFS`) instead of SPIFFS. [[1]](diffhunk://#diff-ceac58bc755e68838243164c8030bfa4d344b42ac9d39d275405c4b9c5706f50L148-R147) [[2]](diffhunk://#diff-e80c43c4fa088dc7e42421d78442fc96ae899ec6b0f422ae0eea63b6cb57733aL125-R125)

**Backward Compatibility and Generalization:**

* Generalized header verification and completion logic in `Updater.cpp` to work for all file system types, not just SPIFFS. [[1]](diffhunk://#diff-d191305f68623de65611bd3810671941f2ef29ef0137bd3106553201f1a3e66fL455-R478) [[2]](diffhunk://#diff-d191305f68623de65611bd3810671941f2ef29ef0137bd3106553201f1a3e66fL474-R497)
* Updated OTA command parsing and handling to support the new file system modes, ensuring correct update behavior for all supported types.

These changes collectively make the OTA update process more robust and extensible for different file system types on ESP32 platforms.

Fixes: https://github.com/espressif/arduino-esp32/issues/9347