### PR TITLE
feat(variants): Add 4D Systems' Round ESP32-P4 MIPI display modules

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -53065,6 +53065,154 @@ esp32p4_4ds_mipi.build.defines=-DBOARD_HAS_PSRAM -D{build.board} -D{build.Displa
 
 ##############################################################
 
+esp32p4_4ds_mipi_round.name=4D Systems ESP32-P4 Round MIPI Displays
+
+esp32p4_4ds_mipi_round.bootloader.tool=esptool_py
+esp32p4_4ds_mipi_round.bootloader.tool.default=esptool_py
+
+esp32p4_4ds_mipi_round.upload.tool=esptool_py
+esp32p4_4ds_mipi_round.upload.tool.default=esptool_py
+esp32p4_4ds_mipi_round.upload.tool.network=esp_ota
+
+esp32p4_4ds_mipi_round.upload.maximum_size=1310720
+esp32p4_4ds_mipi_round.upload.maximum_data_size=327680
+esp32p4_4ds_mipi_round.upload.flags=
+esp32p4_4ds_mipi_round.upload.extra_flags=
+esp32p4_4ds_mipi_round.upload.use_1200bps_touch=false
+esp32p4_4ds_mipi_round.upload.wait_for_upload_port=false
+
+esp32p4_4ds_mipi_round.serial.disableDTR=false
+esp32p4_4ds_mipi_round.serial.disableRTS=false
+
+esp32p4_4ds_mipi_round.build.tarch=riscv32
+esp32p4_4ds_mipi_round.build.target=esp
+esp32p4_4ds_mipi_round.build.mcu=esp32p4
+esp32p4_4ds_mipi_round.build.core=esp32
+esp32p4_4ds_mipi_round.build.variant=esp32p4_4ds_mipi_round
+esp32p4_4ds_mipi_round.build.board=ESP32P4_4DS_MIPI_ROUND
+esp32p4_4ds_mipi_round.build.bootloader_addr=0x2000
+
+esp32p4_4ds_mipi_round.build.usb_mode=0
+esp32p4_4ds_mipi_round.build.cdc_on_boot=0
+esp32p4_4ds_mipi_round.build.msc_on_boot=0
+esp32p4_4ds_mipi_round.build.dfu_on_boot=0
+esp32p4_4ds_mipi_round.build.f_cpu=360000000L
+esp32p4_4ds_mipi_round.build.flash_size=32MB
+esp32p4_4ds_mipi_round.build.flash_freq=80m
+esp32p4_4ds_mipi_round.build.img_freq=80m
+esp32p4_4ds_mipi_round.build.flash_mode=qio
+esp32p4_4ds_mipi_round.build.boot=qio
+esp32p4_4ds_mipi_round.build.partitions=app5M_fat24M_32MB
+
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.default=Disabled
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.default.build.copy_jtag_files=0
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.builtin=Integrated USB JTAG
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.builtin.build.openocdscript=esp32p4-builtin.cfg
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.external=FTDI Adapter
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.external.build.openocdscript=esp32p4-ftdi.cfg
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.external.build.copy_jtag_files=1
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.bridge=ESP USB Bridge
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.bridge.build.openocdscript=esp32p4-bridge.cfg
+esp32p4_4ds_mipi_round.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+esp32p4_4ds_mipi_round.menu.USBMode.default=USB-OTG (TinyUSB)
+esp32p4_4ds_mipi_round.menu.USBMode.default.build.usb_mode=0
+esp32p4_4ds_mipi_round.menu.USBMode.hwcdc=Hardware CDC and JTAG
+esp32p4_4ds_mipi_round.menu.USBMode.hwcdc.build.usb_mode=1
+
+esp32p4_4ds_mipi_round.menu.CDCOnBoot.default=Disabled
+esp32p4_4ds_mipi_round.menu.CDCOnBoot.default.build.cdc_on_boot=0
+esp32p4_4ds_mipi_round.menu.CDCOnBoot.cdc=Enabled
+esp32p4_4ds_mipi_round.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+esp32p4_4ds_mipi_round.menu.MSCOnBoot.default=Disabled
+esp32p4_4ds_mipi_round.menu.MSCOnBoot.default.build.msc_on_boot=0
+esp32p4_4ds_mipi_round.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+esp32p4_4ds_mipi_round.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+esp32p4_4ds_mipi_round.menu.DFUOnBoot.default=Disabled
+esp32p4_4ds_mipi_round.menu.DFUOnBoot.default.build.dfu_on_boot=0
+esp32p4_4ds_mipi_round.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+esp32p4_4ds_mipi_round.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+esp32p4_4ds_mipi_round.menu.UploadMode.default=UART0 / Hardware CDC
+esp32p4_4ds_mipi_round.menu.UploadMode.default.upload.use_1200bps_touch=false
+esp32p4_4ds_mipi_round.menu.UploadMode.default.upload.wait_for_upload_port=false
+esp32p4_4ds_mipi_round.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+esp32p4_4ds_mipi_round.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+esp32p4_4ds_mipi_round.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app5M_little24M_32MB=32M Flash (4.8MB APP/22MB LittleFS)
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app5M_little24M_32MB.build.partitions=large_littlefs_32MB
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app5M_little24M_32MB.upload.maximum_size=4718592
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app13M_data7M_32MB=32M Flash (13MB APP/6.75MB SPIFFS)
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app13M_data7M_32MB.build.partitions=default_32MB
+esp32p4_4ds_mipi_round.menu.PartitionScheme.app13M_data7M_32MB.upload.maximum_size=13107200
+
+## From https://docs.espressif.com/projects/esp-idf/en/latest/esp32p4/api-reference/kconfig.html#config-esp-default-cpu-freq-mhz
+esp32p4_4ds_mipi_round.menu.CPUFreq.360=360MHz
+esp32p4_4ds_mipi_round.menu.CPUFreq.360.build.f_cpu=360000000L
+esp32p4_4ds_mipi_round.menu.CPUFreq.40=40MHz
+esp32p4_4ds_mipi_round.menu.CPUFreq.40.build.f_cpu=40000000L
+
+esp32p4_4ds_mipi_round.menu.UploadSpeed.921600=921600
+esp32p4_4ds_mipi_round.menu.UploadSpeed.921600.upload.speed=921600
+esp32p4_4ds_mipi_round.menu.UploadSpeed.115200=115200
+esp32p4_4ds_mipi_round.menu.UploadSpeed.115200.upload.speed=115200
+esp32p4_4ds_mipi_round.menu.UploadSpeed.256000.windows=256000
+esp32p4_4ds_mipi_round.menu.UploadSpeed.256000.upload.speed=256000
+esp32p4_4ds_mipi_round.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32p4_4ds_mipi_round.menu.UploadSpeed.230400=230400
+esp32p4_4ds_mipi_round.menu.UploadSpeed.230400.upload.speed=230400
+esp32p4_4ds_mipi_round.menu.UploadSpeed.460800.linux=460800
+esp32p4_4ds_mipi_round.menu.UploadSpeed.460800.macosx=460800
+esp32p4_4ds_mipi_round.menu.UploadSpeed.460800.upload.speed=460800
+esp32p4_4ds_mipi_round.menu.UploadSpeed.512000.windows=512000
+esp32p4_4ds_mipi_round.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32p4_4ds_mipi_round.menu.DebugLevel.none=None
+esp32p4_4ds_mipi_round.menu.DebugLevel.none.build.code_debug=0
+esp32p4_4ds_mipi_round.menu.DebugLevel.error=Error
+esp32p4_4ds_mipi_round.menu.DebugLevel.error.build.code_debug=1
+esp32p4_4ds_mipi_round.menu.DebugLevel.warn=Warn
+esp32p4_4ds_mipi_round.menu.DebugLevel.warn.build.code_debug=2
+esp32p4_4ds_mipi_round.menu.DebugLevel.info=Info
+esp32p4_4ds_mipi_round.menu.DebugLevel.info.build.code_debug=3
+esp32p4_4ds_mipi_round.menu.DebugLevel.debug=Debug
+esp32p4_4ds_mipi_round.menu.DebugLevel.debug.build.code_debug=4
+esp32p4_4ds_mipi_round.menu.DebugLevel.verbose=Verbose
+esp32p4_4ds_mipi_round.menu.DebugLevel.verbose.build.code_debug=5
+
+esp32p4_4ds_mipi_round.menu.EraseFlash.none=Disabled
+esp32p4_4ds_mipi_round.menu.EraseFlash.none.upload.erase_cmd=
+esp32p4_4ds_mipi_round.menu.EraseFlash.all=Enabled
+esp32p4_4ds_mipi_round.menu.EraseFlash.all.upload.erase_cmd=-e
+
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34r=ESP32-P4-34R
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34r.build.DisplayModel=ESP32P4_34R
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34r_clb=ESP32-P4-34R-CLB
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34r_clb.build.DisplayModel=ESP32P4_34R
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34rct=ESP32-P4-34RCT
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34rct.build.DisplayModel=ESP32P4_34RCT
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34rct_clb=ESP32-P4-34RCT-CLB
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_34rct_clb.build.DisplayModel=ESP32P4_34RCT
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40r=ESP32-P4-40R
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40r.build.DisplayModel=ESP32P4_40R
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40r_clb=ESP32-P4-40R-CLB
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40r_clb.build.DisplayModel=ESP32P4_40R
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40rct=ESP32-P4-40RCT
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40rct.build.DisplayModel=ESP32P4_40RCT
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40rct_clb=ESP32-P4-40RCT-CLB
+esp32p4_4ds_mipi_round.menu.DisplayModel.esp32p4_40rct_clb.build.DisplayModel=ESP32P4_40RCT
+
+esp32p4_4ds_mipi_round.build.defines=-DBOARD_HAS_PSRAM -D{build.board} -D{build.DisplayModel}
+
+##############################################################
+
 # Axiometa PIXIE M1 - Based on ESP32-S3-Mini-N4R2
 # 4MB Quad SPI Flash, 2MB Quad SPI PSRAM
 

--- a/variants/esp32p4_4ds_mipi_round/pins_arduino.h
+++ b/variants/esp32p4_4ds_mipi_round/pins_arduino.h
@@ -1,0 +1,73 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// Use default UART0 pins
+static const uint8_t TX = 37;
+static const uint8_t RX = 38;
+
+// Default pins (7 and 8) are used by on-board components already,
+// for libraries, this can be set manually
+// so let's keep the default for the user
+static const uint8_t SDA = 2;  // careful, also used as T0 pin
+static const uint8_t SCL = 3;  // careful, also used as T1 pin
+
+static const uint8_t SCK = 6;    // careful, also used as T2 pin
+static const uint8_t MOSI = 14;  // careful, also used as T1 pin
+static const uint8_t MISO = 15;  // careful, also used as T0 pin
+static const uint8_t SS = 16;    // careful, also used as A9 pin
+
+static const uint8_t A0 = 21;
+static const uint8_t A1 = 20;
+static const uint8_t A2 = 19;
+static const uint8_t A3 = 18;
+static const uint8_t A4 = 17;
+static const uint8_t A5 = 52;
+static const uint8_t A6 = 51;
+static const uint8_t A7 = 50;
+static const uint8_t A8 = 49;
+static const uint8_t A9 = 16;  // careful, also used as SPI SS pin
+
+static const uint8_t T0 = 15;  // careful, also used as SPI MISO pin
+static const uint8_t T1 = 14;  // careful, also used as SPI MOSI pin
+static const uint8_t T2 = 6;   // careful, also used as SPI SCK pin
+static const uint8_t T3 = 3;   // careful, also used as I2C SCL pin
+static const uint8_t T4 = 2;   // careful, also used as I2C SDA pin
+
+/* 4D Systems ESP32-P4 round board specific definitions */
+// LCD
+#define LCD_INTERFACE_MIPI
+
+#define LCD_BL_IO        22
+#define LCD_BL_ON_LEVEL  1
+#define LCD_BL_OFF_LEVEL !LCD_BL_ON_LEVEL
+
+#define LCD_RST_IO          23
+#define LCD_RST_ACTIVE_HIGH true
+
+// I2C for on-board components
+#define I2C_SDA 7
+#define I2C_SCL 8
+
+// Touch
+#define CTP_RST 4
+#define CTP_INT 5
+
+// Audio
+#define AMP_CTRL   53
+#define I2S_DSDIN  9
+#define I2S_LRCK   10
+#define I2S_ASDOUT 11
+#define I2S_SCLK   12
+#define I2S_MCLK   13
+
+// SDMMC
+#define BOARD_HAS_SDMMC
+#define BOARD_SDMMC_SLOT           0
+#define BOARD_SDMMC_POWER_CHANNEL  4
+#define BOARD_SDMMC_POWER_PIN      45
+#define BOARD_SDMMC_POWER_ON_LEVEL LOW
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change
This request adds a new board variant for 4D Systems' Round ESP32-P4 MIPI display modules.

## Test Scenarios
We have tested this pull request on Arduino-ESP32 v3.4.0

## Related links
No related links to issues. Product pages are waiting for release.
Datasheets will be available at the time of release in [4D Systems' Resource Centre](https://resources.4dsystems.com.au/).
