### PR TITLE
Add soc_caps.h include to Adafruit FunHouse

### DIFF
--- a/variants/adafruit_funhouse_esp32s2/pins_arduino.h
+++ b/variants/adafruit_funhouse_esp32s2/pins_arduino.h
@@ -2,6 +2,7 @@
 #define Pins_Arduino_h
 
 #include <stdint.h>
+#include "soc/soc_caps.h"
 
 #define USB_VID          0x239A
 #define USB_PID          0x80F9


### PR DESCRIPTION
Looks like it was missed in https://github.com/espressif/arduino-esp32/commit/ab6a25ed8db8431f6d0464b560445ed9e0e62be6

Closes https://github.com/adafruit/Adafruit_SleepyDog/issues/57