### PR TITLE
fix(board): Fix pid parameter for FoBE Quill ESP32S3 Mesh in boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -52133,7 +52133,7 @@ fobe_quill_esp32s3_mesh.name=FoBE Quill ESP32S3 Mesh
 fobe_quill_esp32s3_mesh.vid.0=0x303a
 fobe_quill_esp32s3_mesh.pid.0=0x82f4
 fobe_quill_esp32s3_mesh.vid.1=0x303a
-fobe_quill_esp32s3_mesh.vid.1=0x82f5
+fobe_quill_esp32s3_mesh.pid.1=0x82f5
 fobe_quill_esp32s3_mesh.vid.2=0x303a
 fobe_quill_esp32s3_mesh.pid.2=0x82f6
 


### PR DESCRIPTION
### Description of Change
This is a simple typo fix for the FoBE Quill ESP32S3 Mesh in boards.txt. There were two identical "fobe_quill_esp32s3_mesh.vid.1" entries and the second one was obviously meant to be called "pid", not "vid".

### The problem it solves
Because of this typo in boards.txt Arduino IDE v1.8.19 was failing to detect any COM port.
I'm using Arduino IDE v1.8.19 on Windows 10. I updated ESP32 Core from v3.3.0 to v3.3.1 via the board manager. After restaring Arduino IDE it was no longer detecting any COM ports. Tools -> Port option was greyed out even though a board was connected and was detected by windows device manager. The board itself doesn't matter, the problem isn't even ESP32-related, the IDE just fails to detect any board. I tried launching the arduino_debug.exe and it showed the following error in the terminal:
```
Exception in thread "cc.arduino.packages.discoverers.serial.SerialDiscovery" java.lang.IndexOutOfBoundsException: Index: 2, Size: 2
        at java.util.LinkedList.checkElementIndex(LinkedList.java:555)
        at java.util.LinkedList.get(LinkedList.java:476)
        at processing.app.Platform.resolveDeviceByVendorIdProductId(Platform.java:188)
        at cc.arduino.packages.discoverers.serial.SerialDiscovery.forceRefresh(SerialDiscovery.java:166)
        at cc.arduino.packages.discoverers.serial.SerialDiscovery$1.run(SerialDiscovery.java:96)
        at java.util.TimerThread.mainLoop(Timer.java:555)
        at java.util.TimerThread.run(Timer.java:505)
```
After tracking down the issue I've changed "vid" to "pid" in the boards.txt file and copied it to `c:\Users\USER\AppData\Local\Arduino15\packages\esp32\hardware\esp32\3.3.12` (replacing the already existing boards.txt file). The problem is now gone, arduino_debug.exe shows no errors and Arduino IDE is detecting COM ports normally.

### Test Scenario
Config:
Windows 10
Arduino IDE v1.8.19
Multiple hardware: ESP32-WROOM-32, Arduino Nano, PL2303HX-based usb-ttl converter

Before this change:
Arduino IDE fails to detect any COM port (Tools -> Port option is greyed out even when a board is connected to the PC).
Also arduino_debug.exe shows an error upon launching.

After this change:
Arduino IDE detects COM ports normally (Tools -> Port option allows to select a port).
arduino_debug.exe shows no errors.
