### PR TITLE
fix(docs): Fix incorrect ARDUINO_USB_MODE for USB CDC usage

### DIFF
--- a/docs/en/troubleshooting.rst
+++ b/docs/en/troubleshooting.rst
@@ -149,7 +149,7 @@ Solution
 ^^^^^^^^
 
 Newer ESP32 variants have two possible USB connectors - USB and UART. The UART connector will go through a USB->UART adapter, and will typically present itself with the name of that mfr (eg, Silicon Labs CP210x UART Bridge). The USB connector can be used as a USB-CDC bridge and will appear as an Espressif device (Espressif USB JTAG/serial debug unit). On Espressif devkits, both connections are available, and will be labeled. ESP32 can only use UART, so will only have one connector. Other variants with one connector will typically be using USB. Please check in the product [datasheet](https://products.espressif.com) or [hardware guide](https://www.espressif.com/en/products/devkits) to find Espressif products with the appropriate USB connections for your needs.
-If you use the UART connector, you should disable USB-CDC on boot under the Tools menu (-D ARDUINO_USB_CDC_ON_BOOT=0). If you use the USB connector, you should have that enabled (-D ARDUINO_USB_CDC_ON_BOOT=1) and set USB Mode to "Hardware CDC and JTAG" (-D ARDUINO_USB_MODE=0).
+If you use the UART connector, you should disable USB-CDC on boot under the Tools menu (-D ARDUINO_USB_CDC_ON_BOOT=0). If you use the USB connector, you should have that enabled (-D ARDUINO_USB_CDC_ON_BOOT=1) and set USB Mode to "Hardware CDC and JTAG" (-D ARDUINO_USB_MODE=1).
 USB-CDC may not be able to initialize in time to catch all the data if your device is in a tight reboot loop. This can make it difficult to troubleshoot initialization issues.
 
 SPIFFS mount failed


### PR DESCRIPTION
## Description of Change
Fixes error in Troubleshooting page when enabling serial logging over the built-in USB CDC interface.

When enabling serial logging over the built-in USB CDC interface, both ARDUINO_USB_CDC_ON_BOOT and ARDUINO_USB_MODE should be set to 1

## Test Scenarios
Tested this configuration to enable logging over the built-in USB CDC interface on an ESP32S3