### PR TITLE
fix(ble): Modify size of rssi in BLEAdvertisedDevice.toString()

### DIFF
--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -605,7 +605,7 @@ String BLEAdvertisedDevice::toString() {
     res += val;
   }
   if (haveRSSI()) {
-    char val[4];
+    char val[5];
     snprintf(val, sizeof(val), "%i", getRSSI());
     res += ", rssi: ";
     res += val;


### PR DESCRIPTION
## Description of Change
In BLEAdvertisedDevice.toString(), modify the rssi size to avoid truncation.

### Why
When rssi == `-102`, it print :
`Advertised Device: Name: , Address: 12:34:56:78:9a:bc, manufacturer data: 123456789, txPower: 12, rssi: -10`
because snprintf add `\0` at the end of the array.
So the size of `-102\0` is 5 not 4.
