### PR TITLE
ci(tests): Add result caching for unavailable runners

### DIFF
--- a/.github/scripts/runtime_table_generator.py
+++ b/.github/scripts/runtime_table_generator.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from collections import defaultdict
 
 # Configure logging
@@ -13,6 +13,8 @@ logging.basicConfig(level=logging.DEBUG, format='[%(levelname)s] %(message)s', s
 SUCCESS_SYMBOL = ":white_check_mark:"
 FAILURE_SYMBOL = ":x:"
 ERROR_SYMBOL = ":fire:"
+
+CACHE_STALE_DAYS = 7
 
 
 def _natural_sort_key(s):
@@ -34,6 +36,55 @@ def _junit_status(junit):
     if junit and junit["failures"] > 0:
         return "Failure", FAILURE_SYMBOL
     return "Success", SUCCESS_SYMBOL
+
+
+def _load_previous_results(path):
+    """Load previous test_results.json; return its dict or {} on any error."""
+    if not path:
+        return {}
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except (OSError, json.JSONDecodeError) as e:
+        logging.debug(f"Could not read previous results from {path}: {e}")
+        return {}
+
+
+def _is_cache_fresh(entry):
+    """Return True if the cache entry timestamp is within CACHE_STALE_DAYS."""
+    if not entry or "timestamp" not in entry:
+        return False
+    try:
+        ts = datetime.fromisoformat(entry["timestamp"])
+        # Make timezone-aware if naive (assume UTC)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - ts) < timedelta(days=CACHE_STALE_DAYS)
+    except (ValueError, TypeError) as e:
+        logging.debug(f"Failed to parse cache timestamp: {e}")
+        return False
+
+
+def _make_cache_entry(total, failures, commit_sha):
+    """Build a fresh cache entry dict for a validation test cell."""
+    return {
+        "total": total,
+        "failures": failures,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "commit_sha": commit_sha,
+    }
+
+
+def _render_cached_cell(entry):
+    """Return the markdown cell text for a cached (stale-runner) result."""
+    total = entry.get("total", 0)
+    failures = entry.get("failures", 0)
+    passed = total - failures
+    symbol = FAILURE_SYMBOL if failures > 0 else SUCCESS_SYMBOL
+    return f"|{passed}/{total} {symbol}\\*"
 
 
 def _parse_performance_json(data, test_name_from_path=None):
@@ -145,6 +196,7 @@ parser = argparse.ArgumentParser(description="Generate runtime test results repo
 parser.add_argument("--results", required=True, help="Path to the unity_results.json file")
 parser.add_argument("--sha", default=None, help="Commit SHA (falls back to GITHUB_SHA env var)")
 parser.add_argument("--perf-dir", default=None, help="Path to directory containing performance result_*.json files")
+parser.add_argument("--previous-results", default=None, help="Path to previous test_results.json (used to seed the result cache)")
 args = parser.parse_args()
 
 with open(args.results, "r") as f:
@@ -155,6 +207,11 @@ commit_sha = args.sha or os.environ.get("GITHUB_SHA")
 performance_data_dir = args.perf_dir.rstrip(os.sep) if args.perf_dir else None
 if not commit_sha:
     parser.error("Commit SHA is required: provide via --sha or set the GITHUB_SHA environment variable.")
+
+# Load persistent result cache from previous run
+previous_results = _load_previous_results(args.previous_results)
+result_cache = previous_results.get("cache", {})        # platform -> test_name -> target -> entry
+perf_cache = previous_results.get("perf_cache", {})     # test_name -> target -> entry
 
 # Generate the table
 
@@ -230,6 +287,7 @@ for test in tests:
     proc_test_data[platform][test_name][target]["errors"] += test["errors"]
 
 # Render only executed tests grouped by platform/target/test
+any_cached_cell = False
 for platform in proc_test_data:
     print("")
     print(f"#### {platform.capitalize()}")
@@ -251,14 +309,28 @@ for platform in proc_test_data:
     print("-" + "|:-:" * len(target_list))
 
     platform_executed = proc_test_data.get(platform, {})
+    plat_cache = result_cache.setdefault(platform, {})
     for test_name in sorted(platform_executed.keys()):
+        test_cache = plat_cache.setdefault(test_name, {})
         print(f"{test_name}", end="")
         for target in target_list:
             executed_cell = platform_executed.get(test_name, {}).get(target)
             if executed_cell:
                 if executed_cell["errors"] > 0:
-                    print(f"|Error {ERROR_SYMBOL}", end="")
+                    # Test did not run — try to fall back to cache
+                    cached = test_cache.get(target)
+                    if cached and _is_cache_fresh(cached):
+                        print(_render_cached_cell(cached), end="")
+                        any_cached_cell = True
+                    else:
+                        print(f"|Error {ERROR_SYMBOL}", end="")
                 else:
+                    # Test ran successfully (pass or fail) — update cache
+                    test_cache[target] = _make_cache_entry(
+                        executed_cell["total"],
+                        executed_cell["failures"],
+                        commit_sha,
+                    )
                     print(f"|{executed_cell['total']-executed_cell['failures']}/{executed_cell['total']}", end="")
                     if executed_cell["failures"] > 0:
                         print(f" {FAILURE_SYMBOL}", end="")
@@ -290,26 +362,60 @@ if tests_with_targets:
 
     for test_name in sorted(tests_with_targets.keys()):
         print(f"- **{test_name}**")
+        test_perf_cache = perf_cache.setdefault(test_name, {})
         for target in sorted(tests_with_targets[test_name].keys()):
             entry = tests_with_targets[test_name][target]
-            status_label, status_symbol = _junit_status(perf_junit_status.get((target, test_name)))
-            print(f"  - {_display_target(target)} - {status_label} - {status_symbol}")
-
-            if entry:
-                settings_str = entry.get("settings") or ""
-                runs = entry["runs"]
-                runs_line = f"{settings_str} - {runs} runs" if settings_str else f"{runs} runs"
-                print(f"    - {runs_line}:")
-                for mname in sorted(entry["metrics"].keys(), key=_natural_sort_key):
-                    agg = entry["metrics"][mname]
-                    avg = agg["avg"]
-                    unit = agg.get("unit", "")
-                    unit_str = f" {unit}" if unit else ""
-                    print(f"      - {mname}: {avg}{unit_str}")
+            junit = perf_junit_status.get((target, test_name))
+            if junit and junit["errors"] > 0:
+                # Test did not run — try cache
+                cached = test_perf_cache.get(target)
+                if cached and _is_cache_fresh(cached):
+                    status_label = cached["status"].capitalize()
+                    status_symbol = SUCCESS_SYMBOL if cached["status"] == "success" else FAILURE_SYMBOL
+                    print(f"  - {_display_target(target)} - {status_label} - {status_symbol}\\*")
+                    any_cached_cell = True
+                    if cached.get("metrics"):
+                        settings_str = cached.get("settings") or ""
+                        runs = cached.get("runs", 0)
+                        runs_line = f"{settings_str} - {runs} runs" if settings_str else f"{runs} runs"
+                        print(f"    - {runs_line} (cached):")
+                        for mname in sorted(cached["metrics"].keys(), key=_natural_sort_key):
+                            agg = cached["metrics"][mname]
+                            avg = agg["avg"]
+                            unit = agg.get("unit", "")
+                            unit_str = f" {unit}" if unit else ""
+                            print(f"      - {mname}: {avg}{unit_str}")
+                else:
+                    print(f"  - {_display_target(target)} - Error - {ERROR_SYMBOL}")
+            else:
+                status_label, status_symbol = _junit_status(junit)
+                print(f"  - {_display_target(target)} - {status_label} - {status_symbol}")
+                # Update performance cache entry
+                perf_entry = {
+                    "status": status_label.lower(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "commit_sha": commit_sha,
+                }
+                if entry:
+                    settings_str = entry.get("settings") or ""
+                    runs = entry["runs"]
+                    runs_line = f"{settings_str} - {runs} runs" if settings_str else f"{runs} runs"
+                    print(f"    - {runs_line}:")
+                    for mname in sorted(entry["metrics"].keys(), key=_natural_sort_key):
+                        agg = entry["metrics"][mname]
+                        avg = agg["avg"]
+                        unit = agg.get("unit", "")
+                        unit_str = f" {unit}" if unit else ""
+                        print(f"      - {mname}: {avg}{unit_str}")
+                    perf_entry.update({"runs": entry["runs"], "settings": entry.get("settings", ""), "metrics": entry["metrics"]})
+                test_perf_cache[target] = perf_entry
         print("")
 
 print("\n")
-print(f"Generated on: {datetime.now().strftime('%Y/%m/%d %H:%M:%S')}")
+if any_cached_cell:
+    print("> \\* Result from last successful run (runner currently unavailable)")
+    print("")
+print(f"Generated on: {datetime.now(timezone.utc).strftime('%Y/%m/%d %H:%M:%S UTC')}")
 print("")
 
 try:
@@ -330,7 +436,9 @@ results_data = {
     "commit_sha": commit_sha,
     "tests_failed": os.environ.get("IS_FAILING") == "true",
     "test_data": proc_test_data,
-    "generated_at": datetime.now().isoformat()
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "cache": result_cache,
+    "perf_cache": perf_cache,
 }
 if tests_with_targets:
     perf_out = {}

--- a/.github/scripts/runtime_table_generator.py
+++ b/.github/scripts/runtime_table_generator.py
@@ -210,8 +210,10 @@ if not commit_sha:
 
 # Load persistent result cache from previous run
 previous_results = _load_previous_results(args.previous_results)
-result_cache = previous_results.get("cache", {})        # platform -> test_name -> target -> entry
-perf_cache = previous_results.get("perf_cache", {})     # test_name -> target -> entry
+raw_result_cache = previous_results.get("cache", {})
+result_cache = raw_result_cache if isinstance(raw_result_cache, dict) else {}        # platform -> test_name -> target -> entry
+raw_perf_cache = previous_results.get("perf_cache", {})
+perf_cache = raw_perf_cache if isinstance(raw_perf_cache, dict) else {}     # test_name -> target -> entry
 
 # Generate the table
 
@@ -369,9 +371,10 @@ if tests_with_targets:
             if junit and junit["errors"] > 0:
                 # Test did not run — try cache
                 cached = test_perf_cache.get(target)
-                if cached and _is_cache_fresh(cached):
-                    status_label = cached["status"].capitalize()
-                    status_symbol = SUCCESS_SYMBOL if cached["status"] == "success" else FAILURE_SYMBOL
+                cached_status = cached.get("status") if cached else None
+                if cached and _is_cache_fresh(cached) and cached_status:
+                    status_label = cached_status.capitalize()
+                    status_symbol = SUCCESS_SYMBOL if cached_status == "success" else FAILURE_SYMBOL
                     print(f"  - {_display_target(target)} - {status_label} - {status_symbol}\\*")
                     any_cached_cell = True
                     if cached.get("metrics"):

--- a/.github/scripts/test_runtime_table_generator.py
+++ b/.github/scripts/test_runtime_table_generator.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""
+Local test script for runtime_table_generator.py
+
+Usage:
+    python3 .github/scripts/test_runtime_table_generator.py
+
+Each test case sets up input fixtures in a temporary directory, runs the
+generator, and asserts expected patterns in the markdown output and in the
+saved test_results.json cache.
+
+Edge cases covered:
+  1.  First run (no --previous-results) – all pass        → cache populated, no asterisk
+  2.  First run (no --previous-results) – some fail       → failures shown, cache populated
+  3.  First run (no --previous-results) – runner error    → "Error :fire:", target NOT cached
+  4.  Cache hit – runner now unavailable                  → asterisk + footnote shown
+  5.  Cache miss – runner was already unavailable run 1   → "Error :fire:", no asterisk
+  6.  Result changed (2/2→1/2) – valid run               → NO asterisk (it was a valid run)
+  7.  Stale cache (>7 days) – runner unavailable          → "Error :fire:", no asterisk
+  8.  Cache propagation across three runs                 → asterisk survives run B and run C
+  9.  --previous-results file does not exist              → no crash, no cache loaded
+  10. --previous-results file is corrupt JSON             → no crash, no cache loaded
+  11. --previous-results file is not a dict               → no crash, no cache loaded
+  12. Multiple sketches                                   → each sketch cached independently
+  13. Multi-FQBN builds (Blink0 + Blink1 test names)     → stripped to "Blink", accumulated
+  14. Multi-FQBN partial error (one FQBN errors)         → accumulated errors>0, uses cache
+  15. Multiple platforms (hardware + wokwi)              → each platform handled independently
+  16. Performance test – runner OK                       → perf cache populated, no asterisk
+  17. Performance test – runner unavailable, cache hit   → asterisk + cached metrics shown
+  18. Performance test – runner unavailable, cache miss  → "Error :fire:", no asterisk
+  19. Wokwi-only target not in HW list                   → not shown under Hardware section
+  20. Target in env but not in results                   → shown as "-" (dash)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import shutil
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "runtime_table_generator.py"
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+_failures = []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ts_stale():
+    """Return a timestamp older than CACHE_STALE_DAYS (7 days)."""
+    return (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+
+
+def _unity(suite_details):
+    """Build a minimal unity_results.json dict."""
+    return {"stats": {"suite_details": suite_details}}
+
+
+def _suite(name, tests=3, failures=0, errors=0):
+    return {"name": name, "tests": tests, "failures": failures, "errors": errors}
+
+
+def _cache_entry(total, failures, ts=None, commit_sha="abc"):
+    return {
+        "total": total,
+        "failures": failures,
+        "timestamp": ts or _ts_now(),
+        "commit_sha": commit_sha,
+    }
+
+
+def _test_results(cache=None, perf_cache=None, commit_sha="prev"):
+    """Build a minimal test_results.json dict."""
+    return {
+        "commit_sha": commit_sha,
+        "tests_failed": False,
+        "test_data": {},
+        "generated_at": _ts_now(),
+        "cache": cache or {},
+        "perf_cache": perf_cache or {},
+    }
+
+
+def run_generator(tmpdir, unity, env_extra=None, prev_results=None, sha="abc123", perf_dir=None):
+    """
+    Run runtime_table_generator.py inside *tmpdir*.
+    Returns (stdout, stderr, returncode, saved_cache).
+    saved_cache is the 'cache' dict from the written test_results.json.
+    """
+    unity_path = os.path.join(tmpdir, "unity_results.json")
+    with open(unity_path, "w") as f:
+        json.dump(unity, f)
+
+    prev_path = None
+    if prev_results is not None:
+        prev_path = os.path.join(tmpdir, "previous_results.json")
+        with open(prev_path, "w") as f:
+            if isinstance(prev_results, str):
+                f.write(prev_results)          # allow raw string for corrupt-JSON test
+            else:
+                json.dump(prev_results, f)
+
+    cmd = [sys.executable, str(SCRIPT), "--results", unity_path, "--sha", sha]
+    if prev_path:
+        cmd += ["--previous-results", prev_path]
+    if perf_dir:
+        cmd += ["--perf-dir", perf_dir]
+
+    env = {**os.environ, "HW_TARGETS": "[]", "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+    if env_extra:
+        env.update(env_extra)
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=tmpdir,
+        env=env,
+    )
+
+    saved_cache = {}
+    out_path = os.path.join(tmpdir, "test_results.json")
+    if os.path.exists(out_path):
+        with open(out_path) as f:
+            saved = json.load(f)
+        saved_cache = saved.get("cache", {})
+
+    return result.stdout, result.stderr, result.returncode, saved_cache
+
+
+def assert_test(name, condition, detail=""):
+    if condition:
+        print(f"  {PASS}  {name}")
+    else:
+        msg = f"  {FAIL}  {name}"
+        if detail:
+            msg += f"\n         detail: {detail}"
+        print(msg)
+        _failures.append(name)
+
+
+def section(title):
+    print(f"\n{'='*60}")
+    print(f"  {title}")
+    print('='*60)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+def test_01_first_run_all_pass():
+    section("Test 01 – First run, all pass (no previous results)")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink", tests=3),
+            _suite("validation_hardware_esp32c3_Blink", tests=3),
+            _suite("validation_hardware_esp32s3_Blink", tests=2),
+        ])
+        env = {"HW_TARGETS": '["esp32","esp32s3","esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("shows ESP32 3/3 pass", "3/3 :white_check_mark:" in out)
+        assert_test("shows ESP32-C3 3/3 pass", "3/3 :white_check_mark:" in out)
+        assert_test("shows ESP32-S3 2/2 pass", "2/2 :white_check_mark:" in out)
+        assert_test("no asterisk in output", "\\*" not in out)
+        assert_test("esp32 cached", "esp32" in cache.get("hardware", {}).get("Blink", {}))
+        assert_test("esp32c3 cached", "esp32c3" in cache.get("hardware", {}).get("Blink", {}))
+        assert_test("esp32s3 cached", "esp32s3" in cache.get("hardware", {}).get("Blink", {}))
+
+
+def test_02_first_run_some_fail():
+    section("Test 02 – First run, some failures (no errors)")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink", tests=3, failures=1),
+            _suite("validation_hardware_esp32s3_Blink", tests=2, failures=2),
+        ])
+        env = {"HW_TARGETS": '["esp32","esp32s3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("shows failure symbol for esp32", ":x:" in out)
+        assert_test("no asterisk in output", "\\*" not in out)
+        assert_test("esp32 cached despite failures", "esp32" in cache.get("hardware", {}).get("Blink", {}))
+        assert_test("esp32s3 cached despite all-fail", "esp32s3" in cache.get("hardware", {}).get("Blink", {}))
+        blink_cache = cache.get("hardware", {}).get("Blink", {})
+        assert_test("esp32 cache has 2 failures", blink_cache.get("esp32", {}).get("failures") == 1)
+
+
+def test_03_first_run_runner_error():
+    section("Test 03 – First run, runner error (errors > 0)")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink", tests=3),
+            _suite("validation_hardware_esp32c3_Blink", tests=0, errors=1),  # runner unavailable
+        ])
+        env = {"HW_TARGETS": '["esp32","esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("shows Error :fire: for esp32c3", "Error :fire:" in out)
+        assert_test("no asterisk in output", "\\*" not in out)
+        assert_test("esp32 cached", "esp32" in cache.get("hardware", {}).get("Blink", {}))
+        assert_test("esp32c3 NOT cached (it errored)", "esp32c3" not in cache.get("hardware", {}).get("Blink", {}))
+
+
+def test_04_cache_hit_runner_unavailable():
+    section("Test 04 – Cache hit: runner was available before, now unavailable → asterisk")
+    with tempfile.TemporaryDirectory() as d:
+        prev = _test_results(cache={
+            "hardware": {"Blink": {
+                "esp32":   _cache_entry(3, 0),
+                "esp32c3": _cache_entry(3, 0),   # previously passed
+                "esp32s3": _cache_entry(2, 0),
+            }}
+        })
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink", tests=3),
+            _suite("validation_hardware_esp32c3_Blink", tests=0, errors=1),  # now unavailable
+            _suite("validation_hardware_esp32s3_Blink", tests=2, failures=1),
+        ])
+        env = {"HW_TARGETS": '["esp32","esp32s3","esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("esp32c3 shows cached 3/3 with asterisk", "3/3 :white_check_mark:\\*" in out)
+        assert_test("footnote about runner unavailable shown", "Result from last successful run" in out)
+        assert_test("esp32 has no asterisk (ran fine)", "3/3 :white_check_mark:\\*" not in out.split("esp32c3")[0] if "esp32c3" in out else True)
+        assert_test("esp32s3 has no asterisk (valid run with failure)", "1/2 :x:\\*" not in out)
+        # Cached esp32c3 entry propagated to new test_results.json
+        assert_test("esp32c3 cache propagated to new output", "esp32c3" in cache.get("hardware", {}).get("Blink", {}))
+
+
+def test_05_cache_miss_runner_was_already_unavailable():
+    section("Test 05 – Cache miss: runner had errors in run 1 too → no asterisk")
+    with tempfile.TemporaryDirectory() as d:
+        # Previous results has cache but NOT esp32c3 (it also errored in run 1)
+        prev = _test_results(cache={
+            "hardware": {"Blink": {
+                "esp32":   _cache_entry(3, 0),
+                "esp32s3": _cache_entry(2, 0),
+                # esp32c3 intentionally absent
+            }}
+        })
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink", tests=3),
+            _suite("validation_hardware_esp32c3_Blink", tests=0, errors=1),
+            _suite("validation_hardware_esp32s3_Blink", tests=2),
+        ])
+        env = {"HW_TARGETS": '["esp32","esp32s3","esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, _ = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("esp32c3 shows Error :fire: (no cached result)", "Error :fire:" in out)
+        assert_test("no asterisk in output", "\\*" not in out)
+        assert_test("no footnote shown", "Result from last successful run" not in out)
+
+
+def test_06_result_changed_no_asterisk():
+    section("Test 06 – Result changed (2/2 → 1/2): valid run, NO asterisk")
+    with tempfile.TemporaryDirectory() as d:
+        prev = _test_results(cache={
+            "hardware": {"Blink": {
+                "esp32":   _cache_entry(3, 0),
+                "esp32s3": _cache_entry(2, 0),   # previously 2/2 pass
+            }}
+        })
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink", tests=3),
+            _suite("validation_hardware_esp32s3_Blink", tests=2, failures=1),  # now 1/2
+        ])
+        env = {"HW_TARGETS": '["esp32","esp32s3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("esp32s3 shows 1/2 :x:", "1/2 :x:" in out)
+        assert_test("no asterisk on changed result", "1/2 :x:\\*" not in out)
+        assert_test("no footnote shown", "Result from last successful run" not in out)
+        # Cache should be updated with new result
+        blink = cache.get("hardware", {}).get("Blink", {})
+        assert_test("esp32s3 cache updated with new result", blink.get("esp32s3", {}).get("failures") == 1)
+
+
+def test_07_stale_cache():
+    section("Test 07 – Stale cache (>7 days old): no asterisk shown")
+    with tempfile.TemporaryDirectory() as d:
+        prev = _test_results(cache={
+            "hardware": {"Blink": {
+                "esp32c3": _cache_entry(3, 0, ts=_ts_stale()),  # stale entry
+            }}
+        })
+        unity = _unity([
+            _suite("validation_hardware_esp32c3_Blink", tests=0, errors=1),
+        ])
+        env = {"HW_TARGETS": '["esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, _ = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("shows Error :fire: (stale cache ignored)", "Error :fire:" in out)
+        assert_test("no asterisk shown for stale cache", "\\*" not in out)
+
+
+def test_08_cache_propagation_three_runs():
+    section("Test 08 – Cache propagates across three consecutive error runs")
+    with tempfile.TemporaryDirectory() as d:
+        # Run A: all pass → creates cache
+        unity_all_pass = _unity([
+            _suite("validation_hardware_esp32c3_Blink", tests=3),
+        ])
+        env = {"HW_TARGETS": '["esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        run_generator(d, unity_all_pass, env_extra=env, sha="runA")
+
+        cache_a_path = os.path.join(d, "test_results.json")
+        with open(cache_a_path) as f:
+            results_a = json.load(f)
+        assert_test("Run A: esp32c3 cached", "esp32c3" in results_a.get("cache", {}).get("hardware", {}).get("Blink", {}))
+
+        # Run B: esp32c3 errors → reads Run A cache → shows asterisk
+        unity_errors = _unity([
+            _suite("validation_hardware_esp32c3_Blink", tests=0, errors=1),
+        ])
+        out_b, _, _, cache_b = run_generator(d, unity_errors, env_extra=env, prev_results=results_a, sha="runB")
+        assert_test("Run B: shows asterisk (cache from A)", "\\*" in out_b)
+        assert_test("Run B: esp32c3 cache propagated", "esp32c3" in cache_b.get("hardware", {}).get("Blink", {}))
+
+        # Run C: esp32c3 still errors → reads Run B cache → still shows asterisk
+        with open(os.path.join(d, "test_results.json")) as f:
+            results_b = json.load(f)
+        out_c, _, _, _ = run_generator(d, unity_errors, env_extra=env, prev_results=results_b, sha="runC")
+        assert_test("Run C: asterisk still shown (cache from A via B)", "\\*" in out_c)
+
+
+def test_09_missing_previous_results_file():
+    section("Test 09 – --previous-results file does not exist")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([_suite("validation_hardware_esp32_Blink", tests=3)])
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        cmd = [
+            sys.executable, str(SCRIPT),
+            "--results", os.path.join(d, "unity_results.json"),
+            "--sha", "abc123",
+            "--previous-results", os.path.join(d, "nonexistent.json"),
+        ]
+        unity_path = os.path.join(d, "unity_results.json")
+        with open(unity_path, "w") as f:
+            json.dump(unity, f)
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=d,
+                                env={**os.environ, **env})
+        assert_test("exit code 0 (no crash)", result.returncode == 0)
+        assert_test("output contains Hardware section", "Hardware" in result.stdout)
+        assert_test("no asterisk in output", "\\*" not in result.stdout)
+
+
+def test_10_corrupt_previous_results():
+    section("Test 10 – --previous-results file is corrupt JSON")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([_suite("validation_hardware_esp32_Blink", tests=3)])
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env, prev_results="{not valid json!!!")
+        assert_test("exit code 0 (no crash on corrupt file)", rc == 0)
+        assert_test("output contains Hardware section", "Hardware" in out)
+        assert_test("no asterisk in output", "\\*" not in out)
+
+
+def test_11_previous_results_not_a_dict():
+    section("Test 11 – --previous-results content is not a dict (e.g. a list)")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([_suite("validation_hardware_esp32_Blink", tests=3)])
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        # Write a valid JSON list (not a dict)
+        out, _, rc, _ = run_generator(d, unity, env_extra=env, prev_results="[1, 2, 3]")
+        assert_test("exit code 0 (no crash)", rc == 0)
+        assert_test("no asterisk", "\\*" not in out)
+
+
+def test_12_multiple_sketches():
+    section("Test 12 – Multiple sketches cached independently")
+    with tempfile.TemporaryDirectory() as d:
+        prev = _test_results(cache={
+            "hardware": {
+                "Blink":   {"esp32c3": _cache_entry(3, 0)},
+                "UART":    {"esp32c3": _cache_entry(4, 0)},
+            }
+        })
+        unity = _unity([
+            _suite("validation_hardware_esp32c3_Blink", tests=0, errors=1),
+            _suite("validation_hardware_esp32c3_UART",  tests=0, errors=1),
+        ])
+        env = {"HW_TARGETS": '["esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("Blink cached result shown with asterisk", "3/3 :white_check_mark:\\*" in out)
+        assert_test("UART cached result shown with asterisk", "4/4 :white_check_mark:\\*" in out)
+        assert_test("Blink cache propagated", "Blink" in cache.get("hardware", {}))
+        assert_test("UART cache propagated", "UART" in cache.get("hardware", {}))
+
+
+def test_13_multi_fqbn_builds():
+    section("Test 13 – Multi-FQBN builds (Blink0 + Blink1 → accumulated under 'Blink')")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink0", tests=3, failures=0),
+            _suite("validation_hardware_esp32_Blink1", tests=3, failures=1),
+        ])
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, cache = run_generator(d, unity, env_extra=env)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("Blink shows accumulated 5/6", "5/6 :x:" in out)
+        blink = cache.get("hardware", {}).get("Blink", {})
+        assert_test("accumulated into 'Blink' cache key", "esp32" in blink)
+        assert_test("cache total is 6 (3+3)", blink.get("esp32", {}).get("total") == 6)
+        assert_test("cache failures is 1", blink.get("esp32", {}).get("failures") == 1)
+
+
+def test_14_multi_fqbn_partial_error():
+    section("Test 14 – Multi-FQBN: one FQBN passes, one errors → accumulated errors>0, uses cache")
+    with tempfile.TemporaryDirectory() as d:
+        prev = _test_results(cache={
+            "hardware": {"Blink": {"esp32": _cache_entry(6, 0)}}
+        })
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink0", tests=3, failures=0, errors=0),
+            _suite("validation_hardware_esp32_Blink1", tests=0, failures=0, errors=1),
+        ])
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, _ = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        # Accumulated: total=3, failures=0, errors=1 → errors>0 → use cache
+        assert_test("cached result shown with asterisk", "\\*" in out)
+
+
+def test_15_multiple_platforms():
+    section("Test 15 – Multiple platforms (hardware + wokwi)")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink",   tests=3),
+            _suite("validation_wokwi_esp32s3_Blink",    tests=2),
+        ])
+        env = {
+            "HW_TARGETS":    '["esp32"]',
+            "WOKWI_TARGETS": '["esp32s3"]',
+            "QEMU_TARGETS":  "[]",
+        }
+        out, _, rc, cache = run_generator(d, unity, env_extra=env)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("Hardware section present", "#### Hardware" in out)
+        assert_test("Wokwi section present", "#### Wokwi" in out)
+        assert_test("hardware esp32 cached", "esp32" in cache.get("hardware", {}).get("Blink", {}))
+        assert_test("wokwi esp32s3 cached", "esp32s3" in cache.get("wokwi", {}).get("Blink", {}))
+
+
+def test_16_perf_runner_ok():
+    section("Test 16 – Performance test: runner OK → perf cache populated, no asterisk")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([
+            _suite("performance_hardware_esp32_SpeedTest", tests=1),
+        ])
+        # Create a minimal perf result JSON
+        perf_dir = os.path.join(d, "perf_artifacts", "SpeedTest", "esp32")
+        os.makedirs(perf_dir, exist_ok=True)
+        perf_data = {
+            "test_name": "SpeedTest",
+            "runs": 5,
+            "settings": "freq=240",
+            "metrics": [{"name": "throughput", "value": 100.5, "unit": "MB/s"}],
+        }
+        with open(os.path.join(perf_dir, "result_0.json"), "w") as f:
+            json.dump(perf_data, f)
+
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, _ = run_generator(d, unity, env_extra=env,
+                                      perf_dir=os.path.join(d, "perf_artifacts"))
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("Performance Tests section present", "### Performance Tests" in out)
+        assert_test("throughput metric shown", "throughput" in out)
+        assert_test("no asterisk", "\\*" not in out)
+
+
+def test_17_perf_cache_hit_runner_unavailable():
+    section("Test 17 – Performance test: runner unavailable, cache hit → asterisk")
+    with tempfile.TemporaryDirectory() as d:
+        prev = _test_results(perf_cache={
+            "SpeedTest": {
+                "esp32": {
+                    "status": "success",
+                    "timestamp": _ts_now(),
+                    "commit_sha": "prev",
+                    "runs": 5,
+                    "settings": "freq=240",
+                    "metrics": {"throughput": {"avg": 100.5, "unit": "MB/s"}},
+                }
+            }
+        })
+        unity = _unity([
+            _suite("performance_hardware_esp32_SpeedTest", tests=0, errors=1),
+        ])
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, _ = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("Performance Tests section present", "### Performance Tests" in out)
+        assert_test("asterisk shown for cached perf result", "\\*" in out)
+        assert_test("cached metrics shown", "throughput" in out)
+        assert_test("footnote shown", "Result from last successful run" in out)
+
+
+def test_18_perf_cache_miss_runner_unavailable():
+    section("Test 18 – Performance test: runner unavailable, no cache → Error :fire:")
+    with tempfile.TemporaryDirectory() as d:
+        prev = _test_results()  # empty perf_cache
+        unity = _unity([
+            _suite("performance_hardware_esp32_SpeedTest", tests=0, errors=1),
+        ])
+        env = {"HW_TARGETS": '["esp32"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, _ = run_generator(d, unity, env_extra=env, prev_results=prev)
+
+        assert_test("exit code 0", rc == 0)
+        # Performance error format is "Error - :fire:" (list item, not table cell)
+        assert_test("Error :fire: shown (no cache)", "Error - :fire:" in out)
+        assert_test("no asterisk", "\\*" not in out)
+
+
+def test_19_wokwi_target_not_in_hw_list():
+    section("Test 19 – Wokwi-only target not shown under Hardware section")
+    with tempfile.TemporaryDirectory() as d:
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink",  tests=3),
+            _suite("validation_wokwi_esp32s2_Blink",   tests=2),
+        ])
+        env = {
+            "HW_TARGETS":    '["esp32"]',
+            "WOKWI_TARGETS": '["esp32s2"]',
+            "QEMU_TARGETS":  "[]",
+        }
+        out, _, rc, _ = run_generator(d, unity, env_extra=env)
+
+        assert_test("exit code 0", rc == 0)
+        hw_section = out.split("#### Wokwi")[0] if "#### Wokwi" in out else out
+        assert_test("esp32s2 not in Hardware table", "ESP32-S2" not in hw_section.split("#### Hardware")[-1])
+        wokwi_section = out.split("#### Wokwi")[-1] if "#### Wokwi" in out else ""
+        assert_test("esp32s2 shown in Wokwi table", "ESP32-S2" in wokwi_section)
+
+
+def test_20_target_in_env_but_not_in_results():
+    section("Test 20 – Target in env list but absent from results → shown as '-'")
+    with tempfile.TemporaryDirectory() as d:
+        # Only esp32 has results; esp32c3 is listed in HW_TARGETS but missing from unity
+        unity = _unity([
+            _suite("validation_hardware_esp32_Blink", tests=3),
+        ])
+        env = {"HW_TARGETS": '["esp32","esp32c3"]', "WOKWI_TARGETS": "[]", "QEMU_TARGETS": "[]"}
+        out, _, rc, _ = run_generator(d, unity, env_extra=env)
+
+        assert_test("exit code 0", rc == 0)
+        assert_test("dash shown for missing esp32c3", "|-" in out)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print(f"Running tests against: {SCRIPT}")
+
+    test_01_first_run_all_pass()
+    test_02_first_run_some_fail()
+    test_03_first_run_runner_error()
+    test_04_cache_hit_runner_unavailable()
+    test_05_cache_miss_runner_was_already_unavailable()
+    test_06_result_changed_no_asterisk()
+    test_07_stale_cache()
+    test_08_cache_propagation_three_runs()
+    test_09_missing_previous_results_file()
+    test_10_corrupt_previous_results()
+    test_11_previous_results_not_a_dict()
+    test_12_multiple_sketches()
+    test_13_multi_fqbn_builds()
+    test_14_multi_fqbn_partial_error()
+    test_15_multiple_platforms()
+    test_16_perf_runner_ok()
+    test_17_perf_cache_hit_runner_unavailable()
+    test_18_perf_cache_miss_runner_unavailable()
+    test_19_wokwi_target_not_in_hw_list()
+    test_20_target_in_env_but_not_in_results()
+
+    print(f"\n{'='*60}")
+    total = 20
+    failed = len(set(_failures))  # deduplicate section names
+    passed_count = total - failed
+
+    # Count individual assertions
+    all_assertions = len(_failures)
+    if _failures:
+        print(f"\n{FAIL} {len(_failures)} assertion(s) failed:")
+        for f in _failures:
+            print(f"  - {f}")
+        print()
+        sys.exit(1)
+    else:
+        print(f"\n{PASS} All {total} test cases passed!")
+        sys.exit(0)

