### PR TITLE
fix(example): Update GetMacddress.ino for 8 and 2 byte MACs

### DIFF
--- a/libraries/ESP32/examples/MacAddress/GetMacAddress/GetMacAddress.ino
+++ b/libraries/ESP32/examples/MacAddress/GetMacAddress/GetMacAddress.ino
@@ -72,7 +72,9 @@ String getDefaultMacAddress() {
   if (esp_efuse_mac_get_default(mac_base) == ESP_OK) {
     char buffer[24];  // 8*2 characters for hex + 7 characters for colons + 1 character for null terminator
 #ifdef CONFIG_SOC_IEEE802154_SUPPORTED
-    sprintf(buffer, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", mac_base[0], mac_base[1], mac_base[2], mac_base[3], mac_base[4], mac_base[5], mac_base[6], mac_base[7]);
+    sprintf(
+      buffer, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", mac_base[0], mac_base[1], mac_base[2], mac_base[3], mac_base[4], mac_base[5], mac_base[6], mac_base[7]
+    );
 #else
     sprintf(buffer, "%02X:%02X:%02X:%02X:%02X:%02X", mac_base[0], mac_base[1], mac_base[2], mac_base[3], mac_base[4], mac_base[5]);
 #endif
@@ -92,12 +94,15 @@ String getInterfaceMacAddress(esp_mac_type_t interface) {
     char buffer[24];  // 8*2 characters for hex + 7 characters for colons + 1 character for null terminator
 #ifdef CONFIG_SOC_IEEE802154_SUPPORTED
     if (interface == ESP_MAC_IEEE802154) {
-      sprintf(buffer, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", mac_base[0], mac_base[1], mac_base[2], mac_base[3], mac_base[4], mac_base[5], mac_base[6], mac_base[7]);
-    } else if(interface == ESP_MAC_EFUSE_EXT){
+      sprintf(
+        buffer, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", mac_base[0], mac_base[1], mac_base[2], mac_base[3], mac_base[4], mac_base[5], mac_base[6],
+        mac_base[7]
+      );
+    } else if (interface == ESP_MAC_EFUSE_EXT) {
       sprintf(buffer, "%02X:%02X", mac_base[0], mac_base[1]);
     } else {
 #endif
-    sprintf(buffer, "%02X:%02X:%02X:%02X:%02X:%02X", mac_base[0], mac_base[1], mac_base[2], mac_base[3], mac_base[4], mac_base[5]);
+      sprintf(buffer, "%02X:%02X:%02X:%02X:%02X:%02X", mac_base[0], mac_base[1], mac_base[2], mac_base[3], mac_base[4], mac_base[5]);
 #ifdef CONFIG_SOC_IEEE802154_SUPPORTED
     }
 #endif


### PR DESCRIPTION
This pull request enhances the `GetMacAddress` example for ESP32 by adding support for devices that include IEEE 802.15.4 (Thread/Zigbee) and external MAC addresses, and by updating the code to handle both 6-byte and 8-byte MAC addresses when relevant. The changes ensure the example works correctly on more ESP32 variants and displays the correct MAC address format depending on the interface.

**Support for additional MAC address types and formats:**

* Updated the output header in `setup()` to clarify that MAC addresses may be 6 or 8 bytes, reflecting the new interface support.
* Added conditional code to print IEEE802154 and EXT MAC addresses if the platform supports IEEE 802.15.4, using `esp_read_mac` for these interfaces.

**Generalization for variable MAC address lengths:**

* Modified the `getDefaultMacAddress()` and `getInterfaceMacAddress()` functions to use 8-byte buffers and dynamically format either 6-byte or 8-byte MAC addresses, depending on the interface and configuration. [[1]](diffhunk://#diff-1d05dcd32d0a81cc21eaf01ed3d38fc58df4e3f10a9355f6f934354b84ac627dL62-R78) [[2]](diffhunk://#diff-1d05dcd32d0a81cc21eaf01ed3d38fc58df4e3f10a9355f6f934354b84ac627dL77-R103)

Fixes: https://github.com/espressif/arduino-esp32/issues/12255