### PR TITLE
fix(m5stack_tab5): Add chip variant menu

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -23290,6 +23290,7 @@ m5stack_tab5.build.target=esp
 m5stack_tab5.build.mcu=esp32p4
 m5stack_tab5.build.core=esp32
 m5stack_tab5.build.variant=m5stack_tab5
+m5stack_tab5.build.chip_variant=esp32p4_es
 m5stack_tab5.build.board=M5STACK_TAB5
 m5stack_tab5.build.bootloader_addr=0x2000
 
@@ -23305,6 +23306,13 @@ m5stack_tab5.build.flash_mode=qio
 m5stack_tab5.build.boot=qio
 m5stack_tab5.build.partitions=default
 m5stack_tab5.build.defines=
+
+m5stack_tab5.menu.ChipVariant.prev3=Before v3.00
+m5stack_tab5.menu.ChipVariant.prev3.build.chip_variant=esp32p4_es
+m5stack_tab5.menu.ChipVariant.prev3.build.f_cpu=360000000L
+m5stack_tab5.menu.ChipVariant.postv3=v3.00 or newer
+m5stack_tab5.menu.ChipVariant.postv3.build.chip_variant=esp32p4
+m5stack_tab5.menu.ChipVariant.postv3.build.f_cpu=400000000L
 
 ## IDE 2.0 Seems to not update the value
 m5stack_tab5.menu.JTAGAdapter.default=Disabled


### PR DESCRIPTION
## Description of Change

This pull request updates the `boards.txt` configuration for the `m5stack_tab5` board, adding support for different chip variants and corresponding CPU frequencies based on the board version.

Key configuration changes:

**Chip variant and frequency selection:**
* Added a `chip_variant` field (`esp32p4_es`) to the `m5stack_tab5` build configuration to specify the chip variant used.
* Introduced a new menu option `ChipVariant` with two choices: `Before v3.00` (uses `esp32p4_es` at 360MHz) and `v3.00 or newer` (uses `esp32p4` at 400MHz), allowing users to select the correct chip variant and CPU frequency based on their hardware version.

## Related links

Fixes https://github.com/espressif/arduino-esp32/issues/12324