### PR TITLE
Update README.md to mention ESP32-C5

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here are the ESP32 series supported by the Arduino-ESP32 project:
 |----------|:----------:|:---------------:|:-------------------------------------------------------------------------------------------------:|
 | ESP32    |     Yes    |       Yes       |    [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)    |
 | ESP32-C3 |     Yes    |       Yes       | [ESP32-C3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf) |
-| ESP32-C5 |     No     |       Yes       | [ESP32-C5](https://www.espressif.com/sites/default/files/documentation/esp32-c5_datasheet_en.pdf) |
+| ESP32-C5 |     Yes    |       Yes       | [ESP32-C5](https://www.espressif.com/sites/default/files/documentation/esp32-c5_datasheet_en.pdf) |
 | ESP32-C6 |     Yes    |       Yes       | [ESP32-C6](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf) |
 | ESP32-H2 |     Yes    |       Yes       | [ESP32-H2](https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf) |
 | ESP32-P4 |     Yes    |       Yes       | [ESP32-P4](https://www.espressif.com/sites/default/files/documentation/esp32-p4_datasheet_en.pdf) |


### PR DESCRIPTION
## Description of Change

Update README.md to mention ESP32-C5,. listing the ESP32-C5 there as supported for development and list it as "stable" there.

## Test Scenarios

N/A

## Related links

* https://github.com/espressif/arduino-esp32/pull/11794

and

* https://github.com/espressif/arduino-esp32/discussions/11887
