### PR TITLE
Migrate to wokwi-py-client (update pytest-embedded and esptool)

### DIFF
--- a/.github/scripts/tests_run.sh
+++ b/.github/scripts/tests_run.sh
@@ -88,10 +88,7 @@ function run_test {
         fi
 
         if [ $platform == "wokwi" ]; then
-            extra_args=("--target" "$target" "--embedded-services" "arduino,wokwi" "--wokwi-timeout=$wokwi_timeout")
-            if [[ -f "$sketchdir/scenario.yaml" ]]; then
-                extra_args+=("--wokwi-scenario" "$sketchdir/scenario.yaml")
-            fi
+            extra_args=("--target" "$target" "--embedded-services" "arduino,wokwi")
             if [[ -f "$sketchdir/diagram.$target.json" ]]; then
                 extra_args+=("--wokwi-diagram" "$sketchdir/diagram.$target.json")
             fi
@@ -137,7 +134,6 @@ SCRIPTS_DIR="./.github/scripts"
 COUNT_SKETCHES="${SCRIPTS_DIR}/sketch_utils.sh count"
 
 platform="hardware"
-wokwi_timeout=60000
 chunk_run=0
 options=0
 erase=0
@@ -156,7 +152,6 @@ while [ -n "$1" ]; do
         ;;
     -W )
         shift
-        wokwi_timeout=$1
         if [[ -z $WOKWI_CLI_TOKEN ]]; then
             echo "Wokwi CLI token is not set"
             exit 1

--- a/.github/workflows/tests_wokwi.yml
+++ b/.github/workflows/tests_wokwi.yml
@@ -269,7 +269,7 @@ jobs:
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         run: |
           pip install -U pip
-          pip install -r tests/requirements.txt --extra-index-url https://dl.espressif.com/pypi
+          pip install -r tests/requirements.txt
 
       - name: Install Wokwi CLI
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}

--- a/.github/workflows/tests_wokwi.yml
+++ b/.github/workflows/tests_wokwi.yml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  WOKWI_TIMEOUT: 600000 # Milliseconds
-
 jobs:
   get-artifacts:
     name: Get required artifacts
@@ -271,10 +268,6 @@ jobs:
           pip install -U pip
           pip install -r tests/requirements.txt
 
-      - name: Install Wokwi CLI
-        if: ${{ steps.check-tests.outputs.enabled == 'true' }}
-        run: curl -L https://wokwi.com/ci/install.sh | sh
-
       - name: Wokwi CI Server
         if: ${{ steps.check-tests.outputs.enabled == 'true' }}
         uses: wokwi/wokwi-ci-server-action@a6fabb5a49e080158c7a1d121ea5b789536a82c3 # v1
@@ -294,7 +287,7 @@ jobs:
         env:
           WOKWI_CLI_TOKEN: ${{ secrets.WOKWI_CLI_TOKEN }}
         run: |
-          bash .github/scripts/tests_run.sh -c -type ${{ matrix.type }} -t ${{ matrix.chip }} -i 0 -m 1 -W ${{ env.WOKWI_TIMEOUT }}
+          bash .github/scripts/tests_run.sh -c -type ${{ matrix.type }} -t ${{ matrix.chip }} -i 0 -m 1 -W
 
       - name: Upload ${{ matrix.chip }} ${{ matrix.type }} Wokwi results as cache
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -365,7 +365,7 @@ After the test is finished, you can check the output in the terminal and the gen
 Additionally, for performance tests, you can check the generated JSON file in the same folder.
 
 You can also run the tests in `Wokwi <https://docs.wokwi.com/>`_ or `Espressif's QEMU <https://github.com/espressif/esp-toolchain-docs/tree/main/qemu>`_
-by using the ``-W <timeout_in_ms>`` and ``-Q`` flags respectively. You will need to have the Wokwi and/or QEMU installed in your system
+by using the ``-W`` and ``-Q`` flags respectively. You will need to have the Wokwi and/or QEMU installed in your system
 and set the ``WOKWI_CLI_TOKEN`` and/or ``QEMU_PATH`` environment variables. The ``WOKWI_CLI_TOKEN`` is the CI token that can be obtained from the
 `Wokwi website <https://wokwi.com/dashboard/ci>`_ and the ``QEMU_PATH`` is the path to the QEMU binary.
 
