### PR TITLE
feat(zigbee): Extend switch EPs with get Light methods

### DIFF
--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
@@ -23,6 +23,16 @@ ZigbeeColorDimmerSwitch::ZigbeeColorDimmerSwitch(uint8_t endpoint) : ZigbeeEP(en
   _instance = this;   // Set the static pointer to this instance
   _device = nullptr;  // Initialize light pointer to null
 
+  _light_color_rgb = {0, 0, 0};
+  _light_color_hsv = {0, 0, 255};
+  _light_color_xy = {0, 0};
+  _on_light_state_change = nullptr;
+  _on_light_state_change_with_source = nullptr;
+  _on_light_level_change = nullptr;
+  _on_light_level_change_with_source = nullptr;
+  _on_light_color_change = nullptr;
+  _on_light_color_change_with_source = nullptr;
+
   esp_zb_color_dimmable_switch_cfg_t switch_cfg = ESP_ZB_DEFAULT_COLOR_DIMMABLE_SWITCH_CONFIG();
   _cluster_list = esp_zb_color_dimmable_switch_clusters_create(&switch_cfg);
 
@@ -516,4 +526,339 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
   }
 }
 
+void ZigbeeColorDimmerSwitch::getLightState() {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ON_OFF;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightState(uint16_t group_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ON_OFF;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightState(uint8_t endpoint, uint16_t short_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ON_OFF;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightState(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    memcpy(read_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ON_OFF;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightLevel() {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightLevel(uint16_t group_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightLevel(uint8_t endpoint, uint16_t short_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightLevel(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    memcpy(read_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL;
+    read_req.attr_number = 1;
+    uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
+    read_req.attr_field = &attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightColor() {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightColor(uint16_t group_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightColor(uint8_t endpoint, uint16_t short_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightColor(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    memcpy(read_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightColorHS() {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightColorHS(uint16_t group_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = group_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::getLightColorHS(uint8_t endpoint, uint16_t short_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    read_req.zcl_basic_cmd.dst_addr_u.addr_short = short_addr;
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+} 
+
+void ZigbeeColorDimmerSwitch::getLightColorHS(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
+  if (_is_bound) {
+    esp_zb_zcl_read_attr_cmd_t read_req = {0};
+    read_req.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    read_req.zcl_basic_cmd.src_endpoint = _endpoint;
+    read_req.zcl_basic_cmd.dst_endpoint = endpoint;
+    memcpy(read_req.zcl_basic_cmd.dst_addr_u.addr_long, ieee_addr, sizeof(esp_zb_ieee_addr_t));
+    read_req.clusterID = ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL;
+    read_req.attr_number = 2;
+    uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
+    read_req.attr_field = attr_id;
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_zcl_read_attr_cmd_req(&read_req);
+    esp_zb_lock_release();
+  }
+}
+
+void ZigbeeColorDimmerSwitch::zbAttributeRead(uint16_t cluster_id, const esp_zb_zcl_attribute_t *attribute, uint8_t src_endpoint, esp_zb_zcl_addr_t src_address) {
+  static uint8_t read_config = 0;
+  if (cluster_id == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF) {
+    if (attribute->id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL) {
+      bool light_state = attribute->data.value ? *(bool *)attribute->data.value : false;
+      if (_on_light_state_change) {
+        _on_light_state_change(light_state);
+      }
+      if (_on_light_state_change_with_source) {
+        _on_light_state_change_with_source(light_state, src_endpoint, src_address);
+      }
+    }
+  }
+  if (cluster_id == ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL) {
+    if (attribute->id == ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_U8) {
+      uint8_t light_level = attribute->data.value ? *(uint8_t *)attribute->data.value : 0;
+      if (_on_light_level_change) {
+        _on_light_level_change(light_level);
+      }
+      if (_on_light_level_change_with_source) {
+        _on_light_level_change_with_source(light_level, src_endpoint, src_address);
+      }
+    }
+  }
+  if (cluster_id == ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL) {
+    static bool x_received = false;
+    static bool y_received = false;
+    static bool h_received = false;
+    static bool s_received = false;
+    
+    if (attribute->id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_U16) {
+      _light_color_xy.x = attribute->data.value ? *(uint16_t *)attribute->data.value : 0;
+      x_received = true;
+    }
+    if (attribute->id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_U16) {
+      _light_color_xy.y = attribute->data.value ? *(uint16_t *)attribute->data.value : 0;
+      y_received = true;
+    }
+    
+    if (attribute->id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_U8) {
+      _light_color_hsv.h = attribute->data.value ? *(uint8_t *)attribute->data.value : 0;
+      h_received = true;
+    }
+    if (attribute->id == ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID && attribute->data.type == ESP_ZB_ZCL_ATTR_TYPE_U8) {
+      _light_color_hsv.s = attribute->data.value ? *(uint8_t *)attribute->data.value : 0;
+      s_received = true;
+    }
+    
+    // Process XY color if both X and Y have been received
+    if (x_received && y_received) {
+      _light_color_rgb = espXYToRgbColor(255, _light_color_xy.x, _light_color_xy.y, false);
+      if (_on_light_color_change) {
+        _on_light_color_change(_light_color_rgb.r, _light_color_rgb.g, _light_color_rgb.b);
+      }
+      if (_on_light_color_change_with_source) {
+        _on_light_color_change_with_source(_light_color_rgb.r, _light_color_rgb.g, _light_color_rgb.b, src_endpoint, src_address);
+      }
+      x_received = false; // Reset flags after processing
+      y_received = false;
+    }
+    
+    // Process HS color if both H and S have been received
+    if (h_received && s_received) {
+      _light_color_rgb = espHsvColorToRgbColor(_light_color_hsv);
+      if (_on_light_color_change) {
+        _on_light_color_change(_light_color_rgb.r, _light_color_rgb.g, _light_color_rgb.b);
+      }
+      if (_on_light_color_change_with_source) {
+        _on_light_color_change_with_source(_light_color_rgb.r, _light_color_rgb.g, _light_color_rgb.b, src_endpoint, src_address);
+      }
+      h_received = false; // Reset flags after processing
+      s_received = false;
+    }
+  }
+}
 #endif  // CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.h
@@ -58,10 +58,60 @@ public:
   void setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t endpoint, uint16_t short_addr);
   void setLightColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
 
+  void getLightState();
+  void getLightState(uint16_t group_addr);
+  void getLightState(uint8_t endpoint, uint16_t short_addr);
+  void getLightState(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
+
+  void getLightLevel();
+  void getLightLevel(uint16_t group_addr);
+  void getLightLevel(uint8_t endpoint, uint16_t short_addr);
+  void getLightLevel(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
+
+  void getLightColor();
+  void getLightColor(uint16_t group_addr);
+  void getLightColor(uint8_t endpoint, uint16_t short_addr);
+  void getLightColor(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
+
+  void getLightColorHS();
+  void getLightColorHS(uint16_t group_addr);
+  void getLightColorHS(uint8_t endpoint, uint16_t short_addr);
+  void getLightColorHS(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
+
+  void onLightStateChange(void (*callback)(bool)) {
+    _on_light_state_change = callback;
+  }
+  void onLightStateChangeWithSource(void (*callback)(bool, uint8_t, esp_zb_zcl_addr_t)) {
+    _on_light_state_change_with_source = callback;
+  }
+  void onLightLevelChange(void (*callback)(uint8_t)) {
+    _on_light_level_change = callback;
+  }
+  void onLightLevelChangeWithSource(void (*callback)(uint8_t, uint8_t, esp_zb_zcl_addr_t)) {
+    _on_light_level_change_with_source = callback;
+  }
+  void onLightColorChange(void (*callback)(uint8_t, uint8_t, uint8_t)) {
+    _on_light_color_change = callback;
+  }
+  void onLightColorChangeWithSource(void (*callback)(uint8_t, uint8_t, uint8_t, uint8_t, esp_zb_zcl_addr_t)) {
+    _on_light_color_change_with_source = callback;
+  }
+
 private:
   // save instance of the class in order to use it in static functions
   static ZigbeeColorDimmerSwitch *_instance;
   zb_device_params_t *_device;
+
+  espHsvColor_t _light_color_hsv;
+  espXyColor_t _light_color_xy;
+  espRgbColor_t _light_color_rgb;
+
+  void (*_on_light_state_change)(bool);
+  void (*_on_light_state_change_with_source)(bool, uint8_t, esp_zb_zcl_addr_t);
+  void (*_on_light_level_change)(uint8_t);
+  void (*_on_light_level_change_with_source)(uint8_t, uint8_t, esp_zb_zcl_addr_t);
+  void (*_on_light_color_change)(uint8_t, uint8_t, uint8_t);
+  void (*_on_light_color_change_with_source)(uint8_t, uint8_t, uint8_t, uint8_t, esp_zb_zcl_addr_t);
 
   void findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req);
   void bindCb(esp_zb_zdp_status_t zdo_status, void *user_ctx);
@@ -69,7 +119,7 @@ private:
   static void bindCbWrapper(esp_zb_zdp_status_t zdo_status, void *user_ctx);
   static void findCbWrapper(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t endpoint, void *user_ctx);
 
-  void calculateXY(uint8_t red, uint8_t green, uint8_t blue, uint16_t &x, uint16_t &y);
+  void zbAttributeRead(uint16_t cluster_id, const esp_zb_zcl_attribute_t *attribute, uint8_t src_endpoint, esp_zb_zcl_addr_t src_address) override;
 };
 
 #endif  // CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.h
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.h
@@ -48,15 +48,32 @@ public:
   void lightOnWithTimedOff(uint8_t on_off_control, uint16_t time_on, uint16_t time_off);
   void lightOnWithSceneRecall();
 
+  void getLightState();
+  void getLightState(uint16_t group_addr);
+  void getLightState(uint8_t endpoint, uint16_t short_addr);
+  void getLightState(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr);
+
+  void onLightStateChange(void (*callback)(bool)) {
+    _on_light_state_change = callback;
+  }
+  void onLightStateChangeWithSource(void (*callback)(bool, uint8_t, esp_zb_zcl_addr_t)) {
+    _on_light_state_change_with_source = callback;
+  }
+
 private:
   // save instance of the class in order to use it in static functions
   static ZigbeeSwitch *_instance;
   zb_device_params_t *_device;
+
+  void (*_on_light_state_change)(bool);
+  void (*_on_light_state_change_with_source)(bool, uint8_t, esp_zb_zcl_addr_t);
+
   void findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req);
   void bindCb(esp_zb_zdp_status_t zdo_status, void *user_ctx);
   void findCb(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t endpoint, void *user_ctx);
   static void findCbWrapper(esp_zb_zdp_status_t zdo_status, uint16_t addr, uint8_t endpoint, void *user_ctx);
   static void bindCbWrapper(esp_zb_zdp_status_t zdo_status, void *user_ctx);
+  void zbAttributeRead(uint16_t cluster_id, const esp_zb_zcl_attribute_t *attribute, uint8_t src_endpoint, esp_zb_zcl_addr_t src_address) override;
 };
 
 #endif  // CONFIG_ZB_ENABLED


### PR DESCRIPTION
## Description of Change
This pull request introduces significant improvements to the Zigbee switch and color dimmer switch functionality, focusing on enhanced state polling, attribute readback, and callback handling for light state, level, and color changes. The changes improve how the switch tracks and reports the state of bound lights, and add flexible mechanisms for polling and responding to changes in light attributes.

**Enhanced Zigbee Switch State Polling and Reporting:**

* Added a periodic task (`periodicTask`) in `Zigbee_On_Off_Switch.ino` to poll the light state every second and print bound devices every 10 seconds, improving real-time tracking of connected lights. [[1]](diffhunk://#diff-e809eb3ee5a02e918e37856268acc19dd1caa1f63740f9f71db0d5a25c4a0172R80-R106) [[2]](diffhunk://#diff-e809eb3ee5a02e918e37856268acc19dd1caa1f63740f9f71db0d5a25c4a0172R188-R189)
* Introduced the `onLightStateChange` callback and `light_state` tracking to log state changes and ensure the application responds only to actual changes. [[1]](diffhunk://#diff-e809eb3ee5a02e918e37856268acc19dd1caa1f63740f9f71db0d5a25c4a0172R69-R70) [[2]](diffhunk://#diff-e809eb3ee5a02e918e37856268acc19dd1caa1f63740f9f71db0d5a25c4a0172R134-R135)

**Expanded ZigbeeColorDimmerSwitch Attribute Handling and Callbacks:**

* Implemented multiple `getLightState`, `getLightLevel`, and `getLightColor` methods to support polling light state, level, and color for various addressing modes (group, endpoint, IEEE address), enabling more flexible device management. [[1]](diffhunk://#diff-776842f2c074429e3c7bfbf8736371c0ff1dc696b6edf23c2b0f72e7cb50388fR529-R863) [[2]](diffhunk://#diff-d6bb1eed02b88f79204b1759c6ccac3bc42719bba0698a532550c5ef18885cd4R61-R122)
* Added callback setters (`onLightStateChange`, `onLightLevelChange`, `onLightColorChange`, etc.) to allow users to register handlers for state, level, and color changes, both with and without source information. [[1]](diffhunk://#diff-d6bb1eed02b88f79204b1759c6ccac3bc42719bba0698a532550c5ef18885cd4R61-R122) [[2]](diffhunk://#diff-776842f2c074429e3c7bfbf8736371c0ff1dc696b6edf23c2b0f72e7cb50388fR26-R35)
* Enhanced the attribute readback logic in `zbAttributeRead`, including robust parsing and callback invocation for ON/OFF, level, and color attributes, with proper handling of XY and HS color updates and conversion to RGB.

These changes collectively make the Zigbee switch and color dimmer switch more responsive, extensible, and easier to integrate into applications requiring real-time light state monitoring and control.

## Test Scenarios
Tested with On/Off switch and Light example.

## Related links
Closes #11886 
