### PR TITLE
ESP_I2S: Add configurable I2S port selection

### DIFF
--- a/docs/en/api/i2s.rst
+++ b/docs/en/api/i2s.rst
@@ -54,6 +54,12 @@ In **Master mode** (default) the device is generating clock signal ``sck`` and w
 In **Slave mode** the device listens on attached pins for the clock signal and word select - i.e. unless externally driven the pins will remain LOW.
 This mode is not supported yet.
 
+I2S Port
+********
+
+By default, the I2S driver automatically selects an available I2S controller.
+Applications that need a specific controller, such as dual-I2S audio designs, can select it before initialization using ``setPort()`` or the ``I2SClass`` constructor.
+
 Operation Modes
 ***************
 
@@ -127,6 +133,42 @@ Initialization and deinitialization
 ***********************************
 
 Before initialization, set which pins you want to use.
+
+I2SClass
+^^^^^^^^
+
+Create an I2S object. The optional ``port`` parameter selects the I2S controller.
+If it is not specified, the driver uses ``I2S_NUM_AUTO``.
+
+.. code-block:: arduino
+
+  I2SClass I2S(i2s_port_t port=I2S_NUM_AUTO)
+
+setPort
+^^^^^^^
+
+Set the I2S controller to use. This function must be called before ``begin()``.
+
+.. code-block:: arduino
+
+  bool setPort(i2s_port_t port)
+
+Parameters:
+
+* [in] ``port`` is the I2S controller, for example ``I2S_NUM_0``, another SoC-specific port such as ``I2S_NUM_1``, or ``I2S_NUM_AUTO``.
+
+This function will return ``true`` on success or ``false`` in case of failure.
+
+getPort
+^^^^^^^
+
+Get the configured I2S controller.
+After ``begin()``, this returns the controller allocated by the driver.
+Before ``begin()``, this returns the configured controller value, such as ``I2S_NUM_AUTO``.
+
+.. code-block:: arduino
+
+  i2s_port_t getPort()
 
 begin (Master Mode)
 ^^^^^^^^^^^^^^^^^^^

--- a/libraries/ESP_I2S/examples/Port_selection/Port_selection.ino
+++ b/libraries/ESP_I2S/examples/Port_selection/Port_selection.ino
@@ -1,0 +1,55 @@
+/*
+  This example selects a specific I2S controller before starting the driver.
+
+  It selects I2S_NUM_0 explicitly. Use another SoC-specific controller such as
+  I2S_NUM_1 when the target supports it.
+*/
+
+#include <Arduino.h>
+#include <ESP_I2S.h>
+
+#define I2S_LRC  25
+#define I2S_BCLK 5
+#define I2S_DIN  26
+
+const i2s_port_t selectedPort = I2S_NUM_0;
+
+const int frequency = 440;
+const int amplitude = 500;
+const int sampleRate = 8000;
+const unsigned int halfWavelength = sampleRate / frequency / 2;
+
+I2SClass i2s;
+int32_t sample = amplitude;
+unsigned int count = 0;
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("I2S port selection");
+
+  if (!i2s.setPort(selectedPort)) {
+    Serial.println("Failed to select I2S port!");
+    while (1);
+  }
+
+  i2s.setPins(I2S_BCLK, I2S_LRC, I2S_DIN);
+  if (!i2s.begin(I2S_MODE_STD, sampleRate, I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO)) {
+    Serial.println("Failed to initialize I2S!");
+    while (1);
+  }
+
+  Serial.printf("Allocated I2S port: %d\n", (int)i2s.getPort());
+}
+
+void loop() {
+  if (count % halfWavelength == 0) {
+    sample = -sample;
+  }
+
+  i2s.write(sample);
+  i2s.write(sample >> 8);
+  i2s.write(sample);
+  i2s.write(sample >> 8);
+
+  count++;
+}

