### PR TITLE
WebServer: Use client() instead of _currentClient

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -565,7 +565,7 @@ void WebServer::chunkResponseBegin(const char *contentType) {
   }
 
   _chunkedResponseActive = true;
-  _chunkedClient = _currentClient;
+  _chunkedClient = client();
 
   _contentLength = CONTENT_LENGTH_UNKNOWN;
 
@@ -574,7 +574,7 @@ void WebServer::chunkResponseBegin(const char *contentType) {
   _currentClientWrite(header.c_str(), header.length());
 
   _chunkedResponseActive = true;
-  _chunkedClient = _currentClient;
+  _chunkedClient = client();
 }
 
 void WebServer::chunkWrite(const char *data, size_t length) {
@@ -734,7 +734,7 @@ void WebServer::sendContent(const char *content, size_t contentLength) {
   }
   _currentClientWrite(content, contentLength);
   if (_chunked) {
-    _currentClient.write(footer, 2);
+    client().write(footer, 2);
     if (contentLength == 0) {
       _chunked = false;
     }
@@ -757,7 +757,7 @@ void WebServer::sendContent_P(PGM_P content, size_t size) {
   }
   _currentClientWrite_P(content, size);
   if (_chunked) {
-    _currentClient.write(footer, 2);
+    client().write(footer, 2);
     if (size == 0) {
       _chunked = false;
     }

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -237,7 +237,7 @@ public:
 
   template<typename T> size_t streamFile(T &file, const String &contentType, const int code = 200) {
     _streamFileCore(file.size(), file.name(), contentType, code);
-    return _currentClient.write(file);
+    return client().write(file);
   }
 
   bool _eTagEnabled = false;
@@ -251,10 +251,10 @@ private:
 
 protected:
   virtual size_t _currentClientWrite(const char *b, size_t l) {
-    return _currentClient.write(b, l);
+    return client().write(b, l);
   }
   virtual size_t _currentClientWrite_P(PGM_P b, size_t l) {
-    return _currentClient.write_P(b, l);
+    return client().write_P(b, l);
   }
   void _addRequestHandler(RequestHandler *handler);
   bool _removeRequestHandler(RequestHandler *handler);


### PR DESCRIPTION
This makes it possible to create derived classes properly.

## Description of Change
This change replaces all uses of `_currentClient` in the `WebServer` class by calling the virtual method `client()`.
(Except in `handleClient`, which makes to sense to touch, I think).

This makes it possible to create derived classes, e.g to create TLS-protected web servers.
This was not possible previously due to the hardcoded "plain" `_currentClient`.

Derived classes can now simply override `client()`, e.g. to return the TLS protected socket, and continue using the rest of the class (i.e. all of the HTTP parsing).

## Test Scenarios
I haven't done any tests. I expect no impact on the function of the code. I haven't been able to create a HTTPS server with the changes yet, to confirm it leads to my goal, this takes some additional time.

## Related links

closes #11944