### PR TITLE
feat(board): Add support for DFRobot FireBeetle 2 ESP32-P4

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -13363,6 +13363,147 @@ dfrobot_firebeetle2_esp32c6.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api.ed
 dfrobot_firebeetle2_esp32c6.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
 dfrobot_firebeetle2_esp32c6.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
 dfrobot_firebeetle2_esp32c6.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
+
+##############################################################
+
+dfrobot_firebeetle2_esp32p4.name=DFRobot FireBeetle 2 ESP32-P4
+
+dfrobot_firebeetle2_esp32p4.bootloader.tool=esptool_py
+dfrobot_firebeetle2_esp32p4.bootloader.tool.default=esptool_py
+
+dfrobot_firebeetle2_esp32p4.upload.tool=esptool_py
+dfrobot_firebeetle2_esp32p4.upload.tool.default=esptool_py
+dfrobot_firebeetle2_esp32p4.upload.tool.network=esp_ota
+
+dfrobot_firebeetle2_esp32p4.upload.maximum_size=1310720
+dfrobot_firebeetle2_esp32p4.upload.maximum_data_size=327680
+dfrobot_firebeetle2_esp32p4.upload.flags=
+dfrobot_firebeetle2_esp32p4.upload.extra_flags=
+dfrobot_firebeetle2_esp32p4.upload.use_1200bps_touch=false
+dfrobot_firebeetle2_esp32p4.upload.wait_for_upload_port=false
+
+dfrobot_firebeetle2_esp32p4.serial.disableDTR=false
+dfrobot_firebeetle2_esp32p4.serial.disableRTS=false
+
+dfrobot_firebeetle2_esp32p4.build.tarch=riscv32
+dfrobot_firebeetle2_esp32p4.build.target=esp
+dfrobot_firebeetle2_esp32p4.build.mcu=esp32p4
+dfrobot_firebeetle2_esp32p4.build.core=esp32
+dfrobot_firebeetle2_esp32p4.build.variant=dfrobot_firebeetle2_esp32p4
+dfrobot_firebeetle2_esp32p4.build.chip_variant=esp32p4_es
+dfrobot_firebeetle2_esp32p4.build.board=DFROBOT_FIREBEETLE2_ESP32P4
+dfrobot_firebeetle2_esp32p4.build.bootloader_addr=0x2000
+
+dfrobot_firebeetle2_esp32p4.build.usb_mode=1
+dfrobot_firebeetle2_esp32p4.build.cdc_on_boot=1
+dfrobot_firebeetle2_esp32p4.build.msc_on_boot=0
+dfrobot_firebeetle2_esp32p4.build.dfu_on_boot=0
+dfrobot_firebeetle2_esp32p4.build.f_cpu=360000000L
+dfrobot_firebeetle2_esp32p4.build.flash_size=16MB
+dfrobot_firebeetle2_esp32p4.build.flash_freq=80m
+dfrobot_firebeetle2_esp32p4.build.img_freq=80m
+dfrobot_firebeetle2_esp32p4.build.flash_mode=dio
+dfrobot_firebeetle2_esp32p4.build.boot=qio
+dfrobot_firebeetle2_esp32p4.build.partitions=default
+dfrobot_firebeetle2_esp32p4.build.defines=-DBOARD_HAS_PSRAM
+
+dfrobot_firebeetle2_esp32p4.menu.ChipVariant.prev3=Before v3.00
+dfrobot_firebeetle2_esp32p4.menu.ChipVariant.prev3.build.chip_variant=esp32p4_es
+dfrobot_firebeetle2_esp32p4.menu.ChipVariant.prev3.build.f_cpu=360000000L
+dfrobot_firebeetle2_esp32p4.menu.ChipVariant.postv3=v3.00 or newer
+dfrobot_firebeetle2_esp32p4.menu.ChipVariant.postv3.build.chip_variant=esp32p4
+dfrobot_firebeetle2_esp32p4.menu.ChipVariant.postv3.build.f_cpu=400000000L
+
+## IDE 2.0 Seems to not update the value
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.default=Disabled
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.default.build.copy_jtag_files=0
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.builtin=Integrated USB JTAG
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.builtin.build.openocdscript=esp32p4-builtin.cfg
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.external=FTDI Adapter
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.external.build.openocdscript=esp32p4-ftdi.cfg
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.external.build.copy_jtag_files=1
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.bridge=ESP USB Bridge
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.bridge.build.openocdscript=esp32p4-bridge.cfg
+dfrobot_firebeetle2_esp32p4.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.default.build.partitions=default
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.minimal.build.partitions=minimal
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.no_fs.build.partitions=no_fs
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.no_ota.build.partitions=no_ota
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.huge_app.build.partitions=huge_app
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.fatflash.build.partitions=ffat
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.esp_sr_16=ESP SR 16M (3MB APP/7MB SPIFFS/2.9MB MODEL)
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.esp_sr_16.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.esp_sr_16.upload.extra_flags=0xD10000 {build.path}/srmodels.bin
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.esp_sr_16.build.partitions=esp_sr_16
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.custom=Custom
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.custom.build.partitions=
+dfrobot_firebeetle2_esp32p4.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.921600=921600
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.921600.upload.speed=921600
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.115200=115200
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.115200.upload.speed=115200
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.256000.windows=256000
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.256000.upload.speed=256000
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.230400.windows.upload.speed=256000
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.230400=230400
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.230400.upload.speed=230400
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.460800.linux=460800
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.460800.macosx=460800
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.460800.upload.speed=460800
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.512000.windows=512000
+dfrobot_firebeetle2_esp32p4.menu.UploadSpeed.512000.upload.speed=512000
+
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.none=None
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.none.build.code_debug=0
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.error=Error
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.error.build.code_debug=1
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.warn=Warn
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.warn.build.code_debug=2
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.info=Info
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.info.build.code_debug=3
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.debug=Debug
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.debug.build.code_debug=4
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.verbose=Verbose
+dfrobot_firebeetle2_esp32p4.menu.DebugLevel.verbose.build.code_debug=5
+
+dfrobot_firebeetle2_esp32p4.menu.EraseFlash.none=Disabled
+dfrobot_firebeetle2_esp32p4.menu.EraseFlash.none.upload.erase_cmd=
+dfrobot_firebeetle2_esp32p4.menu.EraseFlash.all=Enabled
+dfrobot_firebeetle2_esp32p4.menu.EraseFlash.all.upload.erase_cmd=-e
+
 ##############################################################
 
 # dfrobot Romeo ESP32-S3

