### PR TITLE
fix(zigbee): electrical measurement types — int16_t for power, uint16_t for others

### DIFF
--- a/docs/en/zigbee/ep_electrical_measurement.rst
+++ b/docs/en/zigbee/ep_electrical_measurement.rst
@@ -150,7 +150,7 @@ This function will return ``true`` if successful, ``false`` otherwise.
 setACMeasurement
 ^^^^^^^^^^^^^^^^
 
-Sets the AC measurement value for a specific measurement type and phase.
+Sets the AC measurement value for a specific measurement type and phase. For power (``ZIGBEE_AC_MEASUREMENT_TYPE_POWER``) the value is ``int16_t``; for other measurement types (voltage, current, power factor, frequency) the value is ``uint16_t``.
 
 .. code-block:: arduino
 
@@ -158,14 +158,14 @@ Sets the AC measurement value for a specific measurement type and phase.
 
 * ``measurement_type`` - AC measurement type constant (ZIGBEE_AC_MEASUREMENT_TYPE_VOLTAGE, ZIGBEE_AC_MEASUREMENT_TYPE_CURRENT, ZIGBEE_AC_MEASUREMENT_TYPE_POWER, ZIGBEE_AC_MEASUREMENT_TYPE_POWER_FACTOR, ZIGBEE_AC_MEASUREMENT_TYPE_FREQUENCY)
 * ``phase_type`` - Phase type constant (ZIGBEE_AC_PHASE_TYPE_NON_SPECIFIC, ZIGBEE_AC_PHASE_TYPE_A, ZIGBEE_AC_PHASE_TYPE_B, ZIGBEE_AC_PHASE_TYPE_C)
-* ``value`` - Measurement value
+* ``value`` - Measurement value (``int16_t`` for power, ``uint16_t`` for voltage, current, power factor, frequency)
 
 This function will return ``true`` if successful, ``false`` otherwise.
 
 setACMinMaxValue
 ^^^^^^^^^^^^^^^^
 
-Sets the minimum and maximum values for an AC measurement type and phase.
+Sets the minimum and maximum values for an AC measurement type and phase. For power (``ZIGBEE_AC_MEASUREMENT_TYPE_POWER``) min/max are ``int16_t``; for other measurement types (voltage, current, power factor, frequency) they are ``uint16_t``.
 
 .. code-block:: arduino
 
@@ -173,8 +173,8 @@ Sets the minimum and maximum values for an AC measurement type and phase.
 
 * ``measurement_type`` - AC measurement type constant (ZIGBEE_AC_MEASUREMENT_TYPE_VOLTAGE, ZIGBEE_AC_MEASUREMENT_TYPE_CURRENT, ZIGBEE_AC_MEASUREMENT_TYPE_POWER, ZIGBEE_AC_MEASUREMENT_TYPE_POWER_FACTOR, ZIGBEE_AC_MEASUREMENT_TYPE_FREQUENCY)
 * ``phase_type`` - Phase type constant (ZIGBEE_AC_PHASE_TYPE_NON_SPECIFIC, ZIGBEE_AC_PHASE_TYPE_A, ZIGBEE_AC_PHASE_TYPE_B, ZIGBEE_AC_PHASE_TYPE_C)
-* ``min`` - Minimum value
-* ``max`` - Maximum value
+* ``min`` - Minimum value (``int16_t`` for power, ``uint16_t`` for voltage, current, power factor, frequency)
+* ``max`` - Maximum value (``int16_t`` for power, ``uint16_t`` for voltage, current, power factor, frequency)
 
 This function will return ``true`` if successful, ``false`` otherwise.
 
@@ -210,7 +210,7 @@ This function will return ``true`` if successful, ``false`` otherwise.
 setACReporting
 ^^^^^^^^^^^^^^
 
-Sets the reporting configuration for AC measurements.
+Sets the reporting configuration for AC measurements. For power (``ZIGBEE_AC_MEASUREMENT_TYPE_POWER``) delta is ``int16_t``; for other measurement types (voltage, current, power factor, frequency) delta is ``uint16_t``.
 
 .. code-block:: arduino
 
@@ -220,7 +220,7 @@ Sets the reporting configuration for AC measurements.
 * ``phase_type`` - Phase type constant (ZIGBEE_AC_PHASE_TYPE_NON_SPECIFIC, ZIGBEE_AC_PHASE_TYPE_A, ZIGBEE_AC_PHASE_TYPE_B, ZIGBEE_AC_PHASE_TYPE_C)
 * ``min_interval`` - Minimum reporting interval in seconds
 * ``max_interval`` - Maximum reporting interval in seconds
-* ``delta`` - Minimum change required to trigger a report
+* ``delta`` - Minimum change required to trigger a report (``int16_t`` for power, ``uint16_t`` for voltage, current, power factor, frequency)
 
 This function will return ``true`` if successful, ``false`` otherwise.
 

--- a/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
@@ -598,16 +598,6 @@ bool ZigbeeElectricalMeasurement::setACMinMaxValue(
     default: log_e("Invalid measurement type"); return false;
   }
 
