### PR TITLE
Add Serial1 TX1/RX1 pin definitions for RAK3112

### DIFF
--- a/variants/rakwireless_rak3112/pins_arduino.h
+++ b/variants/rakwireless_rak3112/pins_arduino.h
@@ -24,6 +24,9 @@ static const uint8_t BAT_VOLT = 21;
 static const uint8_t TX = 43;
 static const uint8_t RX = 44;
 
+static const uint8_t TX = 43;  // add uart1 TX1
+static const uint8_t RX = 44;  // add uart1 RX1
+
 static const uint8_t SDA = 9;
 static const uint8_t SCL = 40;
 


### PR DESCRIPTION
## Description
Added TX1 (GPIO43) and RX1 (GPIO44) pin definitions for Serial1 in `pins_arduino.h` for the RAKwireless RAK3112 variant.

## Changes
- Added `static const uint8_t TX1 = 43;` 
- Added `static const uint8_t RX1 = 44;`
- These pins are available on RAK3112 for additional UART

## Testing
Tested with RAK5860 module and other serial devices. Confirmed that existing Serial (UART0) functionality remains unaffected.


