### PR TITLE
fix(ble): Fix race condition when accessing peers map

### DIFF
--- a/libraries/BLE/examples/Server/Server.ino
+++ b/libraries/BLE/examples/Server/Server.ino
@@ -26,6 +26,7 @@ void setup() {
 
   BLEServer *pServer = BLEDevice::createServer();
   BLEService *pService = pServer->createService(SERVICE_UUID);
+  pServer->advertiseOnDisconnect(true);
   BLECharacteristic *pCharacteristic =
     pService->createCharacteristic(CHARACTERISTIC_UUID, BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_WRITE);
 

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -314,20 +314,31 @@ void BLEServer::startAdvertising() {
 /* TODO do some more tweaks */
 void BLEServer::updatePeerMTU(uint16_t conn_id, uint16_t mtu) {
   // set mtu in conn_status_t
+  m_semaphoreMapAccess.take("updatePeerMTU");
   const std::map<uint16_t, conn_status_t>::iterator it = m_connectedServersMap.find(conn_id);
   if (it != m_connectedServersMap.end()) {
     it->second.mtu = mtu;
-    std::swap(m_connectedServersMap[conn_id], it->second);
   }
+  m_semaphoreMapAccess.give();
 }
 
 std::map<uint16_t, conn_status_t> BLEServer::getPeerDevices(bool _client) {
-  return m_connectedServersMap;
+  m_semaphoreMapAccess.take("getPeerDevices");
+  auto copy = m_connectedServersMap;
+  m_semaphoreMapAccess.give();
+  return copy;
 }
 
 uint16_t BLEServer::getPeerMTU(uint16_t conn_id) {
 #if defined(CONFIG_BLUEDROID_ENABLED)
-  return m_connectedServersMap.find(conn_id)->second.mtu;
+  uint16_t mtu = 0;
+  m_semaphoreMapAccess.take("getPeerMTU");
+  auto it = m_connectedServersMap.find(conn_id);
+  if (it != m_connectedServersMap.end()) {
+    mtu = it->second.mtu;
+  }
+  m_semaphoreMapAccess.give();
+  return mtu;
 #endif
 
 #if defined(CONFIG_NIMBLE_ENABLED)
@@ -338,11 +349,16 @@ uint16_t BLEServer::getPeerMTU(uint16_t conn_id) {
 void BLEServer::addPeerDevice(void *peer, bool _client, uint16_t conn_id) {
   conn_status_t status = {.peer_device = peer, .connected = true, .mtu = 23};
 
+  m_semaphoreMapAccess.take("addPeerDevice");
   m_connectedServersMap.insert(std::pair<uint16_t, conn_status_t>(conn_id, status));
+  m_semaphoreMapAccess.give();
 }
 
 bool BLEServer::removePeerDevice(uint16_t conn_id, bool _client) {
-  return m_connectedServersMap.erase(conn_id) > 0;
+  m_semaphoreMapAccess.take("removePeerDevice");
+  bool result = m_connectedServersMap.erase(conn_id) > 0;
+  m_semaphoreMapAccess.give();
+  return result;
 }
 
 #if !defined(CONFIG_BT_NIMBLE_EXT_ADV) || defined(CONFIG_BLUEDROID_ENABLED)

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -331,11 +331,13 @@ std::map<uint16_t, conn_status_t> BLEServer::getPeerDevices(bool _client) {
 
 uint16_t BLEServer::getPeerMTU(uint16_t conn_id) {
 #if defined(CONFIG_BLUEDROID_ENABLED)
-  uint16_t mtu = 0;
+  uint16_t mtu = 23;
   m_semaphoreMapAccess.take("getPeerMTU");
   auto it = m_connectedServersMap.find(conn_id);
   if (it != m_connectedServersMap.end()) {
     mtu = it->second.mtu;
+  } else {
+    log_w("getPeerMTU: conn_id %u not found, using default MTU %u", conn_id, mtu);
   }
   m_semaphoreMapAccess.give();
   return mtu;

--- a/libraries/BLE/src/BLEServer.h
+++ b/libraries/BLE/src/BLEServer.h
@@ -221,6 +221,10 @@ private:
   FreeRTOS::Semaphore m_semaphoreRegisterAppEvt = FreeRTOS::Semaphore("RegisterAppEvt");
   FreeRTOS::Semaphore m_semaphoreCreateEvt = FreeRTOS::Semaphore("CreateEvt");
   FreeRTOS::Semaphore m_semaphoreOpenEvt = FreeRTOS::Semaphore("OpenEvt");
+  // IMPORTANT:
+  // m_semaphoreMapAccess must never be held while invoking callbacks
+  // or calling into external code. This prevents re-entrant deadlocks.
+  FreeRTOS::Semaphore m_semaphoreMapAccess = FreeRTOS::Semaphore("MapAccess");
   BLEServiceMap m_serviceMap;
   BLEServerCallbacks *m_pServerCallbacks = nullptr;
 


### PR DESCRIPTION
## Description of Change

This pull request introduces several important thread-safety improvements to the BLE server implementation, focusing on protecting access to the `m_connectedServersMap` shared resource. Additionally, it adds a new server configuration option in the example code. These changes help prevent race conditions and potential deadlocks in multithreaded scenarios.

Thread-safety improvements:
* Introduced a dedicated `m_semaphoreMapAccess` semaphore in `BLEServer` to guard all accesses and modifications to `m_connectedServersMap`, ensuring thread-safe operations. A clear comment warns not to hold this semaphore while invoking callbacks to avoid deadlocks. (`BLEServer.h`)
* Wrapped all accesses to `m_connectedServersMap` in the following methods with `m_semaphoreMapAccess`:
  - `updatePeerMTU`
  - `getPeerDevices`
  - `getPeerMTU`
  - `addPeerDevice`
  - `removePeerDevice`
  (`BLEServer.cpp`) [[1]](diffhunk://#diff-3ca371b1423c263a68afe4b35292964b3b9abbf5ffe96c8d1c7aad36d84c7ab5R317-R341) [[2]](diffhunk://#diff-3ca371b1423c263a68afe4b35292964b3b9abbf5ffe96c8d1c7aad36d84c7ab5R352-R361)

Example code enhancement:
* In `Server.ino`, enabled advertising on disconnect by calling `pServer->advertiseOnDisconnect(true);`, improving the BLE server's behavior in client reconnection scenarios.

## Test Scenarios

Tested locally

## Related links

Closes https://github.com/espressif/arduino-esp32/issues/12538