### PR TITLE
fix(build): Fix overflow when counting sketches

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -23,27 +23,33 @@ function check_requirements { # check_requirements <sketchdir> <sdkconfig_path>
         # Check if the sketch requires any configuration options (AND)
         requirements=$(yq eval '.requires[]' "$sketchdir/ci.yml" 2>/dev/null)
         if [[ "$requirements" != "null" && "$requirements" != "" ]]; then
-            for requirement in $requirements; do
-                requirement=$(echo "$requirement" | xargs)
+            while IFS= read -r requirement; do
+                # Trim whitespace and newlines (use sed instead of xargs for compatibility)
+                requirement=$(echo "$requirement" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/[\r\n]//g')
+                # Skip empty lines
+                [[ -z "$requirement" ]] && continue
                 found_line=$(grep -E "^$requirement" "$sdkconfig_path")
                 if [[ "$found_line" == "" ]]; then
                     has_requirements=0
                 fi
-            done
+            done <<< "$requirements"
         fi
 
         # Check if the sketch requires any configuration options (OR)
         requirements_or=$(yq eval '.requires_any[]' "$sketchdir/ci.yml" 2>/dev/null)
         if [[ "$requirements_or" != "null" && "$requirements_or" != "" ]]; then
             local found=false
-            for requirement in $requirements_or; do
-                requirement=$(echo "$requirement" | xargs)
+            while IFS= read -r requirement; do
+                # Trim whitespace and newlines (use sed instead of xargs for compatibility)
+                requirement=$(echo "$requirement" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/[\r\n]//g')
+                # Skip empty lines
+                [[ -z "$requirement" ]] && continue
                 found_line=$(grep -E "^$requirement" "$sdkconfig_path")
                 if [[ "$found_line" != "" ]]; then
                     found=true
                     break
                 fi
-            done
+            done <<< "$requirements_or"
             if [[ "$found" == "false" ]]; then
                 has_requirements=0
             fi
@@ -420,7 +426,8 @@ function count_sketches { # count_sketches <path> [target] [ignore-requirements]
         echo "$sketch" >> sketches.txt
         sketchnum=$((sketchnum + 1))
     done
-    return $sketchnum
+    # Echo count to stdout instead of using return code (which is limited to 0-255)
+    echo "$sketchnum"
 }
 
 function build_sketches { # build_sketches <ide_path> <user_path> <target> <path> <chunk> <total-chunks> [extra-options]
@@ -496,11 +503,9 @@ function build_sketches { # build_sketches <ide_path> <user_path> <target> <path
 
     set +e
     if [ -n "$sketches_file" ]; then
-        count_sketches "$path" "$target" "0" "$sketches_file"
-        local sketchcount=$?
+        local sketchcount=$(count_sketches "$path" "$target" "0" "$sketches_file")
     else
-        count_sketches "$path" "$target"
-        local sketchcount=$?
+        local sketchcount=$(count_sketches "$path" "$target")
     fi
     set -e
     local sketches


### PR DESCRIPTION
## Description of Change

This PR aims to fix a integer overflow when counting sketches. It caused many sketches to not be compiled for SoCs that have over 255 examples.

This pull request improves the robustness and compatibility of the `.github/scripts/sketch_utils.sh` script by refining how requirements are checked and how sketch counts are handled. The main changes focus on better handling of whitespace and empty lines in requirements, and on making the sketch counting function more reliable by avoiding shell return code limitations.

**Requirements handling improvements:**

* Replaced iteration over requirements using `for` loops with `while read` loops to better handle multi-line output and whitespace in the `check_requirements` function. Now, each requirement is trimmed using `sed` for compatibility, and empty lines are skipped. (`.github/scripts/sketch_utils.sh`, [.github/scripts/sketch_utils.shL26-R52](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L26-R52))

**Sketch counting improvements:**

* Modified the `count_sketches` function to output the sketch count to stdout instead of using the shell return code, which is limited to values 0-255. (`.github/scripts/sketch_utils.sh`, [.github/scripts/sketch_utils.shL423-R430](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L423-R430))
* Updated the `build_sketches` function to capture the sketch count from stdout instead of relying on the return code, ensuring accurate handling of counts greater than 255. (`.github/scripts/sketch_utils.sh`, [.github/scripts/sketch_utils.shL499-R508](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L499-R508))

## Test Scenarios

Tested in fork
