### PR TITLE
WiFi: Fix setSleep() using cached instead of provided sleep type

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -779,7 +779,7 @@ bool WiFiGenericClass::setSleep(wifi_ps_type_t sleepType) {
     return true;
   }
 
-  esp_err_t err = esp_wifi_set_ps(_sleepEnabled);
+  esp_err_t err = esp_wifi_set_ps(sleepType);
   if (err != ESP_OK) {
     log_e("esp_wifi_set_ps failed!: 0x%x: %s", err, esp_err_to_name(err));
     return false;


### PR DESCRIPTION
## Description of Change

It seems that with [this commit](https://github.com/espressif/arduino-esp32/commit/5049a93e523efda0aee9e4f20b807751aa5d2460) a bug was introduced, where setSleep() does not set the provided sleep type on the driver, but uses a cached value which defaults to a power saving mode for all platforms expect for ESP32S2.
This only happens if WiFi has already been started in STA mode before invoking setSleep().

In my case (ESP32), when invoking setSleep(false) only once,  this leads to the unexpected result that the sleep mode is still active.

This PR proposes a minimal change to use the provided sleep mode instead of using the cached value.

## Test Scenario

* ESP-IDF v5.5.2
* arduino-esp32 v3.3.6
* ESP32-DevKitC

### Reproduction Steps

1. Initialize WiFi in STA mode
2. Invoke WiFi.setSleep(false)

### Expected Result (with Fix)

WiFi sleep mode is set to WIFI_PS_NONE;

### Actual Result (without Fix)

WiFi sleep mode is set to WIFI_PS_MIN_MODEM;