### PR TITLE
feat(ble): Add function to set pins when using hosted BLE

### DIFF
--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -1220,6 +1220,23 @@ void BLEDevice::setCustomGattsHandler(gatts_event_handler handler) {
 #if defined(CONFIG_NIMBLE_ENABLED)
 
 /**
+ * @brief Set the SDIO pins for connection to external ESP MCU when using ESP-Hosted with NimBLE
+ * @param [in] clk The clock pin
+ * @param [in] cmd The command pin
+ * @param [in] d0 The data pin 0
+ * @param [in] d1 The data pin 1
+ * @param [in] d2 The data pin 2
+ * @param [in] d3 The data pin 3
+ * @param [in] rst The reset pin
+ * @return True if the pins were set successfully.
+ */
+#if CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE
+bool BLEDevice::setPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8_t d3, int8_t rst) {
+  return hostedSetPins(clk, cmd, d0, d1, d2, d3, rst);
+}
+#endif
+
+/**
  * @brief Checks if a peer device is whitelisted.
  * @param [in] address The address to check for in the whitelist.
  * @returns True if the address is in the whitelist.

--- a/libraries/BLE/src/BLEDevice.h
+++ b/libraries/BLE/src/BLEDevice.h
@@ -234,6 +234,10 @@ public:
   static bool setOwnAddr(uint8_t *addr);
   static void setDeviceCallbacks(BLEDeviceCallbacks *cb);
   static bool onWhiteList(BLEAddress &address);
+#if CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE
+  // Set SDIO pins for connection to external ESP MCU
+  static bool setPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8_t d3, int8_t rst);
+#endif
 #endif
 
 private:


### PR DESCRIPTION
## Description of Change

This pull request introduces support for configuring SDIO pins for external ESP MCU connections when using ESP-Hosted with NimBLE. The main changes add a new method to the `BLEDevice` class, allowing users to set the required pins for this setup.

**ESP-Hosted NimBLE integration:**

* Added the `setPins` static method to the `BLEDevice` class in `BLEDevice.h`, enabling configuration of SDIO pins for communication with an external ESP MCU when ESP-Hosted with NimBLE is enabled.
* Implemented the `setPins` method in `BLEDevice.cpp`, which calls `hostedSetPins` to apply the pin configuration. This method is conditionally compiled when `CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE` is set.