### PR TITLE
fix(esp_sr):  Error with debug level log

### DIFF
--- a/libraries/ESP_SR/src/esp32-hal-sr.c
+++ b/libraries/ESP_SR/src/esp32-hal-sr.c
@@ -343,7 +343,7 @@ esp_err_t sr_start(
   // Load WakeWord Detection
   afe_config_t *afe_config = afe_config_init(input_format, models, AFE_TYPE_SR, AFE_MODE_LOW_COST);
   g_sr_data->afe_handle = esp_afe_handle_from_config(afe_config);
-  log_d("load wakenet '%s'", afe_config.wakenet_model_name);
+  log_d("load wakenet '%s'", afe_config->wakenet_model_name);
   g_sr_data->afe_data = g_sr_data->afe_handle->create_from_config(afe_config);
   afe_config_free(afe_config);
 


### PR DESCRIPTION
## Description of Change
When compiling the ESP-SR Basic.ino example with DEBUG LEVEL = VERBOSE, there is a compilation error:
```
Compiling library "ESP_SR"
"C:\\Users\\esp\\AppData\\Local\\arduino\\sketches\\7228D85B768DE4388708EFAE81249F57\\libraries\\ESP_SR\\esp32-hal-sr.c.o"
In file included from C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.1\libraries\ESP_SR\src\esp32-hal-sr.c:39:
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.1\libraries\ESP_SR\src\esp32-hal-sr.c: In function 'sr_start':
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.1\libraries\ESP_SR\src\esp32-hal-sr.c:346:40: error: 'afe_config' is a pointer; did you mean to use '->'?
  346 |   log_d("load wakenet '%s'", afe_config.wakenet_model_name);
      |                                        ^
C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.1\cores\esp32/esp32-hal-log.h:139:76: note: in definition of macro 'log_d'
  139 | #define log_d(format, ...)     log_printf(ARDUHAL_LOG_FORMAT(D, format), ##__VA_ARGS__)
      |                                                                            ^~~~~~~~~~~
Using library ESP_I2S at version 3.3.0 in folder: C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.1\libraries\ESP_I2S 
Using library ESP_SR at version 3.3.0 in folder: C:\Users\esp\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.1\libraries\ESP_SR 
```

## Test Scenarios
Using ESP32-S3 with the https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP_SR/examples/Basic/Basic.ino
Set `Core Debug Level` to `Verbose`.

## Related links
Fixes #11857 