### PR TITLE
fix(board): fix WS2812 color order

### DIFF
--- a/variants/waveshare_esp32_c3_zero/pins_arduino.h
+++ b/variants/waveshare_esp32_c3_zero/pins_arduino.h
@@ -12,6 +12,8 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
 #define RGB_BUILTIN    LED_BUILTIN
 #define RGB_BRIGHTNESS 64
+// Define the color order for the built-in RGB LED
+#define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB
 
 static const uint8_t TX = 21;
 static const uint8_t RX = 20;

--- a/variants/waveshare_esp32_c6_zero/pins_arduino.h
+++ b/variants/waveshare_esp32_c6_zero/pins_arduino.h
@@ -46,7 +46,7 @@ static const uint8_t RGB_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
 #define RGB_BRIGHTNESS 32  // default brightness level (0-255)
 
 // Define the color order for the built-in RGB LED
-#define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB  // default WS2812B color order
+#define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB
 
 // Define the built-in as LED pin (RGB LED) to use with digitalWrite()
 static const uint8_t LED_BUILTIN = RGB_BUILTIN;

--- a/variants/waveshare_esp32_s3_zero/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_zero/pins_arduino.h
@@ -20,6 +20,8 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + WS_RGB;
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
 #define RGB_BUILTIN    LED_BUILTIN
 #define RGB_BRIGHTNESS 64
+// Define the color order for the built-in RGB LED
+#define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB
 
 // Mapping based on the ESP32S3 data sheet - alternate for OUTPUT
 static const uint8_t OUTPUT_IO1 = 1;


### PR DESCRIPTION
## Description of Change

This PR fixes the onboard LED definitions for Waveshare ESP32 Zero variants, which use RGB color order instead of the default GRB.

## Test Scenarios

Verified through testing the [BlinkRGB](https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/GPIO/BlinkRGB/BlinkRGB.ino) example.