### PR TITLE
feat(ble): Add local IRK retrieval and fix peer IRK in bluedroid

### DIFF
--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -701,28 +701,44 @@ bool BLEDevice::getPeerIRK(BLEAddress peerAddress, uint8_t *irk) {
     return false;
   }
 
-  // Find the bonded device that matches the peer address
+  // Find the bonded device that matches the peer address.
+  // Bluedroid may store the bond under the connection-time random address,
+  // so we also try matching against pid_key.static_addr (identity address) as a fallback.
   bool found = false;
 
   for (int i = 0; i < dev_num; i++) {
+    // Check if the PID key (which contains the IRK) is present first
+    if (!(bond_dev[i].bond_key.key_mask & ESP_LE_KEY_PID)) {
+      continue;
+    }
+
     BLEAddress bondAddr(bond_dev[i].bd_addr);
-    if (bondAddr.equals(peerAddress)) {
-      // Check if the PID key (which contains the IRK) is present
-      if (bond_dev[i].bond_key.key_mask & ESP_LE_KEY_PID) {
-        memcpy(irk, bond_dev[i].bond_key.pid_key.irk, 16);
-        found = true;
-        log_d("IRK found for peer: %s", peerAddress.toString().c_str());
-        break;
-      } else {
-        log_w("PID key not present for peer: %s", peerAddress.toString().c_str());
+    BLEAddress identityAddr(bond_dev[i].bond_key.pid_key.static_addr);
+
+    if (bondAddr.equals(peerAddress) || identityAddr.equals(peerAddress)) {
+      // Verify the IRK is non-zero before accepting it
+      bool irk_nonzero = false;
+      for (int j = 0; j < 16; j++) {
+        if (bond_dev[i].bond_key.pid_key.irk[j] != 0) {
+          irk_nonzero = true;
+          break;
+        }
       }
+      if (!irk_nonzero) {
+        log_w("PID key present but IRK is all zeroes for peer: %s", peerAddress.toString().c_str());
+        continue;
+      }
+      memcpy(irk, bond_dev[i].bond_key.pid_key.irk, 16);
+      found = true;
+      log_d("IRK found for peer: %s (bond addr: %s)", peerAddress.toString().c_str(), bondAddr.toString().c_str());
+      break;
     }
   }
 
   free(bond_dev);
 
   if (!found) {
-    log_e("IRK not found for peer");
+    log_e("IRK not found for peer: %s", peerAddress.toString().c_str());
     return false;
   }
 
@@ -826,6 +842,105 @@ String BLEDevice::getPeerIRKBase64(BLEAddress peerAddress) {
 String BLEDevice::getPeerIRKReverse(BLEAddress peerAddress) {
   uint8_t irk[16];
   if (!getPeerIRK(peerAddress, irk)) {
+    return String();
+  }
+
+  String result = "";
+  for (int i = 15; i >= 0; i--) {
+    if (irk[i] < 0x10) {
+      result += "0";
+    }
+    result += String(irk[i], HEX);
+  }
+  result.toUpperCase();
+  return result;
+}
+
+/*
+ * @brief Get the local device's own Identity Resolving Key (IRK).
+ * @param [out] irk Buffer to store the 16-byte IRK.
+ * @return True if successful, false otherwise.
+ * @note The local IRK is generated once and stored persistently.
+ *       It is used to generate Resolvable Private Addresses (RPA).
+ */
+bool BLEDevice::getLocalIRK(uint8_t *irk) {
+  log_v(">> BLEDevice::getLocalIRK()");
+
+  if (!initialized) {
+    log_e("BLE is not initialized. Call BLEDevice::init() first");
+    return false;
+  }
+
+  if (irk == nullptr) {
+    log_e("IRK buffer is null");
+    return false;
+  }
+
+#if defined(CONFIG_BLUEDROID_ENABLED)
+  esp_err_t ret = esp_ble_gap_get_local_irk(irk);
+  if (ret != ESP_OK) {
+    log_e("Failed to get local IRK: %d", ret);
+    return false;
+  }
+  log_v("<< BLEDevice::getLocalIRK()");
+  return true;
+#endif  // CONFIG_BLUEDROID_ENABLED
+
+#if defined(CONFIG_NIMBLE_ENABLED)
+  int rc = ble_gap_read_local_irk(irk);
+  if (rc != 0) {
+    log_e("Failed to get local IRK: %d", rc);
+    return false;
+  }
+  log_v("<< BLEDevice::getLocalIRK()");
+  return true;
+#endif  // CONFIG_NIMBLE_ENABLED
+}
+
+/*
+ * @brief Get the local device's IRK as a comma-separated hex string.
+ * @return String in format "0xXX,0xXX,..." or empty string on failure.
+ */
+String BLEDevice::getLocalIRKString() {
+  uint8_t irk[16];
+  if (!getLocalIRK(irk)) {
+    return String();
+  }
+
+  String result = "";
+  for (int i = 0; i < 16; i++) {
+    result += "0x";
+    if (irk[i] < 0x10) {
+      result += "0";
+    }
+    result += String(irk[i], HEX);
+    if (i < 15) {
+      result += ",";
+    }
+  }
+  return result;
+}
+
+/*
+ * @brief Get the local device's IRK as a Base64 encoded string.
+ * @return Base64 encoded string or empty string on failure.
+ */
+String BLEDevice::getLocalIRKBase64() {
+  uint8_t irk[16];
+  if (!getLocalIRK(irk)) {
+    return String();
+  }
+
+  return base64::encode(irk, 16);
+}
+
+/*
+ * @brief Get the local device's IRK in reverse hex format.
+ * @return String in reverse hex format (uppercase) or empty string on failure.
+ */
+String BLEDevice::getLocalIRKReverse() {
+  uint8_t irk[16];
+  if (!getLocalIRK(irk)) {
     return String();
   }
 

--- a/libraries/BLE/src/BLEDevice.h
+++ b/libraries/BLE/src/BLEDevice.h
@@ -196,6 +196,10 @@ public:
   static String getPeerIRKString(BLEAddress peerAddress);
   static String getPeerIRKBase64(BLEAddress peerAddress);
   static String getPeerIRKReverse(BLEAddress peerAddress);
+  static bool getLocalIRK(uint8_t *irk);
+  static String getLocalIRKString();
+  static String getLocalIRKBase64();
+  static String getLocalIRKReverse();
   static BLEAdvertising *getAdvertising();
   static void startAdvertising();
   static void stopAdvertising();


### PR DESCRIPTION
## Description of Change

This pull request adds comprehensive support for retrieving and displaying the local device's Identity Resolving Key (IRK) in the BLE library and its secure static passkey client/server examples. It also improves peer IRK retrieval logic and clarifies NVS handling for identity key persistence. The main changes are grouped below.

**Local IRK retrieval and display:**

* Added `getLocalIRK`, `getLocalIRKString`, `getLocalIRKBase64`, and `getLocalIRKReverse` methods to `BLEDevice` for accessing the local device's IRK in multiple formats. [[1]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8R859-R957) [[2]](diffhunk://#diff-7d54983ed6d61fa10de96e316460c65092dacd07e0d18042d0bdefa5bd699886R199-R202)
* Updated both `Client_secure_static_passkey.ino` and `Server_secure_static_passkey.ino` to call `get_local_irk()` during setup, printing the IRK in hex, Base64, and reverse hex formats for integration with Home Assistant and ESPresense. [[1]](diffhunk://#diff-ebaca6d6e599e7c62b83b5c499755d97d85476d03173c4d816de153c2e8f82e4R65-R87) [[2]](diffhunk://#diff-ebaca6d6e599e7c62b83b5c499755d97d85476d03173c4d816de153c2e8f82e4L247-R287) [[3]](diffhunk://#diff-002162a16a965a56a4f8d140a5f89918db45affa952879e74e529961457a2e87R57-R79) [[4]](diffhunk://#diff-002162a16a965a56a4f8d140a5f89918db45affa952879e74e529961457a2e87R156-R158)

**Peer IRK retrieval improvements:**

* Enhanced `BLEDevice::getPeerIRK` to search both the peer's connection address and identity address, and to verify the IRK is non-zero before returning it. Improved logging for failure cases.
* Clarified comments in client/server security callbacks to explain address handling and fallback logic during peer IRK retrieval. [[1]](diffhunk://#diff-ebaca6d6e599e7c62b83b5c499755d97d85476d03173c4d816de153c2e8f82e4L126-R158) [[2]](diffhunk://#diff-002162a16a965a56a4f8d140a5f89918db45affa952879e74e529961457a2e87L96-R128)

**NVS handling and documentation:**

* Updated comments in both example setups to warn that erasing NVS will change the device's IRK on every boot, and provided guidance for production use to retain stable IRK. Also explained how to clear only bond data without affecting identity keys. [[1]](diffhunk://#diff-ebaca6d6e599e7c62b83b5c499755d97d85476d03173c4d816de153c2e8f82e4L247-R287) [[2]](diffhunk://#diff-002162a16a965a56a4f8d140a5f89918db45affa952879e74e529961457a2e87L115-R146)

## Test Scenarios

Tested locally with ESP32 (Bluedroid) and ESP32-S3 (NimBLE)

## Related links

https://github.com/espressif/arduino-esp32/issues/11881