@@ -373,7 +373,7 @@ For example, to run the ``uart`` test using Wokwi, you would run:
 
 .. code-block:: bash
 
-    WOKWI_CLI_TOKEN=<your_wokwi_token> ./.github/scripts/tests_run.sh -s uart -t esp32c3 -W <timeout_in_ms>
+    WOKWI_CLI_TOKEN=<your_wokwi_token> ./.github/scripts/tests_run.sh -s uart -t esp32c3 -W
 
 And to run the ``uart`` test using QEMU, you would run:
 
@@ -398,7 +398,6 @@ A test suite contains the following files:
 * ``<test_name>.ino``: The sketch that will be tested. Required.
 * ``ci.json``: The file that specifies how the test suite will be run in the CI system. Optional.
 * ``diagram.<target>.json``: The diagram file that specifies the connections between the components in Wokwi. Optional.
-* ``scenario.yaml``: The scenario file that specifies how Wokwi will interact with the components. Optional.
 * Any other files that are needed for the test suite.
 
 You can read more about the test python API in the `pytest-embedded documentation <https://docs.espressif.com/projects/pytest-embedded/en/latest/usages/expecting.html>`_.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,8 @@
 cryptography==44.0.1
 --only-binary cryptography
 pytest-cov==5.0.0
-pytest-embedded-serial-esp==1.12.0
-pytest-embedded-arduino==1.12.0
-pytest-embedded-wokwi==1.12.0
-pytest-embedded-qemu==1.12.0
-esptool==4.8.1
+pytest-embedded-serial-esp==2.0.0a1
+pytest-embedded-arduino==2.0.0a1
+pytest-embedded-wokwi==2.0.0a1
+pytest-embedded-qemu==2.0.0a1
+esptool==5.1.0

--- a/tests/validation/gpio/test_gpio.py
+++ b/tests/validation/gpio/test_gpio.py
@@ -1,16 +1,17 @@
 import logging
+from pytest_embedded_wokwi import Wokwi
+from pytest_embedded import Dut
 
 
-def test_gpio(dut):
+def test_gpio(dut: Dut, wokwi: Wokwi):
     LOGGER = logging.getLogger(__name__)
 
+    LOGGER.info("Waiting for Button test begin...")
     dut.expect_exact("Button test")
 
-    LOGGER.info("Expecting button press 1")
-    dut.expect_exact("Button pressed 1 times")
+    for i in range(3):
+        LOGGER.info(f"Setting button pressed for {i + 1} seconds")
+        wokwi.client.set_control("btn1", "pressed", 1)
 
-    LOGGER.info("Expecting button press 2")
-    dut.expect_exact("Button pressed 2 times")
-
-    LOGGER.info("Expecting button press 3")
-    dut.expect_exact("Button pressed 3 times")
+        dut.expect_exact(f"Button pressed {i + 1} times")
+        wokwi.client.set_control("btn1", "pressed", 0)


### PR DESCRIPTION
## Description of Change
Migrate from Wokwi CLI to the wokwi-python-client. For this I have updated the dependencies and modified the code to use for testing (GPIO only).

- For using the wokwi-python-client, I have updated esptool to version 5.1.0.
- I have also updated pytest-embedded-* to version 2.0.0a1. This is still in alpha, but I am investigating when a stable version will be available.
- For functional testing, I have also temporarily disabled installation from our [Extra index](https://github.com/espressif/arduino-esp32/compare/master...JakubAndrysek:arduino-esp32:feature/wokwi-py-client#diff-868563e145a89a974cabfb9a607f618ad87f1b07aa1ccc958291538cbc59bce0L272) since there are not those packages available.

## Test Scenarios
Tested in my GitHub Actions - [link](https://github.com/JakubAndrysek/arduino-esp32/actions/runs/17844707711).

## Before merging

- [ ] Revert `--extra-index-url` to `https://dl.espressif.com/pypi`
- [ ] Update `pytest-embedded-*` to stable version when available
