### PR TITLE
fix(uart_ci): Fix UART CI test script

### DIFF
--- a/tests/validation/uart/test_uart.py
+++ b/tests/validation/uart/test_uart.py
@@ -1,2 +1,2 @@
 def test_uart(dut):
-    dut.expect_unity_test_output(timeout=240)
+    dut.expect_unity_test_output(timeout=120)

--- a/tests/validation/uart/test_uart.py
+++ b/tests/validation/uart/test_uart.py
@@ -1,2 +1,2 @@
 def test_uart(dut):
-    dut.expect_unity_test_output(timeout=120)
+    dut.expect_unity_test_output(timeout=240)

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -697,6 +697,7 @@ void setup() {
   for (auto *ref : uart_test_configs) {
     UARTTestConfig &config = *ref;
     config.begin(115200);
+    config.setRxFIFOFull(1); // flushes the onReceive right away
     log_d("Setup internal loop-back from and back to UART%d TX >> UART%d RX", config.uart_num, config.uart_num);
     config.serial.onReceive([&config]() {
       config.onReceive();

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -166,17 +166,17 @@ void basic_transmission_test(void) {
 void change_baudrate_test(void) {
   for (auto *ref : uart_test_configs) {
     UARTTestConfig &config = *ref;
-    log_d("Changing baudrate of UART%d to 9600", config.uart_num);
+    log_d("Changing baudrate of UART%d to 57600", config.uart_num);
 
     //Baudrate error should be within 2% of the target baudrate
-    config.serial.updateBaudRate(9600);
-    TEST_ASSERT_UINT_WITHIN(192, 9600, config.serial.baudRate());
+    config.serial.updateBaudRate(57600);
+    TEST_ASSERT_UINT_WITHIN(192, 60000, config.serial.baudRate());
 
-    log_d("Sending string on UART%d using 9600 baudrate", config.uart_num);
-    config.transmit_and_check_msg("using 9600 baudrate");
+    log_d("Sending string on UART%d using 57600 baudrate", config.uart_num);
+    config.transmit_and_check_msg("using 57600 baudrate");
 
     config.serial.begin(115200);
-    TEST_ASSERT_UINT_WITHIN(2304, 115200, config.serial.baudRate());
+    TEST_ASSERT_UINT_WITHIN(2304, 116000, config.serial.baudRate());
 
     log_d("Sending string on UART%d using 115200 baudrate", config.uart_num);
     config.transmit_and_check_msg("using 115200 baudrate");

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -710,6 +710,10 @@ void setup() {
 
   UNITY_BEGIN();
   RUN_TEST(begin_when_running_test);
+  RUN_TEST(inter_uart_pin_move_test);
+  RUN_TEST(same_uart_pin_swap_test);
+  RUN_TEST(move_rx_tx_to_cts_rts_test);
+  RUN_TEST(cross_uart_cts_rts_test);
   RUN_TEST(basic_transmission_test);
   RUN_TEST(resize_buffers_test);
   RUN_TEST(change_baudrate_test);
@@ -722,10 +726,6 @@ void setup() {
   RUN_TEST(periman_test);
   RUN_TEST(change_pins_test);
   RUN_TEST(hardware_flow_control_test);
-  RUN_TEST(inter_uart_pin_move_test);
-  RUN_TEST(same_uart_pin_swap_test);
-  RUN_TEST(move_rx_tx_to_cts_rts_test);
-  RUN_TEST(cross_uart_cts_rts_test);
   RUN_TEST(end_when_stopped_test);
   UNITY_END();
 }

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -166,14 +166,14 @@ void basic_transmission_test(void) {
 void change_baudrate_test(void) {
   for (auto *ref : uart_test_configs) {
     UARTTestConfig &config = *ref;
-    log_d("Changing baudrate of UART%d to 57600", config.uart_num);
+    log_d("Changing baudrate of UART%d to 9600", config.uart_num);
 
     //Baudrate error should be within 2% of the target baudrate
-    config.serial.updateBaudRate(57600);
-    TEST_ASSERT_UINT_WITHIN(1200, 57600, config.serial.baudRate());
+    config.serial.updateBaudRate(9600);
+    TEST_ASSERT_UINT_WITHIN(192, 9600, config.serial.baudRate());
 
-    log_d("Sending string on UART%d using 57600 baudrate", config.uart_num);
-    config.transmit_and_check_msg("using 57600 baudrate");
+    log_d("Sending string on UART%d using 9600 baudrate", config.uart_num);
+    config.transmit_and_check_msg("using 9600 baudrate");
 
     config.serial.begin(115200);
     TEST_ASSERT_UINT_WITHIN(2304, 115200, config.serial.baudRate());

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -697,7 +697,7 @@ void setup() {
   for (auto *ref : uart_test_configs) {
     UARTTestConfig &config = *ref;
     config.begin(115200);
-    config.setRxFIFOFull(1); // flushes the onReceive right away
+    config.serial.setRxFIFOFull(1); // flushes the onReceive right away
     log_d("Setup internal loop-back from and back to UART%d TX >> UART%d RX", config.uart_num, config.uart_num);
     config.serial.onReceive([&config]() {
       config.onReceive();

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -176,7 +176,7 @@ void change_baudrate_test(void) {
     config.transmit_and_check_msg("using 57600 baudrate");
 
     config.serial.begin(115200);
-    TEST_ASSERT_UINT_WITHIN(2304, 116000, config.serial.baudRate());
+    TEST_ASSERT_UINT_WITHIN(2304, 115200, config.serial.baudRate());
 
     log_d("Sending string on UART%d using 115200 baudrate", config.uart_num);
     config.transmit_and_check_msg("using 115200 baudrate");

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -170,7 +170,7 @@ void change_baudrate_test(void) {
 
     //Baudrate error should be within 2% of the target baudrate
     config.serial.updateBaudRate(57600);
-    TEST_ASSERT_UINT_WITHIN(192, 60000, config.serial.baudRate());
+    TEST_ASSERT_UINT_WITHIN(1200, 57600, config.serial.baudRate());
 
     log_d("Sending string on UART%d using 57600 baudrate", config.uart_num);
     config.transmit_and_check_msg("using 57600 baudrate");

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -166,14 +166,14 @@ void basic_transmission_test(void) {
 void change_baudrate_test(void) {
   for (auto *ref : uart_test_configs) {
     UARTTestConfig &config = *ref;
-    log_d("Changing baudrate of UART%d to 9600", config.uart_num);
+    log_d("Changing baudrate of UART%d to 57600", config.uart_num);
 
     //Baudrate error should be within 2% of the target baudrate
-    config.serial.updateBaudRate(9600);
-    TEST_ASSERT_UINT_WITHIN(192, 9600, config.serial.baudRate());
+    config.serial.updateBaudRate(57600);
+    TEST_ASSERT_UINT_WITHIN(1200, 57600, config.serial.baudRate());
 
-    log_d("Sending string on UART%d using 9600 baudrate", config.uart_num);
-    config.transmit_and_check_msg("using 9600 baudrate");
+    log_d("Sending string on UART%d using 57600 baudrate", config.uart_num);
+    config.transmit_and_check_msg("using 57600 baudrate");
 
     config.serial.begin(115200);
     TEST_ASSERT_UINT_WITHIN(2304, 115200, config.serial.baudRate());
@@ -610,6 +610,7 @@ void same_uart_pin_swap_test(void) {
 
   // Confirm transmission still works with swapped pins (re-set loopback for swapped RX)
   uart_internal_loopback(config.uart_num, orig_tx);
+  config.recv_msg = "";
   config.transmit_and_check_msg("after pin swap");
 
   Serial.println("Same UART pin swap test successful");


### PR DESCRIPTION
## Description of Change
`uart.ino` CI test case reports time out problems when running it with ESP32 and ESP32-S3 when simulating it with Wokwi.
This is beacuse those 2 SoC have more UARTs and it take a bit longer to run the validation test, causing such error.

In order to solve it, the timeout is increased to 240 seconds (4 minute) before failing.
It is enough to  get the test results and it doesn't impact the overall processing time because those test case do not fail taking the loger timeout to process it.

## Test Scenarios
CI Only.

## Related links
Runners with error repot.