### PR TITLE
fix(board): Fix wESP32 board config with new options

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -29533,7 +29533,7 @@ wesp32.build.board=WESP32
 
 wesp32.build.f_cpu=240000000L
 wesp32.build.flash_mode=dio
-wesp32.build.flash_size=4MB
+wesp32.build.flash_size=16MB
 wesp32.build.boot=dio
 wesp32.build.partitions=default
 wesp32.build.defines=
@@ -29542,6 +29542,23 @@ wesp32.menu.FlashFreq.80=80MHz
 wesp32.menu.FlashFreq.80.build.flash_freq=80m
 wesp32.menu.FlashFreq.40=40MHz
 wesp32.menu.FlashFreq.40.build.flash_freq=40m
+
+wesp32.menu.FlashSize.default=16MB (128Mb) rev 7+
+wesp32.menu.FlashSize.default.build.flash_size=16MB
+wesp32.menu.FlashSize.default_4m_flash=4MB (32Mb) rev 5 and below
+wesp32.menu.FlashSize.default_4m_flash.build.flash_size=4MB
+
+wesp32.menu.PartitionScheme.default=16M OTA with large SPIFFS (4.5MB APP/6.8MB SPIFFS)
+wesp32.menu.PartitionScheme.default.build.partitions=large_spiffs_16MB
+wesp32.menu.PartitionScheme.default.upload.maximum_size=4718592
+wesp32.menu.PartitionScheme.default_large_app=16M large OTA app with SPIFFS (6.2MB APP/3.3MB SPIFFS)
+wesp32.menu.PartitionScheme.default_large_app.build.partitions=default_16MB
+wesp32.menu.PartitionScheme.default_large_app.upload.maximum_size=6553600
+wesp32.menu.PartitionScheme.default_fatfs=16M OTA with large FATFS (3MB APP/9.8MB FATFS)
+wesp32.menu.PartitionScheme.default_fatfs.build.partitions=app3M_fat9M_16MB
+wesp32.menu.PartitionScheme.default_fatfs.upload.maximum_size=3145728
+wesp32.menu.PartitionScheme.default_4m_flash=4M OTA app with SPIFFS (1.25MB APP/1.3MB FATFS)
+wesp32.menu.PartitionScheme.default_4m_flash.build.partitions=default
 
 wesp32.menu.UploadSpeed.921600=921600
 wesp32.menu.UploadSpeed.921600.upload.speed=921600

--- a/boards.txt
+++ b/boards.txt
@@ -29557,7 +29557,7 @@ wesp32.menu.PartitionScheme.default_large_app.upload.maximum_size=6553600
 wesp32.menu.PartitionScheme.default_fatfs=16M OTA with large FATFS (3MB APP/9.8MB FATFS)
 wesp32.menu.PartitionScheme.default_fatfs.build.partitions=app3M_fat9M_16MB
 wesp32.menu.PartitionScheme.default_fatfs.upload.maximum_size=3145728
-wesp32.menu.PartitionScheme.default_4m_flash=4M OTA app with SPIFFS (1.25MB APP/1.3MB FATFS)
+wesp32.menu.PartitionScheme.default_4m_flash=4M OTA app with SPIFFS (1.25MB APP/1.3MB SPIFFS)
 wesp32.menu.PartitionScheme.default_4m_flash.build.partitions=default
 
 wesp32.menu.UploadSpeed.921600=921600

--- a/variants/wesp32/pins_arduino.h
+++ b/variants/wesp32/pins_arduino.h
@@ -35,7 +35,7 @@ static const uint8_t T9 = 32;
 #define ETH_PHY_POWER -1
 #define ETH_PHY_MDC   16
 #define ETH_PHY_MDIO  17
-#define ETH_PHY_TYPE  ETH_PHY_LAN8720
+#define ETH_PHY_TYPE  ETH_PHY_RTL8201
 #define ETH_CLK_MODE  ETH_CLOCK_GPIO0_IN
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

## Description of Change
- Provide flash size option to choose 4MB flash (rev 5 and below) or 16MB flash (default, rev 7 and higher).
- Provide appropriate partition scheme options to effectively use either 4MB or 16MB flash sizes.
- Change default Ethernet PHY from LAN8720 to RTL8201 (rev 7 and higher default).

## Test Scenarios
Tested on Arduino 2.3.6 locally with wESP32 rev 8 board.
