### PR TITLE
feat(zigbee): Update esp-zigbee-sdk to latest 1.6.8

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -54,12 +54,12 @@ dependencies:
   espressif/esp_modem:
     version: "^1.1.0"
   espressif/esp-zboss-lib:
-    version: "==1.6.4" # compatible with esp-zigbee-lib 1.6.7
+    version: "==1.6.4" # compatible with esp-zigbee-lib 1.6.8
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/esp-zigbee-lib:
-    version: "==1.6.7"
+    version: "==1.6.8"
     require: public
     rules:
       - if: "target not in [esp32c2, esp32p4]"


### PR DESCRIPTION
## Description of Change
This pull request updates the esp-zigbee-sdk to latest version.

* Bumped `espressif/esp-zigbee-lib` from version 1.6.7 to 1.6.8.

## Test Scenarios

## Related links
Related release note: https://github.com/espressif/esp-zigbee-sdk/blob/main/RELEASE_NOTES.md#5-nov-2025
