### PR TITLE
feat(preferences): Add getStringLength and fix getString/getBytes docs

### DIFF
--- a/docs/en/api/preferences.rst
+++ b/docs/en/api/preferences.rst
@@ -540,22 +540,22 @@ Arduino-esp32 Preferences API
 
 .. code-block:: arduino
 
-    size_t getString(const char* key, char* value, size_t len);
+    size_t getString(const char* key, char* value, size_t maxLen);
 ..
 
    **Parameters**
       * ``key`` (Required)
       * ``value`` (Required)
-         - a buffer of a size large enough to hold ``len`` bytes
-      * ``len`` (Required)
-         - the number of type ``char``` to be written to the buffer pointed to by ``value``
+         - buffer to receive the null-terminated string
+      * ``maxLen`` (Required)
+         - maximum number of bytes (including the null terminator) that can be written to ``value``
 
    **Returns**
-      * if successful; the number of bytes equal to ``len`` is written to the buffer pointed to by ``value``, and the method returns ``1``.
-      * if the method fails, nothing is written to the buffer pointed to by ``value`` and the method returns ``0``.
+      * if successful: that many bytes (including the null terminator) are written to the buffer pointed to by ``value``, and the method returns that number of bytes.
+      * if the method fails: nothing is written to the buffer and the method returns ``0``.
 
    **Notes**
-      * ``len`` must equal the number of bytes stored against the key or the call will fail.
+      * ``maxLen`` must be greater than or equal to the number of bytes stored against the key (including the null terminator) or the call will fail. Use ``getStringLength`` to obtain the required size before calling.
       * A message providing the reason for a failed call is sent to the arduino-esp32 ``log_e`` facility.
 
 
@@ -582,6 +582,28 @@ Arduino-esp32 Preferences API
       * ``defaultValue`` must be of type ``String``.
 
 
+``getStringLength``
+*******************
+
+   Get the number of bytes (including the null terminator) stored for a string value against a key in the currently open namespace. Use this to size a buffer before calling ``getString(key, value, maxLen)``.
+
+.. code-block:: arduino
+
+   size_t getStringLength(const char* key);
+
+..
+
+   **Parameters**
+      * ``key`` (Required)
+
+   **Returns**
+      * if successful: the number of bytes in the value stored against ``key`` (including the null terminator); ``0`` otherwise.
+
+   **Notes**
+      * This method will fail (return 0) if the key does not exist or is not of type String.
+      * A message providing the reason for a failed call is sent to the arduino-esp32 ``log_e`` facility.
+
+
 ``getBytes``
 *************
 
@@ -589,23 +611,23 @@ Copy a series of bytes stored against a given key in the currently open namespac
 
 .. code-block:: arduino
 
-   size_t getBytes(const char* key, void * buf, size_t len);
+   size_t getBytes(const char* key, void * buf, size_t maxLen);
 
 ..
 
    **Parameters**
       * ``key`` (Required)
       * ``buf`` (Required)
-         - a buffer of a size large enough to hold ``len`` bytes.
-      * ``len`` (Required)
-         - the number of bytes to be written to the buffer pointed to by ``buf``
+         - buffer to receive the bytes
+      * ``maxLen`` (Required)
+         - maximum number of bytes that can be written to ``buf``
 
    **Returns**
-      * if successful, the number of bytes equal to ``len`` is written to buffer ``buf``, and the method returns ``len``.
-      * if the method fails, nothing is written to the buffer and the method returns ``0``.
+      * if successful: that many bytes are written to the buffer pointed to by ``buf``, and the method returns that number of bytes.
+      * if the method fails: nothing is written to the buffer and the method returns ``0``.
 
    **Notes**
-      * ``len`` must equal the number of bytes stored against the key or the call will fail.
+      * ``maxLen`` must be greater than or equal to the number of bytes stored against the key or the call will fail. Use ``getBytesLength`` to obtain the required size before calling.
       * A message providing the reason for a failed call is sent to the arduino-esp32 ``log_e`` facility.
 
 

--- a/libraries/Preferences/src/Preferences.cpp
+++ b/libraries/Preferences/src/Preferences.cpp
@@ -516,6 +516,19 @@ String Preferences::getString(const char *key, const String defaultValue) {
   return String(buf);
 }
 
+size_t Preferences::getStringLength(const char *key) {
+  size_t len = 0;
+  if (!_started || !key) {
+    return 0;
+  }
+  esp_err_t err = nvs_get_str(_handle, key, NULL, &len);
+  if (err) {
+    log_e("nvs_get_str len fail: %s %s", key, nvs_error(err));
+    return 0;
+  }
+  return len;
+}
+
 size_t Preferences::getBytesLength(const char *key) {
   size_t len = 0;
   if (!_started || !key) {

--- a/libraries/Preferences/src/Preferences.h
+++ b/libraries/Preferences/src/Preferences.h
@@ -80,6 +80,7 @@ public:
   bool getBool(const char *key, bool defaultValue = false);
   size_t getString(const char *key, char *value, size_t maxLen);
   String getString(const char *key, String defaultValue = String());
+  size_t getStringLength(const char *key);
   size_t getBytesLength(const char *key);
   size_t getBytes(const char *key, void *buf, size_t maxLen);
   size_t freeEntries();


### PR DESCRIPTION
## Description of Change
This pull request updates the Preferences API in Arduino-esp32 to improve clarity and usability when retrieving strings and byte arrays from storage. The changes focus on making buffer sizing safer and more predictable by introducing new helper methods and updating documentation accordingly.

**API improvements for buffer sizing:**

* Added a new method `getStringLength(const char* key)` to the `Preferences` class and its implementation, allowing users to determine the required buffer size (including the null terminator) before calling `getString`. [[1]](diffhunk://#diff-9981aa000c9de41bfcc2a8b9ae3dd1c09e644c32a65d1f786641dd9c8cd8129bR83) [[2]](diffhunk://#diff-db0cc70ec05e1a1b776c34eb1c6ba93a2b051025a292472d8317ff4a85fda2ffR519-R531)
* Updated the signature and documentation for `getString` and `getBytes` to use `maxLen` instead of `len`, clarifying that this parameter represents the maximum buffer size (including the null terminator for strings), and advising users to use the new length methods to avoid buffer overflows. [[1]](diffhunk://#diff-d798707a457bd4d1ab671c33bb3d5c1c385f446e4b1cfbad5e141198d0e50f8aL543-R558) [[2]](diffhunk://#diff-d798707a457bd4d1ab671c33bb3d5c1c385f446e4b1cfbad5e141198d0e50f8aR585-R630)

**Documentation enhancements:**

* Added detailed documentation for the new `getStringLength` method, including usage notes and return values.
* Improved parameter and return value descriptions for `getString` and `getBytes`, making it clearer how to safely use these methods and what to expect on success or failure. [[1]](diffhunk://#diff-d798707a457bd4d1ab671c33bb3d5c1c385f446e4b1cfbad5e141198d0e50f8aL543-R558) [[2]](diffhunk://#diff-d798707a457bd4d1ab671c33bb3d5c1c385f446e4b1cfbad5e141198d0e50f8aR585-R630)

## Test Scenarios
Tested on ESP32.

## Related links
Closes #12335 