### PR TITLE
fix(ble): Fix default advertising name in NimBLE

### DIFF
--- a/libraries/BLE/src/BLEAdvertising.cpp
+++ b/libraries/BLE/src/BLEAdvertising.cpp
@@ -1216,6 +1216,20 @@ bool BLEAdvertising::start(uint32_t duration, void (*advCompleteCB)(BLEAdvertisi
 
   int rc = 0;
 
+  // Use the device name from BLEDevice for advertising
+  // Note: ble_svc_gap_device_name() doesn't reliably return the name set via
+  // ble_svc_gap_device_name_set(), so we store and use the name directly (like SimpleBLE does)
+  // If setName() was called on advertising, m_name will already be set and we use that
+  if (m_name.isEmpty()) {
+    m_name = BLEDevice::getDeviceName();
+    if (m_name.length() > 0) {
+      m_advData.name = (uint8_t *)m_name.c_str();
+      m_advData.name_len = m_name.length();
+      m_advData.name_is_complete = 1;
+      m_advDataSet = false;  // Force rebuild of advertising data
+    }
+  }
+
   if (!m_customAdvData && !m_advDataSet) {
     //start with 3 bytes for the flags data
     uint8_t payloadLen = (2 + 1);

--- a/libraries/BLE/src/BLEDevice.h
+++ b/libraries/BLE/src/BLEDevice.h
@@ -229,6 +229,7 @@ public:
   static void onReset(int reason);
   static void onSync(void);
   static void host_task(void *param);
+  static String getDeviceName();
   static bool setOwnAddrType(uint8_t type);
   static bool setOwnAddr(BLEAddress &addr);
   static bool setOwnAddr(uint8_t *addr);
@@ -270,6 +271,7 @@ private:
   static BLEDeviceCallbacks defaultDeviceCallbacks;
   static BLEDeviceCallbacks *m_pDeviceCallbacks;
   static ble_gap_event_listener m_listener;
+  static String m_deviceName;
 #endif
 
   /***************************************************************************


### PR DESCRIPTION
## Description of Change

This pull request improves how the BLE device name is managed and advertised by ensuring consistent storage and retrieval across the BLE stack. The main focus is on reliably setting and using the device name for BLE advertising, addressing issues where the underlying GAP service did not always reflect the intended name.

**Device Name Management Improvements:**

* Added a static member `m_deviceName` to `BLEDevice` to store the device name persistently, and provided a static `getDeviceName()` method for access (`BLEDevice.cpp`, `BLEDevice.h`). [[1]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8R122) [[2]](diffhunk://#diff-7d54983ed6d61fa10de96e316460c65092dacd07e0d18042d0bdefa5bd699886R232) [[3]](diffhunk://#diff-7d54983ed6d61fa10de96e316460c65092dacd07e0d18042d0bdefa5bd699886R274) [[4]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8R1330-R1337)
* Changed the initialization logic to store the device name in `m_deviceName` during `BLEDevice::init` instead of immediately setting it on the GAP service, deferring the actual GAP update until BLE stack synchronization (`BLEDevice.cpp`).
* Updated `BLEDevice::onSync` to set the device name on the GAP service from `m_deviceName` after stack synchronization, improving reliability and ensuring the device name is always correctly set (`BLEDevice.cpp`).

**Advertising Logic Enhancements:**

* Modified `BLEAdvertising::start` to retrieve the device name directly from `BLEDevice::getDeviceName()` if not already set, and ensure it is included in the advertising data, working around issues with the GAP service name getter (`BLEAdvertising.cpp`).

## Test Scenarios

Tested locally
