### PR TITLE
fix(ble): Fix address types in Bluedroid

### DIFF
--- a/libraries/BLE/src/BLEAddress.cpp
+++ b/libraries/BLE/src/BLEAddress.cpp
@@ -48,9 +48,7 @@
 
 BLEAddress::BLEAddress() {
   memset(m_address, 0, ESP_BD_ADDR_LEN);
-#if defined(CONFIG_NIMBLE_ENABLED)
   m_addrType = 0;
-#endif
 }
 
 /**
@@ -63,11 +61,9 @@ bool BLEAddress::equals(const BLEAddress &otherAddress) const {
 }
 
 bool BLEAddress::operator==(const BLEAddress &otherAddress) const {
-#if defined(CONFIG_NIMBLE_ENABLED)
   if (m_addrType != otherAddress.m_addrType) {
     return false;
   }
-#endif
   return memcmp(otherAddress.m_address, m_address, ESP_BD_ADDR_LEN) == 0;
 }
 
@@ -97,6 +93,22 @@ bool BLEAddress::operator>(const BLEAddress &otherAddress) const {
  */
 uint8_t *BLEAddress::getNative() {
   return m_address;
+}
+
+/**
+ * @brief Return the address type.
+ * @return The address type.
+ */
+uint8_t BLEAddress::getType() const {
+  return m_addrType;
+}
+
+/**
+ * @brief Set the address type.
+ * @param [in] type The address type.
+ */
+void BLEAddress::setType(uint8_t type) {
+  m_addrType = type;
 }
 
 /**
@@ -135,9 +147,11 @@ String BLEAddress::toString() const {
 /**
  * @brief Create an address from the native ESP32 representation.
  * @param [in] address The native representation.
+ * @param [in] type The address type.
  */
