### PR TITLE
fix: Add upload flags to boards.txt for Twin AIoT Module to resolve upload error

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -52353,6 +52353,8 @@ twinaiot.upload.tool.network=esp_ota
 
 twinaiot.upload.maximum_size=1310720
 twinaiot.upload.maximum_data_size=327680
+twinaiot.upload.flags=
+twinaiot.upload.extra_flags=
 twinaiot.upload.use_1200bps_touch=false
 twinaiot.upload.wait_for_upload_port=false
 


### PR DESCRIPTION
This pull request addresses a missing board definition for the Twin AIoT module in the boards.txt file, resolving a critical upload error. This change is to solve the error we received in the twinaiot module that we added in the [previous PR](https://github.com/espressif/arduino-esp32/pull/11755). 

**Problem Description**
When attempting to upload a sketch to the Twin AIoT board, the build and upload process failed due to a missing line in the board's configuration file. The specific error message received was:

No such command '{upload.flags}'

This error was caused by the absence of the upload.flags and upload.extra_flags parameters in the Twin AIoT Module definition. The Arduino IDE's build system, which uses the platform.txt template, was unable to correctly format the esptool.py command-line arguments without these keys, leading to a failed upload.

**Solution**
This pull request adds the following lines to the Twin AIoT Module definition in the boards.txt file:

twinaiot.upload.flags=
twinaiot.upload.extra_flags=

This simple correction ensures that the build system can properly resolve the command-line arguments, allowing the firmware upload to proceed without errors.

**Test Scenario**
This change has been tested on the following hardware and software configuration:

Hardware: Twin AIoT Module (ESP32-S3-Mini-1 N4R2)

Software: Arduino IDE 2.3.6

Test: A simple "Blink" sketch was successfully compiled and uploaded, confirming that the upload process works as expected.