### PR TITLE
fix(5ghz): Rework WiFi LR logic for 5GHz chips

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -494,11 +494,11 @@ void WiFiGenericClass::enableLongRange(bool enable) {
 #endif
 
 #if SOC_WIFI_SUPPORT_5G
-  #if CONFIG_SOC_WIFI_HE_SUPPORT
-    #define WIFI_PROTOCOL_DEFAULT_5G (WIFI_PROTOCOL_11A | WIFI_PROTOCOL_11N | WIFI_PROTOCOL_11AC | WIFI_PROTOCOL_11AX)
-  #else
-    #define WIFI_PROTOCOL_DEFAULT_5G (WIFI_PROTOCOL_11A | WIFI_PROTOCOL_11N | WIFI_PROTOCOL_11AC)
-  #endif
+#if CONFIG_SOC_WIFI_HE_SUPPORT
+#define WIFI_PROTOCOL_DEFAULT_5G (WIFI_PROTOCOL_11A | WIFI_PROTOCOL_11N | WIFI_PROTOCOL_11AC | WIFI_PROTOCOL_11AX)
+#else
+#define WIFI_PROTOCOL_DEFAULT_5G (WIFI_PROTOCOL_11A | WIFI_PROTOCOL_11N | WIFI_PROTOCOL_11AC)
+#endif
 #endif
 
 static bool _wifi_is_lr_enabled(wifi_interface_t ifx) {
@@ -510,10 +510,7 @@ static bool _wifi_is_lr_enabled(wifi_interface_t ifx) {
     return false;
   }
   if (band_mode == WIFI_BAND_MODE_AUTO) {
-    wifi_protocols_t protocols = {
-      .ghz_2g = 0,
-      .ghz_5g = 0
-    };
+    wifi_protocols_t protocols = {.ghz_2g = 0, .ghz_5g = 0};
     err = esp_wifi_get_protocols(ifx, &protocols);
     if (err != ESP_OK) {
       log_e("Failed to get Current Protocols: 0x%x: %s", err, esp_err_to_name(err));
@@ -542,10 +539,7 @@ static bool _wifi_enable_lr(wifi_interface_t ifx) {
     return false;
   }
   if (band_mode == WIFI_BAND_MODE_AUTO) {
-    wifi_protocols_t protocols = {
-      .ghz_2g = WIFI_PROTOCOL_LR,
-      .ghz_5g = WIFI_PROTOCOL_DEFAULT_5G
-    };
+    wifi_protocols_t protocols = {.ghz_2g = WIFI_PROTOCOL_LR, .ghz_5g = WIFI_PROTOCOL_DEFAULT_5G};
     err = esp_wifi_set_protocols(ifx, &protocols);
     if (err != ESP_OK) {
       log_e("Failed to set LR Protocol: 0x%x: %s", err, esp_err_to_name(err));
@@ -574,10 +568,7 @@ static bool _wifi_disable_lr(wifi_interface_t ifx) {
     return false;
   }
   if (band_mode == WIFI_BAND_MODE_AUTO) {
-    wifi_protocols_t protocols = {
-      .ghz_2g = WIFI_PROTOCOL_DEFAULT,
-      .ghz_5g = WIFI_PROTOCOL_DEFAULT_5G
-    };
+    wifi_protocols_t protocols = {.ghz_2g = WIFI_PROTOCOL_DEFAULT, .ghz_5g = WIFI_PROTOCOL_DEFAULT_5G};
     err = esp_wifi_set_protocols(ifx, &protocols);
     if (err != ESP_OK) {
       log_e("Failed to set Default Protocol: 0x%x: %s", err, esp_err_to_name(err));


### PR DESCRIPTION
This pull request refactors and enhances how Long Range (LR) WiFi mode is enabled and disabled, especially for platforms supporting multiple bands (2.4GHz and 5GHz) and newer ESP-IDF versions. The changes introduce helper functions to manage LR mode more robustly and update the logic in the main WiFi mode handler to use these helpers, improving maintainability and compatibility.

**Long Range (LR) WiFi Protocol Handling:**

* Introduced helper functions `_wifi_is_lr_enabled`, `_wifi_enable_lr`, and `_wifi_disable_lr` to encapsulate the logic for detecting, enabling, and disabling Long Range WiFi mode, with special handling for platforms supporting both 2.4GHz and 5GHz bands and ESP-IDF >= 5.4.2.
* Defined new protocol bitmask macros (`WIFI_PROTOCOL_DEFAULT`, `WIFI_PROTOCOL_DEFAULT_5G`) to simplify protocol selection based on hardware and configuration support.

**Refactoring of WiFi mode logic:**

* Updated the `WiFiGenericClass::mode` method to use the new helper functions for enabling/disabling LR mode, replacing direct protocol manipulation with more robust and readable code. This ensures correct protocol handling and better error reporting.
* Removed duplicated protocol macro definitions from inside the function, centralizing them at the top for clarity and maintainability.

Fixes: https://github.com/espressif/arduino-esp32/issues/12200