### PR TITLE
test(esp_now): Add validation test for ESP-NOW

### DIFF
--- a/tests/validation/esp_now/ci.yml
+++ b/tests/validation/esp_now/ci.yml
@@ -1,0 +1,14 @@
+tags:
+  - two_duts
+
+multi_device:
+  device0: master
+  device1: slave
+
+platforms:
+  # Wokwi and QEMU do not support multi-device tests
+  wokwi: false
+  qemu: false
+
+requires:
+  - CONFIG_SOC_WIFI_SUPPORTED=y

--- a/tests/validation/esp_now/master/master.ino
+++ b/tests/validation/esp_now/master/master.ino
@@ -1,0 +1,405 @@
+/*
+ * ESP-NOW validation test – Master device
+ *
+ * Phases:
+ *   1  Init, pre-begin edge cases, master broadcast send (onNewPeer)
+ *   2  Slave broadcast send + recv_bcast flag verification
+ *   3  Unicast master → slave
+ *   4  Unicast slave → master
+ *   5  Peer management: getters, addr()/setRate() edge cases, operator bool
+ *      (between 5 and 6: setKey is called; isEncrypted / encrypted-peer-count printed)
+ *   6  Encrypted unicast master → slave
+ *   7  Maximum-length payload master → slave
+ *   8  Peer remove / re-add
+ *   9  end() / begin() lifecycle + ESP_NOW.write() broadcast to all peers
+ */
+
+#include <Arduino.h>
+#include "ESP32_NOW.h"
+#include "WiFi.h"
+#include <esp_mac.h>
+
+#define ESPNOW_WIFI_CHANNEL 1
+#define ESPNOW_PMK          "pmk1234567890123"  /* exactly 16 bytes */
+#define ESPNOW_LMK          "lmk1234567890123"  /* exactly 16 bytes */
+
+/* ---------- Inheritable peer with callbacks and helpers ---------- */
+
+class TestPeer : public ESP_NOW_Peer {
+public:
+  volatile bool sent_cb    = false;
+  volatile bool sent_ok    = false;
+  volatile bool recv_cb    = false;
+  volatile bool recv_bcast = false;
+  volatile size_t recv_len = 0;
+  uint8_t recv_buf[1470]   = {};
+
+  TestPeer(const uint8_t *mac, uint8_t ch, wifi_interface_t ifc, const uint8_t *lmk = nullptr)
+    : ESP_NOW_Peer(mac, ch, ifc, lmk) {}
+  ~TestPeer() {
+    remove();
+  }
+
+  bool begin() {
+    return add();
+  }
+
+  bool sendMsg(const uint8_t *data, size_t len) {
+    sent_cb = false;
+    sent_ok = false;
+    return send(data, len) == len;
+  }
+
+  void onSent(bool success) override {
+    sent_ok = success;
+    sent_cb = true;
+  }
+
+  void onReceive(const uint8_t *data, size_t len, bool broadcast) override {
+    recv_bcast = broadcast;
+    size_t n   = len < sizeof(recv_buf) ? len : sizeof(recv_buf);
+    memcpy(recv_buf, data, n);
+    recv_len = n;
+    recv_cb  = true;
+  }
+
+  bool waitSent(uint32_t ms = 5000) {
+    uint32_t t = millis();
+    while (!sent_cb) {
+      if (millis() - t > ms) {
+        return false;
+      }
+      delay(5);
+    }
+    return true;
+  }
+
+  bool waitRecv(uint32_t ms = 5000) {
+    uint32_t t = millis();
+    while (!recv_cb) {
+      if (millis() - t > ms) {
+        return false;
+      }
+      delay(5);
+    }
+    return true;
+  }
+};
+
+/* ---------- Globals ---------- */
+
+static uint8_t peer_mac[6] = {};
+static TestPeer *bcast_peer = nullptr;
+static TestPeer *slave_peer = nullptr;
+
+/* ---------- Helpers ---------- */
+
+static bool parseMac(const String &s, uint8_t *mac) {
+  unsigned int m[6];
+  if (sscanf(s.c_str(), "%x:%x:%x:%x:%x:%x", &m[0], &m[1], &m[2], &m[3], &m[4], &m[5]) == 6) {
+    for (int i = 0; i < 6; i++) {
+      mac[i] = (uint8_t)m[i];
+    }
+    return true;
+  }
+  return false;
+}
+
+/* Blocks until "START\n" is received from the test script. */
+static void waitForStart(int phase) {
+  Serial.printf("[MASTER] Ready for phase %d\n", phase);
+  while (true) {
+    if (Serial.available()) {
+      String s = Serial.readStringUntil('\n');
+      s.trim();
+      if (s == "START") {
+        Serial.printf("[MASTER] Phase %d started\n", phase);
+        return;
+      }
+    }
+    delay(10);
+  }
+}
+
+/* ---------- setup ---------- */
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  /* ---------- Startup synchronisation ----------
+   * Block until the test script is ready so that both DUTs start together
+   * even when one device finishes flashing significantly before the other. */
+  waitForStart(0);
+
+  /* ---------- WiFi init ---------- */
+  WiFi.mode(WIFI_STA);
+  WiFi.setChannel(ESPNOW_WIFI_CHANNEL);
+  while (!WiFi.STA.started()) {
+    delay(100);
+  }
+
+  /* ---------- MAC exchange with test script ---------- */
+  uint8_t self_mac[6];
+  WiFi.macAddress(self_mac);
+  Serial.printf("[MASTER] MAC: " MACSTR "\n", MAC2STR(self_mac));
+  Serial.println("[MASTER] Send peer MAC:");
+  String mac_str = "";
+  while (mac_str.length() == 0) {
+    if (Serial.available()) {
+      mac_str = Serial.readStringUntil('\n');
+      mac_str.trim();
+    }
+    delay(10);
+  }
+  if (!parseMac(mac_str, peer_mac)) {
+    Serial.println("[MASTER] ERROR: invalid peer MAC");
+    while (true) {
+      delay(1000);
+    }
+  }
+  Serial.printf("[MASTER] Peer MAC: " MACSTR "\n", MAC2STR(peer_mac));
+
+  /* ====================================================
+   * Phase 1 – Init, pre-begin edge cases, broadcast
+   * ==================================================== */
+
+  /* Test API before begin() (edge cases). */
+  Serial.printf("[MASTER] getVersion before begin: %d\n", ESP_NOW.getVersion());
+  Serial.printf("[MASTER] getMaxDataLen before begin: %d\n", ESP_NOW.getMaxDataLen());
+  Serial.printf("[MASTER] getTotalPeerCount before begin: %d\n", ESP_NOW.getTotalPeerCount());
+
+  /* Init ESP-NOW with PMK. */
+  if (!ESP_NOW.begin((const uint8_t *)ESPNOW_PMK)) {
+    Serial.println("[MASTER] ERROR: begin() failed");
+    while (true) {
+      delay(1000);
+    }
+  }
+  Serial.printf("[MASTER] Version: %d\n", ESP_NOW.getVersion());
+  Serial.printf("[MASTER] Max data len: %d\n", ESP_NOW.getMaxDataLen());
+  Serial.printf("[MASTER] availableForWrite: %d\n", ESP_NOW.availableForWrite());
+
+  /* Create broadcast peer (no LMK). */
+  bcast_peer = new TestPeer(ESP_NOW.BROADCAST_ADDR, ESPNOW_WIFI_CHANNEL, WIFI_IF_STA);
+  if (!bcast_peer->begin()) {
+    Serial.println("[MASTER] ERROR: failed to add broadcast peer");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  waitForStart(1);
+
+  bcast_peer->sendMsg((const uint8_t *)"Hello broadcast", 15);
+  if (bcast_peer->waitSent(5000)) {
+    Serial.printf("[MASTER] Broadcast sent: %s\n", bcast_peer->sent_ok ? "success" : "failed");
+  } else {
+    Serial.println("[MASTER] Broadcast sent: timeout");
+  }
+
+  /* Add slave_peer now so its onReceive fires for the slave's broadcast in phase 2. */
+  slave_peer = new TestPeer(peer_mac, ESPNOW_WIFI_CHANNEL, WIFI_IF_STA);
+  if (!slave_peer->begin()) {
+    Serial.println("[MASTER] ERROR: failed to add slave peer");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  /* ====================================================
+   * Phase 2 – Slave broadcast + recv_bcast flag
+   * ==================================================== */
+
+  slave_peer->recv_cb = false;
+  waitForStart(2);
+
+  /* Slave sends a broadcast; our slave_peer.onReceive fires with broadcast=true. */
+  if (slave_peer->waitRecv(10000)) {
+    Serial.printf("[MASTER] Received slave broadcast: %.*s\n", (int)slave_peer->recv_len, (char *)slave_peer->recv_buf);
+    Serial.printf("[MASTER] Received as broadcast: %s\n", slave_peer->recv_bcast ? "true" : "false");
+  } else {
+    Serial.println("[MASTER] ERROR: no broadcast from slave");
+  }
+
+  /* ====================================================
+   * Phase 3 – Unicast master → slave
+   * ==================================================== */
+
+  waitForStart(3);
+
+  slave_peer->sendMsg((const uint8_t *)"Phase3:M->S", 11);
+  if (slave_peer->waitSent(5000)) {
+    Serial.printf("[MASTER] Unicast to slave: %s\n", slave_peer->sent_ok ? "success" : "failed");
+  } else {
+    Serial.println("[MASTER] Unicast to slave: timeout");
+  }
+
+  /* ====================================================
+   * Phase 4 – Unicast slave → master
+   * ==================================================== */
+
+  slave_peer->recv_cb = false;
+  waitForStart(4);
+
+  if (slave_peer->waitRecv(10000)) {
+    Serial.printf("[MASTER] Received from slave: %.*s\n", (int)slave_peer->recv_len, (char *)slave_peer->recv_buf);
+  } else {
+    Serial.println("[MASTER] ERROR: no message from slave");
+  }
+
+  /* ====================================================
+   * Phase 5 – Peer management: getters and edge cases
+   * ==================================================== */
+
+  waitForStart(5);
+
+  Serial.printf("[MASTER] Total peers: %d\n", ESP_NOW.getTotalPeerCount());
+  Serial.printf("[MASTER] Encrypted peers: %d\n", ESP_NOW.getEncryptedPeerCount());
+  Serial.printf("[MASTER] Slave channel: %u\n", slave_peer->getChannel());
+  Serial.printf("[MASTER] Slave interface: %d\n", (int)slave_peer->getInterface());
+  Serial.printf("[MASTER] Slave isEncrypted: %s\n", slave_peer->isEncrypted() ? "true" : "false");
+
+  /* operator bool(): true when added. */
+  Serial.printf("[MASTER] slave_peer bool (added): %s\n", (bool)*slave_peer ? "true" : "false");
+
+  /* addr() getter: should return slave's MAC. */
+  Serial.printf("[MASTER] Slave addr: " MACSTR "\n", MAC2STR(slave_peer->addr()));
+
+  /* addr() setter edge case: must fail while peer is added and ESP-NOW is running. */
+  uint8_t dummy[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+  Serial.printf("[MASTER] addr() set while added: %s\n", slave_peer->addr(dummy) ? "success" : "failed");
+
+  /* Confirm addr is unchanged after failed setter. */
+  Serial.printf("[MASTER] Slave addr unchanged: %s\n", memcmp(slave_peer->addr(), peer_mac, 6) == 0 ? "true" : "false");
+
+  /* setRate() edge case: must fail while peer is added and ESP-NOW is running. */
+  esp_now_rate_config_t rate_cfg = slave_peer->getRate();
+  Serial.printf("[MASTER] setRate() while added: %s\n", slave_peer->setRate(&rate_cfg) ? "success" : "failed");
+
+  /* ---- setKey (between phases 5 and 6) ---- */
+  if (slave_peer->setKey((const uint8_t *)ESPNOW_LMK)) {
+    Serial.printf("[MASTER] isEncrypted after setKey: %s\n", slave_peer->isEncrypted() ? "true" : "false");
+  } else {
+    Serial.println("[MASTER] ERROR: setKey failed");
+  }
+  Serial.printf("[MASTER] Encrypted peers after setKey: %d\n", ESP_NOW.getEncryptedPeerCount());
+
+  /* ====================================================
+   * Phase 6 – Encrypted unicast master → slave
+   * ==================================================== */
+
+  waitForStart(6);
+
+  slave_peer->sent_cb = false;
+  slave_peer->sendMsg((const uint8_t *)"EncryptedMsg", 12);
+  if (slave_peer->waitSent(5000)) {
+    Serial.printf("[MASTER] Encrypted message sent: %s\n", slave_peer->sent_ok ? "success" : "failed");
+  } else {
+    Serial.println("[MASTER] Encrypted message sent: timeout");
+  }
+
+  /* ====================================================
+   * Phase 7 – Maximum-length payload
+   * ==================================================== */
+
+  int max_len = ESP_NOW.getMaxDataLen();
+  uint8_t *large_buf = (uint8_t *)malloc(max_len);
+  if (!large_buf) {
+    Serial.println("[MASTER] ERROR: malloc failed");
+    while (true) {
+      delay(1000);
+    }
+  }
+  for (int i = 0; i < max_len; i++) {
+    large_buf[i] = (uint8_t)(i & 0xFF);
+  }
+
+  waitForStart(7);
+
+  slave_peer->sent_cb = false;
+  slave_peer->sendMsg(large_buf, max_len);
+  free(large_buf);
+  if (slave_peer->waitSent(5000)) {
+    Serial.printf("[MASTER] Large payload sent: %d bytes (%s)\n", max_len, slave_peer->sent_ok ? "success" : "failed");
+  } else {
+    Serial.println("[MASTER] Large payload sent: timeout");
+  }
+
+  /* ====================================================
+   * Phase 8 – Peer remove / re-add
+   * ==================================================== */
+
+  waitForStart(8);
+
+  ESP_NOW.removePeer(*slave_peer);
+  /* operator bool() should be false after remove. */
+  Serial.printf("[MASTER] slave_peer bool (removed): %s\n", (bool)*slave_peer ? "true" : "false");
+  Serial.printf("[MASTER] Total peers after remove: %d\n", ESP_NOW.getTotalPeerCount());
+
+  /* Re-add – peer still holds the LMK from phase 6. */
+  if (slave_peer->begin()) {
+    Serial.printf("[MASTER] Total peers after re-add: %d\n", ESP_NOW.getTotalPeerCount());
+    slave_peer->sent_cb = false;
+    slave_peer->sendMsg((const uint8_t *)"AfterReAdd", 10);
+    if (slave_peer->waitSent(5000)) {
+      Serial.printf("[MASTER] Send after re-add: %s\n", slave_peer->sent_ok ? "success" : "failed");
+    } else {
+      Serial.println("[MASTER] Send after re-add: timeout");
+    }
+  } else {
+    Serial.println("[MASTER] ERROR: failed to re-add slave peer");
+  }
+
+  /* ====================================================
+   * Phase 9 – end() / begin() lifecycle + ESP_NOW.write()
+   * ==================================================== */
+
+  /* Perform end/begin BEFORE waitForStart so both devices are fully re-initialised. */
+  if (ESP_NOW.end()) {
+    Serial.println("[MASTER] end(): success");
+  } else {
+    Serial.println("[MASTER] end(): failed");
+  }
+
+  delay(200);
+
+  if (ESP_NOW.begin((const uint8_t *)ESPNOW_PMK)) {
+    Serial.println("[MASTER] begin() after end: success");
+  } else {
+    Serial.println("[MASTER] begin() after end: failed");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  /* Re-add slave peer (LMK still set from phase 6). bcast_peer is NOT re-added,
+   * so ESP_NOW.write() will send only to slave_peer (clean single-recipient test). */
+  if (!slave_peer->begin()) {
+    Serial.println("[MASTER] ERROR: failed to re-add slave peer after reinit");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  waitForStart(9);
+
+  /* Test ESP_NOW.write() – sends to all registered peers (only slave_peer here). */
+  slave_peer->sent_cb = false;
+  const uint8_t write_data[] = "WriteToAll";
+  size_t written = ESP_NOW.write(write_data, sizeof(write_data) - 1);
+  Serial.printf("[MASTER] ESP_NOW.write() bytes: %d\n", (int)written);
+  if (slave_peer->waitSent(5000)) {
+    Serial.printf("[MASTER] ESP_NOW.write() sent: %s\n", slave_peer->sent_ok ? "success" : "failed");
+  } else {
+    Serial.println("[MASTER] ESP_NOW.write() sent: timeout");
+  }
+
+  Serial.println("[MASTER] Test complete");
+}
+
+void loop() {
+  delay(1000);
+}

--- a/tests/validation/esp_now/master/master.ino
+++ b/tests/validation/esp_now/master/master.ino
@@ -128,7 +128,7 @@ void setup() {
     delay(10);
   }
 
-  /* ---------- Startup synchronisation ----------
+  /* ---------- Startup synchronization ----------
    * Block until the test script is ready so that both DUTs start together
    * even when one device finishes flashing significantly before the other. */
   waitForStart(0);

--- a/tests/validation/esp_now/master/master.ino
+++ b/tests/validation/esp_now/master/master.ino
@@ -20,22 +20,21 @@
 #include <esp_mac.h>
 
 #define ESPNOW_WIFI_CHANNEL 1
-#define ESPNOW_PMK          "pmk1234567890123"  /* exactly 16 bytes */
-#define ESPNOW_LMK          "lmk1234567890123"  /* exactly 16 bytes */
+#define ESPNOW_PMK          "pmk1234567890123" /* exactly 16 bytes */
+#define ESPNOW_LMK          "lmk1234567890123" /* exactly 16 bytes */
 
 /* ---------- Inheritable peer with callbacks and helpers ---------- */
 
 class TestPeer : public ESP_NOW_Peer {
 public:
-  volatile bool sent_cb    = false;
-  volatile bool sent_ok    = false;
-  volatile bool recv_cb    = false;
+  volatile bool sent_cb = false;
+  volatile bool sent_ok = false;
+  volatile bool recv_cb = false;
   volatile bool recv_bcast = false;
   volatile size_t recv_len = 0;
-  uint8_t recv_buf[1470]   = {};
+  uint8_t recv_buf[1470] = {};
 
-  TestPeer(const uint8_t *mac, uint8_t ch, wifi_interface_t ifc, const uint8_t *lmk = nullptr)
-    : ESP_NOW_Peer(mac, ch, ifc, lmk) {}
+  TestPeer(const uint8_t *mac, uint8_t ch, wifi_interface_t ifc, const uint8_t *lmk = nullptr) : ESP_NOW_Peer(mac, ch, ifc, lmk) {}
   ~TestPeer() {
     remove();
   }
@@ -57,10 +56,10 @@ public:
 
   void onReceive(const uint8_t *data, size_t len, bool broadcast) override {
     recv_bcast = broadcast;
-    size_t n   = len < sizeof(recv_buf) ? len : sizeof(recv_buf);
+    size_t n = len < sizeof(recv_buf) ? len : sizeof(recv_buf);
     memcpy(recv_buf, data, n);
     recv_len = n;
-    recv_cb  = true;
+    recv_cb = true;
   }
 
   bool waitSent(uint32_t ms = 5000) {

--- a/tests/validation/esp_now/slave/slave.ino
+++ b/tests/validation/esp_now/slave/slave.ino
@@ -97,6 +97,9 @@ static void onNewPeer(const esp_now_recv_info_t *info, const uint8_t *data, int 
   if (memcmp(info->des_addr, ESP_NOW.BROADCAST_ADDR, ESP_NOW_ETH_ALEN) != 0) {
     return;
   }
+  if (memcmp(info->src_addr, peer_mac, ESP_NOW_ETH_ALEN) != 0) {
+    return;
+  }
   master_peer = new TestPeer(info->src_addr, ESPNOW_WIFI_CHANNEL, WIFI_IF_STA);
   if (!master_peer || !master_peer->begin()) {
     delete master_peer;

--- a/tests/validation/esp_now/slave/slave.ino
+++ b/tests/validation/esp_now/slave/slave.ino
@@ -1,0 +1,391 @@
+/*
+ * ESP-NOW validation test – Slave device
+ *
+ * Phases mirror the master.  The slave:
+ *   – registers an onNewPeer callback to capture the first broadcast (phase 1)
+ *   – adds its own broadcast peer to send a broadcast in phase 2
+ *   – uses the dynamically-created master_peer for all subsequent receives/sends
+ */
+
+#include <Arduino.h>
+#include "ESP32_NOW.h"
+#include "WiFi.h"
+#include <esp_mac.h>
+
+#define ESPNOW_WIFI_CHANNEL 1
+#define ESPNOW_PMK          "pmk1234567890123"  /* exactly 16 bytes */
+#define ESPNOW_LMK          "lmk1234567890123"  /* exactly 16 bytes */
+
+/* ---------- Inheritable peer with callbacks and helpers ---------- */
+
+class TestPeer : public ESP_NOW_Peer {
+public:
+  volatile bool sent_cb    = false;
+  volatile bool sent_ok    = false;
+  volatile bool recv_cb    = false;
+  volatile bool recv_bcast = false;
+  volatile size_t recv_len = 0;
+  uint8_t recv_buf[1470]   = {};
+
+  TestPeer(const uint8_t *mac, uint8_t ch, wifi_interface_t ifc, const uint8_t *lmk = nullptr)
+    : ESP_NOW_Peer(mac, ch, ifc, lmk) {}
+  ~TestPeer() {
+    remove();
+  }
+
+  bool begin() {
+    return add();
+  }
+
+  bool sendMsg(const uint8_t *data, size_t len) {
+    sent_cb = false;
+    sent_ok = false;
+    return send(data, len) == len;
+  }
+
+  void onSent(bool success) override {
+    sent_ok = success;
+    sent_cb = true;
+  }
+
+  void onReceive(const uint8_t *data, size_t len, bool broadcast) override {
+    recv_bcast = broadcast;
+    size_t n   = len < sizeof(recv_buf) ? len : sizeof(recv_buf);
+    memcpy(recv_buf, data, n);
+    recv_len = n;
+    recv_cb  = true;
+  }
+
+  bool waitSent(uint32_t ms = 5000) {
+    uint32_t t = millis();
+    while (!sent_cb) {
+      if (millis() - t > ms) {
+        return false;
+      }
+      delay(5);
+    }
+    return true;
+  }
+
+  bool waitRecv(uint32_t ms = 5000) {
+    uint32_t t = millis();
+    while (!recv_cb) {
+      if (millis() - t > ms) {
+        return false;
+      }
+      delay(5);
+    }
+    return true;
+  }
+};
+
+/* ---------- Globals ---------- */
+
+static uint8_t peer_mac[6] = {};         /* master's MAC (from serial exchange) */
+static TestPeer *master_peer = nullptr;  /* created inside onNewPeer callback    */
+static TestPeer *bcast_peer  = nullptr;  /* broadcast peer for phase 2           */
+static volatile bool bcast_received  = false;
+static char bcast_msg[32] = {};
+
+/* ---------- onNewPeer callback (fires for unknown senders) ---------- */
+
+static void onNewPeer(const esp_now_recv_info_t *info, const uint8_t *data, int len, void *arg) {
+  if (master_peer != nullptr) {
+    return; /* already registered */
+  }
+  /* Only accept broadcasts from the expected master MAC. */
+  if (memcmp(info->des_addr, ESP_NOW.BROADCAST_ADDR, ESP_NOW_ETH_ALEN) != 0) {
+    return;
+  }
+  master_peer = new TestPeer(info->src_addr, ESPNOW_WIFI_CHANNEL, WIFI_IF_STA);
+  if (!master_peer || !master_peer->begin()) {
+    delete master_peer;
+    master_peer = nullptr;
+    return;
+  }
+  size_t n = (size_t)len < sizeof(bcast_msg) - 1 ? (size_t)len : sizeof(bcast_msg) - 1;
+  memcpy(bcast_msg, data, n);
+  bcast_msg[n]   = '\0';
+  bcast_received = true;
+}
+
+/* ---------- Helpers ---------- */
+
+static bool parseMac(const String &s, uint8_t *mac) {
+  unsigned int m[6];
+  if (sscanf(s.c_str(), "%x:%x:%x:%x:%x:%x", &m[0], &m[1], &m[2], &m[3], &m[4], &m[5]) == 6) {
+    for (int i = 0; i < 6; i++) {
+      mac[i] = (uint8_t)m[i];
+    }
+    return true;
+  }
+  return false;
+}
+
+/* Blocks until "START\n" is received from the test script. */
+static void waitForStart(int phase) {
+  Serial.printf("[SLAVE] Ready for phase %d\n", phase);
+  while (true) {
+    if (Serial.available()) {
+      String s = Serial.readStringUntil('\n');
+      s.trim();
+      if (s == "START") {
+        Serial.printf("[SLAVE] Phase %d started\n", phase);
+        return;
+      }
+    }
+    delay(10);
+  }
+}
+
+/* ---------- setup ---------- */
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  /* ---------- Startup synchronisation ----------
+   * Block until the test script is ready so that both DUTs start together
+   * even when one device finishes flashing significantly before the other. */
+  waitForStart(0);
+
+  /* ---------- WiFi init ---------- */
+  WiFi.mode(WIFI_STA);
+  WiFi.setChannel(ESPNOW_WIFI_CHANNEL);
+  while (!WiFi.STA.started()) {
+    delay(100);
+  }
+
+  /* ---------- MAC exchange with test script ---------- */
+  uint8_t self_mac[6];
+  WiFi.macAddress(self_mac);
+  Serial.printf("[SLAVE] MAC: " MACSTR "\n", MAC2STR(self_mac));
+  Serial.println("[SLAVE] Send peer MAC:");
+  String mac_str = "";
+  while (mac_str.length() == 0) {
+    if (Serial.available()) {
+      mac_str = Serial.readStringUntil('\n');
+      mac_str.trim();
+    }
+    delay(10);
+  }
+  if (!parseMac(mac_str, peer_mac)) {
+    Serial.println("[SLAVE] ERROR: invalid peer MAC");
+    while (true) {
+      delay(1000);
+    }
+  }
+  Serial.printf("[SLAVE] Peer MAC: " MACSTR "\n", MAC2STR(peer_mac));
+
+  /* ====================================================
+   * Phase 1 – Init, register onNewPeer, wait for broadcast
+   * ==================================================== */
+
+  if (!ESP_NOW.begin((const uint8_t *)ESPNOW_PMK)) {
+    Serial.println("[SLAVE] ERROR: begin() failed");
+    while (true) {
+      delay(1000);
+    }
+  }
+  Serial.printf("[SLAVE] Version: %d\n", ESP_NOW.getVersion());
+  Serial.printf("[SLAVE] Max data len: %d\n", ESP_NOW.getMaxDataLen());
+
+  /* Register callback for unknown senders (fires on first broadcast). */
+  ESP_NOW.onNewPeer(onNewPeer, nullptr);
+
+  waitForStart(1);
+
+  /* Wait for the broadcast from master, which triggers onNewPeer. */
+  uint32_t t = millis();
+  while (!bcast_received && millis() - t < 10000) {
+    delay(10);
+  }
+  if (bcast_received && master_peer) {
+    Serial.printf("[SLAVE] Received broadcast: %s\n", bcast_msg);
+    Serial.printf("[SLAVE] master_peer bool (added): %s\n", (bool)*master_peer ? "true" : "false");
+  } else {
+    Serial.println("[SLAVE] ERROR: no broadcast received");
+  }
+
+  /* Add slave-side broadcast peer so we can send a broadcast in phase 2. */
+  bcast_peer = new TestPeer(ESP_NOW.BROADCAST_ADDR, ESPNOW_WIFI_CHANNEL, WIFI_IF_STA);
+  if (!bcast_peer->begin()) {
+    Serial.println("[SLAVE] ERROR: failed to add broadcast peer");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  /* ====================================================
+   * Phase 2 – Slave broadcast + recv_bcast flag
+   * ==================================================== */
+
+  waitForStart(2);
+
+  bcast_peer->sendMsg((const uint8_t *)"Hello from slave bcast", 22);
+  if (bcast_peer->waitSent(5000)) {
+    Serial.printf("[SLAVE] Broadcast sent: %s\n", bcast_peer->sent_ok ? "success" : "failed");
+  } else {
+    Serial.println("[SLAVE] Broadcast sent: timeout");
+  }
+
+  /* ====================================================
+   * Phase 3 – Unicast master → slave
+   * ==================================================== */
+
+  master_peer->recv_cb = false;
+  waitForStart(3);
+
+  if (master_peer->waitRecv(10000)) {
+    Serial.printf("[SLAVE] Received unicast: %.*s\n", (int)master_peer->recv_len, (char *)master_peer->recv_buf);
+  } else {
+    Serial.println("[SLAVE] ERROR: no unicast received");
+  }
+
+  /* ====================================================
+   * Phase 4 – Unicast slave → master
+   * ==================================================== */
+
+  waitForStart(4);
+
+  master_peer->sendMsg((const uint8_t *)"Phase4:S->M", 11);
+  if (master_peer->waitSent(5000)) {
+    Serial.printf("[SLAVE] Unicast to master: %s\n", master_peer->sent_ok ? "success" : "failed");
+  } else {
+    Serial.println("[SLAVE] Unicast to master: timeout");
+  }
+
+  /* ====================================================
+   * Phase 5 – Peer management: getters and edge cases
+   * ==================================================== */
+
+  waitForStart(5);
+
+  /* Slave has master_peer (from phase 1) + bcast_peer (from phase 2) = 2 total. */
+  Serial.printf("[SLAVE] Total peers: %d\n", ESP_NOW.getTotalPeerCount());
+  Serial.printf("[SLAVE] Encrypted peers: %d\n", ESP_NOW.getEncryptedPeerCount());
+  Serial.printf("[SLAVE] Master channel: %u\n", master_peer->getChannel());
+  Serial.printf("[SLAVE] Master interface: %d\n", (int)master_peer->getInterface());
+  Serial.printf("[SLAVE] Master isEncrypted: %s\n", master_peer->isEncrypted() ? "true" : "false");
+
+  /* operator bool(): true when added. */
+  Serial.printf("[SLAVE] master_peer bool (added): %s\n", (bool)*master_peer ? "true" : "false");
+
+  /* addr() getter: should return master's MAC. */
+  Serial.printf("[SLAVE] Master addr: " MACSTR "\n", MAC2STR(master_peer->addr()));
+
+  /* addr() setter edge case: must fail while peer is added and ESP-NOW is running. */
+  uint8_t dummy[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+  Serial.printf("[SLAVE] addr() set while added: %s\n", master_peer->addr(dummy) ? "success" : "failed");
+
+  /* Confirm addr is unchanged after failed setter. */
+  Serial.printf("[SLAVE] Master addr unchanged: %s\n", memcmp(master_peer->addr(), peer_mac, 6) == 0 ? "true" : "false");
+
+  /* setRate() edge case: must fail while peer is added and ESP-NOW is running. */
+  esp_now_rate_config_t rate_cfg = master_peer->getRate();
+  Serial.printf("[SLAVE] setRate() while added: %s\n", master_peer->setRate(&rate_cfg) ? "success" : "failed");
+
+  /* ---- setKey (between phases 5 and 6) ---- */
+  if (master_peer->setKey((const uint8_t *)ESPNOW_LMK)) {
+    Serial.printf("[SLAVE] isEncrypted after setKey: %s\n", master_peer->isEncrypted() ? "true" : "false");
+  } else {
+    Serial.println("[SLAVE] ERROR: setKey failed");
+  }
+  Serial.printf("[SLAVE] Encrypted peers after setKey: %d\n", ESP_NOW.getEncryptedPeerCount());
+
+  /* ====================================================
+   * Phase 6 – Encrypted unicast master → slave
+   * ==================================================== */
+
+  master_peer->recv_cb = false;
+  waitForStart(6);
+
+  if (master_peer->waitRecv(10000)) {
+    Serial.printf("[SLAVE] Received encrypted: %.*s\n", (int)master_peer->recv_len, (char *)master_peer->recv_buf);
+  } else {
+    Serial.println("[SLAVE] ERROR: no encrypted message received");
+  }
+
+  /* ====================================================
+   * Phase 7 – Maximum-length payload
+   * ==================================================== */
+
+  int max_len = ESP_NOW.getMaxDataLen();
+  master_peer->recv_cb = false;
+  waitForStart(7);
+
+  if (master_peer->waitRecv(10000)) {
+    /* Verify received length and byte pattern. */
+    bool pattern_ok = ((int)master_peer->recv_len == max_len);
+    for (size_t i = 0; i < master_peer->recv_len && pattern_ok; i++) {
+      if (master_peer->recv_buf[i] != (uint8_t)(i & 0xFF)) {
+        pattern_ok = false;
+      }
+    }
+    Serial.printf("[SLAVE] Large payload received: %d bytes\n", (int)master_peer->recv_len);
+    Serial.printf("[SLAVE] Large payload pattern: %s\n", pattern_ok ? "ok" : "error");
+  } else {
+    Serial.println("[SLAVE] ERROR: no large payload received");
+  }
+
+  /* ====================================================
+   * Phase 8 – Peer remove / re-add (master side only)
+   * ==================================================== */
+
+  /* Slave just receives; no peer changes on this side. */
+  master_peer->recv_cb = false;
+  waitForStart(8);
+
+  if (master_peer->waitRecv(10000)) {
+    Serial.printf("[SLAVE] Received after re-add: %.*s\n", (int)master_peer->recv_len, (char *)master_peer->recv_buf);
+  } else {
+    Serial.println("[SLAVE] ERROR: no message after re-add");
+  }
+
+  /* ====================================================
+   * Phase 9 – end() / begin() lifecycle + ESP_NOW.write()
+   * ==================================================== */
+
+  /* Perform end/begin BEFORE waitForStart so both devices are fully re-initialised. */
+  if (ESP_NOW.end()) {
+    Serial.println("[SLAVE] end(): success");
+  } else {
+    Serial.println("[SLAVE] end(): failed");
+  }
+
+  delay(200);
+
+  if (ESP_NOW.begin((const uint8_t *)ESPNOW_PMK)) {
+    Serial.println("[SLAVE] begin() after end: success");
+  } else {
+    Serial.println("[SLAVE] begin() after end: failed");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  /* Re-add master peer (LMK still set from phase 6). */
+  if (!master_peer->begin()) {
+    Serial.println("[SLAVE] ERROR: failed to re-add master peer after reinit");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  master_peer->recv_cb = false;
+  waitForStart(9);
+
+  if (master_peer->waitRecv(10000)) {
+    Serial.printf("[SLAVE] Received after reinit: %.*s\n", (int)master_peer->recv_len, (char *)master_peer->recv_buf);
+  } else {
+    Serial.println("[SLAVE] ERROR: no message after reinit");
+  }
+
+  Serial.println("[SLAVE] Test complete");
+}
+
+void loop() {
+  delay(1000);
+}

--- a/tests/validation/esp_now/slave/slave.ino
+++ b/tests/validation/esp_now/slave/slave.ino
@@ -148,7 +148,7 @@ void setup() {
     delay(10);
   }
 
-  /* ---------- Startup synchronisation ----------
+  /* ---------- Startup synchronization ----------
    * Block until the test script is ready so that both DUTs start together
    * even when one device finishes flashing significantly before the other. */
   waitForStart(0);

--- a/tests/validation/esp_now/slave/slave.ino
+++ b/tests/validation/esp_now/slave/slave.ino
@@ -13,22 +13,21 @@
 #include <esp_mac.h>
 
 #define ESPNOW_WIFI_CHANNEL 1
-#define ESPNOW_PMK          "pmk1234567890123"  /* exactly 16 bytes */
-#define ESPNOW_LMK          "lmk1234567890123"  /* exactly 16 bytes */
+#define ESPNOW_PMK          "pmk1234567890123" /* exactly 16 bytes */
+#define ESPNOW_LMK          "lmk1234567890123" /* exactly 16 bytes */
 
 /* ---------- Inheritable peer with callbacks and helpers ---------- */
 
 class TestPeer : public ESP_NOW_Peer {
 public:
-  volatile bool sent_cb    = false;
-  volatile bool sent_ok    = false;
-  volatile bool recv_cb    = false;
+  volatile bool sent_cb = false;
+  volatile bool sent_ok = false;
+  volatile bool recv_cb = false;
   volatile bool recv_bcast = false;
   volatile size_t recv_len = 0;
-  uint8_t recv_buf[1470]   = {};
+  uint8_t recv_buf[1470] = {};
 
-  TestPeer(const uint8_t *mac, uint8_t ch, wifi_interface_t ifc, const uint8_t *lmk = nullptr)
-    : ESP_NOW_Peer(mac, ch, ifc, lmk) {}
+  TestPeer(const uint8_t *mac, uint8_t ch, wifi_interface_t ifc, const uint8_t *lmk = nullptr) : ESP_NOW_Peer(mac, ch, ifc, lmk) {}
   ~TestPeer() {
     remove();
   }
@@ -50,10 +49,10 @@ public:
 
   void onReceive(const uint8_t *data, size_t len, bool broadcast) override {
     recv_bcast = broadcast;
-    size_t n   = len < sizeof(recv_buf) ? len : sizeof(recv_buf);
+    size_t n = len < sizeof(recv_buf) ? len : sizeof(recv_buf);
     memcpy(recv_buf, data, n);
     recv_len = n;
-    recv_cb  = true;
+    recv_cb = true;
   }
 
   bool waitSent(uint32_t ms = 5000) {
@@ -81,10 +80,10 @@ public:
 
 /* ---------- Globals ---------- */
 
-static uint8_t peer_mac[6] = {};         /* master's MAC (from serial exchange) */
-static TestPeer *master_peer = nullptr;  /* created inside onNewPeer callback    */
-static TestPeer *bcast_peer  = nullptr;  /* broadcast peer for phase 2           */
-static volatile bool bcast_received  = false;
+static uint8_t peer_mac[6] = {};        /* master's MAC (from serial exchange) */
+static TestPeer *master_peer = nullptr; /* created inside onNewPeer callback    */
+static TestPeer *bcast_peer = nullptr;  /* broadcast peer for phase 2           */
+static volatile bool bcast_received = false;
 static char bcast_msg[32] = {};
 
 /* ---------- onNewPeer callback (fires for unknown senders) ---------- */
@@ -108,7 +107,7 @@ static void onNewPeer(const esp_now_recv_info_t *info, const uint8_t *data, int 
   }
   size_t n = (size_t)len < sizeof(bcast_msg) - 1 ? (size_t)len : sizeof(bcast_msg) - 1;
   memcpy(bcast_msg, data, n);
-  bcast_msg[n]   = '\0';
+  bcast_msg[n] = '\0';
   bcast_received = true;
 }
 

--- a/tests/validation/esp_now/test_esp_now.py
+++ b/tests/validation/esp_now/test_esp_now.py
@@ -1,0 +1,244 @@
+"""
+ESP-NOW multi-DUT validation test.
+
+device0 = master (tests/validation/esp_now/master)
+device1 = slave  (tests/validation/esp_now/slave)
+
+Test phases
+-----------
+1  Init, pre-begin edge cases, master broadcast (onNewPeer)
+2  Slave broadcast + recv_bcast flag verification
+3  Unicast master → slave
+4  Unicast slave → master
+5  Peer-management getters + addr()/setRate() edge cases
+   (between 5 and 6: setKey printed before "Ready for phase 6")
+6  Encrypted unicast master → slave
+7  Maximum-length payload
+8  Peer remove / re-add
+9  end() / begin() lifecycle + ESP_NOW.write()
+"""
+
+import logging
+import re
+
+LOGGER = logging.getLogger(__name__)
+
+
+def start_phase(master, slave, phase, timeout=60):
+    """Synchronise both DUTs into a phase.
+
+    Slave receives START before master to avoid race conditions where the
+    master starts sending before the slave has set up its receive state.
+    """
+    LOGGER.info("Waiting for devices ready: phase %d", phase)
+    slave.expect_exact(f"[SLAVE] Ready for phase {phase}", timeout=timeout)
+    master.expect_exact(f"[MASTER] Ready for phase {phase}", timeout=timeout)
+    LOGGER.info("Starting phase %d", phase)
+    slave.write("START")
+    slave.expect_exact(f"[SLAVE] Phase {phase} started", timeout=10)
+    master.write("START")
+    master.expect_exact(f"[MASTER] Phase {phase} started", timeout=10)
+    LOGGER.info("Phase %d active on both devices", phase)
+
+
+def test_esp_now(dut):
+    master = dut[0]
+    slave = dut[1]
+
+    # ------------------------------------------------------------------ #
+    # Phase 0 – Startup synchronisation                                   #
+    # Block until both DUTs have booted and are waiting, then release     #
+    # them together regardless of flash-time differences.                 #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 0: Startup synchronisation ===")
+    start_phase(master, slave, 0, timeout=120)
+
+    # ------------------------------------------------------------------ #
+    # MAC exchange                                                         #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("Exchanging MAC addresses")
+
+    master_mac_match = master.expect(r"\[MASTER\] MAC: ([0-9A-Fa-f:]+)", timeout=30)
+    master_mac = master_mac_match.group(1).decode()
+    LOGGER.info("Master MAC: %s", master_mac)
+
+    slave_mac_match = slave.expect(r"\[SLAVE\] MAC: ([0-9A-Fa-f:]+)", timeout=30)
+    slave_mac = slave_mac_match.group(1).decode()
+    LOGGER.info("Slave MAC: %s", slave_mac)
+
+    master.expect_exact("[MASTER] Send peer MAC:", timeout=10)
+    master.write(slave_mac)
+    master.expect(rf"\[MASTER\] Peer MAC: {re.escape(slave_mac)}", timeout=10)
+
+    slave.expect_exact("[SLAVE] Send peer MAC:", timeout=10)
+    slave.write(master_mac)
+    slave.expect(rf"\[SLAVE\] Peer MAC: {re.escape(master_mac)}", timeout=10)
+
+    # ------------------------------------------------------------------ #
+    # Phase 1 – Init, pre-begin edge cases, broadcast                     #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 1: Init and broadcast ===")
+
+    # Pre-begin edge cases: all three getters must return -1.
+    master.expect_exact("[MASTER] getVersion before begin: -1", timeout=30)
+    master.expect_exact("[MASTER] getMaxDataLen before begin: -1", timeout=10)
+    master.expect_exact("[MASTER] getTotalPeerCount before begin: -1", timeout=10)
+
+    # After begin(), version must be ≥ 1 and maxDataLen must be 250 or 1470.
+    version_match = master.expect(r"\[MASTER\] Version: (\d+)", timeout=15)
+    version = int(version_match.group(1).decode())
+    assert version >= 1, f"Unexpected ESP-NOW version: {version}"
+
+    maxlen_match = master.expect(r"\[MASTER\] Max data len: (\d+)", timeout=10)
+    max_data_len = int(maxlen_match.group(1).decode())
+    assert max_data_len in (250, 1470), f"Unexpected max data len: {max_data_len}"
+
+    # availableForWrite() must equal getMaxDataLen().
+    avail_match = master.expect(r"\[MASTER\] availableForWrite: (\d+)", timeout=10)
+    assert int(avail_match.group(1).decode()) == max_data_len
+
+    slave.expect(r"\[SLAVE\] Version: (\d+)", timeout=30)
+    slave.expect(r"\[SLAVE\] Max data len: (\d+)", timeout=10)
+
+    start_phase(master, slave, 1)
+
+    master.expect_exact("[MASTER] Broadcast sent: success", timeout=15)
+    slave.expect_exact("[SLAVE] Received broadcast: Hello broadcast", timeout=15)
+    slave.expect_exact("[SLAVE] master_peer bool (added): true", timeout=10)
+
+    # ------------------------------------------------------------------ #
+    # Phase 2 – Slave broadcast + recv_bcast flag verification            #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 2: Slave broadcast + recv_bcast flag ===")
+    start_phase(master, slave, 2)
+
+    # Slave sends broadcast; master's slave_peer.onReceive fires with broadcast=true.
+    slave.expect_exact("[SLAVE] Broadcast sent: success", timeout=15)
+    master.expect_exact("[MASTER] Received slave broadcast: Hello from slave bcast", timeout=15)
+    master.expect_exact("[MASTER] Received as broadcast: true", timeout=10)
+
+    # ------------------------------------------------------------------ #
+    # Phase 3 – Unicast master → slave                                    #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 3: Unicast master → slave ===")
+    start_phase(master, slave, 3)
+
+    master.expect_exact("[MASTER] Unicast to slave: success", timeout=15)
+    slave.expect_exact("[SLAVE] Received unicast: Phase3:M->S", timeout=15)
+
+    # ------------------------------------------------------------------ #
+    # Phase 4 – Unicast slave → master                                    #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 4: Unicast slave → master ===")
+    start_phase(master, slave, 4)
+
+    slave.expect_exact("[SLAVE] Unicast to master: success", timeout=15)
+    master.expect_exact("[MASTER] Received from slave: Phase4:S->M", timeout=15)
+
+    # ------------------------------------------------------------------ #
+    # Phase 5 – Peer management                                           #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 5: Peer management ===")
+    start_phase(master, slave, 5)
+
+    # Master: broadcast_peer + slave_peer = 2 total, 0 encrypted.
+    master.expect_exact("[MASTER] Total peers: 2", timeout=15)
+    master.expect_exact("[MASTER] Encrypted peers: 0", timeout=10)
+    master.expect_exact("[MASTER] Slave channel: 1", timeout=10)
+    master.expect_exact("[MASTER] Slave interface: 0", timeout=10)
+    master.expect_exact("[MASTER] Slave isEncrypted: false", timeout=10)
+    master.expect_exact("[MASTER] slave_peer bool (added): true", timeout=10)
+
+    # addr() getter must return the slave's MAC.
+    slave_addr_match = master.expect(r"\[MASTER\] Slave addr: ([0-9A-Fa-f:]+)", timeout=10)
+    assert slave_addr_match.group(1).decode().upper() == slave_mac.upper()
+
+    # addr() setter and setRate() must fail while peer is added and running.
+    master.expect_exact("[MASTER] addr() set while added: failed", timeout=10)
+    master.expect_exact("[MASTER] Slave addr unchanged: true", timeout=10)
+    master.expect_exact("[MASTER] setRate() while added: failed", timeout=10)
+
+    # Slave: master_peer (phase 1) + bcast_peer (phase 2) = 2 total, 0 encrypted.
+    slave.expect_exact("[SLAVE] Total peers: 2", timeout=15)
+    slave.expect_exact("[SLAVE] Encrypted peers: 0", timeout=10)
+    slave.expect_exact("[SLAVE] Master channel: 1", timeout=10)
+    slave.expect_exact("[SLAVE] Master interface: 0", timeout=10)
+    slave.expect_exact("[SLAVE] Master isEncrypted: false", timeout=10)
+    slave.expect_exact("[SLAVE] master_peer bool (added): true", timeout=10)
+
+    master_addr_match = slave.expect(r"\[SLAVE\] Master addr: ([0-9A-Fa-f:]+)", timeout=10)
+    assert master_addr_match.group(1).decode().upper() == master_mac.upper()
+
+    slave.expect_exact("[SLAVE] addr() set while added: failed", timeout=10)
+    slave.expect_exact("[SLAVE] Master addr unchanged: true", timeout=10)
+    slave.expect_exact("[SLAVE] setRate() while added: failed", timeout=10)
+
+    # setKey outputs appear between phases 5 and 6 (before "Ready for phase 6").
+    master.expect_exact("[MASTER] isEncrypted after setKey: true", timeout=10)
+    master.expect_exact("[MASTER] Encrypted peers after setKey: 1", timeout=10)
+    slave.expect_exact("[SLAVE] isEncrypted after setKey: true", timeout=10)
+    slave.expect_exact("[SLAVE] Encrypted peers after setKey: 1", timeout=10)
+
+    # ------------------------------------------------------------------ #
+    # Phase 6 – Encrypted unicast                                         #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 6: Encrypted unicast ===")
+    start_phase(master, slave, 6)
+
+    master.expect_exact("[MASTER] Encrypted message sent: success", timeout=15)
+    slave.expect_exact("[SLAVE] Received encrypted: EncryptedMsg", timeout=15)
+
+    # ------------------------------------------------------------------ #
+    # Phase 7 – Maximum-length payload                                    #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 7: Maximum-length payload ===")
+    start_phase(master, slave, 7)
+
+    sent_match = master.expect(r"\[MASTER\] Large payload sent: (\d+) bytes \(success\)", timeout=15)
+    sent_len = int(sent_match.group(1).decode())
+    assert sent_len == max_data_len, f"Expected {max_data_len} bytes, master sent {sent_len}"
+
+    recv_match = slave.expect(r"\[SLAVE\] Large payload received: (\d+) bytes", timeout=15)
+    recv_len = int(recv_match.group(1).decode())
+    assert recv_len == max_data_len, f"Expected {max_data_len} bytes, slave received {recv_len}"
+
+    slave.expect_exact("[SLAVE] Large payload pattern: ok", timeout=10)
+
+    # ------------------------------------------------------------------ #
+    # Phase 8 – Peer remove / re-add                                      #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 8: Peer remove / re-add ===")
+    start_phase(master, slave, 8)
+
+    # operator bool() must be false immediately after remove.
+    master.expect_exact("[MASTER] slave_peer bool (removed): false", timeout=15)
+    # Only broadcast_peer remains.
+    master.expect_exact("[MASTER] Total peers after remove: 1", timeout=10)
+    # After re-add, count returns to 2 (still encrypted since LMK was retained).
+    master.expect_exact("[MASTER] Total peers after re-add: 2", timeout=10)
+    master.expect_exact("[MASTER] Send after re-add: success", timeout=15)
+    slave.expect_exact("[SLAVE] Received after re-add: AfterReAdd", timeout=15)
+
+    # ------------------------------------------------------------------ #
+    # Phase 9 – end() / begin() lifecycle + ESP_NOW.write()              #
+    # ------------------------------------------------------------------ #
+    LOGGER.info("=== Phase 9: end() / begin() lifecycle + ESP_NOW.write() ===")
+
+    # end/begin happen before the phase handshake; expect them before start_phase.
+    master.expect_exact("[MASTER] end(): success", timeout=15)
+    master.expect_exact("[MASTER] begin() after end: success", timeout=15)
+    slave.expect_exact("[SLAVE] end(): success", timeout=15)
+    slave.expect_exact("[SLAVE] begin() after end: success", timeout=15)
+
+    start_phase(master, slave, 9)
+
+    # ESP_NOW.write() sends to all registered peers (only slave_peer after reinit).
+    write_bytes_match = master.expect(r"\[MASTER\] ESP_NOW\.write\(\) bytes: (\d+)", timeout=15)
+    assert int(write_bytes_match.group(1).decode()) > 0
+    master.expect_exact("[MASTER] ESP_NOW.write() sent: success", timeout=15)
+    slave.expect_exact("[SLAVE] Received after reinit: WriteToAll", timeout=15)
+
+    master.expect_exact("[MASTER] Test complete", timeout=15)
+    slave.expect_exact("[SLAVE] Test complete", timeout=15)
+
+    LOGGER.info("All phases passed")

--- a/tests/validation/esp_now/test_esp_now.py
+++ b/tests/validation/esp_now/test_esp_now.py
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def start_phase(master, slave, phase, timeout=60):
-    """Synchronise both DUTs into a phase.
+    """Synchronize both DUTs into a phase.
 
     Slave receives START before master to avoid race conditions where the
     master starts sending before the slave has set up its receive state.
@@ -46,11 +46,11 @@ def test_esp_now(dut):
     slave = dut[1]
 
     # ------------------------------------------------------------------ #
-    # Phase 0 – Startup synchronisation                                   #
+    # Phase 0 – Startup synchronization                                   #
     # Block until both DUTs have booted and are waiting, then release     #
     # them together regardless of flash-time differences.                 #
     # ------------------------------------------------------------------ #
-    LOGGER.info("=== Phase 0: Startup synchronisation ===")
+    LOGGER.info("=== Phase 0: Startup synchronization ===")
     start_phase(master, slave, 0, timeout=120)
 
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Description of Change

This pull request introduces a comprehensive multi-device validation test suite for ESP-NOW functionality, focusing on communication and peer management between two devices (master and slave). It adds a new Python test orchestrator, a detailed Arduino-based slave implementation, and supporting test configuration for CI. The changes ensure robust testing of ESP-NOW features across a variety of scenarios, including broadcasts, unicasts, encryption, peer management, and lifecycle operations.

**New multi-device ESP-NOW validation test suite:**

* Adds a Python-based test orchestrator for multi-phase, multi-device ESP-NOW validation, synchronizing master and slave devices and verifying communication and peer management in detail (`test_esp_now.py`).
* Implements a complete Arduino test program for the slave device, handling all phases of ESP-NOW peer discovery, broadcast/unicast messaging, encryption, and peer lifecycle management (`slave.ino`).

**Test infrastructure and configuration:**

* Introduces a test configuration file to enable multi-device testing, specify required platforms, and set hardware requirements for the ESP-NOW validation test (`ci.yml`).

## Test Scenarios

Tested locally
