### PR TITLE
fix(rak3112): add missing TX1/RX1 pin definitions for Serial1

### DIFF
--- a/variants/rakwireless_rak3112/pins_arduino.h
+++ b/variants/rakwireless_rak3112/pins_arduino.h
@@ -24,6 +24,9 @@ static const uint8_t BAT_VOLT = 21;
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 
+static const uint8_t TX1 = 43;  // UART1 default TX pin for RAK3112
+static const uint8_t RX1 = 44;  // UART1 default RX pin for RAK3112
+
 static const uint8_t SDA = 9;
 static const uint8_t SCL = 40;
 


### PR DESCRIPTION
## Problem Description
The current pin definition file (`pins_arduino.h`)(pins_arduino.h) for the RAK3112 development board is missing the default pin definitions for `Serial1` (UART1), specifically the definitions for `TX1`(TX1) and `RX1`(RX1).
This prevents users from directly using the default initialization method `Serial1.begin(115200)`, requiring them to manually specify the pin numbers, which is inconsistent with the Arduino API convention and can easily cause confusion.

## Changes Made
This commit adds constant definitions for `TX1` and `RX1` to the `variants/rak3112/pins_arduino.h` file(TX1 and RX1 to the variants/rak3112/pins_arduino.h).
According to the RAK3112 hardware schematic (or official documentation/actual circuit), the default pins for `Serial1`(Serial1) are fixed as follows:
- **TX1 = GPIO43**
- **RX1 = GPIO44**

This modification is **minimal and non-intrusive**, only adding the missing definitions and not affecting any other existing code, pins, or board configurations.

## Testing
1. Verified on actual RAK3112 hardware.
2. After the modification, `Serial1.begin(112500);` successfully initializes and allows normal serial communication with external devices (e.g., RAK5860 module).
3. Existing functionalities (e.g., `Serial`) have been tested and confirmed to be working correctly.

## Other Information
This issue was discovered during actual project development, and the team has confirmed the necessity of this modification.
