### PR TITLE
fix(idf6): Fix examples for ESP-IDF 6

### DIFF
--- a/cores/esp32/esp32-hal-rmt.h
+++ b/cores/esp32/esp32-hal-rmt.h
@@ -18,6 +18,11 @@
 #include "soc/soc_caps.h"
 #if SOC_RMT_SUPPORTED
 
+// Definition of SOC_RMT_TX_CANDIDATES_PER_GROUP is removed in ESP-IDF 6
+#ifndef SOC_RMT_TX_CANDIDATES_PER_GROUP
+#define SOC_RMT_TX_CANDIDATES_PER_GROUP 5
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libraries/ESP32/examples/DeepSleep/TouchWakeUp/TouchWakeUp.ino
+++ b/libraries/ESP32/examples/DeepSleep/TouchWakeUp/TouchWakeUp.ino
@@ -15,6 +15,9 @@ Pranav Cherukupalli <cherukupallip@gmail.com>
 */
 
 #include <Arduino.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "hal/touch_sensor_legacy_types.h"
+#endif
 
 #if CONFIG_IDF_TARGET_ESP32
 #define THRESHOLD 40 /* Greater the value, more the sensitivity */

--- a/libraries/ESP32/examples/HFP_HCI_Audio/HFP_HCI_Audio.ino
+++ b/libraries/ESP32/examples/HFP_HCI_Audio/HFP_HCI_Audio.ino
@@ -748,7 +748,11 @@ void setup() {
   logEspCall("esp_bt_gap_set_pin", esp_bt_gap_set_pin(ESP_BT_PIN_TYPE_VARIABLE, 0, unused_pin_code));
 
   // Set the device name shown to the user during pairing.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  logEspCall("esp_bt_gap_set_device_name", esp_bt_gap_set_device_name("ESP32_HFP_AUDIO"));
+#else
   logEspCall("esp_bt_dev_set_device_name", esp_bt_dev_set_device_name("ESP32_HFP_AUDIO"));
+#endif
 
   // Set the Class of Device so the phone identifies us as a hands-free audio device.
   esp_bt_cod_t cod = {};

--- a/libraries/ESP32/examples/HFP_HCI_Audio_I2S/HFP_HCI_Audio_I2S.ino
+++ b/libraries/ESP32/examples/HFP_HCI_Audio_I2S/HFP_HCI_Audio_I2S.ino
@@ -734,7 +734,11 @@ void setup() {
 
   // Advertise a friendly name so the phone's Bluetooth menu shows something
   // recognizable rather than a raw MAC address.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  logEspCall("esp_bt_gap_set_device_name", esp_bt_gap_set_device_name("ESP32_HFP_BRIDGE"));
+#else
   logEspCall("esp_bt_dev_set_device_name", esp_bt_dev_set_device_name("ESP32_HFP_BRIDGE"));
+#endif
 
   // Set the Class of Device (CoD) to Audio/Video + Hands-free subclass.
   // This tells the phone the device is a hands-free unit so it offers HFP

--- a/libraries/ESP32/examples/RMT/Legacy_RMT_Driver_Compatible/Legacy_RMT_Driver_Compatible.ino
+++ b/libraries/ESP32/examples/RMT/Legacy_RMT_Driver_Compatible/Legacy_RMT_Driver_Compatible.ino
@@ -15,7 +15,7 @@
 #error "ESP32_ARDUINO_NO_RGB_BUILTIN is not defined, this example is intended to demonstrate the RMT Legacy driver."
 #error "Please add the file 'build_opt.h' with '-DESP32_ARDUINO_NO_RGB_BUILTIN' to your Arduino project folder."
 
-#else
+#elif ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
 
 // add the file "build_opt.h" to your Arduino project folder with "-DESP32_ARDUINO_NO_RGB_BUILTIN" to use the RMT Legacy driver
 // rgbLedWrite() is a function that writes to the RGB LED and it won't be available here
@@ -36,4 +36,12 @@ void loop() {
   delay(5000);
 }
 
-#endif  // ESP32_ARDUINO_NO_RGB_BUILTIN
+#else
+
+// Legacy RMT driver is not available from ESP-IDF v6.0
+
+void setup() {}
+
+void loop() {}
+
+#endif  // ESP32_ARDUINO_NO_RGB_BUILTIN || pre IDF6

--- a/libraries/ESP_SR/examples/Basic/ci.yml
+++ b/libraries/ESP_SR/examples/Basic/ci.yml
@@ -5,7 +5,7 @@ fqbn:
     - espressif:esp32:esp32p4:USBMode=default,ChipVariant=postv3,PartitionScheme=esp_sr_16,FlashSize=16M,FlashMode=qio
 
 requires:
-  - CONFIG_SOC_I2S_SUPPORTED=y
+  - CONFIG_MODEL_IN_FLASH=y
 
 targets:
   esp32: false

--- a/libraries/Update/examples/HTTPS_OTA_Update/HTTPS_OTA_Update.ino
+++ b/libraries/Update/examples/HTTPS_OTA_Update/HTTPS_OTA_Update.ino
@@ -42,14 +42,19 @@ static HttpsOTAStatus_t otastatus;
 
 void HttpEvent(HttpEvent_t *event) {
   switch (event->event_id) {
-    case HTTP_EVENT_ERROR:        Serial.println("Http Event Error"); break;
-    case HTTP_EVENT_ON_CONNECTED: Serial.println("Http Event On Connected"); break;
-    case HTTP_EVENT_HEADER_SENT:  Serial.println("Http Event Header Sent"); break;
-    case HTTP_EVENT_ON_HEADER:    Serial.printf("Http Event On Header, key=%s, value=%s\n", event->header_key, event->header_value); break;
-    case HTTP_EVENT_ON_DATA:      break;
-    case HTTP_EVENT_ON_FINISH:    Serial.println("Http Event On Finish"); break;
-    case HTTP_EVENT_DISCONNECTED: Serial.println("Http Event Disconnected"); break;
-    case HTTP_EVENT_REDIRECT:     Serial.println("Http Event Redirect"); break;
+    case HTTP_EVENT_ERROR:               Serial.println("Http Event Error"); break;
+    case HTTP_EVENT_ON_CONNECTED:        Serial.println("Http Event On Connected"); break;
+    case HTTP_EVENT_HEADER_SENT:         Serial.println("Http Event Header Sent"); break;
+    case HTTP_EVENT_ON_HEADER:           Serial.printf("Http Event On Header, key=%s, value=%s\n", event->header_key, event->header_value); break;
+    case HTTP_EVENT_ON_DATA:             break;
+    case HTTP_EVENT_ON_FINISH:           Serial.println("Http Event On Finish"); break;
+    case HTTP_EVENT_DISCONNECTED:        Serial.println("Http Event Disconnected"); break;
+    case HTTP_EVENT_REDIRECT:            Serial.println("Http Event Redirect"); break;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    case HTTP_EVENT_ON_HEADERS_COMPLETE: Serial.println("Http Event On Headers Complete"); break;
+    case HTTP_EVENT_ON_STATUS_CODE:      Serial.println("Http Event On Status Code"); break;
+#endif
+    default:                             break;
   }
 }
 

--- a/libraries/Update/examples/HTTPS_OTA_Update/HTTPS_OTA_Update.ino
+++ b/libraries/Update/examples/HTTPS_OTA_Update/HTTPS_OTA_Update.ino
@@ -42,19 +42,19 @@ static HttpsOTAStatus_t otastatus;
 
 void HttpEvent(HttpEvent_t *event) {
   switch (event->event_id) {
-    case HTTP_EVENT_ERROR:               Serial.println("Http Event Error"); break;
-    case HTTP_EVENT_ON_CONNECTED:        Serial.println("Http Event On Connected"); break;
-    case HTTP_EVENT_HEADER_SENT:         Serial.println("Http Event Header Sent"); break;
-    case HTTP_EVENT_ON_HEADER:           Serial.printf("Http Event On Header, key=%s, value=%s\n", event->header_key, event->header_value); break;
-    case HTTP_EVENT_ON_DATA:             break;
-    case HTTP_EVENT_ON_FINISH:           Serial.println("Http Event On Finish"); break;
-    case HTTP_EVENT_DISCONNECTED:        Serial.println("Http Event Disconnected"); break;
-    case HTTP_EVENT_REDIRECT:            Serial.println("Http Event Redirect"); break;
+    case HTTP_EVENT_ERROR:        Serial.println("Http Event Error"); break;
+    case HTTP_EVENT_ON_CONNECTED: Serial.println("Http Event On Connected"); break;
+    case HTTP_EVENT_HEADER_SENT:  Serial.println("Http Event Header Sent"); break;
+    case HTTP_EVENT_ON_HEADER:    Serial.printf("Http Event On Header, key=%s, value=%s\n", event->header_key, event->header_value); break;
+    case HTTP_EVENT_ON_DATA:      break;
+    case HTTP_EVENT_ON_FINISH:    Serial.println("Http Event On Finish"); break;
+    case HTTP_EVENT_DISCONNECTED: Serial.println("Http Event Disconnected"); break;
+    case HTTP_EVENT_REDIRECT:     Serial.println("Http Event Redirect"); break;
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
     case HTTP_EVENT_ON_HEADERS_COMPLETE: Serial.println("Http Event On Headers Complete"); break;
     case HTTP_EVENT_ON_STATUS_CODE:      Serial.println("Http Event On Status Code"); break;
 #endif
-    default:                             break;
+    default: break;
   }
 }
 

--- a/libraries/Update/src/Updater_Signing.cpp
+++ b/libraries/Update/src/Updater_Signing.cpp
@@ -116,9 +116,8 @@ bool UpdaterRSAVerifier::verify(SHA2Builder *hash, const void *signature, size_t
   // In mbedtls 4.x, MBEDTLS_PK_SIGALG_RSA_PSS maps to PSA_ALG_RSA_PSS_ANY_SALT,
   // which accepts any salt length used during signing. This matches the
   // PSS.MAX_LENGTH salt produced by bin_signing.py.
-  int ret = mbedtls_pk_verify_ext(
-    MBEDTLS_PK_SIGALG_RSA_PSS, (mbedtls_pk_context *)_ctx, md_type, hashBytes, hash_size, (const unsigned char *)signature, key_len
-  );
+  int ret =
+    mbedtls_pk_verify_ext(MBEDTLS_PK_SIGALG_RSA_PSS, (mbedtls_pk_context *)_ctx, md_type, hashBytes, hash_size, (const unsigned char *)signature, key_len);
 #else
   // PSS.MAX_LENGTH salt = key_len - hash_size - 2
   int expected_salt_len = (int)key_len - (int)hash_size - 2;

--- a/libraries/Update/src/Updater_Signing.cpp
+++ b/libraries/Update/src/Updater_Signing.cpp
@@ -7,17 +7,33 @@
 #ifdef UPDATE_SIGN
 
 #include "Updater_Signing.h"
+#include "mbedtls/build_info.h"
 #include "mbedtls/pk.h"
+#include "mbedtls/md.h"
+#include "mbedtls/asn1.h"
+#if MBEDTLS_VERSION_MAJOR >= 4
+#include "psa/crypto.h"
+#else
 #include "mbedtls/rsa.h"
 #include "mbedtls/ecdsa.h"
 #include "mbedtls/ecp.h"
-#include "mbedtls/md.h"
-#include "mbedtls/asn1.h"
+#endif
 #include "esp32-hal-log.h"
 
 // ==================== UpdaterRSAVerifier (using mbedtls) ====================
 
 UpdaterRSAVerifier::UpdaterRSAVerifier(const uint8_t *pubkey, size_t pubkeyLen, int hashType) : _hashType(hashType), _valid(false) {
+#if MBEDTLS_VERSION_MAJOR >= 4
+  // mbedtls 4.x routes PK operations through PSA; PSA must be initialised before
+  // any cryptographic operation, including parsing a public key.
+  psa_status_t psa_ret = psa_crypto_init();
+  if (psa_ret != PSA_SUCCESS) {
+    log_e("PSA crypto init failed: %d", (int)psa_ret);
+    _ctx = nullptr;
+    return;
+  }
+#endif
+
   _ctx = new mbedtls_pk_context;
   mbedtls_pk_init((mbedtls_pk_context *)_ctx);
 
@@ -29,10 +45,18 @@ UpdaterRSAVerifier::UpdaterRSAVerifier(const uint8_t *pubkey, size_t pubkeyLen, 
   }
 
   // Verify it's an RSA key
+#if MBEDTLS_VERSION_MAJOR >= 4
+  // mbedtls_pk_get_type was removed in 4.x; use the PSA can_do query instead.
+  if (!mbedtls_pk_can_do_psa((mbedtls_pk_context *)_ctx, PSA_ALG_RSA_PSS_ANY_SALT(PSA_ALG_SHA_256), PSA_KEY_USAGE_VERIFY_HASH)) {
+    log_e("Public key is not RSA");
+    return;
+  }
+#else
   if (mbedtls_pk_get_type((mbedtls_pk_context *)_ctx) != MBEDTLS_PK_RSA) {
     log_e("Public key is not RSA");
     return;
   }
+#endif
 
   _valid = true;
   log_i("RSA public key loaded successfully");
@@ -65,21 +89,39 @@ bool UpdaterRSAVerifier::verify(SHA2Builder *hash, const void *signature, size_t
   hash->getBytes(hashBytes);
   size_t hash_size = hash->getHashSize();
 
-  // Use RSA-PSS verification to match bin_signing.py which signs with PSS padding
-  // and salt_length=PSS.MAX_LENGTH (which equals key_len - hash_size - 2)
+  // RSA signatures are always exactly key_len bytes. The buffer may be
+  // zero-padded to a larger size (e.g. 512), so use key_len as the actual
+  // signature length to avoid MBEDTLS_ERR_PK_SIG_LEN_MISMATCH.
+#if MBEDTLS_VERSION_MAJOR >= 4
+  // mbedtls 4.x removed mbedtls_rsa_get_len / direct RSA context access;
+  // derive the modulus byte length from the PK bit length instead.
+  size_t key_len = (mbedtls_pk_get_bitlen((mbedtls_pk_context *)_ctx) + 7) / 8;
+#else
   mbedtls_rsa_context *rsa_ctx = mbedtls_pk_rsa(*(mbedtls_pk_context *)_ctx);
   if (!rsa_ctx) {
     log_e("Failed to get RSA context");
     return false;
   }
+  size_t key_len = mbedtls_rsa_get_len(rsa_ctx);
+#endif
 
-  int key_len = (int)mbedtls_rsa_get_len(rsa_ctx);
-  if ((size_t)key_len > signatureLen) {
-    log_e("Signature buffer (%u bytes) smaller than RSA key length (%d bytes)", (unsigned)signatureLen, key_len);
+  if (key_len == 0 || key_len > signatureLen) {
+    log_e("Signature buffer (%u bytes) smaller than RSA key length (%u bytes)", (unsigned)signatureLen, (unsigned)key_len);
     return false;
   }
+
+  // Use RSA-PSS verification to match bin_signing.py which signs with PSS padding
+  // and salt_length=PSS.MAX_LENGTH (which equals key_len - hash_size - 2).
+#if MBEDTLS_VERSION_MAJOR >= 4
+  // In mbedtls 4.x, MBEDTLS_PK_SIGALG_RSA_PSS maps to PSA_ALG_RSA_PSS_ANY_SALT,
+  // which accepts any salt length used during signing. This matches the
+  // PSS.MAX_LENGTH salt produced by bin_signing.py.
+  int ret = mbedtls_pk_verify_ext(
+    MBEDTLS_PK_SIGALG_RSA_PSS, (mbedtls_pk_context *)_ctx, md_type, hashBytes, hash_size, (const unsigned char *)signature, key_len
+  );
+#else
   // PSS.MAX_LENGTH salt = key_len - hash_size - 2
-  int expected_salt_len = key_len - (int)hash_size - 2;
+  int expected_salt_len = (int)key_len - (int)hash_size - 2;
   if (expected_salt_len < 0) {
     log_e("RSA key too small for hash algorithm");
     return false;
@@ -89,12 +131,10 @@ bool UpdaterRSAVerifier::verify(SHA2Builder *hash, const void *signature, size_t
   pss_opts.mgf1_hash_id = md_type;
   pss_opts.expected_salt_len = expected_salt_len;
 
-  // RSA signatures are always exactly key_len bytes. The buffer may be
-  // zero-padded to a larger size (e.g. 512), so use key_len as the actual
-  // signature length to avoid MBEDTLS_ERR_PK_SIG_LEN_MISMATCH.
   int ret = mbedtls_pk_verify_ext(
     MBEDTLS_PK_RSASSA_PSS, &pss_opts, (mbedtls_pk_context *)_ctx, md_type, hashBytes, hash_size, (const unsigned char *)signature, key_len
   );
+#endif
 
   if (ret == 0) {
     log_i("RSA signature verified successfully");
@@ -108,6 +148,17 @@ bool UpdaterRSAVerifier::verify(SHA2Builder *hash, const void *signature, size_t
 // ==================== UpdaterECDSAVerifier (using mbedtls) ====================
 
 UpdaterECDSAVerifier::UpdaterECDSAVerifier(const uint8_t *pubkey, size_t pubkeyLen, int hashType) : _hashType(hashType), _valid(false) {
+#if MBEDTLS_VERSION_MAJOR >= 4
+  // mbedtls 4.x routes PK operations through PSA; PSA must be initialised before
+  // any cryptographic operation, including parsing a public key.
+  psa_status_t psa_ret = psa_crypto_init();
+  if (psa_ret != PSA_SUCCESS) {
+    log_e("PSA crypto init failed: %d", (int)psa_ret);
+    _ctx = nullptr;
+    return;
+  }
+#endif
+
   _ctx = new mbedtls_pk_context;
   mbedtls_pk_init((mbedtls_pk_context *)_ctx);
 
@@ -119,11 +170,19 @@ UpdaterECDSAVerifier::UpdaterECDSAVerifier(const uint8_t *pubkey, size_t pubkeyL
   }
 
   // Verify it's an ECDSA key
+#if MBEDTLS_VERSION_MAJOR >= 4
+  // mbedtls_pk_get_type was removed in 4.x; use the PSA can_do query instead.
+  if (!mbedtls_pk_can_do_psa((mbedtls_pk_context *)_ctx, PSA_ALG_ECDSA(PSA_ALG_SHA_256), PSA_KEY_USAGE_VERIFY_HASH)) {
+    log_e("Public key is not ECDSA");
+    return;
+  }
+#else
   mbedtls_pk_type_t type = mbedtls_pk_get_type((mbedtls_pk_context *)_ctx);
   if (type != MBEDTLS_PK_ECKEY && type != MBEDTLS_PK_ECDSA) {
     log_e("Public key is not ECDSA");
     return;
   }
+#endif
 
   _valid = true;
   log_i("ECDSA public key loaded successfully");
@@ -171,6 +230,8 @@ bool UpdaterECDSAVerifier::verify(SHA2Builder *hash, const void *signature, size
     }
   }
 
+  // mbedtls_pk_verify accepts the legacy DER-encoded ECDSA signature format in
+  // both 3.x and 4.x, so the same call works across versions.
   int ret = mbedtls_pk_verify((mbedtls_pk_context *)_ctx, md_type, hashBytes, hash->getHashSize(), sig_start, actualSigLen);
 
   if (ret == 0) {

--- a/libraries/Update/src/Updater_Signing.cpp
+++ b/libraries/Update/src/Updater_Signing.cpp
@@ -24,7 +24,7 @@
 
 UpdaterRSAVerifier::UpdaterRSAVerifier(const uint8_t *pubkey, size_t pubkeyLen, int hashType) : _hashType(hashType), _valid(false) {
 #if MBEDTLS_VERSION_MAJOR >= 4
-  // mbedtls 4.x routes PK operations through PSA; PSA must be initialised before
+  // mbedtls 4.x routes PK operations through PSA; PSA must be initialized before
   // any cryptographic operation, including parsing a public key.
   psa_status_t psa_ret = psa_crypto_init();
   if (psa_ret != PSA_SUCCESS) {
@@ -148,7 +148,7 @@ bool UpdaterRSAVerifier::verify(SHA2Builder *hash, const void *signature, size_t
 
 UpdaterECDSAVerifier::UpdaterECDSAVerifier(const uint8_t *pubkey, size_t pubkeyLen, int hashType) : _hashType(hashType), _valid(false) {
 #if MBEDTLS_VERSION_MAJOR >= 4
-  // mbedtls 4.x routes PK operations through PSA; PSA must be initialised before
+  // mbedtls 4.x routes PK operations through PSA; PSA must be initialized before
   // any cryptographic operation, including parsing a public key.
   psa_status_t psa_ret = psa_crypto_init();
   if (psa_ret != PSA_SUCCESS) {

--- a/libraries/WiFi/examples/FTM/FTM_Initiator/FTM_Initiator.ino
+++ b/libraries/WiFi/examples/FTM/FTM_Initiator/FTM_Initiator.ino
@@ -39,7 +39,9 @@ void onFtmReport(arduino_event_t *event) {
     // The estimated distance in meters may vary depending on some factors (see README file)
     Serial.printf("FTM Estimate: Distance: %.2f m, Return Time: %" PRIu32 " ns\n", (float)report->dist_est / 100.0, report->rtt_est);
     // Pointer to FTM Report with multiple entries, should be freed after use
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
     free(report->ftm_report_data);
+#endif
   } else {
     Serial.print("FTM Error: ");
     Serial.println(status_str[report->status]);

--- a/libraries/WiFi/examples/WPS/WPS.ino
+++ b/libraries/WiFi/examples/WPS/WPS.ino
@@ -46,7 +46,11 @@ void wpsStart() {
     return;
   }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  err = esp_wifi_wps_start();
+#else
   err = esp_wifi_wps_start(0);
+#endif
   if (err != ESP_OK) {
     Serial.printf("WPS Start Failed: 0x%x: %s\n", err, esp_err_to_name(err));
   }

--- a/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
+++ b/libraries/WiFiProv/examples/WiFiProv/WiFiProv.ino
@@ -68,13 +68,13 @@ void setup() {
   // Sample uuid that user can pass during provisioning using BLE
   uint8_t uuid[16] = {0xb4, 0xdf, 0x5a, 0x1c, 0x3f, 0x6b, 0xf4, 0xbf, 0xea, 0x4a, 0x82, 0x03, 0x04, 0x90, 0x1a, 0x02};
   WiFiProv.beginProvision(
-    NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BLE, NETWORK_PROV_SECURITY_1, pop, service_name, service_key, uuid, reset_provisioned
+    NETWORK_PROV_SCHEME_BLE, NETWORK_PROV_SCHEME_HANDLER_FREE_BLE, NETWORK_PROV_SECURITY, pop, service_name, service_key, uuid, reset_provisioned
   );
   log_d("ble qr");
   WiFiProv.printQR(service_name, pop, "ble");
 #else
   Serial.println("Begin Provisioning using Soft AP");
-  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE, NETWORK_PROV_SECURITY_1, pop, service_name, service_key);
+  WiFiProv.beginProvision(NETWORK_PROV_SCHEME_SOFTAP, NETWORK_PROV_SCHEME_HANDLER_NONE, NETWORK_PROV_SECURITY, pop, service_name, service_key);
   log_d("wifi qr");
   WiFiProv.printQR(service_name, pop, "softap");
 #endif

--- a/tests/validation/touch/touch.ino
+++ b/tests/validation/touch/touch.ino
@@ -2,6 +2,9 @@
 #include <unity.h>
 #include "soc/soc_caps.h"
 #include "hal/touch_sensor_ll.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include "hal/touch_sensor_legacy_types.h"
+#endif
 
 #if CONFIG_IDF_TARGET_ESP32
 


### PR DESCRIPTION
This pull request introduces a range of compatibility updates and improvements to ensure the ESP32 Arduino core and its libraries work correctly with ESP-IDF v6.x and mbedTLS v4.x, while maintaining backward compatibility with earlier versions. The changes include conditional compilation for API changes, updates to cryptographic signature verification logic, and minor configuration and memory management adjustments.

**ESP-IDF v6.x Compatibility Updates:**

- Updated Bluetooth device name setting in `HFP_HCI_Audio.ino` and `HFP_HCI_Audio_I2S.ino` to use `esp_bt_gap_set_device_name` for ESP-IDF v6.x and above, while retaining the old API for previous versions. [[1]](diffhunk://#diff-85af81928559973c2d5388525618cb9c1edf4334500f1933ba5226254a0750eaR751-R755) [[2]](diffhunk://#diff-c0849b753d71db2905c4bda577e17e12a9ea6f1876be896ad38eacd28d798bc8R737-R741)
- Adjusted RMT driver usage in `Legacy_RMT_Driver_Compatible.ino` to disable legacy RMT driver support for ESP-IDF v6.x and above, reflecting its removal. [[1]](diffhunk://#diff-403d3e37425fb7b8a653e673e170a01ca8a247da6a2e400c18f36302f91b355fL18-R18) [[2]](diffhunk://#diff-403d3e37425fb7b8a653e673e170a01ca8a247da6a2e400c18f36302f91b355fL39-R47)
- Added missing constant definition for `SOC_RMT_TX_CANDIDATES_PER_GROUP` if not present (removed in ESP-IDF 6).
- Updated WPS start and FTM report memory handling to match ESP-IDF v6.x API changes. [[1]](diffhunk://#diff-b14ec4c1c1ed77ecba70bc596200b11516efecc6105a0b6aae4d6cd9ba3c13a5R49-R53) [[2]](diffhunk://#diff-c3b3ffaedfd80ae2ff47de3193d68f11ac42cf1c589540c1bf78a9cfc1ad1ae7R42-R44)
- Included new HTTP event types for ESP-IDF v6.x in `HTTPS_OTA_Update.ino`.
- Updated provisioning security macro usage in `WiFiProv.ino` for compatibility with ESP-IDF v6.x.
- Added conditional inclusion of `hal/touch_sensor_legacy_types.h` in touch-related examples and tests for ESP-IDF v6.x. [[1]](diffhunk://#diff-616062c321176d7639c54af705b5fe57d2f05e85abbdac2b43a3d09f8dd5dfd9R18-R20) [[2]](diffhunk://#diff-c2729cb6c3384cde9b6a199155d89d38fc0fd4286d83823449d9ebb7a14793f4R5-R7)

**mbedTLS v4.x Cryptographic Signature Verification:**

- Refactored `Updater_Signing.cpp` to support mbedTLS v4.x, including:
  - Conditional inclusion of new headers and PSA crypto initialization for cryptographic operations. [[1]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R10-R36) [[2]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R151-R161)
  - Updated RSA and ECDSA public key type checks to use PSA queries in mbedTLS v4.x. [[1]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R48-R59) [[2]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R173-R185)
  - Adjusted RSA signature verification logic to handle key length and salt length changes in mbedTLS v4.x, ensuring compatibility with signatures produced by `bin_signing.py`. [[1]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5L68-R124) [[2]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5L92-R137)
  - Ensured ECDSA signature verification remains compatible across mbedTLS versions.

**Configuration and Build Adjustments:**

- Updated the CI configuration for the ESP_SR example to require `CONFIG_MODEL_IN_FLASH` instead of `CONFIG_SOC_I2S_SUPPORTED`.

---

**ESP-IDF v6.x Compatibility:**
- Updated Bluetooth device name APIs and RMT driver logic in examples to handle ESP-IDF v6.x API changes. [[1]](diffhunk://#diff-85af81928559973c2d5388525618cb9c1edf4334500f1933ba5226254a0750eaR751-R755) [[2]](diffhunk://#diff-c0849b753d71db2905c4bda577e17e12a9ea6f1876be896ad38eacd28d798bc8R737-R741) [[3]](diffhunk://#diff-403d3e37425fb7b8a653e673e170a01ca8a247da6a2e400c18f36302f91b355fL18-R18) [[4]](diffhunk://#diff-403d3e37425fb7b8a653e673e170a01ca8a247da6a2e400c18f36302f91b355fL39-R47)
- Added missing constant definition for RMT if not present in ESP-IDF 6.
- Handled new/changed APIs for WPS, FTM, HTTP events, provisioning, and touch sensor headers. [[1]](diffhunk://#diff-b14ec4c1c1ed77ecba70bc596200b11516efecc6105a0b6aae4d6cd9ba3c13a5R49-R53) [[2]](diffhunk://#diff-c3b3ffaedfd80ae2ff47de3193d68f11ac42cf1c589540c1bf78a9cfc1ad1ae7R42-R44) [[3]](diffhunk://#diff-faa2ba8369b1bf18ba2664f435b50dc80c39fee04dd4f7430b5ca3ae0c9d4e84R53-R57) [[4]](diffhunk://#diff-0119ee5b37b26aab3f21a85b85b2adbe66c3b25218dc487baef9e91fc7882b13L71-R77) [[5]](diffhunk://#diff-616062c321176d7639c54af705b5fe57d2f05e85abbdac2b43a3d09f8dd5dfd9R18-R20) [[6]](diffhunk://#diff-c2729cb6c3384cde9b6a199155d89d38fc0fd4286d83823449d9ebb7a14793f4R5-R7)

**mbedTLS v4.x Support:**
- Refactored cryptographic signature verification logic in `Updater_Signing.cpp` for mbedTLS v4.x, including PSA initialization, public key type checks, and signature verification logic for both RSA and ECDSA. [[1]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R10-R36) [[2]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R48-R59) [[3]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5L68-R124) [[4]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5L92-R137) [[5]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R151-R161) [[6]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R173-R185) [[7]](diffhunk://#diff-7ecb67c5fb83e357c5197c0e6b31ed39674fd4a1fb4c8f71f51fd5a69369d9e5R233-R234)

**Configuration:**
- Changed ESP_SR example CI requirement to `CONFIG_MODEL_IN_FLASH`.