### PR TITLE
fix(rmt): forces enabling reading channel

### DIFF
--- a/cores/esp32/esp32-hal-rmt.c
+++ b/cores/esp32/esp32-hal-rmt.c
@@ -402,9 +402,8 @@ static bool _rmtRead(int pin, rmt_data_t *data, size_t *num_rmt_symbols, bool wa
   bus->num_symbols_read = num_rmt_symbols;
 
   if (waitForData) {
-    // must force stopping a previous reading first
+    // resets the reading channel to start fresh
     rmt_disable(bus->rmt_channel_h);
-    // enable it again for reading a new data
     rmt_enable(bus->rmt_channel_h);
   }
 


### PR DESCRIPTION
## Description of Change

Added logic to stop and restart RMT channel for data reading in blocking mode.

## Test Scenarios

Tested using ESP32-S3 and this sketch:

``` cpp
rmt_data_t *rbuf = NULL;
size_t rbuf_size = 1024;
const uint8_t rmtPin = 2;

void setup() {
  Serial.begin(115200);
  Serial.setDebugOutput(true);
  delay(3000);
  rbuf = (rmt_data_t *)malloc(sizeof(rmt_data_t) * rbuf_size);
}

void loop() {
  const uint32_t rmt_timeout = 2000;

  if (!rbuf) {
    Serial.println("rbuf is NULL... malloc failed.");
  } else {
    // init and read RMT channel
    if (rmtInit(rmtPin, RMT_RX_MODE, RMT_MEM_NUM_BLOCKS_2, 10000000)) {
        rbuf_size = 1024;
        if (rmtRead(rmtPin, rbuf, &rbuf_size, rmt_timeout == 0 ? RMT_WAIT_FOR_EVER : rmt_timeout)) {
          Serial.println("RMT :: nothing was read - returned after timeout");
        } else {
          Serial.println(String("RMT :: ") + String(rbuf_size) + " bytes were read!");
        }
    }
  }
  delay(3000);
  Serial.println();
  Serial.println("Next RMT reading attampt...");
  Serial.println();

#if 0 // testing workaround 
  // this also solves the issue once we reinit it in loop() and it enables RX Channel again 
  if (!rmtDeinit(rmtPin)) {
    Serial.println("Failed to deinit RMT.");
  }
#endif
}

```

## Related links
Fixes #12267 