### PR TITLE
ci(p4): Change default revision for P4

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -155,7 +155,7 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
             esp32c3_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32c6_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32h2_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32p4_opts=$(echo "PSRAM=enabled,USBMode=default,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32p4_opts=$(echo "PSRAM=enabled,USBMode=default,ChipVariant=postv3,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32c5_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
 
             # Select the common part of the FQBN based on the target.  The rest will be

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -174,7 +174,7 @@ Currently, the default FQBNs are:
 * ``espressif:esp32:esp32c3``
 * ``espressif:esp32:esp32c6``
 * ``espressif:esp32:esp32h2``
-* ``espressif:esp32:esp32p4:USBMode=default``
+* ``espressif:esp32:esp32p4:USBMode=default,ChipVariant=postv3``
 
 There are two ways to alter the FQBNs used to compile the sketches: by using the ``fqbn`` or ``fqbn_append`` fields in the ``ci.yml`` file.
 

--- a/libraries/ESP_SR/examples/Basic/ci.yml
+++ b/libraries/ESP_SR/examples/Basic/ci.yml
@@ -2,7 +2,7 @@ fqbn:
   esp32s3:
     - espressif:esp32:esp32s3:USBMode=default,PartitionScheme=esp_sr_16,FlashSize=16M,FlashMode=dio
   esp32p4:
-    - espressif:esp32:esp32p4:USBMode=default,PartitionScheme=esp_sr_16,FlashSize=16M,FlashMode=qio
+    - espressif:esp32:esp32p4:USBMode=default,ChipVariant=postv3,PartitionScheme=esp_sr_16,FlashSize=16M,FlashMode=qio
 
 requires:
   - CONFIG_SOC_I2S_SUPPORTED=y

--- a/tests/validation/nvs/ci.yml
+++ b/tests/validation/nvs/ci.yml
@@ -23,10 +23,10 @@ fqbn:
     - espressif:esp32:esp32s3:PSRAM=opi,USBMode=default,PartitionScheme=huge_app,FlashMode=qio120
     - espressif:esp32:esp32s3:PSRAM=opi,USBMode=default,PartitionScheme=huge_app,FlashMode=dio
   esp32p4:
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,PartitionScheme=huge_app,FlashMode=dio
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,PartitionScheme=huge_app,FlashMode=dio,FlashFreq=40
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,PartitionScheme=huge_app,FlashMode=qio
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,PartitionScheme=huge_app,FlashMode=qio,FlashFreq=40
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=dio
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=dio,FlashFreq=40
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=qio
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=qio,FlashFreq=40
 
 platforms:
   qemu: false


### PR DESCRIPTION
## Description of Change

This pull request updates the configuration for the ESP32-P4 board to explicitly specify the `ChipVariant=postv3` option in all build scripts, documentation, and CI configuration files. This ensures that builds for ESP32-P4 target the correct chip variant and are consistent across the project.

**Build and configuration updates:**

* Updated the ESP32-P4 build options in `.github/scripts/sketch_utils.sh` to include `ChipVariant=postv3`, ensuring the correct chip variant is set during sketch builds.

**Documentation updates:**

* Modified the list of default FQBNs in `docs/en/contributing.rst` to show `ChipVariant=postv3` for ESP32-P4, reflecting the new standard configuration.

**CI configuration updates:**

* Updated the ESP32-P4 FQBNs in `libraries/ESP_SR/examples/Basic/ci.yml` to include `ChipVariant=postv3` for all build variants.
* Updated the ESP32-P4 FQBNs in `tests/validation/nvs/ci.yml` to include `ChipVariant=postv3` for all build variants, ensuring consistency in validation tests.

## Test Scenarios

CI
