### PR TITLE
fix(uart_ci): changed pins for running on real P4 boards

### DIFF
--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -673,8 +673,8 @@ void setup() {
   uart_test_configs = {
 #if SOC_UART_HP_NUM >= 2 && defined(RX1) && defined(TX1)
 #if CONFIG_IDF_TARGET_ESP32P4
-    // Using real ESP32-P4 board demands using brokenout pins of the EV board 
-    new UARTTestConfig(1, Serial1, 2, 3),    // RX1= 2 TX1 = 3 ESP32-P4 only TAB5 (ECO-2)=OK || EV BOard (ECO5)=OK
+    // Using a real ESP32-P4 board requires the broken-out pins of the EV board
+    new UARTTestConfig(1, Serial1, 2, 3),    // RX1 = 2, TX1 = 3; ESP32-P4 only: TAB5 (ECO-2) = OK || EV board (ECO5) = OK
 #else
     // Other SoC than ESP32-P4 shall use regular UART1 pins
     new UARTTestConfig(1, Serial1, RX1, TX1),

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -91,11 +91,13 @@ public:
     }
     while (available--) {
       c = (char)serial.read();
-      if (c >= 32 && c <= 128) {
+      if (c > 31 && c < 128) {
         recv_msg += c;
-        //      } else {
-        //        Serial.printf("UART%d onReceive() got a non readable character 0x%x='%c'\r\n", uart_num, c, c);
-        //        Serial.flush();
+#if 0
+      } else {
+        Serial.printf("UART%d onReceive() got a non readable character 0x%x='%c'\r\n", uart_num, c, c);
+        Serial.flush();
+#endif
       }
     }
   }
@@ -103,10 +105,8 @@ public:
 
 /* Utility global variables */
 
-[[maybe_unused]]
-static const int NEW_RX1 = 9;
-[[maybe_unused]]
-static const int NEW_TX1 = 10;
+static const int NEW_RX1 = SDA;
+static const int NEW_TX1 = SCL;
 std::vector<UARTTestConfig *> uart_test_configs;
 
 /* Utility functions */
@@ -421,8 +421,7 @@ void auto_baudrate_test(void) {
 
   if (TEST_UART_NUM == 1) {
     selected_serial = &Serial1;
-    // UART1 pins were swapped because of ESP32-P4
-    uart_internal_loopback(0, /*RX1*/ TX1);
+    uart_internal_loopback(0, RX1);
   } else {
 #ifdef RX2
     selected_serial = &Serial2;
@@ -599,7 +598,7 @@ void same_uart_pin_swap_test(void) {
   int8_t orig_tx = config.default_tx_pin;
 
   // Swap RX and TX on the same UART
-  log_d("Swapping RX(%d) and TX(%d) on UART%d", orig_rx, orig_tx, config.uart_num);
+  log_i("Swapping RX(%d) and TX(%d) on UART%d", orig_rx, orig_tx, config.uart_num);
   bool ret = config.serial.setPins(orig_tx, orig_rx);
   TEST_ASSERT_TRUE(ret);
 
@@ -673,8 +672,13 @@ void setup() {
 
   uart_test_configs = {
 #if SOC_UART_HP_NUM >= 2 && defined(RX1) && defined(TX1)
-    // inverting RX1<->TX1 because ESP32-P4 has a problem with loopback on RX1 :: GPIO11 <-- UART_TX SGINAL
-    new UARTTestConfig(1, Serial1, TX1, RX1),
+#if CONFIG_IDF_TARGET_ESP32P4
+    // Using real ESP32-P4 board demands using brokenout pins of the EV board 
+    new UARTTestConfig(1, Serial1, 2, 3),    // RX1= 2 TX1 = 3 ESP32-P4 only TAB5 (ECO-2)=OK || EV BOard (ECO5)=OK
+#else
+    // Other SoC than ESP32-P4 shall use regular UART1 pins
+    new UARTTestConfig(1, Serial1, RX1, TX1),
+#endif
 #endif
 #if SOC_UART_HP_NUM >= 3 && defined(RX2) && defined(TX2)
     new UARTTestConfig(2, Serial2, RX2, TX2),

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -600,7 +600,7 @@ void same_uart_pin_swap_test(void) {
   int8_t orig_tx = config.default_tx_pin;
 
   // Swap RX and TX on the same UART
-  log_i("Swapping RX(%d) and TX(%d) on UART%d", orig_rx, orig_tx, config.uart_num);
+  log_d("Swapping RX(%d) and TX(%d) on UART%d", orig_rx, orig_tx, config.uart_num);
   bool ret = config.serial.setPins(orig_tx, orig_rx);
   TEST_ASSERT_TRUE(ret);
 

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -678,7 +678,7 @@ void setup() {
     // Using a real ESP32-P4 board requires the broken-out pins of the EV board
     new UARTTestConfig(1, Serial1, 2, 3),    // RX1 = 2, TX1 = 3; ESP32-P4 only: TAB5 (ECO-2) = OK || EV board (ECO5) = OK
 #else
-    // Other SoC than ESP32-P4 shall use regular UART1 pins
+    // Non-ESP32-P4 targets should use the regular UART1 pins
     new UARTTestConfig(1, Serial1, RX1, TX1),
 #endif
 #endif

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -105,8 +105,10 @@ public:
 
 /* Utility global variables */
 
- [[maybe_unused]] static const int NEW_RX1 = SDA;
- [[maybe_unused]] static const int NEW_TX1 = SCL;
+ [[maybe_unused]]
+ static const int NEW_RX1 = 9;
+ [[maybe_unused]]
+ static const int NEW_TX1 = 10;
 std::vector<UARTTestConfig *> uart_test_configs;
 
 /* Utility functions */

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -676,7 +676,7 @@ void setup() {
 #if SOC_UART_HP_NUM >= 2 && defined(RX1) && defined(TX1)
 #if CONFIG_IDF_TARGET_ESP32P4
     // Using a real ESP32-P4 board requires the broken-out pins of the EV board
-    new UARTTestConfig(1, Serial1, 2, 3),    // RX1 = 2, TX1 = 3; ESP32-P4 only: TAB5 (ECO-2) = OK || EV board (ECO5) = OK
+    new UARTTestConfig(1, Serial1, 2, 3),  // RX1 = 2, TX1 = 3; ESP32-P4 only: TAB5 (ECO-2) = OK || EV board (ECO5) = OK
 #else
     // Non-ESP32-P4 targets should use the regular UART1 pins
     new UARTTestConfig(1, Serial1, RX1, TX1),

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -105,10 +105,10 @@ public:
 
 /* Utility global variables */
 
- [[maybe_unused]]
- static const int NEW_RX1 = 9;
- [[maybe_unused]]
- static const int NEW_TX1 = 10;
+[[maybe_unused]]
+static const int NEW_RX1 = 9;
+[[maybe_unused]]
+static const int NEW_TX1 = 10;
 std::vector<UARTTestConfig *> uart_test_configs;
 
 /* Utility functions */

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -105,8 +105,8 @@ public:
 
 /* Utility global variables */
 
-static const int NEW_RX1 = SDA;
-static const int NEW_TX1 = SCL;
+ [[maybe_unused]] static const int NEW_RX1 = SDA;
+ [[maybe_unused]] static const int NEW_TX1 = SCL;
 std::vector<UARTTestConfig *> uart_test_configs;
 
 /* Utility functions */


### PR DESCRIPTION
## Description of Change
The UART `same_uart_pin_swap_test()` that is a test case for swapping RX and TX pins in order to verify if the core code would correctly swap the pins and work correctly was failing with ESP32-P4 using real hardware due to the UART1 pin definition using pins 10 and 11.

In real boards those pins can be used for SDIO communication with ESP32-C6 (M5Stack TAB5) or for connecting with ES8311 (ESP32-P4 Function EV Board) and so on.

Therefore, the PR fixes it and uses pins 2 and 3 for the ESP32-P4 UART1 given that those are usually broken out in most boards.


## Test Scenarios
Tested using real Hardware for ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-H2, ESP32-P4 ECO2, ESP32-P4 ECO5.

Tested using the `uart.ino` sketch.


## Related links
None.