### PR TITLE
feat(espnow): Add PHY configuration for ESP-NOW packets

### DIFF
--- a/libraries/ESP_NOW/src/ESP32_NOW.cpp
+++ b/libraries/ESP_NOW/src/ESP32_NOW.cpp
@@ -18,7 +18,9 @@ static void *new_arg = nullptr;  // * tx_arg = nullptr, * rx_arg = nullptr,
 static bool _esp_now_has_begun = false;
 static ESP_NOW_Peer *_esp_now_peers[ESP_NOW_MAX_TOTAL_PEER_NUM];
 
-static esp_err_t _esp_now_add_peer(const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface, const uint8_t *lmk, esp_now_rate_config_t *rate_config, ESP_NOW_Peer *_peer = nullptr) {
+static esp_err_t _esp_now_add_peer(
+  const uint8_t *mac_addr, uint8_t channel, wifi_interface_t iface, const uint8_t *lmk, esp_now_rate_config_t *rate_config, ESP_NOW_Peer *_peer = nullptr
+) {
   log_i("Adding peer " MACSTR, MAC2STR(mac_addr));
   if (esp_now_is_peer_exist(mac_addr)) {
     log_e("Peer Already Exists");

--- a/libraries/ESP_NOW/src/ESP32_NOW.h
+++ b/libraries/ESP_NOW/src/ESP32_NOW.h
@@ -68,7 +68,10 @@ protected:
   bool remove();
   size_t send(const uint8_t *data, int len);
 
-  ESP_NOW_Peer(const uint8_t *mac_addr, uint8_t channel = 0, wifi_interface_t iface = WIFI_IF_AP, const uint8_t *lmk = nullptr, esp_now_rate_config_t *rate_config = nullptr);
+  ESP_NOW_Peer(
+    const uint8_t *mac_addr, uint8_t channel = 0, wifi_interface_t iface = WIFI_IF_AP, const uint8_t *lmk = nullptr,
+    esp_now_rate_config_t *rate_config = nullptr
+  );
 
 public:
   virtual ~ESP_NOW_Peer() {}


### PR DESCRIPTION
## Description of Change

This pull request enhances the ESP-NOW library by introducing support for configuring and managing the PHY rate for individual peers, improving logging, and adding error handling for peer management operations. The changes ensure that rate configuration can be set per peer before initialization and are applied correctly when ESP-NOW starts or when peers are added.

### PHY Rate Configuration Enhancements
* Added ability to set and get PHY rate configuration for each peer via new `setRate()` and `getRate()` methods in `ESP_NOW_Peer`, and included a default rate configuration macro (`DEFAULT_ESPNOW_RATE_CONFIG`). [[1]](diffhunk://#diff-3d83a79963540c700f30ac3e009a6c6213295be5b42570a7b7851e622d705a18R14-R22) [[2]](diffhunk://#diff-3d83a79963540c700f30ac3e009a6c6213295be5b42570a7b7851e622d705a18R61) [[3]](diffhunk://#diff-3d83a79963540c700f30ac3e009a6c6213295be5b42570a7b7851e622d705a18R85-R87) [[4]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R384-R388) [[5]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R464-R495)
* Modified peer creation and addition logic to accept and use rate configuration, ensuring the correct rate is set when a peer is added and when ESP-NOW is started. [[1]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4L21-R22) [[2]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4L339-R373) [[3]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4L359-R399) [[4]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R221-R228)
* Implemented `_esp_now_set_all_peers_rate()` to apply rate configuration to all peers after ESP-NOW initialization.

### Improved Logging and Error Handling
* Enhanced log messages for peer addition, removal, and error cases, making debugging and peer management more transparent. [[1]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R44-R62) [[2]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4L374-R422) [[3]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R435-R436)
* Added error logs when ESP-NOW is not initialized for relevant operations, improving feedback for incorrect usage. [[1]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R277) [[2]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R291) [[3]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R331)

### API Documentation and Usability
* Clarified usage in header comments and added documentation for new rate configuration methods, making the API easier to use and understand for developers. [[1]](diffhunk://#diff-3d83a79963540c700f30ac3e009a6c6213295be5b42570a7b7851e622d705a18R41-R42) [[2]](diffhunk://#diff-e93eb803759abdb0bad15a9e69d377a294f3408e8253bd5998994ad3ec02faf4R464-R495)

These changes collectively improve the flexibility, reliability, and maintainability of the ESP-NOW library, especially for applications requiring custom PHY rate settings per peer.

## Test Scenarios

Tested locally
