### PR TITLE
feat(board): Add Lonely Binary S3 board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -11407,261 +11407,6 @@ lolin_s3_pro.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
-lonely_esp32s3.name=Lonely Binary ESP32S3 N16R8
-
-lonely_esp32s3.bootloader.tool=esptool_py
-lonely_esp32s3.bootloader.tool.default=esptool_py
-
-lonely_esp32s3.upload.tool=esptool_py
-lonely_esp32s3.upload.tool.default=esptool_py
-lonely_esp32s3.upload.tool.network=esp_ota
-
-lonely_esp32s3.upload.maximum_size=1310720
-lonely_esp32s3.upload.maximum_data_size=327680
-lonely_esp32s3.upload.flags=
-lonely_esp32s3.upload.extra_flags=
-lonely_esp32s3.upload.use_1200bps_touch=false
-lonely_esp32s3.upload.wait_for_upload_port=false
-
-lonely_esp32s3.serial.disableDTR=false
-lonely_esp32s3.serial.disableRTS=false
-
-lonely_esp32s3.build.tarch=xtensa
-lonely_esp32s3.build.bootloader_addr=0x0
-lonely_esp32s3.build.target=esp32s3
-lonely_esp32s3.build.mcu=esp32s3
-lonely_esp32s3.build.core=esp32
-lonely_esp32s3.build.variant=esp32s3
-lonely_esp32s3.build.board=ESP32S3_DEV
-
-lonely_esp32s3.build.usb_mode=1
-lonely_esp32s3.build.cdc_on_boot=1
-lonely_esp32s3.build.msc_on_boot=0
-lonely_esp32s3.build.dfu_on_boot=0
-lonely_esp32s3.build.f_cpu=240000000L
-lonely_esp32s3.build.flash_size=16MB
-lonely_esp32s3.build.flash_freq=80m
-lonely_esp32s3.build.flash_mode=dio
-lonely_esp32s3.build.boot=qio
-lonely_esp32s3.build.boot_freq=80m
-lonely_esp32s3.build.partitions=default
-lonely_esp32s3.build.defines=DBOARD_HAS_PSRAM
-lonely_esp32s3.build.loop_core=
-lonely_esp32s3.build.event_core=
-lonely_esp32s3.build.psram_type=opi
-lonely_esp32s3.build.memory_type={build.boot}_{build.psram_type}
-
-## IDE 2.0 Seems to not update the value
-lonely_esp32s3.menu.JTAGAdapter.default=Disabled
-lonely_esp32s3.menu.JTAGAdapter.default.build.copy_jtag_files=0
-lonely_esp32s3.menu.JTAGAdapter.builtin=Integrated USB JTAG
-lonely_esp32s3.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
-lonely_esp32s3.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
-lonely_esp32s3.menu.JTAGAdapter.external=FTDI Adapter
-lonely_esp32s3.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
-lonely_esp32s3.menu.JTAGAdapter.external.build.copy_jtag_files=1
-lonely_esp32s3.menu.JTAGAdapter.bridge=ESP USB Bridge
-lonely_esp32s3.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
-lonely_esp32s3.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
-
-lonely_esp32s3.menu.PSRAM.opi=OPI PSRAM
-lonely_esp32s3.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
-lonely_esp32s3.menu.PSRAM.opi.build.psram_type=opi
-lonely_esp32s3.menu.PSRAM.qspi=QSPI PSRAM
-lonely_esp32s3.menu.PSRAM.qspi.build.defines=-DBOARD_HAS_PSRAM
-lonely_esp32s3.menu.PSRAM.qspi.build.psram_type=qspi
-lonely_esp32s3.menu.PSRAM.disabled=Disabled
-lonely_esp32s3.menu.PSRAM.disabled.build.defines=
-lonely_esp32s3.menu.PSRAM.disabled.build.psram_type=qspi
-
-lonely_esp32s3.menu.FlashMode.qio=QIO 80MHz
-lonely_esp32s3.menu.FlashMode.qio.build.flash_mode=dio
-lonely_esp32s3.menu.FlashMode.qio.build.boot=qio
-lonely_esp32s3.menu.FlashMode.qio.build.boot_freq=80m
-lonely_esp32s3.menu.FlashMode.qio.build.flash_freq=80m
-lonely_esp32s3.menu.FlashMode.qio120=QIO 120MHz
-lonely_esp32s3.menu.FlashMode.qio120.build.flash_mode=dio
-lonely_esp32s3.menu.FlashMode.qio120.build.boot=qio
-lonely_esp32s3.menu.FlashMode.qio120.build.boot_freq=120m
-lonely_esp32s3.menu.FlashMode.qio120.build.flash_freq=80m
-lonely_esp32s3.menu.FlashMode.dio=DIO 80MHz
-lonely_esp32s3.menu.FlashMode.dio.build.flash_mode=dio
-lonely_esp32s3.menu.FlashMode.dio.build.boot=dio
-lonely_esp32s3.menu.FlashMode.dio.build.boot_freq=80m
-lonely_esp32s3.menu.FlashMode.dio.build.flash_freq=80m
-lonely_esp32s3.menu.FlashMode.opi=OPI 80MHz
-lonely_esp32s3.menu.FlashMode.opi.build.flash_mode=dout
-lonely_esp32s3.menu.FlashMode.opi.build.boot=opi
-lonely_esp32s3.menu.FlashMode.opi.build.boot_freq=80m
-lonely_esp32s3.menu.FlashMode.opi.build.flash_freq=80m
-
-lonely_esp32s3.menu.FlashSize.16M=16MB (128Mb)
-lonely_esp32s3.menu.FlashSize.16M.build.flash_size=16MB
-lonely_esp32s3.menu.FlashSize.4M=4MB (32Mb)
-lonely_esp32s3.menu.FlashSize.4M.build.flash_size=4MB
-lonely_esp32s3.menu.FlashSize.8M=8MB (64Mb)
-lonely_esp32s3.menu.FlashSize.8M.build.flash_size=8MB
-lonely_esp32s3.menu.FlashSize.32M=32MB (256Mb)
-lonely_esp32s3.menu.FlashSize.32M.build.flash_size=32MB
-
-lonely_esp32s3.menu.LoopCore.1=Core 1
-lonely_esp32s3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
-lonely_esp32s3.menu.LoopCore.0=Core 0
-lonely_esp32s3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
-
-lonely_esp32s3.menu.EventsCore.1=Core 1
-lonely_esp32s3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
-lonely_esp32s3.menu.EventsCore.0=Core 0
-lonely_esp32s3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
-
-lonely_esp32s3.menu.USBMode.hwcdc=Hardware CDC and JTAG
-lonely_esp32s3.menu.USBMode.hwcdc.build.usb_mode=1
-lonely_esp32s3.menu.USBMode.default=USB-OTG (TinyUSB)
-lonely_esp32s3.menu.USBMode.default.build.usb_mode=0
-
-lonely_esp32s3.menu.CDCOnBoot.default=Enabled
-lonely_esp32s3.menu.CDCOnBoot.default.build.cdc_on_boot=1
-lonely_esp32s3.menu.CDCOnBoot.cdc=Disabled
-lonely_esp32s3.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
-
-lonely_esp32s3.menu.MSCOnBoot.default=Disabled
-lonely_esp32s3.menu.MSCOnBoot.default.build.msc_on_boot=0
-lonely_esp32s3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
-lonely_esp32s3.menu.MSCOnBoot.msc.build.msc_on_boot=1
-
-lonely_esp32s3.menu.DFUOnBoot.default=Disabled
-lonely_esp32s3.menu.DFUOnBoot.default.build.dfu_on_boot=0
-lonely_esp32s3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
-lonely_esp32s3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
-
-lonely_esp32s3.menu.UploadMode.default=UART0 / Hardware CDC
-lonely_esp32s3.menu.UploadMode.default.upload.use_1200bps_touch=false
-lonely_esp32s3.menu.UploadMode.default.upload.wait_for_upload_port=false
-lonely_esp32s3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
-lonely_esp32s3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
-lonely_esp32s3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
-
-lonely_esp32s3.menu.PartitionScheme.default=16M Flash (3MB APP/9.9MB FATFS)
-lonely_esp32s3.menu.PartitionScheme.default.build.partitions=default
-lonely_esp32s3.menu.PartitionScheme.default.upload.maximum_size=3145728
-lonely_esp32s3.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
-lonely_esp32s3.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
-lonely_esp32s3.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
-lonely_esp32s3.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
-lonely_esp32s3.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
-lonely_esp32s3.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
-lonely_esp32s3.menu.PartitionScheme.minimal.build.partitions=minimal
-lonely_esp32s3.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
-lonely_esp32s3.menu.PartitionScheme.no_fs.build.partitions=no_fs
-lonely_esp32s3.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
-lonely_esp32s3.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
-lonely_esp32s3.menu.PartitionScheme.no_ota.build.partitions=no_ota
-lonely_esp32s3.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
-lonely_esp32s3.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
-lonely_esp32s3.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
-lonely_esp32s3.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
-lonely_esp32s3.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
-lonely_esp32s3.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
-lonely_esp32s3.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
-lonely_esp32s3.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
-lonely_esp32s3.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
-lonely_esp32s3.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
-lonely_esp32s3.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
-lonely_esp32s3.menu.PartitionScheme.huge_app.build.partitions=huge_app
-lonely_esp32s3.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
-lonely_esp32s3.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
-lonely_esp32s3.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
-lonely_esp32s3.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
-lonely_esp32s3.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
-lonely_esp32s3.menu.PartitionScheme.fatflash.build.partitions=ffat
-lonely_esp32s3.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
-lonely_esp32s3.menu.PartitionScheme.rainmaker=RainMaker 4MB
-lonely_esp32s3.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
-lonely_esp32s3.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
-lonely_esp32s3.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
-lonely_esp32s3.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
-lonely_esp32s3.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
-lonely_esp32s3.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
-lonely_esp32s3.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
-lonely_esp32s3.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
-lonely_esp32s3.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
-lonely_esp32s3.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
-lonely_esp32s3.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
-lonely_esp32s3.menu.PartitionScheme.app5M_little24M_32MB=32M Flash (4.8MB APP/22MB LittleFS)
-lonely_esp32s3.menu.PartitionScheme.app5M_little24M_32MB.build.partitions=large_littlefs_32MB
-lonely_esp32s3.menu.PartitionScheme.app5M_little24M_32MB.upload.maximum_size=4718592
-lonely_esp32s3.menu.PartitionScheme.app13M_data7M_32MB=32M Flash (13MB APP/6.75MB SPIFFS)
-lonely_esp32s3.menu.PartitionScheme.app13M_data7M_32MB.build.partitions=default_32MB
-lonely_esp32s3.menu.PartitionScheme.app13M_data7M_32MB.upload.maximum_size=13107200
-lonely_esp32s3.menu.PartitionScheme.esp_sr_16=ESP SR 16M (3MB APP/7MB SPIFFS/2.9MB MODEL)
-lonely_esp32s3.menu.PartitionScheme.esp_sr_16.upload.maximum_size=3145728
-lonely_esp32s3.menu.PartitionScheme.esp_sr_16.upload.extra_flags=0xD10000 {build.path}/srmodels.bin
-lonely_esp32s3.menu.PartitionScheme.esp_sr_16.build.partitions=esp_sr_16
-esp32s3.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
-esp32s3.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
-esp32s3.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
-esp32s3.menu.PartitionScheme.zigbee_zczr_8MB=Zigbee ZCZR 8MB with spiffs
-esp32s3.menu.PartitionScheme.zigbee_zczr_8MB.build.partitions=zigbee_zczr_8MB
-esp32s3.menu.PartitionScheme.zigbee_zczr_8MB.upload.maximum_size=3407872
-lonely_esp32s3.menu.PartitionScheme.custom=Custom
-lonely_esp32s3.menu.PartitionScheme.custom.build.partitions=
-lonely_esp32s3.menu.PartitionScheme.custom.upload.maximum_size=16777216
-
-lonely_esp32s3.menu.CPUFreq.240=240MHz (WiFi)
-lonely_esp32s3.menu.CPUFreq.240.build.f_cpu=240000000L
-lonely_esp32s3.menu.CPUFreq.160=160MHz (WiFi)
-lonely_esp32s3.menu.CPUFreq.160.build.f_cpu=160000000L
-lonely_esp32s3.menu.CPUFreq.80=80MHz (WiFi)
-lonely_esp32s3.menu.CPUFreq.80.build.f_cpu=80000000L
-lonely_esp32s3.menu.CPUFreq.40=40MHz
-lonely_esp32s3.menu.CPUFreq.40.build.f_cpu=40000000L
-lonely_esp32s3.menu.CPUFreq.20=20MHz
-lonely_esp32s3.menu.CPUFreq.20.build.f_cpu=20000000L
-lonely_esp32s3.menu.CPUFreq.10=10MHz
-lonely_esp32s3.menu.CPUFreq.10.build.f_cpu=10000000L
-
-lonely_esp32s3.menu.UploadSpeed.921600=921600
-lonely_esp32s3.menu.UploadSpeed.921600.upload.speed=921600
-lonely_esp32s3.menu.UploadSpeed.115200=115200
-lonely_esp32s3.menu.UploadSpeed.115200.upload.speed=115200
-lonely_esp32s3.menu.UploadSpeed.256000.windows=256000
-lonely_esp32s3.menu.UploadSpeed.256000.upload.speed=256000
-lonely_esp32s3.menu.UploadSpeed.230400.windows.upload.speed=256000
-lonely_esp32s3.menu.UploadSpeed.230400=230400
-lonely_esp32s3.menu.UploadSpeed.230400.upload.speed=230400
-lonely_esp32s3.menu.UploadSpeed.460800.linux=460800
-lonely_esp32s3.menu.UploadSpeed.460800.macosx=460800
-lonely_esp32s3.menu.UploadSpeed.460800.upload.speed=460800
-lonely_esp32s3.menu.UploadSpeed.512000.windows=512000
-lonely_esp32s3.menu.UploadSpeed.512000.upload.speed=512000
-
-lonely_esp32s3.menu.DebugLevel.none=None
-lonely_esp32s3.menu.DebugLevel.none.build.code_debug=0
-lonely_esp32s3.menu.DebugLevel.error=Error
-lonely_esp32s3.menu.DebugLevel.error.build.code_debug=1
-lonely_esp32s3.menu.DebugLevel.warn=Warn
-lonely_esp32s3.menu.DebugLevel.warn.build.code_debug=2
-lonely_esp32s3.menu.DebugLevel.info=Info
-lonely_esp32s3.menu.DebugLevel.info.build.code_debug=3
-lonely_esp32s3.menu.DebugLevel.debug=Debug
-lonely_esp32s3.menu.DebugLevel.debug.build.code_debug=4
-lonely_esp32s3.menu.DebugLevel.verbose=Verbose
-lonely_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
-
-lonely_esp32s3.menu.EraseFlash.none=Disabled
-lonely_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
-lonely_esp32s3.menu.EraseFlash.all=Enabled
-lonely_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
-
-lonely_esp32s3.menu.ZigbeeMode.default=Disabled
-lonely_esp32s3.menu.ZigbeeMode.default.build.zigbee_mode=
-lonely_esp32s3.menu.ZigbeeMode.default.build.zigbee_libs=
-lonely_esp32s3.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
-lonely_esp32s3.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
-lonely_esp32s3.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
-
-##############################################################
-
 lolin32.name=WEMOS LOLIN32
 
 lolin32.bootloader.tool=esptool_py