-BLEAddress::BLEAddress(esp_bd_addr_t address) {
+BLEAddress::BLEAddress(esp_bd_addr_t address, uint8_t type) {
   memcpy(m_address, address, ESP_BD_ADDR_LEN);
+  m_addrType = type;
 }
 
 /**
@@ -150,13 +164,15 @@ BLEAddress::BLEAddress(esp_bd_addr_t address) {
  * which is 17 characters in length.
  *
  * @param [in] stringAddress The hex representation of the address.
+ * @param [in] type The address type.
  */
-BLEAddress::BLEAddress(const String &stringAddress) {
+BLEAddress::BLEAddress(const String &stringAddress, uint8_t type) {
   if (stringAddress.length() != 17) {
     return;
   }
 
   int data[6];
+  m_addrType = type;
   sscanf(stringAddress.c_str(), "%x:%x:%x:%x:%x:%x", &data[0], &data[1], &data[2], &data[3], &data[4], &data[5]);
 
   for (size_t index = 0; index < sizeof(m_address); index++) {
@@ -184,10 +200,6 @@ BLEAddress::BLEAddress(uint8_t address[ESP_BD_ADDR_LEN], uint8_t type) {
 BLEAddress::BLEAddress(ble_addr_t address) {
   memcpy(m_address, address.val, ESP_BD_ADDR_LEN);
   m_addrType = address.type;
-}
-
-uint8_t BLEAddress::getType() const {
-  return m_addrType;
 }
 
 /**

--- a/libraries/BLE/src/BLEAddress.h
+++ b/libraries/BLE/src/BLEAddress.h
@@ -72,6 +72,8 @@ public:
   bool operator>(const BLEAddress &otherAddress) const;
   bool operator>=(const BLEAddress &otherAddress) const;
   uint8_t *getNative();
+  uint8_t getType() const;
+  void setType(uint8_t type);
   String toString() const;
 
   /***************************************************************************
@@ -79,8 +81,8 @@ public:
    ***************************************************************************/
 
 #if defined(CONFIG_BLUEDROID_ENABLED)
-  BLEAddress(esp_bd_addr_t address);
-  BLEAddress(const String &stringAddress);
+  BLEAddress(esp_bd_addr_t address, uint8_t type = 0);
+  BLEAddress(const String &stringAddress, uint8_t type = 0);
 #endif
 
   /***************************************************************************
@@ -91,7 +93,6 @@ public:
   BLEAddress(ble_addr_t address);
   BLEAddress(const String &stringAddress, uint8_t type = BLE_ADDR_PUBLIC);
   BLEAddress(uint8_t address[ESP_BD_ADDR_LEN], uint8_t type = BLE_ADDR_PUBLIC);
-  uint8_t getType() const;
 #endif
 
 private:
@@ -100,14 +101,7 @@ private:
    ***************************************************************************/
 
   uint8_t m_address[ESP_BD_ADDR_LEN];
-
-  /***************************************************************************
-   *                       NimBLE private properties                         *
-   ***************************************************************************/
-
-#if defined(CONFIG_NIMBLE_ENABLED)
   uint8_t m_addrType;
-#endif
 };
 
 #endif /* CONFIG_BLUEDROID_ENABLED || CONFIG_NIMBLE_ENABLED */

--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -83,7 +83,6 @@ BLEAdvertisedDevice::BLEAdvertisedDevice(const BLEAdvertisedDevice &other) {
   m_pScan = other.m_pScan;
   m_advType = other.m_advType;
   m_address = other.m_address;
-  m_addressType = other.m_addressType;
 
 #if defined(CONFIG_NIMBLE_ENABLED)
   m_callbackSent = other.m_callbackSent;
@@ -130,7 +129,6 @@ BLEAdvertisedDevice &BLEAdvertisedDevice::operator=(const BLEAdvertisedDevice &o
   m_pScan = other.m_pScan;
   m_advType = other.m_advType;
   m_address = other.m_address;
-  m_addressType = other.m_addressType;
 
 #if defined(CONFIG_NIMBLE_ENABLED)
   m_callbackSent = other.m_callbackSent;
@@ -768,7 +766,7 @@ uint8_t *BLEAdvertisedDevice::getPayload() {
 }
 
 uint8_t BLEAdvertisedDevice::getAddressType() {
-  return m_addressType;
+  return m_address.getType();
 }
 
 ble_frame_type_t BLEAdvertisedDevice::getFrameType() {
@@ -788,7 +786,7 @@ ble_frame_type_t BLEAdvertisedDevice::getFrameType() {
 }
 
 void BLEAdvertisedDevice::setAddressType(uint8_t type) {
-  m_addressType = type;
+  m_address.setType(type);
 }
 
 size_t BLEAdvertisedDevice::getPayloadLength() {

--- a/libraries/BLE/src/BLEAdvertisedDevice.h
+++ b/libraries/BLE/src/BLEAdvertisedDevice.h
@@ -141,7 +141,6 @@ private:
   std::vector<BLEUUID> m_serviceDataUUIDs;
   uint8_t *m_payload;
   size_t m_payloadLength = 0;
-  uint8_t m_addressType;
   uint8_t m_advType;
   bool m_isLegacyAdv;
 

--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -422,6 +422,11 @@ void BLEClientCallbacks::onDisconnect(BLEClient *pClient) {
 bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
   log_i(">> connect(%s)", address.toString().c_str());
 
+  // Use explicitly provided type, or fall back to the address's stored type
+  if (type == 0xFF) {
+    type = address.getType();
+  }
+
   // Configuration for retry logic
   const int maxRetries = 3;
   const int retryDelayMs = 100;
@@ -893,9 +898,14 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
     return false;
   }
 
+  // Use explicitly provided type, or fall back to the address's stored type
+  if (type == 0xFF) {
+    type = address.getType();
+  }
+
   ble_addr_t peerAddr_t;
   memcpy(&peerAddr_t.val, address.getNative(), 6);
-  peerAddr_t.type = address.getType();
+  peerAddr_t.type = type;
   if (ble_gap_conn_find_by_addr(&peerAddr_t, NULL) == 0) {
     log_e("A connection to %s already exists", address.toString().c_str());
     return false;

--- a/libraries/BLE/src/BLEClient.h
+++ b/libraries/BLE/src/BLEClient.h
@@ -88,7 +88,7 @@ public:
   ~BLEClient();
   bool connect(BLEAdvertisedDevice *device);
   bool connectTimeout(BLEAdvertisedDevice *device, uint32_t timeoutMS = portMAX_DELAY);
-  bool connect(BLEAddress address, uint8_t type = 0, uint32_t timeoutMS = portMAX_DELAY);
+  bool connect(BLEAddress address, uint8_t type = 0xFF, uint32_t timeoutMS = portMAX_DELAY);
   bool secureConnection();
   int disconnect(uint8_t reason = BLE_ERR_REM_USER_CONN_TERM);
   BLEAddress getPeerAddress();

--- a/libraries/BLE/src/BLEScan.cpp
+++ b/libraries/BLE/src/BLEScan.cpp
@@ -338,7 +338,7 @@ void BLEScan::handleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_
 
           // Examine our list of previously scanned addresses and, if we found this one already,
           // ignore it.
-          BLEAddress advertisedAddress(param->scan_rst.bda);
+          BLEAddress advertisedAddress(param->scan_rst.bda, param->scan_rst.ble_addr_type);
           bool found = false;
           bool shouldDelete = true;
 


### PR DESCRIPTION
## Description of Change

This pull request refactors how BLE address types are managed throughout the codebase, making address type handling more consistent and encapsulated within the `BLEAddress` class. The changes eliminate redundant storage of address type in multiple classes and ensure that address type is always associated with the address itself. This improves maintainability and reduces the risk of mismatched address/type pairs.

Key changes include:

### BLEAddress class improvements

* Added `getType()` and `setType()` methods to `BLEAddress`, and updated all constructors to accept an optional address type parameter, defaulting to 0 or `BLE_ADDR_PUBLIC` as appropriate. This centralizes address type management in `BLEAddress`. [[1]](diffhunk://#diff-bc65ec54fd4c8bdc1abd4b89471e44fe11ca5a3d2aef2c816188b23a35dc0f1fR98-R113) [[2]](diffhunk://#diff-6afc79682e5ba5fdfd52dca3eab90a375aab913509f246ab5177e9310195c0ecR75-R85) [[3]](diffhunk://#diff-6afc79682e5ba5fdfd52dca3eab90a375aab913509f246ab5177e9310195c0ecL94) [[4]](diffhunk://#diff-bc65ec54fd4c8bdc1abd4b89471e44fe11ca5a3d2aef2c816188b23a35dc0f1fR150-R154) [[5]](diffhunk://#diff-bc65ec54fd4c8bdc1abd4b89471e44fe11ca5a3d2aef2c816188b23a35dc0f1fR167-R175)
* Removed conditional compilation for address type storage—`m_addrType` is now always present in `BLEAddress`, simplifying the class and making type handling consistent regardless of BLE stack. [[1]](diffhunk://#diff-6afc79682e5ba5fdfd52dca3eab90a375aab913509f246ab5177e9310195c0ecL103-L110) [[2]](diffhunk://#diff-bc65ec54fd4c8bdc1abd4b89471e44fe11ca5a3d2aef2c816188b23a35dc0f1fL51-L53) [[3]](diffhunk://#diff-bc65ec54fd4c8bdc1abd4b89471e44fe11ca5a3d2aef2c816188b23a35dc0f1fL66-L70) [[4]](diffhunk://#diff-bc65ec54fd4c8bdc1abd4b89471e44fe11ca5a3d2aef2c816188b23a35dc0f1fL189-L192)

### BLEAdvertisedDevice class refactor

* Removed the redundant `m_addressType` member from `BLEAdvertisedDevice`; all address type logic now uses the encapsulated type in `BLEAddress`. Updated getter and setter to delegate to `BLEAddress`. [[1]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33L86) [[2]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33L133) [[3]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33L771-R769) [[4]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33L791-R789) [[5]](diffhunk://#diff-53e0a4b685a23068b436e80fc763be808a9cd6d1f457c7c4db46cee331b91b55L144)

### BLEClient connection improvements

* Changed the `BLEClient::connect` method signature to use `type = 0xFF` as a sentinel value. If `type` is `0xFF`, the method falls back to the address's stored type, ensuring correct and flexible type handling during connection. [[1]](diffhunk://#diff-076e56fe388d1558bb95fedc1f0b1e8bceb94d61d8380da286518c165833a591L91-R91) [[2]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aR425-R429) [[3]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aR901-R908)

### General codebase consistency

* Updated all code that creates `BLEAddress` objects to provide the address type where available, ensuring that the type is always set correctly at construction.

These changes make address type management more robust, reduce the chance of bugs from mismatched address/type pairs, and simplify the codebase.

## Test Scenarios

Tested locally with ESP32

## Related links

Closes https://github.com/espressif/arduino-esp32/issues/11939
