### PR TITLE
fix(zigbee): Set manuf_specific to 0 to use short frame header

### DIFF
--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
@@ -239,7 +239,7 @@ bool ZigbeeAnalog::reportAnalogInput() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ANALOG_INPUT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);
@@ -261,7 +261,7 @@ bool ZigbeeAnalog::reportAnalogOutput() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ANALOG_OUTPUT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeBinary.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeBinary.cpp
@@ -153,7 +153,7 @@ bool ZigbeeBinary::reportBinaryInput() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_BINARY_INPUT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);
@@ -297,7 +297,7 @@ bool ZigbeeBinary::reportBinaryOutput() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_BINARY_OUTPUT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -137,7 +137,7 @@ bool ZigbeeCarbonDioxideSensor::report() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
@@ -292,7 +292,7 @@ bool ZigbeeElectricalMeasurement::reportDC(ZIGBEE_DC_MEASUREMENT_TYPE measuremen
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);
@@ -978,7 +978,7 @@ bool ZigbeeElectricalMeasurement::reportAC(ZIGBEE_AC_MEASUREMENT_TYPE measuremen
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
@@ -133,7 +133,7 @@ bool ZigbeeFlowSensor::report() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeIlluminanceSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeIlluminanceSensor.cpp
@@ -115,7 +115,7 @@ bool ZigbeeIlluminanceSensor::report() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_ILLUMINANCE_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
@@ -418,7 +418,7 @@ bool ZigbeeMultistate::reportMultistateInput() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_MULTI_INPUT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);
@@ -440,7 +440,7 @@ bool ZigbeeMultistate::reportMultistateOutput() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_MULTI_OUTPUT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
@@ -78,7 +78,7 @@ bool ZigbeeOccupancySensor::report() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeePM25Sensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePM25Sensor.cpp
@@ -127,7 +127,7 @@ bool ZigbeePM25Sensor::report() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_PM2_5_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -123,7 +123,7 @@ bool ZigbeePressureSensor::report() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -128,8 +128,8 @@ bool ZigbeeTempSensor::reportTemperature() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U; //Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
-  report_attr_cmd.dis_default_resp = 0x00U; //Default response is enabled.
+  report_attr_cmd.manuf_specific = 0x00U;    //Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.dis_default_resp = 0x00U;  //Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);
   esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
@@ -183,7 +183,7 @@ bool ZigbeeTempSensor::reportHumidity() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);

