### PR TITLE
ci(sign): Fix signing in Windows

### DIFF
--- a/.github/workflows/build_py_tools.yml
+++ b/.github/workflows/build_py_tools.yml
@@ -119,16 +119,14 @@ jobs:
 
       - name: Sign binaries
         if: matrix.os == 'windows-latest'
-        env:
-          CERTIFICATE: ${{ secrets.CERTIFICATE }}
-          CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
-        shell: pwsh
-        run: |
-          $data = Write-Output ${{ env.CHANGED_TOOLS }}
-          foreach ( $node in $data )
-          {
-            ./.github/pytools/Sign-File.ps1 -Path ./${{ env.DISTPATH }}/$node.exe
-          }
+        uses: espressif/release-sign@33f3684091168d78b2cf6c8265bd9968c376254c # master
+        with:
+          path: ./${{ env.DISTPATH }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-keyvault-uri: ${{ secrets.AZURE_KEYVAULT_URI }}
+          azure-keyvault-cert-name: ${{ secrets.AZURE_KEYVAULT_CERT_NAME }}
 
       - name: Test binaries
         shell: bash


### PR DESCRIPTION
## Description of Change

This pull request updates the Windows binary signing process in the `build_py_tools.yml` GitHub Actions workflow. The manual PowerShell script for signing is replaced with the standardized `espressif/release-sign` GitHub Action, which integrates with Azure Key Vault for certificate management.

**CI/CD Workflow Improvements:**

* Replaced the custom PowerShell signing script with the `espressif/release-sign` GitHub Action, leveraging Azure Key Vault secrets for more secure and maintainable binary signing on Windows. (.github/workflows/build_py_tools.yml)

## Test Scenarios

Will test after merge in open PR.
