### PR TITLE
feat(net): Add ETH handle to events and data to lost_ip

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -107,14 +107,17 @@ void ETHClass::_onEthEvent(int32_t event_id, void *event_data) {
   } else if (event_id == ETHERNET_EVENT_DISCONNECTED) {
     log_v("%s Disconnected", desc());
     arduino_event.event_id = ARDUINO_EVENT_ETH_DISCONNECTED;
+    arduino_event.event_info.eth_disconnected = handle();
     clearStatusBits(ESP_NETIF_CONNECTED_BIT | ESP_NETIF_HAS_IP_BIT | ESP_NETIF_HAS_LOCAL_IP6_BIT | ESP_NETIF_HAS_GLOBAL_IP6_BIT);
   } else if (event_id == ETHERNET_EVENT_START) {
     log_v("%s Started", desc());
     arduino_event.event_id = ARDUINO_EVENT_ETH_START;
+    arduino_event.event_info.eth_started = handle();
     setStatusBits(ESP_NETIF_STARTED_BIT);
   } else if (event_id == ETHERNET_EVENT_STOP) {
     log_v("%s Stopped", desc());
     arduino_event.event_id = ARDUINO_EVENT_ETH_STOP;
+    arduino_event.event_info.eth_stopped = handle();
     clearStatusBits(
       ESP_NETIF_STARTED_BIT | ESP_NETIF_CONNECTED_BIT | ESP_NETIF_HAS_IP_BIT | ESP_NETIF_HAS_LOCAL_IP6_BIT | ESP_NETIF_HAS_GLOBAL_IP6_BIT
       | ESP_NETIF_HAS_STATIC_IP_BIT

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -99,9 +99,13 @@ typedef enum {
 typedef union {
   ip_event_ap_staipassigned_t wifi_ap_staipassigned;
   ip_event_got_ip_t got_ip;
+  ip_event_got_ip_t lost_ip;
   ip_event_got_ip6_t got_ip6;
 #if CONFIG_ETH_ENABLED
+  esp_eth_handle_t eth_started;
+  esp_eth_handle_t eth_stopped;
   esp_eth_handle_t eth_connected;
+  esp_eth_handle_t eth_disconnected;
 #endif
 #if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED
   wifi_event_sta_scan_done_t wifi_scan_done;

--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -97,6 +97,7 @@ void NetworkInterface::_onIpEvent(int32_t event_id, void *event_data) {
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_VERBOSE
     log_v("%s Lost IP", desc());
 #endif
+    memcpy(&arduino_event.event_info.lost_ip, event_data, sizeof(ip_event_got_ip_t));
 #if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED
     if (_interface_id == ESP_NETIF_ID_STA) {
       arduino_event.event_id = ARDUINO_EVENT_WIFI_STA_LOST_IP;


### PR DESCRIPTION
This pull request enhances the Ethernet and network event handling by ensuring that event data is consistently populated for various Ethernet and IP-related events. The main improvements include passing the Ethernet handle in more event types and adding support for lost IP event data.

**Ethernet event handling improvements:**

* The Ethernet handle (`esp_eth_handle_t`) is now included in the event info for `ETHERNET_EVENT_DISCONNECTED`, `ETHERNET_EVENT_START`, and `ETHERNET_EVENT_STOP` events, ensuring consumers of these events have access to the relevant interface handle. [[1]](diffhunk://#diff-ac446ab01e7ad1e517b6da5f710759cf9f867d668175edc0f988aa032a0f8c94R110-R120) [[2]](diffhunk://#diff-e97f4086d35f03b5c11e58388816516e0b9d7daa3aa84da8e0a68140683afee1R102-R108)

**Network event data structure updates:**

* The `arduino_event_info_t` union now includes fields for `eth_started`, `eth_stopped`, and `eth_disconnected`, in addition to the existing `eth_connected`, to support the new event info assignments.
* Added a `lost_ip` field to `arduino_event_info_t` to store information about lost IP events.

**Lost IP event handling:**

* The lost IP event now copies the IP event data (`ip_event_got_ip_t`) into the new `lost_ip` field, ensuring that details about the lost IP are available to event consumers. [[1]](diffhunk://#diff-b5d6011f70d313cb93bdeec5f973a759842d096bd3532cf28d6a744f204c7b42R100) [[2]](diffhunk://#diff-e97f4086d35f03b5c11e58388816516e0b9d7daa3aa84da8e0a68140683afee1R102-R108)

cc: @TD-er 