@@ -54628,5 +54373,195 @@ arduino_nesso_n1.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api.ed -lzboss_st
 arduino_nesso_n1.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
 arduino_nesso_n1.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 arduino_nesso_n1.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
+
+##############################################################
+
+lonely_esp32s3.name=Lonely Binary ESP32S3 N16R8
+
+lonely_esp32s3.bootloader.tool=esptool_py
+lonely_esp32s3.bootloader.tool.default=esptool_py
+
+lonely_esp32s3.upload.tool=esptool_py
+lonely_esp32s3.upload.tool.default=esptool_py
+lonely_esp32s3.upload.tool.network=esp_ota
+
+lonely_esp32s3.upload.maximum_size=1310720
+lonely_esp32s3.upload.maximum_data_size=327680
+lonely_esp32s3.upload.flags=
+lonely_esp32s3.upload.extra_flags=
+lonely_esp32s3.upload.use_1200bps_touch=false
+lonely_esp32s3.upload.wait_for_upload_port=false
+
+lonely_esp32s3.serial.disableDTR=false
+lonely_esp32s3.serial.disableRTS=false
+
+lonely_esp32s3.build.tarch=xtensa
+lonely_esp32s3.build.bootloader_addr=0x0
+lonely_esp32s3.build.target=esp32s3
+lonely_esp32s3.build.mcu=esp32s3
+lonely_esp32s3.build.core=esp32
+lonely_esp32s3.build.variant=esp32s3
+lonely_esp32s3.build.board=ESP32S3_DEV
+
+lonely_esp32s3.build.usb_mode=1
+lonely_esp32s3.build.cdc_on_boot=1
+lonely_esp32s3.build.msc_on_boot=0
+lonely_esp32s3.build.dfu_on_boot=0
+lonely_esp32s3.build.f_cpu=240000000L
+lonely_esp32s3.build.flash_size=16MB
+lonely_esp32s3.build.flash_freq=80m
+lonely_esp32s3.build.flash_mode=dio
+lonely_esp32s3.build.boot=qio
+lonely_esp32s3.build.boot_freq=80m
+lonely_esp32s3.build.partitions=default
+lonely_esp32s3.build.defines=DBOARD_HAS_PSRAM
+lonely_esp32s3.build.loop_core=
+lonely_esp32s3.build.event_core=
+lonely_esp32s3.build.psram_type=opi
+lonely_esp32s3.build.memory_type={build.boot}_{build.psram_type}
+
+## IDE 2.0 Seems to not update the value
+lonely_esp32s3.menu.JTAGAdapter.default=Disabled
+lonely_esp32s3.menu.JTAGAdapter.default.build.copy_jtag_files=0
+lonely_esp32s3.menu.JTAGAdapter.builtin=Integrated USB JTAG
+lonely_esp32s3.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
+lonely_esp32s3.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+lonely_esp32s3.menu.JTAGAdapter.external=FTDI Adapter
+lonely_esp32s3.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+lonely_esp32s3.menu.JTAGAdapter.external.build.copy_jtag_files=1
+lonely_esp32s3.menu.JTAGAdapter.bridge=ESP USB Bridge
+lonely_esp32s3.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+lonely_esp32s3.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+lonely_esp32s3.menu.PSRAM.opi=OPI PSRAM
+lonely_esp32s3.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+lonely_esp32s3.menu.PSRAM.opi.build.psram_type=opi
+lonely_esp32s3.menu.PSRAM.disabled=Disabled
+lonely_esp32s3.menu.PSRAM.disabled.build.defines=
+lonely_esp32s3.menu.PSRAM.disabled.build.psram_type=qspi
+
+lonely_esp32s3.menu.FlashMode.qio=QIO 80MHz
+lonely_esp32s3.menu.FlashMode.qio.build.flash_mode=dio
+lonely_esp32s3.menu.FlashMode.qio.build.boot=qio
+lonely_esp32s3.menu.FlashMode.qio.build.boot_freq=80m
+lonely_esp32s3.menu.FlashMode.qio.build.flash_freq=80m
+lonely_esp32s3.menu.FlashMode.qio120=QIO 120MHz
+lonely_esp32s3.menu.FlashMode.qio120.build.flash_mode=dio
+lonely_esp32s3.menu.FlashMode.qio120.build.boot=qio
+lonely_esp32s3.menu.FlashMode.qio120.build.boot_freq=120m
+lonely_esp32s3.menu.FlashMode.qio120.build.flash_freq=80m
+lonely_esp32s3.menu.FlashMode.dio=DIO 80MHz
+lonely_esp32s3.menu.FlashMode.dio.build.flash_mode=dio
+lonely_esp32s3.menu.FlashMode.dio.build.boot=dio
+lonely_esp32s3.menu.FlashMode.dio.build.boot_freq=80m
+lonely_esp32s3.menu.FlashMode.dio.build.flash_freq=80m
+lonely_esp32s3.menu.FlashMode.opi=OPI 80MHz
+lonely_esp32s3.menu.FlashMode.opi.build.flash_mode=dout
+lonely_esp32s3.menu.FlashMode.opi.build.boot=opi
+lonely_esp32s3.menu.FlashMode.opi.build.boot_freq=80m
+lonely_esp32s3.menu.FlashMode.opi.build.flash_freq=80m
+
+lonely_esp32s3.menu.FlashSize.16M=16MB (128Mb)
+lonely_esp32s3.menu.FlashSize.16M.build.flash_size=16MB
+lonely_esp32s3.menu.FlashSize.4M=4MB (32Mb)
+lonely_esp32s3.menu.FlashSize.4M.build.flash_size=4MB
+lonely_esp32s3.menu.FlashSize.8M=8MB (64Mb)
+lonely_esp32s3.menu.FlashSize.8M.build.flash_size=8MB
+lonely_esp32s3.menu.FlashSize.32M=32MB (256Mb)
+lonely_esp32s3.menu.FlashSize.32M.build.flash_size=32MB
+
+lonely_esp32s3.menu.LoopCore.1=Core 1
+lonely_esp32s3.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+lonely_esp32s3.menu.LoopCore.0=Core 0
+lonely_esp32s3.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+lonely_esp32s3.menu.EventsCore.1=Core 1
+lonely_esp32s3.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+lonely_esp32s3.menu.EventsCore.0=Core 0
+lonely_esp32s3.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+lonely_esp32s3.menu.USBMode.hwcdc=Hardware CDC and JTAG
+lonely_esp32s3.menu.USBMode.hwcdc.build.usb_mode=1
+lonely_esp32s3.menu.USBMode.default=USB-OTG (TinyUSB)
+lonely_esp32s3.menu.USBMode.default.build.usb_mode=0
+
+lonely_esp32s3.menu.CDCOnBoot.default=Enabled
+lonely_esp32s3.menu.CDCOnBoot.default.build.cdc_on_boot=1
+lonely_esp32s3.menu.CDCOnBoot.cdc=Disabled
+lonely_esp32s3.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+lonely_esp32s3.menu.MSCOnBoot.default=Disabled
+lonely_esp32s3.menu.MSCOnBoot.default.build.msc_on_boot=0
+lonely_esp32s3.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+lonely_esp32s3.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+lonely_esp32s3.menu.DFUOnBoot.default=Disabled
+lonely_esp32s3.menu.DFUOnBoot.default.build.dfu_on_boot=0
+lonely_esp32s3.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+lonely_esp32s3.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+lonely_esp32s3.menu.UploadMode.default=UART0 / Hardware CDC
+lonely_esp32s3.menu.UploadMode.default.upload.use_1200bps_touch=false
+lonely_esp32s3.menu.UploadMode.default.upload.wait_for_upload_port=false
+lonely_esp32s3.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+lonely_esp32s3.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+lonely_esp32s3.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+lonely_esp32s3.menu.PartitionScheme.default=16M Flash (3MB APP/9.9MB FATFS)
+lonely_esp32s3.menu.PartitionScheme.default.build.partitions=default
+lonely_esp32s3.menu.PartitionScheme.default.upload.maximum_size=3145728
+
+lonely_esp32s3.menu.CPUFreq.240=240MHz (WiFi)
+lonely_esp32s3.menu.CPUFreq.240.build.f_cpu=240000000L
+lonely_esp32s3.menu.CPUFreq.160=160MHz (WiFi)
+lonely_esp32s3.menu.CPUFreq.160.build.f_cpu=160000000L
+lonely_esp32s3.menu.CPUFreq.80=80MHz (WiFi)
+lonely_esp32s3.menu.CPUFreq.80.build.f_cpu=80000000L
+lonely_esp32s3.menu.CPUFreq.40=40MHz
+lonely_esp32s3.menu.CPUFreq.40.build.f_cpu=40000000L
+lonely_esp32s3.menu.CPUFreq.20=20MHz
+lonely_esp32s3.menu.CPUFreq.20.build.f_cpu=20000000L
+lonely_esp32s3.menu.CPUFreq.10=10MHz
+lonely_esp32s3.menu.CPUFreq.10.build.f_cpu=10000000L
+
+lonely_esp32s3.menu.UploadSpeed.921600=921600
+lonely_esp32s3.menu.UploadSpeed.921600.upload.speed=921600
+lonely_esp32s3.menu.UploadSpeed.115200=115200
+lonely_esp32s3.menu.UploadSpeed.115200.upload.speed=115200
+lonely_esp32s3.menu.UploadSpeed.256000.windows=256000
+lonely_esp32s3.menu.UploadSpeed.256000.upload.speed=256000
+lonely_esp32s3.menu.UploadSpeed.230400.windows.upload.speed=256000
+lonely_esp32s3.menu.UploadSpeed.230400=230400
+lonely_esp32s3.menu.UploadSpeed.230400.upload.speed=230400
+lonely_esp32s3.menu.UploadSpeed.460800.linux=460800
+lonely_esp32s3.menu.UploadSpeed.460800.macosx=460800
+lonely_esp32s3.menu.UploadSpeed.460800.upload.speed=460800
+lonely_esp32s3.menu.UploadSpeed.512000.windows=512000
+lonely_esp32s3.menu.UploadSpeed.512000.upload.speed=512000
+
+lonely_esp32s3.menu.DebugLevel.none=None
+lonely_esp32s3.menu.DebugLevel.none.build.code_debug=0
+lonely_esp32s3.menu.DebugLevel.error=Error
+lonely_esp32s3.menu.DebugLevel.error.build.code_debug=1
+lonely_esp32s3.menu.DebugLevel.warn=Warn
+lonely_esp32s3.menu.DebugLevel.warn.build.code_debug=2
+lonely_esp32s3.menu.DebugLevel.info=Info
+lonely_esp32s3.menu.DebugLevel.info.build.code_debug=3
+lonely_esp32s3.menu.DebugLevel.debug=Debug
+lonely_esp32s3.menu.DebugLevel.debug.build.code_debug=4
+lonely_esp32s3.menu.DebugLevel.verbose=Verbose
+lonely_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
+
+lonely_esp32s3.menu.EraseFlash.none=Disabled
+lonely_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
+lonely_esp32s3.menu.EraseFlash.all=Enabled
+lonely_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
+
+lonely_esp32s3.menu.ZigbeeMode.default=Disabled
+lonely_esp32s3.menu.ZigbeeMode.default.build.zigbee_mode=
+lonely_esp32s3.menu.ZigbeeMode.default.build.zigbee_libs=
+lonely_esp32s3.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
+lonely_esp32s3.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+lonely_esp32s3.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
 
 ##############################################################


### PR DESCRIPTION
Added board to boards.txt for Lonely Binary S3 N16R8

-----------
## Description of Change
Added the Lonely Binary ESP32S3 N16R8 board to boards.txt. This makes it easier for those with this board to not have to set each individual setting every time they open Arduino IDE.

## Test Scenarios
I have tested my pull request using arduino-esp32 version 3.3.5 and Arduino IDE 2.3.7 using the aforementioned Lonely Binary ESP32S3 N16R8 board. I successfully tested Wi-Fi, Bluetooth, RGBW LED, and GPIO / etc. using Blink, FastLED, Beacon_Scanner, WifiAccessPoint, and SerialPassthrough. All test scenarios compiled and uploaded with no issues and ran fine on the board.

## Related links

[Manufacturer Arduino IDE Information](https://lonelybinary.com/en-us/blogs/esp32-family-getting-started-guide/02_05_arduino-setup-guide)
[Board Information](https://lonelybinary.com/en-us/collections/development-board/products/s3?variant=43784065712285)