### PR TITLE
Update required components for IDF 6.0 CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ set(min_v6_idf_version "6.0.0")
 if (idf_version VERSION_LESS min_v6_idf_version)
   list(APPEND priv_requires usb)
 else()
-  list(APPEND requires esp_hal_ledc esp_driver_i2c esp_driver_ledc esp_driver_sdm esp_driver_tsens esp_driver_rmt esp_driver_i2s esp_driver_dac)
+  list(APPEND requires esp_hal_uart esp_hal_ledc esp_hal_ana_conv esp_hal_gpio esp_hal_i2c esp_hal_gpspi esp_hal_timg esp_driver_i2c esp_driver_ledc esp_driver_sdm esp_driver_tsens esp_driver_rmt esp_driver_i2s esp_driver_uart esp_driver_dac)
 endif()
 
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThread)


### PR DESCRIPTION
for compile Arduino as a component of IDF 6.0. Currently ESP32-C2 and C61 fails with IDF.

CI compile fail https://github.com/pioarduino/platform-espressif32/actions/runs/24909479940/job/72947199733
