### PR TITLE
IDF v5.5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-2c211b23-v3"
+              "version": "idf-release_v5.5-2c211b23-v4"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-2c211b23-v3",
+          "version": "idf-release_v5.5-2c211b23-v4",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v3.zip",
-              "checksum": "SHA-256:1374b9353a425bff8a63575c64ddc38cbac736bef91fd02e6ef54af8b4946a7b",
-              "size": "519017046"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-2c211b23-v4.zip",
+              "checksum": "SHA-256:d92d469b28dba51bca61756545ee0297407ae53f80c440edc518219aa4aa7ddb",
+              "size": "519200324"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 6e6ce24
esp-idf: v5.5.3 2c211b2367
arduino: master 6c26486d6
tinyusb: master 766ac4f7a
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.7.1
espressif__esp-modbus: 1.0.18
espressif__esp-nn: 1.1.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.5
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_modem: 2.0.0
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.9.1
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~4
espressif__mdns: 1.10.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.20.4
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
espressif__dl_fft: 0.3.1
espressif__eppp_link: 1.1.4
espressif__esp-dsp: 1.7.0
espressif__esp-sr: 2.3.1
espressif__esp_hosted: 2.12.3
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 1.4.1
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__wifi_remote_over_eppp: 0.3.1
```
