### PR TITLE
fix(matter_docs): updates ESP32-C5 Matter WiFi table

### DIFF
--- a/docs/en/libraries.rst
+++ b/docs/en/libraries.rst
@@ -53,7 +53,7 @@ Here is a matrix of the library support status for the main features and periphe
 +----------------------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
 | Matter (Thread) [6]_ | |n/a| | |n/a| | |n/a| | |yes| | |yes| | |n/a| | |yes| | |n/a| | |n/a| | |n/a| |
 +----------------------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| Matter (Wi-Fi)       | |yes| | |no|  | |yes| | |yes| | |yes| | |no|  | |n/a| | |n/a| | |yes| | |yes| |
+| Matter (Wi-Fi) [7]_  | |yes| | |no|  | |yes| | |no|  | |yes| | |no|  | |n/a| | |n/a| | |yes| | |yes| |
 +----------------------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
 | MIPI CSI             | |n/a| | |n/a| | |n/a| | |n/a| | |n/a| | |n/a| | |n/a| | |no|  | |n/a| | |n/a| |
 +----------------------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
@@ -108,6 +108,10 @@ Here is a matrix of the library support status for the main features and periphe
 .. [6] Matter over Thread is supported by our library but is not included in the pre-compiled libraries for ESP32-C6 and ESP32-C5.
    In order to use Matter over Thread, you need to use Arduino as an ESP-IDF component or rebuild the static libraries.
    Check the `Arduino_ESP_Matter_over_OpenThread example <https://github.com/espressif/arduino-esp32/tree/master/idf_component_examples/Arduino_ESP_Matter_over_OpenThread>`_ for more details.
+
+.. [7] Matter over Wi-Fi is supported by our library but is not included in the pre-compiled libraries for ESP32-C5.
+   Although ESP32-C5 has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only.
+   In order to use Matter over Wi-Fi, you need to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
 
 .. note:: The ESP32-C2 and ESP32-C61 are only supported using Arduino as an ESP-IDF component or by rebuilding the static libraries.
 


### PR DESCRIPTION
## Description of Change
Fixes Documentation Libraries peripherals & features table related to Matter WiFi for ESP32-C5. 

## Test Scenarios
CI Only.

## Related links
None