### PR TITLE
feat(bt): Add BT memory tracking and wrapping

### DIFF
--- a/cores/esp32/esp32-hal-alloc-ble-mem.h
+++ b/cores/esp32/esp32-hal-alloc-ble-mem.h
@@ -1,0 +1,44 @@
+// Copyright 2015-2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ESP32_HAL_ALLOC_BLE_MEM_H
+#define ESP32_HAL_ALLOC_BLE_MEM_H
+
+#include "soc/soc_caps.h"
+#include "sdkconfig.h"
+
+#if defined(CONFIG_BT_CONTROLLER_ENABLED) && defined(CONFIG_SOC_BLE_SUPPORTED)
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Flag defined in esp32-hal-bt.c, set by constructors when BLE libraries are linked
+extern bool _bleLibraryInUse;
+
+// Constructor runs before app_main(), setting the flag if any BLE library is used.
+// Multiple libraries including this header just set the same flag to true.
+__attribute__((constructor)) static void _setBleLibraryInUse(void) {
+  _bleLibraryInUse = true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_BT_CONTROLLER_ENABLED && CONFIG_SOC_BLE_SUPPORTED */
+
+#endif /* ESP32_HAL_ALLOC_BLE_MEM_H */

--- a/cores/esp32/esp32-hal-alloc-bt-classic-mem.h
+++ b/cores/esp32/esp32-hal-alloc-bt-classic-mem.h
@@ -1,0 +1,44 @@
+// Copyright 2015-2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ESP32_HAL_ALLOC_BT_CLASSIC_MEM_H
+#define ESP32_HAL_ALLOC_BT_CLASSIC_MEM_H
+
+#include "soc/soc_caps.h"
+#include "sdkconfig.h"
+
+#if defined(CONFIG_BT_CONTROLLER_ENABLED) && defined(CONFIG_BT_CLASSIC_ENABLED)
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Flag defined in esp32-hal-bt.c, set by constructors when BT Classic libraries are linked
+extern bool _btClassicLibraryInUse;
+
+// Constructor runs before app_main(), setting the flag if any BT Classic library is used.
+// Multiple libraries including this header just set the same flag to true.
+__attribute__((constructor)) static void _setBtClassicLibraryInUse(void) {
+  _btClassicLibraryInUse = true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_BT_CONTROLLER_ENABLED && CONFIG_BT_CLASSIC_ENABLED */
+
+#endif /* ESP32_HAL_ALLOC_BT_CLASSIC_MEM_H */

--- a/cores/esp32/esp32-hal-bt-mem.h
+++ b/cores/esp32/esp32-hal-bt-mem.h
@@ -15,30 +15,9 @@
 #ifndef ESP32_HAL_BT_MEM_H
 #define ESP32_HAL_BT_MEM_H
 
-#include "soc/soc_caps.h"
-#include "sdkconfig.h"
-
-#if defined(SOC_BT_CLASSIC_SUPPORTED) || defined(SOC_BLE_SUPPORTED)
-
-#include <stdbool.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-// Flag defined in esp32-hal-bt.c, set by constructors when BT libraries are linked
-extern bool _btLibraryInUse;
-
-// Constructor runs before app_main(), setting the flag if any BT library is used.
-// Multiple libraries including this header just set the same flag to true.
-__attribute__((constructor)) static void _setBtLibraryInUse(void) {
-  _btLibraryInUse = true;
-}
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* SOC_BT_SUPPORTED */
+// DEPRECATED: File for backwards compatibility with existing code
+// TODO: Remove this file in v4.0. Use esp32-hal-alloc-ble-mem.h and esp32-hal-alloc-bt-classic-mem.h instead.
+#include "esp32-hal-alloc-ble-mem.h"
+#include "esp32-hal-alloc-bt-classic-mem.h"
 
 #endif /* ESP32_HAL_BT_MEM_H */

--- a/cores/esp32/esp32-hal-bt.c
+++ b/cores/esp32/esp32-hal-bt.c
@@ -17,14 +17,40 @@
 #if SOC_BT_SUPPORTED
 #if (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && __has_include("esp_bt.h")
 
-// Flag set by constructors in esp32-hal-bt-mem.h when BT libraries are linked
-bool _btLibraryInUse = false;
+// Flags set by constructors in esp32-hal-alloc-ble-mem.h and esp32-hal-alloc-bt-classic-mem.h
+// when BLE and/or BT Classic libraries are linked
+bool _bleLibraryInUse = false;
+bool _btClassicLibraryInUse = false;
+
+// Track whether BT memory has been released per mode.
+// ESP-IDF provides no API to query release state, so we track it here.
+static bool _bleMemReleased = false;
+#if defined(CONFIG_BT_CLASSIC_ENABLED)
+static bool _classicMemReleased = false;
+#else
+static bool _classicMemReleased = true;  // No Classic BT on this chip
+#endif
+
+// DEPRECATED: Remove this function in v4.0. Use btClassicInUse() and bleInUse() instead.
+// Only for backwards compatibility with existing code.
+bool _btInUse_default(void) {
+  return false;
+}
+
+// DEPRECATED: Remove this function in v4.0. Use btClassicInUse() and bleInUse() instead.
+// Only for backwards compatibility with existing code.
+__attribute__((weak, alias("_btInUse_default"))) bool btInUse(void);
 
 // Default behavior: release BTDM memory (~36KB) unless a BT library is used or user overrides.
-// BT libraries include esp32-hal-bt-mem.h which sets _btLibraryInUse = true via constructor.
-// Users can also provide their own strong btInUse() implementation.
-__attribute__((weak)) bool btInUse(void) {
-  return _btLibraryInUse;
+// BT libraries include esp32-hal-alloc-ble-mem.h and esp32-hal-alloc-bt-classic-mem.h which set
+// _bleLibraryInUse and _btClassicLibraryInUse to true via constructor.
+// Users can also provide their own strong *InUse() implementation.
+__attribute__((weak)) bool btClassicInUse(void) {
+  return _btClassicLibraryInUse;
+}
+
+__attribute__((weak)) bool bleInUse(void) {
+  return _bleLibraryInUse;
 }
 
 #include "esp_bt.h"
@@ -36,6 +62,20 @@ __attribute__((weak)) bool btInUse(void) {
 #else
 #define BT_MODE ESP_BT_MODE_BLE
 #endif
+
+static void _btUpdateMemReleasedFlags(esp_bt_mode_t mode);
+static esp_bt_mode_t _btAvailableMemForMode(esp_bt_mode_t mode);
+
+// Convert a bt_mode value to the corresponding ESP-IDF mode bitmask.
+static esp_bt_mode_t _btModeToEspMode(bt_mode mode) {
+  switch (mode) {
+    case BT_MODE_BLE:        return ESP_BT_MODE_BLE;
+    case BT_MODE_CLASSIC_BT: return ESP_BT_MODE_CLASSIC_BT;
+    case BT_MODE_BTDM:
+    case BT_MODE_DEFAULT:
+    default:                 return ESP_BT_MODE_BTDM;
+  }
+}
 
 bool btStarted() {
   return (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED);
@@ -58,12 +98,18 @@ bool btStartMode(bt_mode mode) {
   // esp_bt_controller_enable(MODE) This mode must be equal as the mode in “cfg” of esp_bt_controller_init().
   cfg.mode = esp_bt_mode;
   if (cfg.mode == ESP_BT_MODE_CLASSIC_BT) {
-    esp_bt_controller_mem_release(ESP_BT_MODE_BLE);
+    btMemRelease(BT_MODE_BLE);
   }
 #else
   // other esp variants dont support BT-classic / DM.
   esp_bt_mode = BT_MODE;
 #endif
+
+  // If any memory required for this mode has already been released,
+  // esp_bt_controller_init() will crash — refuse the request gracefully.
+  if (_btAvailableMemForMode(esp_bt_mode) != esp_bt_mode) {
+    return false;
+  }
 
   if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED) {
     return true;
@@ -115,6 +161,182 @@ bool btStop() {
   return false;
 }
 
+bool btMemReleased(bt_mode mode) {
+  switch (mode) {
+    case BT_MODE_BLE:        return _bleMemReleased;
+    case BT_MODE_CLASSIC_BT: return _classicMemReleased;
+    case BT_MODE_BTDM:
+    case BT_MODE_DEFAULT:
+    default:                 return _bleMemReleased && _classicMemReleased;
+  }
+}
+
+void btMarkMemReleased(bt_mode mode) {
+  _btUpdateMemReleasedFlags(_btModeToEspMode(mode));
+}
+
+// Update tracking flags based on an ESP-IDF BT mode bitmask.
+static void _btUpdateMemReleasedFlags(esp_bt_mode_t mode) {
+  if (mode & ESP_BT_MODE_BLE) {
+    _bleMemReleased = true;
+  }
+  if (mode & ESP_BT_MODE_CLASSIC_BT) {
+    _classicMemReleased = true;
+  }
+}
+
+// Return the subset of `mode` bits whose memory has not yet been released.
+//
+// Each bit in the ESP-IDF `esp_bt_mode_t` bitmask represents an independent BT
+// sub-system (BLE, Classic, or both). Once memory for a sub-system has been
+// freed via esp_bt_mem_release() or esp_bt_controller_mem_release(), attempting
+// to use it again (e.g. by passing the same bits to a real release function or
+// to the controller initializer) will cause an ESP-IDF error or memory
+// corruption.
+//
+// This helper strips out any bits that are already tracked as released, so
+// callers only ever act on bits that are still backed by physical memory.
+//
+// @param mode  Bitmask of BT mode bits to query (e.g. ESP_BT_MODE_BLE,
+//              ESP_BT_MODE_CLASSIC_BT, or ESP_BT_MODE_BTDM).
+// @return      The subset of `mode` bits whose memory is still available.
+//              Returns 0 (ESP_BT_MODE_IDLE) if all requested memory has already
+//              been released.
+static esp_bt_mode_t _btAvailableMemForMode(esp_bt_mode_t mode) {
+  if (_bleMemReleased) {
+    mode = (esp_bt_mode_t)(mode & ~ESP_BT_MODE_BLE);
+  }
+  if (_classicMemReleased) {
+    mode = (esp_bt_mode_t)(mode & ~ESP_BT_MODE_CLASSIC_BT);
+  }
+  return mode;
+}
+
+// ============================================================================
+// Linker --wrap intercepts for esp_bt_mem_release /
+//                               esp_bt_controller_mem_release
+// ============================================================================
+//
+// WHY THIS IS NEEDED
+// ------------------
+// ESP-IDF's BT memory-release functions can be called by code outside of
+// Arduino (most notably the Matter stack, via
+//   connectedhomeip/.../bluedroid/BLEManagerImpl::InitESPBleLayer(), which
+// calls esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT)).
+// Without interception, those external calls would free memory that our
+// tracking flags do not know about, making btMemReleased() return stale
+// values.  Worse, a later call to btMemRelease() could try to release memory
+// that is already gone, causing an ESP-IDF error or memory corruption.
+//
+// HOW --wrap WORKS
+// ----------------
+// The GNU linker --wrap=<symbol> flag redirects every reference to <symbol>
+// in the final link to __wrap_<symbol> instead, and makes the original
+// function available as __real_<symbol>.  The flags are added in platform.txt:
+//
+//   -Wl,--wrap=esp_bt_mem_release
+//   -Wl,--wrap=esp_bt_controller_mem_release
+//
+// This works because IDF component libraries ship as independent static
+// archives (.a files, built by esp32-arduino-lib-builder) whose object files
+// carry unresolved cross-archive references.  Those references are resolved
+// only at the final Arduino sketch link step, so --wrap is applied in time.
+//
+// WHY IT WORKS WITH esp-matter
+// ----------------------------
+// The connectedhomeip chip library (libespressif__esp_matter.a / libCHIP.a)
+// is also shipped as a plain static archive with no partial linking (ld -r).
+// The call to esp_bt_controller_mem_release inside BLEManagerImpl.o therefore
+// remains an unresolved external reference until the final sketch link, where
+// our --wrap flag redirects it to __wrap_esp_bt_controller_mem_release.
+//
+// DOUBLE-RELEASE GUARD
+// --------------------
+// Each wrapper first strips out any mode bits that are already tracked as
+// released.  If nothing remains to release it returns ESP_OK immediately,
+// turning a would-be double-release into a harmless no-op.  If there are
+// unreleased bits it calls the real function for only those bits, then
+// updates the tracking flags on success.
+//
+// WHAT COULD BREAK THIS MECHANISM
+// --------------------------------
+// 1. Partial linking (ld -r / --relocatable):
+//    If a future version of esp32-arduino-lib-builder or esp-matter merges
+//    the BLEManagerImpl object directly into the bt library via a partial link
+//    step, the call to esp_bt_controller_mem_release would be resolved inside
+//    the partially-linked archive before the final link, bypassing --wrap.
+//    Monitor both repos for any ld -r / OBJECT_LIBRARY / link_whole usage
+//    that touches BLEManagerImpl.
+//
+// 2. Inlining or LTO:
+//    If link-time optimization (LTO) is ever enabled across the IDF libraries,
+//    the linker may inline esp_bt_controller_mem_release directly at the
+//    call site before --wrap runs, bypassing the intercept.  LTO across
+//    prebuilt static archives is currently not used in this SDK.
+//
+// 3. Direct ROM calls:
+//    If Espressif were to move esp_bt_mem_release or
+//    esp_bt_controller_mem_release into ROM (as some boot/sys functions are),
+//    the call would resolve against the ROM symbol, not the RAM copy, and
+//    --wrap would not intercept it.  This has not happened as of ESP-IDF 5.x,
+//    but check the ROM symbol map when upgrading IDF major versions.
+//
+// 4. dlopen / dynamic loading:
+//    --wrap is a static-link-time mechanism.  Any code loaded dynamically at
+//    runtime that calls the ESP-IDF functions directly would bypass it.
+//    The ESP32 does not support dynamic loading in normal Arduino builds, so
+//    this is not currently a concern.
+// ============================================================================
+
+extern esp_err_t __real_esp_bt_mem_release(esp_bt_mode_t mode);
+esp_err_t __wrap_esp_bt_mem_release(esp_bt_mode_t mode) {
+  mode = _btAvailableMemForMode(mode);
+  if (!mode) {
+    return ESP_OK;
+  }
+  esp_err_t ret = __real_esp_bt_mem_release(mode);
+  if (ret == ESP_OK) {
+    _btUpdateMemReleasedFlags(mode);
+  }
+  return ret;
+}
+
+extern esp_err_t __real_esp_bt_controller_mem_release(esp_bt_mode_t mode);
+esp_err_t __wrap_esp_bt_controller_mem_release(esp_bt_mode_t mode) {
+  mode = _btAvailableMemForMode(mode);
+  if (!mode) {
+    return ESP_OK;
+  }
+  esp_err_t ret = __real_esp_bt_controller_mem_release(mode);
+  if (ret == ESP_OK) {
+    _btUpdateMemReleasedFlags(mode);
+  }
+  return ret;
+}
+
+bool btMemRelease(bt_mode mode) {
+#if CONFIG_BT_CONTROLLER_ENABLED
+  esp_bt_mode_t esp_mode = _btAvailableMemForMode(_btModeToEspMode(mode));
+  if (!esp_mode) {
+    return true;  // Already released
+  }
+
+  // esp_bt_mem_release() releases both the controller memory and the host stack
+  // memory for the given mode. It is a superset of esp_bt_controller_mem_release()
+  // and is the correct API to use here to maximize freed memory.
+  // The --wrap intercept above will update the tracking flags on success.
+  esp_err_t ret = esp_bt_mem_release(esp_mode);
+  if (ret != ESP_OK) {
+    log_e("BT memory release failed: %s", esp_err_to_name(ret));
+    return false;
+  }
+
+  return true;
+#else
+  return false;
+#endif
+}
+
 #else  // !__has_include("esp_bt.h") || !(defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED))
 bool btStarted() {
   return false;
@@ -127,6 +349,16 @@ bool btStart() {
 bool btStop() {
   return false;
 }
+
+bool btMemRelease(bt_mode mode) {
+  return true;
+}
+
+bool btMemReleased(bt_mode mode) {
+  return true;
+}
+
+void btMarkMemReleased(bt_mode mode) {}
 
 #endif /* !__has_include("esp_bt.h") || !(defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) */
 

--- a/cores/esp32/esp32-hal-bt.h
+++ b/cores/esp32/esp32-hal-bt.h
@@ -33,14 +33,33 @@ typedef enum {
 
 // Returns true if BT memory should be kept, false to release it (~36KB).
 // Default (weak): returns false unless a BT library is linked.
-// BT libraries include esp32-hal-bt-mem.h which automatically sets a flag.
-// Users may also provide their own strong btInUse() to override.
+// BT libraries include esp32-hal-alloc-ble-mem.h and esp32-hal-alloc-bt-classic-mem.h which set
+// _bleLibraryInUse and _btClassicLibraryInUse to true via constructor.
+// Users may also provide their own strong *InUse() to override.
+bool _btInUse_default(void);
 bool btInUse(void);
+bool btClassicInUse(void);
+bool bleInUse(void);
 
 bool btStarted();
 bool btStart();
 bool btStartMode(bt_mode mode);
 bool btStop();
+
+// Release BT memory for the given mode and track the release.
+// ESP-IDF provides no API to query whether memory has been released,
+// so this function maintains the state internally.
+// Returns true on success or if memory was already released.
+bool btMemRelease(bt_mode mode);
+
+// Returns true if BT memory for the given mode has already been released.
+bool btMemReleased(bt_mode mode);
+
+// Mark BT memory for the given mode as released without calling ESP-IDF.
+// Use this when an external component (e.g. the ESP-IDF Matter stack) has
+// already released BT memory on its own, so that btMemReleased() reflects
+// the true state and btMemRelease() does not attempt a double-release.
+void btMarkMemReleased(bt_mode mode);
 
 #ifdef __cplusplus
 }

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -346,7 +346,7 @@ void initArduino() {
     log_e("Failed to initialize NVS! Error: %d", err);
   }
 #if (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && CONFIG_BT_CONTROLLER_ENABLED && SOC_BT_SUPPORTED && __has_include("esp_bt.h")
-  bool userOverriddenBtInUse = ((void*)btInUse != (void*)_btInUse_default);
+  bool userOverriddenBtInUse = ((void *)btInUse != (void *)_btInUse_default);
   if (!btClassicInUse() && !(userOverriddenBtInUse && btInUse())) {
     btMemRelease(BT_MODE_CLASSIC_BT);
   }

--- a/cores/esp32/esp32-hal-misc.c
+++ b/cores/esp32/esp32-hal-misc.c
@@ -290,7 +290,10 @@ bool verifyRollbackLater() {
 
 #if (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && SOC_BT_SUPPORTED && __has_include("esp_bt.h")
 // declared here, defined in esp32-hal-bt.c (weak so users can override)
+extern bool _btInUse_default(void);
 extern bool btInUse(void);
+extern bool btClassicInUse(void);
+extern bool bleInUse(void);
 #endif
 
 #if CONFIG_SPIRAM_SUPPORT || CONFIG_SPIRAM
@@ -342,9 +345,13 @@ void initArduino() {
   if (err) {
     log_e("Failed to initialize NVS! Error: %d", err);
   }
-#if (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && SOC_BT_SUPPORTED && __has_include("esp_bt.h")
-  if (!btInUse()) {
-    esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
+#if (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && CONFIG_BT_CONTROLLER_ENABLED && SOC_BT_SUPPORTED && __has_include("esp_bt.h")
+  bool userOverriddenBtInUse = ((void*)btInUse != (void*)_btInUse_default);
+  if (!btClassicInUse() && !(userOverriddenBtInUse && btInUse())) {
+    btMemRelease(BT_MODE_CLASSIC_BT);
+  }
+  if (!bleInUse() && !(userOverriddenBtInUse && btInUse())) {
+    btMemRelease(BT_MODE_BLE);
   }
 #endif
   init();

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -61,7 +61,7 @@
 
 #if defined(ARDUINO_ARCH_ESP32)
 #include "esp32-hal-bt.h"
-#include "esp32-hal-bt-mem.h"
+#include "esp32-hal-alloc-ble-mem.h"
 #endif
 
 #include "esp32-hal-log.h"
@@ -293,6 +293,14 @@ bool BLEDevice::init(String deviceName) {
   log_i("Initializing BLE stack: %s", getBLEStackString().c_str());
 
   esp_err_t errRc = ESP_OK;
+
+#if defined(CONFIG_BT_CONTROLLER_ENABLED)
+  if (btMemReleased(BT_MODE_BLE)) {
+    log_e("BLE memory has been released. Cannot initialize BLE.");
+    return false;
+  }
+#endif
+
 #if defined(CONFIG_BLUEDROID_ENABLED)
 #if defined(ARDUINO_ARCH_ESP32)
   if (!btStart()) {
@@ -313,10 +321,6 @@ bool BLEDevice::init(String deviceName) {
     log_e("nvs_flash_init: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
     return false;
   }
-
-#ifndef CONFIG_BT_CLASSIC_ENABLED
-  esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
-#endif
 
   esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
   errRc = esp_bt_controller_init(&bt_cfg);
@@ -1141,9 +1145,8 @@ void BLEDevice::deinit(bool release_memory) {
   // Only release memory if requested (this prevents reinitialization)
   if (release_memory) {
 #ifdef ARDUINO_ARCH_ESP32
-    // Require tests because we released classic BT memory and this can cause crash (most likely not, esp-idf takes care of it)
 #if CONFIG_BT_CONTROLLER_ENABLED
-    esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
+    btMemRelease(BT_MODE_BLE);
 #endif
 #endif
   }

--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -27,7 +27,7 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 #include "esp32-hal-log.h"
-#include "esp32-hal-bt-mem.h"
+#include "esp32-hal-alloc-bt-classic-mem.h"
 #endif
 
 #include "BluetoothSerial.h"
@@ -882,10 +882,12 @@ void BluetoothSerial::end() {
 }
 
 /**
- * free additional ~30kB ram, reset is required to enable BT again
+ * free additional ~30kB ram, reset is required to enable BT Classic again
  */
 void BluetoothSerial::memrelease() {
-  esp_bt_mem_release(ESP_BT_MODE_BTDM);
+#if defined(CONFIG_BT_CONTROLLER_ENABLED)
+  btMemRelease(BT_MODE_CLASSIC_BT);
+#endif
 }
 
 void BluetoothSerial::onConfirmRequest(ConfirmRequestCb cb) {

--- a/libraries/ESP32/examples/HFP_HCI_Audio/HFP_HCI_Audio.ino
+++ b/libraries/ESP32/examples/HFP_HCI_Audio/HFP_HCI_Audio.ino
@@ -78,7 +78,7 @@
 // -----------------------------------------------------------------------------
 // Includes
 // -----------------------------------------------------------------------------
-#include "esp32-hal-bt-mem.h"
+#include "esp32-hal-alloc-bt-classic-mem.h"
 #include "esp32-hal-bt.h"
 #include "esp_bt.h"
 #include "esp_bt_device.h"

--- a/libraries/ESP32/examples/HFP_HCI_Audio_I2S/HFP_HCI_Audio_I2S.ino
+++ b/libraries/ESP32/examples/HFP_HCI_Audio_I2S/HFP_HCI_Audio_I2S.ino
@@ -65,7 +65,7 @@
 // Includes
 // -----------------------------------------------------------------------------
 #include <Arduino.h>
-#include "esp32-hal-bt-mem.h"          // btStartMode(), BT_MODE_CLASSIC_BT
+#include "esp32-hal-alloc-bt-classic-mem.h"
 #include "esp32-hal-bt.h"              // btStarted()
 #include "esp_bt.h"                    // esp_bt_controller_*
 #include "esp_bt_device.h"             // esp_bt_dev_set_device_name()

--- a/libraries/Matter/src/Matter.cpp
+++ b/libraries/Matter/src/Matter.cpp
@@ -22,10 +22,11 @@
 #include "platform/ESP32/OpenthreadLauncher.h"
 #endif
 
-// This prevents initArduino() from releasing BTDM controller memory before the
+// This prevents initArduino() from releasing BLE memory before the
 // Matter stack can use Bluetooth transport.
 #if CONFIG_ENABLE_CHIPOBLE
-#include "esp32-hal-bt-mem.h"
+#include "esp32-hal-alloc-ble-mem.h"
+#include "esp32-hal-bt.h"
 #endif
 
 using namespace esp_matter;
@@ -163,6 +164,13 @@ void ArduinoMatter::begin() {
     log_e("No Matter endpoint has been created. Please create an endpoint first.");
     return;
   }
+
+#if defined(CONFIG_BT_CONTROLLER_ENABLED)
+  if (isBLECommissioningEnabled() && btMemReleased(BT_MODE_BLE)) {
+    log_e("BLE memory has been released. BLE commissioning is not available.");
+    return;
+  }
+#endif
 
 #if CONFIG_ENABLE_MATTER_OVER_THREAD
   // Set OpenThread platform config

--- a/libraries/SimpleBLE/src/SimpleBLE.cpp
+++ b/libraries/SimpleBLE/src/SimpleBLE.cpp
@@ -21,7 +21,8 @@
 #include "esp32-hal-log.h"
 
 #if defined(ARDUINO_ARCH_ESP32)
-#include "esp32-hal-bt-mem.h"
+#include "esp32-hal-bt.h"
+#include "esp32-hal-alloc-ble-mem.h"
 #endif
 
 #if defined(SOC_BLE_SUPPORTED)
@@ -174,6 +175,13 @@ static bool _init_gap(const char *name) {
     log_d("BLE already initialized, skipping");
     return true;
   }
+
+#if defined(CONFIG_BT_CONTROLLER_ENABLED)
+  if (btMemReleased(BT_MODE_BLE)) {
+    log_e("BLE memory has been released. Cannot initialize BLE.");
+    return false;
+  }
+#endif
 
 #if defined(CONFIG_BLUEDROID_ENABLED)
   if (!btStarted() && !btStart()) {

--- a/platform.txt
+++ b/platform.txt
@@ -52,7 +52,7 @@ compiler.cpreprocessor.flags="@{compiler.sdk.path}/flags/defines" "-I{build.sour
 compiler.c.flags=-MMD -c "@{compiler.sdk.path}/flags/c_flags" {compiler.warning_flags} {compiler.optimization_flags} {compiler.common_werror_flags}
 compiler.cpp.flags=-MMD -c "@{compiler.sdk.path}/flags/cpp_flags" {compiler.warning_flags} {compiler.optimization_flags} {compiler.common_werror_flags}
 compiler.S.flags=-MMD -c -x assembler-with-cpp "@{compiler.sdk.path}/flags/S_flags" {compiler.warning_flags} {compiler.optimization_flags}
-compiler.c.elf.flags="-Wl,--Map={build.path}/{build.project_name}.map" "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-L{compiler.sdk.path}/{build.memory_type}" "-Wl,--wrap=esp_panic_handler" "@{compiler.sdk.path}/flags/ld_flags" "@{compiler.sdk.path}/flags/ld_scripts"
+compiler.c.elf.flags="-Wl,--Map={build.path}/{build.project_name}.map" "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-L{compiler.sdk.path}/{build.memory_type}" "-Wl,--wrap=esp_panic_handler" "-Wl,--wrap=esp_bt_mem_release" "-Wl,--wrap=esp_bt_controller_mem_release" "@{compiler.sdk.path}/flags/ld_flags" "@{compiler.sdk.path}/flags/ld_scripts"
 compiler.c.elf.libs="@{compiler.sdk.path}/flags/ld_libs"
 compiler.ar.flags=cr
 

--- a/tests/validation/bt_inuse_override/bt_inuse_override.ino
+++ b/tests/validation/bt_inuse_override/bt_inuse_override.ino
@@ -1,0 +1,80 @@
+// Validation test for the btInUse() strong-override backwards-compatibility path.
+//
+// This sketch deliberately does NOT include esp32-hal-alloc-ble-mem.h or
+// esp32-hal-alloc-bt-classic-mem.h, so bleInUse() and btClassicInUse() both
+// return false. Instead it provides a strong btInUse() returning true, exactly
+// as legacy user code would. initArduino() must detect the strong override via
+// the pointer comparison and skip all memory releases.
+
+#include <Arduino.h>
+#include "esp32-hal-bt.h"
+#include "sdkconfig.h"
+#include "soc/soc_caps.h"
+
+#if SOC_BT_SUPPORTED && (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && __has_include("esp_bt.h") && defined(CONFIG_BT_CONTROLLER_ENABLED)
+
+// Strong override — simulates legacy user code keeping all BT memory.
+// bleInUse() and btClassicInUse() are both false (no alloc headers included),
+// so this is the ONLY thing that should prevent memory from being released.
+bool btInUse(void) {
+  return true;
+}
+
+static int pass_count = 0;
+static int fail_count = 0;
+
+static void check(bool ok, const char *desc) {
+  if (ok) {
+    Serial.printf("[BT_INUSE_OVERRIDE] PASS: %s\n", desc);
+    pass_count++;
+  } else {
+    Serial.printf("[BT_INUSE_OVERRIDE] FAIL: %s\n", desc);
+    fail_count++;
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) { delay(10); }
+
+  Serial.println("[BT_INUSE_OVERRIDE] Ready");
+
+  // Verify the pointer comparison correctly identifies the strong override.
+  extern bool _btInUse_default(void);
+  check((void *)btInUse != (void *)_btInUse_default, "btInUse does NOT point to default (strong override detected)");
+
+  // Sub-functions return false (no alloc headers) — the strong btInUse() override
+  // is the only reason initArduino() should have kept memory.
+  check(!bleInUse(), "bleInUse() is false (no alloc-ble-mem header included)");
+  check(!btClassicInUse(), "btClassicInUse() is false (no alloc-bt-classic-mem header included)");
+
+  // Neither mode's memory should have been released by initArduino().
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem NOT released despite bleInUse=false (btInUse override protected it)");
+#if CONFIG_BT_CLASSIC_ENABLED
+  check(!btMemReleased(BT_MODE_CLASSIC_BT), "Classic BT mem NOT released despite btClassicInUse=false (btInUse override protected it)");
+#else
+  check(btMemReleased(BT_MODE_CLASSIC_BT), "Classic BT mem reported released (not supported on this chip)");
+#endif
+
+  // Confirm BT is actually startable — memory is intact.
+  check(btStart(), "btStart() succeeds (memory was preserved by btInUse override)");
+  check(btStarted(), "btStarted() true");
+  check(btStop(), "btStop() succeeds");
+
+  Serial.printf("[BT_INUSE_OVERRIDE] %d passed, %d failed\n", pass_count, fail_count);
+  Serial.printf("[BT_INUSE_OVERRIDE] %s\n", (fail_count == 0) ? "PASSED" : "FAILED");
+}
+
+void loop() {}
+
+#else
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) { delay(10); }
+  Serial.println("[BT_INUSE_OVERRIDE] SKIP: BT controller not available");
+}
+
+void loop() {}
+
+#endif

--- a/tests/validation/bt_inuse_override/bt_inuse_override.ino
+++ b/tests/validation/bt_inuse_override/bt_inuse_override.ino
@@ -11,7 +11,8 @@
 #include "sdkconfig.h"
 #include "soc/soc_caps.h"
 
-#if SOC_BT_SUPPORTED && (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && __has_include("esp_bt.h") && defined(CONFIG_BT_CONTROLLER_ENABLED)
+#if SOC_BT_SUPPORTED && (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) \
+  && __has_include("esp_bt.h") && defined(CONFIG_BT_CONTROLLER_ENABLED)
 
 // Strong override — simulates legacy user code keeping all BT memory.
 // bleInUse() and btClassicInUse() are both false (no alloc headers included),
@@ -35,7 +36,9 @@ static void check(bool ok, const char *desc) {
 
 void setup() {
   Serial.begin(115200);
-  while (!Serial) { delay(10); }
+  while (!Serial) {
+    delay(10);
+  }
 
   Serial.println("[BT_INUSE_OVERRIDE] Ready");
 
@@ -71,7 +74,9 @@ void loop() {}
 
 void setup() {
   Serial.begin(115200);
-  while (!Serial) { delay(10); }
+  while (!Serial) {
+    delay(10);
+  }
   Serial.println("[BT_INUSE_OVERRIDE] SKIP: BT controller not available");
 }
 

--- a/tests/validation/bt_inuse_override/ci.yml
+++ b/tests/validation/bt_inuse_override/ci.yml
@@ -1,0 +1,6 @@
+requires:
+  - CONFIG_SOC_BLE_SUPPORTED=y
+  - CONFIG_BT_CONTROLLER_ENABLED=y
+
+platforms:
+  qemu: false

--- a/tests/validation/bt_inuse_override/test_bt_inuse_override.py
+++ b/tests/validation/bt_inuse_override/test_bt_inuse_override.py
@@ -1,0 +1,3 @@
+def test_bt_inuse_override(dut):
+    dut.expect_exact("[BT_INUSE_OVERRIDE] Ready", timeout=30)
+    dut.expect_exact("[BT_INUSE_OVERRIDE] PASSED", timeout=30)

--- a/tests/validation/bt_mem_wrap/bt_mem_wrap.ino
+++ b/tests/validation/bt_mem_wrap/bt_mem_wrap.ino
@@ -32,7 +32,7 @@
 //     intercept).  All subsequent wrap calls must be no-ops.
 //
 //   Phase 7 — btStart() fails after btMemRelease()
-//     Verifies that once BT memory has been freed, attempting to initialise
+//     Verifies that once BT memory has been freed, attempting to initialize
 //     the BT controller fails gracefully (ESP-IDF rejects the init request).
 //
 //   Phase 8 — full lifecycle: start, release-while-running (rejected), stop, release
@@ -160,7 +160,7 @@ static void phase_4() {
 
 // Phase 5: cross-API double-free (reversed order) — release via direct
 // esp_bt_mem_release() first, then call btMemRelease().  The Arduino API must
-// recognise that the tracking flag is already set and return true without
+// recognize that the tracking flag is already set and return true without
 // attempting a second real release.
 static void phase_5() {
   Serial.println("[BT_MEM_WRAP] Phase 5: cross-API double-free (esp_bt_mem_release then btMemRelease)");
@@ -215,7 +215,7 @@ static void phase_7() {
   check(btMemRelease(BT_MODE_BLE), "btMemRelease(BLE) succeeds");
   check(btMemReleased(BT_MODE_BLE), "tracking updated");
 
-  // BT memory is gone — the controller cannot be initialised.
+  // BT memory is gone — the controller cannot be initialized.
   check(!btStart(), "btStart() returns false after btMemRelease");
   check(!btStarted(), "btStarted() false after failed btStart");
 }

--- a/tests/validation/bt_mem_wrap/bt_mem_wrap.ino
+++ b/tests/validation/bt_mem_wrap/bt_mem_wrap.ino
@@ -1,0 +1,394 @@
+// Validation test for the --wrap linker intercept on esp_bt_mem_release /
+// esp_bt_controller_mem_release (see cores/esp32/esp32-hal-bt.c).
+//
+// The test is split into phases, each driven by the Python harness via serial
+// after a hard reset, so every phase starts with a fully fresh BT memory state.
+//
+//   Phase 1 — btMemRelease() Arduino API
+//     Verifies that the Arduino API succeeds, updates the tracking flag, and
+//     that a second call is a safe no-op.
+//
+//   Phase 2 — direct esp_bt_controller_mem_release()
+//     Simulates an external component (e.g. the Matter stack) calling the
+//     ESP-IDF function directly.  The __wrap_esp_bt_controller_mem_release
+//     intercept must update the tracking flag and guard against double-release.
+//
+//   Phase 3 — direct esp_bt_mem_release()
+//     Same as phase 2 but for the combined host+controller release path
+//     intercepted by __wrap_esp_bt_mem_release.
+//
+//   Phase 4 — cross-API double-free (btMemRelease → esp_bt_controller_mem_release)
+//     Releases via the Arduino API first, then calls esp_bt_controller_mem_release()
+//     directly.  Both wraps share the same tracking flags, so the second call
+//     must be a no-op regardless of which API is used.
+//
+//   Phase 5 — cross-API double-free (esp_bt_mem_release → btMemRelease)
+//     Releases via direct esp_bt_mem_release() first, then via the Arduino API.
+//     Mirrors phase 4 in the opposite order.
+//
+//   Phase 6 — btMarkMemReleased() sentinel
+//     Marks memory as released via btMarkMemReleased() without performing a
+//     real release (simulating a ROM or pre-wrap call that bypassed the
+//     intercept).  All subsequent wrap calls must be no-ops.
+//
+//   Phase 7 — btStart() fails after btMemRelease()
+//     Verifies that once BT memory has been freed, attempting to initialise
+//     the BT controller fails gracefully (ESP-IDF rejects the init request).
+//
+//   Phase 8 — full lifecycle: start, release-while-running (rejected), stop, release
+//     Starts BT to confirm the memory is intact, then attempts btMemRelease()
+//     while the controller is still active (must fail without updating tracking),
+//     stops BT cleanly, and finally releases memory successfully.
+//
+//   Phase 9 — Matter-style release (Classic BT)
+//     Simulates the Matter stack calling esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT)
+//     during its BLE initialization to free the unused Classic BT controller memory before
+//     starting BLE commissioning.
+//
+//   Phase 10 — btInUse() pointer comparison
+//     Verifies that when btInUse resolves to the default weak alias (_btInUse_default),
+//     the pointer comparison correctly identifies it as NOT a user override, and
+//     memory release is governed solely by the sub-functions (bleInUse / btClassicInUse).
+//     Since this sketch includes both alloc headers, both flags are true and
+//     memory should NOT be released by initArduino().
+//
+// The Python test sends "PHASE N\n" over serial after each hard reset and
+// checks the pass/fail output.
+
+#include <Arduino.h>
+#include "esp32-hal-bt.h"
+// Including esp32-hal-alloc-bt-classic-mem.h and esp32-hal-alloc-ble-mem.h sets
+// _btClassicLibraryInUse and _bleLibraryInUse to true via constructors,
+// which prevents initArduino() from auto-releasing BT memory before setup()
+// runs. Without this, every phase would start with memory already released.
+#include "esp32-hal-alloc-bt-classic-mem.h"
+#include "esp32-hal-alloc-ble-mem.h"
+#include "sdkconfig.h"
+#include "soc/soc_caps.h"
+
+#if SOC_BT_SUPPORTED && (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && __has_include("esp_bt.h") && defined(CONFIG_BT_CONTROLLER_ENABLED)
+
+#include "esp_bt.h"
+
+static int pass_count = 0;
+static int fail_count = 0;
+
+static void check(bool ok, const char *desc) {
+  if (ok) {
+    Serial.printf("[BT_MEM_WRAP] PASS: %s\n", desc);
+    pass_count++;
+  } else {
+    Serial.printf("[BT_MEM_WRAP] FAIL: %s\n", desc);
+    fail_count++;
+  }
+}
+
+// Phase 1: btMemRelease() internally calls esp_bt_mem_release() which is
+// intercepted by __wrap_esp_bt_mem_release.  Verify the tracking flag is
+// updated and that a second call is a harmless no-op.
+static void phase_1() {
+  Serial.println("[BT_MEM_WRAP] Phase 1: btMemRelease API");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+  check(btMemRelease(BT_MODE_BLE), "btMemRelease(BLE) succeeds");
+  check(btMemReleased(BT_MODE_BLE), "tracking updated after btMemRelease");
+
+  // Second call: __wrap_esp_bt_mem_release strips the already-released BLE
+  // bit, skips the real call and returns ESP_OK.  btMemRelease() maps that
+  // to true.
+  check(btMemRelease(BT_MODE_BLE), "second btMemRelease is a no-op (returns true)");
+  check(btMemReleased(BT_MODE_BLE), "tracking still true after double call");
+}
+
+// Phase 2: call esp_bt_controller_mem_release() directly, as an external
+// component would.  __wrap_esp_bt_controller_mem_release must update the
+// tracking flag and guard against a double-release.
+static void phase_2() {
+  Serial.println("[BT_MEM_WRAP] Phase 2: direct esp_bt_controller_mem_release");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+
+  esp_err_t ret = esp_bt_controller_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "esp_bt_controller_mem_release returns ESP_OK");
+  check(btMemReleased(BT_MODE_BLE), "wrap updated tracking after controller_mem_release");
+
+  // Double-release guard: wrap strips already-released bits, skips real call.
+  ret = esp_bt_controller_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "double esp_bt_controller_mem_release is a no-op (ESP_OK)");
+  check(btMemReleased(BT_MODE_BLE), "tracking still true after double controller call");
+}
+
+// Phase 3: call esp_bt_mem_release() directly (host + controller combined).
+// __wrap_esp_bt_mem_release must update the tracking flag and guard against
+// a double-release.
+static void phase_3() {
+  Serial.println("[BT_MEM_WRAP] Phase 3: direct esp_bt_mem_release");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+
+  esp_err_t ret = esp_bt_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "esp_bt_mem_release returns ESP_OK");
+  check(btMemReleased(BT_MODE_BLE), "wrap updated tracking after bt_mem_release");
+
+  // Double-release guard.
+  ret = esp_bt_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "double esp_bt_mem_release is a no-op (ESP_OK)");
+  check(btMemReleased(BT_MODE_BLE), "tracking still true after double bt_mem_release");
+}
+
+// Phase 4: cross-API double-free — release via the Arduino btMemRelease() API
+// first, then call esp_bt_controller_mem_release() directly.  Although the two
+// paths go through different __wrap functions, they share the same tracking
+// flags, so the second call must detect the already-released state and return
+// ESP_OK without touching memory.
+static void phase_4() {
+  Serial.println("[BT_MEM_WRAP] Phase 4: cross-API double-free (btMemRelease then esp_bt_controller_mem_release)");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+
+  // First release via the Arduino API (uses __wrap_esp_bt_mem_release internally).
+  check(btMemRelease(BT_MODE_BLE), "btMemRelease(BLE) succeeds");
+  check(btMemReleased(BT_MODE_BLE), "tracking updated after btMemRelease");
+
+  // Second release via the other direct ESP-IDF path: __wrap_esp_bt_controller_mem_release
+  // checks the same flag and must skip the real call.
+  esp_err_t ret = esp_bt_controller_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "esp_bt_controller_mem_release after btMemRelease is ESP_OK (no-op)");
+  check(btMemReleased(BT_MODE_BLE), "tracking still true after cross-API double-free");
+}
+
+// Phase 5: cross-API double-free (reversed order) — release via direct
+// esp_bt_mem_release() first, then call btMemRelease().  The Arduino API must
+// recognise that the tracking flag is already set and return true without
+// attempting a second real release.
+static void phase_5() {
+  Serial.println("[BT_MEM_WRAP] Phase 5: cross-API double-free (esp_bt_mem_release then btMemRelease)");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+
+  // First release via the direct ESP-IDF path (__wrap_esp_bt_mem_release).
+  esp_err_t ret = esp_bt_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "direct esp_bt_mem_release succeeds");
+  check(btMemReleased(BT_MODE_BLE), "tracking updated by wrap");
+
+  // Second release via the Arduino API: sees the flag already set → no-op.
+  check(btMemRelease(BT_MODE_BLE), "btMemRelease after esp_bt_mem_release is true (no-op)");
+  check(btMemReleased(BT_MODE_BLE), "tracking still true after cross-API double-free");
+}
+
+// Phase 6: btMarkMemReleased() as a pre-release sentinel.
+// Marks BLE memory as released without calling any real ESP-IDF function
+// (simulates a release that occurred outside the wrap, e.g. via a ROM call).
+// Every subsequent wrap call must treat the memory as already gone and return
+// ESP_OK without performing a real release.
+static void phase_6() {
+  Serial.println("[BT_MEM_WRAP] Phase 6: btMarkMemReleased sentinel");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+
+  // Flag the memory as released without going through ESP-IDF.
+  btMarkMemReleased(BT_MODE_BLE);
+  check(btMemReleased(BT_MODE_BLE), "btMarkMemReleased updates tracking flag");
+
+  // All three release paths must now be no-ops.
+  esp_err_t ret = esp_bt_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "esp_bt_mem_release after btMarkMemReleased is ESP_OK (no real call)");
+
+  ret = esp_bt_controller_mem_release(ESP_BT_MODE_BLE);
+  check(ret == ESP_OK, "esp_bt_controller_mem_release after btMarkMemReleased is ESP_OK (no real call)");
+
+  check(btMemRelease(BT_MODE_BLE), "btMemRelease after btMarkMemReleased is true (no-op)");
+  check(btMemReleased(BT_MODE_BLE), "tracking still true after all no-op calls");
+}
+
+// Phase 7: btStart() must fail after btMemRelease().
+// Once the BT controller memory has been freed it cannot be reclaimed.
+// esp_bt_controller_init() will reject the request, so btStart() must return
+// false and btStarted() must remain false.
+static void phase_7() {
+  Serial.println("[BT_MEM_WRAP] Phase 7: btStart fails after btMemRelease");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+  check(!btStarted(), "BT not started at boot");
+
+  check(btMemRelease(BT_MODE_BLE), "btMemRelease(BLE) succeeds");
+  check(btMemReleased(BT_MODE_BLE), "tracking updated");
+
+  // BT memory is gone — the controller cannot be initialised.
+  check(!btStart(), "btStart() returns false after btMemRelease");
+  check(!btStarted(), "btStarted() false after failed btStart");
+}
+
+// Phase 8: full lifecycle — start BT, attempt release while running (must be
+// rejected without corrupting tracking state), stop BT, then release memory.
+//
+// This exercises two important invariants:
+//   a) btMemRelease() must not update tracking when the underlying ESP-IDF call
+//      fails (i.e. while the controller is active).
+//   b) After a clean btStop(), btMemRelease() must succeed.
+static void phase_8() {
+  Serial.println("[BT_MEM_WRAP] Phase 8: start, release-while-running rejected, stop, release");
+
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+  check(!btStarted(), "BT not started at boot");
+
+  // Start BT while memory is still available.
+  check(btStart(), "btStart() succeeds before any memory release");
+  check(btStarted(), "btStarted() true after btStart");
+
+  // Attempt to release memory while the controller is still active.
+  // ESP-IDF will reject the request; btMemRelease() must return false and
+  // must NOT mark the memory as released.
+  check(!btMemRelease(BT_MODE_BLE), "btMemRelease while BT is running returns false");
+  check(!btMemReleased(BT_MODE_BLE), "tracking NOT updated after rejected release");
+
+  // Stop BT cleanly (disable + deinit → controller returns to IDLE state).
+  check(btStop(), "btStop() succeeds");
+  check(!btStarted(), "btStarted() false after btStop");
+
+  // Memory release must now succeed because the controller is idle.
+  check(btMemRelease(BT_MODE_BLE), "btMemRelease succeeds after btStop");
+  check(btMemReleased(BT_MODE_BLE), "tracking updated after successful release");
+}
+
+// Phase 9: Matter-style release — simulate BLEManagerImpl::InitESPBleLayer().
+//
+// The Matter stack (connectedhomeip BLEManagerImpl on ESP32) calls
+// esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT) during its BLE
+// initialization to free the unused Classic BT controller memory before
+// starting BLE commissioning.
+//
+// On chips without Classic BT this code path is not taken; on ESP32 the
+// __wrap_esp_bt_controller_mem_release intercept must:
+//   a) update the Classic BT tracking flag so btMemReleased(BT_MODE_CLASSIC_BT)
+//      returns true, and
+//   b) NOT touch the BLE tracking flag, leaving BLE fully usable for
+//      commissioning via btStartMode(BT_MODE_BLE).
+//
+// This test verifies both invariants and then confirms that a subsequent
+// btStartMode(BT_MODE_BLE) succeeds — proving that the --wrap intercept does
+// not crash or corrupt state when called from the Matter stack.
+#if CONFIG_BT_CLASSIC_ENABLED
+static void phase_9() {
+  Serial.println("[BT_MEM_WRAP] Phase 9: Matter-style Classic BT release (BLEManagerImpl simulation)");
+
+  check(!btMemReleased(BT_MODE_CLASSIC_BT), "Classic BT mem not released at boot");
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released at boot");
+
+  // Simulate the exact call that Matter's BLEManagerImpl makes on ESP32.
+  esp_err_t ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+  check(ret == ESP_OK, "Matter-style esp_bt_controller_mem_release(CLASSIC) returns ESP_OK");
+  check(btMemReleased(BT_MODE_CLASSIC_BT), "Classic BT tracking updated after Matter-style release");
+  check(!btMemReleased(BT_MODE_BLE), "BLE tracking NOT affected by Classic BT release");
+
+  // BLE must still be usable — Matter uses it for commissioning.
+  check(btStartMode(BT_MODE_BLE), "btStartMode(BLE) succeeds after Classic BT released");
+  check(btStarted(), "btStarted() true after BLE start");
+  check(btStop(), "btStop() succeeds");
+  check(!btStarted(), "btStarted() false after btStop");
+}
+#else
+static void phase_9() {
+  // Classic BT is not supported on this chip, so Matter will not call
+  // esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT).  Nothing to test.
+  Serial.println("[BT_MEM_WRAP] Phase 9: SKIP (Classic BT not supported on this target)");
+}
+#endif
+
+// Phase 10: btInUse() pointer comparison — no user override in this sketch.
+// Verifies that when btInUse resolves to the default weak alias (_btInUse_default),
+// the pointer comparison correctly identifies it as NOT a user override, and
+// memory release is governed solely by the sub-functions (bleInUse / btClassicInUse).
+// Since this sketch includes both alloc headers, both flags are true and
+// memory should NOT be released by initArduino().
+static void phase_10() {
+  Serial.println("[BT_MEM_WRAP] Phase 10: btInUse pointer comparison (no strong override)");
+
+  extern bool _btInUse_default(void);
+  bool isDefault = ((void *)btInUse == (void *)_btInUse_default);
+  check(isDefault, "btInUse points to default (no strong user override)");
+
+  // Both alloc headers are included in this sketch, so sub-functions return true
+  // and initArduino() must NOT have released any memory.
+  check(!btMemReleased(BT_MODE_BLE), "BLE mem not released (bleInUse was true)");
+
+#if CONFIG_BT_CLASSIC_ENABLED
+  check(!btMemReleased(BT_MODE_CLASSIC_BT), "Classic BT mem not released (btClassicInUse was true)");
+#else
+  check(btMemReleased(BT_MODE_CLASSIC_BT), "Classic BT mem reported released (not supported on this chip)");
+#endif
+}
+
+static void run_phase(int phase) {
+  pass_count = 0;
+  fail_count = 0;
+
+  switch (phase) {
+    case 1: phase_1(); break;
+    case 2: phase_2(); break;
+    case 3: phase_3(); break;
+    case 4: phase_4(); break;
+    case 5: phase_5(); break;
+    case 6: phase_6(); break;
+    case 7: phase_7(); break;
+    case 8: phase_8(); break;
+    case 9: phase_9(); break;
+    case 10: phase_10(); break;
+    default:
+      Serial.printf("[BT_MEM_WRAP] ERROR: unknown phase %d\n", phase);
+      return;
+  }
+
+  Serial.printf("[BT_MEM_WRAP] Phase %d: %d passed, %d failed\n", phase, pass_count, fail_count);
+  Serial.printf("[BT_MEM_WRAP] Phase %d: %s\n", phase, (fail_count == 0) ? "PASSED" : "FAILED");
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[BT_MEM_WRAP] Ready");
+  Serial.println("[BT_MEM_WRAP] Send phase:");
+
+  // Wait for "PHASE N" from the test harness.
+  String cmd = "";
+  while (cmd.length() == 0) {
+    if (Serial.available()) {
+      cmd = Serial.readStringUntil('\n');
+      cmd.trim();
+    }
+    delay(10);
+  }
+
+  Serial.printf("[BT_MEM_WRAP] Received: %s\n", cmd.c_str());
+
+  if (cmd.startsWith("PHASE ")) {
+    int phase = cmd.substring(6).toInt();
+    run_phase(phase);
+    // Restart after every phase so the next phase starts with a clean BT
+    // memory state.  This avoids relying on dut.hard_reset() which is not
+    // reliably available in all test environments.
+    Serial.flush();
+    ESP.restart();
+  } else {
+    Serial.printf("[BT_MEM_WRAP] ERROR: unexpected command: %s\n", cmd.c_str());
+  }
+}
+
+void loop() {}
+
+#else  // BT controller not available
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+  Serial.println("[BT_MEM_WRAP] SKIP: BT controller not available");
+}
+
+void loop() {}
+
+#endif

--- a/tests/validation/bt_mem_wrap/bt_mem_wrap.ino
+++ b/tests/validation/bt_mem_wrap/bt_mem_wrap.ino
@@ -66,7 +66,8 @@
 #include "sdkconfig.h"
 #include "soc/soc_caps.h"
 
-#if SOC_BT_SUPPORTED && (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) && __has_include("esp_bt.h") && defined(CONFIG_BT_CONTROLLER_ENABLED)
+#if SOC_BT_SUPPORTED && (defined(CONFIG_BLUEDROID_ENABLED) || defined(CONFIG_NIMBLE_ENABLED)) \
+  && __has_include("esp_bt.h") && defined(CONFIG_BT_CONTROLLER_ENABLED)
 
 #include "esp_bt.h"
 
@@ -324,19 +325,17 @@ static void run_phase(int phase) {
   fail_count = 0;
 
   switch (phase) {
-    case 1: phase_1(); break;
-    case 2: phase_2(); break;
-    case 3: phase_3(); break;
-    case 4: phase_4(); break;
-    case 5: phase_5(); break;
-    case 6: phase_6(); break;
-    case 7: phase_7(); break;
-    case 8: phase_8(); break;
-    case 9: phase_9(); break;
+    case 1:  phase_1(); break;
+    case 2:  phase_2(); break;
+    case 3:  phase_3(); break;
+    case 4:  phase_4(); break;
+    case 5:  phase_5(); break;
+    case 6:  phase_6(); break;
+    case 7:  phase_7(); break;
+    case 8:  phase_8(); break;
+    case 9:  phase_9(); break;
     case 10: phase_10(); break;
-    default:
-      Serial.printf("[BT_MEM_WRAP] ERROR: unknown phase %d\n", phase);
-      return;
+    default: Serial.printf("[BT_MEM_WRAP] ERROR: unknown phase %d\n", phase); return;
   }
 
   Serial.printf("[BT_MEM_WRAP] Phase %d: %d passed, %d failed\n", phase, pass_count, fail_count);

--- a/tests/validation/bt_mem_wrap/ci.yml
+++ b/tests/validation/bt_mem_wrap/ci.yml
@@ -1,0 +1,6 @@
+requires:
+  - CONFIG_SOC_BLE_SUPPORTED=y
+  - CONFIG_BT_CONTROLLER_ENABLED=y
+
+platforms:
+  qemu: false

--- a/tests/validation/bt_mem_wrap/test_bt_mem_wrap.py
+++ b/tests/validation/bt_mem_wrap/test_bt_mem_wrap.py
@@ -1,0 +1,62 @@
+import logging
+
+
+def test_bt_mem_wrap(dut):
+    LOGGER = logging.getLogger(__name__)
+
+    def run_phase(n, description):
+        LOGGER.info("Phase %d: %s", n, description)
+        dut.expect_exact("[BT_MEM_WRAP] Ready", timeout=30)
+        dut.expect_exact("[BT_MEM_WRAP] Send phase:")
+        dut.write(f"PHASE {n}\n")
+        dut.expect_exact(f"[BT_MEM_WRAP] Phase {n}: PASSED", timeout=30)
+        LOGGER.info("Phase %d passed", n)
+
+    # Phase 1: btMemRelease() Arduino API + double-free guard.
+    run_phase(1, "btMemRelease API")
+
+    # Phase 2: direct esp_bt_controller_mem_release() + double-free guard.
+    # Simulates an external component (e.g. Matter) releasing memory directly.
+    run_phase(2, "direct esp_bt_controller_mem_release")
+
+    # Phase 3: direct esp_bt_mem_release() + double-free guard.
+    run_phase(3, "direct esp_bt_mem_release")
+
+    # Phase 4: cross-API double-free — btMemRelease() then direct
+    # esp_bt_controller_mem_release().  Different wrap functions but the same
+    # tracking flags, so the second call must be a no-op.
+    run_phase(4, "cross-API double-free (btMemRelease then esp_bt_controller_mem_release)")
+
+    # Phase 5: cross-API double-free (reversed) — direct esp_bt_mem_release()
+    # then btMemRelease().
+    run_phase(5, "cross-API double-free (esp_bt_mem_release then btMemRelease)")
+
+    # Phase 6: btMarkMemReleased() as a sentinel — marks memory released without
+    # a real ESP-IDF call; all subsequent wrap calls must be no-ops.
+    run_phase(6, "btMarkMemReleased sentinel")
+
+    # Phase 7: btStart() must fail after btMemRelease() — the freed memory
+    # cannot be reclaimed, so the controller init must be rejected.
+    run_phase(7, "btStart fails after btMemRelease")
+
+    # Phase 8: full lifecycle — btStart() succeeds, btMemRelease() while running
+    # is rejected without corrupting tracking state, btStop() cleans up, then
+    # btMemRelease() finally succeeds.
+    run_phase(8, "start, release-while-running rejected, stop, release")
+
+    # Phase 9: Matter-style release — simulates BLEManagerImpl::InitESPBleLayer()
+    # calling esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT) on ESP32.
+    # The __wrap intercept must update only the Classic BT tracking flag and
+    # leave BLE usable for commissioning.  On chips without Classic BT the
+    # phase is a compile-time no-op and always passes.
+    run_phase(9, "Matter-style Classic BT release (BLEManagerImpl simulation)")
+
+    # Phase 10: btInUse() pointer comparison — no user override in this test.
+    # Verifies that when btInUse resolves to the default weak alias (_btInUse_default),
+    # the pointer comparison correctly identifies it as NOT a user override, and
+    # memory release is governed solely by the sub-functions (bleInUse / btClassicInUse).
+    # Since this test includes both alloc headers, both flags are true and
+    # memory should NOT be released by initArduino().
+    run_phase(10, "btInUse pointer comparison (no strong override)")
+
+    LOGGER.info("BT memory wrap test passed!")


### PR DESCRIPTION
## Description of Change

This pull request refactors and improves the management of Bluetooth (BT) memory on ESP32 devices, introducing more robust tracking and safer release of BT memory for both BLE and Classic BT modes. It replaces the old, monolithic memory management with mode-specific tracking for BLE and Classic BT, provides new APIs for memory release and status checking, and enhances compatibility with external components (such as the Matter stack) that may also release BT memory. The changes also deprecate the old `esp32-hal-bt-mem.h` in favor of new headers, and update all relevant libraries to use the new system.

**Bluetooth Memory Management Refactor**

* Introduced new headers `esp32-hal-alloc-ble-mem.h` and `esp32-hal-alloc-bt-classic-mem.h` to separately track BLE and Classic BT library usage, replacing the old `esp32-hal-bt-mem.h` (now deprecated). These headers set flags via constructors to indicate if BLE or Classic BT libraries are linked. [[1]](diffhunk://#diff-fdf03da4e8356d1274374e617fa42c4566e347315b5fd5d5b591e3d5b972e1faR1-R44) [[2]](diffhunk://#diff-f27bc8d3b28063280aab3a58079c45c759359c450527ab6767a2d60f4adf12c6R1-R44) [[3]](diffhunk://#diff-e401958717da5f80036cbf9338d4244507d7f456be5c6b4568dd915c6242d8fcL18-R21)

* Refactored `esp32-hal-bt.c` to:
  - Replace the single `_btLibraryInUse` flag with `_bleLibraryInUse` and `_btClassicLibraryInUse`.
  - Add new APIs: `btClassicInUse()`, `bleInUse()`, `btMemRelease()`, `btMemReleased()`, and `btMarkMemReleased()` for fine-grained memory management and state tracking.
  - Track memory release state for BLE and Classic BT modes internally, since ESP-IDF does not provide a query API.
  - Implement linker `--wrap` intercepts for `esp_bt_mem_release` and `esp_bt_controller_mem_release` to safely handle memory releases by external components and prevent double-free errors. [[1]](diffhunk://#diff-c0c693d9727dd97b18efbaed86dccbb030fb64e87322696d23f505c751aa5afcL20-R47) [[2]](diffhunk://#diff-c0c693d9727dd97b18efbaed86dccbb030fb64e87322696d23f505c751aa5afcR60-R73) [[3]](diffhunk://#diff-c0c693d9727dd97b18efbaed86dccbb030fb64e87322696d23f505c751aa5afcL61-R107) [[4]](diffhunk://#diff-c0c693d9727dd97b18efbaed86dccbb030fb64e87322696d23f505c751aa5afcR158-R333) [[5]](diffhunk://#diff-c0c693d9727dd97b18efbaed86dccbb030fb64e87322696d23f505c751aa5afcR347-R356) [[6]](diffhunk://#diff-62ba80e61b574d4931f73f355b777067d9def6ebc2f0e0aec6a2d89c7cbd19deL36-R62)

**Library and Example Updates**

* Updated all library and example includes to use the new memory management headers instead of the deprecated `esp32-hal-bt-mem.h`. [[1]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8L64-R64) [[2]](diffhunk://#diff-b406953f9017472f4e9771264a9a3f5785801de59ea4e88e63afdf04b0d4fdd1L30-R30) [[3]](diffhunk://#diff-85af81928559973c2d5388525618cb9c1edf4334500f1933ba5226254a0750eaL81-R81)

* Modified BLE and BluetoothSerial libraries to use the new `btMemRelease()` and `btMemReleased()` APIs for safer and more accurate BT memory release, and to prevent initialization if memory has already been released. [[1]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8R296-R303) [[2]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8L317-L320) [[3]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8L1144-R1149) [[4]](diffhunk://#diff-b406953f9017472f4e9771264a9a3f5785801de59ea4e88e63afdf04b0d4fdd1L885-R890)

**Core Initialization Changes**

* Updated `initArduino()` and related code to use the new per-mode memory release checks and APIs, ensuring that memory for unused BT modes is released as early as possible and only when safe. [[1]](diffhunk://#diff-9ebb068880a66ac4e5e7f3acd0b56453006f9fdfe61a13e64cd088d7208c0db2R294-R295) [[2]](diffhunk://#diff-9ebb068880a66ac4e5e7f3acd0b56453006f9fdfe61a13e64cd088d7208c0db2L345-R352)

**Deprecation and Backward Compatibility**

* Marked `esp32-hal-bt-mem.h` as deprecated and maintained it only for backwards compatibility, with a note to remove it in v4.0.

These changes improve memory efficiency, safety, and compatibility for Bluetooth features on ESP32, especially in complex applications or when integrating with other frameworks.

## Test Scenarios

Tested locally