### PR TITLE
Add support for ESP32-S3 PowerFeather V2

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -42134,6 +42134,178 @@ esp32s3_powerfeather.menu.EraseFlash.all=Enabled
 esp32s3_powerfeather.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
+# ESP32-S3 PowerFeather V2
+
+esp32s3_powerfeather_v2.name=ESP32-S3 PowerFeather V2
+esp32s3_powerfeather_v2.vid.0=0x303a
+esp32s3_powerfeather_v2.pid.0=0x81BB
+
+esp32s3_powerfeather_v2.bootloader.tool=esptool_py
+esp32s3_powerfeather_v2.bootloader.tool.default=esptool_py
+
+esp32s3_powerfeather_v2.upload.tool=esptool_py
+esp32s3_powerfeather_v2.upload.tool.default=esptool_py
+esp32s3_powerfeather_v2.upload.tool.network=esp_ota
+
+esp32s3_powerfeather_v2.upload.maximum_size=1310720
+esp32s3_powerfeather_v2.upload.maximum_data_size=327680
+esp32s3_powerfeather_v2.upload.flags=
+esp32s3_powerfeather_v2.upload.extra_flags=
+esp32s3_powerfeather_v2.upload.use_1200bps_touch=false
+esp32s3_powerfeather_v2.upload.wait_for_upload_port=false
+
+esp32s3_powerfeather_v2.serial.disableDTR=false
+esp32s3_powerfeather_v2.serial.disableRTS=false
+
+esp32s3_powerfeather_v2.build.tarch=xtensa
+esp32s3_powerfeather_v2.build.bootloader_addr=0x0
+esp32s3_powerfeather_v2.build.target=esp32s3
+esp32s3_powerfeather_v2.build.mcu=esp32s3
+esp32s3_powerfeather_v2.build.core=esp32
+esp32s3_powerfeather_v2.build.variant=esp32s3_powerfeather
+esp32s3_powerfeather_v2.build.board=ESP32S3_POWERFEATHER_V2
+
+esp32s3_powerfeather_v2.build.usb_mode=1
+esp32s3_powerfeather_v2.build.cdc_on_boot=1
+esp32s3_powerfeather_v2.build.msc_on_boot=0
+esp32s3_powerfeather_v2.build.dfu_on_boot=0
+esp32s3_powerfeather_v2.build.f_cpu=240000000L
+esp32s3_powerfeather_v2.build.flash_size=8MB
+esp32s3_powerfeather_v2.build.flash_freq=80m
+esp32s3_powerfeather_v2.build.flash_mode=dio
+esp32s3_powerfeather_v2.build.boot=qio
+esp32s3_powerfeather_v2.build.boot_freq=80m
+esp32s3_powerfeather_v2.build.partitions=default_8MB
+esp32s3_powerfeather_v2.build.defines=-DPOWERFEATHER_BOARD_V2
+esp32s3_powerfeather_v2.build.loop_core=
+esp32s3_powerfeather_v2.build.event_core=
+esp32s3_powerfeather_v2.build.flash_type=qio
+esp32s3_powerfeather_v2.build.psram_type=qspi
+esp32s3_powerfeather_v2.build.memory_type={build.flash_type}_{build.psram_type}
+
+esp32s3_powerfeather_v2.menu.PSRAM.disabled=Disabled
+esp32s3_powerfeather_v2.menu.PSRAM.disabled.build.defines=-DPOWERFEATHER_BOARD_V2
+esp32s3_powerfeather_v2.menu.PSRAM.disabled.build.psram_type=qspi
+esp32s3_powerfeather_v2.menu.PSRAM.enabled=QSPI PSRAM
+esp32s3_powerfeather_v2.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -DPOWERFEATHER_BOARD_V2
+esp32s3_powerfeather_v2.menu.PSRAM.enabled.build.psram_type=qspi
+
+esp32s3_powerfeather_v2.menu.FlashMode.qio=QIO 80MHz
+esp32s3_powerfeather_v2.menu.FlashMode.qio.build.flash_mode=dio
+esp32s3_powerfeather_v2.menu.FlashMode.qio.build.boot=qio
+esp32s3_powerfeather_v2.menu.FlashMode.qio.build.boot_freq=80m
+esp32s3_powerfeather_v2.menu.FlashMode.qio.build.flash_freq=80m
+esp32s3_powerfeather_v2.menu.FlashMode.qio120=QIO 120MHz
+esp32s3_powerfeather_v2.menu.FlashMode.qio120.build.flash_mode=dio
+esp32s3_powerfeather_v2.menu.FlashMode.qio120.build.boot=qio
+esp32s3_powerfeather_v2.menu.FlashMode.qio120.build.boot_freq=120m
+esp32s3_powerfeather_v2.menu.FlashMode.qio120.build.flash_freq=80m
+esp32s3_powerfeather_v2.menu.FlashMode.dio=DIO 80MHz
+esp32s3_powerfeather_v2.menu.FlashMode.dio.build.flash_mode=dio
+esp32s3_powerfeather_v2.menu.FlashMode.dio.build.boot=dio
+esp32s3_powerfeather_v2.menu.FlashMode.dio.build.boot_freq=80m
+esp32s3_powerfeather_v2.menu.FlashMode.dio.build.flash_freq=80m
+
+esp32s3_powerfeather_v2.menu.LoopCore.1=Core 1
+esp32s3_powerfeather_v2.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+esp32s3_powerfeather_v2.menu.LoopCore.0=Core 0
+esp32s3_powerfeather_v2.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+esp32s3_powerfeather_v2.menu.EventsCore.1=Core 1
+esp32s3_powerfeather_v2.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+esp32s3_powerfeather_v2.menu.EventsCore.0=Core 0
+esp32s3_powerfeather_v2.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+esp32s3_powerfeather_v2.menu.USBMode.hwcdc=Hardware CDC and JTAG
+esp32s3_powerfeather_v2.menu.USBMode.hwcdc.build.usb_mode=1
+esp32s3_powerfeather_v2.menu.USBMode.default=USB-OTG (TinyUSB)
+esp32s3_powerfeather_v2.menu.USBMode.default.build.usb_mode=0
+
+esp32s3_powerfeather_v2.menu.CDCOnBoot.cdc=Enabled
+esp32s3_powerfeather_v2.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+esp32s3_powerfeather_v2.menu.CDCOnBoot.default=Disabled
+esp32s3_powerfeather_v2.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+esp32s3_powerfeather_v2.menu.MSCOnBoot.default=Disabled
+esp32s3_powerfeather_v2.menu.MSCOnBoot.default.build.msc_on_boot=0
+esp32s3_powerfeather_v2.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+esp32s3_powerfeather_v2.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+esp32s3_powerfeather_v2.menu.DFUOnBoot.default=Disabled
+esp32s3_powerfeather_v2.menu.DFUOnBoot.default.build.dfu_on_boot=0
+esp32s3_powerfeather_v2.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+esp32s3_powerfeather_v2.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+esp32s3_powerfeather_v2.menu.UploadMode.default=UART0 / Hardware CDC
+esp32s3_powerfeather_v2.menu.UploadMode.default.upload.use_1200bps_touch=false
+esp32s3_powerfeather_v2.menu.UploadMode.default.upload.wait_for_upload_port=false
+esp32s3_powerfeather_v2.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+esp32s3_powerfeather_v2.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+esp32s3_powerfeather_v2.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+esp32s3_powerfeather_v2.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+esp32s3_powerfeather_v2.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32s3_powerfeather_v2.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32s3_powerfeather_v2.menu.PartitionScheme.default_ffat_8MB=8M with ffat (3MB APP/1.5MB FATFS)
+esp32s3_powerfeather_v2.menu.PartitionScheme.default_ffat_8MB.build.partitions=default_ffat_8MB
+esp32s3_powerfeather_v2.menu.PartitionScheme.default_ffat_8MB.upload.maximum_size=3342336
+esp32s3_powerfeather_v2.menu.PartitionScheme.large_spiffs_8MB=Large SPIFFS (1.2MB APP/5.3MB SPIFFS)
+esp32s3_powerfeather_v2.menu.PartitionScheme.large_spiffs_8MB.build.partitions=large_spiffs_8MB
+esp32s3_powerfeather_v2.menu.PartitionScheme.large_spiffs_8MB.upload.maximum_size=1310720
+esp32s3_powerfeather_v2.menu.PartitionScheme.large_ffat_8MB=Large FFAT (1.2MB APP/5.3MB FATFS)
+esp32s3_powerfeather_v2.menu.PartitionScheme.large_ffat_8MB.build.partitions=large_ffat_8MB
+esp32s3_powerfeather_v2.menu.PartitionScheme.large_ffat_8MB.upload.maximum_size=1310720
+esp32s3_powerfeather_v2.menu.PartitionScheme.max_app_8MB=Maximum APP (7.9MB APP No OTA/No FS)
+esp32s3_powerfeather_v2.menu.PartitionScheme.max_app_8MB.build.partitions=max_app_8MB
+esp32s3_powerfeather_v2.menu.PartitionScheme.max_app_8MB.upload.maximum_size=8257536
+
+esp32s3_powerfeather_v2.menu.CPUFreq.240=240MHz (WiFi)
+esp32s3_powerfeather_v2.menu.CPUFreq.240.build.f_cpu=240000000L
+esp32s3_powerfeather_v2.menu.CPUFreq.160=160MHz (WiFi)
+esp32s3_powerfeather_v2.menu.CPUFreq.160.build.f_cpu=160000000L
+esp32s3_powerfeather_v2.menu.CPUFreq.80=80MHz (WiFi)
+esp32s3_powerfeather_v2.menu.CPUFreq.80.build.f_cpu=80000000L
+esp32s3_powerfeather_v2.menu.CPUFreq.40=40MHz
+esp32s3_powerfeather_v2.menu.CPUFreq.40.build.f_cpu=40000000L
+esp32s3_powerfeather_v2.menu.CPUFreq.20=20MHz
+esp32s3_powerfeather_v2.menu.CPUFreq.20.build.f_cpu=20000000L
+esp32s3_powerfeather_v2.menu.CPUFreq.10=10MHz
+esp32s3_powerfeather_v2.menu.CPUFreq.10.build.f_cpu=10000000L
+
+esp32s3_powerfeather_v2.menu.UploadSpeed.921600=921600
+esp32s3_powerfeather_v2.menu.UploadSpeed.921600.upload.speed=921600
+esp32s3_powerfeather_v2.menu.UploadSpeed.115200=115200
+esp32s3_powerfeather_v2.menu.UploadSpeed.115200.upload.speed=115200
+esp32s3_powerfeather_v2.menu.UploadSpeed.256000.windows=256000
+esp32s3_powerfeather_v2.menu.UploadSpeed.256000.upload.speed=256000
+esp32s3_powerfeather_v2.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32s3_powerfeather_v2.menu.UploadSpeed.230400=230400
+esp32s3_powerfeather_v2.menu.UploadSpeed.230400.upload.speed=230400
+esp32s3_powerfeather_v2.menu.UploadSpeed.460800.linux=460800
+esp32s3_powerfeather_v2.menu.UploadSpeed.460800.macosx=460800
+esp32s3_powerfeather_v2.menu.UploadSpeed.460800.upload.speed=460800
+esp32s3_powerfeather_v2.menu.UploadSpeed.512000.windows=512000
+esp32s3_powerfeather_v2.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32s3_powerfeather_v2.menu.DebugLevel.none=None
+esp32s3_powerfeather_v2.menu.DebugLevel.none.build.code_debug=0
+esp32s3_powerfeather_v2.menu.DebugLevel.error=Error
+esp32s3_powerfeather_v2.menu.DebugLevel.error.build.code_debug=1
+esp32s3_powerfeather_v2.menu.DebugLevel.warn=Warn
+esp32s3_powerfeather_v2.menu.DebugLevel.warn.build.code_debug=2
+esp32s3_powerfeather_v2.menu.DebugLevel.info=Info
+esp32s3_powerfeather_v2.menu.DebugLevel.info.build.code_debug=3
+esp32s3_powerfeather_v2.menu.DebugLevel.debug=Debug
+esp32s3_powerfeather_v2.menu.DebugLevel.debug.build.code_debug=4
+esp32s3_powerfeather_v2.menu.DebugLevel.verbose=Verbose
+esp32s3_powerfeather_v2.menu.DebugLevel.verbose.build.code_debug=5
+
+esp32s3_powerfeather_v2.menu.EraseFlash.none=Disabled
+esp32s3_powerfeather_v2.menu.EraseFlash.none.upload.erase_cmd=
+esp32s3_powerfeather_v2.menu.EraseFlash.all=Enabled
+esp32s3_powerfeather_v2.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
 # senseBox MCU ESP32-S2
 
 sensebox_mcu_esp32s2.name=senseBox MCU-S2 ESP32-S2


### PR DESCRIPTION
## Description of Change

Adds a new `variant` directory for `esp32s3_powerfeather_v2`, under which the `pins_arduino.h` is created.
Entries for `esp32s3_powerfeather_v2` in `boards.txt` are added.

## Tests scenarios

- [ ] `pins_arduino.h` is ok
- [x] `boards.txt` entries are ok

## Related links
Website: https://www.powerfeather.dev/
Allocation for PID under Espressif VID used in this PR: https://github.com/espressif/usb-pids/pull/123

Related PRs for V1: 

https://github.com/espressif/arduino-esp32/pull/8889 
https://github.com/espressif/arduino-esp32/pull/9052
https://github.com/espressif/arduino-esp32/pull/9398

