### PR TITLE
fix(matter_docs): fixes the Matter features table for the ESP32-C5

### DIFF
--- a/libraries/Matter/examples/MatterColorLight/README.md
+++ b/libraries/Matter/examples/MatterColorLight/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterCommissionTest/README.md
+++ b/libraries/Matter/examples/MatterCommissionTest/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device connection to smart home 
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterComposedLights/README.md
+++ b/libraries/Matter/examples/MatterComposedLights/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, a single Matter node containing 
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterContactSensor/README.md
+++ b/libraries/Matter/examples/MatterContactSensor/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterDimmableLight/README.md
+++ b/libraries/Matter/examples/MatterDimmableLight/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterDimmablePlugin/README.md
+++ b/libraries/Matter/examples/MatterDimmablePlugin/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterEnhancedColorLight/README.md
+++ b/libraries/Matter/examples/MatterEnhancedColorLight/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterEvents/README.md
+++ b/libraries/Matter/examples/MatterEvents/README.md
@@ -11,15 +11,15 @@ The application showcases Matter event handling, commissioning, and automatic de
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterFan/README.md
+++ b/libraries/Matter/examples/MatterFan/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterHumiditySensor/README.md
+++ b/libraries/Matter/examples/MatterHumiditySensor/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, sensor data reporting to smart h
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterLambdaSingleCallbackManyEPs/README.md
+++ b/libraries/Matter/examples/MatterLambdaSingleCallbackManyEPs/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, multiple endpoint management, an
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterMinimum/README.md
+++ b/libraries/Matter/examples/MatterMinimum/README.md
@@ -11,15 +11,15 @@ The application showcases the minimal implementation for Matter commissioning an
 | ESP32-S2 | ✅ | ❌ | ❌ | Optional | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Optional | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Optional | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Optional | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Optional | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Optional | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Optional | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterOccupancySensor/README.md
+++ b/libraries/Matter/examples/MatterOccupancySensor/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, sensor data reporting to smart h
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterOccupancyWithHoldTime/README.md
+++ b/libraries/Matter/examples/MatterOccupancyWithHoldTime/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, sensor data reporting to smart h
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterOnIdentify/README.md
+++ b/libraries/Matter/examples/MatterOnIdentify/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterOnOffLight/README.md
+++ b/libraries/Matter/examples/MatterOnOffLight/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterOnOffPlugin/README.md
+++ b/libraries/Matter/examples/MatterOnOffPlugin/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterPressureSensor/README.md
+++ b/libraries/Matter/examples/MatterPressureSensor/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, sensor data reporting to smart h
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterRainSensor/README.md
+++ b/libraries/Matter/examples/MatterRainSensor/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterSimpleBlinds/README.md
+++ b/libraries/Matter/examples/MatterSimpleBlinds/README.md
@@ -10,15 +10,15 @@ This is a minimal example demonstrating how to create a Matter-compatible window
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterSmartButton/README.md
+++ b/libraries/Matter/examples/MatterSmartButton/README.md
@@ -12,14 +12,14 @@ The application showcases Matter commissioning, sending button click events to s
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterStatus/README.md
+++ b/libraries/Matter/examples/MatterStatus/README.md
@@ -10,15 +10,15 @@ This example demonstrates how to check enabled Matter features and connectivity 
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterTemperatureControlledCabinet/README.md
+++ b/libraries/Matter/examples/MatterTemperatureControlledCabinet/README.md
@@ -12,15 +12,15 @@ This example demonstrates how to create a Matter-compatible temperature controll
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterTemperatureControlledCabinetLevels/README.md
+++ b/libraries/Matter/examples/MatterTemperatureControlledCabinetLevels/README.md
@@ -12,15 +12,15 @@ This example demonstrates how to create a Matter-compatible temperature controll
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterTemperatureLight/README.md
+++ b/libraries/Matter/examples/MatterTemperatureLight/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterTemperatureSensor/README.md
+++ b/libraries/Matter/examples/MatterTemperatureSensor/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, sensor data reporting to smart h
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterThermostat/README.md
+++ b/libraries/Matter/examples/MatterThermostat/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, thermostat control via smart hom
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterWaterFreezeDetector/README.md
+++ b/libraries/Matter/examples/MatterWaterFreezeDetector/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterWaterLeakDetector/README.md
+++ b/libraries/Matter/examples/MatterWaterLeakDetector/README.md
@@ -11,15 +11,15 @@ The application showcases Matter commissioning, device control via smart home ec
 | ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 

--- a/libraries/Matter/examples/MatterWindowCovering/README.md
+++ b/libraries/Matter/examples/MatterWindowCovering/README.md
@@ -10,15 +10,15 @@ This example demonstrates how to create a Matter-compatible window covering devi
 | ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
 | ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
-| ESP32-C5 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
 | ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
 | ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
 
 ### Note on Commissioning:
 
 - **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
-- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
-- **ESP32-C5** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project as an ESP-IDF component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been precompiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 ## Features
 


### PR DESCRIPTION
## Description of Change
ESP32-C5 has been configured in Lib Builder to support Matter over Thread (no WiFi).
This is due to restrictions of SRAM space when running Thread + WiFi and Matter all together as done for the ESP32-C6.

This is fixed in all ESP32 Arduino Matter README,md files for the examples.

## Test Scenarios
CI only

## Related links
None