### PR TITLE
ci(c5): Enable PSRAM by default

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -156,7 +156,7 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
             esp32c6_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32h2_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32p4_opts=$(echo "PSRAM=enabled,USBMode=default,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32c5_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32c5_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
 
             # Select the common part of the FQBN based on the target.  The rest will be
             # appended depending on the passed options.


### PR DESCRIPTION
## Description of Change

This pull request makes a small adjustment to the build options for the ESP32-C5 target in the `build_sketch` function. The change ensures that PSRAM is enabled by default for ESP32-C5 builds, aligning its configuration with other ESP32 variants that require PSRAM.

* Added `PSRAM=enabled` to the `esp32c5_opts` variable in `.github/scripts/sketch_utils.sh` to enable PSRAM by default for ESP32-C5 builds.

## Test Scenarios

Tested locally.