--- a/libraries/ESP_I2S/keywords.txt
+++ b/libraries/ESP_I2S/keywords.txt
@@ -13,6 +13,8 @@ ESP_I2S	KEYWORD1
 #######################################
 
 onEvent	KEYWORD2
+setPort	KEYWORD2
+getPort	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -28,16 +28,16 @@
 typedef decltype(((i2s_chan_config_t *)nullptr)->id) i2s_chan_id_t;
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
-#define I2S_DEFAULT_CFG(_port)                                                                                                                              \
-  {                                                                                                                                                         \
-    .id = (i2s_chan_id_t)_port, .role = I2S_ROLE_MASTER, .dma_desc_num = 6, .dma_frame_num = 240, .auto_clear = true, .auto_clear_before_cb = false, .allow_pd = 0, \
-    .intr_priority = 0                                                                                                                                      \
+#define I2S_DEFAULT_CFG(_port)                                                                                                                       \
+  {                                                                                                                                                  \
+    .id = (i2s_chan_id_t)_port, .role = I2S_ROLE_MASTER, .dma_desc_num = 6, .dma_frame_num = 240, .auto_clear = true, .auto_clear_before_cb = false, \
+    .allow_pd = 0, .intr_priority = 0                                                                                                                \
   }
 #else
-#define I2S_DEFAULT_CFG(_port)                                                                                                               \
-  {                                                                                                                                          \
+#define I2S_DEFAULT_CFG(_port)                                                                                                                       \
+  {                                                                                                                                                  \
     .id = (i2s_chan_id_t)_port, .role = I2S_ROLE_MASTER, .dma_desc_num = 6, .dma_frame_num = 240, .auto_clear = true, .auto_clear_before_cb = false, \
-    .intr_priority = 0                                                                                                                       \
+    .intr_priority = 0                                                                                                                               \
   }
 #endif
 

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -25,16 +25,18 @@
 
 #define I2S_READ_CHUNK_SIZE 1920
 
+typedef decltype(((i2s_chan_config_t *)nullptr)->id) i2s_chan_id_t;
+
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
-#define I2S_DEFAULT_CFG()                                                                                                                                   \
+#define I2S_DEFAULT_CFG(_port)                                                                                                                              \
   {                                                                                                                                                         \
-    .id = I2S_NUM_AUTO, .role = I2S_ROLE_MASTER, .dma_desc_num = 6, .dma_frame_num = 240, .auto_clear = true, .auto_clear_before_cb = false, .allow_pd = 0, \
+    .id = (i2s_chan_id_t)_port, .role = I2S_ROLE_MASTER, .dma_desc_num = 6, .dma_frame_num = 240, .auto_clear = true, .auto_clear_before_cb = false, .allow_pd = 0, \
     .intr_priority = 0                                                                                                                                      \
   }
 #else
-#define I2S_DEFAULT_CFG()                                                                                                                    \
+#define I2S_DEFAULT_CFG(_port)                                                                                                               \
   {                                                                                                                                          \
-    .id = I2S_NUM_AUTO, .role = I2S_ROLE_MASTER, .dma_desc_num = 6, .dma_frame_num = 240, .auto_clear = true, .auto_clear_before_cb = false, \
+    .id = (i2s_chan_id_t)_port, .role = I2S_ROLE_MASTER, .dma_desc_num = 6, .dma_frame_num = 240, .auto_clear = true, .auto_clear_before_cb = false, \
     .intr_priority = 0                                                                                                                       \
   }
 #endif
@@ -153,6 +155,10 @@
   } while (0)
 #define I2S_ERROR_CHECK_RETURN_FALSE(x) I2S_ERROR_CHECK_RETURN(x, false)
 
+static bool isValidI2SPort(i2s_port_t port) {
+  return port == I2S_NUM_AUTO || (port >= I2S_NUM_0 && port < I2S_NUM_AUTO);
+}
+
 // Default read, no resmpling and temp buffer necessary
 static esp_err_t i2s_channel_read_default(i2s_chan_handle_t handle, char *tmp_buf, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   return i2s_channel_read(handle, (char *)dst, len, bytes_read, timeout_ms);
@@ -204,9 +210,10 @@ static esp_err_t i2s_channel_read_16_stereo_to_mono(i2s_chan_handle_t handle, ch
   return ESP_OK;
 }
 
-I2SClass::I2SClass() {
+I2SClass::I2SClass(i2s_port_t port) {
   last_error = ESP_OK;
   _mode = I2S_MODE_MAX;  // Initialize to invalid mode to indicate I2S not started
+  _port = port;
 
   tx_chan = NULL;
   tx_sample_rate = 0;
@@ -260,6 +267,30 @@ bool I2SClass::i2sDetachBus(void *bus_pointer) {
     bus->end();
   }
   return true;
+}
+
+bool I2SClass::setPort(i2s_port_t port) {
+  if (_mode < I2S_MODE_MAX) {
+    log_e("I2S port must be set before begin()");
+    return false;
+  }
+  if (!isValidI2SPort(port)) {
+    log_e("Invalid I2S port selected.");
+    return false;
+  }
+  _port = port;
+  return true;
+}
+
+i2s_port_t I2SClass::getPort() {
+  i2s_chan_handle_t chan = tx_chan != NULL ? tx_chan : rx_chan;
+  if (chan != NULL) {
+    i2s_chan_info_t info;
+    if (i2s_channel_get_info(chan, &info) == ESP_OK) {
+      return info.id;
+    }
+  }
+  return _port;
 }
 
 // Set pins for STD and TDM mode
@@ -358,7 +389,7 @@ bool I2SClass::initSTD(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mo
   }
 
   // I2S configuration
-  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG();
+  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
   if (_dout >= 0 && _din >= 0) {
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, &tx_chan, &rx_chan));
   } else if (_dout >= 0) {
@@ -467,7 +498,7 @@ bool I2SClass::initTDM(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mo
   }
 
   // I2S configuration
-  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG();
+  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
   if (_dout >= 0 && _din >= 0) {
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, &tx_chan, &rx_chan));
   } else if (_dout >= 0) {
@@ -558,7 +589,7 @@ bool I2SClass::initPDMtx(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_
   }
 
   // I2S configuration
-  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG();
+  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
   I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, &tx_chan, NULL));
 
   i2s_pdm_tx_config_t i2s_pdm_tx_config = I2S_PDM_TX_CHAN_CFG(rate, bits_cfg, ch);
