### PR TITLE
feat(hosted): Add error logs if HTTP fails

### DIFF
--- a/libraries/ESP_HostedOTA/src/ESP_HostedOTA.cpp
+++ b/libraries/ESP_HostedOTA/src/ESP_HostedOTA.cpp
@@ -143,6 +143,10 @@ bool updateEspHostedSlave() {
     // Step 15: Clean up allocated buffer
     free(buff);
     Serial.println();
+  } else if (httpCode == HTTP_CODE_NOT_FOUND) {
+    Serial.println("ERROR: Update file not found!");
+  } else {
+    Serial.printf("ERROR: HTTP request failed with code %d!", httpCode);
   }
 
   // Step 16: Close HTTP connection


### PR DESCRIPTION
This pull request introduces improved error reporting for the OTA update process in `ESP_HostedOTA.cpp`. The code now provides more specific feedback when the update file is not found or when other HTTP errors occur.

Error handling improvements:

* Added a check for `HTTP_CODE_NOT_FOUND` and a corresponding error message when the update file is missing.
* Added a generic error message for other HTTP error codes, including the code in the output for easier debugging.