### PR TITLE
fix(network): Fix getting fallback DNS server

### DIFF
--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -352,7 +352,7 @@ bool NetworkInterface::enableIPv6(bool en) {
 }
 
 bool NetworkInterface::dnsIP(uint8_t dns_no, IPAddress ip) {
-  if (_esp_netif == NULL || dns_no > 2) {
+  if (_esp_netif == NULL || dns_no >= ESP_NETIF_DNS_MAX) {
     return false;
   }
   esp_netif_flags_t flags = esp_netif_get_flags(_esp_netif);
@@ -708,11 +708,11 @@ IPAddress NetworkInterface::gatewayIP() const {
 }
 
 IPAddress NetworkInterface::dnsIP(uint8_t dns_no) const {
-  if (_esp_netif == NULL) {
+  if (_esp_netif == NULL || dns_no >= ESP_NETIF_DNS_MAX) {
     return IPAddress();
   }
   esp_netif_dns_info_t d;
-  if (esp_netif_get_dns_info(_esp_netif, dns_no ? ESP_NETIF_DNS_BACKUP : ESP_NETIF_DNS_MAIN, &d) != ESP_OK) {
+  if (esp_netif_get_dns_info(_esp_netif, (esp_netif_dns_type_t)dns_no, &d) != ESP_OK) {
     return IPAddress();
   }
   if (d.ip.type == ESP_IPADDR_TYPE_V6) {


### PR DESCRIPTION
## Description of Change
- Fix getting fallback DNS server address using `NetworkInterface::dnsIP(uint8_t dns_no)` function. Until now it only allowed to get main and backup servers.
- Remove magic number in `NetworkInterface::dnsIP(uint8_t dns_no, IPAddress ip)` function.

## Test Scenarios
Tested with arduino-esp32 v3.3.3 on ESP32 with WiFi STA, ETH and PPP.

## Related links