@@ -642,7 +673,7 @@ bool I2SClass::initPDMrx(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_
   }
 
   // I2S configuration
-  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG();
+  i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
   I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, NULL, &rx_chan));
 
   i2s_pdm_rx_config_t i2s_pdf_rx_config = I2S_PDM_RX_CHAN_CFG(rate, bits_cfg, ch);
@@ -693,6 +724,10 @@ bool I2SClass::begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_c
   /* Setup I2S peripheral */
   if (mode >= I2S_MODE_MAX) {
     log_e("Invalid I2S mode selected.");
+    return false;
+  }
+  if (!isValidI2SPort(_port)) {
+    log_e("Invalid I2S port selected.");
     return false;
   }
   _mode = mode;

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -155,8 +155,23 @@ typedef decltype(((i2s_chan_config_t *)nullptr)->id) i2s_chan_id_t;
   } while (0)
 #define I2S_ERROR_CHECK_RETURN_FALSE(x) I2S_ERROR_CHECK_RETURN(x, false)
 
+// I2S_NUM_AUTO == -1 in IDF v6, so it cannot serve as the upper bound for valid ports.
+// SOC_I2S_NUM (from soc/soc_caps.h) is hardware-derived in IDF <=5 but was removed in
+// IDF v6, so fall back to the chip's physical I2S controller count there.
+#ifndef I2S_NUM_MAX
+#ifdef SOC_I2S_NUM
+#define I2S_NUM_MAX SOC_I2S_NUM
+#elif defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S3)
+#define I2S_NUM_MAX 2
+#elif defined(CONFIG_IDF_TARGET_ESP32P4)
+#define I2S_NUM_MAX 3
+#else
+#define I2S_NUM_MAX 1
+#endif
+#endif
+
 static bool isValidI2SPort(i2s_port_t port) {
-  return port == I2S_NUM_AUTO || (port >= I2S_NUM_0 && port < I2S_NUM_AUTO);
+  return port == I2S_NUM_AUTO || (port >= I2S_NUM_0 && port < (i2s_port_t)I2S_NUM_MAX);
 }
 
 // Default read, no resmpling and temp buffer necessary

