### PR TITLE
fix(vfs): fix stat initialization, close #11908

### DIFF
--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -281,7 +281,7 @@ VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs
         setvbuf(_f, NULL, _IOFBF, DEFAULT_FILE_BUFFER_SIZE);
       }
     } else {
-      log_w("stat(%s) failed", temp);
+      log_e("stat(%s) failed", temp);
     }
   }
   free(temp);


### PR DESCRIPTION
## Description of Change
This PR fixes the bug of an uninitialised stat structure in various modes.

## Test Scenarios
Tested on ESP32 and ESP32-S3


## Related links

closes #11908 

