### PR TITLE
feat(build): Export additional build files through the Arduino IDE

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -195,6 +195,36 @@ recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build
 recipe.size.regex=^(?:\.iram0\.text|\.iram0\.vectors|\.dram0\.data|\.dram1\.data|\.flash\.text|\.flash\.rodata|\.flash\.appdesc|\.flash\.init_array|\.eh_frame|)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.dram0\.data|\.dram0\.bss|\.dram1\.data|\.dram1\.bss|\.noinit)\s+([0-9]+).*
 
+## Export extra build artifacts when "Export compiled Binary" is selected
+
+## By default Arduino IDE exports everything that starts with the sketch name
+## We need to export other files as well
+
+## Define FQBN transformation logic as reusable properties
+## Converts FQBN to vendor.arch.board format matching Arduino IDE default export path
+recipe.hooks.savehex.fqbn_to_dir=FQBN_DIR=$(echo '{build.fqbn}' | cut -d: -f1-3 | tr ':' '.')
+recipe.hooks.savehex.fqbn_to_dir.windows=$env:FQBN_DIR=('{build.fqbn}' -split ':')[0..2] -join '.'
+
+## Export partitions.csv (for reference)
+recipe.hooks.savehex.postsavehex.1.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/partitions.csv' '{sketch_path}/build/'$FQBN_DIR'/partitions.csv' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.1.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\partitions.csv' ('{sketch_path}\build\' + $env:FQBN_DIR + '\partitions.csv')"
+
+## Export sdkconfig (for reference)
+recipe.hooks.savehex.postsavehex.2.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/sdkconfig' '{sketch_path}/build/'$FQBN_DIR'/sdkconfig' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.2.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\sdkconfig' ('{sketch_path}\build\' + $env:FQBN_DIR + '\sdkconfig')"
+
+## Export flash_args
+recipe.hooks.savehex.postsavehex.3.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/flash_args' '{sketch_path}/build/'$FQBN_DIR'/flash_args' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.3.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\flash_args' ('{sketch_path}\build\' + $env:FQBN_DIR + '\flash_args')"
+
+## Export boot_app0.bin
+recipe.hooks.savehex.postsavehex.4.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{runtime.platform.path}/tools/partitions/boot_app0.bin' '{sketch_path}/build/'$FQBN_DIR'/boot_app0.bin' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.4.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{runtime.platform.path}\tools\partitions\boot_app0.bin' ('{sketch_path}\build\' + $env:FQBN_DIR + '\boot_app0.bin')"
+
+## Export build.options.json
+recipe.hooks.savehex.postsavehex.5.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/build.options.json' '{sketch_path}/build/'$FQBN_DIR'/build.options.json' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.5.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\build.options.json' ('{sketch_path}\build\' + $env:FQBN_DIR + '\build.options.json')"
+
 ## Required discoveries and monitors
 ## ---------------------------------
 pluggable_discovery.required.0=builtin:serial-discovery


### PR DESCRIPTION
## Description of Change

This pull request enhances the Arduino build process by ensuring that additional build artifacts are exported when the "Export compiled Binary" option is selected in the Arduino IDE. The changes introduce logic to consistently export several important files alongside the compiled binary, improving the ability to reference or reuse these artifacts.

This won't affect normal compilation. Only when exporting binaries.

Export of additional build artifacts:

* Added hooks to export `partitions.csv`, `sdkconfig`, `flash_args`, and `boot_app0.bin` files to the build output directory when exporting a compiled binary, for both Unix and Windows environments.

Build process improvements:

* Introduced reusable properties to transform the FQBN (Fully Qualified Board Name) into a directory format that matches the Arduino IDE's default export path, ensuring compatibility and organization of exported files.

## Test Scenarios

Tested locally in macOS and Windows
