### PR TITLE
ci(codeql): Do not cancel jobs if one fails

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,7 @@ jobs:
     name: CodeQL ${{ matrix.language }} analysis
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         language: [python, actions, cpp]
 


### PR DESCRIPTION
## Description of Change

This pull request makes a small update to the CodeQL workflow configuration. The change disables the "fail-fast" behavior in the job matrix, allowing all matrix jobs to run to completion even if one fails.