### PR TITLE
feat(xiao esp32c5): Add definitions for battery voltage sampling pin and enable pin

### DIFF
--- a/variants/XIAO_ESP32C5/pins_arduino.h
+++ b/variants/XIAO_ESP32C5/pins_arduino.h
@@ -39,7 +39,7 @@ static const uint8_t D8 = 8;
 static const uint8_t D9 = 9;
 static const uint8_t D10 = 10;
 
-static const uint8_t BAT_Voltage_Read = 6;
-static const uint8_t BAT_Voltage_Read_EN = 26;
+static const uint8_t BAT_VOLT_PIN = 6;
+static const uint8_t BAT_VOLT_PIN_EN = 26;
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
Added battery management pins for the XIAO ESP32C5, defined as follows:
- Battery voltage sampling pin (GPIO6)
- Battery enable pin (GPIO26)

These definitions allow users to easily monitor the battery voltage on the XIAO ESP32C5 development board.

## Test Scenarios
Tested and verified on the XIAO ESP32C5 hardware:
- Reading battery voltage via GPIO6
- Enabling/disabling battery function via GPIO26

## Related links
[espressif/arduino-esp32#11677](https://github.com/espressif/arduino-esp32/pull/11677)
