### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -51,7 +51,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-d66ebb86-v1"
+              "version": "idf-release_v5.5-64726df1-v1"
             },
             {
               "packager": "esp32",
@@ -104,63 +104,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-d66ebb86-v1",
+          "version": "idf-release_v5.5-64726df1-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-d66ebb86-v1.zip",
-              "checksum": "SHA-256:e44eefcf645cbf3d8f9270c0cdcc836621cbb10a8f5fac62e337d0da2e564fc8",
-              "size": "508996777"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-64726df1-v1.zip",
+              "checksum": "SHA-256:1bd5ff9495383eb2cf3a30e0073905d316a6a99808cedda05b98ba42c547f67a",
+              "size": "509066962"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 3a40c78
esp-idf: release/v5.5 64726df15e
arduino: master cd44ed420
tinyusb: master 7ee288bc2
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.5
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_delta_ota: 1.1.3
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 1.4.2
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.7.2
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.9.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.3
espressif__dl_fft: 0.3.1
espressif__eppp_link: 1.1.3
espressif__esp-dsp: 1.6.0
espressif__esp-sr: 2.2.1
espressif__esp_hosted: 2.6.8
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 0.13.0
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
```
