### PR TITLE
ci(wokwi): Enable targets using ESP-hosted in Wi-Fi test

### DIFF
--- a/tests/validation/wifi/ci.yml
+++ b/tests/validation/wifi/ci.yml
@@ -17,5 +17,6 @@ platforms:
   hardware: false
   qemu: false
 
-requires:
+requires_any:
   - CONFIG_SOC_WIFI_SUPPORTED=y
+  - CONFIG_ESP_WIFI_REMOTE_ENABLED=y


### PR DESCRIPTION
## Description of Change

Wokwi added support for ESP-Hosted.

This pull request makes a small update to the `tests/validation/wifi/ci.yml` workflow file. The change broadens the conditions under which the workflow runs by allowing it to proceed if either `CONFIG_SOC_WIFI_SUPPORTED=y` or `CONFIG_ESP_WIFI_REMOTE_ENABLED=y` is set, instead of requiring only the first condition.

## Test Scenarios

Tested locally
