### PR TITLE
feat(board): expose logging subsystem arduino IDE

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -19,6 +19,7 @@ menu.EraseFlash=Erase All Flash Before Sketch Upload
 menu.JTAGAdapter=JTAG Adapter
 menu.ZigbeeMode=Zigbee Mode
 menu.PinNumbers=Pin Numbering
+menu.LoggingSubsystem=Logging Subsystem
 
 # Custom options
 menu.Revision=Board Revision
@@ -36923,6 +36924,11 @@ XIAO_ESP32S3.menu.EraseFlash.none=Disabled
 XIAO_ESP32S3.menu.EraseFlash.none.upload.erase_cmd=
 XIAO_ESP32S3.menu.EraseFlash.all=Enabled
 XIAO_ESP32S3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+XIAO_ESP32S3.menu.LoggingSubsystem.Arduino=Arduino
+XIAO_ESP32S3.menu.LoggingSubsystem.Arduino.build.log_subsystem=
+XIAO_ESP32S3.menu.LoggingSubsystem.ESP_IDF=ESP_IDF
+XIAO_ESP32S3.menu.LoggingSubsystem.ESP_IDF.build.log_subsystem=-DUSE_ESP_IDF_LOG
 
 ##############################################################
 

--- a/platform.txt
+++ b/platform.txt
@@ -102,7 +102,8 @@ build.code_debug=0
 build.defines=
 build.loop_core=
 build.event_core=
-build.extra_flags=-DARDUINO_HOST_OS="{runtime.os}" -DARDUINO_FQBN="{build.fqbn}" -DESP32=ESP32 -DCORE_DEBUG_LEVEL={build.code_debug} {build.loop_core} {build.event_core} {build.defines} {build.extra_flags.{build.mcu}} {build.zigbee_mode}
+build.log_subsystem=
+build.extra_flags=-DARDUINO_HOST_OS="{runtime.os}" -DARDUINO_FQBN="{build.fqbn}" -DESP32=ESP32 -DCORE_DEBUG_LEVEL={build.code_debug} {build.loop_core} {build.event_core} {build.defines} {build.extra_flags.{build.mcu}} {build.zigbee_mode} {build.log_subsystem}
 build.extra_libs=
 build.memory_type={build.boot}_qspi
 


### PR DESCRIPTION
## Description of Change

* introduce `Logging Subsystem` option in arduino IDE
  * introduces `arduino` and `esp_idf` options
* `esp_idf` option sets the `build.log_subsystem` variable to `-DUSE_ESP_IDF_LOG`, which is passed into `build.extra_flags`
* `arduino` option is an empty str and therefore no new flags are added to `build.extra_flags`
* cannot use `build.defines` as that conflicts with the PSRAM `-D` flag?

note: this only adds it for XIAO ESP32S3; I can add it to the rest of the boards if that's desirable, but hoping y'all might have some automation for that.

## Test Scenarios

Hardware: `FQBN: espressif:esp32:XIAO_ESP32S3:DebugLevel=debug,PSRAM=opi,LoggingSubsystem=ESP_IDF`
Software: whatever is pulled in by current `main`

Example sketch:

```c++
// define some custom logger fx
int syslogger(const char *format, va_list args) {
  char buffer[256];
  vsnprintf(buffer, sizeof(buffer), format, args);

  // some custom write (e.g., for me I wrote to a remote syslog endpoint)
  Serial.print(buffer);

  va_end(args);
  return strlen(buffer);
}

void setup() {
  esp_log_set_vprintf(syslogger);
}

void loop() {
  ESP_LOGD("my_app", "hello world");
}
```

Without this change, `ESP_LOGD` only goes to serial? with this change, `syslogger` is used correctly.

## Related links

#4845 introduced `USE_ESP_IDF_LOG`