### PR TITLE
fix(wifi): Fix crashes in init/deinit cycles

### DIFF
--- a/libraries/Network/src/NetworkEvents.cpp
+++ b/libraries/Network/src/NetworkEvents.cpp
@@ -35,6 +35,10 @@ NetworkEvents::~NetworkEvents() {
     vQueueDelete(_arduino_event_queue);
     _arduino_event_queue = NULL;
   }
+  if (_mtx != NULL) {
+    vSemaphoreDelete(_mtx);
+    _mtx = NULL;
+  }
 }
 
 static uint32_t _initial_bits = 0;
@@ -53,6 +57,14 @@ bool NetworkEvents::initNetworkEvents() {
     _arduino_event_queue = xQueueCreate(32, sizeof(arduino_event_t *));
     if (!_arduino_event_queue) {
       log_e("Network Event Queue Create Failed!");
+      return false;
+    }
+  }
+
+  if (!_mtx) {
+    _mtx = xSemaphoreCreateMutex();
+    if (!_mtx) {
+      log_e("Network Event Mutex Create Failed!");
       return false;
     }
   }
@@ -119,9 +131,7 @@ void NetworkEvents::_checkForEvent() {
     }
     log_v("Network Event: %d - %s", event->event_id, eventName(event->event_id));
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-    std::unique_lock<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
+    _lock();
 
     // iterate over registered callbacks
     for (auto &i : _cbEventList) {
@@ -142,9 +152,7 @@ void NetworkEvents::_checkForEvent() {
       }
     }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-    lock.unlock();
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
+    _unlock();
 
     // release the event object's memory
     delete event;
@@ -167,12 +175,11 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventCb cbEvent, arduino_ev
     return 0;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.emplace_back(++_current_id, cbEvent, nullptr, nullptr, event);
