### PR TITLE
fix(recipes): fixes platform.txt for older arduino-build version

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -183,7 +183,7 @@ recipe.hooks.objcopy.postobjcopy.3.pattern_args=--chip {build.mcu} merge-bin -o 
 recipe.hooks.objcopy.postobjcopy.3.pattern="{tools.esptool_py.path}/{tools.esptool_py.cmd}" {recipe.hooks.objcopy.postobjcopy.3.pattern_args}
 
 # Generate flash_args file
-# Please leave the whitespace as is. It avoids a bug in older arduino-builder versions shipped with IDE 1.x - the problem happens if there is a quote (') character that is directly followed by a whitespace
+# Do NOT change the spacing: specifically, do not insert whitespace between a closing quote (') and the following redirection/operator symbols (>, >>, &&). This avoids a bug in older arduino-builder versions shipped with IDE 1.x, which occurs if a quote (') character is directly followed by a whitespace.
 recipe.hooks.objcopy.postobjcopy.4.pattern=/usr/bin/env bash -c "echo '--flash-mode {build.flash_mode} --flash-freq {build.img_freq} --flash-size {build.flash_size}'>'{build.path}/flash_args'&& echo '{build.bootloader_addr} {build.project_name}.bootloader.bin'>> '{build.path}/flash_args'&& echo '0x8000 {build.project_name}.partitions.bin'>> '{build.path}/flash_args'&& echo '0xe000 boot_app0.bin'>> '{build.path}/flash_args'&& echo '0x10000 {build.project_name}.bin'>> '{build.path}/flash_args'"
 recipe.hooks.objcopy.postobjcopy.4.pattern.windows=cmd /c echo --flash-mode {build.flash_mode} --flash-freq {build.img_freq} --flash-size {build.flash_size} > "{build.path}\flash_args" && echo {build.bootloader_addr} {build.project_name}.bootloader.bin >> "{build.path}\flash_args" && echo 0x8000 {build.project_name}.partitions.bin >> "{build.path}\flash_args" && echo 0xe000 boot_app0.bin >> "{build.path}\flash_args" && echo 0x10000 {build.project_name}.bin >> "{build.path}\flash_args"
 


### PR DESCRIPTION
## Description of Change
Some users have reported issues with IDE 1.x based on Linux and issues with CI that relies on Arduino Packages that need arduino-build 1.3

This PR has a small fix that seems to solve such issue as stated by @bjscheue in https://github.com/espressif/arduino-esp32/issues/12159#issuecomment-3700179832

## Test Scenarios
CI and using IDE to build basic sketches.

## Related links
Closes #12159 
