### PR TITLE
fix(wifi): Fix WiFi.disconnect(true, true) not working

### DIFF
--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -525,25 +525,6 @@ bool STAClass::connect(
 #endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
 
 bool STAClass::disconnect(bool eraseap, unsigned long timeout) {
-  if (eraseap) {
-    if (!started()) {
-      log_e("STA not started! You must call begin first.");
-      return false;
-    }
-    wifi_config_t conf;
-    memset(&conf, 0, sizeof(wifi_config_t));
-    esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &conf);
-    if (err != ESP_OK) {
-      log_e("STA clear config failed! 0x%x: %s", err, esp_err_to_name(err));
-      return false;
-    }
-  }
-
-  if (!connected()) {
-    log_w("STA already disconnected.");
-    return true;
-  }
-
   esp_err_t err = esp_wifi_disconnect();
   if (err != ESP_OK) {
     log_e("STA disconnect failed! 0x%x: %s", err, esp_err_to_name(err));
@@ -556,6 +537,20 @@ bool STAClass::disconnect(bool eraseap, unsigned long timeout) {
       delay(5);
     }
     if (connected()) {
+      return false;
+    }
+  }
+
+  if (eraseap) {
+    if (!started()) {
+      log_e("STA not started! You must call begin first.");
+      return false;
+    }
+    wifi_config_t conf;
+    memset(&conf, 0, sizeof(wifi_config_t));
+    esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &conf);
+    if (err != ESP_OK) {
+      log_e("STA clear config failed! 0x%x: %s", err, esp_err_to_name(err));
       return false;
     }
   }


### PR DESCRIPTION
This pull request refactors the order of operations in the `STAClass::disconnect` method to improve reliability and maintain correct behavior when disconnecting from WiFi. The main change is moving the logic that clears the WiFi configuration (`eraseap` block) to execute after the disconnect operation, rather than before.

WiFi disconnect logic refactor:

* The code that handles clearing the WiFi configuration (`eraseap` logic) now runs after the call to `esp_wifi_disconnect`, ensuring the device is disconnected before erasing its settings. (`libraries/WiFi/src/STA.cpp`, [[1]](diffhunk://#diff-fcf930a1c1c949e34e74528fc20ec629d3a704e97db75fadc89b8b4fb6cde7a4L528-L546) [[2]](diffhunk://#diff-fcf930a1c1c949e34e74528fc20ec629d3a704e97db75fadc89b8b4fb6cde7a4R544-R557)
* Removed the check for whether the device is already disconnected, so disconnect is always attempted regardless of current connection state. (`libraries/WiFi/src/STA.cpp`, [libraries/WiFi/src/STA.cppL528-L546](diffhunk://#diff-fcf930a1c1c949e34e74528fc20ec629d3a704e97db75fadc89b8b4fb6cde7a4L528-L546))

Fixes: https://github.com/espressif/arduino-esp32/issues/11742