### PR TITLE
fix(i2c): Set I2C master log level to none

### DIFF
--- a/cores/esp32/esp32-hal-i2c-ng.c
+++ b/cores/esp32/esp32-hal-i2c-ng.c
@@ -156,6 +156,9 @@ esp_err_t i2cInit(uint8_t i2c_num, int8_t sda, int8_t scl, uint32_t frequency) {
     }
   }
 
+  // Silence messages coming from the IDF driver
+  esp_log_level_set("i2c.master", ESP_LOG_NONE);
+
 init_fail:
 #if !CONFIG_DISABLE_HAL_LOCKS
   //release lock


### PR DESCRIPTION
Silence log messages from the I2C master driver.

Closes: https://github.com/espressif/arduino-esp32/issues/11787