### PR TITLE
Added Ethernet definitions and UART2 pins

### DIFF
--- a/variants/esp32-evb/pins_arduino.h
+++ b/variants/esp32-evb/pins_arduino.h
@@ -18,8 +18,8 @@ static const uint8_t RX = 3;
 #define ETH_PHY_ADDR  0
 #define ETH_PHY_MDC   23
 #define ETH_PHY_MDIO  18
-#define ETH_PHY_POWER -1	                // no GPIO used to toggle power supply, always on
-#define ETH_CLK_MODE ETH_CLOCK_GPIO0_IN	  // clock supplied by CR1
+#define ETH_PHY_POWER -1                  // no GPIO used to toggle power supply, always on
+#define ETH_CLK_MODE  ETH_CLOCK_GPIO0_IN  // clock supplied by CR1
 
 static const uint8_t SDA = 13;
 static const uint8_t SCL = 16;


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

-----------
## Description of Change
The pins_arduino.h for the Oliemx ESP32-EVB is missing several relevant entries that are availabe for the (almost identical) Olimex POE and Olimex POE-ISO. If these are not defined (especially ETH_PHY_ADDR), then begin() in ETH.h will always return false. This does not affect DHCP-established network connections, but rather those where you use a static IP address.

## Test Scenarios
I have tested my Pull Request on Olimex ESP32-EVB using Ethernet with static IP address.

## Related links
Closes #12311 
