### PR TITLE
fix(bounty): Provide fixes for reported bugbounty

### DIFF
--- a/libraries/NetBIOS/src/NetBIOS.cpp
+++ b/libraries/NetBIOS/src/NetBIOS.cpp
@@ -77,6 +77,10 @@ void NetBIOS::_onPacket(AsyncUDPPacket &packet) {
     nbns_question_t *question = (nbns_question_t *)packet.data();
     if (0 == (question->flags1 & 0x80)) {
       char name[NBNS_MAX_HOSTNAME_LEN + 1];
+      // Ensure name_len cannot exceed the actual name buffer size
+      if (question->name_len == 0 || question->name_len > NBNS_MAX_HOSTNAME_LEN) {
+        return;  // Reject oversized or empty name
+      }
       _getnbname(&question->name[0], (char *)&name, question->name_len);
       if (_name.equals(name)) {
         nbns_answer_t nbnsa;

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -170,6 +170,10 @@ bool WebServer::_parseRequest(NetworkClient &client) {
         } else if (headerValue.startsWith(F("multipart/"))) {
           boundaryStr = headerValue.substring(headerValue.indexOf('=') + 1);
           boundaryStr.replace("\"", "");
+          if (boundaryStr.length() > 70) {  // RFC 2046: max boundary length is 70
+            log_e("Invalid boundary length: %s", boundaryStr.c_str());
+            return false;
+          }
           isForm = true;
         }
       } else if (headerName.equalsIgnoreCase(F("Content-Length"))) {

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -202,6 +202,17 @@ bool WebServer::authenticate(THandlerFunctionAuthCheck fn) {
     if (!_username.length()) {
       goto exf;
     }
+    // The digest "uri" parameter may include a query string, while _currentUri
+    // is parsed without it. Normalize by comparing only the path portion.
+    String _uriPath = _uri;
+    int qmarkIndex = _uriPath.indexOf('?');
+    if (qmarkIndex >= 0) {
+      _uriPath = _uriPath.substring(0, qmarkIndex);
+    }
+    if (_uriPath != _currentUri) {
+      log_e("Authentication Failed: URI mismatch");
+      goto exf;
+    }
 
     String params[] = {_realm, _uri};
     String *password = fn(DIGEST_AUTH, _username, params);


### PR DESCRIPTION
This pull request introduces several security and robustness improvements across the NetBIOS and WebServer libraries. The main focus is on input validation and authentication enhancements to prevent potential misuse and ensure protocol compliance.

**Input validation and security:**

* Added a check in `NetBIOS.cpp` to reject NetBIOS name queries with oversized names, preventing potential buffer overflows or malformed packet handling.
* Enforced the RFC 2046 maximum boundary length (70 characters) in multipart form parsing within `Parsing.cpp`, aborting uploads that exceed this limit to guard against malformed requests.

**Authentication robustness:**

* Improved authentication in `WebServer.cpp` by adding a URI match check during digest authentication, logging and rejecting attempts with mismatched URIs to prevent unauthorized access.