### PR TITLE
ci(wokwi): Add re-trigger option which ignores cached results

### DIFF
--- a/.github/workflows/tests_hw_wokwi.yml
+++ b/.github/workflows/tests_hw_wokwi.yml
@@ -619,6 +619,8 @@ jobs:
           needs.get-artifacts.outputs.rerun_wokwi_test == 'true'
         continue-on-error: true
         run: |
-          gh pr edit ${{ needs.get-artifacts.outputs.pr_num }} --repo ${{ github.repository }} --remove-label 'Re-trigger Wokwi Tests'
+          gh pr edit "$PR_NUM" --repo "$GITHUB_REPOSITORY" --remove-label 'Re-trigger Wokwi Tests'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ needs.get-artifacts.outputs.pr_num }}
+          GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Description of Change
This pull request updates the `.github/workflows/tests_hw_wokwi.yml` workflow to allow pull request to force a rerun of Wokwi tests by adding a "Re-trigger Wokwi Tests" label. The workflow will now check for this label, ignore cached results if present, and automatically remove the label after use. These changes improve the flexibility and usability of the testing workflow for contributors.

This option is added, as in some scenarios when fix was done on Wokwi side, we need to rerun for all targets and not only for the failing once.

**Support for re-triggering Wokwi tests via PR label:**

* Added logic in the workflow to detect the presence of a "Re-trigger Wokwi Tests" label on pull requests (`rerun_wokwi_test`), and set an output variable accordingly. [[1]](diffhunk://#diff-36b3dd47533746ca0ce7afb9e66f58fcfc45c44cde7ae2f0084b8ded49c8b29aR124-R136) [[2]](diffhunk://#diff-36b3dd47533746ca0ce7afb9e66f58fcfc45c44cde7ae2f0084b8ded49c8b29aR33) [[3]](diffhunk://#diff-36b3dd47533746ca0ce7afb9e66f58fcfc45c44cde7ae2f0084b8ded49c8b29aR161) [[4]](diffhunk://#diff-36b3dd47533746ca0ce7afb9e66f58fcfc45c44cde7ae2f0084b8ded49c8b29aR211)
* Modified the test execution logic to ignore cached results and rerun tests if the label is present, ensuring tests are rerun when explicitly requested.
* Added a step to automatically remove the "Re-trigger Wokwi Tests" label from the pull request after the rerun is triggered, keeping the PR labels clean.

**Workflow permissions:**

* Updated workflow permissions to allow writing to pull requests, which is required for label management.

## Test Scenarios

## Related links
