### PR TITLE
PPPClass: Add configurable boot delay after reset sequence

### DIFF
--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -141,8 +141,8 @@ esp_modem_dce_t *PPPClass::handle() const {
 
 PPPClass::PPPClass()
   : _dce(NULL), _pin_tx(-1), _pin_rx(-1), _pin_rts(-1), _pin_cts(-1), _flow_ctrl(ESP_MODEM_FLOW_CONTROL_NONE), _pin_rst(-1), _pin_rst_act_low(true),
-    _pin_rst_delay(200), _pin(NULL), _apn(NULL), _rx_buffer_size(4096), _tx_buffer_size(512), _mode(ESP_MODEM_MODE_COMMAND), _uart_num(UART_NUM_1),
-    _ppp_event_handle(0) {}
+    _pin_rst_delay(200), _boot_delay(100), _pin(NULL), _apn(NULL), _rx_buffer_size(4096), _tx_buffer_size(512), _mode(ESP_MODEM_MODE_COMMAND),
+    _uart_num(UART_NUM_1), _ppp_event_handle(0) {}
 
 PPPClass::~PPPClass() {}
 
@@ -152,10 +152,11 @@ bool PPPClass::pppDetachBus(void *bus_pointer) {
   return true;
 }
 
-void PPPClass::setResetPin(int8_t rst, bool active_low, uint32_t reset_delay) {
+void PPPClass::setResetPin(int8_t rst, bool active_low, uint32_t reset_delay, uint32_t boot_delay) {
   _pin_rst = digitalPinToGPIONumber(rst);
   _pin_rst_act_low = active_low;
   _pin_rst_delay = reset_delay;
+  _boot_delay = boot_delay;
 }
 
 bool PPPClass::setPins(int8_t tx, int8_t rx, int8_t rts, int8_t cts, esp_modem_flow_ctrl_t flow_ctrl) {
@@ -288,7 +289,7 @@ bool PPPClass::begin(ppp_modem_model_t model, uint8_t uart_num, int baud_rate) {
     digitalWrite(_pin_rst, !_pin_rst_act_low);
     delay(_pin_rst_delay);
     digitalWrite(_pin_rst, _pin_rst_act_low);
-    delay(100);
+    delay(_boot_delay);
   }
 
   /* Start the DCE */

--- a/libraries/PPP/src/PPP.h
+++ b/libraries/PPP/src/PPP.h
@@ -40,7 +40,7 @@ public:
   bool setPins(int8_t tx, int8_t rx, int8_t rts = -1, int8_t cts = -1, esp_modem_flow_ctrl_t flow_ctrl = ESP_MODEM_FLOW_CONTROL_NONE);
 
   // Using the reset pin of the module ensures that proper communication can be achieved
-  void setResetPin(int8_t rst, bool active_low = true, uint32_t reset_delay = 200);
+  void setResetPin(int8_t rst, bool active_low = true, uint32_t reset_delay = 200, uint32_t boot_delay = 100);
 
   // Modem DCE APIs
   int RSSI() const;
@@ -117,6 +117,7 @@ private:
   int8_t _pin_rst;
   bool _pin_rst_act_low;
   uint32_t _pin_rst_delay;
+  uint32_t _boot_delay;
   const char *_pin;
   const char *_apn;
   int _rx_buffer_size;


### PR DESCRIPTION
## Description of Change

This Pull Request introduces a configurable boot delay after the modem reset sequence in PPPClass.

Previously, the code assumed that the modem would be ready to communicate approximately 100 ms after reset, which is not always true for some modules. In particular, with the SIMCom SIM7070, the modem may still be booting and not yet responsive to AT commands at that point.

To address this, a new _boot_delay parameter was added and integrated into the reset flow. This delay is applied after releasing the reset pin and before attempting to initialize the DCE or synchronize with the modem, ensuring that the modem has sufficient time to complete its boot process.

## Test Scenarios
1. Reset pin connected and controlled by PPP.setResetPin()
2. Verified modem behavior with and without extended boot delay
3. Confirmed that without the additional delay the modem may fail to respond to initial AT synchronization
4. Confirmed stable and repeatable PPP startup when the boot delay is applied

## Related links
https://github.com/espressif/arduino-esp32/pull/12314

These captures show the behavior with and without the boot delay commit. The time during which PWRKEY is held low for the SIM7070 to perform a reset is approximately 12.5 seconds. After the reset sequence completes, the modem requires an additional ~5 seconds to finish booting before it becomes responsive to AT commands.

Without accounting for this boot time, the PPP initialization may start too early, causing synchronization failures. The added boot delay ensures that the modem is fully operational before esp_modem_sync() and subsequent PPP initialization steps are executed.

[Captures.zip](https://github.com/user-attachments/files/25210345/Captures.zip)


