### PR TITLE
fix(tests): Fix GPIO and PeriMan tests

### DIFF
--- a/tests/validation/gpio/gpio.ino
+++ b/tests/validation/gpio/gpio.ino
@@ -13,7 +13,6 @@
 
 volatile int interruptCounter = 0;
 volatile bool interruptFlag = false;
-volatile unsigned long lastInterruptTime = 0;
 
 // Variables for interrupt with argument test
 volatile int argInterruptCounter = 0;
@@ -34,7 +33,6 @@ void waitForSyncAck(const String &token = "OK") {
 void setUp(void) {
   interruptCounter = 0;
   interruptFlag = false;
-  lastInterruptTime = 0;
   argInterruptCounter = 0;
   argInterruptFlag = false;
   receivedArg = 0;
@@ -43,22 +41,14 @@ void setUp(void) {
 void tearDown(void) {}
 
 void IRAM_ATTR buttonISR() {
-  unsigned long currentTime = millis();
-  if (currentTime - lastInterruptTime > 50) {
-    interruptCounter = interruptCounter + 1;
-    interruptFlag = true;
-    lastInterruptTime = currentTime;
-  }
+  interruptCounter = interruptCounter + 1;
+  interruptFlag = true;
 }
 
 void IRAM_ATTR buttonISRWithArg(void *arg) {
-  unsigned long currentTime = millis();
-  if (currentTime - lastInterruptTime > 50) {
-    argInterruptCounter = argInterruptCounter + 1;
-    argInterruptFlag = true;
-    receivedArg = *(int *)arg;
-    lastInterruptTime = currentTime;
-  }
+  argInterruptCounter = argInterruptCounter + 1;
+  argInterruptFlag = true;
+  receivedArg = *(int *)arg;
 }
 
 void test_read_basic(void) {

--- a/tests/validation/i2c_master/i2c_master.ino
+++ b/tests/validation/i2c_master/i2c_master.ino
@@ -108,7 +108,7 @@ void ds1307_get_time(uint8_t *sec, uint8_t *min, uint8_t *hour, uint8_t *day, ui
 void ds1307_set_time(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day, uint8_t month, uint16_t year) {
   Wire.beginTransmission(DS1307_ADDR);
   Wire.write(0x00);
-  Wire.write(DEC2BCD(sec));
+  Wire.write(DEC2BCD(sec) | 0x80);  //Set halt bit to stop clock
   Wire.write(DEC2BCD(min));
   Wire.write(DEC2BCD(hour));
   Wire.write(DEC2BCD(0));  //Ignore day of week
@@ -207,6 +207,22 @@ void change_clock() {
 
   //Check time
   TEST_ASSERT_EQUAL(start_sec, read_sec);
+  TEST_ASSERT_EQUAL(start_min, read_min);
+  TEST_ASSERT_EQUAL(start_hour, read_hour);
+  TEST_ASSERT_EQUAL(start_day, read_day);
+  TEST_ASSERT_EQUAL(start_month, read_month);
+  TEST_ASSERT_EQUAL(start_year, read_year);
+
+  //Run clock for 5 seconds to check that we can write
+  ds1307_start();
+  delay(5000);
+  ds1307_stop();
+
+  //Get time
+  ds1307_get_time(&read_sec, &read_min, &read_hour, &read_day, &read_month, &read_year);
+
+  //Check time
+  TEST_ASSERT_NOT_EQUAL(start_sec, read_sec);  //Seconds should have changed
   TEST_ASSERT_EQUAL(start_min, read_min);
   TEST_ASSERT_EQUAL(start_hour, read_hour);
   TEST_ASSERT_EQUAL(start_day, read_day);

--- a/tests/validation/periman/periman.ino
+++ b/tests/validation/periman/periman.ino
@@ -10,6 +10,8 @@
  * - ETH: ETH requires a ethernet port to be connected before the pins are attached
  */
 
+#include <Arduino.h>
+
 #if SOC_I2S_SUPPORTED
 #include "ESP_I2S.h"
 #endif
@@ -71,7 +73,10 @@ void setup_test(String test_name, int8_t rx_pin = UART1_RX_DEFAULT, int8_t tx_pi
 
   pinMode(uart1_rx_pin, INPUT_PULLUP);
   pinMode(uart1_tx_pin, OUTPUT);
+  // Ensure Serial1 is initialized and callback is set (in case it was terminated previously)
   Serial1.setPins(uart1_rx_pin, uart1_tx_pin);
+  Serial1.begin(115200);
+  Serial1.onReceive(onReceive_cb);
   uart_internal_loopback(1, uart1_rx_pin);
   delay(100);
   log_v("Running %s test", test_name.c_str());
@@ -86,11 +91,15 @@ void teardown_test(void) {
     Serial1.print(current_test);
     Serial1.println(" test: This should not be printed");
     Serial1.flush();
-
-    Serial1.setPins(uart1_rx_pin, uart1_tx_pin);
-    uart_internal_loopback(1, uart1_rx_pin);
-    delay(100);
   }
+
+  // Even if test didn't execute, ensure Serial1 is initialized
+  // (in case it was terminated by a previous test or setup issue)
+  Serial1.setPins(uart1_rx_pin, uart1_tx_pin);
+  Serial1.begin(115200);
+  Serial1.onReceive(onReceive_cb);
+  uart_internal_loopback(1, uart1_rx_pin);
+  delay(100);
 
   Serial1.print(current_test);
   Serial1.println(" test: This should be printed");


### PR DESCRIPTION
## Description of Change

This pull request introduces improvements to resource management and reliability in the ESP I2S library and its related validation tests. The most important changes focus on preventing recursive calls and ensuring proper initialization and teardown of hardware interfaces, as well as refining test logic for I2C and GPIO peripherals.

**I2S resource management improvements:**

* Added `_mode` initialization to `I2SClass` to indicate when I2S is not started, and updated `i2sDetachBus` to only call `end()` if I2S was initialized, preventing unnecessary resource cleanup. [[1]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8R195) [[2]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L242-R245)
* Updated the `end()` method in `I2SClass` to prevent recursion by checking if already ended and resetting `_mode` before deinitializing pins, using the saved mode for cleanup logic. [[1]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8R709-R718) [[2]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L723-R736)

**Validation test reliability:**

* In `periman.ino`, ensured `Serial1` is always properly initialized and its callback set during both setup and teardown, even if previous tests terminated the interface. [[1]](diffhunk://#diff-a2a6b0b1f0af7591aeaa93e1215d480b4faa0ad7d97af9605ca98ca0446a8797R76-R79) [[2]](diffhunk://#diff-a2a6b0b1f0af7591aeaa93e1215d480b4faa0ad7d97af9605ca98ca0446a8797R94-L93)
* In `gpio.ino`, removed debounce logic and related variables from interrupt service routines and test setup, simplifying the interrupt handling for validation. [[1]](diffhunk://#diff-b79d2c3f8a8ecb15d0ef378126ff976017b51920c18aba60c6145c8cca027f89L16) [[2]](diffhunk://#diff-b79d2c3f8a8ecb15d0ef378126ff976017b51920c18aba60c6145c8cca027f89L37) [[3]](diffhunk://#diff-b79d2c3f8a8ecb15d0ef378126ff976017b51920c18aba60c6145c8cca027f89L46-L61)

**I2C clock test enhancements:**

* Modified DS1307 RTC test logic to set the halt bit when writing seconds, and added a 5-second run/stop sequence to verify clock operation and time change. [[1]](diffhunk://#diff-fc73ad47f8bfa0fac20b2eaa6b631e08f43bc39f2817bc0b86c3bdfc3cc0782bL111-R111) [[2]](diffhunk://#diff-fc73ad47f8bfa0fac20b2eaa6b631e08f43bc39f2817bc0b86c3bdfc3cc0782bR215-R230)

**General improvements:**

* Added missing `#include <Arduino.h>` in `periman.ino` for consistency and compatibility.

## Test Scenarios

Locally
