### PR TITLE
refactor(wifi): Refactor WiFi sleep modes

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -149,7 +149,6 @@ public:
 protected:
   static bool _persistent;
   static bool _long_range;
-  static wifi_mode_t _forceSleepLastMode;
   static wifi_ps_type_t _sleepEnabled;
   static bool _wifiUseStaticBuffers;
 


### PR DESCRIPTION
## Description of Change
Refactor `WiFiGenericClass::setSleep()` and `WiFiGenericClass::getSleep()` functions.

`WiFiGenericClass::setSleep()` was returning false when requested mode was the same as already set, which is not expected behavior. 

I have refactored functions logic, unified variables names, removed unused variable `_forceSleepLastMode` from `WiFiGenericClass`.

---

I am not sure if [this ifdef](https://github.com/espressif/arduino-esp32/compare/master...szerwi:refactor/wifi_sleep?expand=1#diff-0aa87997f6f48b5397f969144b34ce0ad4da8e173aee854c1cf2e1bf69ecf3aaL378-L383) should be kept. Is there any reason to disable modem sleep for ESP32 S2? I haven't found any info about it in ESP-IDF docs.

## Test Scenarios
Tested on v3.3.4 and ESP32 DevKit

## Related links
