### PR TITLE
Refactor touch pad error logging

### DIFF
--- a/cores/esp32/esp32-hal-gpio.c
+++ b/cores/esp32/esp32-hal-gpio.c
@@ -33,20 +33,21 @@
 #include "soc/touch_sensor_periph.h"
 
 int8_t digitalPinToTouchChannel(uint8_t pin) {
-  int8_t ret = -1;
   if (pin < SOC_GPIO_PIN_COUNT) {
     for (uint8_t i = 0; i < SOC_TOUCH_SENSOR_NUM; i++) {
       if (touch_sensor_channel_io_map[i] == pin) {
-        ret = i;
-        break;
+        return i;
       }
     }
   }
-  return ret;
+
+  log_e("No touch pad on selected pin(%u)!", pin);
+  return -1;
 }
 #else
 // No Touch Sensor available
 int8_t digitalPinToTouchChannel(uint8_t pin) {
+  log_e("Touch sensor not available on this chip");
   return -1;
 }
 #endif

--- a/cores/esp32/esp32-hal-touch-ng.c
+++ b/cores/esp32/esp32-hal-touch-ng.c
@@ -332,7 +332,6 @@ static void __touchChannelInit(int pad) {
 static touch_value_t __touchRead(uint8_t pin) {
   int8_t pad = digitalPinToTouchChannel(pin);
   if (pad < 0) {
-    log_e(" No touch pad on selected pin!");
     return 0;
   }
 
@@ -360,7 +359,6 @@ static touch_value_t __touchRead(uint8_t pin) {
 static void __touchConfigInterrupt(uint8_t pin, void (*userFunc)(void), void *Args, bool callWithArgs, touch_value_t threshold) {
   int8_t pad = digitalPinToTouchChannel(pin);
   if (pad < 0) {
-    log_e(" No touch pad on selected pin!");
     return;
   }
 
@@ -446,7 +444,6 @@ bool touchInterruptGetLastStatus(uint8_t pin) {
 void touchSleepWakeUpEnable(uint8_t pin, touch_value_t threshold) {
   int8_t pad = digitalPinToTouchChannel(pin);
   if (pad < 0) {
-    log_e(" No touch pad on selected pin!");
     return;
   }
 

--- a/cores/esp32/esp32-hal-touch.c
+++ b/cores/esp32/esp32-hal-touch.c
@@ -206,7 +206,6 @@ static void __touchChannelInit(int pad) {
 static touch_value_t __touchRead(uint8_t pin) {
   int8_t pad = digitalPinToTouchChannel(pin);
   if (pad < 0) {
-    log_e(" No touch pad on selected pin!");
     return 0;
   }
 
@@ -233,7 +232,6 @@ static touch_value_t __touchRead(uint8_t pin) {
 static void __touchConfigInterrupt(uint8_t pin, void (*userFunc)(void), void *Args, touch_value_t threshold, bool callWithArgs) {
   int8_t pad = digitalPinToTouchChannel(pin);
   if (pad < 0) {
-    log_e(" No touch pad on selected pin!");
     return;
   }
 
@@ -295,7 +293,6 @@ bool touchInterruptGetLastStatus(uint8_t pin) {
 void touchSleepWakeUpEnable(uint8_t pin, touch_value_t threshold) {
   int8_t pad = digitalPinToTouchChannel(pin);
   if (pad < 0) {
-    log_e(" No touch pad on selected pin!");
     return;
   }
 


### PR DESCRIPTION
This pull request adds the display of the pin number when an incorrect pin is specified and removes duplicated log lines across multiple functions.  
These changes improve debugging clarity.

#### Problem Description

Previously, functions like touchRead() would log "No touch pad on selected pin!" when an invalid pin was specified, but the log did not include the actual pin number.
This made it harder to identify which pin caused the issue during debugging.

#### Description of Change

* Removed duplicated log_e("No touch pad on selected pin!") calls from multiple functions.
* Centralized the error log inside digitalPinToTouchChannel().
* Extended the error message to include the pin number for better debugging context.
* Added log_e() in digitalPinToTouchChannel() when no touch sensor is available on the chip.

#### Test Scenario

This change has been tested on the following hardware and software configuration:

Hardware: ESP32-S3-WROOM-1 N16R8, ESP-WROOM-32
Software: Pioarduino 1.1.0

```cpp
#include <Arduino.h>

void setup()
{
}

void loop()
{
  touch_value_t value = touchRead(18);
  log_i("value: %lu", value);
  delay(1000);
}
```