--- a/.github/workflows/tests_results.yml
+++ b/.github/workflows/tests_results.yml
@@ -270,7 +270,7 @@ jobs:
           mv -f ./unity_results.json ./runtime-test-results/unity_results.json
           touch $REPORT_FILE
           wget https://raw.githubusercontent.com/${{ github.repository }}/master/.github/scripts/runtime_table_generator.py -O ./runtime-test-results/runtime_table_generator.py
-          python3 ./runtime-test-results/runtime_table_generator.py --results ./runtime-test-results/unity_results.json --sha $ORIGINAL_SHA --perf-dir ./artifacts >> $REPORT_FILE
+          python3 ./runtime-test-results/runtime_table_generator.py --results ./runtime-test-results/unity_results.json --sha $ORIGINAL_SHA --perf-dir ./artifacts --previous-results ./runtime-test-results/test_results.json >> $REPORT_FILE
           mv -f ./test_results.json ./runtime-test-results/test_results.json
           rm -rf artifacts
 


### PR DESCRIPTION
## Description of Change

This pull request enhances the `runtime_table_generator.py` script to introduce persistent caching of test and performance results, allowing the workflow to display results from previous successful runs when runners are unavailable. This improves the reliability and informativeness of the runtime test reports, especially when some tests fail to execute due to runner issues. The workflow is also updated to make use of the new caching mechanism.

