### PR TITLE
Tone frequency of 0 is no longer set on the pin

### DIFF
--- a/cores/esp32/Tone.cpp
+++ b/cores/esp32/Tone.cpp
@@ -50,7 +50,10 @@ static void tone_task(void *) {
             _pin = tone_msg.pin;
           }
           ledcWriteTone(tone_msg.pin, tone_msg.frequency);
+        } else {
+          ledcWriteTone(tone_msg.pin, 0); // make sure it stops in case something is playing with 0 duration (endless)
         }
+        
         if (tone_msg.duration) {
           delay(tone_msg.duration);
           ledcWriteTone(tone_msg.pin, 0);


### PR DESCRIPTION
## Description of Change
Setting a tone frequency of 0 with some duration works already before this change, but it will generate error messages as the frequency is too low.
This change prevents attempting to output the frequency and prevents the errrors, but still applies the duration.

This effectively allows to submit a more complex tone pattern at once that includes pauses.

## Test Scenarios
ESP32-S3
