### PR TITLE
feat(littlefs): Adjust log level during formatting

### DIFF
--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -96,11 +96,13 @@ void LittleFSFS::end() {
 }
 
 bool LittleFSFS::format() {
+  esp_log_level_set("*", ESP_LOG_NONE);
   bool wdt_active = disableCore0WDT();
   esp_err_t err = esp_littlefs_format(partitionLabel_);
   if (wdt_active) {
     enableCore0WDT();
   }
+  esp_log_level_set("*", (esp_log_level_t)CONFIG_LOG_DEFAULT_LEVEL);
   if (err) {
     log_e("Formatting LittleFS failed! Error: %d", err);
     return false;


### PR DESCRIPTION
This pull request introduces a minor but important improvement to the `LittleFSFS::format()` method in `LittleFS.cpp`. The change temporarily suppresses all ESP logging during the filesystem format operation to reduce log noise and then restores the default log level afterwards.

- Logging control during formatting:
  * Suppresses all ESP logs by setting the log level to `ESP_LOG_NONE` before calling `esp_littlefs_format`, and restores the previous log level afterwards to minimise unnecessary log output during the format process.

Implemented the same as in SPIFFS: https://github.com/espressif/arduino-esp32/blob/3.3.4/libraries/SPIFFS/src/SPIFFS.cpp#L93-L106

Fixes:
```bash
E (15795) esp_littlefs: mount failed,  (-84)
E (15799) esp_littlefs: Failed to initialize LittleFS
E (31716) task_wdt: esp_task_wdt_reset(707): task not found
E (31722) task_wdt: esp_task_wdt_reset(707): task not found
E (31756) task_wdt: esp_task_wdt_reset(707): task not found
E (31757) task_wdt: esp_task_wdt_reset(707): task not found
E (31758) task_wdt: esp_task_wdt_reset(707): task not found
E (31761) task_wdt: esp_task_wdt_reset(707): task not found
E (31796) task_wdt: esp_task_wdt_reset(707): task not found
E (31797) task_wdt: esp_task_wdt_reset(707): task not found
E (31798) task_wdt: esp_task_wdt_reset(707): task not found
E (31801) task_wdt: esp_task_wdt_reset(707): task not found
E (31806) task_wdt: esp_task_wdt_reset(707): task not found
```