### PR TITLE
fix(export): Fix binary export for IDE v1

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -202,28 +202,33 @@ recipe.size.regex.data=^(?:\.dram0\.data|\.dram0\.bss|\.dram1\.data|\.dram1\.bss
 
 ## Define FQBN transformation logic as reusable properties
 ## Converts FQBN to vendor.arch.board format matching Arduino IDE default export path
-recipe.hooks.savehex.fqbn_to_dir=FQBN_DIR=$(echo '{build.fqbn}' | cut -d: -f1-3 | tr ':' '.')
-recipe.hooks.savehex.fqbn_to_dir.windows=$env:FQBN_DIR=('{build.fqbn}' -split ':')[0..2] -join '.'
+recipe.hooks.savehex.fqbn_to_dir=FQBN_DIR=$(echo '{build.fqbn}' | cut -d: -f1-3 | tr ':' '.') && mkdir -p '{sketch_path}/build/'$FQBN_DIR
+recipe.hooks.savehex.fqbn_to_dir.windows=$env:FQBN_DIR=('{build.fqbn}' -split ':')[0..2] -join '.'; $dest='{sketch_path}\build\' + $env:FQBN_DIR; New-Item -ItemType Directory -Force -Path $dest | Out-Null
+
+## Export all files starting with sketch name (*.bin, *.elf, *.map, etc.)
+## IDE v1 does not do this automatically like IDE v2
+recipe.hooks.savehex.postsavehex.0.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp -f '{build.path}/{build.project_name}.'* '{sketch_path}/build/'$FQBN_DIR'/' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.0.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -Force -ErrorAction SilentlyContinue -Path '{build.path}\{build.project_name}.*' -Destination $dest"
 
 ## Export partitions.csv (for reference)
-recipe.hooks.savehex.postsavehex.1.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/partitions.csv' '{sketch_path}/build/'$FQBN_DIR'/partitions.csv' 2>/dev/null || true"
-recipe.hooks.savehex.postsavehex.1.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\partitions.csv' ('{sketch_path}\build\' + $env:FQBN_DIR + '\partitions.csv')"
+recipe.hooks.savehex.postsavehex.1.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp -f '{build.path}/partitions.csv' '{sketch_path}/build/'$FQBN_DIR'/partitions.csv' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.1.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -Force -ErrorAction SilentlyContinue '{build.path}\partitions.csv' ($dest + '\partitions.csv')"
 
 ## Export sdkconfig (for reference)
-recipe.hooks.savehex.postsavehex.2.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/sdkconfig' '{sketch_path}/build/'$FQBN_DIR'/sdkconfig' 2>/dev/null || true"
-recipe.hooks.savehex.postsavehex.2.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\sdkconfig' ('{sketch_path}\build\' + $env:FQBN_DIR + '\sdkconfig')"
+recipe.hooks.savehex.postsavehex.2.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp -f '{build.path}/sdkconfig' '{sketch_path}/build/'$FQBN_DIR'/sdkconfig' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.2.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -Force -ErrorAction SilentlyContinue '{build.path}\sdkconfig' ($dest + '\sdkconfig')"
 
 ## Export flash_args
-recipe.hooks.savehex.postsavehex.3.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/flash_args' '{sketch_path}/build/'$FQBN_DIR'/flash_args' 2>/dev/null || true"
-recipe.hooks.savehex.postsavehex.3.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\flash_args' ('{sketch_path}\build\' + $env:FQBN_DIR + '\flash_args')"
+recipe.hooks.savehex.postsavehex.3.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp -f '{build.path}/flash_args' '{sketch_path}/build/'$FQBN_DIR'/flash_args' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.3.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -Force -ErrorAction SilentlyContinue '{build.path}\flash_args' ($dest + '\flash_args')"
 
 ## Export boot_app0.bin
-recipe.hooks.savehex.postsavehex.4.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{runtime.platform.path}/tools/partitions/boot_app0.bin' '{sketch_path}/build/'$FQBN_DIR'/boot_app0.bin' 2>/dev/null || true"
-recipe.hooks.savehex.postsavehex.4.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{runtime.platform.path}\tools\partitions\boot_app0.bin' ('{sketch_path}\build\' + $env:FQBN_DIR + '\boot_app0.bin')"
+recipe.hooks.savehex.postsavehex.4.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp -f '{runtime.platform.path}/tools/partitions/boot_app0.bin' '{sketch_path}/build/'$FQBN_DIR'/boot_app0.bin' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.4.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -Force -ErrorAction SilentlyContinue '{runtime.platform.path}\tools\partitions\boot_app0.bin' ($dest + '\boot_app0.bin')"
 
 ## Export build.options.json
-recipe.hooks.savehex.postsavehex.5.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp '{build.path}/build.options.json' '{sketch_path}/build/'$FQBN_DIR'/build.options.json' 2>/dev/null || true"
-recipe.hooks.savehex.postsavehex.5.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -ErrorAction SilentlyContinue '{build.path}\build.options.json' ('{sketch_path}\build\' + $env:FQBN_DIR + '\build.options.json')"
+recipe.hooks.savehex.postsavehex.5.pattern=/usr/bin/env bash -c "{recipe.hooks.savehex.fqbn_to_dir} && cp -f '{build.path}/build.options.json' '{sketch_path}/build/'$FQBN_DIR'/build.options.json' 2>/dev/null || true"
+recipe.hooks.savehex.postsavehex.5.pattern.windows=powershell -Command "{recipe.hooks.savehex.fqbn_to_dir}; Copy-Item -Force -ErrorAction SilentlyContinue '{build.path}\build.options.json' ($dest + '\build.options.json')"
 
 ## Required discoveries and monitors
 ## ---------------------------------


### PR DESCRIPTION
## Description of Change

This pull request updates the `platform.txt` to fix exporting binaries when using IDE v1. The main changes ensure that all relevant build files are exported consistently to a board-specific directory, and that export operations are more robust across both Unix and Windows environments.

**Export logic and artifact handling:**

* Enhanced the FQBN-to-directory conversion logic to always create the destination directory before exporting files, ensuring the export path exists on both Unix and Windows systems.
* Updated export commands to copy all files matching the sketch name (e.g., `.bin`, `.elf`, `.map`, etc.) to the board-specific build directory, addressing a gap in Arduino IDE v1 behavior.
* Added the `-f` (force) flag to all Unix `cp` commands and the `-Force` flag to all Windows `Copy-Item` commands, making file overwrites explicit and improving reliability.

**Consistency and maintainability:**

* Refactored export patterns for reference files (`partitions.csv`, `sdkconfig`, `flash_args`, `boot_app0.bin`, `build.options.json`) to use the new directory logic and force overwrite, ensuring all exported artifacts are handled in a uniform way.

## Test Scenarios

Tested in Windows and macOS in both IDE v1 and v2

## Related links

Closes #12175
