### PR TITLE
feat: Add support for the Waveshare ESP32-C3-Zero

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -54065,3 +54065,165 @@ arduino_nesso_n1.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 arduino_nesso_n1.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
 
 ##############################################################
+
+waveshare_esp32_c3_zero.name=Waveshare ESP32-C3-Zero
+
+waveshare_esp32_c3_zero.bootloader.tool=esptool_py
+waveshare_esp32_c3_zero.bootloader.tool.default=esptool_py
+
+waveshare_esp32_c3_zero.upload.tool=esptool_py
+waveshare_esp32_c3_zero.upload.tool.default=esptool_py
+waveshare_esp32_c3_zero.upload.tool.network=esp_ota
+
+waveshare_esp32_c3_zero.upload.maximum_size=1310720
+waveshare_esp32_c3_zero.upload.maximum_data_size=327680
+waveshare_esp32_c3_zero.upload.flags=
+waveshare_esp32_c3_zero.upload.extra_flags=
+waveshare_esp32_c3_zero.upload.use_1200bps_touch=false
+waveshare_esp32_c3_zero.upload.wait_for_upload_port=false
+
+waveshare_esp32_c3_zero.serial.disableDTR=false
+waveshare_esp32_c3_zero.serial.disableRTS=false
+
+waveshare_esp32_c3_zero.build.tarch=riscv32
+waveshare_esp32_c3_zero.build.target=esp
+waveshare_esp32_c3_zero.build.mcu=esp32c3
+waveshare_esp32_c3_zero.build.core=esp32
+waveshare_esp32_c3_zero.build.variant=waveshare_esp32_c3_zero
+waveshare_esp32_c3_zero.build.board=WAVESHARE_ESP32_C3_ZERO
+waveshare_esp32_c3_zero.build.bootloader_addr=0x0
+
+waveshare_esp32_c3_zero.build.cdc_on_boot=1
+waveshare_esp32_c3_zero.build.f_cpu=160000000L
+waveshare_esp32_c3_zero.build.flash_size=4MB
+waveshare_esp32_c3_zero.build.flash_freq=80m
+waveshare_esp32_c3_zero.build.flash_mode=qio
+waveshare_esp32_c3_zero.build.boot=qio
+waveshare_esp32_c3_zero.build.partitions=default
+waveshare_esp32_c3_zero.build.defines=
+
+## IDE 2.0 Seems to not update the value
+waveshare_esp32_c3_zero.menu.JTAGAdapter.default=Disabled
+waveshare_esp32_c3_zero.menu.JTAGAdapter.default.build.copy_jtag_files=0
+waveshare_esp32_c3_zero.menu.JTAGAdapter.builtin=Integrated USB JTAG
+waveshare_esp32_c3_zero.menu.JTAGAdapter.builtin.build.openocdscript=esp32c3-builtin.cfg
+waveshare_esp32_c3_zero.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+waveshare_esp32_c3_zero.menu.JTAGAdapter.external=FTDI Adapter
+waveshare_esp32_c3_zero.menu.JTAGAdapter.external.build.openocdscript=esp32c3-ftdi.cfg
+waveshare_esp32_c3_zero.menu.JTAGAdapter.external.build.copy_jtag_files=1
+waveshare_esp32_c3_zero.menu.JTAGAdapter.bridge=ESP USB Bridge
+waveshare_esp32_c3_zero.menu.JTAGAdapter.bridge.build.openocdscript=esp32c3-bridge.cfg
+waveshare_esp32_c3_zero.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+waveshare_esp32_c3_zero.menu.CDCOnBoot.default=Enabled
+waveshare_esp32_c3_zero.menu.CDCOnBoot.default.build.cdc_on_boot=1
+waveshare_esp32_c3_zero.menu.CDCOnBoot.cdc=Disabled
+waveshare_esp32_c3_zero.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+waveshare_esp32_c3_zero.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_c3_zero.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_c3_zero.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.minimal.build.partitions=minimal
+waveshare_esp32_c3_zero.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
+waveshare_esp32_c3_zero.menu.PartitionScheme.no_fs.build.partitions=no_fs
+waveshare_esp32_c3_zero.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
+waveshare_esp32_c3_zero.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_c3_zero.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_c3_zero.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_c3_zero.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_c3_zero.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_c3_zero.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
+waveshare_esp32_c3_zero.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_c3_zero.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_c3_zero.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_c3_zero.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_c3_zero.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_c3_zero.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+waveshare_esp32_c3_zero.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+waveshare_esp32_c3_zero.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+waveshare_esp32_c3_zero.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+waveshare_esp32_c3_zero.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+waveshare_esp32_c3_zero.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+waveshare_esp32_c3_zero.menu.PartitionScheme.custom=Custom
+waveshare_esp32_c3_zero.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_c3_zero.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_c3_zero.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_c3_zero.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_c3_zero.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_c3_zero.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_c3_zero.menu.CPUFreq.40=40MHz
+waveshare_esp32_c3_zero.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_c3_zero.menu.CPUFreq.20=20MHz
+waveshare_esp32_c3_zero.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_c3_zero.menu.CPUFreq.10=10MHz
+waveshare_esp32_c3_zero.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_c3_zero.menu.FlashMode.qio=QIO
+waveshare_esp32_c3_zero.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_c3_zero.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_c3_zero.menu.FlashMode.dio=DIO
+waveshare_esp32_c3_zero.menu.FlashMode.dio.build.flash_mode=dio
+waveshare_esp32_c3_zero.menu.FlashMode.dio.build.boot=dio
+
+waveshare_esp32_c3_zero.menu.FlashFreq.80=80MHz
+waveshare_esp32_c3_zero.menu.FlashFreq.80.build.flash_freq=80m
+waveshare_esp32_c3_zero.menu.FlashFreq.40=40MHz
+waveshare_esp32_c3_zero.menu.FlashFreq.40.build.flash_freq=40m
+
+waveshare_esp32_c3_zero.menu.FlashSize.4M=4MB (32Mb)
+waveshare_esp32_c3_zero.menu.FlashSize.4M.build.flash_size=4MB
+
+waveshare_esp32_c3_zero.menu.UploadSpeed.921600=921600
+waveshare_esp32_c3_zero.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_c3_zero.menu.UploadSpeed.115200=115200
+waveshare_esp32_c3_zero.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_c3_zero.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_c3_zero.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_c3_zero.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_c3_zero.menu.UploadSpeed.230400=230400
+waveshare_esp32_c3_zero.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_c3_zero.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_c3_zero.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_c3_zero.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_c3_zero.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_c3_zero.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_c3_zero.menu.DebugLevel.none=None
+waveshare_esp32_c3_zero.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_c3_zero.menu.DebugLevel.error=Error
+waveshare_esp32_c3_zero.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_c3_zero.menu.DebugLevel.warn=Warn
+waveshare_esp32_c3_zero.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_c3_zero.menu.DebugLevel.info=Info
+waveshare_esp32_c3_zero.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_c3_zero.menu.DebugLevel.debug=Debug
+waveshare_esp32_c3_zero.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_c3_zero.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_c3_zero.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_c3_zero.menu.EraseFlash.none=Disabled
+waveshare_esp32_c3_zero.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_esp32_c3_zero.menu.EraseFlash.all=Enabled
+waveshare_esp32_c3_zero.menu.EraseFlash.all.upload.erase_cmd=-e
+
+waveshare_esp32_c3_zero.menu.ZigbeeMode.default=Disabled
+waveshare_esp32_c3_zero.menu.ZigbeeMode.default.build.zigbee_mode=
+waveshare_esp32_c3_zero.menu.ZigbeeMode.default.build.zigbee_libs=
+waveshare_esp32_c3_zero.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
+waveshare_esp32_c3_zero.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+waveshare_esp32_c3_zero.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
+
+##############################################################

