### PR TITLE
feat(wifi): Remove AP and STA end() from the destructors

### DIFF
--- a/libraries/WiFi/src/AP.cpp
+++ b/libraries/WiFi/src/AP.cpp
@@ -158,7 +158,9 @@ APClass::APClass() : _wifi_ap_event_handle(0) {
 }
 
 APClass::~APClass() {
-  end();
+  // Calling end() here causes a lot of WiFi code to be linked to the final executable by just including "WiFi.h"
+  // If globals are disabled, then the user should call WiFi.AP.end() before destroying the WiFi object
+  // end();
   _ap_network_if = NULL;
 }
 

--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -242,7 +242,9 @@ STAClass::STAClass()
 }
 
 STAClass::~STAClass() {
-  end();
+  // Calling end() here causes a lot of WiFi code to be linked to the final executable by just including "WiFi.h"
+  // If globals are disabled, then the user should call WiFi.STA.end() before destroying the WiFi object
+  // end();
   _sta_network_if = NULL;
 }
 


### PR DESCRIPTION
This pull request updates the destructors for both `APClass` and `STAClass` in the WiFi library to prevent unnecessary code from being linked when including `WiFi.h`. The `end()` method calls in the destructors are now commented out, with added comments explaining that users should explicitly call `end()` if globals are disabled.

Resource management and code size optimization:

* [`AP.cpp`](diffhunk://#diff-c06974a6b0a509d5e3b33ad8da77105fbe8affaa604c47b72a30c8d1fec7a2a7L161-R163): Commented out the call to `end()` in `APClass` destructor to avoid linking extra WiFi code by default and added guidance for users about manual cleanup.
* [`STA.cpp`](diffhunk://#diff-fcf930a1c1c949e34e74528fc20ec629d3a704e97db75fadc89b8b4fb6cde7a4L245-R247): Commented out the call to `end()` in `STAClass` destructor with similar rationale and user instructions as above.