### PR TITLE
IDF v5.5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-87912cd2-v1"
+              "version": "idf-release_v5.5-2c211b23-v2"
             },
             {
               "packager": "esp32",
@@ -84,7 +84,7 @@
             {
               "packager": "esp32",
               "name": "esptool_py",
-              "version": "5.1.0"
+              "version": "5.2.0"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-87912cd2-v1",
+          "version": "idf-release_v5.5-2c211b23-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-87912cd2-v1.zip",
-              "checksum": "SHA-256:6246ec5d62b485815f36c38b21f7fb2bf74ff7f0a84b066122b4de6d19589724",
-              "size": "517848606"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v2.zip",
+              "checksum": "SHA-256:818428281595a5f84518186ed75857d72d6f33510d78e823800896b5e8cfcccf",
+              "size": "519017651"
             }
           ]
         },
@@ -472,56 +472,56 @@
         },
         {
           "name": "esptool_py",
-          "version": "5.1.0",
+          "version": "5.2.0",
           "systems": [
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.1.0/esptool-v5.1.0-linux-aarch64.tar.gz",
-              "archiveFileName": "esptool-v5.1.0-linux-aarch64.tar.gz",
-              "checksum": "SHA-256:d2b60d4570cd4919b87eddcbeaab2e0411548b5aab865c234aed8ecc8e5403ac",
-              "size": "56292242"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-aarch64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-linux-aarch64.tar.gz",
+              "checksum": "SHA-256:a3a0fc13ada8d69dddbdfff1c765fa0b88fb578a83d02315be9c15fefa6ca58e",
+              "size": "66991044"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.1.0/esptool-v5.1.0-linux-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.1.0-linux-amd64.tar.gz",
-              "checksum": "SHA-256:49d572d50f6b1f089d1d81d3bd3bd357fbcc40f4f8fd4874f2dc51ad534abb01",
-              "size": "57690602"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-linux-amd64.tar.gz",
+              "checksum": "SHA-256:0a9f6c913fccfacac9261eb2acd8060010db5933c18c8e47cb32377eaa7202a3",
+              "size": "73991509"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.1.0/esptool-v5.1.0-linux-armv7.tar.gz",
-              "archiveFileName": "esptool-v5.1.0-linux-armv7.tar.gz",
-              "checksum": "SHA-256:e22ecb0293fe73c80d0a5fd05873f9ea49a68985b16991cf5980d2b90c8c7276",
-              "size": "53396928"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-armv7.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-linux-armv7.tar.gz",
+              "checksum": "SHA-256:dbf92966eb6ad5f4d068d8b2461f534b15219cb405083a38d26519284e91b73a",
+              "size": "57875713"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.1.0/esptool-v5.1.0-macos-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.1.0-macos-amd64.tar.gz",
-              "checksum": "SHA-256:c485511e0906cb1e0277c5eecff1c4a77b89d76d0c940b685dc9fce2fad4b242",
-              "size": "59088390"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-macos-amd64.tar.gz",
+              "checksum": "SHA-256:dcb6c38cb10e1d7ca5ce658687e4abe47dfda22284857673b55cae010ff5f5ee",
+              "size": "58174910"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.1.0/esptool-v5.1.0-macos-arm64.tar.gz",
-              "archiveFileName": "esptool-v5.1.0-macos-arm64.tar.gz",
-              "checksum": "SHA-256:5d5aab5b64b10dc5001cfa96b5bfa48393ae561e6d797c41a1fdd3f5d3843d03",
-              "size": "56092727"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-arm64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-macos-arm64.tar.gz",
+              "checksum": "SHA-256:2b45270273ff96b6394bd6e317b153cf4a42869ca917d2bcebafc9a3cdac0e1e",
+              "size": "54970972"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.1.0/esptool-v5.1.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.1.0-windows-amd64.zip",
-              "checksum": "SHA-256:f68a8f7728adfc59cd60f9424928199e76eac66372c7bdc23898aa32753a437a",
-              "size": "59936293"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
+              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
+              "size": "58319204"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.1.0/esptool-v5.1.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.1.0-windows-amd64.zip",
-              "checksum": "SHA-256:f68a8f7728adfc59cd60f9424928199e76eac66372c7bdc23898aa32753a437a",
-              "size": "59936293"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
+              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
+              "size": "58319204"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 6fb338a
esp-idf: v5.5.3 2c211b2367
arduino: master fb25e62cc
tinyusb: master bd1e79bc6
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.7.0
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.5
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp32-camera:
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_jpeg: 1.3.1
espressif__esp_matter: 1.4.1
espressif__esp_modem: 2.0.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.8.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__libsodium: 1.0.20~3
espressif__mdns: 1.10.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.4
espressif__dl_fft: 0.3.1
espressif__eppp_link: 1.1.4
espressif__esp-sr: 2.3.1
espressif__esp_hosted: 2.11.7
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 1.3.2
espressif__wifi_remote_over_eppp: 0.3.1
```
