### PR TITLE
feat(s3): Split libs for each SoC and add S3 support

### DIFF
--- a/.github/scripts/lib-github-release.sh
+++ b/.github/scripts/lib-github-release.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Common functions for GitHub Release operations
+# This library is sourced by release scripts
+# Disable shellcheck warning about $? uses.
+# shellcheck disable=SC2181
+
+function get_file_size {
+    local file="$1"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        eval "$(stat -s "$file")"
+        local res="$?"
+        echo "${st_size:?}"
+        return $res
+    else
+        stat --printf="%s" "$file"
+        return $?
+    fi
+}
+
+function git_upload_asset {
+    local file="$1"
+    local release_id="$2"
+    local name
+    name=$(basename "$file")
+    # local mime=$(file -b --mime-type "$file")
+    curl -X POST -sH "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/octet-stream" --data-binary @"$file" "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id/assets?name=$name"
+}
+
+function git_safe_upload_asset {
+    local file="$1"
+    local release_id="$2"
+    local name
+    local size
+    local upload_res
+
+    name=$(basename "$file")
+    size=$(get_file_size "$file")
+
+    if ! upload_res=$(git_upload_asset "$file" "$release_id"); then
+        >&2 echo "ERROR: Failed to upload '$name' ($?)"
+        return 1
+    fi
+
+    up_size=$(echo "$upload_res" | jq -r '.size')
+    if [ "$up_size" -ne "$size" ]; then
+        >&2 echo "ERROR: Uploaded size does not match! $up_size != $size"
+        #git_delete_asset
+        return 1
+    fi
+    echo "$upload_res" | jq -r '.browser_download_url'
+    return $?
+}
+
+function git_upload_to_pages {
+    local path=$1
+    local src=$2
+
+    if [ ! -f "$src" ]; then
+        >&2 echo "Input is not a file! Aborting..."
+        return 1
+    fi
+
+    local info
+    local type
+    local message
+    local sha=""
+    local content=""
+
+    info=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.object+json" -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path?ref=gh-pages")
+    type=$(echo "$info" | jq -r '.type')
+    message=$(basename "$path")
+
+    if [ "$type" == "file" ]; then
+        sha=$(echo "$info" | jq -r '.sha')
+        sha=",\"sha\":\"$sha\""
+        message="Updating $message"
+    elif [ ! "$type" == "null" ]; then
+        >&2 echo "Wrong type '$type'"
+        return 1
+    else
+        message="Creating $message"
+    fi
+
+    content=$(base64 -i "$src")
+    data="{\"branch\":\"gh-pages\",\"message\":\"$message\",\"content\":\"$content\"$sha}"
+
+    echo "$data" | curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw+json" -X PUT --data @- "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path"
+}
+
+function git_safe_upload_to_pages {
+    local path=$1
+    local file="$2"
+    local name
+    local size
+    local upload_res
+
+    name=$(basename "$file")
+    size=$(get_file_size "$file")
+
+    if ! upload_res=$(git_upload_to_pages "$path" "$file"); then
+        >&2 echo "ERROR: Failed to upload '$name' ($?)"
+        return 1
+    fi
+
+    up_size=$(echo "$upload_res" | jq -r '.content.size')
+    if [ "$up_size" -ne "$size" ]; then
+        >&2 echo "ERROR: Uploaded size does not match! $up_size != $size"
+        #git_delete_asset
+        return 1
+    fi
+    echo "$upload_res" | jq -r '.content.download_url'
+    return $?
+}

--- a/.github/scripts/on-pages.sh
+++ b/.github/scripts/on-pages.sh
@@ -23,7 +23,7 @@ function git_remove_from_pages {
     local sha
     local message
 
-    info=$(curl -s -k -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.object+json" -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path?ref=gh-pages")
+    info=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.object+json" -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path?ref=gh-pages")
     type=$(echo "$info" | jq -r '.type')
 
     if [ ! "$type" == "file" ]; then
