### PR TITLE
fix(boards): Enable CDC on Boot by default for Waveshare ESP32-S3-ZERO

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -42936,10 +42936,10 @@ waveshare_esp32_s3_zero.menu.USBMode.hwcdc.build.usb_mode=1
 waveshare_esp32_s3_zero.menu.USBMode.default=USB-OTG (TinyUSB)
 waveshare_esp32_s3_zero.menu.USBMode.default.build.usb_mode=0
 
-waveshare_esp32_s3_zero.menu.CDCOnBoot.default=Disabled
-waveshare_esp32_s3_zero.menu.CDCOnBoot.default.build.cdc_on_boot=0
-waveshare_esp32_s3_zero.menu.CDCOnBoot.cdc=Enabled
-waveshare_esp32_s3_zero.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+waveshare_esp32_s3_zero.menu.CDCOnBoot.default=Enabled
+waveshare_esp32_s3_zero.menu.CDCOnBoot.default.build.cdc_on_boot=1
+waveshare_esp32_s3_zero.menu.CDCOnBoot.cdc=Disabled
+waveshare_esp32_s3_zero.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
 
 waveshare_esp32_s3_zero.menu.MSCOnBoot.default=Disabled
 waveshare_esp32_s3_zero.menu.MSCOnBoot.default.build.msc_on_boot=0


### PR DESCRIPTION
## Description of Change
This PR enables `CDC on Boot` by default for the [Waveshare ESP32-S3-ZERO](https://www.waveshare.com/wiki/ESP32-S3-Zero) board.

This board does not include a dedicated USB-to-UART converter and relies on its native USB for serial communication. The previous default (`Disabled`) prevented the serial monitor from working out-of-the-box, leading to a confusing user experience. This change ensures that `Serial.print()` functions as expected immediately after flashing, significantly improving usability.

https://www.waveshare.com/wiki/ESP32-S3-Zero
https://files.waveshare.com/wiki/ESP32-S3-Zero/ESP32-S3-Zero-Sch.pdf

## Test Scenarios
N/A

## Related links
N/A
