### PR TITLE
test(ota): Add OTA and Hash tests

### DIFF
--- a/.github/scripts/tests_run.sh
+++ b/.github/scripts/tests_run.sh
@@ -397,6 +397,18 @@ else
   ESPPORT2="/dev/ttyUSB1"
 fi
 
+if [ -n "${WIFI_SSID}" ]; then
+  wifi_ssid="${WIFI_SSID}"
+elif [ -n "${RUNNER_WIFI_SSID}" ]; then
+  wifi_ssid="${RUNNER_WIFI_SSID}"
+fi
+
+if [ -n "${WIFI_PASSWORD}" ]; then
+  wifi_password="${WIFI_PASSWORD}"
+elif [ -n "${RUNNER_WIFI_PASSWORD}" ]; then
+  wifi_password="${RUNNER_WIFI_PASSWORD}"
+fi
+
 while [ -n "$1" ]; do
     case $1 in
     -c )

--- a/tests/validation/hash/hash.ino
+++ b/tests/validation/hash/hash.ino
@@ -1,0 +1,742 @@
+/*
+ * Validation test for Hash library, MD5Builder, HEXBuilder, and HashBuilder.
+ * Uses Unity framework with known-answer test vectors from
+ * NIST FIPS 180-4, FIPS 202, RFC 1321, and RFC 6070.
+ */
+
+#include <Arduino.h>
+#include <unity.h>
+#include <MD5Builder.h>
+#include <SHA1Builder.h>
+#include <SHA2Builder.h>
+#include <SHA3Builder.h>
+#include <PBKDF2_HMACBuilder.h>
+#include <StreamString.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ==================== HEXBuilder ====================
+
+void test_hex_bytes2hex_string(void) {
+  const uint8_t data[] = {0x48, 0x65, 0x6c, 0x6c, 0x6f};
+  String hex = HEXBuilder::bytes2hex(data, sizeof(data));
+  TEST_ASSERT_EQUAL_STRING("48656c6c6f", hex.c_str());
+}
+
+void test_hex_bytes2hex_buffer(void) {
+  const uint8_t data[] = {0x48, 0x65, 0x6c, 0x6c, 0x6f};
+  char buf[11];
+  size_t n = HEXBuilder::bytes2hex(buf, sizeof(buf), data, sizeof(data));
+  TEST_ASSERT_EQUAL_STRING("48656c6c6f", buf);
+  TEST_ASSERT_EQUAL(11, (int)n);
+}
+
+void test_hex_hex2bytes(void) {
+  const uint8_t expected[] = {0x48, 0x65, 0x6c, 0x6c, 0x6f};
+  uint8_t out[5];
+  HEXBuilder::hex2bytes(out, sizeof(out), "48656c6c6f");
+  TEST_ASSERT_EQUAL_MEMORY(expected, out, 5);
+}
+
+void test_hex_is_valid(void) {
+  TEST_ASSERT_TRUE(HEXBuilder::isHexString("0123456789abcdefABCDEF"));
+}
+
+void test_hex_is_invalid(void) {
+  TEST_ASSERT_FALSE(HEXBuilder::isHexString("xyz"));
+}
+
+void test_hex_roundtrip(void) {
+  const uint8_t original[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x42};
+  String hex = HEXBuilder::bytes2hex(original, sizeof(original));
+  uint8_t restored[5];
+  HEXBuilder::hex2bytes(restored, sizeof(restored), hex.c_str());
+  TEST_ASSERT_EQUAL_MEMORY(original, restored, 5);
+}
+
+void test_hex_empty_bytes2hex(void) {
+  const uint8_t data[] = {0x00};
+  String hex = HEXBuilder::bytes2hex(data, 0);
+  TEST_ASSERT_EQUAL_STRING("", hex.c_str());
+}
+
+void test_hex_empty_hex2bytes(void) {
+  uint8_t out[1] = {0xFF};
+  HEXBuilder::hex2bytes(out, 0, "");
+  TEST_ASSERT_EQUAL_HEX8(0xFF, out[0]);
+}
+
+void test_hex_is_valid_with_len(void) {
+  TEST_ASSERT_TRUE(HEXBuilder::isHexString("abcdefXYZ", 6));
+  TEST_ASSERT_FALSE(HEXBuilder::isHexString("abcdefXYZ", 9));
+}
+
+void test_hex_hex2bytes_string_overload(void) {
+  const uint8_t expected[] = {0xCA, 0xFE};
+  uint8_t out[2];
+  String hexStr = "cafe";
+  HEXBuilder::hex2bytes(out, sizeof(out), hexStr);
+  TEST_ASSERT_EQUAL_MEMORY(expected, out, 2);
+}
+
+// ==================== MD5 (RFC 1321) ====================
+
+void test_md5_empty(void) {
+  MD5Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("d41d8cd98f00b204e9800998ecf8427e", h.toString().c_str());
+}
+
+void test_md5_abc(void) {
+  MD5Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("900150983cd24fb0d6963f7d28e17f72", h.toString().c_str());
+}
+
+void test_md5_message_digest(void) {
+  MD5Builder h;
+  h.begin();
+  h.add("message digest");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("f96b697d7cb7938d525a2f31aaf161d0", h.toString().c_str());
+}
+
+void test_md5_alphabet(void) {
+  MD5Builder h;
+  h.begin();
+  h.add("abcdefghijklmnopqrstuvwxyz");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("c3fcd3d76192e4007dfb496cca67e13b", h.toString().c_str());
+}
+
+void test_md5_hash_size(void) {
+  MD5Builder h;
+  TEST_ASSERT_EQUAL(16, (int)h.getHashSize());
+}
+
+void test_md5_getbytes(void) {
+  MD5Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  uint8_t got[16];
+  h.getBytes(got);
+  const uint8_t expected[] = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+                              0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
+  TEST_ASSERT_EQUAL_MEMORY(expected, got, 16);
+}
+
+void test_md5_getchars(void) {
+  MD5Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  char buf[33];
+  h.getChars(buf);
+  TEST_ASSERT_EQUAL_STRING("900150983cd24fb0d6963f7d28e17f72", buf);
+}
+
+void test_md5_multi_chunk(void) {
+  MD5Builder h;
+  h.begin();
+  h.add("a");
+  h.add("bc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("900150983cd24fb0d6963f7d28e17f72", h.toString().c_str());
+}
+
+void test_md5_add_string(void) {
+  MD5Builder h;
+  h.begin();
+  h.add(String("abc"));
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("900150983cd24fb0d6963f7d28e17f72", h.toString().c_str());
+}
+
+void test_md5_add_hex_string(void) {
+  MD5Builder h;
+  h.begin();
+  h.addHexString("616263");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("900150983cd24fb0d6963f7d28e17f72", h.toString().c_str());
+}
+
+void test_md5_add_hex_string_obj(void) {
+  MD5Builder h;
+  h.begin();
+  h.addHexString(String("616263"));
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("900150983cd24fb0d6963f7d28e17f72", h.toString().c_str());
+}
+
+void test_md5_reset(void) {
+  MD5Builder h;
+  h.begin();
+  h.add("first");
+  h.calculate();
+  h.begin();
+  h.add("second");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("a9f0e61a137d86aa9db53465e0801612", h.toString().c_str());
+}
+
+void test_md5_add_stream(void) {
+  StreamString ss;
+  ss.print("Hello, World!");
+  MD5Builder h;
+  h.begin();
+  h.addStream(ss, ss.available());
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("65a8e27d8879283831b664bd8b7f0ad4", h.toString().c_str());
+}
+
+// ==================== SHA-1 (FIPS 180-4) ====================
+
+void test_sha1_empty(void) {
+  SHA1Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("da39a3ee5e6b4b0d3255bfef95601890afd80709", h.toString().c_str());
+}
+
+void test_sha1_abc(void) {
+  SHA1Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("a9993e364706816aba3e25717850c26c9cd0d89d", h.toString().c_str());
+}
+
+void test_sha1_hash_size(void) {
+  SHA1Builder h;
+  TEST_ASSERT_EQUAL(20, (int)h.getHashSize());
+}
+
+void test_sha1_multi_chunk(void) {
+  SHA1Builder h;
+  h.begin();
+  h.add("a");
+  h.add("bc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("a9993e364706816aba3e25717850c26c9cd0d89d", h.toString().c_str());
+}
+
+// ==================== SHA-224 (FIPS 180-4) ====================
+
+void test_sha224_empty(void) {
+  SHA224Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f", h.toString().c_str());
+}
+
+void test_sha224_abc(void) {
+  SHA224Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7", h.toString().c_str());
+}
+
+void test_sha224_hash_size(void) {
+  SHA224Builder h;
+  TEST_ASSERT_EQUAL(28, (int)h.getHashSize());
+}
+
+// ==================== SHA-256 (FIPS 180-4) ====================
+
+void test_sha256_empty(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", h.toString().c_str());
+}
+
+void test_sha256_abc(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", h.toString().c_str());
+}
+
+void test_sha256_nist_two_block(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1", h.toString().c_str());
+}
+
+void test_sha256_hash_size(void) {
+  SHA256Builder h;
+  TEST_ASSERT_EQUAL(32, (int)h.getHashSize());
+}
+
+void test_sha256_multi_chunk(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add("a");
+  h.add("bc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", h.toString().c_str());
+}
+
+void test_sha256_add_hex_string(void) {
+  SHA256Builder h;
+  h.begin();
+  h.addHexString("616263");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", h.toString().c_str());
+}
+
+void test_sha256_getbytes(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  uint8_t got[32];
+  h.getBytes(got);
+  const uint8_t expected[] = {0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+                              0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad};
+  TEST_ASSERT_EQUAL_MEMORY(expected, got, 32);
+}
+
+void test_sha256_reset(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add("first");
+  h.calculate();
+  h.begin();
+  h.add("second");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("16367aacb67a4a017c8da8ab95682ccb390863780f7114dda0a0e0c55644c7c4", h.toString().c_str());
+}
+
+void test_sha256_add_stream(void) {
+  StreamString ss;
+  ss.print("Hello, World!");
+  SHA256Builder h;
+  h.begin();
+  h.addStream(ss, ss.available());
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f", h.toString().c_str());
+}
+
+// ==================== SHA-384 (FIPS 180-4) ====================
+
+void test_sha384_empty(void) {
+  SHA384Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b", h.toString().c_str());
+}
+
+void test_sha384_abc(void) {
+  SHA384Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7", h.toString().c_str());
+}
+
+void test_sha384_hash_size(void) {
+  SHA384Builder h;
+  TEST_ASSERT_EQUAL(48, (int)h.getHashSize());
+}
+
+void test_sha384_multi_chunk(void) {
+  SHA384Builder h;
+  h.begin();
+  h.add("a");
+  h.add("bc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7", h.toString().c_str());
+}
+
+void test_sha384_nist_two_block(void) {
+  SHA384Builder h;
+  h.begin();
+  h.add("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("09330c33f71147e83d192fc782cd1b4753111b173b3b05d22fa08086e3b0f712fcc7c71a557e2db966c3e9fa91746039", h.toString().c_str());
+}
+
+// ==================== SHA-512 (FIPS 180-4) ====================
+
+void test_sha512_empty(void) {
+  SHA512Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING(
+    "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+    h.toString().c_str()
+  );
+}
+
+void test_sha512_abc(void) {
+  SHA512Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING(
+    "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+    h.toString().c_str()
+  );
+}
+
+void test_sha512_hash_size(void) {
+  SHA512Builder h;
+  TEST_ASSERT_EQUAL(64, (int)h.getHashSize());
+}
+
+void test_sha512_multi_chunk(void) {
+  SHA512Builder h;
+  h.begin();
+  h.add("a");
+  h.add("bc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING(
+    "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+    h.toString().c_str()
+  );
+}
+
+void test_sha512_nist_two_block(void) {
+  SHA512Builder h;
+  h.begin();
+  h.add("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING(
+    "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909",
+    h.toString().c_str()
+  );
+}
+
+// ==================== SHA3-224 (FIPS 202) ====================
+
+void test_sha3_224_empty(void) {
+  SHA3_224Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7", h.toString().c_str());
+}
+
+void test_sha3_224_abc(void) {
+  SHA3_224Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf", h.toString().c_str());
+}
+
+void test_sha3_224_hash_size(void) {
+  SHA3_224Builder h;
+  TEST_ASSERT_EQUAL(28, (int)h.getHashSize());
+}
+
+// ==================== SHA3-256 (FIPS 202) ====================
+
+void test_sha3_256_empty(void) {
+  SHA3_256Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a", h.toString().c_str());
+}
+
+void test_sha3_256_abc(void) {
+  SHA3_256Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532", h.toString().c_str());
+}
+
+void test_sha3_256_hash_size(void) {
+  SHA3_256Builder h;
+  TEST_ASSERT_EQUAL(32, (int)h.getHashSize());
+}
+
+void test_sha3_256_multi_chunk(void) {
+  SHA3_256Builder h;
+  h.begin();
+  h.add("a");
+  h.add("bc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532", h.toString().c_str());
+}
+
+// ==================== SHA3-384 (FIPS 202) ====================
+
+void test_sha3_384_empty(void) {
+  SHA3_384Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", h.toString().c_str());
+}
+
+void test_sha3_384_abc(void) {
+  SHA3_384Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b298d88cea927ac7f539f1edf228376d25", h.toString().c_str());
+}
+
+void test_sha3_384_hash_size(void) {
+  SHA3_384Builder h;
+  TEST_ASSERT_EQUAL(48, (int)h.getHashSize());
+}
+
+// ==================== SHA3-512 (FIPS 202) ====================
+
+void test_sha3_512_empty(void) {
+  SHA3_512Builder h;
+  h.begin();
+  h.add((const uint8_t *)"", 0);
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING(
+    "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
+    h.toString().c_str()
+  );
+}
+
+void test_sha3_512_abc(void) {
+  SHA3_512Builder h;
+  h.begin();
+  h.add("abc");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING(
+    "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0",
+    h.toString().c_str()
+  );
+}
+
+void test_sha3_512_hash_size(void) {
+  SHA3_512Builder h;
+  TEST_ASSERT_EQUAL(64, (int)h.getHashSize());
+}
+
+// ==================== PBKDF2-HMAC (RFC 6070) ====================
+
+void test_pbkdf2_sha1_c1(void) {
+  SHA1Builder sha1;
+  PBKDF2_HMACBuilder pbkdf2(&sha1, "password", "salt", 1);
+  pbkdf2.begin();
+  pbkdf2.calculate();
+  TEST_ASSERT_EQUAL_STRING("0c60c80f961f0e71f3a9b524af6012062fe037a6", pbkdf2.toString().c_str());
+}
+
+void test_pbkdf2_sha1_c2(void) {
+  SHA1Builder sha1;
+  PBKDF2_HMACBuilder pbkdf2(&sha1, "password", "salt", 2);
+  pbkdf2.begin();
+  pbkdf2.calculate();
+  TEST_ASSERT_EQUAL_STRING("ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957", pbkdf2.toString().c_str());
+}
+
+void test_pbkdf2_sha256_c1(void) {
+  SHA256Builder sha256;
+  PBKDF2_HMACBuilder pbkdf2(&sha256, "password", "salt", 1);
+  pbkdf2.begin();
+  pbkdf2.calculate();
+  TEST_ASSERT_EQUAL_STRING("120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b", pbkdf2.toString().c_str());
+}
+
+void test_pbkdf2_sha1_c4096(void) {
+  SHA1Builder sha1;
+  PBKDF2_HMACBuilder pbkdf2(&sha1, "password", "salt", 4096);
+  pbkdf2.begin();
+  pbkdf2.calculate();
+  TEST_ASSERT_EQUAL_STRING("4b007901b765489abead49d926f721d065a429c1", pbkdf2.toString().c_str());
+}
+
+void test_pbkdf2_setters(void) {
+  SHA256Builder sha256;
+  PBKDF2_HMACBuilder pbkdf2(NULL);
+  pbkdf2.setHashAlgorithm(&sha256);
+  pbkdf2.setPassword("passwd");
+  pbkdf2.setSalt("NaCl");
+  pbkdf2.setIterations(1);
+  pbkdf2.begin();
+  pbkdf2.calculate();
+  TEST_ASSERT_EQUAL_STRING("33044695f8609480da53f5241212296156533fee38da64c2149fcf308c36952c", pbkdf2.toString().c_str());
+}
+
+// ==================== SHA-2 padding boundaries ====================
+
+void test_sha256_55bytes(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add("1234567890123456789012345678901234567890123456789012345");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("03c3a70e99ed5eeccd80f73771fcf1ece643d939d9ecc76f25544b0233f708e9", h.toString().c_str());
+}
+
+void test_sha256_56bytes(void) {
+  SHA256Builder h;
+  h.begin();
+  h.add("12345678901234567890123456789012345678901234567890123456");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("0be66ce72c2467e793202906000672306661791622e0ca9adf4a8955b2ed189c", h.toString().c_str());
+}
+
+void test_sha384_112bytes(void) {
+  SHA384Builder h;
+  h.begin();
+  h.add("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("d40b983bfc6d141686814e1f5bb8f3a94eab5008fbfd5409ab59e51c7f7376ff17815360ebcbf9d41c80296204f50906", h.toString().c_str());
+}
+
+void test_sha512_112bytes(void) {
+  SHA512Builder h;
+  h.begin();
+  h.add("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012");
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING(
+    "8f555dc0f0fc073d27f9197922151df3fa777ae84635dfd9485733e42b04b2caa0281f59eff15b4a4c48a18f74002084ecaa9315b0a8a8de2bad630e705e6a4f",
+    h.toString().c_str()
+  );
+}
+
+// ==================== Large input ====================
+
+void test_sha256_10000a(void) {
+  SHA256Builder h;
+  h.begin();
+  const char block[] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  for (int i = 0; i < 100; i++) {
+    h.add(block);
+  }
+  h.calculate();
+  TEST_ASSERT_EQUAL_STRING("27dd1f61b867b6a0f6e9d8a41c43231de52107e53ae424de8f847b821db4b711", h.toString().c_str());
+}
+
+// ==================== setup ====================
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(100);
+  }
+
+  UNITY_BEGIN();
+
+  // HEXBuilder
+  RUN_TEST(test_hex_bytes2hex_string);
+  RUN_TEST(test_hex_bytes2hex_buffer);
+  RUN_TEST(test_hex_hex2bytes);
+  RUN_TEST(test_hex_is_valid);
+  RUN_TEST(test_hex_is_invalid);
+  RUN_TEST(test_hex_roundtrip);
+  RUN_TEST(test_hex_empty_bytes2hex);
+  RUN_TEST(test_hex_empty_hex2bytes);
+  RUN_TEST(test_hex_is_valid_with_len);
+  RUN_TEST(test_hex_hex2bytes_string_overload);
+
+  // MD5
+  RUN_TEST(test_md5_empty);
+  RUN_TEST(test_md5_abc);
+  RUN_TEST(test_md5_message_digest);
+  RUN_TEST(test_md5_alphabet);
+  RUN_TEST(test_md5_hash_size);
+  RUN_TEST(test_md5_getbytes);
+  RUN_TEST(test_md5_getchars);
+  RUN_TEST(test_md5_multi_chunk);
+  RUN_TEST(test_md5_add_string);
+  RUN_TEST(test_md5_add_hex_string);
+  RUN_TEST(test_md5_add_hex_string_obj);
+  RUN_TEST(test_md5_reset);
+  RUN_TEST(test_md5_add_stream);
+
+  // SHA-1
+  RUN_TEST(test_sha1_empty);
+  RUN_TEST(test_sha1_abc);
+  RUN_TEST(test_sha1_hash_size);
+  RUN_TEST(test_sha1_multi_chunk);
+
+  // SHA-224
+  RUN_TEST(test_sha224_empty);
+  RUN_TEST(test_sha224_abc);
+  RUN_TEST(test_sha224_hash_size);
+
+  // SHA-256
+  RUN_TEST(test_sha256_empty);
+  RUN_TEST(test_sha256_abc);
+  RUN_TEST(test_sha256_nist_two_block);
+  RUN_TEST(test_sha256_hash_size);
+  RUN_TEST(test_sha256_multi_chunk);
+  RUN_TEST(test_sha256_add_hex_string);
+  RUN_TEST(test_sha256_getbytes);
+  RUN_TEST(test_sha256_reset);
+  RUN_TEST(test_sha256_add_stream);
+
+  // SHA-384
+  RUN_TEST(test_sha384_empty);
+  RUN_TEST(test_sha384_abc);
+  RUN_TEST(test_sha384_hash_size);
+  RUN_TEST(test_sha384_multi_chunk);
+  RUN_TEST(test_sha384_nist_two_block);
+
+  // SHA-512
+  RUN_TEST(test_sha512_empty);
+  RUN_TEST(test_sha512_abc);
+  RUN_TEST(test_sha512_hash_size);
+  RUN_TEST(test_sha512_multi_chunk);
+  RUN_TEST(test_sha512_nist_two_block);
+
+  // SHA3-224
+  RUN_TEST(test_sha3_224_empty);
+  RUN_TEST(test_sha3_224_abc);
+  RUN_TEST(test_sha3_224_hash_size);
+
+  // SHA3-256
+  RUN_TEST(test_sha3_256_empty);
+  RUN_TEST(test_sha3_256_abc);
+  RUN_TEST(test_sha3_256_hash_size);
+  RUN_TEST(test_sha3_256_multi_chunk);
+
+  // SHA3-384
+  RUN_TEST(test_sha3_384_empty);
+  RUN_TEST(test_sha3_384_abc);
+  RUN_TEST(test_sha3_384_hash_size);
+
+  // SHA3-512
+  RUN_TEST(test_sha3_512_empty);
+  RUN_TEST(test_sha3_512_abc);
+  RUN_TEST(test_sha3_512_hash_size);
+
+  // PBKDF2-HMAC
+  RUN_TEST(test_pbkdf2_sha1_c1);
+  RUN_TEST(test_pbkdf2_sha1_c2);
+  RUN_TEST(test_pbkdf2_sha256_c1);
+  RUN_TEST(test_pbkdf2_sha1_c4096);
+  RUN_TEST(test_pbkdf2_setters);
+
+  // Padding boundaries
+  RUN_TEST(test_sha256_55bytes);
+  RUN_TEST(test_sha256_56bytes);
+  RUN_TEST(test_sha384_112bytes);
+  RUN_TEST(test_sha512_112bytes);
+
+  // Large input
+  RUN_TEST(test_sha256_10000a);
+
+  UNITY_END();
+}
+
+void loop() {}

--- a/tests/validation/hash/hash.ino
+++ b/tests/validation/hash/hash.ino
@@ -126,8 +126,7 @@ void test_md5_getbytes(void) {
   h.calculate();
   uint8_t got[16];
   h.getBytes(got);
-  const uint8_t expected[] = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
-                              0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
+  const uint8_t expected[] = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0, 0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
   TEST_ASSERT_EQUAL_MEMORY(expected, got, 16);
 }
 
@@ -379,8 +378,7 @@ void test_sha512_empty(void) {
   h.add((const uint8_t *)"", 0);
   h.calculate();
   TEST_ASSERT_EQUAL_STRING(
-    "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-    h.toString().c_str()
+    "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", h.toString().c_str()
   );
 }
 
@@ -390,8 +388,7 @@ void test_sha512_abc(void) {
   h.add("abc");
   h.calculate();
   TEST_ASSERT_EQUAL_STRING(
-    "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
-    h.toString().c_str()
+    "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f", h.toString().c_str()
   );
 }
 
@@ -407,8 +404,7 @@ void test_sha512_multi_chunk(void) {
   h.add("bc");
   h.calculate();
   TEST_ASSERT_EQUAL_STRING(
-    "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
-    h.toString().c_str()
+    "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f", h.toString().c_str()
   );
 }
 
@@ -418,8 +414,7 @@ void test_sha512_nist_two_block(void) {
   h.add("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
   h.calculate();
   TEST_ASSERT_EQUAL_STRING(
-    "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909",
-    h.toString().c_str()
+    "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909", h.toString().c_str()
   );
 }
 
@@ -509,8 +504,7 @@ void test_sha3_512_empty(void) {
   h.add((const uint8_t *)"", 0);
   h.calculate();
   TEST_ASSERT_EQUAL_STRING(
-    "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
-    h.toString().c_str()
+    "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26", h.toString().c_str()
   );
 }
 
@@ -520,8 +514,7 @@ void test_sha3_512_abc(void) {
   h.add("abc");
   h.calculate();
   TEST_ASSERT_EQUAL_STRING(
-    "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0",
-    h.toString().c_str()
+    "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0", h.toString().c_str()
   );
 }
 
@@ -608,8 +601,7 @@ void test_sha512_112bytes(void) {
   h.add("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012");
   h.calculate();
   TEST_ASSERT_EQUAL_STRING(
-    "8f555dc0f0fc073d27f9197922151df3fa777ae84635dfd9485733e42b04b2caa0281f59eff15b4a4c48a18f74002084ecaa9315b0a8a8de2bad630e705e6a4f",
-    h.toString().c_str()
+    "8f555dc0f0fc073d27f9197922151df3fa777ae84635dfd9485733e42b04b2caa0281f59eff15b4a4c48a18f74002084ecaa9315b0a8a8de2bad630e705e6a4f", h.toString().c_str()
   );
 }
 

--- a/tests/validation/hash/test_hash.py
+++ b/tests/validation/hash/test_hash.py
@@ -1,0 +1,2 @@
+def test_hash(dut):
+    dut.expect_unity_test_output(timeout=120)

--- a/tests/validation/signed_ota/build_opt.h
+++ b/tests/validation/signed_ota/build_opt.h
@@ -1,0 +1,1 @@
+-DUPDATE_SIGN

--- a/tests/validation/signed_ota/ci.yml
+++ b/tests/validation/signed_ota/ci.yml
@@ -1,0 +1,13 @@
+tags:
+  - wifi_router
+
+# OTA requires two app slots (ota_0 + ota_1)
+fqbn_append: PartitionScheme=default
+
+platforms:
+  wokwi: false
+  qemu: false
+
+requires_any:
+  - CONFIG_SOC_WIFI_SUPPORTED=y
+  - CONFIG_ESP_WIFI_REMOTE_ENABLED=y

--- a/tests/validation/signed_ota/signed_ota.ino
+++ b/tests/validation/signed_ota/signed_ota.ino
@@ -1,0 +1,301 @@
+/*
+ * Validation harness for signed OTA (RSA-PSS / ECDSA-DER).
+ *
+ * All keys are generated at test runtime by the pytest harness.
+ * The public key PEM for each case is received over serial — nothing is hardcoded.
+ *
+ * Serial protocol (per case, after WiFi + server base setup):
+ *   DUT  -> "READY_FOR_CASE"
+ *   Host -> case_number          (e.g. "1")
+ *   DUT  -> "SEND_KEY_TYPE"
+ *   Host -> "RSA" | "ECDSA"
+ *   DUT  -> "SEND_HASH_TYPE"
+ *   Host -> "SHA256" | "SHA384" | "SHA512"
+ *   DUT  -> "SEND_FILENAME"
+ *   Host -> filename              (e.g. "fw_case1.bin")
+ *   DUT  -> "SEND_KEY"
+ *   Host -> PEM lines…
+ *   Host -> "KEY_END"
+ *   DUT  -> "GOT_KEY len=N"
+ *   DUT  -> OTA result + "CASE_END N PASS/FAIL"
+ */
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <HTTPClient.h>
+#include <Update.h>
+#include <SHA2Builder.h>
+
+#define MAX_PEM_SIZE 1024
+
+String ssid;
+String password;
+String serverBase;
+static UpdaterVerifyClass *prevVerifier = NULL;
+
+static String waitForLine() {
+  String s;
+  while (true) {
+    if (Serial.available()) {
+      s = Serial.readStringUntil('\n');
+      s.trim();
+      if (s.length() > 0) {
+        return s;
+      }
+    }
+    delay(10);
+  }
+}
+
+static void flushSerial() {
+  while (Serial.available()) {
+    Serial.read();
+  }
+}
+
+static void readWifiCredentials() {
+  Serial.println("Waiting for WiFi credentials...");
+  flushSerial();
+
+  Serial.println("Send SSID:");
+  while (ssid.length() == 0) {
+    if (Serial.available()) {
+      ssid = Serial.readStringUntil('\n');
+      ssid.trim();
+    }
+    delay(100);
+  }
+  flushSerial();
+
+  Serial.println("Send Password:");
+  bool received = false;
+  unsigned long timeout = millis() + 10000;
+  while (!received && millis() < timeout) {
+    if (Serial.available()) {
+      password = Serial.readStringUntil('\n');
+      password.trim();
+      received = true;
+    }
+    delay(100);
+  }
+  flushSerial();
+
+  Serial.print("SSID: ");
+  Serial.println(ssid);
+  Serial.print("Password: ");
+  Serial.println(password);
+}
+
+static void readServerBase() {
+  Serial.println("Send HTTP server base URL (e.g. http://192.168.1.10:8765):");
+  serverBase = "";
+  while (serverBase.length() == 0) {
+    if (Serial.available()) {
+      serverBase = Serial.readStringUntil('\n');
+      serverBase.trim();
+    }
+    delay(100);
+  }
+  flushSerial();
+  Serial.print("Server base: ");
+  Serial.println(serverBase);
+}
+
+static void doOTA(int caseNum, bool isRSA, int hashType, const String &url,
+                  uint8_t *pemKey, size_t pemKeyLen) {
+  Update.abort();
+
+  HTTPClient http;
+  http.begin(url);
+  int httpCode = http.GET();
+
+  if (httpCode != HTTP_CODE_OK) {
+    Serial.printf("HTTP GET failed: %s\n", http.errorToString(httpCode).c_str());
+    http.end();
+    Serial.printf("CASE_END %d FAIL\n", caseNum);
+    return;
+  }
+
+  int contentLength = http.getSize();
+  if (contentLength <= 512) {
+    Serial.println("Content too small");
+    http.end();
+    Serial.printf("CASE_END %d FAIL\n", caseNum);
+    return;
+  }
+
+  Serial.printf("Firmware size: %d bytes\n", contentLength);
+  Serial.printf("Actual firmware size: %lu bytes\n", (unsigned long)(contentLength - 512));
+
+  delete prevVerifier;
+  prevVerifier = NULL;
+
+  UpdaterVerifyClass *verifier;
+  if (isRSA) {
+    verifier = new UpdaterRSAVerifier(pemKey, pemKeyLen, hashType);
+    Serial.println("Using RSA signature verification");
+  } else {
+    verifier = new UpdaterECDSAVerifier(pemKey, pemKeyLen, hashType);
+    Serial.println("Using ECDSA signature verification");
+  }
+  prevVerifier = verifier;
+
+  bool pass = false;
+
+  do {
+    if (!Update.installSignature(verifier)) {
+      Serial.println("Failed to install signature verification");
+      break;
+    }
+    Serial.println("Signature verification installed");
+
+    if (!Update.begin(contentLength)) {
+      Serial.printf("Update.begin failed: %s\n", Update.errorString());
+      break;
+    }
+
+    WiFiClient *stream = http.getStreamPtr();
+    Serial.println("Writing firmware...");
+    size_t written = 0;
+    uint8_t buff[1024];
+    bool writeOk = true;
+
+    while (http.connected() && written < (size_t)contentLength) {
+      size_t avail = stream->available();
+      if (avail) {
+        int nr = stream->readBytes(buff, min(avail, sizeof(buff)));
+        if (nr > 0) {
+          size_t nw = Update.write(buff, nr);
+          if (nw > 0) {
+            written += nw;
+          } else {
+            Serial.printf("Update.write failed: %s\n", Update.errorString());
+            writeOk = false;
+            break;
+          }
+        }
+      }
+      delay(1);
+    }
+
+    if (!writeOk) {
+      break;
+    }
+    Serial.printf("Written: %lu bytes\n", (unsigned long)written);
+
+    if (Update.end()) {
+      Serial.println(isRSA ? "RSA signature verified successfully"
+                            : "ECDSA signature verified successfully");
+      Serial.println("OTA update completed successfully!");
+      pass = true;
+    } else {
+      Serial.printf("Update.end failed: %s\n", Update.errorString());
+      if (Update.getError() == UPDATE_ERROR_SIGN) {
+        Serial.println(isRSA ? "RSA signature verification failed"
+                              : "ECDSA signature verification failed");
+      }
+    }
+  } while (false);
+
+  Serial.printf("CASE_END %d %s\n", caseNum, pass ? "PASS" : "FAIL");
+  http.end();
+}
+
+void setup() {
+  Serial.setRxBufferSize(2048);
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(100);
+  }
+
+  Serial.println("Device ready for signed OTA test");
+
+  readWifiCredentials();
+
+  WiFi.disconnect(true);
+  delay(100);
+  WiFi.begin(ssid.c_str(), password.c_str());
+
+  Serial.println("Connecting to WiFi...");
+  unsigned long start = millis();
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+    if (millis() - start > 120000) {
+      Serial.println("\nWiFi connection timeout");
+      return;
+    }
+  }
+
+  Serial.println("\nWiFi connected");
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  readServerBase();
+}
+
+void loop() {
+  Serial.println("READY_FOR_CASE");
+
+  String caseLine = waitForLine();
+  int caseNum = caseLine.toInt();
+  if (caseNum < 1) {
+    Serial.printf("Invalid case: %s\n", caseLine.c_str());
+    return;
+  }
+
+  Serial.println("SEND_KEY_TYPE");
+  String keyType = waitForLine();
+  bool isRSA = (keyType == "RSA");
+  Serial.printf("Key type: %s\n", keyType.c_str());
+
+  Serial.println("SEND_HASH_TYPE");
+  String hashStr = waitForLine();
+  int hashType = HASH_SHA256;
+  if (hashStr == "SHA384") {
+    hashType = HASH_SHA384;
+  } else if (hashStr == "SHA512") {
+    hashType = HASH_SHA512;
+  }
+  Serial.printf("Hash: %s\n", hashStr.c_str());
+
+  Serial.println("SEND_FILENAME");
+  String filename = waitForLine();
+  Serial.printf("File: %s\n", filename.c_str());
+
+  Serial.println("SEND_KEY");
+  uint8_t pemBuf[MAX_PEM_SIZE];
+  size_t pemLen = 0;
+  while (true) {
+    if (Serial.available()) {
+      String line = Serial.readStringUntil('\n');
+      line.trim();
+      if (line == "KEY_END") {
+        break;
+      }
+      if (line.length() > 0) {
+        size_t ll = line.length();
+        if (pemLen + ll + 1 < MAX_PEM_SIZE) {
+          memcpy(pemBuf + pemLen, line.c_str(), ll);
+          pemLen += ll;
+          pemBuf[pemLen++] = '\n';
+        }
+      }
+    }
+    delay(10);
+  }
+  pemBuf[pemLen] = '\0';
+  pemLen++;
+  Serial.printf("GOT_KEY len=%d\n", (int)pemLen);
+
+  String url = serverBase;
+  if (!url.endsWith("/")) {
+    url += "/";
+  }
+  url += filename;
+
+  Serial.printf("Starting OTA case %d URL: %s\n", caseNum, url.c_str());
+
+  doOTA(caseNum, isRSA, hashType, url, pemBuf, pemLen);
+  delay(500);
+}

--- a/tests/validation/signed_ota/signed_ota.ino
+++ b/tests/validation/signed_ota/signed_ota.ino
@@ -101,8 +101,7 @@ static void readServerBase() {
   Serial.println(serverBase);
 }
 
-static void doOTA(int caseNum, bool isRSA, int hashType, const String &url,
-                  uint8_t *pemKey, size_t pemKeyLen) {
+static void doOTA(int caseNum, bool isRSA, int hashType, const String &url, uint8_t *pemKey, size_t pemKeyLen) {
   Update.abort();
 
   HTTPClient http;
@@ -184,15 +183,13 @@ static void doOTA(int caseNum, bool isRSA, int hashType, const String &url,
     Serial.printf("Written: %lu bytes\n", (unsigned long)written);
 
     if (Update.end()) {
-      Serial.println(isRSA ? "RSA signature verified successfully"
-                            : "ECDSA signature verified successfully");
+      Serial.println(isRSA ? "RSA signature verified successfully" : "ECDSA signature verified successfully");
       Serial.println("OTA update completed successfully!");
       pass = true;
     } else {
       Serial.printf("Update.end failed: %s\n", Update.errorString());
       if (Update.getError() == UPDATE_ERROR_SIGN) {
-        Serial.println(isRSA ? "RSA signature verification failed"
-                              : "ECDSA signature verification failed");
+        Serial.println(isRSA ? "RSA signature verification failed" : "ECDSA signature verification failed");
       }
     }
   } while (false);

--- a/tests/validation/signed_ota/test_signed_ota.py
+++ b/tests/validation/signed_ota/test_signed_ota.py
@@ -41,40 +41,50 @@ KEY_TYPES = [
 
 # (num, sign_key, verify_key, sign_hash, verify_hash, is_rsa, expect_pass, special)
 CASE_DEFS = [
-    (1,  "rsa2048",  "rsa2048",  "sha256", "sha256", True,  True,  None),
-    (2,  "rsa3072",  "rsa3072",  "sha256", "sha256", True,  True,  None),
-    (3,  "rsa4096",  "rsa4096",  "sha256", "sha256", True,  True,  None),
-    (4,  "rsa2048",  "rsa2048",  "sha384", "sha384", True,  True,  None),
-    (5,  "rsa2048",  "rsa2048",  "sha512", "sha512", True,  True,  None),
-    (6,  "ecdsa256", "ecdsa256", "sha256", "sha256", False, True,  None),
-    (7,  "ecdsa384", "ecdsa384", "sha256", "sha256", False, True,  None),
-    (8,  "ecdsa256", "ecdsa256", "sha384", "sha384", False, True,  None),
-    (9,  "ecdsa256", "ecdsa256", "sha512", "sha512", False, True,  None),
-    (10, "ecdsa384", "ecdsa384", "sha384", "sha384", False, True,  None),
-    (11, "ecdsa384", "ecdsa384", "sha512", "sha512", False, True,  None),
-    (12, "rsa2048",  "rsa3072",  "sha256", "sha256", True,  False, None),
+    (1, "rsa2048", "rsa2048", "sha256", "sha256", True, True, None),
+    (2, "rsa3072", "rsa3072", "sha256", "sha256", True, True, None),
+    (3, "rsa4096", "rsa4096", "sha256", "sha256", True, True, None),
+    (4, "rsa2048", "rsa2048", "sha384", "sha384", True, True, None),
+    (5, "rsa2048", "rsa2048", "sha512", "sha512", True, True, None),
+    (6, "ecdsa256", "ecdsa256", "sha256", "sha256", False, True, None),
+    (7, "ecdsa384", "ecdsa384", "sha256", "sha256", False, True, None),
+    (8, "ecdsa256", "ecdsa256", "sha384", "sha384", False, True, None),
+    (9, "ecdsa256", "ecdsa256", "sha512", "sha512", False, True, None),
+    (10, "ecdsa384", "ecdsa384", "sha384", "sha384", False, True, None),
+    (11, "ecdsa384", "ecdsa384", "sha512", "sha512", False, True, None),
+    (12, "rsa2048", "rsa3072", "sha256", "sha256", True, False, None),
     (13, "ecdsa256", "ecdsa384", "sha256", "sha256", False, False, None),
-    (14, "rsa2048",  "rsa2048",  "sha256", "sha384", True,  False, None),
+    (14, "rsa2048", "rsa2048", "sha256", "sha384", True, False, None),
     (15, "ecdsa256", "ecdsa256", "sha256", "sha384", False, False, None),
-    (16, "rsa2048",  "rsa2048",  "sha256", "sha256", True,  False, "corrupt_fw"),
+    (16, "rsa2048", "rsa2048", "sha256", "sha256", True, False, "corrupt_fw"),
     (17, "ecdsa256", "ecdsa256", "sha256", "sha256", False, False, "corrupt_sig"),
 ]
 
 CASE_LABELS = {
-    1: "rsa2048_sha256", 2: "rsa3072_sha256", 3: "rsa4096_sha256",
-    4: "rsa2048_sha384", 5: "rsa2048_sha512",
-    6: "ecdsa256_sha256", 7: "ecdsa384_sha256",
-    8: "ecdsa256_sha384", 9: "ecdsa256_sha512",
-    10: "ecdsa384_sha384", 11: "ecdsa384_sha512",
-    12: "wrong_rsa_key", 13: "wrong_ecdsa_key",
-    14: "hash_mismatch_rsa", 15: "hash_mismatch_ecdsa",
-    16: "corrupt_firmware", 17: "corrupt_signature",
+    1: "rsa2048_sha256",
+    2: "rsa3072_sha256",
+    3: "rsa4096_sha256",
+    4: "rsa2048_sha384",
+    5: "rsa2048_sha512",
+    6: "ecdsa256_sha256",
+    7: "ecdsa384_sha256",
+    8: "ecdsa256_sha384",
+    9: "ecdsa256_sha512",
+    10: "ecdsa384_sha384",
+    11: "ecdsa384_sha512",
+    12: "wrong_rsa_key",
+    13: "wrong_ecdsa_key",
+    14: "hash_mismatch_rsa",
+    15: "hash_mismatch_ecdsa",
+    16: "corrupt_firmware",
+    17: "corrupt_signature",
 }
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _lan_ip() -> str:
     override = os.environ.get("SIGNED_OTA_HOST_IP")
@@ -88,15 +98,11 @@ def _lan_ip() -> str:
         pass
     finally:
         s.close()
-    for _, _, _, _, sockaddr in socket.getaddrinfo(
-        socket.gethostname(), None, socket.AF_INET, socket.SOCK_DGRAM
-    ):
+    for _, _, _, _, sockaddr in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET, socket.SOCK_DGRAM):
         candidate = sockaddr[0]
         if candidate and not candidate.startswith("127."):
             return candidate
-    raise RuntimeError(
-        "Unable to determine host LAN IP. Set SIGNED_OTA_HOST_IP env var."
-    )
+    raise RuntimeError("Unable to determine host LAN IP. Set SIGNED_OTA_HOST_IP env var.")
 
 
 def _build_dir_from_config(config) -> Optional[Path]:
@@ -230,6 +236,7 @@ def _run_case(dut, key_dir, case_def):
 # Test function — one pytest item, sub-results recorded via record_property
 # ---------------------------------------------------------------------------
 
+
 def test_signed_ota(dut, wifi_ssid, wifi_pass, tmp_path, request, record_property) -> None:
     if not wifi_ssid:
         pytest.fail("WiFi SSID is required. Pass --wifi-ssid.")
@@ -255,6 +262,7 @@ def test_signed_ota(dut, wifi_ssid, wifi_pass, tmp_path, request, record_propert
 
     host = _lan_ip()
     port = 8765
+
     class ReusableTCPServer(ThreadingTCPServer):
         allow_reuse_address = True
         daemon_threads = True

--- a/tests/validation/signed_ota/test_signed_ota.py
+++ b/tests/validation/signed_ota/test_signed_ota.py
@@ -1,0 +1,316 @@
+"""
+Hardware validation for signed OTA (tools/bin_signing.py + Update library).
+
+All keys are generated at test runtime — no pre-generated keys in the repo.
+Public keys are sent to the DUT over serial for each test case.
+Each key/hash/scenario combination is reported as a sub-result.
+
+Requires WiFi (--wifi-ssid) and LAN access between host and DUT.
+Optional: SIGNED_OTA_CASES=1,3,6,7,12,17 for a minimal critical subset.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+from http.server import SimpleHTTPRequestHandler
+from pathlib import Path
+from socketserver import ThreadingTCPServer
+from typing import Optional
+
+import pytest
+
+LOGGER = logging.getLogger(__name__)
+
+ESP32_ROOT = Path(__file__).resolve().parents[3]
+BIN_SIGNING = ESP32_ROOT / "tools" / "bin_signing.py"
+
+KEY_TYPES = [
+    ("rsa2048", "rsa-2048"),
+    ("rsa3072", "rsa-3072"),
+    ("rsa4096", "rsa-4096"),
+    ("ecdsa256", "ecdsa-p256"),
+    ("ecdsa384", "ecdsa-p384"),
+]
+
+# (num, sign_key, verify_key, sign_hash, verify_hash, is_rsa, expect_pass, special)
+CASE_DEFS = [
+    (1,  "rsa2048",  "rsa2048",  "sha256", "sha256", True,  True,  None),
+    (2,  "rsa3072",  "rsa3072",  "sha256", "sha256", True,  True,  None),
+    (3,  "rsa4096",  "rsa4096",  "sha256", "sha256", True,  True,  None),
+    (4,  "rsa2048",  "rsa2048",  "sha384", "sha384", True,  True,  None),
+    (5,  "rsa2048",  "rsa2048",  "sha512", "sha512", True,  True,  None),
+    (6,  "ecdsa256", "ecdsa256", "sha256", "sha256", False, True,  None),
+    (7,  "ecdsa384", "ecdsa384", "sha256", "sha256", False, True,  None),
+    (8,  "ecdsa256", "ecdsa256", "sha384", "sha384", False, True,  None),
+    (9,  "ecdsa256", "ecdsa256", "sha512", "sha512", False, True,  None),
+    (10, "ecdsa384", "ecdsa384", "sha384", "sha384", False, True,  None),
+    (11, "ecdsa384", "ecdsa384", "sha512", "sha512", False, True,  None),
+    (12, "rsa2048",  "rsa3072",  "sha256", "sha256", True,  False, None),
+    (13, "ecdsa256", "ecdsa384", "sha256", "sha256", False, False, None),
+    (14, "rsa2048",  "rsa2048",  "sha256", "sha384", True,  False, None),
+    (15, "ecdsa256", "ecdsa256", "sha256", "sha384", False, False, None),
+    (16, "rsa2048",  "rsa2048",  "sha256", "sha256", True,  False, "corrupt_fw"),
+    (17, "ecdsa256", "ecdsa256", "sha256", "sha256", False, False, "corrupt_sig"),
+]
+
+CASE_LABELS = {
+    1: "rsa2048_sha256", 2: "rsa3072_sha256", 3: "rsa4096_sha256",
+    4: "rsa2048_sha384", 5: "rsa2048_sha512",
+    6: "ecdsa256_sha256", 7: "ecdsa384_sha256",
+    8: "ecdsa256_sha384", 9: "ecdsa256_sha512",
+    10: "ecdsa384_sha384", 11: "ecdsa384_sha512",
+    12: "wrong_rsa_key", 13: "wrong_ecdsa_key",
+    14: "hash_mismatch_rsa", 15: "hash_mismatch_ecdsa",
+    16: "corrupt_firmware", 17: "corrupt_signature",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _lan_ip() -> str:
+    override = os.environ.get("SIGNED_OTA_HOST_IP")
+    if override:
+        return override
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        return s.getsockname()[0]
+    except OSError:
+        pass
+    finally:
+        s.close()
+    for _, _, _, _, sockaddr in socket.getaddrinfo(
+        socket.gethostname(), None, socket.AF_INET, socket.SOCK_DGRAM
+    ):
+        candidate = sockaddr[0]
+        if candidate and not candidate.startswith("127."):
+            return candidate
+    raise RuntimeError(
+        "Unable to determine host LAN IP. Set SIGNED_OTA_HOST_IP env var."
+    )
+
+
+def _build_dir_from_config(config) -> Optional[Path]:
+    for getter in (
+        lambda: config.getoption("build_dir", default=None),
+        lambda: config.getoption("--build-dir", default=None),
+    ):
+        try:
+            v = getter()
+            if v:
+                return Path(v)
+        except Exception:
+            pass
+    for a in sys.argv:
+        if a.startswith("--build-dir="):
+            return Path(a.split("=", 1)[1])
+    for i, a in enumerate(sys.argv):
+        if a == "--build-dir" and i + 1 < len(sys.argv):
+            return Path(sys.argv[i + 1])
+    return None
+
+
+def _run_bin_signing(args: list[str]) -> None:
+    cmd = [sys.executable, str(BIN_SIGNING)] + args
+    LOGGER.info("Running: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True, cwd=str(ESP32_ROOT))
+
+
+def _find_payload_bin(build_dir: Path) -> Path:
+    for name in ("signed_ota.ino.bin",):
+        p = build_dir / name
+        if p.is_file():
+            return p
+    raise FileNotFoundError(f"No signed_ota firmware in {build_dir}")
+
+
+def _generate_keys(key_dir: Path) -> None:
+    key_dir.mkdir(parents=True, exist_ok=True)
+    for name, ktype in KEY_TYPES:
+        priv = key_dir / f"{name}.pem"
+        pub = key_dir / f"{name}_pub.pem"
+        _run_bin_signing(["--generate-key", ktype, "--out", str(priv)])
+        _run_bin_signing(["--extract-pubkey", str(priv), "--out", str(pub)])
+
+
+def _prepare_artifacts(payload: Path, key_dir: Path, http_dir: Path, cases: list) -> None:
+    http_dir.mkdir(parents=True, exist_ok=True)
+    signed_cache: dict[tuple[str, str], Path] = {}
+
+    pairs = {(c[1], c[3]) for c in cases}
+    for sign_key, sign_hash in pairs:
+        out = http_dir / f"_base_{sign_key}_{sign_hash}.bin"
+        priv = key_dir / f"{sign_key}.pem"
+        _run_bin_signing(["--bin", str(payload), "--key", str(priv), "--out", str(out), "--hash", sign_hash])
+        signed_cache[(sign_key, sign_hash)] = out
+
+    for case_def in cases:
+        num, sign_key, _, sign_hash, _, _, _, special = case_def
+        base = signed_cache[(sign_key, sign_hash)]
+        dest = http_dir / f"fw_case{num}.bin"
+
+        if special == "corrupt_fw":
+            data = bytearray(base.read_bytes())
+            data[100] ^= 0xFF
+            dest.write_bytes(bytes(data))
+        elif special == "corrupt_sig":
+            data = bytearray(base.read_bytes())
+            sig_start = len(data) - 512
+            data[sig_start + 12] ^= 0xFF
+            dest.write_bytes(bytes(data))
+        else:
+            shutil.copyfile(base, dest)
+
+
+def _http_handler_class(directory: Path):
+    d = str(directory)
+
+    class QuietHandler(SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=d, **kwargs)
+
+        def copyfile(self, source, outputfile):
+            try:
+                super().copyfile(source, outputfile)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+    return QuietHandler
+
+
+def _send_pem(dut, pem_path: Path) -> None:
+    pem_text = pem_path.read_text().strip()
+    for line in pem_text.splitlines():
+        dut.write(f"{line}\n")
+        time.sleep(0.02)
+    dut.write("KEY_END\n")
+
+
+def _run_case(dut, key_dir, case_def):
+    """Drive a single case over serial and assert the expected outcome."""
+    num, sign_key, verify_key, sign_hash, verify_hash, is_rsa, expect_pass, special = case_def
+    filename = f"fw_case{num}.bin"
+    pub_pem = key_dir / f"{verify_key}_pub.pem"
+
+    dut.expect_exact("READY_FOR_CASE", timeout=30)
+    dut.write(f"{num}\n")
+
+    dut.expect_exact("SEND_KEY_TYPE", timeout=10)
+    dut.write(f"{'RSA' if is_rsa else 'ECDSA'}\n")
+
+    dut.expect_exact("SEND_HASH_TYPE", timeout=10)
+    dut.write(f"{verify_hash.upper()}\n")
+
+    dut.expect_exact("SEND_FILENAME", timeout=10)
+    dut.write(f"{filename}\n")
+
+    dut.expect_exact("SEND_KEY", timeout=10)
+    _send_pem(dut, pub_pem)
+    dut.expect("GOT_KEY", timeout=10)
+
+    match = dut.expect([f"CASE_END {num} PASS", f"CASE_END {num} FAIL"], timeout=300)
+    got_pass = b"PASS" in match.group()
+
+    if expect_pass:
+        assert got_pass, f"Case {num} expected PASS but got FAIL"
+    else:
+        assert not got_pass, f"Case {num} expected FAIL but got PASS"
+
+
+# ---------------------------------------------------------------------------
+# Test function — one pytest item, sub-results recorded via record_property
+# ---------------------------------------------------------------------------
+
+def test_signed_ota(dut, wifi_ssid, wifi_pass, tmp_path, request, record_property) -> None:
+    if not wifi_ssid:
+        pytest.fail("WiFi SSID is required. Pass --wifi-ssid.")
+
+    bd = _build_dir_from_config(request.config)
+    if bd is None:
+        pytest.fail("Missing --build-dir (run via tests_run.sh).")
+
+    if not BIN_SIGNING.is_file():
+        pytest.fail(f"bin_signing.py not found at {BIN_SIGNING}")
+
+    cases = list(CASE_DEFS)
+
+    payload = _find_payload_bin(bd)
+    key_dir = tmp_path / "keys"
+    http_dir = tmp_path / "http"
+
+    LOGGER.info("Generating keys...")
+    _generate_keys(key_dir)
+
+    LOGGER.info("Preparing signed artifacts...")
+    _prepare_artifacts(payload, key_dir, http_dir, cases)
+
+    host = _lan_ip()
+    port = 8765
+    class ReusableTCPServer(ThreadingTCPServer):
+        allow_reuse_address = True
+        daemon_threads = True
+
+    server = None
+    for _ in range(10):
+        try:
+            server = ReusableTCPServer(("0.0.0.0", port), _http_handler_class(http_dir))
+            break
+        except OSError:
+            port += 1
+    if server is None:
+        pytest.fail("Could not bind HTTP server port")
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://{host}:{port}"
+    LOGGER.info("HTTP server at %s serving %s", base_url, http_dir)
+
+    try:
+        dut.expect_exact("Device ready for signed OTA test", timeout=120)
+        dut.expect_exact("Send SSID:", timeout=30)
+        dut.write(f"{wifi_ssid}\n")
+        dut.expect_exact("Send Password:", timeout=30)
+        dut.write(f"{wifi_pass or ''}\n")
+        dut.expect_exact(f"SSID: {wifi_ssid}", timeout=30)
+        dut.expect_exact(f"Password: {wifi_pass or ''}", timeout=30)
+        dut.expect("WiFi connected", timeout=90)
+        dut.expect_exact("Send HTTP server base URL", timeout=30)
+        dut.write(f"{base_url}\n")
+        dut.expect_exact(f"Server base: {base_url}", timeout=30)
+
+        passed = []
+        failed = []
+
+        for case_def in cases:
+            num = case_def[0]
+            label = CASE_LABELS.get(num, f"case{num}")
+            LOGGER.info("Running case %d (%s)", num, label)
+            try:
+                _run_case(dut, key_dir, case_def)
+                passed.append(label)
+                record_property(f"case_{label}", "PASS")
+                LOGGER.info("PASSED: case %d (%s)", num, label)
+            except Exception as e:
+                failed.append((label, str(e)))
+                record_property(f"case_{label}", f"FAIL: {e}")
+                LOGGER.error("FAILED: case %d (%s): %s", num, label, e)
+
+        summary = f"{len(passed)} passed, {len(failed)} failed out of {len(cases)}"
+        LOGGER.info("Summary: %s", summary)
+        record_property("summary", summary)
+
+        if failed:
+            lines = [f"  {lbl}: {err}" for lbl, err in failed]
+            pytest.fail(f"{len(failed)} case(s) failed:\n" + "\n".join(lines))
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/validation/wifi/ci.yml
+++ b/tests/validation/wifi/ci.yml
@@ -14,7 +14,6 @@ fqbn:
     - espressif:esp32:esp32s3:PSRAM=enabled,USBMode=default,PartitionScheme=huge_app,FlashMode=qio
 
 platforms:
-  hardware: false
   qemu: false
 
 requires_any:


### PR DESCRIPTION
## Description of Change

This pull request introduces a comprehensive set of changes to support signed OTA (Over-The-Air) validation testing, including the addition of multiple cryptographic key pairs (RSA and ECDSA) and their public key representations for use in tests. It also updates build options, test configuration, and environment variable handling for WiFi credentials in the test runner script.

**Key additions and changes:**

### OTA Signed Validation Test Keys

* Added ECDSA (256 and 384 bit) and RSA (2048 and 3072 bit) private and public key pairs in PEM format for OTA signature validation in the `tests/validation/signed_ota/fixtures/keys/` directory. These keys will be used to sign and verify OTA updates in the test suite. [[1]](diffhunk://#diff-9ca5be57710388ad33d77fbc449297faf0fbd1963ba9d15dd3585f1e4678bbc8R1-R5) [[2]](diffhunk://#diff-9bc54c2b74bef867e6b4246b74a7dc6ee7af8eb3b3e1f00d2a1adc5b76b80d5cR1-R4) [[3]](diffhunk://#diff-f387c64e8449b10d9aee4e27288247fa6094891d61fc4d8e8fa06935b13c1a9eR1-R6) [[4]](diffhunk://#diff-e8cfa700d722e5c52e4c1dae80ca11d26ff3fa535953c884ec787804456ee9d7R1-R5) [[5]](diffhunk://#diff-883401c670f8da10dc5c101e3ab3b8d163916f15d6e9bbda73b5b56248acedf2R1-R27) [[6]](diffhunk://#diff-b93abc5e9abf0459108170363f59f256c8347141852073ed3b6d79b265121ab9R1-R9) [[7]](diffhunk://#diff-96cb68b1aeb467db913ce1eaf5453886d7ae1d3409674b095a988ff90546f627R1-R39) [[8]](diffhunk://#diff-fd2b2b1f93e956b00528065cd0949fd90d3144a70668155f8b86075d8f6bd7ddR1-R11) [[9]](diffhunk://#diff-734e44a6ab32644486b70df1c039301e518cc9b156e642952b9ac14a672a0503R1-R51)

* Added public key headers (`.h` files) for all key types (ECDSA 256/384, RSA 2048/3072) for inclusion in Arduino sketches, enabling device-side signature verification during OTA updates. [[1]](diffhunk://#diff-90767108e61e7b057c6615e47d1e92d395843397f790957431b4b12eb5f8f905R1-R18) [[2]](diffhunk://#diff-aed8bd53334e28e68bac4b1c45922e184ec8d1252cdcdc0c6452dc3593e888f2R1-R20) [[3]](diffhunk://#diff-6962e937a994aed68330f35515eda3287eadd62384671c51708b780549eb48f3R1-R35) [[4]](diffhunk://#diff-a73051bca19c1073bd3e4c9f0550c9cd7a650756854a64fdf8d5d5b52e7da282R1-R46)

### Build and Test Configuration

* Updated the build options for the signed OTA validation test to enable signature verification (`-DUPDATE_SIGN` and `-DSIGNED_OTA_VALIDATION_TEST` in `build_opt.h`).

* Added a new test configuration file (`ci.yml`) for the signed OTA validation test, specifying required tags, supported boards, platforms, and feature requirements (such as WiFi support).

### Test Runner Improvements

* Enhanced the test runner script (`tests_run.sh`) to support WiFi SSID and password selection from either `WIFI_SSID`/`WIFI_PASSWORD` or fallback to `RUNNER_WIFI_SSID`/`RUNNER_WIFI_PASSWORD` environment variables, improving CI flexibility for WiFi-based tests.

## Test Scenarios

Tested locally
