### PR TITLE
fix(wifi): Fix printDiag() when WiFi not initialized

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -45,13 +45,13 @@ extern "C" {
  * @param p Print interface
  */
 void WiFiClass::printDiag(Print &p) {
-  const char *modes[] = {"NULL", "STA", "AP", "STA+AP"};
+  const char *modes[] = {"NULL", "STA", "AP", "STA+AP", "NAN"};
 
-  wifi_mode_t mode;
+  wifi_mode_t mode = WIFI_MODE_NULL;
   esp_wifi_get_mode(&mode);
 
-  uint8_t primaryChan;
-  wifi_second_chan_t secondChan;
+  uint8_t primaryChan = 0;
+  wifi_second_chan_t secondChan = WIFI_SECOND_CHAN_NONE;
   esp_wifi_get_channel(&primaryChan, &secondChan);
 
   p.print("Mode: ");
@@ -67,7 +67,7 @@ void WiFiClass::printDiag(Print &p) {
         p.println(wifi_station_get_connect_status());
     */
 
-  wifi_config_t conf;
+  wifi_config_t conf = {0};
   esp_wifi_get_config((wifi_interface_t)WIFI_IF_STA, &conf);
 
   const char *ssid = reinterpret_cast<const char *>(conf.sta.ssid);


### PR DESCRIPTION
## Description of Change
Initialize local variables at declaration in `WiFiClass::printDiag(Print &p)` to prevent crash when WiFi is not initialized.
Previously, when WiFi was not initialized, `mode` could be any value leading to crash when trying to print its value.

Also added `NAN` value to `modes[]`, as `wifi_mode_t` can have following values:
```
typedef enum {
    WIFI_MODE_NULL = 0,  /**< Null mode */
    WIFI_MODE_STA,       /**< Wi-Fi station mode */
    WIFI_MODE_AP,        /**< Wi-Fi soft-AP mode */
    WIFI_MODE_APSTA,     /**< Wi-Fi station + soft-AP mode */
    WIFI_MODE_NAN,       /**< Wi-Fi NAN mode */
    WIFI_MODE_MAX
} wifi_mode_t;
```

## Test Scenarios
Tested on arduino-esp32 v3.3.4 and ESP32 DevKit

## Related links
