### PR TITLE
fix(codeql): Fix codeQL warnings

### DIFF
--- a/.github/scripts/get_affected.py
+++ b/.github/scripts/get_affected.py
@@ -108,10 +108,12 @@ import json
 import subprocess
 import shutil
 import fnmatch
+import logging
 
 script_dir = Path(__file__).resolve().parent
 project_root = (script_dir / "../../").resolve()
 
+logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s', stream=sys.stderr)
 
 def resolve_changed_path_to_project_relative(path: str) -> str:
     """
@@ -129,13 +131,13 @@ def resolve_changed_path_to_project_relative(path: str) -> str:
     if p.is_absolute():
         try:
             return str(p.resolve().relative_to(project_root))
-        except ValueError:
-            pass
+        except ValueError as e:
+            logging.warning("Absolute path %s is outside project root: %s", raw, e)
     else:
         try:
             return str((Path.cwd() / p).resolve().relative_to(project_root))
-        except ValueError:
-            pass
+        except ValueError as e:
+            logging.warning("Relative path %s is outside project root: %s", raw, e)
         if (project_root / p).is_file():
             return p.as_posix()
 
@@ -551,7 +553,8 @@ def run_ctags_and_index(paths: list[str]) -> tuple[dict[str, set[str]], dict[str
             continue
         try:
             tag = json.loads(line)
-        except Exception:
+        except Exception as e:
+            logging.warning("Failed to parse ctags JSON line %r: %s", line, e)
             continue
 
         path = tag.get("path")
@@ -707,7 +710,7 @@ def build_dependencies_graph() -> None:
             with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                 content = f.read()
         except Exception as e:
-            print(f"Warning: Could not read file {file}: {e}", file=sys.stderr)
+            logging.warning("Could not read file %s: %s", file, e)
             continue
 
         for match in include_regex.finditer(content):

--- a/.gitlab/scripts/gen_hw_jobs.py
+++ b/.gitlab/scripts/gen_hw_jobs.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import logging
 import yaml
 import os
 import sys
@@ -17,6 +18,8 @@ import urllib.error
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 TESTS_ROOT = REPO_ROOT / "tests"
+
+logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s', stream=sys.stderr)
 
 # Ensure we run from repo root so relative paths work consistently
 try:
@@ -342,8 +345,8 @@ def any_runner_matches(required_tags: Iterable[str], runners: list[dict]) -> boo
         except Exception as e:
             # Be robust to unexpected runner payloads
             runner_id = r.get("id", "unknown")
-            sys.stderr.write(f"[WARN] Error checking runner #{runner_id} against required tags: {e}\n")
-            sys.stderr.write(traceback.format_exc() + "\n")
+            logging.warning("Error checking runner #%s against required tags: %s", runner_id, e)
+            logging.debug(traceback.format_exc())
             continue
     return False
 

--- a/libraries/FS/src/FSImpl.h
+++ b/libraries/FS/src/FSImpl.h
@@ -22,8 +22,30 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 namespace fs {
+
+// RAII lock guard for the per-filesystem recursive mutex.
+class FSLockGuard {
+public:
+  explicit FSLockGuard(SemaphoreHandle_t mtx) : _mtx(mtx) {
+    if (_mtx) {
+      xSemaphoreTakeRecursive(_mtx, portMAX_DELAY);
+    }
+  }
+  ~FSLockGuard() {
+    if (_mtx) {
+      xSemaphoreGiveRecursive(_mtx);
+    }
+  }
+  FSLockGuard(const FSLockGuard &) = delete;
+  FSLockGuard &operator=(const FSLockGuard &) = delete;
+
+private:
+  SemaphoreHandle_t _mtx;
+};
 
 class FileImpl {
 public:
@@ -51,10 +73,15 @@ public:
 class FSImpl {
 protected:
   const char *_mountpoint;
+  SemaphoreHandle_t _mtx;
 
 public:
-  FSImpl() : _mountpoint(NULL) {}
-  virtual ~FSImpl() {}
+  FSImpl() : _mountpoint(NULL), _mtx(xSemaphoreCreateRecursiveMutex()) {}
+  virtual ~FSImpl() {
+    if (_mtx) {
+      vSemaphoreDelete(_mtx);
+    }
+  }
   virtual FileImplPtr open(const char *path, const char *mode, const bool create) = 0;
   virtual bool exists(const char *path) = 0;
   virtual bool rename(const char *pathFrom, const char *pathTo) = 0;

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -23,6 +23,7 @@ using namespace fs;
 #define DEFAULT_FILE_BUFFER_SIZE 4096
 
 FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return FileImplPtr();
@@ -88,6 +89,7 @@ FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create
 }
 
 bool VFSImpl::exists(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -102,6 +104,7 @@ bool VFSImpl::exists(const char *fpath) {
 }
 
 bool VFSImpl::rename(const char *pathFrom, const char *pathTo) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -138,6 +141,7 @@ bool VFSImpl::rename(const char *pathFrom, const char *pathTo) {
 }
 
 bool VFSImpl::remove(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -164,19 +168,9 @@ bool VFSImpl::remove(const char *fpath) {
 }
 
 bool VFSImpl::mkdir(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
-    return false;
-  }
-
-  VFSFileImpl f(this, fpath, "r");
-  if (f && f.isDirectory()) {
-    f.close();
-    //log_w("%s already exists", fpath);
-    return true;
-  } else if (f) {
-    f.close();
-    log_e("%s is a file", fpath);
     return false;
   }
 
@@ -189,12 +183,45 @@ bool VFSImpl::mkdir(const char *fpath) {
 
   snprintf(temp, tempLen, "%s%s", _mountpoint, fpath);
 
+  // Note: the stat() → opendir() → ::mkdir() sequence below contains a
+  // TOCTOU (time-of-check / time-of-use) window between individual syscalls.
+  // The per-filesystem mutex (_mtx) held by the caller (VFSImpl::mkdir) ensures
+  // that no other Arduino FS API call on the same filesystem can interleave
+  // here.  Code that bypasses the Arduino FS layer (direct fopen/stat/mkdir
+  // calls) is not covered by this mutex.
+
+  // stat() reports the path type without consuming a file descriptor.
+  struct stat st;
+  if (stat(temp, &st) == 0) {
+    free(temp);
+    if (S_ISDIR(st.st_mode)) {
+      //log_w("%s already exists", fpath);
+      return true;
+    }
+    log_e("%s is a file", fpath);
+    return false;
+  }
+
+  // stat() failed (path does not exist).  On SPIFFS the filesystem is flat and
+  // virtual directories are always reachable via opendir() regardless of
+  // whether any files with that path prefix exist yet.  A successful opendir()
+  // here means the path is an accessible virtual directory – treat it as
+  // already present so we avoid calling ::mkdir() (which SPIFFS does not
+  // support and would return an error).
+  DIR *d = opendir(temp);
+  if (d) {
+    closedir(d);
+    free(temp);
+    return true;
+  }
+
   auto rc = ::mkdir(temp, ACCESSPERMS);
   free(temp);
   return rc == 0;
 }
 
 bool VFSImpl::rmdir(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -236,37 +263,46 @@ VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs
     return;
   }
 
-  // For read mode, check if file exists first to determine type
+  // For read mode, detect whether the path is a directory or a regular file.
+  // The per-filesystem mutex held by VFSImpl::open serialises this constructor
+  // against all other Arduino FS API calls on the same filesystem, so the
+  // fopen/stat/opendir sequence is free of TOCTOU races from concurrent Arduino
+  // FS callers.  Code that bypasses the Arduino FS layer (direct fopen/stat
+  // calls) is not covered by the mutex.
   if (!mode || mode[0] == 'r') {
-    if (!stat(temp, &_stat)) {
-      //file found
-      if (S_ISREG(_stat.st_mode)) {
+    _f = fopen(temp, mode);
+    if (_f) {
+      // fopen() succeeded — but on POSIX-style VFS layers (including ESP-IDF's
+      // LittleFS VFS), open(2) can succeed on a directory with O_RDONLY.  Use
+      // stat to confirm the path is a regular file before treating it as one.
+      struct stat type_stat;
+      if (stat(temp, &type_stat) == 0 && S_ISDIR(type_stat.st_mode)) {
+        // Path is a directory; close the file handle and open as a directory.
+        fclose(_f);
+        _f = NULL;
+        _d = opendir(temp);
+        _isDirectory = (_d != NULL);
+      } else {
         _isDirectory = false;
-        _f = fopen(temp, mode);
-        if (!_f) {
-          log_e("fopen(%s) failed", temp);
-        }
-        if (_f && (_stat.st_blksize == 0)) {
+        if (!stat(temp, &_stat) && (_stat.st_blksize == 0)) {
           setvbuf(_f, NULL, _IOFBF, DEFAULT_FILE_BUFFER_SIZE);
         }
-      } else if (S_ISDIR(_stat.st_mode)) {
-        _isDirectory = true;
-        _d = opendir(temp);
-        if (!_d) {
-          log_e("opendir(%s) failed", temp);
-        }
-      } else {
-        log_e("Unknown type 0x%08" PRIX32 " for file %s", (uint32_t)((_stat.st_mode) & _IFMT), temp);
       }
     } else {
-      //file not found
-      //try to open as directory
-      _d = opendir(temp);
-      if (_d) {
-        _isDirectory = true;
-      } else {
-        _isDirectory = false;
-        //log_w("stat(%s) failed", temp);
+      // fopen failed — check via stat whether this is a directory.
+      // stat() does not consume a file descriptor, so it can succeed even when
+      // the filesystem's open-file limit has been reached.  If stat reports a
+      // regular file we skip opendir() so an exhausted fd pool is not
+      // misidentified as a directory.  If stat itself fails (as it does for
+      // SPIFFS virtual directories which have no named entry of their own) we
+      // still try opendir() because SPIFFS virtual directories are only
+      // reachable that way.
+      struct stat dir_stat;
+      int stat_rc = stat(temp, &dir_stat);
+      bool statIsFile = (stat_rc == 0 && !S_ISDIR(dir_stat.st_mode));
+      if (!statIsFile) {
+        _d = opendir(temp);
+        _isDirectory = (_d != NULL);
       }
     }
   } else {

--- a/tests/validation/fs/fs.ino
+++ b/tests/validation/fs/fs.ino
@@ -655,6 +655,72 @@ void test_write_read_patterns() {
   V.remove(path);
 }
 
+// Regression test for the TOCTOU fix in VFSFileImpl::VFSFileImpl (libraries/FS/src/vfs_api.cpp).
+//
+// The original code used stat() to determine the file type and then called fopen() or opendir()
+// based on the result, creating a race window between the check and the open.  The fix removes
+// that window by attempting fopen() first and falling back to opendir() on failure.
+//
+// We cannot reproduce the race deterministically on embedded hardware, but we can verify that
+// the fixed code path correctly identifies both files and directories when opened in read mode,
+// which would catch any regression in the type-detection logic.
+void test_open_read_mode_type_detection() {
+  auto &V = gFS->vfs();
+
+  // --- regular file opened in read mode ---
+  const char *filePath = "/toctou_file.txt";
+  {
+    File w = V.open(filePath, FILE_WRITE);
+    TEST_ASSERT_TRUE_MESSAGE(w, "setup: could not create file");
+    w.print("toctou");
+    w.close();
+  }
+
+  {
+    // Open the same path in read mode: must be detected as a file, not a directory
+    File f = V.open(filePath, FILE_READ);
+    TEST_ASSERT_TRUE_MESSAGE(f, "open(file, FILE_READ) failed");
+    TEST_ASSERT_FALSE_MESSAGE(f.isDirectory(), "regular file incorrectly detected as directory");
+    String content = f.readString();
+    TEST_ASSERT_EQUAL_STRING("toctou", content.c_str());
+    f.close();
+  }
+
+  V.remove(filePath);
+
+  // --- directory opened with default (read) mode ---
+  if (strcmp(gFS->name(), "spiffs") == 0) {
+    // SPIFFS does not have real directories; skip directory portion
+    TEST_MESSAGE("Skipping directory portion for SPIFFS");
+    return;
+  }
+
+  const char *dirPath = "/toctou_dir";
+  const char *childPath = "/toctou_dir/child.txt";
+  {
+    TEST_ASSERT_TRUE_MESSAGE(V.mkdir(dirPath), "setup: could not create directory");
+    File w = V.open(childPath, FILE_WRITE);
+    TEST_ASSERT_TRUE_MESSAGE(w, "setup: could not create child file");
+    w.print("child");
+    w.close();
+  }
+
+  {
+    // Open the directory path without an explicit mode (defaults to read).
+    // Must be detected as a directory so that openNextFile() works.
+    File d = V.open(dirPath);
+    TEST_ASSERT_TRUE_MESSAGE(d, "open(dir) failed");
+    TEST_ASSERT_TRUE_MESSAGE(d.isDirectory(), "directory incorrectly detected as file");
+    File child = d.openNextFile();
+    TEST_ASSERT_TRUE_MESSAGE(child, "openNextFile() returned no entry in non-empty directory");
+    child.close();
+    d.close();
+  }
+
+  V.remove(childPath);
+  V.rmdir(dirPath);
+}
+
 void test_directory_operations_edge_cases() {
   auto &V = gFS->vfs();
   TEST_ASSERT_TRUE(V.mkdir("/test_dir"));
@@ -757,6 +823,7 @@ static void run_suite_for(IFileSystem &fs) {
   RUN_TEST(test_write_read_patterns);
   RUN_TEST(test_directory_operations_edge_cases);
   RUN_TEST(test_max_open_files_limit);
+  RUN_TEST(test_open_read_mode_type_detection);
   gFS = nullptr;
 }
 

--- a/tools/espota.py
+++ b/tools/espota.py
@@ -444,10 +444,10 @@ def serve(  # noqa: C901
                         logging.warning("Unexpected response from device: '%s'", data)
 
                 except socket.timeout:
-                    logging.debug("Timeout waiting for result (attempt %d/10)", count)
+                    logging.warning("Timeout waiting for result (attempt %d/10)", count)
                     continue
                 except Exception as e:
-                    logging.debug("Error receiving result (attempt %d/10): %s", count, str(e))
+                    logging.warning("Error receiving result (attempt %d/10): %s", count, str(e))
                     # Don't return error here, continue trying
                     continue
 


### PR DESCRIPTION
## Description of Change

This pull request introduces two main groups of changes: improvements to filesystem concurrency and correctness in the Arduino FS implementation, and enhancements to error reporting in various Python scripts. The filesystem changes add a per-filesystem mutex to prevent race conditions, refactor type detection logic to avoid TOCTOU (time-of-check to time-of-use) bugs, and add regression tests to ensure correctness. The Python scripts now use the `logging` module for consistent warning and debug output instead of direct `print` or `sys.stderr` writes.

**Filesystem concurrency and correctness improvements:**

* Added a per-filesystem recursive mutex (`_mtx`) to `FSImpl` and created an `FSLockGuard` RAII class to ensure all filesystem operations are serialized, preventing race conditions. All major VFS operations (`open`, `exists`, `rename`, `remove`, `mkdir`, `rmdir`) are now protected by this lock (`libraries/FS/src/FSImpl.h`, `libraries/FS/src/vfs_api.cpp`). [[1]](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR25-R49) [[2]](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR76-R84) [[3]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R26) [[4]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R92) [[5]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R107) [[6]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R144) [[7]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R171-L182)
* Refactored the logic in `VFSFileImpl`'s constructor to eliminate a TOCTOU bug by attempting `fopen` first and falling back to `opendir` or `stat` as needed, ensuring correct file/directory type detection even under concurrent access (`libraries/FS/src/vfs_api.cpp`).
* Updated the `mkdir` implementation to use `stat` and `opendir` for accurate directory existence checks, with comments explaining the mutex's role in preventing TOCTOU issues (`libraries/FS/src/vfs_api.cpp`).
* Added a regression test to verify correct detection of files and directories when opened in read mode, ensuring the TOCTOU fix works as intended (`tests/validation/fs/fs.ino`). [[1]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR658-R723) [[2]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR826)

**Python script error reporting improvements:**

* Replaced direct `print` and `sys.stderr.write` calls with the `logging` module for consistent warning and debug output in `.github/scripts/get_affected.py`, `.gitlab/scripts/gen_hw_jobs.py`, and `tools/espota.py`. This includes logging for file read errors, JSON parsing errors, and runner tag checking errors. [[1]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eR111-R116) [[2]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eL132-R140) [[3]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eL554-R557) [[4]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eL710-R713) [[5]](diffhunk://#diff-cb05372cb8ac168498a5b21304396c01a62b55bdb37a0df4df8bf4f20ad16e65R5) [[6]](diffhunk://#diff-cb05372cb8ac168498a5b21304396c01a62b55bdb37a0df4df8bf4f20ad16e65R22-R23) [[7]](diffhunk://#diff-cb05372cb8ac168498a5b21304396c01a62b55bdb37a0df4df8bf4f20ad16e65L345-R349) [[8]](diffhunk://#diff-3a20fb51cb5644c9971f7f638b9adb3280104bb451f561977ca6c349c4f993a2L447-R450)

## Test Scenarios

Tested locally