### PR TITLE
fix(i2s): Make playWAV and playMP3 take const data

### DIFF
--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -1082,6 +1082,10 @@ uint8_t *I2SClass::recordWAV(size_t rec_seconds, size_t *out_size) {
 }
 
 void I2SClass::playWAV(const uint8_t *data, size_t len) {
+  if (data == NULL || len < WAVE_HEADER_SIZE) {
+    log_e("Invalid WAV data or length");
+    return;
+  }
   const pcm_wav_header_t *header = (const pcm_wav_header_t *)data;
   if (header->fmt_chunk.audio_format != 1) {
     log_e("Audio format is not PCM!");

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -1081,13 +1081,13 @@ uint8_t *I2SClass::recordWAV(size_t rec_seconds, size_t *out_size) {
   return NULL;
 }
 
-void I2SClass::playWAV(uint8_t *data, size_t len) {
-  pcm_wav_header_t *header = (pcm_wav_header_t *)data;
+void I2SClass::playWAV(const uint8_t *data, size_t len) {
+  const pcm_wav_header_t *header = (const pcm_wav_header_t *)data;
   if (header->fmt_chunk.audio_format != 1) {
     log_e("Audio format is not PCM!");
     return;
   }
-  wav_data_chunk_t *data_chunk = &header->data_chunk;
+  const wav_data_chunk_t *data_chunk = &header->data_chunk;
   size_t data_offset = 0;
   while (memcmp(data_chunk->subchunk_id, "data", 4) != 0) {
     log_d(
@@ -1095,7 +1095,7 @@ void I2SClass::playWAV(uint8_t *data, size_t len) {
       data_chunk->subchunk_size + 8
     );
     data_offset += data_chunk->subchunk_size + 8;
-    data_chunk = (wav_data_chunk_t *)(data + WAVE_HEADER_SIZE + data_offset - 8);
+    data_chunk = (const wav_data_chunk_t *)(data + WAVE_HEADER_SIZE + data_offset - 8);
   }
   log_d(
     "Play WAV: rate:%" PRIu32 ", bits:%u, channels:%u, size:%" PRIu32, header->fmt_chunk.sample_rate, header->fmt_chunk.bits_per_sample,
@@ -1106,15 +1106,15 @@ void I2SClass::playWAV(uint8_t *data, size_t len) {
 }
 
 #if ARDUINO_HAS_MP3_DECODER
-bool I2SClass::playMP3(uint8_t *src, size_t src_len) {
+bool I2SClass::playMP3(const uint8_t *src, size_t src_len) {
   int16_t outBuf[MAX_NCHAN * MAX_NGRAN * MAX_NSAMP];
-  uint8_t *readPtr = NULL;
+  const uint8_t *readPtr = NULL;
   int bytesAvailable = 0, err = 0, offset = 0;
   MP3FrameInfo frameInfo;
   HMP3Decoder decoder = NULL;
 
   bytesAvailable = src_len;
-  readPtr = src;
+  readPtr = (const uint8_t *)src;
 
   decoder = MP3InitDecoder();
   if (decoder == NULL) {
@@ -1123,13 +1123,13 @@ bool I2SClass::playMP3(uint8_t *src, size_t src_len) {
   }
 
   do {
-    offset = MP3FindSyncWord(readPtr, bytesAvailable);
+    offset = MP3FindSyncWord((unsigned char *)readPtr, bytesAvailable);
     if (offset < 0) {
       break;
     }
     readPtr += offset;
     bytesAvailable -= offset;
-    err = MP3Decode(decoder, &readPtr, &bytesAvailable, outBuf, 0);
+    err = MP3Decode(decoder, (unsigned char **)&readPtr, &bytesAvailable, outBuf, 0);
     if (err) {
       log_e("Decode ERROR: %d", err);
       MP3FreeDecoder(decoder);

--- a/libraries/ESP_I2S/src/ESP_I2S.h
+++ b/libraries/ESP_I2S/src/ESP_I2S.h
@@ -95,10 +95,10 @@ public:
   // Record short PCM WAV to memory with current RX settings. Returns buffer that must be freed by the user.
   uint8_t *recordWAV(size_t rec_seconds, size_t *out_size);
   // Play short PCM WAV from memory
-  void playWAV(uint8_t *data, size_t len);
+  void playWAV(const uint8_t *data, size_t len);
 #if ARDUINO_HAS_MP3_DECODER
   // Play short MP3 from memory
-  bool playMP3(uint8_t *src, size_t src_len);
+  bool playMP3(const uint8_t *src, size_t src_len);
 #endif
 
 private:


### PR DESCRIPTION
This pull request updates the `I2SClass` audio playback methods to improve type safety and clarify intent by making input buffers `const` where appropriate. This helps prevent accidental modification of input data and makes the API usage clearer. The changes also include some necessary type casts to maintain compatibility with external decoder APIs.

**API and Type Safety Improvements:**

* Changed the `playWAV` and `playMP3` method signatures in `I2SClass` to accept `const uint8_t*` instead of `uint8_t*`, ensuring input buffers are not modified and making the interface safer and clearer (`ESP_I2S.h`, `ESP_I2S.cpp`). [[1]](diffhunk://#diff-e4065872b7a7ae36efad2c93fa0a6b8cd14d5be6ea526159583f3d94a26bc503L98-R101) [[2]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1084-R1098) [[3]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1109-R1117)
* Updated internal pointers and type casts in both `playWAV` and `playMP3` to use `const` correctness, and added explicit casts when interacting with third-party decoder functions that require non-const pointers (`ESP_I2S.cpp`). [[1]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1084-R1098) [[2]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1109-R1117) [[3]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1126-R1132)

Fixes: https://github.com/espressif/arduino-esp32/issues/12565