--- a/variants/dfrobot_firebeetle2_esp32p4/pins_arduino.h
+++ b/variants/dfrobot_firebeetle2_esp32p4/pins_arduino.h
@@ -1,0 +1,61 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BOOT_MODE 35
+// BOOT_MODE2 36 pullup
+
+static const uint8_t LED_BUILTIN = 3;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 37;
+static const uint8_t RX = 38;
+
+static const uint8_t SDA = 7;
+static const uint8_t SCL = 8;
+
+// Use GPIOs 36 or lower on the P4 DevKit to avoid LDO power issues with high numbered GPIOs.
+static const uint8_t SS = 31;
+static const uint8_t MOSI = 29;
+static const uint8_t MISO = 30;
+static const uint8_t SCK = 28;
+
+static const uint8_t A0 = 20;
+static const uint8_t A1 = 21;
+static const uint8_t A2 = 22;
+static const uint8_t A3 = 23;
+static const uint8_t A4 = 51;
+static const uint8_t A5 = 49;
+static const uint8_t A6 = 50;
+static const uint8_t A7 = 52;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 5;
+static const uint8_t T2 = 7;
+static const uint8_t T3 = 8;
+
+//I2S Microphone
+static const uint8_t MIC_I2S_CLK = 12;
+static const uint8_t MIC_I2S_DATA = 9;
+
+//SDMMC
+#define BOARD_HAS_SDMMC
+#define BOARD_SDMMC_SLOT           0
+#define BOARD_SDMMC_POWER_CHANNEL  4
+#define BOARD_SDMMC_POWER_PIN      45
+#define BOARD_SDMMC_POWER_ON_LEVEL LOW
+
+//WIFI - ESP32C6
+#define BOARD_HAS_SDIO_ESP_HOSTED
+#define BOARD_SDIO_ESP_HOSTED_CLK   18
+#define BOARD_SDIO_ESP_HOSTED_CMD   19
+#define BOARD_SDIO_ESP_HOSTED_D0    14
+#define BOARD_SDIO_ESP_HOSTED_D1    15
+#define BOARD_SDIO_ESP_HOSTED_D2    16
+#define BOARD_SDIO_ESP_HOSTED_D3    17
+#define BOARD_SDIO_ESP_HOSTED_RESET 54
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
This pull request introduces support for the DFRobot FireBeetle 2 ESP32-P4 board by adding its configuration to the Arduino build system and defining its pin mappings. The most important changes are grouped below:

**Board configuration and build settings:**

* Added configuration entries for the `dfrobot_firebeetle2_esp32p4` board in `boards.txt`, including upload tools, build settings, partition schemes, JTAG adapter options, upload speeds, debug levels, and flash erase options. This enables the board to be selected and built in the Arduino IDE.

**Pin mapping and hardware definitions:**

* Created the `pins_arduino.h` file for the `dfrobot_firebeetle2_esp32p4` variant, defining all key pin mappings (digital, analog, SPI, I2C, I2S, SDMMC, and WiFi/SDIO), as well as board-specific macros for features like SDMMC and WiFi. This ensures compatibility with Arduino sketches and libraries.

Product Wiki: https://wiki.dfrobot.com/SKU_DFR1172_FireBeetle_2_Board_ESP32_P4