### PR TITLE
ci(hosted): Copy esp-hosted binaries to gh-pages

### DIFF
--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -391,6 +391,11 @@ pushd "$OUTPUT_DIR" >/dev/null
 tar -cJf "$LIBS_XZ" "esp32-arduino-libs"
 popd >/dev/null
 
+# Copy esp-hosted binaries
+
+mkdir -p "$GITHUB_WORKSPACE/hosted"
+cp "$OUTPUT_DIR/esp32-arduino-libs/hosted"/*.bin "$GITHUB_WORKSPACE/hosted/"
+
 # Upload ZIP and XZ libs to release page
 
 echo "Uploading ZIP libs to release page ..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,45 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_UPLOAD_PAT }}
         run: bash ./.github/scripts/on-release.sh
+
+      - name: Upload hosted binaries
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: hosted
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/hosted
+
+  upload-hosted-binaries:
+    name: Upload hosted binaries
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: gh-pages
+
+      - name: Download hosted binaries
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: hosted
+          path: ${{ github.workspace }}/hosted-latest
+
+      - name: Copy hosted binaries to proper directory and commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOOLS_UPLOAD_PAT }}
+        run: |
+          # Create hosted directory if it doesn't exist
+          mkdir -p ${{ github.workspace }}/hosted
+
+          # Copy hosted binaries to proper directory without overwriting existing files
+          cp -n ${{ github.workspace }}/hosted-latest/*.bin ${{ github.workspace }}/hosted/
+
+          # Commit the changes
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add hosted/*.bin
+          if ! git diff --cached --quiet; then
+            git commit -m "Add new esp-hosted slave binaries"
+            git push origin HEAD:gh-pages
+          fi


### PR DESCRIPTION
## Description of Change

This pull request enhances the release workflow to support the handling and distribution of esp-hosted binaries. It introduces steps to copy these binaries during the release process, uploads them as build artifacts, and then commits them to the `gh-pages` branch for distribution. The main changes are grouped below:

**Release Script and Artifact Handling:**

* Updated `.github/scripts/on-release.sh` to copy esp-hosted `.bin` files from the build output to a new `hosted` directory in the workspace, preparing them for upload.
* Modified `.github/workflows/release.yml` to upload the `hosted` binaries as a build artifact after the main release script runs.

**Distribution via GitHub Pages:**

* Added a new `upload-hosted-binaries` job to the workflow that:
  * Checks out the `gh-pages` branch.
  * Downloads the `hosted` binaries artifact.
  * Copies new binaries to the appropriate directory without overwriting existing files.
  * Commits and pushes any new binaries to `gh-pages`, making them available for distribution.