-  return _cbEventList.back().id;
+  network_event_handle_t id = _cbEventList.back().id;
+  _unlock();
+  return id;
 }
 
 network_event_handle_t NetworkEvents::onEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event) {
@@ -180,12 +187,11 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventFuncCb cbEvent, arduin
     return 0;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.emplace_back(++_current_id, nullptr, cbEvent, nullptr, event);
-  return _cbEventList.back().id;
+  network_event_handle_t id = _cbEventList.back().id;
+  _unlock();
+  return id;
 }
 
 network_event_handle_t NetworkEvents::onEvent(NetworkEventSysCb cbEvent, arduino_event_id_t event) {
@@ -193,12 +199,11 @@ network_event_handle_t NetworkEvents::onEvent(NetworkEventSysCb cbEvent, arduino
     return 0;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.emplace_back(++_current_id, nullptr, nullptr, cbEvent, event);
-  return _cbEventList.back().id;
+  network_event_handle_t id = _cbEventList.back().id;
+  _unlock();
+  return id;
 }
 
 network_event_handle_t NetworkEvents::onSysEvent(NetworkEventCb cbEvent, arduino_event_id_t event) {
@@ -206,12 +211,11 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventCb cbEvent, arduino
     return 0;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.emplace(_cbEventList.begin(), ++_current_id, cbEvent, nullptr, nullptr, event);
-  return _cbEventList.front().id;
+  network_event_handle_t id = _cbEventList.front().id;
+  _unlock();
+  return id;
 }
 
 network_event_handle_t NetworkEvents::onSysEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event) {
@@ -219,12 +223,11 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventFuncCb cbEvent, ard
     return 0;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.emplace(_cbEventList.begin(), ++_current_id, nullptr, cbEvent, nullptr, event);
-  return _cbEventList.front().id;
+  network_event_handle_t id = _cbEventList.front().id;
+  _unlock();
+  return id;
 }
 
 network_event_handle_t NetworkEvents::onSysEvent(NetworkEventSysCb cbEvent, arduino_event_id_t event) {
@@ -232,12 +235,11 @@ network_event_handle_t NetworkEvents::onSysEvent(NetworkEventSysCb cbEvent, ardu
     return 0;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.emplace(_cbEventList.begin(), ++_current_id, nullptr, nullptr, cbEvent, event);
-  return _cbEventList.front().id;
+  network_event_handle_t id = _cbEventList.front().id;
+  _unlock();
+  return id;
 }
 
 void NetworkEvents::removeEvent(NetworkEventCb cbEvent, arduino_event_id_t event) {
@@ -245,10 +247,7 @@ void NetworkEvents::removeEvent(NetworkEventCb cbEvent, arduino_event_id_t event
     return;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.erase(
     std::remove_if(
       _cbEventList.begin(), _cbEventList.end(),
@@ -258,6 +257,7 @@ void NetworkEvents::removeEvent(NetworkEventCb cbEvent, arduino_event_id_t event
     ),
     _cbEventList.end()
   );
+  _unlock();
 }
 
 void NetworkEvents::removeEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t event) {
@@ -265,10 +265,7 @@ void NetworkEvents::removeEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t e
     return;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.erase(
     std::remove_if(
       _cbEventList.begin(), _cbEventList.end(),
@@ -278,6 +275,7 @@ void NetworkEvents::removeEvent(NetworkEventFuncCb cbEvent, arduino_event_id_t e
     ),
     _cbEventList.end()
   );
+  _unlock();
 }
 
 void NetworkEvents::removeEvent(NetworkEventSysCb cbEvent, arduino_event_id_t event) {
@@ -285,10 +283,7 @@ void NetworkEvents::removeEvent(NetworkEventSysCb cbEvent, arduino_event_id_t ev
     return;
   }
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.erase(
     std::remove_if(
       _cbEventList.begin(), _cbEventList.end(),
@@ -298,13 +293,11 @@ void NetworkEvents::removeEvent(NetworkEventSysCb cbEvent, arduino_event_id_t ev
     ),
     _cbEventList.end()
   );
+  _unlock();
 }
 
 void NetworkEvents::removeEvent(network_event_handle_t id) {
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  std::lock_guard<std::mutex> lock(_mtx);
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
-
+  _lock();
   _cbEventList.erase(
     std::remove_if(
       _cbEventList.begin(), _cbEventList.end(),
@@ -314,6 +307,7 @@ void NetworkEvents::removeEvent(network_event_handle_t id) {
     ),
     _cbEventList.end()
   );
+  _unlock();
 }
 
 int NetworkEvents::setStatusBits(int bits) {

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -19,9 +19,6 @@
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/event_groups.h"
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-#include <mutex>
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
 
 #if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED
 #include "esp_wifi_types.h"
@@ -304,10 +301,30 @@ private:
   // registered events callbacks container
   std::vector<NetworkEventCbList_t> _cbEventList;
 
-#if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
-  // container access mutex
-  std::mutex _mtx;
-#endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
+  // Protects _cbEventList from concurrent access. The event dispatch task
+  // (higher priority) can preempt the Arduino task during vector modifications,
+  // leading to corrupted reads. Created in initNetworkEvents() alongside the
+  // event task; NULL before that, which is safe because without the event task
+  // there is no concurrent access.
+  SemaphoreHandle_t _mtx = NULL;
+
+  /**
+   * @brief Lock the _mtx mutex
+   */
+  inline void _lock() {
+    if (_mtx) {
+      xSemaphoreTake(_mtx, portMAX_DELAY);
+    }
+  }
+
+  /**
+   * @brief Unlock the _mtx mutex
+   */
+  inline void _unlock() {
+    if (_mtx) {
+      xSemaphoreGive(_mtx);
+    }
+  }
 
   /**
    * @brief task function that picks events from an event queue and calls registered callbacks


### PR DESCRIPTION
## Description of Change

This pull request refactors the `NetworkEvents` class to improve thread safety and portability by replacing the use of the C++ `std::mutex` with a FreeRTOS semaphore (`SemaphoreHandle_t`) for protecting access to the event callback list. This ensures correct synchronization and avoiding crashes on both single-core and multi-core systems, and removes conditional compilation based on core count.

Key changes:

**Synchronization and Thread Safety:**
* Replaced all usage of `std::mutex` and related C++ locking constructs with FreeRTOS semaphore (`xSemaphoreTake`/`xSemaphoreGive`) to protect access to `_cbEventList`, ensuring thread safety across all supported platforms, regardless of the number of CPU cores. [[1]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886L122-R131) [[2]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886L145-R152) [[3]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886L170-R247) [[4]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886R257-R265) [[5]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886R275-R283) [[6]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886R293-R297) [[7]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886R307)
* Created the semaphore in the `NetworkEvents` constructor and deleted it in the destructor to manage its lifecycle and prevent resource leaks. [[1]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886L18-R23) [[2]](diffhunk://#diff-e018f5e4afc57971155f44c13fbd663eeec0e982ac987f81cdeaed2630656886R43-R46)

**Code Simplification and Portability:**
* Removed all conditional compilation and code dependencies on `std::mutex`, making the codebase simpler and more portable to environments where the C++ standard library is unavailable or undesirable. [[1]](diffhunk://#diff-e97f4086d35f03b5c11e58388816516e0b9d7daa3aa84da8e0a68140683afee1L22-L24) [[2]](diffhunk://#diff-e97f4086d35f03b5c11e58388816516e0b9d7daa3aa84da8e0a68140683afee1L307-R308)

These changes make the event system more robust and maintainable in the context of embedded systems using FreeRTOS.

## Test Scenarios

Tested locally with the same sketch where I found this bug