### PR TITLE
feat(hosted): Update and enhance logging of esp-hosted

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -109,7 +109,7 @@ dependencies:
     rules:
       - if: "target in [esp32s3, esp32p4]"
   espressif/esp_hosted:
-    version: "^2.8.0"
+    version: "^2.9.2"
     rules:
       - if: "target == esp32p4"
   espressif/esp_wifi_remote:

--- a/libraries/ESP_HostedOTA/src/ESP_HostedOTA.cpp
+++ b/libraries/ESP_HostedOTA/src/ESP_HostedOTA.cpp
@@ -73,6 +73,7 @@ bool updateEspHostedSlave() {
     NetworkClient *stream = https.getStreamPtr();
 
     // Step 11: Initialize the ESP-Hosted update process
+    Serial.println("Beginning update process...");
     if (!hostedBeginUpdate()) {
       Serial.println("ERROR: esp-hosted update start failed!");
       https.end();
@@ -118,21 +119,24 @@ bool updateEspHostedSlave() {
 
         // Step 14: Check if entire firmware has been downloaded
         if (len == 0) {
+          Serial.println();
           // Finalize the update process
+          Serial.println("Finalizing update process...");
           if (!hostedEndUpdate()) {
-            Serial.println("\nERROR: esp-hosted update end failed!");
+            Serial.println("ERROR: esp-hosted update end failed!");
             break;
           }
 
           // Activate the new firmware
+          Serial.println("Activating new firmware...");
           if (!hostedActivateUpdate()) {
-            Serial.println("\nERROR: esp-hosted update activate failed!");
+            Serial.println("ERROR: esp-hosted update activate failed!");
             break;
           }
 
           // Update completed successfully
           updateSuccess = true;
-          Serial.println("\nSUCCESS: esp-hosted co-processor updated!");
+          Serial.println("SUCCESS: esp-hosted co-processor updated!");
           break;
         }
       }


### PR DESCRIPTION
This pull request introduces a minor dependency update and improves the logging output during the ESP-Hosted OTA update process to provide clearer status information.

Dependency update:

* Updated the `espressif/esp_hosted` dependency version from `^2.8.0` to `^2.9.2` in `idf_component.yml`, ensuring the project uses the latest compatible release.

Logging improvements in OTA update:

* Added and enhanced `Serial.println` statements in `ESP_HostedOTA.cpp` to provide clearer feedback during the update process, including messages for beginning the update, finalizing, activating new firmware, and reporting success or errors. [[1]](diffhunk://#diff-50345d024e2cd71e6dddcf6590f89efff48e0eb4b34d5ae0e6ed96dec1b6a2c2R76) [[2]](diffhunk://#diff-50345d024e2cd71e6dddcf6590f89efff48e0eb4b34d5ae0e6ed96dec1b6a2c2R122-R139)