### PR TITLE
fix(codeql): Fix codeQL warnings

### DIFF
--- a/.github/scripts/get_affected.py
+++ b/.github/scripts/get_affected.py
@@ -108,10 +108,12 @@ import json
 import subprocess
 import shutil
 import fnmatch
+import logging
 
 script_dir = Path(__file__).resolve().parent
 project_root = (script_dir / "../../").resolve()
 
+logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s', stream=sys.stderr)
 
 def resolve_changed_path_to_project_relative(path: str) -> str:
     """
@@ -129,13 +131,13 @@ def resolve_changed_path_to_project_relative(path: str) -> str:
     if p.is_absolute():
         try:
             return str(p.resolve().relative_to(project_root))
-        except ValueError:
-            pass
+        except ValueError as e:
+            logging.warning("Absolute path %s is outside project root: %s", raw, e)
     else:
         try:
             return str((Path.cwd() / p).resolve().relative_to(project_root))
-        except ValueError:
-            pass
+        except ValueError as e:
+            logging.warning("Relative path %s is outside project root: %s", raw, e)
         if (project_root / p).is_file():
             return p.as_posix()
 
@@ -551,7 +553,8 @@ def run_ctags_and_index(paths: list[str]) -> tuple[dict[str, set[str]], dict[str
             continue
         try:
             tag = json.loads(line)
-        except Exception:
+        except Exception as e:
+            logging.warning("Failed to parse ctags JSON line %r: %s", line, e)
             continue
 
         path = tag.get("path")
@@ -707,7 +710,7 @@ def build_dependencies_graph() -> None:
             with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                 content = f.read()
         except Exception as e:
-            print(f"Warning: Could not read file {file}: {e}", file=sys.stderr)
+            logging.warning("Could not read file %s: %s", file, e)
             continue
 
         for match in include_regex.finditer(content):

--- a/.gitlab/scripts/gen_hw_jobs.py
+++ b/.gitlab/scripts/gen_hw_jobs.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import logging
 import yaml
 import os
 import sys
@@ -17,6 +18,8 @@ import urllib.error
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 TESTS_ROOT = REPO_ROOT / "tests"
+
+logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s', stream=sys.stderr)
 
 # Ensure we run from repo root so relative paths work consistently
 try:
@@ -342,8 +345,8 @@ def any_runner_matches(required_tags: Iterable[str], runners: list[dict]) -> boo
         except Exception as e:
             # Be robust to unexpected runner payloads
             runner_id = r.get("id", "unknown")
-            sys.stderr.write(f"[WARN] Error checking runner #{runner_id} against required tags: {e}\n")
-            sys.stderr.write(traceback.format_exc() + "\n")
+            logging.warning("Error checking runner #%s against required tags: %s", runner_id, e)
+            logging.debug(traceback.format_exc())
             continue
     return False
 

--- a/.gitlab/scripts/gen_hw_jobs.py
+++ b/.gitlab/scripts/gen_hw_jobs.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 TESTS_ROOT = REPO_ROOT / "tests"
 
-logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s', stream=sys.stderr)
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s", stream=sys.stderr)
 
 # Ensure we run from repo root so relative paths work consistently
 try:

--- a/tools/espota.py
+++ b/tools/espota.py
@@ -444,10 +444,10 @@ def serve(  # noqa: C901
                         logging.warning("Unexpected response from device: '%s'", data)
 
                 except socket.timeout:
-                    logging.debug("Timeout waiting for result (attempt %d/10)", count)
+                    logging.warning("Timeout waiting for result (attempt %d/10)", count)
                     continue
                 except Exception as e:
-                    logging.debug("Error receiving result (attempt %d/10): %s", count, str(e))
+                    logging.warning("Error receiving result (attempt %d/10): %s", count, str(e))
                     # Don't return error here, continue trying
                     continue
 


### PR DESCRIPTION
## Description of Change

This pull request introduces two main sets of changes: improvements to logging and error reporting in Python scripts, and significant enhancements to the thread safety and correctness of the Arduino filesystem (FS) API implementation in C++. The FS API changes address a race condition (TOCTOU bug) in file and directory handling, add a mutex for thread safety, and introduce a regression test to verify the fix.

**Filesystem API improvements and bugfixes:**

* Added a per-filesystem recursive mutex (`_mtx`) and an RAII lock guard (`FSLockGuard`) in `FSImpl` to ensure thread safety for all FS operations. All major FS API methods now acquire this lock, preventing concurrent access issues. [[1]](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR25-R49) [[2]](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR76-R84) [[3]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R26) [[4]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R92) [[5]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R107) [[6]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R144) [[7]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R171-L182) [[8]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R186-R224)
* Fixed a TOCTOU (time-of-check/time-of-use) race in `VFSFileImpl` constructor: now attempts `fopen()` first, then uses `stat()` and `opendir()` to correctly detect file vs directory, closing the race window present in the previous implementation.
* Added a regression test (`test_open_read_mode_type_detection`) to `tests/validation/fs/fs.ino` to verify correct detection of files and directories in read mode and prevent future regressions of the TOCTOU bug. [[1]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR658-R723) [[2]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR826)

**Logging and error reporting improvements in scripts:**

* Standardized logging in `.github/scripts/get_affected.py` and `.gitlab/scripts/gen_hw_jobs.py` by using the `logging` module instead of direct `print` or `sys.stderr.write` calls, ensuring consistent and configurable error reporting. [[1]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eR111-R116) [[2]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eL132-R140) [[3]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eL554-R557) [[4]](diffhunk://#diff-87e8d12df55e7070bbde6952b4db391b08f194004ce6e23e44ddfc8c9dbf122eL710-R713) [[5]](diffhunk://#diff-cb05372cb8ac168498a5b21304396c01a62b55bdb37a0df4df8bf4f20ad16e65R5) [[6]](diffhunk://#diff-cb05372cb8ac168498a5b21304396c01a62b55bdb37a0df4df8bf4f20ad16e65R22-R23) [[7]](diffhunk://#diff-cb05372cb8ac168498a5b21304396c01a62b55bdb37a0df4df8bf4f20ad16e65L345-R349)
* Improved error logging in `tools/espota.py` by promoting certain debug messages to warnings, making timeouts and exceptions more visible.

## Test Scenarios

Tested locally
