### PR TITLE
fix(ble): Add missing modifier keys for HID Keyboard

### DIFF
--- a/libraries/BLE/src/HIDKeyboardTypes.h
+++ b/libraries/BLE/src/HIDKeyboardTypes.h
@@ -32,7 +32,7 @@ enum MODIFIER_KEY {
   KEY_CTRL = BIT(0),
   KEY_SHIFT = BIT(1),
   KEY_ALT = BIT(2),
-  KEY_GUI = BIT(3),  /*!< GUI key (Command on macOS, Windows key on Windows) */
+  KEY_GUI = BIT(3), /*!< GUI key (Command on macOS, Windows key on Windows) */
   /* Left modifiers */
   KEY_LEFT_CTRL = BIT(0),
   KEY_LEFT_SHIFT = BIT(1),


### PR DESCRIPTION
## Description of Change

This pull request updates the `HIDKeyboardTypes.h` header to improve clarity and flexibility in handling keyboard modifier keys. The main focus is on expanding and clarifying the definitions of modifier keys, introducing both left and right variants, and using bitwise definitions for better compatibility.

Modifier key improvements:

* Switched modifier key definitions from fixed integer values to use the `BIT()` macro, making them clearer and more maintainable. (`KEY_CTRL`, `KEY_SHIFT`, `KEY_ALT`)
* Added explicit definitions for left and right modifier keys (`KEY_LEFT_CTRL`, `KEY_RIGHT_CTRL`, etc.), and included the GUI (Windows/Command) key for both sides.
* Included the `esp_bit_defs.h` header to provide the `BIT()` macro used in the new definitions.

## Related links

Closes [#12084](https://github.com/espressif/arduino-esp32/issues/12084)
