### PR TITLE
Fix BLERemoteCharacteristic::readValue() (nimble-based) memory leak bug for multiple reads

### DIFF
--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -938,6 +938,7 @@ String BLERemoteCharacteristic::readValue() {
 
   m_semaphoreReadCharEvt.take("readValue");
   m_value = value;
+  if(m_rawData) free(m_rawData);
   m_rawData = (uint8_t *)calloc(value.length(), sizeof(uint8_t));
   for (size_t i = 0; i < value.length(); i++) {
     m_rawData[i] = value[i];


### PR DESCRIPTION
Fixes #12446
Problem:
If readValue() is done only once per pClient existence or if services are cleared then there is no issue. If readValue() is done multiple times previous m_rawData pointer is lost leading to memory leak.
Solution:
Before assigning new memory for the next readValue() or readUInt16() if m_rawData is freed if not nullptr.
Used code suggested in #12446 using xiao esp32 s3