### PR TITLE
fix: prevent heap corruption in TwoWire::requestFrom

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -486,10 +486,6 @@ size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop) {
     return 0;
   }
 #endif /* SOC_I2C_SUPPORT_SLAVE */
-  if (rxBuffer == NULL || txBuffer == NULL) {
-    log_e("NULL buffer pointer");
-    return 0;
-  }
   esp_err_t err = ESP_OK;
 #if !CONFIG_DISABLE_HAL_LOCKS
   TaskHandle_t task = xTaskGetCurrentTaskHandle();
@@ -502,6 +498,27 @@ size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop) {
     currentTaskHandle = task;
   }
 #endif
+
+  if (rxBuffer == NULL || txBuffer == NULL) {
+    log_e("NULL buffer pointer");
+#if !CONFIG_DISABLE_HAL_LOCKS
+      currentTaskHandle = NULL;
+      // release lock
+      xSemaphoreGive(lock);
+#endif // !CONFIG_DISABLE_HAL_LOCKS
+    return 0;
+  }
+
+  if (size > bufferSize) {
+    log_e("Requested size (%zu) exceeds I2C buffer size (%zu)", size, bufferSize);
+#if !CONFIG_DISABLE_HAL_LOCKS
+      currentTaskHandle = NULL;
+      // release lock
+      xSemaphoreGive(lock);
+#endif // !CONFIG_DISABLE_HAL_LOCKS
+    return 0;
+  }
+
   if (nonStop) {
     if (address != txAddress) {
       log_e("Unfinished Repeated Start transaction! Expected address do not match! %u != %u", address, txAddress);


### PR DESCRIPTION
Added a check to verify that the requested size does not exceed the internal I2C buffer size. Previously, requesting more bytes than the buffer could hold led to a buffer overflow and heap corruption.

Board: ESP32-3248S035 (or any other with a touch screen on the gt911 driver)

```cpp
#include <Arduino.h>
#include <Wire.h>

#define GT911_ADDR 0x5D

#define GT911_CONFIG_SIZE 0xB9
#define GT911_CONFIG_START 0x8047

#define PIN_TOUCH_INT 21
#define PIN_TOUCH_RST 25

#define PIN_I2C_SDA 33
#define PIN_I2C_SCL 32

uint8_t _conf_buf[GT911_CONFIG_SIZE]{0};

void check_heap()
{
  if (heap_caps_check_integrity_all(true))
  {
    log_i("Heap is healthy");
  }
}

void reset_gt911()
{
  pinMode(PIN_TOUCH_INT, OUTPUT);
  pinMode(PIN_TOUCH_RST, OUTPUT);

  digitalWrite(PIN_TOUCH_INT, 0);
  digitalWrite(PIN_TOUCH_RST, 0);
  delay(10);
  digitalWrite(PIN_TOUCH_INT, 0);
  delay(1);
  digitalWrite(PIN_TOUCH_RST, 1);
  delay(5);
  digitalWrite(PIN_TOUCH_INT, 0);
  delay(50);
  pinMode(PIN_TOUCH_INT, INPUT);
  delay(50);
}

void read_block_data(uint8_t* out_buf, uint16_t reg, uint8_t size)
{
  Wire.beginTransmission(GT911_ADDR);
  Wire.write(reg >> 8);
  Wire.write(reg & 0xFF);
  Wire.endTransmission();

  log_i("Before");
  check_heap();
  Wire.requestFrom(GT911_ADDR, size);
  log_i("After");
  check_heap();

  for (uint8_t i = 0; i < size && Wire.available(); ++i)
    out_buf[i] = Wire.read();
}

void setup()
{
  // Wire.setBufferSize(GT911_CONFIG_SIZE);
  Wire.begin(PIN_I2C_SDA, PIN_I2C_SCL);
  reset_gt911();
  read_block_data(_conf_buf, GT911_CONFIG_START, GT911_CONFIG_SIZE);
}

void loop()
{
}
```

Log:
```log[    42][I][esp32-hal-i2c-ng.c:112] i2cInit(): Initializing I2C Master: num=0 sda=33 scl=32 freq=100000 
[   170][I][main.cpp:73] read_block_data(): Before  
[   175][I][main.cpp:40] check_heap(): Heap is healthy  
[   199][I][main.cpp:76] read_block_data(): After  
CORRUPT HEAP: Bad tail at 0x3ffb83f8. Expected 0xbaad5678 got 0xffffffff  
Guru Meditation Error: Core  1 panic'ed (Interrupt wdt timeout on CPU1).
```