**Persistent result caching and fallback display:**

* Added logic to load previous results from a `test_results.json` cache, and use cached results to fill in test and performance results when current runs fail (e.g., due to unavailable runners). Stale results are clearly marked in the output. (`.github/scripts/runtime_table_generator.py`) [[1]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R41-R89) [[2]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R211-R215) [[3]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R312-R333) [[4]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R365-R398) [[5]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R410-R418) [[6]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54L333-R441)
* Introduced cache freshness checks, with a configurable staleness window (`CACHE_STALE_DAYS`), to ensure only recent results are reused. (`.github/scripts/runtime_table_generator.py`) [[1]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R17-R18) [[2]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R41-R89)

**Workflow integration:**

* Modified the test results workflow to pass the previous results file to the script, enabling the caching mechanism across runs. (`.github/workflows/tests_results.yml`)

**Timestamp and output improvements:**

* All timestamps are now timezone-aware and shown in UTC for consistency and clarity. (`.github/scripts/runtime_table_generator.py`) [[1]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54L7-R7) [[2]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54R410-R418) [[3]](diffhunk://#diff-b901b3a504115a5ea21eb3a18d92ccd44cba7bf943d527563c15e524ad71fe54L333-R441)
* The report now includes a clear note when cached results are displayed, improving transparency for users. (`.github/scripts/runtime_table_generator.py`)

These changes make the runtime test reporting more robust and user-friendly, especially in CI environments with intermittent runner availability.

## Test Scenarios

Tested locally with script
