### PR TITLE
fix(fs): Fix potential race contition

### DIFF
--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -273,6 +273,12 @@ const char *FS::mountpoint() {
 
 void FSImpl::mountpoint(const char *mp) {
   _mountpoint = mp;
+  if (mp && !_mtx) {
+    _mtx = xSemaphoreCreateRecursiveMutex();
+    if (!_mtx) {
+      log_w("Failed to create recursive mutex. Time-of-check to time-of-use race condition may occur.");
+    }
+  }
 }
 
 const char *FSImpl::mountpoint() {

--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -276,7 +276,8 @@ void FSImpl::mountpoint(const char *mp) {
   if (mp && !_mtx) {
     _mtx = xSemaphoreCreateRecursiveMutex();
     if (!_mtx) {
-      log_w("Failed to create recursive mutex. Time-of-check to time-of-use race condition may occur.");
+      log_w("Failed to create recursive mutex for filesystem in mountpoint %s", mp ? mp : "NULL");
+      log_w("Some filesystem operations on this mountpoint will continue without synchronization and will not be serialized.");
     }
   }
 }

--- a/libraries/FS/src/FSImpl.h
+++ b/libraries/FS/src/FSImpl.h
@@ -22,8 +22,30 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 namespace fs {
+
+// RAII lock guard for the per-filesystem recursive mutex.
+class FSLockGuard {
+public:
+  explicit FSLockGuard(SemaphoreHandle_t mtx) : _mtx(mtx) {
+    if (_mtx) {
+      xSemaphoreTakeRecursive(_mtx, portMAX_DELAY);
+    }
+  }
+  ~FSLockGuard() {
+    if (_mtx) {
+      xSemaphoreGiveRecursive(_mtx);
+    }
+  }
+  FSLockGuard(const FSLockGuard &) = delete;
+  FSLockGuard &operator=(const FSLockGuard &) = delete;
+
+private:
+  SemaphoreHandle_t _mtx;
+};
 
 class FileImpl {
 public:
@@ -51,10 +73,16 @@ public:
 class FSImpl {
 protected:
   const char *_mountpoint;
+  SemaphoreHandle_t _mtx;
 
 public:
-  FSImpl() : _mountpoint(NULL) {}
-  virtual ~FSImpl() {}
+  FSImpl() : _mountpoint(NULL), _mtx(NULL) {}
+  virtual ~FSImpl() {
+    if (_mtx) {
+      vSemaphoreDelete(_mtx);
+    }
+  }
+
   virtual FileImplPtr open(const char *path, const char *mode, const bool create) = 0;
   virtual bool exists(const char *path) = 0;
   virtual bool rename(const char *pathFrom, const char *pathTo) = 0;

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -265,7 +265,7 @@ VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode)
   }
 
   // For read mode, detect whether the path is a directory or a regular file.
-  // The per-filesystem mutex held by VFSImpl::open serialises this constructor
+  // The per-filesystem mutex held by VFSImpl::open serializes this constructor
   // against other VFSImpl entry points (open/exists/rename/remove/mkdir/rmdir)
   // on the same filesystem. VFSFileImpl I/O operations (read/write/close) and
   // code that bypasses the Arduino FS layer (direct fopen/stat calls) are NOT

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -275,7 +275,7 @@ VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs
       // fopen() succeeded — but on POSIX-style VFS layers (including ESP-IDF's
       // LittleFS VFS), open(2) can succeed on a directory with O_RDONLY.  Use
       // stat to confirm the path is a regular file before treating it as one.
-      if (stat(temp, &_stat) == 0 && S_ISDIR(_stat.st_mode)) {
+      if (fstat(fileno(_f), &_stat) == 0 && S_ISDIR(_stat.st_mode)) {
         // Path is a directory; close the file handle and open as a directory.
         fclose(_f);
         _f = NULL;

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -23,6 +23,7 @@ using namespace fs;
 #define DEFAULT_FILE_BUFFER_SIZE 4096
 
 FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return FileImplPtr();
@@ -33,15 +34,6 @@ FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create
     return FileImplPtr();
   }
 
-  size_t tempLen = strlen(_mountpoint) + strlen(fpath) + 1;
-  char *temp = (char *)malloc(tempLen);
-  if (!temp) {
-    log_e("malloc failed");
-    return FileImplPtr();
-  }
-
-  snprintf(temp, tempLen, "%s%s", _mountpoint, fpath);
-
   // Try to open as file first - let the file operation handle errors
   if (mode && mode[0] != 'r') {
     // For write modes, attempt to create directories if needed
@@ -49,11 +41,18 @@ FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create
       char *token;
       char *folder = (char *)malloc(strlen(fpath) + 1);
 
+      if (!folder) {
+        log_e("Folder name malloc failed");
+        return FileImplPtr();
+      }
+
       int start_index = 0;
       int end_index = 0;
 
       token = strchr(fpath + 1, '/');
-      end_index = (token - fpath);
+      if (token != NULL) {
+        end_index = (token - fpath);
+      }
 
       while (token != NULL) {
         memcpy(folder, fpath + start_index, end_index - start_index);
@@ -62,7 +61,6 @@ FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create
         if (!VFSImpl::mkdir(folder)) {
           log_e("Creating folder: %s failed!", folder);
           free(folder);
-          free(temp);
           return FileImplPtr();
         }
 
@@ -77,17 +75,16 @@ FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create
     }
 
     // Try to open the file directly - let fopen handle errors
-    free(temp);
     return std::make_shared<VFSFileImpl>(this, fpath, mode);
   }
 
   // For read mode, let the VFSFileImpl constructor handle the file opening
   // This avoids the TOCTOU race condition while maintaining proper functionality
-  free(temp);
   return std::make_shared<VFSFileImpl>(this, fpath, mode);
 }
 
 bool VFSImpl::exists(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -102,6 +99,7 @@ bool VFSImpl::exists(const char *fpath) {
 }
 
 bool VFSImpl::rename(const char *pathFrom, const char *pathTo) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -138,6 +136,7 @@ bool VFSImpl::rename(const char *pathFrom, const char *pathTo) {
 }
 
 bool VFSImpl::remove(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -164,19 +163,9 @@ bool VFSImpl::remove(const char *fpath) {
 }
 
 bool VFSImpl::mkdir(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
-    return false;
-  }
-
-  VFSFileImpl f(this, fpath, "r");
-  if (f && f.isDirectory()) {
-    f.close();
-    //log_w("%s already exists", fpath);
-    return true;
-  } else if (f) {
-    f.close();
-    log_e("%s is a file", fpath);
     return false;
   }
 
@@ -189,12 +178,45 @@ bool VFSImpl::mkdir(const char *fpath) {
 
   snprintf(temp, tempLen, "%s%s", _mountpoint, fpath);
 
+  // Note: the stat() → opendir() → ::mkdir() sequence below contains a
+  // TOCTOU (time-of-check / time-of-use) window between individual syscalls.
+  // The per-filesystem mutex (_mtx) held by the caller (VFSImpl::mkdir) ensures
+  // that no other Arduino FS API call on the same filesystem can interleave
+  // here.  Code that bypasses the Arduino FS layer (direct fopen/stat/mkdir
+  // calls) is not covered by this mutex.
+
+  // stat() reports the path type without consuming a file descriptor.
+  struct stat st;
+  if (stat(temp, &st) == 0) {
+    free(temp);
+    if (S_ISDIR(st.st_mode)) {
+      //log_w("%s already exists", fpath);
+      return true;
+    }
+    log_e("%s is a file", fpath);
+    return false;
+  }
+
+  // stat() failed (path does not exist).  On SPIFFS the filesystem is flat and
+  // virtual directories are always reachable via opendir() regardless of
+  // whether any files with that path prefix exist yet.  A successful opendir()
+  // here means the path is an accessible virtual directory – treat it as
+  // already present so we avoid calling ::mkdir() (which SPIFFS does not
+  // support and would return an error).
+  DIR *d = opendir(temp);
+  if (d) {
+    closedir(d);
+    free(temp);
+    return true;
+  }
+
   auto rc = ::mkdir(temp, ACCESSPERMS);
   free(temp);
   return rc == 0;
 }
 
 bool VFSImpl::rmdir(const char *fpath) {
+  FSLockGuard lock(_mtx);
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -220,7 +242,12 @@ bool VFSImpl::rmdir(const char *fpath) {
   return rc == 0;
 }
 
-VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs(fs), _f(NULL), _d(NULL), _path(NULL), _isDirectory(false), _written(false) {
+VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs(fs), _f(NULL), _d(NULL), _path(NULL), _isDirectory(false), _stat{}, _written(false) {
+  if (!mode) {
+    log_w("mode is NULL, using default read mode");
+    mode = "r";
+  }
+
   size_t tempLen = strlen(_fs->_mountpoint) + strlen(fpath) + 1;
   char *temp = (char *)malloc(tempLen);
   if (!temp) {
@@ -236,37 +263,51 @@ VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs
     return;
   }
 
-  // For read mode, check if file exists first to determine type
-  if (!mode || mode[0] == 'r') {
-    if (!stat(temp, &_stat)) {
-      //file found
-      if (S_ISREG(_stat.st_mode)) {
-        _isDirectory = false;
-        _f = fopen(temp, mode);
-        if (!_f) {
-          log_e("fopen(%s) failed", temp);
-        }
-        if (_f && (_stat.st_blksize == 0)) {
-          setvbuf(_f, NULL, _IOFBF, DEFAULT_FILE_BUFFER_SIZE);
-        }
-      } else if (S_ISDIR(_stat.st_mode)) {
-        _isDirectory = true;
+  // For read mode, detect whether the path is a directory or a regular file.
+  // The per-filesystem mutex held by VFSImpl::open serialises this constructor
+  // against other VFSImpl entry points (open/exists/rename/remove/mkdir/rmdir)
+  // on the same filesystem. VFSFileImpl I/O operations (read/write/close) and
+  // code that bypasses the Arduino FS layer (direct fopen/stat calls) are NOT
+  // covered by the mutex.
+  if (mode[0] == 'r') {
+    _f = fopen(temp, mode);
+    if (_f) {
+      // fopen() succeeded — but on POSIX-style VFS layers (including ESP-IDF's
+      // LittleFS VFS), open(2) can succeed on a directory with O_RDONLY.  Use
+      // stat to confirm the path is a regular file before treating it as one.
+      if (stat(temp, &_stat) == 0 && S_ISDIR(_stat.st_mode)) {
+        // Path is a directory; close the file handle and open as a directory.
+        fclose(_f);
+        _f = NULL;
         _d = opendir(temp);
+        _isDirectory = (_d != NULL);
         if (!_d) {
           log_e("opendir(%s) failed", temp);
         }
       } else {
-        log_e("Unknown type 0x%08" PRIX32 " for file %s", (uint32_t)((_stat.st_mode) & _IFMT), temp);
+        _isDirectory = false;
+        if (_stat.st_blksize == 0) {
+          setvbuf(_f, NULL, _IOFBF, DEFAULT_FILE_BUFFER_SIZE);
+        }
       }
     } else {
-      //file not found
-      //try to open as directory
-      _d = opendir(temp);
-      if (_d) {
-        _isDirectory = true;
+      // fopen failed — check via stat whether this is a directory.
+      // stat() does not consume a file descriptor, so it can succeed even when
+      // the filesystem's open-file limit has been reached.  If stat reports a
+      // regular file we skip opendir() so an exhausted fd pool is not
+      // misidentified as a directory.  If stat itself fails (as it does for
+      // SPIFFS virtual directories which have no named entry of their own) we
+      // still try opendir() because SPIFFS virtual directories are only
+      // reachable that way.
+      [[maybe_unused]] int fopen_errno = errno;
+      struct stat dir_stat;
+      int stat_rc = stat(temp, &dir_stat);
+      bool statIsFile = (stat_rc == 0 && !S_ISDIR(dir_stat.st_mode));
+      if (!statIsFile) {
+        _d = opendir(temp);
+        _isDirectory = (_d != NULL);
       } else {
-        _isDirectory = false;
-        //log_w("stat(%s) failed", temp);
+        log_e("fopen(%s, %s) failed: %d (%s)", temp, mode, fopen_errno, strerror(fopen_errno));
       }
     }
   } else {

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -242,7 +242,8 @@ bool VFSImpl::rmdir(const char *fpath) {
   return rc == 0;
 }
 
-VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs(fs), _f(NULL), _d(NULL), _path(NULL), _isDirectory(false), _stat{}, _written(false) {
+VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode)
+  : _fs(fs), _f(NULL), _d(NULL), _path(NULL), _isDirectory(false), _stat{}, _written(false) {
   if (!mode) {
     log_w("mode is NULL, using default read mode");
     mode = "r";
@@ -299,7 +300,8 @@ VFSFileImpl::VFSFileImpl(VFSImpl *fs, const char *fpath, const char *mode) : _fs
       // SPIFFS virtual directories which have no named entry of their own) we
       // still try opendir() because SPIFFS virtual directories are only
       // reachable that way.
-      [[maybe_unused]] int fopen_errno = errno;
+      [[maybe_unused]]
+      int fopen_errno = errno;
       struct stat dir_stat;
       int stat_rc = stat(temp, &dir_stat);
       bool statIsFile = (stat_rc == 0 && !S_ISDIR(dir_stat.st_mode));

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -180,10 +180,10 @@ bool VFSImpl::mkdir(const char *fpath) {
 
   // Note: the stat() → opendir() → ::mkdir() sequence below contains a
   // TOCTOU (time-of-check / time-of-use) window between individual syscalls.
-  // The per-filesystem mutex (_mtx) held by the caller (VFSImpl::mkdir) ensures
-  // that no other Arduino FS API call on the same filesystem can interleave
-  // here.  Code that bypasses the Arduino FS layer (direct fopen/stat/mkdir
-  // calls) is not covered by this mutex.
+  // The per-filesystem mutex (_mtx) held by this function ensures that no
+  // other Arduino FS API call on the same filesystem can interleave here.
+  // Code that bypasses the Arduino FS layer (direct fopen/stat/mkdir calls)
+  // is not covered by this mutex.
 
   // stat() reports the path type without consuming a file descriptor.
   struct stat st;

--- a/tests/validation/fs/fs.ino
+++ b/tests/validation/fs/fs.ino
@@ -655,6 +655,72 @@ void test_write_read_patterns() {
   V.remove(path);
 }
 
+// Regression test for the TOCTOU fix in VFSFileImpl::VFSFileImpl (libraries/FS/src/vfs_api.cpp).
+//
+// The original code used stat() to determine the file type and then called fopen() or opendir()
+// based on the result, creating a race window between the check and the open.  The fix removes
+// that window by attempting fopen() first and falling back to opendir() on failure.
+//
+// We cannot reproduce the race deterministically on embedded hardware, but we can verify that
+// the fixed code path correctly identifies both files and directories when opened in read mode,
+// which would catch any regression in the type-detection logic.
+void test_open_read_mode_type_detection() {
+  auto &V = gFS->vfs();
+
+  // --- regular file opened in read mode ---
+  const char *filePath = "/toctou_file.txt";
+  {
+    File w = V.open(filePath, FILE_WRITE);
+    TEST_ASSERT_TRUE_MESSAGE(w, "setup: could not create file");
+    w.print("toctou");
+    w.close();
+  }
+
+  {
+    // Open the same path in read mode: must be detected as a file, not a directory
+    File f = V.open(filePath, FILE_READ);
+    TEST_ASSERT_TRUE_MESSAGE(f, "open(file, FILE_READ) failed");
+    TEST_ASSERT_FALSE_MESSAGE(f.isDirectory(), "regular file incorrectly detected as directory");
+    String content = f.readString();
+    TEST_ASSERT_EQUAL_STRING("toctou", content.c_str());
+    f.close();
+  }
+
+  V.remove(filePath);
+
+  // --- directory opened with default (read) mode ---
+  if (strcmp(gFS->name(), "spiffs") == 0) {
+    // SPIFFS does not have real directories; skip directory portion
+    TEST_MESSAGE("Skipping directory portion for SPIFFS");
+    return;
+  }
+
+  const char *dirPath = "/toctou_dir";
+  const char *childPath = "/toctou_dir/child.txt";
+  {
+    TEST_ASSERT_TRUE_MESSAGE(V.mkdir(dirPath), "setup: could not create directory");
+    File w = V.open(childPath, FILE_WRITE);
+    TEST_ASSERT_TRUE_MESSAGE(w, "setup: could not create child file");
+    w.print("child");
+    w.close();
+  }
+
+  {
+    // Open the directory path without an explicit mode (defaults to read).
+    // Must be detected as a directory so that openNextFile() works.
+    File d = V.open(dirPath);
+    TEST_ASSERT_TRUE_MESSAGE(d, "open(dir) failed");
+    TEST_ASSERT_TRUE_MESSAGE(d.isDirectory(), "directory incorrectly detected as file");
+    File child = d.openNextFile();
+    TEST_ASSERT_TRUE_MESSAGE(child, "openNextFile() returned no entry in non-empty directory");
+    child.close();
+    d.close();
+  }
+
+  V.remove(childPath);
+  V.rmdir(dirPath);
+}
+
 void test_directory_operations_edge_cases() {
   auto &V = gFS->vfs();
   TEST_ASSERT_TRUE(V.mkdir("/test_dir"));
@@ -757,6 +823,7 @@ static void run_suite_for(IFileSystem &fs) {
   RUN_TEST(test_write_read_patterns);
   RUN_TEST(test_directory_operations_edge_cases);
   RUN_TEST(test_max_open_files_limit);
+  RUN_TEST(test_open_read_mode_type_detection);
   gFS = nullptr;
 }
 


### PR DESCRIPTION
## Description of Change

This pull request introduces a per-filesystem recursive mutex to the Arduino FS layer to eliminate time-of-check-to-time-of-use (TOCTOU) race conditions in file and directory operations. It also refactors the logic for detecting file types when opening paths, improves error handling, and adds a regression test to verify the fix. The most important changes are grouped below.

### Thread Safety and TOCTOU Fixes

* Introduced a per-filesystem recursive mutex (`_mtx`) in `FSImpl`, created during mount, and used to serialize all FS API calls, preventing TOCTOU race conditions. (`libraries/FS/src/FSImpl.h` [[1]](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR76-R85) `libraries/FS/src/FS.cpp` [[2]](diffhunk://#diff-b80c6bdaac6e1221c08312e5a724c4bf6df37ae2321abf960b99c5cff47cff2aR276-R281)
* Added an RAII-style `FSLockGuard` to manage mutex locking/unlocking around all public FS operations. (`libraries/FS/src/FSImpl.h` [libraries/FS/src/FSImpl.hR25-R49](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR25-R49))
* Wrapped all `VFSImpl` methods that mutate or check the filesystem in `FSLockGuard` to enforce mutual exclusion. (`libraries/FS/src/vfs_api.cpp` [[1]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R26) [[2]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L80-R87) [[3]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R102) [[4]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R139) [[5]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R166-L182) [[6]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47R181-R219) [[7]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L223-R250)

### File Type Detection and Error Handling

* Refactored `VFSFileImpl` constructor to always try `fopen()` first when opening in read mode, then fallback to `opendir()` and `stat()` as needed, removing the TOCTOU window and improving file/directory detection. (`libraries/FS/src/vfs_api.cpp` [libraries/FS/src/vfs_api.cppL239-R310](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L239-R310))
* Improved error handling and logging throughout file and directory operations, including handling of allocation failures and invalid modes. (`libraries/FS/src/vfs_api.cpp` [[1]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L36-R55) [[2]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L223-R250)

### Testing

* Added a regression test (`test_open_read_mode_type_detection`) to verify that the TOCTOU fix correctly detects files and directories when opening paths in read mode, preventing regressions. (`tests/validation/fs/fs.ino` [[1]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR658-R723) [[2]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR826)

## Test Scenarios

Tested locally