--- a/libraries/Zigbee/src/ep/ZigbeeWindSpeedSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeWindSpeedSensor.cpp
@@ -138,7 +138,7 @@ bool ZigbeeWindSpeedSensor::reportWindSpeed() {
   report_attr_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
   report_attr_cmd.clusterID = ESP_ZB_ZCL_CLUSTER_ID_WIND_SPEED_MEASUREMENT;
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  report_attr_cmd.manuf_specific = 0x00U;  // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
+  report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
   esp_zb_lock_acquire(portMAX_DELAY);


### PR DESCRIPTION
## Description of Change
This pull request standardizes the way Zigbee attribute reporting commands are constructed across multiple sensor and endpoint classes. Specifically, it replaces the use of the `manuf_code` field with the `manuf_specific` field (set to indicate a standard profile command), and explicitly enables default responses by setting the `dis_default_resp` field to 0. These changes align the command structure with the Zigbee Cluster Library (ZCL) specification and improve code consistency.

**This ensures, that latest HA (ZHA) version 2026.2.0 works with the Zigbee library.**

**Zigbee attribute reporting command updates:**

* Replaced `manuf_code` with `manuf_specific = 0x00U` in all report command structures to indicate standard profile commands and ensure the manufacturer code is not included in the ZCL frame header. [[1]](diffhunk://#diff-9c07cffec174e036750a5e5df6331866586d1ca816114600906f550e5e3fa940L242-R243) [[2]](diffhunk://#diff-9c07cffec174e036750a5e5df6331866586d1ca816114600906f550e5e3fa940L263-R265) [[3]](diffhunk://#diff-ca6ba1362dfc4a0c4ab4e566cfa1d4af7d5e71d1f00c086b5992261b7a458cc5L156-R157) [[4]](diffhunk://#diff-ca6ba1362dfc4a0c4ab4e566cfa1d4af7d5e71d1f00c086b5992261b7a458cc5L299-R301) [[5]](diffhunk://#diff-d5ef5f17d7ae91bd2e23daf83e33566324e99e491d3885543205d5e77f2d4e38L140-R141) [[6]](diffhunk://#diff-5be116ed6a03e3806b9b63d07af1e996e0b2b27766107a594be549190a8348a8L295-R296) [[7]](diffhunk://#diff-5be116ed6a03e3806b9b63d07af1e996e0b2b27766107a594be549190a8348a8L980-R982) [[8]](diffhunk://#diff-8ce97d7d52868dd3182c8e31a9a42d7c2ec09f6dc88b023ab976d9bd8b2f29fdL136-R137) [[9]](diffhunk://#diff-3b387a4c0f1e4bb2a0948badc5bc7368b674acb8a5306e456fa81b2de5e293e5L118-R119) [[10]](diffhunk://#diff-7f724d718c8b09467e8fa020a2ca7ddf7852e516f58c1110d20683bc68fb5360L421-R422) [[11]](diffhunk://#diff-7f724d718c8b09467e8fa020a2ca7ddf7852e516f58c1110d20683bc68fb5360L442-R444) [[12]](diffhunk://#diff-20f6e282e39c44a2c6419209ff9c401914a0ee0347b52a925a2aef14a8fd85f8L81-R82) [[13]](diffhunk://#diff-15e617f403b53a9076df6507079a6617b16e09d836cf781b9834d6eec824b0d5L130-R131) [[14]](diffhunk://#diff-b12e14d9be9b46f58c8e0bc224ef1ca9b45f7e5d99ffac71c2ce0acce4e37195L126-R127) [[15]](diffhunk://#diff-50569207474db022bc5aa2aa53f966cfb4b4f0b1d8035bacf2e7b67f1dd16ec4L131-R132) [[16]](diffhunk://#diff-cbcfc32c0b707a7153497fee53c0f1214840857a8793c51019be71c870c6beb3L141-R142)
* Set `dis_default_resp = 0x00U` in all report command structures to explicitly enable default responses. [[1]](diffhunk://#diff-9c07cffec174e036750a5e5df6331866586d1ca816114600906f550e5e3fa940L242-R243) [[2]](diffhunk://#diff-9c07cffec174e036750a5e5df6331866586d1ca816114600906f550e5e3fa940L263-R265) [[3]](diffhunk://#diff-ca6ba1362dfc4a0c4ab4e566cfa1d4af7d5e71d1f00c086b5992261b7a458cc5L156-R157) [[4]](diffhunk://#diff-ca6ba1362dfc4a0c4ab4e566cfa1d4af7d5e71d1f00c086b5992261b7a458cc5L299-R301) [[5]](diffhunk://#diff-d5ef5f17d7ae91bd2e23daf83e33566324e99e491d3885543205d5e77f2d4e38L140-R141) [[6]](diffhunk://#diff-5be116ed6a03e3806b9b63d07af1e996e0b2b27766107a594be549190a8348a8L295-R296) [[7]](diffhunk://#diff-5be116ed6a03e3806b9b63d07af1e996e0b2b27766107a594be549190a8348a8L980-R982) [[8]](diffhunk://#diff-8ce97d7d52868dd3182c8e31a9a42d7c2ec09f6dc88b023ab976d9bd8b2f29fdL136-R137) [[9]](diffhunk://#diff-3b387a4c0f1e4bb2a0948badc5bc7368b674acb8a5306e456fa81b2de5e293e5L118-R119) [[10]](diffhunk://#diff-7f724d718c8b09467e8fa020a2ca7ddf7852e516f58c1110d20683bc68fb5360L421-R422) [[11]](diffhunk://#diff-7f724d718c8b09467e8fa020a2ca7ddf7852e516f58c1110d20683bc68fb5360L442-R444) [[12]](diffhunk://#diff-20f6e282e39c44a2c6419209ff9c401914a0ee0347b52a925a2aef14a8fd85f8L81-R82) [[13]](diffhunk://#diff-15e617f403b53a9076df6507079a6617b16e09d836cf781b9834d6eec824b0d5L130-R131) [[14]](diffhunk://#diff-b12e14d9be9b46f58c8e0bc224ef1ca9b45f7e5d99ffac71c2ce0acce4e37195L126-R127) [[15]](diffhunk://#diff-50569207474db022bc5aa2aa53f966cfb4b4f0b1d8035bacf2e7b67f1dd16ec4L131-R132) [[16]](diffhunk://#diff-cbcfc32c0b707a7153497fee53c0f1214840857a8793c51019be71c870c6beb3L141-R142)

## Test Scenarios
Tested using ESP32C6 loaded with Temperature sensor example connected to ZHA on HA version 2026.2.0.

## Related links
Issue report from homeassistant-core GH https://github.com/home-assistant/core/issues/162249
