### PR TITLE
fix(zigbee): Time cluster - Epoch starts from year 2000

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -436,8 +436,7 @@ bool ZigbeeEP::setTime(tm time) {
   uint32_t zb_utctime = zb_utctime_from_unix(unix_ts);
   log_d("Setting ZCL UTCTime to %" PRIu32 " s since 2000-01-01 UTC", zb_utctime);
   esp_zb_lock_acquire(portMAX_DELAY);
-  ret =
-    esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, &zb_utctime, false);
+  ret = esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, &zb_utctime, false);
   esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set time: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -22,6 +22,29 @@
 #include "esp_zigbee_cluster.h"
 #include "zcl/esp_zigbee_zcl_power_config.h"
 
+#include <stdint.h>
+
+/* ZigBee ZCL UTCTime: seconds since 2000-01-01 00:00:00 UTC (not Unix 1970 epoch). */
+static constexpr int64_t ZIGBEE_UTCTIME_UNIX_OFFSET_SEC = 946684800LL;
+
+static uint32_t zb_utctime_from_unix(time_t unix_ts) {
+  if (unix_ts == (time_t)-1) {
+    return 0;
+  }
+  int64_t sec = (int64_t)unix_ts - ZIGBEE_UTCTIME_UNIX_OFFSET_SEC;
+  if (sec < 0) {
+    return 0;
+  }
+  if (sec > (int64_t)UINT32_MAX) {
+    return UINT32_MAX;
+  }
+  return (uint32_t)sec;
+}
+
+static time_t unix_time_from_zb_utctime(uint32_t zb_sec) {
+  return (time_t)(ZIGBEE_UTCTIME_UNIX_OFFSET_SEC + (int64_t)zb_sec);
+}
+
 /* Zigbee End Device Class */
 ZigbeeEP::ZigbeeEP(uint8_t endpoint) {
   _endpoint = endpoint;
@@ -355,11 +378,11 @@ void ZigbeeEP::zbOTAState(bool otaActive) {
 }
 
 bool ZigbeeEP::addTimeCluster(tm time, int32_t gmt_offset) {
-  time_t utc_time = 0;
+  uint32_t zb_utctime = 0;
   // Check if time is set
   if (time.tm_year > 0) {
-    // Convert time to UTC
-    utc_time = mktime(&time);
+    time_t unix_ts = mktime(&time);
+    zb_utctime = zb_utctime_from_unix(unix_ts);
   }
 
   // Create time cluster server attributes
@@ -369,7 +392,7 @@ bool ZigbeeEP::addTimeCluster(tm time, int32_t gmt_offset) {
     log_e("Failed to add time zone attribute: 0x%x: %s", ret, esp_err_to_name(ret));
     return false;
   }
-  ret = esp_zb_time_cluster_add_attr(time_cluster_server, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, (void *)&utc_time);
+  ret = esp_zb_time_cluster_add_attr(time_cluster_server, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, (void *)&zb_utctime);
   if (ret != ESP_OK) {
     log_e("Failed to add time attribute: 0x%x: %s", ret, esp_err_to_name(ret));
     return false;
@@ -397,11 +420,16 @@ bool ZigbeeEP::addTimeCluster(tm time, int32_t gmt_offset) {
 
 bool ZigbeeEP::setTime(tm time) {
   esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  time_t utc_time = mktime(&time);
-  // Cast to uint32_t is safe until year 2106.
-  log_d("Setting time to %" PRIu32, (uint32_t)utc_time);
+  time_t unix_ts = mktime(&time);
+  if (unix_ts == (time_t)-1) {
+    log_e("Invalid calendar time");
+    return false;
+  }
+  uint32_t zb_utctime = zb_utctime_from_unix(unix_ts);
+  log_d("Setting ZCL UTCTime to %" PRIu32 " s since 2000-01-01 UTC", zb_utctime);
   esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, &utc_time, false);
+  ret =
+    esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, &zb_utctime, false);
   esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set time: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
@@ -458,7 +486,8 @@ tm ZigbeeEP::getTime(uint8_t endpoint, int32_t short_addr, esp_zb_ieee_addr_t ie
     return tm();
   }
 
-  struct tm *timeinfo = localtime(&_read_time);
+  time_t unix_ts = unix_time_from_zb_utctime((uint32_t)_read_time);
+  struct tm *timeinfo = localtime(&unix_ts);
   if (timeinfo) {
     // Update time
     setTime(*timeinfo);

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -26,22 +26,27 @@
 
 /* ZigBee ZCL UTCTime: seconds since 2000-01-01 00:00:00 UTC (not Unix 1970 epoch). */
 static constexpr int64_t ZIGBEE_UTCTIME_UNIX_OFFSET_SEC = 946684800LL;
+static constexpr uint32_t ZIGBEE_UTCTIME_INVALID = UINT32_MAX;
 
 static uint32_t zb_utctime_from_unix(time_t unix_ts) {
   if (unix_ts == (time_t)-1) {
-    return 0;
+    return ZIGBEE_UTCTIME_INVALID;
   }
   int64_t sec = (int64_t)unix_ts - ZIGBEE_UTCTIME_UNIX_OFFSET_SEC;
   if (sec < 0) {
-    return 0;
+    return ZIGBEE_UTCTIME_INVALID;
   }
   if (sec > (int64_t)UINT32_MAX) {
-    return UINT32_MAX;
+    return ZIGBEE_UTCTIME_INVALID;
   }
   return (uint32_t)sec;
 }
 
 static time_t unix_time_from_zb_utctime(uint32_t zb_sec) {
+  /* 0xFFFFFFFF is a reserved/invalid Zigbee UTCTime sentinel. */
+  if (zb_sec == UINT32_MAX) {
+    return (time_t)-1;
+  }
   return (time_t)(ZIGBEE_UTCTIME_UNIX_OFFSET_SEC + (int64_t)zb_sec);
 }
 

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -43,8 +43,7 @@ static uint32_t zb_utctime_from_unix(time_t unix_ts) {
 }
 
 static time_t unix_time_from_zb_utctime(uint32_t zb_sec) {
-  /* 0xFFFFFFFF is a reserved/invalid Zigbee UTCTime sentinel. */
-  if (zb_sec == UINT32_MAX) {
+  if (zb_sec == ZIGBEE_UTCTIME_INVALID) {
     return (time_t)-1;
   }
   return (time_t)(ZIGBEE_UTCTIME_UNIX_OFFSET_SEC + (int64_t)zb_sec);
@@ -387,6 +386,10 @@ bool ZigbeeEP::addTimeCluster(tm time, int32_t gmt_offset) {
   // Check if time is set
   if (time.tm_year > 0) {
     time_t unix_ts = mktime(&time);
+    if (unix_ts == (time_t)-1) {
+      log_e("Invalid calendar time");
+      return false;
+    }
     zb_utctime = zb_utctime_from_unix(unix_ts);
   }
 


### PR DESCRIPTION
## Description of Change
This pull request updates the handling of time in the Zigbee endpoint code to correctly use the ZigBee ZCL UTCTime format, which is defined as seconds since 2000-01-01 00:00:00 UTC (not the Unix epoch). The changes introduce explicit conversion functions between Unix time and ZigBee time and update all relevant logic to use these conversions, ensuring accurate time representation and compatibility with the ZigBee specification.

**Time handling improvements:**

* Added `zb_utctime_from_unix` and `unix_time_from_zb_utctime` helper functions to convert between Unix time and ZigBee ZCL UTCTime, including proper epoch offset and range checks. (`libraries/Zigbee/src/ZigbeeEP.cpp`)
* Updated the `addTimeCluster` and `setTime` methods to use ZigBee ZCL UTCTime instead of Unix time, ensuring that time attributes are set and logged according to the ZigBee specification. (`libraries/Zigbee/src/ZigbeeEP.cpp`) [[1]](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750L358-R385) [[2]](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750L372-R395) [[3]](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750L400-R432)
* Modified the `getTime` method to convert the stored ZigBee UTCTime back to Unix time before formatting it as a `tm` struct, ensuring correct time retrieval. (`libraries/Zigbee/src/ZigbeeEP.cpp`)

## Test Scenarios
Tested using the temperature sensor example running on C6 connecting to HA (ZHA) receiving correct time. Also tested connecting to second ESP32-C6 loaded with thermostat example. Time getting and setting is correct.

## Related links
Closes #12545 
Closes https://github.com/zigpy/zha/issues/750