### PR TITLE
fix(menu): remove unused flash size option for 4D Systems MIPI LCDs

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -52648,11 +52648,6 @@ esp32p4_4ds_mipi.menu.CPUFreq.360.build.f_cpu=360000000L
 esp32p4_4ds_mipi.menu.CPUFreq.40=40MHz
 esp32p4_4ds_mipi.menu.CPUFreq.40.build.f_cpu=40000000L
 
-esp32p4_4ds_mipi.menu.FlashSize.16M=16MB (128Mb)
-esp32p4_4ds_mipi.menu.FlashSize.16M.build.flash_size=16MB
-esp32p4_4ds_mipi.menu.FlashSize.32M=32MB (256Mb)
-esp32p4_4ds_mipi.menu.FlashSize.32M.build.flash_size=32MB
-
 esp32p4_4ds_mipi.menu.UploadSpeed.921600=921600
 esp32p4_4ds_mipi.menu.UploadSpeed.921600.upload.speed=921600
 esp32p4_4ds_mipi.menu.UploadSpeed.115200=115200


### PR DESCRIPTION
## Description of Change

This removes the unused menu for flash size in 4D Systems MIPI LCDs. Products will release with 32MB flash only.

## Test Scenarios

Tested by modifying v3.3.1

## Related links

N/A