### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-9bb7aa84-v2"
+              "version": "idf-release_v5.5-f56bea3d-v2"
             },
             {
               "packager": "esp32",
@@ -79,7 +79,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20250707"
+              "version": "v0.12.0-esp32-20251215"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-9bb7aa84-v2",
+          "version": "idf-release_v5.5-f56bea3d-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-9bb7aa84-v2.zip",
-              "checksum": "SHA-256:a404a45e2251f3647137970bc7366e60e1b9536c59268df5612f289ca5b2080a",
-              "size": "509488664"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-f56bea3d-v2.zip",
+              "checksum": "SHA-256:6f050fdf78125c41eb6b59bbb6083226243e48e62d7121b4b9d1efdb3cb0d96e",
+              "size": "510993611"
             }
           ]
         },
@@ -417,56 +417,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20250707",
+          "version": "v0.12.0-esp32-20251215",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-linux-amd64-0.12.0-esp32-20250707.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250707.tar.gz",
-              "checksum": "SHA-256:766293bd7a08900d3536f87a0a7ade960f07266f16e4147f95ca5ce4e15d4c5d",
-              "size": "2489724"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-linux-amd64-0.12.0-esp32-20251215.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20251215.tar.gz",
+              "checksum": "SHA-256:5e6ff40aeca23bdd203cde04d60bc808c0e6bff110eadcbce3d602618c880531",
+              "size": "2547606"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-linux-arm64-0.12.0-esp32-20250707.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250707.tar.gz",
-              "checksum": "SHA-256:34b6883c372444b49950893b2fc0101aefd10d404a88ef72c97e80199f8544d3",
-              "size": "2371243"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-linux-arm64-0.12.0-esp32-20251215.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20251215.tar.gz",
+              "checksum": "SHA-256:29f98e2f90cd37924b714562b876a471d444a8f2aec428c6760e82bbf3b54cca",
+              "size": "2399117"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-linux-armel-0.12.0-esp32-20250707.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250707.tar.gz",
-              "checksum": "SHA-256:fd48492cf3ee16577c661fdccc14c349d34a9ab93aac5039ddf72332d4f4b70b",
-              "size": "2517680"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-linux-armel-0.12.0-esp32-20251215.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20251215.tar.gz",
+              "checksum": "SHA-256:25de2b2dd0f5b437f5d5540c505eb9d0fbb971256ab13acd19642f8acdbd5cee",
+              "size": "2554256"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-macos-0.12.0-esp32-20250707.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250707.tar.gz",
-              "checksum": "SHA-256:6267be53892a76d535938a1b044b685adc7d292f090447e8a3e3d0f0996474d1",
-              "size": "2585348"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-macos-0.12.0-esp32-20251215.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20251215.tar.gz",
+              "checksum": "SHA-256:956dd02ccf35116d565be2b148e041bd47c135e551a1f5097eae756d7d4dd079",
+              "size": "2710467"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-macos-arm64-0.12.0-esp32-20250707.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250707.tar.gz",
-              "checksum": "SHA-256:150e938ac48a6ee031ddbc8b31043bc7f2073ab2ee4896b658918d35899673c3",
-              "size": "2628741"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-macos-arm64-0.12.0-esp32-20251215.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20251215.tar.gz",
+              "checksum": "SHA-256:e6414c8db2ab09b687eaf765b1e69a92aecdcfe44e073d6f47ff829777e2e823",
+              "size": "2535504"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-win32-0.12.0-esp32-20250707.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250707.zip",
-              "checksum": "SHA-256:666274b04af7f36b430b6d063006051c37b8635b5175735ad5af07a1fbc6f486",
-              "size": "3034680"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-win32-0.12.0-esp32-20251215.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20251215.zip",
+              "checksum": "SHA-256:032a3791c256c974bceced073dc8cf0e18c07a75f39592110cbe71fc8de914b2",
+              "size": "3109352"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250707/openocd-esp32-win64-0.12.0-esp32-20250707.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250707.zip",
-              "checksum": "SHA-256:5186ba3f7ee29fb6ab68a4ed7bb417211bad76ecdcdf9280a9187ebfd549a3c1",
-              "size": "3034680"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-win64-0.12.0-esp32-20251215.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20251215.zip",
+              "checksum": "SHA-256:d406be70d26098ced57eefcf636c4b4c184cd8c151204a459bb6ccbe4aa47eca",
+              "size": "3109355"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master dd8478c
esp-idf: release/v5.5 f56bea3d1f
arduino: master 03a6f9a8f
tinyusb: master 5e6e9e6ad
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.5
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 2.0.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.8.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~3
espressif__mdns: 1.9.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.3
espressif__dl_fft: 0.3.1
espressif__esp-sr: 2.3.0
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
espressif__eppp_link: 1.1.4
espressif__esp_hosted: 2.9.3
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 1.2.4
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__wifi_remote_over_eppp: 0.3.0
```
