### PR TITLE
fix(uart): solves pinSet order with UART begin

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -665,6 +665,14 @@ int8_t uart_get_TxPin(uint8_t uart_num) {
   return _uart_bus_array[uart_num]._txPin;
 }
 
+int8_t uart_get_CtsPin(uint8_t uart_num) {
+  return _uart_bus_array[uart_num]._ctsPin;
+}
+
+int8_t uart_get_RtsPin(uint8_t uart_num) {
+  return _uart_bus_array[uart_num]._rtsPin;
+}
+
 // Routines that take care of UART events will be in the HardwareSerial Class code
 void uartGetEventQueue(uart_t *uart, QueueHandle_t *q) {
   // passing back NULL for the Queue pointer when UART is not initialized yet
@@ -1184,8 +1192,12 @@ uart_t *uartBegin(
   UART_MUTEX_UNLOCK();
 
   // uartSetPins detaches previous pins if new ones are used over a previous begin()
+  // If CTS/RTS pins were pre-configured via setPins() before begin(), use those instead of UART_PIN_NO_CHANGE
   if (retCode) {
-    retCode &= uartSetPins(uart_nr, rxPin, txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    int8_t ctsPin_to_set = uart->_ctsPin >= 0 ? uart->_ctsPin : UART_PIN_NO_CHANGE;
+    int8_t rtsPin_to_set = uart->_rtsPin >= 0 ? uart->_rtsPin : UART_PIN_NO_CHANGE;
+    log_v("UART%u calling uartSetPins with pre-configured CTS/RTS: ctsPin=%d, rtsPin=%d", uart_nr, ctsPin_to_set, rtsPin_to_set);
+    retCode &= uartSetPins(uart_nr, rxPin, txPin, ctsPin_to_set, rtsPin_to_set);
   }
   if (!retCode) {
     log_e("UART%u initialization error.", uart->num);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -787,11 +787,23 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   // get UART information
   uart_t *uart = &_uart_bus_array[uart_num];
 
+  //log_v("setting UART%u pins: prev->new RX(%d->%d) TX(%d->%d) CTS(%d->%d) RTS(%d->%d)", uart_num,
+  //        uart->_rxPin, rxPin, uart->_txPin, txPin, uart->_ctsPin, ctsPin, uart->_rtsPin, rtsPin); vTaskDelay(10);
+
   bool retCode = true;
   UART_MUTEX_LOCK();
 
-  //log_v("setting UART%u pins: prev->new RX(%d->%d) TX(%d->%d) CTS(%d->%d) RTS(%d->%d)", uart_num,
-  //        uart->_rxPin, rxPin, uart->_txPin, txPin, uart->_ctsPin, ctsPin, uart->_rtsPin, rtsPin); vTaskDelay(10);
+  // If driver is not yet installed, just store the pin configuration
+  // The pins will be properly attached when the driver is installed in uartBegin()
+  if (!uartIsDriverInstalled(uart)) {
+    log_v("UART%u: Driver not yet installed, storing pins for later attachment (RX:%d, TX:%d)", uart_num, rxPin, txPin);
+    if (rxPin >= 0) uart->_rxPin = rxPin;
+    if (txPin >= 0) uart->_txPin = txPin;
+    if (ctsPin >= 0) uart->_ctsPin = ctsPin;
+    if (rtsPin >= 0) uart->_rtsPin = rtsPin;
+    UART_MUTEX_UNLOCK();
+    return true;
+  }
 
   // mute bus detaching callbacks to avoid terminating the UART driver when both RX and TX pins are detached
   peripheral_bus_deinit_cb_t rxDeinit = perimanGetBusDeinit(ESP32_BUS_TYPE_UART_RX);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1194,12 +1194,8 @@ uart_t *uartBegin(
   // uartSetPins detaches previous pins if new ones are used over a previous begin()
   // If any pins were pre-configured via setPins() before begin(), use those instead of UART_PIN_NO_CHANGE
   if (retCode) {
-    int8_t rxPin_to_set = (rxPin >= 0) ? rxPin : (uart->_rxPin >= 0 ? uart->_rxPin : UART_PIN_NO_CHANGE);
-    int8_t txPin_to_set = (txPin >= 0) ? txPin : (uart->_txPin >= 0 ? uart->_txPin : UART_PIN_NO_CHANGE);
-    int8_t ctsPin_to_set = uart->_ctsPin >= 0 ? uart->_ctsPin : UART_PIN_NO_CHANGE;
-    int8_t rtsPin_to_set = uart->_rtsPin >= 0 ? uart->_rtsPin : UART_PIN_NO_CHANGE;
-    log_v("UART%u calling uartSetPins: RX=%d, TX=%d, CTS=%d, RTS=%d", uart_nr, rxPin_to_set, txPin_to_set, ctsPin_to_set, rtsPin_to_set);
-    retCode &= uartSetPins(uart_nr, rxPin_to_set, txPin_to_set, ctsPin_to_set, rtsPin_to_set);
+    log_v("UART%u calling uartSetPins: RX=%d, TX=%d, CTS=%d, RTS=%d", uart_nr, rxPin, txPin, uart->_ctsPin, uart->_rtsPin);
+    retCode &= uartSetPins(uart_nr, rxPin, txPin, uart->_ctsPin, uart->_rtsPin);
   }
   if (!retCode) {
     log_e("UART%u initialization error.", uart->num);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -1192,12 +1192,14 @@ uart_t *uartBegin(
   UART_MUTEX_UNLOCK();
 
   // uartSetPins detaches previous pins if new ones are used over a previous begin()
-  // If CTS/RTS pins were pre-configured via setPins() before begin(), use those instead of UART_PIN_NO_CHANGE
+  // If any pins were pre-configured via setPins() before begin(), use those instead of UART_PIN_NO_CHANGE
   if (retCode) {
+    int8_t rxPin_to_set = (rxPin >= 0) ? rxPin : (uart->_rxPin >= 0 ? uart->_rxPin : UART_PIN_NO_CHANGE);
+    int8_t txPin_to_set = (txPin >= 0) ? txPin : (uart->_txPin >= 0 ? uart->_txPin : UART_PIN_NO_CHANGE);
     int8_t ctsPin_to_set = uart->_ctsPin >= 0 ? uart->_ctsPin : UART_PIN_NO_CHANGE;
     int8_t rtsPin_to_set = uart->_rtsPin >= 0 ? uart->_rtsPin : UART_PIN_NO_CHANGE;
-    log_v("UART%u calling uartSetPins with pre-configured CTS/RTS: ctsPin=%d, rtsPin=%d", uart_nr, ctsPin_to_set, rtsPin_to_set);
-    retCode &= uartSetPins(uart_nr, rxPin, txPin, ctsPin_to_set, rtsPin_to_set);
+    log_v("UART%u calling uartSetPins: RX=%d, TX=%d, CTS=%d, RTS=%d", uart_nr, rxPin_to_set, txPin_to_set, ctsPin_to_set, rtsPin_to_set);
+    retCode &= uartSetPins(uart_nr, rxPin_to_set, txPin_to_set, ctsPin_to_set, rtsPin_to_set);
   }
   if (!retCode) {
     log_e("UART%u initialization error.", uart->num);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -87,6 +87,8 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
 // helper functions
 int8_t uart_get_RxPin(uint8_t uart_num);
 int8_t uart_get_TxPin(uint8_t uart_num);
+int8_t uart_get_CtsPin(uint8_t uart_num);
+int8_t uart_get_RtsPin(uint8_t uart_num);
 
 // Enables or disables HW Flow Control function -- needs also to set CTS and/or RTS pins
 //    UART_HW_FLOWCTRL_DISABLE = 0x0   disable hardware flow control


### PR DESCRIPTION
## Description of Change

When setting UART pins and later initializing it, the RX pin is not correctly configured.

## Test Scenarios

ESP32 / ESP32-S3 / ESP32-C3
Also tested with  CI Validation sketch.

``` cpp
// UART1 pins
#define UART1_RX 2
#define UART1_TX 4

// TEST_MODE 0 ==> begin() does both, initialize UART1 and also set the RX/TX pins
// TEST_MODE 1 ==> begin() initialize UART1 and later set the RX/TX pins
// TEST_MODE 1 ==> set the UART1 RX/TX pins and later initialize it with begin() 
#define TEST_MODE 0 // 0, 1 or 2

void setup () {
  // console
  Serial0.begin(115200);

#if TEST_MODE == 0    // This test case works
  Serial1.begin(115200, SERIAL_8N1, UART1_RX, UART1_TX);
#elif TEST_MODE == 1  // This test case works
  Serial1.begin(115200);
  Serial1.setPins(UART1_RX, UART1_TX);
#elif TEST_MODE == 2  // ===> This test case fails with UART1 read()
  Serial1.setPins(UART1_RX, UART1_TX);
  Serial1.begin(115200);
#endif
}

// Loopback UART0 and UART1
void loop() {
  while (Serial0.available()) {
    Serial1.write((char) Serial0.read());
  }
  while (Serial1.available()) {
    Serial0.write((char) Serial1.read());
  }
  delay(1);
}
```
w

## Related links
Related to #12527