### PR TITLE
fix(hosted): Make BLE work on older hosted firmwares

### DIFF
--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -252,15 +252,20 @@ bool hostedInitBLE() {
   if (!hostedInit()) {
     return false;
   }
-  esp_err_t err = esp_hosted_bt_controller_init();
-  if (err != ESP_OK) {
-    log_e("esp_hosted_bt_controller_init failed: %s", esp_err_to_name(err));
-    return false;
-  }
-  err = esp_hosted_bt_controller_enable();
-  if (err != ESP_OK) {
-    log_e("esp_hosted_bt_controller_enable failed: %s", esp_err_to_name(err));
-    return false;
+
+  uint32_t slave_version = ESP_HOSTED_VERSION_VAL(slave_version_struct.major1, slave_version_struct.minor1, slave_version_struct.patch1);
+  uint32_t min_version = ESP_HOSTED_VERSION_VAL(2, 6, 0);
+  if (slave_version >= min_version) {
+    esp_err_t err = esp_hosted_bt_controller_init();
+    if (err != ESP_OK) {
+      log_e("esp_hosted_bt_controller_init failed: %s", esp_err_to_name(err));
+      return false;
+    }
+    err = esp_hosted_bt_controller_enable();
+    if (err != ESP_OK) {
+      log_e("esp_hosted_bt_controller_enable failed: %s", esp_err_to_name(err));
+      return false;
+    }
   }
   hosted_ble_active = true;
   return true;
@@ -274,15 +279,19 @@ bool hostedInitWiFi() {
 
 bool hostedDeinitBLE() {
   log_i("Deinitializing ESP-Hosted for BLE");
-  esp_err_t err = esp_hosted_bt_controller_disable();
-  if (err != ESP_OK) {
-    log_e("esp_hosted_bt_controller_disable failed: %s", esp_err_to_name(err));
-    return false;
-  }
-  err = esp_hosted_bt_controller_deinit(false);
-  if (err != ESP_OK) {
-    log_e("esp_hosted_bt_controller_deinit failed: %s", esp_err_to_name(err));
-    return false;
+  uint32_t slave_version = ESP_HOSTED_VERSION_VAL(slave_version_struct.major1, slave_version_struct.minor1, slave_version_struct.patch1);
+  uint32_t min_version = ESP_HOSTED_VERSION_VAL(2, 6, 0);
+  if (slave_version >= min_version) {
+    esp_err_t err = esp_hosted_bt_controller_disable();
+    if (err != ESP_OK) {
+      log_e("esp_hosted_bt_controller_disable failed: %s", esp_err_to_name(err));
+      return false;
+    }
+    err = esp_hosted_bt_controller_deinit(false);
+    if (err != ESP_OK) {
+      log_e("esp_hosted_bt_controller_deinit failed: %s", esp_err_to_name(err));
+      return false;
+    }
   }
   hosted_ble_active = false;
   if (!hosted_wifi_active) {


### PR DESCRIPTION
This pull request updates the BLE initialization and deinitialization logic in `cores/esp32/esp32-hal-hosted.c` to ensure that Bluetooth controller operations are only performed if the slave firmware version meets a minimum requirement. This helps maintain compatibility and prevents errors on older firmware versions.

**Version compatibility checks for BLE operations:**

* Added a check in `hostedInitBLE()` to only initialize and enable the Bluetooth controller if the slave firmware version is at least 2.6.0. [[1]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR255-R258) [[2]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR269)
* Added a similar check in `hostedDeinitBLE()` to only disable and deinitialize the Bluetooth controller if the slave firmware version is at least 2.6.0. [[1]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR282-R284) [[2]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR295)