### PR TITLE
fix(dhcp): Fix DHCP Captive Portal URL

### DIFF
--- a/libraries/WiFi/src/AP.cpp
+++ b/libraries/WiFi/src/AP.cpp
@@ -319,7 +319,8 @@ bool APClass::enableDhcpCaptivePortal() {
 
   // Create Captive Portal URL: http://192.168.0.4
   strcpy(captiveportal_uri, "http://");
-  strcat(captiveportal_uri, String(localIP()).c_str());
+  strcat(captiveportal_uri, localIP().toString().c_str());
+  log_i("DHCP Captive Portal URL: %s", captiveportal_uri);
 
   // Stop DHCPS
   err = esp_netif_dhcps_stop(_esp_netif);


### PR DESCRIPTION
This pull request makes a minor improvement to the logging in the DHCP captive portal setup. It updates how the local IP address is converted to a string and adds a log statement to output the captive portal URL.

- Improved string conversion for the local IP address and added a log statement to display the DHCP Captive Portal URL in `enableDhcpCaptivePortal()` in `AP.cpp`.

Reported: https://github.com/espressif/arduino-esp32/issues/11399#issuecomment-3765631583