--- a/libraries/ESP_I2S/src/ESP_I2S.h
+++ b/libraries/ESP_I2S/src/ESP_I2S.h
@@ -17,6 +17,10 @@
 #include "driver/i2s_pdm.h"
 #endif
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#define i2s_port_t int
+#endif
+
 typedef esp_err_t (*i2s_channel_read_fn)(i2s_chan_handle_t handle, char *tmp_buf, void *dest, size_t size, size_t *bytes_read, uint32_t timeout_ms);
 
 typedef enum {
@@ -42,8 +46,11 @@ typedef enum {
 
 class I2SClass : public Stream {
 public:
-  I2SClass();
+  explicit I2SClass(i2s_port_t port = I2S_NUM_AUTO);
   ~I2SClass();
+
+  bool setPort(i2s_port_t port);
+  i2s_port_t getPort();
 
   //STD + TDM mode
   void setPins(int8_t bclk, int8_t ws, int8_t dout, int8_t din = -1, int8_t mclk = -1);
@@ -97,6 +104,7 @@ public:
 private:
   esp_err_t last_error;
   i2s_mode_t _mode;
+  i2s_port_t _port;
 
   i2s_chan_handle_t tx_chan;
   uint32_t tx_sample_rate;


### PR DESCRIPTION
## Description of Change
Adds an optional I2S controller selection API to `ESP_I2S` while keeping the current default behavior as `I2S_NUM_AUTO`.

This PR adds:
- `I2SClass(i2s_port_t port = I2S_NUM_AUTO)`
- `bool setPort(i2s_port_t port)`, callable before `begin()`
- `i2s_port_t getPort()`, returning the allocated controller after `begin()`

The selected port is applied to STD, TDM, PDM TX, and PDM RX channel initialization paths. The I2S documentation, Arduino keywords, and a focused `Port_selection` example are updated for the new API.

## Test Scenarios
Tested with local Arduino-ESP32 build tooling:

- `git diff --check`
- `.github/scripts/sketch_utils.sh build -ai "$HOME/bin" -au "$HOME/Arduino" -s libraries/ESP_I2S/examples/Simple_tone -t esp32c6`
- `.github/scripts/sketch_utils.sh build -ai "$HOME/bin" -au "$HOME/Arduino" -s libraries/ESP_I2S/examples/Simple_tone -t esp32s3`
- `.github/scripts/sketch_utils.sh build -ai "$HOME/bin" -au "$HOME/Arduino" -s libraries/ESP_I2S/examples/Simple_tone -t esp32p4`
- `.github/scripts/sketch_utils.sh build -ai "$HOME/bin" -au "$HOME/Arduino" -s libraries/ESP_I2S/examples/Port_selection -t esp32c6`
- `.github/scripts/sketch_utils.sh build -ai "$HOME/bin" -au "$HOME/Arduino" -s libraries/ESP_I2S/examples/Port_selection -t esp32s3`
- `.github/scripts/sketch_utils.sh build -ai "$HOME/bin" -au "$HOME/Arduino" -s libraries/ESP_I2S/examples/Port_selection -t esp32p4`
- `python3 .github/scripts/include_checker.py libraries/ESP_I2S/examples/Port_selection/Port_selection.ino`

## Related links
Closes #12555