-  [[maybe_unused]]
-  int16_t int16_min_value = (int16_t)min_value;
-  [[maybe_unused]]
-  int16_t int16_max_value = (int16_t)max_value;
-  [[maybe_unused]]
-  uint16_t uint16_min_value = (uint16_t)min_value;
-  [[maybe_unused]]
-  uint16_t uint16_max_value = (uint16_t)max_value;
-
-  //TODO: Log info about min and max values for different measurement types
   switch (measurement_type) {
     case ZIGBEE_AC_MEASUREMENT_TYPE_VOLTAGE:
       switch (phase_type) {
@@ -669,15 +659,32 @@ bool ZigbeeElectricalMeasurement::setACMinMaxValue(
     esp_zb_cluster_list_get_cluster(_cluster_list, ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
 
   esp_err_t ret = ESP_OK;
-  ret = esp_zb_cluster_update_attr(electrical_measurement_cluster, attr_min_id, (void *)&min_value);
-  if (ret != ESP_OK) {
-    log_e("Failed to set min value: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  ret = esp_zb_cluster_update_attr(electrical_measurement_cluster, attr_max_id, (void *)&max_value);
-  if (ret != ESP_OK) {
-    log_e("Failed to set max value: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
+  if (measure_type == ZIGBEE_AC_MEASUREMENT_TYPE_POWER) {
+    int16_t int16_min_value = (int16_t)min_value;
+    int16_t int16_max_value = (int16_t)max_value;
+    ret = esp_zb_cluster_update_attr(electrical_measurement_cluster, attr_min_id, (void *)&int16_min_value);
+    if (ret != ESP_OK) {
+      log_e("Failed to set min value: 0x%x: %s", ret, esp_err_to_name(ret));
+      return false;
+    }
+    ret = esp_zb_cluster_update_attr(electrical_measurement_cluster, attr_max_id, (void *)&int16_max_value);
+    if (ret != ESP_OK) {
+      log_e("Failed to set max value: 0x%x: %s", ret, esp_err_to_name(ret));
+      return false;
+    }
+  } else {
+    uint16_t uint16_min_value = (uint16_t)min_value;
+    uint16_t uint16_max_value = (uint16_t)max_value;
+    ret = esp_zb_cluster_update_attr(electrical_measurement_cluster, attr_min_id, (void *)&uint16_min_value);
+    if (ret != ESP_OK) {
+      log_e("Failed to set min value: 0x%x: %s", ret, esp_err_to_name(ret));
+      return false;
+    }
+    ret = esp_zb_cluster_update_attr(electrical_measurement_cluster, attr_max_id, (void *)&uint16_max_value);
+    if (ret != ESP_OK) {
+      log_e("Failed to set max value: 0x%x: %s", ret, esp_err_to_name(ret));
+      return false;
+    }
   }
   return true;
 }

--- a/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.h
+++ b/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.h
@@ -95,15 +95,15 @@ public:
    */
   // Add an AC measurement type for selected phase type
   bool addACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, ZIGBEE_AC_PHASE_TYPE phase_type);
-  // Set the AC measurement value for the given measurement type and phase type (uint16_t for voltage, current and frequency, int32_t for power)
+  // Set the AC measurement value for the given measurement type and phase type (uint16_t for voltage, current and frequency, int16_t for power)
   bool setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, ZIGBEE_AC_PHASE_TYPE phase_type, int32_t value);
-  // Set the AC min and max value for the given measurement type and phase type (uint16_t for voltage, current and frequency, int32_t for power)
+  // Set the AC min and max value for the given measurement type and phase type (uint16_t for voltage, current and frequency, int16_t for power)
   bool setACMinMaxValue(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, ZIGBEE_AC_PHASE_TYPE phase_type, int32_t min, int32_t max);
   // Set the AC multiplier and divisor for the given measurement type (common for all phases)
   bool setACMultiplierDivisor(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, uint16_t multiplier, uint16_t divisor);
   // Set the AC power factor for the given phase type (-100 to 100 %)
   bool setACPowerFactor(ZIGBEE_AC_PHASE_TYPE phase_type, int8_t power_factor);
-  // Set the AC reporting interval for the given measurement type and phase type in seconds and delta (measurement change - uint16_t for voltage, current and frequency, int32_t for power)
+  // Set the AC reporting interval for the given measurement type and phase type in seconds and delta (measurement change - uint16_t for voltage, current and frequency, int16_t for power)
   bool
     setACReporting(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, ZIGBEE_AC_PHASE_TYPE phase_type, uint16_t min_interval, uint16_t max_interval, int32_t delta);
   // Report the AC measurement value for the given measurement type and phase type


### PR DESCRIPTION
## Description of Change
This pull request clarifies and corrects the data types used for AC measurement values, min/max values, and reporting deltas in both the Zigbee Electrical Measurement code and its documentation. The main focus is to ensure that power measurements use `int16_t` (to support negative values), while other types (voltage, current, power factor, frequency) use `uint16_t`.

**Documentation updates:**

- Improved documentation in `ep_electrical_measurement.rst` to specify that power uses `int16_t` and other types use `uint16_t` for value, min/max, and delta parameters. [[1]](diffhunk://#diff-e95beae12324abe5dfc2783600bb938fb0d3e465727b6c1ae991d8f3a4c6677bL153-R177) [[2]](diffhunk://#diff-e95beae12324abe5dfc2783600bb938fb0d3e465727b6c1ae991d8f3a4c6677bL213-R213) [[3]](diffhunk://#diff-e95beae12324abe5dfc2783600bb938fb0d3e465727b6c1ae991d8f3a4c6677bL223-R223)

**Code changes:**

- Updated comments in `ZigbeeElectricalMeasurement.h` to accurately describe the expected data types for each measurement type, aligning with the actual implementation.
- Refactored `setACMinMaxValue` in `ZigbeeElectricalMeasurement.cpp` to properly cast and store min/max values as `int16_t` for power and `uint16_t` for other types, ensuring correct type handling at runtime. [[1]](diffhunk://#diff-5be116ed6a03e3806b9b63d07af1e996e0b2b27766107a594be549190a8348a8L601-L610) [[2]](diffhunk://#diff-5be116ed6a03e3806b9b63d07af1e996e0b2b27766107a594be549190a8348a8L672-R688)

These changes help prevent type-related bugs and make the API usage clearer for developers.

## Test Scenarios
Compilation tests only.

## Related links
Closes #12351
