### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -113,57 +113,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "checksum": "SHA-256:78bba21b51de46a461a3c17daf78e77d8bb48eb59715c8e14a4433f939f9f4c3",
+              "size": "518965722"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master a5e4f96
esp-idf: v5.5.3 2c211b2367
arduino: master 6e31ebdde
tinyusb: master 41a00f498
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.5
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 2.0.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.8.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~3
espressif__mdns: 1.9.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.4
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
espressif__dl_fft: 0.3.1
espressif__eppp_link: 1.1.4
espressif__esp-sr: 2.3.1
espressif__esp_hosted: 2.11.7
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 1.3.2
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__wifi_remote_over_eppp: 0.3.1
```
