### PR TITLE
fix(zigbee): Increase stack memory in examples

### DIFF
--- a/libraries/Zigbee/examples/Zigbee_Illuminance_Sensor/Zigbee_Illuminance_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Illuminance_Sensor/Zigbee_Illuminance_Sensor.ino
@@ -108,7 +108,7 @@ void setup() {
   Serial.println();
 
   // Start illuminance sensor reading task
-  xTaskCreate(illuminance_sensor_value_update, "illuminance_sensor_update", 2048, NULL, 10, NULL);
+  xTaskCreate(illuminance_sensor_value_update, "illuminance_sensor_update", 3072, NULL, 10, NULL);
 
   // Set reporting schedule for illuminance value measurement in seconds, must be called after Zigbee.begin()
   // min_interval and max_interval in seconds, delta

--- a/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
+++ b/libraries/Zigbee/examples/Zigbee_Temp_Hum_Sensor_Sleepy/Zigbee_Temp_Hum_Sensor_Sleepy.ino
@@ -185,7 +185,7 @@ void setup() {
   Serial.println("Successfully connected to Zigbee network");
 
   // Start Temperature sensor reading task
-  xTaskCreate(meausureAndSleep, "temp_sensor_update", 2048, NULL, 10, NULL);
+  xTaskCreate(meausureAndSleep, "temp_sensor_update", 3072, NULL, 10, NULL);
 }
 
 void loop() {

--- a/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/Zigbee_Temperature_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Temperature_Sensor/Zigbee_Temperature_Sensor.ino
@@ -111,7 +111,7 @@ void setup() {
   Serial.println(localTime, "%A, %B %d %Y %H:%M:%S");
 
   // Start Temperature sensor reading task
-  xTaskCreate(temp_sensor_value_update, "temp_sensor_update", 2048, NULL, 10, NULL);
+  xTaskCreate(temp_sensor_value_update, "temp_sensor_update", 3072, NULL, 10, NULL);
 
   // Set reporting interval for temperature measurement in seconds, must be called after Zigbee.begin()
   // min_interval and max_interval in seconds, delta (temp change in 0,1 °C)

--- a/libraries/Zigbee/examples/Zigbee_Wind_Speed_Sensor/Zigbee_Wind_Speed_Sensor.ino
+++ b/libraries/Zigbee/examples/Zigbee_Wind_Speed_Sensor/Zigbee_Wind_Speed_Sensor.ino
@@ -89,7 +89,7 @@ void setup() {
   Serial.println();
 
   // Start Wind speed sensor reading task
-  xTaskCreate(windspeed_sensor_value_update, "wind_speed_sensor_update", 2048, NULL, 10, NULL);
+  xTaskCreate(windspeed_sensor_value_update, "wind_speed_sensor_update", 3072, NULL, 10, NULL);
 
   // Set reporting interval for windspeed measurement in seconds, must be called after Zigbee.begin()
   // min_interval and max_interval in seconds, delta (WindSpeed change in m/s)


### PR DESCRIPTION
## Description of Change
This pull request increases the stack size allocated to sensor reading tasks in several Zigbee sensor example sketches. The stack size for each sensor's FreeRTOS task is increased from 2048 to 3072 bytes to improve task stability and prevent potential stack overflows.

## Test Scenarios
Tested by @AndroidCrypto

## Related links
Closes #12561 