### PR TITLE
feat(WebServer): skip buffering PUT body when no handler is registered

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -214,34 +214,34 @@ bool WebServer::_parseRequest(NetworkClient &client) {
         _parseArguments(searchStr);
         skipBodyRead = true;
       } else {
-      size_t plainLength;
-      char *plainBuf = readBytesWithTimeout(client, _clientContentLength, plainLength, HTTP_MAX_POST_WAIT);
-      if (plainLength < (size_t)_clientContentLength) {
-        free(plainBuf);
-        return false;
-      }
-      if (_clientContentLength > 0) {
-        if (isEncoded) {
-          //url encoded form
-          if (searchStr != "") {
-            searchStr += '&';
+        size_t plainLength;
+        char *plainBuf = readBytesWithTimeout(client, _clientContentLength, plainLength, HTTP_MAX_POST_WAIT);
+        if (plainLength < (size_t)_clientContentLength) {
+          free(plainBuf);
+          return false;
+        }
+        if (_clientContentLength > 0) {
+          if (isEncoded) {
+            //url encoded form
+            if (searchStr != "") {
+              searchStr += '&';
+            }
+            searchStr += plainBuf;
           }
-          searchStr += plainBuf;
-        }
-        _parseArguments(searchStr);
-        if (!isEncoded) {
-          //plain post json or other data
-          RequestArgument &arg = _currentArgs[_currentArgCount++];
-          arg.key = F("plain");
-          arg.value = String(plainBuf);
-        }
+          _parseArguments(searchStr);
+          if (!isEncoded) {
+            //plain post json or other data
+            RequestArgument &arg = _currentArgs[_currentArgCount++];
+            arg.key = F("plain");
+            arg.value = String(plainBuf);
+          }
 
-        log_v("Plain: %s", plainBuf);
-        free(plainBuf);
-      } else {
-        // No content - but we can still have arguments in the URL.
-        _parseArguments(searchStr);
-      }
+          log_v("Plain: %s", plainBuf);
+          free(plainBuf);
+        } else {
+          // No content - but we can still have arguments in the URL.
+          _parseArguments(searchStr);
+        }
       }
     } else {
       // it IS a form


### PR DESCRIPTION
## Description of Change
For PUT requests with no registered handler (i.e. the request will be dispatched to onNotFound), skip reading the entire request body into RAM and skip clearing the TCP receive buffer afterward.

   Backward compatibility:
   - All non-PUT methods: unchanged
   - PUT with a registered handler: body is read into RAM as before
   - PUT with a canRaw handler: uses the existing raw streaming path
   - Only PUT without any matching handler: body stays in TCP buffer


## Test Scenarios

This allows the onNotFound handler to stream the body directly from client() in small chunks, which is essential for constrained devices like ESP32-C3 (~150KB free heap) that cannot buffer large file uploads in memory.  The primary use case is WebDAV file upload (PUT), where the body can be tens of megabytes.

https://github.com/crosspoint-reader/crosspoint-reader/pull/1030/changes/c3fe996b90af2a36d3f951afaae024225979ce9c

## Related links
Issue #12380