@@ -38,7 +38,7 @@ function git_remove_from_pages {
     sha=$(echo "$info" | jq -r '.sha')
     message="Deleting "$(basename "$path")
     local json="{\"branch\":\"gh-pages\",\"message\":\"$message\",\"sha\":\"$sha\"}"
-    echo "$json" | curl -s -k -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw+json" -X DELETE --data @- "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path"
+    echo "$json" | curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw+json" -X DELETE --data @- "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path"
 }
 
 function git_upload_to_pages {
@@ -56,7 +56,7 @@ function git_upload_to_pages {
     local sha=""
     local content=""
 
-    info=$(curl -s -k -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.object+json" -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path?ref=gh-pages")
+    info=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.object+json" -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path?ref=gh-pages")
     type=$(echo "$info" | jq -r '.type')
     message=$(basename "$path")
 
@@ -74,7 +74,7 @@ function git_upload_to_pages {
     content=$(base64 -i "$src")
     data="{\"branch\":\"gh-pages\",\"message\":\"$message\",\"content\":\"$content\"$sha}"
 
-    echo "$data" | curl -s -k -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw+json" -X PUT --data @- "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path"
+    echo "$data" | curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw+json" -X PUT --data @- "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path"
 }
 
 function git_safe_upload_to_pages {

--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -30,13 +30,19 @@ RELEASE_ID=$(echo "$EVENT_JSON" | jq -r '.release.id')
 
 SCRIPTS_DIR="./.github/scripts"
 OUTPUT_DIR="$GITHUB_WORKSPACE/build"
-PACKAGE_NAME="esp32-$RELEASE_TAG"
+PACKAGE_NAME="esp32-core-$RELEASE_TAG"
 PACKAGE_JSON_MERGE="$GITHUB_WORKSPACE/.github/scripts/merge_packages.py"
 PACKAGE_JSON_TEMPLATE="$GITHUB_WORKSPACE/package/package_esp32_index.template.json"
 PACKAGE_JSON_DEV="package_esp32_dev_index.json"
 PACKAGE_JSON_REL="package_esp32_index.json"
 PACKAGE_JSON_DEV_CN="package_esp32_dev_index_cn.json"
 PACKAGE_JSON_REL_CN="package_esp32_index_cn.json"
+
+# Source SoC configuration
+source "$SCRIPTS_DIR/socs_config.sh"
+
+# Source common GitHub release functions
+source "$SCRIPTS_DIR/lib-github-release.sh"
 
 echo "Event: $GITHUB_EVENT_NAME, Repo: $GITHUB_REPOSITORY, Path: $GITHUB_WORKSPACE, Ref: $GITHUB_REF"
 echo "Action: $action, Branch: $RELEASE_BRANCH, ID: $RELEASE_ID"
@@ -54,109 +60,33 @@ if [ -n "${VENDOR}" ]; then
     echo "Setting packager: $VENDOR"
 fi
 
-function get_file_size {
-    local file="$1"
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        eval "$(stat -s "$file")"
-        local res="$?"
-        echo "${st_size:?}"
-        return $res
-    else
-        stat --printf="%s" "$file"
-        return $?
-    fi
-}
+#
+# Replace a literal string while skipping the first N occurrences (file-wide).
+# Portable across macOS/Linux (avoids sed "skip first match" differences).
+#
+# skip_n semantics:
+#   - skip_n=0 : replace all occurrences (skip none)
+#   - skip_n=1 : skip the first occurrence, replace all subsequent ones
+#   - skip_n=N : skip the first N occurrences, then replace the rest
+#
+# Usage:
+#   replace_literal_skip_n <skip_n> <from_literal> <to_literal> <infile> <outfile>
+#
+function replace_literal_skip_n {
+    local skip_n="$1"
+    local from_literal="$2"
+    local to_literal="$3"
+    local infile="$4"
+    local outfile="$5"
 
-function git_upload_asset {
-    local name
-    name=$(basename "$1")
-    # local mime=$(file -b --mime-type "$1")
-    curl -k -X POST -sH "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/octet-stream" --data-binary @"$1" "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=$name"
-}
-
-function git_safe_upload_asset {
-    local file="$1"
-    local name
-    local size
-    local upload_res
-
-    name=$(basename "$file")
-    size=$(get_file_size "$file")
-
-    if ! upload_res=$(git_upload_asset "$file"); then
-        >&2 echo "ERROR: Failed to upload '$name' ($?)"
+    if [ -z "$infile" ] || [ -z "$outfile" ]; then
+        >&2 echo "ERROR: replace_literal_skip_n: missing infile/outfile"
         return 1
     fi
 
-    up_size=$(echo "$upload_res" | jq -r '.size')
-    if [ "$up_size" -ne "$size" ]; then
-        >&2 echo "ERROR: Uploaded size does not match! $up_size != $size"
-        #git_delete_asset
-        return 1
-    fi
-    echo "$upload_res" | jq -r '.browser_download_url'
-    return $?
-}
-
-function git_upload_to_pages {
-    local path=$1
-    local src=$2
-
-    if [ ! -f "$src" ]; then
-        >&2 echo "Input is not a file! Aborting..."
-        return 1
-    fi
-
-    local info
-    local type
-    local message
-    local sha=""
-    local content=""
-
-    info=$(curl -s -k -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.object+json" -X GET "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path?ref=gh-pages")
-    type=$(echo "$info" | jq -r '.type')
-    message=$(basename "$path")
-
-    if [ "$type" == "file" ]; then
-        sha=$(echo "$info" | jq -r '.sha')
-        sha=",\"sha\":\"$sha\""
-        message="Updating $message"
-    elif [ ! "$type" == "null" ]; then
-        >&2 echo "Wrong type '$type'"
-        return 1
-    else
-        message="Creating $message"
-    fi
-
-    content=$(base64 -i "$src")
-    data="{\"branch\":\"gh-pages\",\"message\":\"$message\",\"content\":\"$content\"$sha}"
-
-    echo "$data" | curl -s -k -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3.raw+json" -X PUT --data @- "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/$path"
-}
-
-function git_safe_upload_to_pages {
-    local path=$1
-    local file="$2"
-    local name
-    local size
-    local upload_res
-
-    name=$(basename "$file")
-    size=$(get_file_size "$file")
-
-    if ! upload_res=$(git_upload_to_pages "$path" "$file"); then
-        >&2 echo "ERROR: Failed to upload '$name' ($?)"
-        return 1
-    fi
-
-    up_size=$(echo "$upload_res" | jq -r '.content.size')
-    if [ "$up_size" -ne "$size" ]; then
-        >&2 echo "ERROR: Uploaded size does not match! $up_size != $size"
-        #git_delete_asset
-        return 1
-    fi
-    echo "$upload_res" | jq -r '.content.download_url'
-    return $?
+    SKIP="$skip_n" FROM="$from_literal" TO="$to_literal" \
+        perl -pe 'BEGIN{$s=$ENV{SKIP}+0;$from=$ENV{FROM};$to=$ENV{TO};$i=0;} s/\Q$from\E/($i++<$s)?$&:$to/ge' \
+        "$infile" > "$outfile"
 }
 
 function merge_package_json {
@@ -215,11 +145,9 @@ git config --global user.name "github-actions[bot]"
 git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git add .
 
-# We should only commit if there are changes
-need_update_commit=true
+# Create version update commit if there are changes
 if git diff --cached --quiet; then
     echo "Version already updated"
-    need_update_commit=false
 else
     echo "Creating version update commit..."
     git commit -m "change(version): Update core version to $RELEASE_TAG"
@@ -283,8 +211,10 @@ X32TC_NEW_NAME="esp-x32"
 echo "Generating platform.txt..."
 cat "$GITHUB_WORKSPACE/platform.txt" | \
 sed "s/version=.*/version=$RELEASE_TAG/g" | \
-sed 's/tools\.esp32-arduino-libs\.path\.windows=.*//g' | \
-sed 's/{runtime\.platform\.path}.tools.esp32-arduino-libs/\{runtime.tools.esp32-arduino-libs.path\}/g' | \
+sed 's|{runtime\.platform\.path}/tools/esp32-arduino-libs|{runtime.tools.{build.chip_variant}-libs.path}|g' | \
+sed 's|{runtime\.platform\.path}\\tools\\esp32-arduino-libs|{runtime.tools.{build.chip_variant}-libs.path}|g' | \
+sed 's|compiler\.sdk\.path={tools\.esp32-arduino-libs\.path}/{build\.chip_variant}|compiler.sdk.path={tools.esp32-arduino-libs.path}|g' | \
+sed '/compiler\.sdk\.path\.windows={tools\.esp32-arduino-libs\.path}/d' | \
 sed 's/{runtime\.platform\.path}.tools.xtensa-esp-elf-gdb/\{runtime.tools.xtensa-esp-elf-gdb.path\}/g' | \
 sed "s/{runtime\.platform\.path}.tools.xtensa-esp-elf/\\{runtime.tools.$X32TC_NEW_NAME.path\\}/g" | \
 sed 's/{runtime\.platform\.path}.tools.riscv32-esp-elf-gdb/\{runtime.tools.riscv32-esp-elf-gdb.path\}/g' | \
@@ -344,14 +274,14 @@ echo
 
 # Upload ZIP package to release page
 echo "Uploading ZIP package to release page ..."
-PACKAGE_URL=$(git_safe_upload_asset "$PACKAGE_PATH")
+PACKAGE_URL=$(git_safe_upload_asset "$PACKAGE_PATH" "$RELEASE_ID")
 echo "Package Uploaded"
 echo "Download URL: $PACKAGE_URL"
 echo
 
 # Upload XZ package to release page
 echo "Uploading XZ package to release page ..."
-PACKAGE_XZ_URL=$(git_safe_upload_asset "$PACKAGE_XZ_PATH")
+PACKAGE_XZ_URL=$(git_safe_upload_asset "$PACKAGE_XZ_PATH" "$RELEASE_ID")
 echo "Package Uploaded"
 echo "Download URL: $PACKAGE_XZ_URL"
 echo
@@ -396,16 +326,93 @@ popd >/dev/null
 mkdir -p "$GITHUB_WORKSPACE/hosted"
 cp "$OUTPUT_DIR/esp32-arduino-libs/hosted"/*.bin "$GITHUB_WORKSPACE/hosted/"
 
-# Upload ZIP and XZ libs to release page
+# Create per-SoC ZIPs
+echo "Creating per-SoC libs ZIPs..."
 
-echo "Uploading ZIP libs to release page ..."
-LIBS_ZIP_URL=$(git_safe_upload_asset "$OUTPUT_DIR/$LIBS_ZIP")
-echo "ZIP libs Uploaded"
-echo "Download URL: $LIBS_ZIP_URL"
-echo
+declare -A SOC_ZIP_URLS
+declare -A SOC_ZIP_FILES
+declare -A SOC_CHECKSUMS
+declare -A SOC_SIZES
+
+pushd "$OUTPUT_DIR" >/dev/null
+
+for soc_variant in "${CORE_VARIANTS[@]}"; do
+    echo "Creating ZIP for $soc_variant..."
+
+    # Create temporary directory structure for this SoC variant
+    temp_dir="$soc_variant-libs"
+    mkdir -p "$temp_dir"
+
+    # Copy the entire contents of the SoC variant folder (flatten one layer), excluding build files
+    if [ -d "esp32-arduino-libs/$soc_variant" ]; then
+        for item in "esp32-arduino-libs/$soc_variant"/*; do
+            name=$(basename "$item")
+            # Skip build/development files
+            if [[ "$name" == "dependencies.lock" || \
+                  "$name" == "pioarduino-build.py" ]]; then
+                continue
+            fi
+            cp -r "$item" "$temp_dir/"
+        done
+    else
+        echo "ERROR: Variant folder not found: esp32-arduino-libs/$soc_variant"
+        exit 1
+    fi
+
+    # Create ZIP
+    # Arduino Board Manager requires exactly ONE top-level directory in tool archives.
+    # Zip the folder itself (not its contents) so it becomes the archive root.
+    soc_zip="$soc_variant-libs-$RELEASE_TAG.zip"
+    zip -qr "$soc_zip" "$temp_dir"
+
+    # Calculate checksum and size before uploading
+    checksum=$(sha256sum "$soc_zip" | awk '{print $1}')
+    size=$(stat -c%s "$soc_zip")
+
+    # Clean up temp directory
+    rm -rf "$temp_dir"
+
+    # Upload ZIP (S3 if configured, otherwise GitHub)
+    if [ "$ENABLE_S3" == "true" ] && [ -n "$S3_BUCKET_NAME" ] && [ -n "$S3_BUCKET_REGION" ]; then
+        echo "Uploading $soc_zip to S3..."
+        s3_key="$soc_zip"
+        aws s3 cp "$OUTPUT_DIR/$soc_zip" "s3://$S3_BUCKET_NAME/arduino/$RELEASE_TAG/$s3_key" --acl public-read --cache-control "public, max-age=31536000, immutable" --content-type application/zip
+        soc_zip_url="https://$S3_BUCKET_NAME.s3.$S3_BUCKET_REGION.amazonaws.com/arduino/$RELEASE_TAG/$s3_key"
+        echo "$soc_zip Uploaded to S3"
+        echo "S3 URL: $soc_zip_url"
+
+        # Upload "latest" version to S3
+        latest_zip="${soc_variant}-libs-latest.zip"
+        cp "$OUTPUT_DIR/$soc_zip" "$OUTPUT_DIR/$latest_zip"
+        echo "Uploading $latest_zip (latest) to S3..."
+        aws s3 cp "$OUTPUT_DIR/$latest_zip" "s3://$S3_BUCKET_NAME/arduino/latest/$latest_zip" --acl public-read --cache-control "no-cache, must-revalidate" --content-type application/zip
+        latest_zip_url="https://$S3_BUCKET_NAME.s3.$S3_BUCKET_REGION.amazonaws.com/arduino/latest/$latest_zip"
+        echo "$latest_zip Uploaded to S3"
+        echo "S3 URL: $latest_zip_url"
+    else
+        echo "Uploading $soc_zip to GitHub releases..."
+        soc_zip_url=$(git_safe_upload_asset "$OUTPUT_DIR/$soc_zip" "$RELEASE_ID")
+        echo "$soc_zip Uploaded to GitHub"
+        echo "GitHub URL: $soc_zip_url"
+    fi
+
+    # Store URLs, filenames, checksums and sizes for JSON update
+    SOC_ZIP_URLS["$soc_variant"]="$soc_zip_url"
+    SOC_ZIP_FILES["$soc_variant"]="$soc_zip"
+    SOC_CHECKSUMS["$soc_variant"]="$checksum"
+    SOC_SIZES["$soc_variant"]="$size"
+
+    # Clean up ZIP files
+    rm -f "$soc_zip"
+    if [ "$ENABLE_S3" == "true" ] && [ -n "$S3_BUCKET_NAME" ] && [ -n "$S3_BUCKET_REGION" ]; then
+        rm -f "$latest_zip"
+    fi
+done
+
+popd >/dev/null
 
 echo "Uploading XZ libs to release page ..."
-LIBS_XZ_URL=$(git_safe_upload_asset "$OUTPUT_DIR/$LIBS_XZ")
+LIBS_XZ_URL=$(git_safe_upload_asset "$OUTPUT_DIR/$LIBS_XZ" "$RELEASE_ID")
 echo "XZ libs Uploaded"
 echo "Download URL: $LIBS_XZ_URL"
 echo
@@ -413,11 +420,32 @@ echo
 # Update libs URLs in JSON template
 echo "Updating libs URLs in JSON template ..."
 
-# Update all libs URLs in the JSON template
-libs_jq_arg="(.packages[0].tools[] | select(.name == \"esp32-arduino-libs\") | .systems[].url) = \"$LIBS_ZIP_URL\" |\
-             (.packages[0].tools[] | select(.name == \"esp32-arduino-libs\") | .systems[].archiveFileName) = \"$LIBS_ZIP\""
+# Get the existing systems structure from the esp32-arduino-libs tool
+# We'll use this as a template for each new SoC tool
+existing_systems=$(cat "$PACKAGE_JSON_TEMPLATE" | jq '.packages[0].tools[] | select(.name == "esp32-arduino-libs") | .systems')
 
-cat "$PACKAGE_JSON_TEMPLATE" | jq "$libs_jq_arg" > "$OUTPUT_DIR/package-libs-updated.json"
+# Remove existing esp32-arduino-libs tool and toolsDependency, then add new per-SoC tools and dependencies
+jq_args="del(.packages[0].tools[] | select(.name == \"esp32-arduino-libs\"))"
+jq_args+=" | del(.packages[0].platforms[0].toolsDependencies[] | select(.name == \"esp32-arduino-libs\"))"
+
+# Iterate over each SoC variant to update the JSON template
+for soc_variant in "${CORE_VARIANTS[@]}"; do
+    tool_name="${soc_variant}-libs"
+    tool_url="${SOC_ZIP_URLS[$soc_variant]}"
+    tool_file="${SOC_ZIP_FILES[$soc_variant]}"
+    checksum="${SOC_CHECKSUMS[$soc_variant]}"
+    size="${SOC_SIZES[$soc_variant]}"
+
+    # Update the systems array with new URL, filename, checksum and size
+    updated_systems=$(echo "$existing_systems" | jq --arg url "$tool_url" --arg file "$tool_file" --arg checksum "SHA-256:$checksum" --arg size "$size" '
+        map(.url = $url | .archiveFileName = $file | .checksum = $checksum | .size = $size)
+    ')
+
+    jq_args+=" | .packages[0].tools += [{\"name\": \"$tool_name\", \"version\": \"${RELEASE_TAG}\", \"systems\": $updated_systems}]"
+    jq_args+=" | .packages[0].platforms[0].toolsDependencies += [{\"packager\": \"esp32\", \"name\": \"$tool_name\", \"version\": \"${RELEASE_TAG}\"}]"
+done
+
+cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_args" > "$OUTPUT_DIR/package-libs-updated.json"
 PACKAGE_JSON_TEMPLATE="$OUTPUT_DIR/package-libs-updated.json"
 
 echo "Libs URLs updated in JSON template"
@@ -459,15 +487,23 @@ jq_arg=".packages[0].platforms[0].version = \"$RELEASE_TAG\" | \
 
 # Generate package JSONs
 echo "Generating $PACKAGE_JSON_DEV ..."
-cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$OUTPUT_DIR/$PACKAGE_JSON_DEV"
-# On MacOS the sed command won't skip the first match. Use gsed instead.
-sed '0,/github\.com\//!s|github\.com/|dl.espressif.cn/github_assets/|g' "$OUTPUT_DIR/$PACKAGE_JSON_DEV" > "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN"
+tmp_pkg_json="$OUTPUT_DIR/${PACKAGE_JSON_DEV}.raw"
+cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$tmp_pkg_json"
+# For some reason downloads from dl.espressif.com keep failing. Commenting out for now.
+# replace_literal_skip_n 2 "github.com/" "dl.espressif.com/github_assets/" "$tmp_pkg_json" "$OUTPUT_DIR/$PACKAGE_JSON_DEV"
+cp "$tmp_pkg_json" "$OUTPUT_DIR/$PACKAGE_JSON_DEV" # Can remove this once we have a fix for dl.espressif.com
+replace_literal_skip_n 1 "github.com/" "dl.espressif.cn/github_assets/" "$tmp_pkg_json" "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN"
+rm -f "$tmp_pkg_json"
 python "$SCRIPTS_DIR/release_append_cn.py" "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN"
 if [ "$RELEASE_PRE" == "false" ]; then
     echo "Generating $PACKAGE_JSON_REL ..."
-    cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$OUTPUT_DIR/$PACKAGE_JSON_REL"
-    # On MacOS the sed command won't skip the first match. Use gsed instead.
-    sed '0,/github\.com\//!s|github\.com/|dl.espressif.cn/github_assets/|g' "$OUTPUT_DIR/$PACKAGE_JSON_REL" > "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
+    tmp_pkg_json="$OUTPUT_DIR/${PACKAGE_JSON_REL}.raw"
+    cat "$PACKAGE_JSON_TEMPLATE" | jq "$jq_arg" > "$tmp_pkg_json"
+    # For some reason downloads from dl.espressif.com keep failing. Commenting out for now.
+    # replace_literal_skip_n 2 "github.com/" "dl.espressif.com/github_assets/" "$tmp_pkg_json" "$OUTPUT_DIR/$PACKAGE_JSON_REL"
+    cp "$tmp_pkg_json" "$OUTPUT_DIR/$PACKAGE_JSON_REL" # Can remove this once we have a fix for dl.espressif.com
+    replace_literal_skip_n 1 "github.com/" "dl.espressif.cn/github_assets/" "$tmp_pkg_json" "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
+    rm -f "$tmp_pkg_json"
     python "$SCRIPTS_DIR/release_append_cn.py" "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN"
 fi
 
@@ -511,97 +547,13 @@ if [ "$RELEASE_PRE" == "false" ]; then
     fi
 fi
 
-# Test the package JSONs
-
-echo "Installing arduino-cli ..."
-export PATH="/home/runner/bin:$PATH"
-source "${SCRIPTS_DIR}/install-arduino-cli.sh"
-
-# For the Chinese mirror, we can't test the package JSONs as the Chinese mirror might not be updated yet.
-
-echo "Testing $PACKAGE_JSON_DEV install ..."
-
-echo "Installing esp32 ..."
-arduino-cli core install esp32:esp32 --additional-urls "file://$OUTPUT_DIR/$PACKAGE_JSON_DEV"
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to install esp32 ($?)"
-    exit 1
-fi
-
-echo "Compiling example ..."
-arduino-cli compile --fqbn esp32:esp32:esp32 "$GITHUB_WORKSPACE"/libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to compile example ($?)"
-    exit 1
-fi
-
-echo "Uninstalling esp32 ..."
-arduino-cli core uninstall esp32:esp32
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to uninstall esp32 ($?)"
-    exit 1
-fi
-
-echo "Test successful!"
-
-if [ "$RELEASE_PRE" == "false" ]; then
-    echo "Testing $PACKAGE_JSON_REL install ..."
-
-    echo "Installing esp32 ..."
-    arduino-cli core install esp32:esp32 --additional-urls "file://$OUTPUT_DIR/$PACKAGE_JSON_REL"
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Failed to install esp32 ($?)"
-        exit 1
-    fi
-
-    echo "Compiling example ..."
-    arduino-cli compile --fqbn esp32:esp32:esp32 "$GITHUB_WORKSPACE"/libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Failed to compile example ($?)"
-        exit 1
-    fi
-
-    echo "Uninstalling esp32 ..."
-    arduino-cli core uninstall esp32:esp32
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Failed to uninstall esp32 ($?)"
-        exit 1
-    fi
-
-    echo "Test successful!"
-fi
-
-# Upload package JSONs
-
-echo "Uploading $PACKAGE_JSON_DEV ..."
-echo "Download URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV")"
-echo "Pages URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_DEV" "$OUTPUT_DIR/$PACKAGE_JSON_DEV")"
-echo "Download CN URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN")"
-echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_DEV_CN" "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN")"
-echo
-if [ "$RELEASE_PRE" == "false" ]; then
-    echo "Uploading $PACKAGE_JSON_REL ..."
-    echo "Download URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL")"
-    echo "Pages URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL")"
-    echo "Download CN URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN")"
-    echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_REL_CN" "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN")"
-    echo
-fi
-
-if [ "$need_update_commit" == "true" ]; then
-    echo "Pushing version update commit..."
-    git push
-    new_tag_commit=$(git rev-parse HEAD)
-    echo "New commit: $new_tag_commit"
-
-    echo "Moving tag $RELEASE_TAG to $new_tag_commit..."
-    git tag -f "$RELEASE_TAG" "$new_tag_commit"
-    git push --force origin "$RELEASE_TAG"
-fi
-
-set +e
-
 ##
-## DONE
+## Build complete - testing and uploading will be handled by GitHub Actions workflow
 ##
-echo "DONE!"
+echo "Build complete! Package JSONs generated."
+echo "- $PACKAGE_JSON_DEV"
+echo "- $PACKAGE_JSON_DEV_CN"
+if [ "$RELEASE_PRE" == "false" ]; then
+    echo "- $PACKAGE_JSON_REL"
+    echo "- $PACKAGE_JSON_REL_CN"
+fi

--- a/.github/scripts/socs_config.sh
+++ b/.github/scripts/socs_config.sh
@@ -25,6 +25,19 @@ ALL_SOCS=(
     "esp32s3"
 )
 
+# All supported SoC variants by the ESP32 Arduino core
+CORE_VARIANTS=(
+    "esp32"
+    "esp32c3"
+    "esp32c5"
+    "esp32c6"
+    "esp32h2"
+    "esp32p4"
+    "esp32p4_es"
+    "esp32s2"
+    "esp32s3"
+)
+
 # SoCs to skip in library builds (no pre-built libs available)
 SKIP_LIB_BUILD_SOCS=(
     "esp32c2"
@@ -275,6 +288,7 @@ done < <(_compute_build_test_targets)
 
 ALL_SOCS_CSV=$(array_to_csv "${ALL_SOCS[@]}")
 CORE_SOCS_CSV=$(array_to_csv "${CORE_SOCS[@]}")
+CORE_VARIANTS_CSV=$(array_to_csv "${CORE_VARIANTS[@]}")
 HW_TEST_TARGETS_CSV=$(array_to_csv "${HW_TEST_TARGETS[@]}")
 WOKWI_TEST_TARGETS_CSV=$(array_to_csv "${WOKWI_TEST_TARGETS[@]}")
 QEMU_TEST_TARGETS_CSV=$(array_to_csv "${QEMU_TEST_TARGETS[@]}")
@@ -284,6 +298,7 @@ IDF_COMPONENT_TARGETS_CSV=$(array_to_csv "${IDF_COMPONENT_TARGETS[@]}")
 # Export commonly used variables for backward compatibility
 export ALL_SOCS_CSV
 export CORE_SOCS_CSV
+export CORE_VARIANTS_CSV
 export HW_TEST_TARGETS_CSV
 export WOKWI_TEST_TARGETS_CSV
 export QEMU_TEST_TARGETS_CSV

--- a/.github/scripts/test-package-json.sh
+++ b/.github/scripts/test-package-json.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Test package JSON installation and compilation
+# Disable shellcheck warning about $? uses.
+# shellcheck disable=SC2181
+
+set -e
+
+SCRIPTS_DIR="./.github/scripts"
+OUTPUT_DIR="$GITHUB_WORKSPACE/build"
+PACKAGE_JSON_DEV="package_esp32_dev_index.json"
+PACKAGE_JSON_REL="package_esp32_index.json"
+
+# Get release info
+RELEASE_PRE="${RELEASE_PRE:-false}"
+
+# Convert path to absolute and handle Windows paths for file:// URLs
+function get_file_url {
+    local file_path="$1"
+
+    # Get absolute path
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+        # On Windows, convert to absolute path and use forward slashes
+        abs_path=$(cd "$(dirname "$file_path")" && pwd -W)/$(basename "$file_path") 2>/dev/null || echo "$file_path"
+        # Ensure forward slashes and proper file:// format for Windows
+        abs_path="${abs_path//\\//}"
+        echo "file:///$abs_path"
+    else
+        # On Unix systems, just ensure absolute path
+        if [[ "$file_path" = /* ]]; then
+            echo "file://$file_path"
+        else
+            echo "file://$(cd "$(dirname "$file_path")" && pwd)/$(basename "$file_path")"
+        fi
+    fi
+}
+
+echo "Installing arduino-cli ..."
+# Set up PATH based on OS
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    export PATH="$HOME/bin:$PATH"
+else
+    export PATH="/home/runner/bin:$HOME/bin:$PATH"
+fi
+
+source "${SCRIPTS_DIR}/install-arduino-cli.sh"
+
+# For the Chinese mirror, we can't test the package JSONs as the Chinese mirror might not be updated yet.
+# So we only test the main package JSON files.
+
+echo ""
+echo "==========================================="
+echo "Testing $PACKAGE_JSON_DEV"
+echo "==========================================="
+
+echo "Installing esp32 core ..."
+package_json_url=$(get_file_url "$OUTPUT_DIR/$PACKAGE_JSON_DEV")
+echo "Package JSON URL: $package_json_url"
+arduino-cli core install esp32:esp32 --additional-urls "$package_json_url"
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to install esp32 ($?)"
+    exit 1
+fi
+
+echo "Compiling example ..."
+arduino-cli compile --fqbn esp32:esp32:esp32 "$GITHUB_WORKSPACE"/libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to compile example ($?)"
+    exit 1
+fi
+
+echo "Uninstalling esp32 core ..."
+arduino-cli core uninstall esp32:esp32
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to uninstall esp32 ($?)"
+    exit 1
+fi
+
+echo "✓ Test successful for $PACKAGE_JSON_DEV"
+
+if [ "$RELEASE_PRE" == "false" ]; then
+    echo ""
+    echo "==========================================="
+    echo "Testing $PACKAGE_JSON_REL"
+    echo "==========================================="
+
+    echo "Installing esp32 core ..."
+    package_json_url=$(get_file_url "$OUTPUT_DIR/$PACKAGE_JSON_REL")
+    echo "Package JSON URL: $package_json_url"
+    arduino-cli core install esp32:esp32 --additional-urls "$package_json_url"
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to install esp32 ($?)"
+        exit 1
+    fi
+
+    echo "Compiling example ..."
+    arduino-cli compile --fqbn esp32:esp32:esp32 "$GITHUB_WORKSPACE"/libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to compile example ($?)"
+        exit 1
+    fi
+
+    echo "Uninstalling esp32 core ..."
+    arduino-cli core uninstall esp32:esp32
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to uninstall esp32 ($?)"
+        exit 1
+    fi
+
+    echo "✓ Test successful for $PACKAGE_JSON_REL"
+fi
+
+echo ""
+echo "==========================================="
+echo "✓ All tests passed on $(uname -s)!"
+echo "==========================================="

--- a/.github/scripts/upload-release-assets.sh
+++ b/.github/scripts/upload-release-assets.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Upload package JSONs and push version commit
+# Disable shellcheck warning about $? uses.
+# shellcheck disable=SC2181
+
+set -e
+
+SCRIPTS_DIR="./.github/scripts"
+
+# Source common GitHub release functions
+source "$SCRIPTS_DIR/lib-github-release.sh"
+
+OUTPUT_DIR="$GITHUB_WORKSPACE/build"
+PACKAGE_JSON_DEV="package_esp32_dev_index.json"
+PACKAGE_JSON_REL="package_esp32_index.json"
+PACKAGE_JSON_DEV_CN="package_esp32_dev_index_cn.json"
+PACKAGE_JSON_REL_CN="package_esp32_index_cn.json"
+
+echo "Uploading package JSONs ..."
+
+echo "Uploading $PACKAGE_JSON_DEV ..."
+echo "Download URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV" "$RELEASE_ID")"
+echo "Pages URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_DEV" "$OUTPUT_DIR/$PACKAGE_JSON_DEV")"
+echo "Download CN URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN" "$RELEASE_ID")"
+echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_DEV_CN" "$OUTPUT_DIR/$PACKAGE_JSON_DEV_CN")"
+echo
+
+if [ "$RELEASE_PRE" == "false" ]; then
+    echo "Uploading $PACKAGE_JSON_REL ..."
+    echo "Download URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL" "$RELEASE_ID")"
+    echo "Pages URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_REL" "$OUTPUT_DIR/$PACKAGE_JSON_REL")"
+    echo "Download CN URL: $(git_safe_upload_asset "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN" "$RELEASE_ID")"
+    echo "Pages CN URL: $(git_safe_upload_to_pages "$PACKAGE_JSON_REL_CN" "$OUTPUT_DIR/$PACKAGE_JSON_REL_CN")"
+    echo
+fi
+
+# Update version and push if needed
+echo "Updating version..."
+if ! "${SCRIPTS_DIR}/update-version.sh" "$RELEASE_TAG"; then
+    echo "ERROR: update_version failed!"
+    exit 1
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add .
+
+# Check if there are changes to commit
+if git diff --cached --quiet; then
+    echo "Version already updated, no commit needed."
+else
+    echo "Creating version update commit..."
+    git commit -m "change(version): Update core version to $RELEASE_TAG"
+
+    echo "Pushing version update commit..."
+    git push
+    new_tag_commit=$(git rev-parse HEAD)
+    echo "New commit: $new_tag_commit"
+
+    echo "Moving tag $RELEASE_TAG to $new_tag_commit..."
+    git tag -f "$RELEASE_TAG" "$new_tag_commit"
+    git push --force origin "$RELEASE_TAG"
+
+    echo "Version commit pushed successfully!"
+fi
+
+echo "Upload complete!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,12 @@ permissions:
   contents: write
   pages: write
 
+env:
+  ENABLE_S3: false # Set to true to upload libs to S3 rather than GitHub releases
+
 jobs:
   build:
-    name: Publish Release
+    name: Build Release Package
     runs-on: ubuntu-latest
 
     steps:
@@ -26,14 +29,22 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install packaging
-        run: pip install packaging
+      - name: Install dependencies
+        run: pip install packaging pyserial
 
-      - name: Install pyserial
-        run: pip install pyserial
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        if: ${{ env.ENABLE_S3 == 'true' && vars.S3_BUCKET_NAME != '' && vars.S3_BUCKET_REGION != '' }}
+        with:
+          aws-access-key-id: ${{ secrets.S3_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.S3_BUCKET_REGION }}
 
       - name: Build Release
         env:
+          ENABLE_S3: ${{ env.ENABLE_S3 }}
+          S3_BUCKET_NAME: ${{ vars.S3_BUCKET_NAME }}
+          S3_BUCKET_REGION: ${{ vars.S3_BUCKET_REGION }}
           GITHUB_TOKEN: ${{ secrets.TOOLS_UPLOAD_PAT }}
         run: bash ./.github/scripts/on-release.sh
 
@@ -43,6 +54,75 @@ jobs:
           name: hosted
           if-no-files-found: ignore
           path: ${{ github.workspace }}/hosted
+
+      - name: Upload build JSONs for testing
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: build-output
+          path: ${{ github.workspace }}/build
+          if-no-files-found: error
+
+  test-package:
+    name: Test Package on ${{ matrix.os }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ secrets.TOOLS_UPLOAD_PAT }}
+          ref: ${{ github.event.release.target_commitish }}
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
+        with:
+          python-version: "3.x"
+
+      - name: Install pyserial
+        run: pip install pyserial
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: build-output
+          path: ${{ github.workspace }}/build
+
+      - name: Test package installation
+        env:
+          RELEASE_PRE: ${{ github.event.release.prerelease }}
+        run: bash ./.github/scripts/test-package-json.sh
+
+  upload-and-finalize:
+    name: Upload Package JSONs and Finalize Release
+    needs: [build, test-package]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ secrets.TOOLS_UPLOAD_PAT }}
+          ref: ${{ github.event.release.target_commitish }}
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: build-output
+          path: ${{ github.workspace }}/build
+
+      - name: Upload package JSONs to release and GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOOLS_UPLOAD_PAT }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRE: ${{ github.event.release.prerelease }}
+          RELEASE_ID: ${{ github.event.release.id }}
+        run: bash ./.github/scripts/upload-release-assets.sh
 
   upload-hosted-binaries:
     name: Upload hosted binaries


### PR DESCRIPTION
## Description of Change

This pull request significantly refactors and improves the GitHub Actions release scripts for the ESP32 Arduino core. The main focus is on modularizing shared logic, supporting per-SoC (System on Chip) library packaging and publishing, and enhancing the maintainability and flexibility of the release process. The changes introduce a new shared library for GitHub release functions, update the release workflow to generate and upload per-SoC library ZIPs, and streamline the JSON package generation and upload steps.

**Key changes:**

### Modularization and Shared Logic

- Introduced a new shared script, `lib-github-release.sh`, containing reusable functions for file size calculation, asset uploading, and GitHub Pages publishing. This reduces code duplication and centralizes maintenance of common release logic. (`.github/scripts/lib-github-release.sh`, `.github/scripts/on-release.sh`) [[1]](diffhunk://#diff-2eb772489e9ed2cf164314b7b1c40e2c9435d2a213be0387ab47ab9b7265e30eR1-R113) [[2]](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL33-R46) [[3]](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL57-R84) [[4]](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL347-R279)

### Per-SoC Library Packaging and Publishing

- Added support for building and uploading per-SoC library ZIPs for all supported SoC variants, using the new `CORE_VARIANTS` array defined in `socs_config.sh`. Each SoC variant gets its own ZIP archive, which is uploaded either to S3 (if configured) or GitHub Releases. The package JSON template is updated to reference these per-SoC tools, improving granularity and future extensibility. (`.github/scripts/on-release.sh`, `.github/scripts/socs_config.sh`) [[1]](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL399-R443) [[2]](diffhunk://#diff-c4d6d1be0c8ffa5b57a893d3520948c0cfc84a787fdf4f4657bc83be326b2168R28-R40) [[3]](diffhunk://#diff-c4d6d1be0c8ffa5b57a893d3520948c0cfc84a787fdf4f4657bc83be326b2168R291)

### Improvements to Release and Package Generation

- Changed the package naming convention from `esp32-$RELEASE_TAG` to `esp32-core-$RELEASE_TAG` for clarity and consistency. (`.github/scripts/on-release.sh`)
- Enhanced the script logic for updating and generating package JSONs, including a new `replace_literal_skip_n` function for portable and flexible string replacement, and improved handling of download URLs for mirrors. (`.github/scripts/on-release.sh`) [[1]](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL57-R84) [[2]](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL462-R501)

### Platform File and Miscellaneous Fixes

- Updated `platform.txt` generation to use new variable references and improve compatibility with per-variant library paths. (`.github/scripts/on-release.sh`)
- Fixed script path handling in `find_all_boards.sh` for better portability. (`.github/scripts/find_all_boards.sh`)

### Workflow and Testing Adjustments

- Removed in-script arduino-cli installation and package testing, delegating these steps to the GitHub Actions workflow for better separation of concerns and reliability. The script now focuses solely on building and uploading artifacts. (`.github/scripts/on-release.sh`)

These changes collectively modernize the release process, make it easier to add new SoC variants, and improve maintainability for future development.

## Test Scenarios

CI tested in my fork and libs tested locally

https://github.com/lucasssvaz/arduino-esp32/actions/runs/20955954431

Generated JSON:

https://raw.githubusercontent.com/lucasssvaz/arduino-esp32/gh-pages/package_esp32_dev_index.json