### PR TITLE
fix(net): Allow setting custom base MAC on ESP32

### DIFF
--- a/libraries/Network/src/NetworkManager.cpp
+++ b/libraries/Network/src/NetworkManager.cpp
@@ -20,7 +20,7 @@ bool NetworkManager::begin() {
     initialized = true;
 #if CONFIG_IDF_TARGET_ESP32
     uint8_t mac[8];
-    if (esp_efuse_mac_get_default(mac) == ESP_OK) {
+    if (esp_base_mac_addr_get(mac) != ESP_OK && esp_efuse_mac_get_default(mac) == ESP_OK) {
       esp_base_mac_addr_set(mac);
     }
 #endif


### PR DESCRIPTION
This pull request updates the logic for initializing the MAC address in the `NetworkManager::begin()` method to ensure the base MAC address is set only if it hasn't already been set. This helps prevent unnecessary re-setting of the MAC address and improves reliability on ESP32 devices.

- **Network initialization improvement:**
  * Updated the MAC address initialization logic in `NetworkManager::begin()` to first check if the base MAC address is already set using `esp_base_mac_addr_get()`. Only if it isn't set, the code then retrieves the default MAC from eFUSE and sets it with `esp_base_mac_addr_set()`.

Fixes: https://github.com/espressif/arduino-esp32/issues/12180