### PR TITLE
fix(ble): Fix GAP name persistance with NimBLE

### DIFF
--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -567,6 +567,14 @@ bool BLEScan::stop() {
   return true;
 }  // stop
 
+/**
+ * @brief Get the status of the scanner.
+ * @return true if scanning is active.
+ */
+bool BLEScan::isScanning() {
+  return !m_stopped;
+}  // isScanning
+
 #endif  // CONFIG_BLUEDROID_ENABLED
 
 /***************************************************************************

--- a/libraries/BLE/src/BLEScan.h
+++ b/libraries/BLE/src/BLEScan.h
@@ -121,6 +121,7 @@ public:
   void erase(BLEAddress address);
   BLEScanResults *getResults();
   void clearResults();
+  bool isScanning();
 
   /***************************************************************************
    *                       Bluedroid public declarations                     *
@@ -141,7 +142,6 @@ public:
 
 #if defined(CONFIG_NIMBLE_ENABLED)
   void setDuplicateFilter(bool enabled);
-  bool isScanning();
   void clearDuplicateCache();
 #endif
 

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -188,6 +188,17 @@ void BLEServer::start() {
     return;
   }
 
+  // Re-set the device name after ble_gatts_start() because ble_svc_gap_init()
+  // (called in createServer) resets it to the default "nimble" from sdkconfig.
+  // The GAP service device name must be set after the GATT server is started.
+  String deviceName = BLEDevice::getDeviceName();
+  if (deviceName.length() > 0) {
+    rc = ble_svc_gap_device_name_set(deviceName.c_str());
+    if (rc != 0) {
+      log_e("ble_svc_gap_device_name_set: rc=%d %s", rc, BLEUtils::returnCodeToString(rc));
+    }
+  }
+
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
   ble_gatts_show_local();
 #endif


### PR DESCRIPTION
## Description of Change

This pull request introduces a new method to check the scanning status of the BLE scanner and ensures the device name is correctly set after starting the BLE server. The changes improve the BLE API's usability and reliability.

**BLEScan API improvements:**

* Added a new `isScanning()` method to the `BLEScan` class and its implementation, allowing users to check if a BLE scan is currently active. [[1]](diffhunk://#diff-c2cda952774b57ccb41b4f66753abcce87a3cd4c9bf8f8a43459ab8b808a6abeR124) [[2]](diffhunk://#diff-6bafb50ee95fba7544fd5cba0b71fc46025fe939893b987b513eb4df6642d997R570-R577)
* Moved the declaration of `isScanning()` outside the `CONFIG_NIMBLE_ENABLED` preprocessor block in `BLEScan.h`, making it available regardless of the BLE stack in use.

**BLEServer device name handling:**

* Updated `BLEServer::start()` to re-set the device name after starting the GATT server, ensuring the configured device name is used instead of the default. This addresses an issue where the device name could revert to "nimble" after initialization.

## Test Scenarios

Tested locally with ESP32-C6
