### PR TITLE
fix(update): Check that there is a free OTA partition before writing

### DIFF
--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -232,7 +232,7 @@ bool UpdateClass::begin(size_t size, int command, int ledPin, uint8_t ledOn, con
 
   if (command == U_FLASH) {
     _partition = esp_ota_get_next_update_partition(NULL);
-    if (!_partition) {
+    if (!_partition || _partition == esp_ota_get_running_partition()) {
       _error = UPDATE_ERROR_NO_PARTITION;
       return false;
     }


### PR DESCRIPTION
## Description of Change
Added a check to see that next OTA partition is not the running partition. Writing to the active partition causes an immediate crash.

## Test Scenarios
Tested on an ESP32, but should be quite universal

## Related links
Brought up in #12252, but that user is not expecting a fix.