### PR TITLE
fix(ble): Fix BLE examples for iPhone

### DIFF
--- a/libraries/BLE/examples/Server/Server.ino
+++ b/libraries/BLE/examples/Server/Server.ino
@@ -31,7 +31,7 @@ void setup() {
   pAdvertising->addServiceUUID(SERVICE_UUID);
   pAdvertising->setScanResponse(true);
   pAdvertising->setMinPreferred(0x06);  // functions that help with iPhone connections issue
-  pAdvertising->setMinPreferred(0x12);
+  pAdvertising->setMaxPreferred(0x12);
   BLEDevice::startAdvertising();
   Serial.println("Characteristic defined! Now you can read it in your phone!");
 }

--- a/libraries/BLE/examples/Server_secure_authorization/Server_secure_authorization.ino
+++ b/libraries/BLE/examples/Server_secure_authorization/Server_secure_authorization.ino
@@ -140,7 +140,7 @@ void setup() {
   pAdvertising->addServiceUUID(SERVICE_UUID);
   pAdvertising->setScanResponse(true);
   pAdvertising->setMinPreferred(0x06);  // helps with iPhone connections
-  pAdvertising->setMinPreferred(0x12);
+  pAdvertising->setMaxPreferred(0x12);
 
   BLEDevice::startAdvertising();
 

--- a/libraries/BLE/examples/Server_secure_static_passkey/Server_secure_static_passkey.ino
+++ b/libraries/BLE/examples/Server_secure_static_passkey/Server_secure_static_passkey.ino
@@ -185,7 +185,7 @@ void setup() {
   pAdvertising->addServiceUUID(SERVICE_UUID);
   pAdvertising->setScanResponse(true);
   pAdvertising->setMinPreferred(0x06);  // functions that help with iPhone connections issue
-  pAdvertising->setMinPreferred(0x12);
+  pAdvertising->setMaxPreferred(0x12);
   BLEDevice::startAdvertising();
   Serial.println("Characteristic defined! Now you can read it in your phone!");
 }


### PR DESCRIPTION
## Description of Change

This pull request updates the BLE advertising configuration in several example server files to use the correct method for setting the maximum preferred connection interval, which helps improve compatibility with iPhone connections.

**BLE advertising configuration fixes:**

* Changed from `setMinPreferred(0x12)` to `setMaxPreferred(0x12)` in the `setup()` function of the following example files to correctly set the maximum preferred connection interval:
  - `libraries/BLE/examples/Server/Server.ino`
  - `libraries/BLE/examples/Server_secure_authorization/Server_secure_authorization.ino`
  - `libraries/BLE/examples/Server_secure_static_passkey/Server_secure_static_passkey.ino`

## Test Scenarios

Tested locally
