### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-87912cd2-v2"
+              "version": "idf-release_v5.5-87912cd2-v3"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-87912cd2-v2",
+          "version": "idf-release_v5.5-87912cd2-v3",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v2.zip",
-              "checksum": "SHA-256:0756ae6b78e5ebc411867744a0c2ae597ce8fa8f66febfe66e5d6d079a6b4b06",
-              "size": "512249407"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v3.zip",
+              "checksum": "SHA-256:7a0084430695117009fdd7f180fe2995fcb82edf42287bfe3cac4425332e1dd4",
+              "size": "512249978"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master dd8478c
esp-idf: release/v5.5 0fd9f0aa93
arduino: master 411b5b190
tinyusb: master 6e891c6dc
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__dl_fft: 0.3.1
espressif__eppp_link: 1.1.4
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.2
espressif__esp-sr: 2.3.0
espressif__esp-tflite-micro: 1.3.5
espressif__esp_hosted: 2.9.6
espressif__esp_modem: 2.0.0
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 1.2.4
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__libsodium: 1.0.20~3
espressif__mdns: 1.9.1
espressif__network_provisioning: 1.0.2
espressif__wifi_remote_over_eppp: 0.3.0
joltwallet__littlefs: 1.20.3
espressif__cbor: 0.6.1~4
espressif__esp-serial-flasher: 0.0.11
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.8.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
```
