### PR TITLE
feat(tinyusb_cdc): avoid infinite loop when TinyUSB CDC layer hangs

### DIFF
--- a/cores/esp32/USBCDC.cpp
+++ b/cores/esp32/USBCDC.cpp
@@ -405,7 +405,7 @@ size_t USBCDC::write(const uint8_t *buffer, size_t size) {
     return 0;
   }
   size_t to_send = size, so_far = 0;
-  // writeTimeout will prevent that TinyUSB failure locks the while(to_send) loop 
+  // writeTimeout will prevent that TinyUSB failure locks the while(to_send) loop
   uint32_t writeTimeout = millis() + tx_timeout_ms;
   while (to_send) {
     if (!tud_cdc_n_connected(itf) || (int32_t)(millis() - writeTimeout) >= 0) {


### PR DESCRIPTION
## Description of Change
Added a timeout check to prevent locking during CDC writing.

## Test Scenarios
ESP32-S3/S2 with the sketch:

``` cpp
// ESP32-S3 | ESP32-S2 
// Arduino IDE Setting: CDC on Boot = ENABLED (both S2|S3) 
// Arduino IDE Setting for S3: USB Mode = USB OTG (TinyUSB) ||  Upload Mode =  USB OTG CDC (TinyUSB)
// First time sketch upload may require to make the ESP32-S2/S3 to enter in Download Mode
// In order to achieve it: Hold BOOT Button pressed, press and release RESET button then release BOOT button.
#include "USB.h"
#include "USBHIDGamepad.h"
USBHIDGamepad Gamepad;

#define RGB_LED_PIN 48 // some ESP32-S3 may use pin 38 or something else. S2 Devkit uses pin 18

void setup() {
  Serial.begin();  // TinyUSB CDC Port
  while(!Serial) {
    // blinks RGB LED to tell user that the Serial Terminal has not been open
    rgbLedWrite(RGB_LED_PIN, 64, 0, 0);  // RED
    delay(250);
    rgbLedWrite(RGB_LED_PIN, 0, 0, 0);  // OFF
    delay(250);
  }
  USB.begin();
  Gamepad.begin();
  Serial.println("TinyUSB Sketch will send CDC and HID reports in loop()");
}

uint32_t c = 0;
void loop() {
  Serial.println(String(c++) + " ==> Hello ESP32S3");
  //delay(500);  // remove this line for the TinyUSB bug -- note: a minimum delay(2) here solves the issue....
  if (c & 1) {
    Gamepad.pressButton(0);
  } else {
    Gamepad.releaseButton(0);
  }
  //delay(500);  // remove this line for the TinyUSB bug
}
```

## Related links
Related to, but not final solution for:
 https://github.com/espressif/arduino-esp32/issues/10836
 https://github.com/espressif/arduino-esp32/issues/11600
 https://github.com/espressif/arduino-esp32/issues/10307