### PR TITLE
fix(wifi): Fix uninitialized struct warning

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -67,7 +67,8 @@ void WiFiClass::printDiag(Print &p) {
         p.println(wifi_station_get_connect_status());
     */
 
-  wifi_config_t conf = {0};
+  wifi_config_t conf;
+  memset(&conf, 0, sizeof(wifi_config_t));
   esp_wifi_get_config((wifi_interface_t)WIFI_IF_STA, &conf);
 
   const char *ssid = reinterpret_cast<const char *>(conf.sta.ssid);


### PR DESCRIPTION
## Description of Change

This pull request makes a minor change to the initialization of the `wifi_config_t` structure in the `WiFi.cpp` file. The change replaces the use of brace initialization with an explicit call to `memset` to zero out the structure, ensuring consistent and clear initialization.

* Changed initialization of `wifi_config_t conf` from brace initialization to using `memset` for zeroing the structure in `WiFiClass::printDiag` (`WiFi.cpp`).

## Test Scenarios

Tested locally
