### PR TITLE
feat(components): Update cbor to 0.6.1~4

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -94,7 +94,7 @@ dependencies:
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/cbor:
-    version: "0.6.0~1"
+    version: "0.6.1~4"
     rules:
       - if: "target not in [esp32c2, esp32p4]"
   espressif/qrcode:


### PR DESCRIPTION
This pull request updates a dependency version in the `idf_component.yml` file. The only change is an upgrade of the `espressif/cbor` component version.

* Upgraded the `espressif/cbor` dependency from version `0.6.0~1` to `0.6.1~4` in `idf_component.yml` to ensure compatibility and access to the latest fixes and features.

Fixes: https://github.com/espressif/esp32-arduino-lib-builder/issues/332