### PR TITLE
fix(example): Remove broken, useless print

### DIFF
--- a/libraries/ESP_I2S/examples/ES8388_loopback/ES8388.cpp
+++ b/libraries/ESP_I2S/examples/ES8388_loopback/ES8388.cpp
@@ -102,10 +102,6 @@ void ES8388::reset() {
   uint8_t regconfig;
 
   log_v("Resetting ES8388...");
-  log_d(
-    "Current configuration: _bpsamp=%u, _samprate=%" PRIu32 ", _nchannels=%u, _audio_mode=%u, _dac_output=%u, _adc_input=%u, _mic_gain=%u", _bpsamp, _samprate,
-    _nchannels, _audio_mode, _dac_output, _adc_input, _mic_gain,
-  );
 
   writeReg(ES8388_DACCONTROL3, ES8388_DACMUTE_MUTED | ES8388_DACLER_NORMAL | ES8388_DACSOFTRAMP_DISABLE | ES8388_DACRAMPRATE_4LRCK);
 


### PR DESCRIPTION
## Description of Change

This pull request makes a minor change to the `ES8388.cpp` file by removing a debug log statement from the `reset()` function. This cleans up unnecessary logging output during the reset process that was causing compilation errors.

* Removed a detailed debug log statement that printed the current configuration parameters from the `ES8388::reset()` method in `ES8388.cpp`.