--- a/variants/waveshare_esp32_c3_zero/pins_arduino.h
+++ b/variants/waveshare_esp32_c3_zero/pins_arduino.h
@@ -1,0 +1,49 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define PIN_RGB_LED 10
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+
+static const uint8_t TX = 21;
+static const uint8_t RX = 20;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+static const uint8_t SS = 7;
+static const uint8_t MOSI = 6;
+static const uint8_t MISO = 5;
+static const uint8_t SCK = 4;
+
+static const uint8_t A0 = 0;
+static const uint8_t A1 = 1;
+static const uint8_t A2 = 2;
+static const uint8_t A3 = 3;
+static const uint8_t A4 = 4;
+static const uint8_t A5 = 5;
+
+static const uint8_t D0 = 0;
+static const uint8_t D1 = 1;
+static const uint8_t D2 = 2;
+static const uint8_t D3 = 3;
+static const uint8_t D4 = 4;
+static const uint8_t D5 = 5;
+static const uint8_t D6 = 6;
+static const uint8_t D7 = 7;
+static const uint8_t D8 = 8;
+static const uint8_t D9 = 9;
+static const uint8_t D10 = 10;
+static const uint8_t D11 = 20;
+static const uint8_t D12 = 21;
+
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
**Description of Change**
This pull request adds support for the [Waveshare ESP32-C3-Zero](https://www.waveshare.com/wiki/ESP32-C3-Zero) board to the Arduino-ESP32 core.

Changes include:

  1.Added board entry in boards.txt
  2.Created variants/waveshare_esp32_c3_zero with pin mapping
**Test Scenarios**
I have tested the following scenarios to verify the board support:

  1.Verified compilation and upload with Arduino IDE 2.3.4 and Espressif Arduino-ESP32 v3.3.3
  2.Tested basic examples successfully on the Waveshare ESP32-C3-Zero board
The following examples were compiled, uploaded, and executed successfully:

  1.Blink (WS2812 LED with digitalWrite)
  2.Blink RGB (WS2812 / RGB LED with rgbLedWrite)
  3.Serial CDC (USB communication)
  4.WiFi (WiFiClient example)
