### PR TITLE
SPI ETH drivers do not compile with C2 under IDF 6.0

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -152,15 +152,15 @@ dependencies:
   espressif/w5500:
     version: "^1.0.1"
     rules:
-      - if: idf_version >= 6.0
+      - if: "idf_version >= 6.0 && target != esp32c2"
   espressif/dm9051:
     version: "^1.1.0"
     rules:
-      - if: idf_version >= 6.0
+      - if: "idf_version >= 6.0 && target != esp32c2"
   espressif/ksz8851snl:
     version: "^1.0.0"
     rules:
-      - if: idf_version >= 6.0
+      - if: "idf_version >= 6.0 && target != esp32c2"
 examples:
   - path: ./idf_component_examples/Arduino_ESP_Matter_over_OpenThread
   - path: ./idf_component_examples/hello_world


### PR DESCRIPTION
no change for other MCUs