### PR TITLE
Fix: chunk size formatting to use unsigned hex

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -727,7 +727,7 @@ void WebServer::sendContent(const char *content, size_t contentLength) {
   if (_chunked) {
     char *chunkSize = (char *)malloc(11);
     if (chunkSize) {
-      sprintf(chunkSize, "%zx%s", contentLength, footer);
+      sprintf(chunkSize, "%x%s", (unsigned)contentLength, footer);
       _currentClientWrite(chunkSize, strlen(chunkSize));
       free(chunkSize);
     }
@@ -750,7 +750,7 @@ void WebServer::sendContent_P(PGM_P content, size_t size) {
   if (_chunked) {
     char *chunkSize = (char *)malloc(11);
     if (chunkSize) {
-      sprintf(chunkSize, "%zx%s", size, footer);
+      sprintf(chunkSize, "%x%s", (unsigned)size, footer);
       _currentClientWrite(chunkSize, strlen(chunkSize));
       free(chunkSize);
     }


### PR DESCRIPTION
since nanolib does not support `%z`

Webserver crashes when Arduino is compiled as component of IDF and nanolib is used.

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Fix crash in Webserver when nanolib is used from ESP32-P4

## Test Scenarios
Using Webserver with P4 and using nanolib

