### PR TITLE
fix(net): Rework NO_GLOBALS to not act on dependent network classes

### DIFF
--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -127,9 +127,7 @@ private:
   mdns_txt_item_t *_getResultTxt(int idx, int txtIdx);
 };
 
-#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
 extern MDNSResponder MDNS;
-#endif
 
 #endif  /* CONFIG_MDNS_MAX_INTERFACES */
 #endif  //ESP32MDNS_H

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -1174,6 +1174,8 @@ size_t ETHClass::printDriverInfo(Print &out) const {
   return bytes;
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ETH)
 ETHClass ETH;
+#endif
 
 #endif /* CONFIG_ETH_ENABLED */

--- a/libraries/Network/src/NetworkManager.h
+++ b/libraries/Network/src/NetworkManager.h
@@ -31,6 +31,4 @@ public:
   }
 };
 
-#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_NETWORK)
 extern NetworkManager Network;
-#endif

--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -763,6 +763,8 @@ size_t PPPClass::printDriverInfo(Print &out) const {
   return bytes;
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_PPP)
 PPPClass PPP;
+#endif
 
 #endif /* CONFIG_LWIP_PPP_SUPPORT */

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -72,8 +72,6 @@ public:
   bool isProvEnabled();
 };
 
-#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_WIFI)
 extern WiFiClass WiFi;
-#endif
 
 #endif /* SOC_WIFI_SUPPORTED */


### PR DESCRIPTION
This pull request standardizes the way global instances are conditionally defined across several network-related libraries. Specifically, it ensures that global objects like `WiFi`, `ETH`, `PPP`, `Network`, and `MDNS` are only instantiated when the appropriate macros are not defined, improving consistency and configurability throughout the codebase.

Conditional global instance definitions:

* Added `#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ETH)` guard around the global `ETH` instance in `ETH.cpp` for consistency with other modules.
* Added `#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_PPP)` guard around the global `PPP` instance in `PPP.cpp`.
* Removed unconditional global instance declarations and ensured that `WiFi`, `Network`, and `MDNS` are only declared when the appropriate macros are not defined in their respective header files (`WiFi.h`, `NetworkManager.h`, `ESPmDNS.h`). [[1]](diffhunk://#diff-5b1a1002b118bcde24940cdc4bf554dadf7bea896a7b3215e152dd8e4e3c90d6L75-L77) [[2]](diffhunk://#diff-ba67f259e0a7b8b27937e6f9f2d44df353a431a956cedaf966294607b835bd3cL34-L36) [[3]](diffhunk://#diff-f0770d4cfa51821373a4d4d8ff85e8e6de765242c21c85c80dba3cd161995c1dL130-L132)

Closes: https://github.com/espressif/arduino-esp32/issues/11871