### PR TITLE
feat(udp): Allow for packets up to 1460 bytes

### DIFF
--- a/libraries/AsyncUDP/src/AsyncUDP.cpp
+++ b/libraries/AsyncUDP/src/AsyncUDP.cpp
@@ -15,6 +15,8 @@ extern "C" {
 
 #include "lwip/priv/tcpip_priv.h"
 
+#define CONFIG_UDP_MSS 1460
+
 #ifndef CONFIG_ARDUINO_UDP_TASK_STACK_SIZE
 #define CONFIG_ARDUINO_UDP_TASK_STACK_SIZE 4096
 #endif
@@ -273,8 +275,8 @@ static bool _udp_task_stop(){
 
 AsyncUDPMessage::AsyncUDPMessage(size_t size) {
   _index = 0;
-  if (size > CONFIG_TCP_MSS) {
-    size = CONFIG_TCP_MSS;
+  if (size > CONFIG_UDP_MSS) {
+    size = CONFIG_UDP_MSS;
   }
   _size = size;
   _buffer = (uint8_t *)malloc(size);
@@ -764,8 +766,8 @@ size_t AsyncUDP::writeTo(const uint8_t *data, size_t len, const ip_addr_t *addr,
       return 0;
     }
   }
-  if (len > CONFIG_TCP_MSS) {
-    len = CONFIG_TCP_MSS;
+  if (len > CONFIG_UDP_MSS) {
+    len = CONFIG_UDP_MSS;
   }
   _lastErr = ERR_OK;
   pbuf *pbt = pbuf_alloc(PBUF_TRANSPORT, len, PBUF_RAM);


### PR DESCRIPTION
This pull request updates the maximum segment size configuration for UDP operations in the `AsyncUDP.cpp` file. The changes ensure that UDP-related buffer allocations and data transmissions use the correct maximum segment size constant, improving protocol correctness and maintainability.

Configuration updates:

* Added a new constant definition for `CONFIG_UDP_MSS` set to 1460 to specify the maximum segment size for UDP.
* Updated buffer allocation logic in the `AsyncUDPMessage` constructor to use `CONFIG_UDP_MSS` instead of `CONFIG_TCP_MSS`, ensuring UDP messages do not exceed the appropriate segment size.
* Modified the `AsyncUDP::writeTo` method to use `CONFIG_UDP_MSS` for limiting the length of outgoing UDP packets, replacing the previous use of `CONFIG_TCP_MSS`.

Fixes: https://github.com/espressif/arduino-esp32/issues/12162