### PR TITLE
fix(zigbee): Fix missing Zigbee lock in getTime() and getTimezone() in ZigbeeEP causing assert crash

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -485,7 +485,9 @@ tm ZigbeeEP::getTime(uint8_t endpoint, int32_t short_addr, esp_zb_ieee_addr_t ie
   _read_time = 0;
 
   log_v("Reading time from endpoint %u", endpoint);
+  esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_read_attr_cmd_req(&read_req);
+  esp_zb_lock_release();
 
   //Wait for response or timeout
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -539,7 +541,9 @@ int32_t ZigbeeEP::getTimezone(uint8_t endpoint, int32_t short_addr, esp_zb_ieee_
   _read_timezone = 0;
 
   log_v("Reading timezone from endpoint %u", endpoint);
+  esp_zb_lock_acquire(portMAX_DELAY);
   esp_zb_zcl_read_attr_cmd_req(&read_req);
+  esp_zb_lock_release();
 
   //Wait for response or timeout
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {


### PR DESCRIPTION
## Description of Change

`ZigbeeEP::getTime()` and `ZigbeeEP::getTimezone()` call `esp_zb_zcl_read_attr_cmd_req()` without holding the Zigbee lock (`esp_zb_lock_acquire`), while all other similar API calls in the library are correctly wrapped with it.

This causes a race condition: when these methods are called from a non-Zigbee task context, the unprotected call to `esp_zb_zcl_read_attr_cmd_req()` corrupts FreeRTOS critical section nesting, resulting in:

```
assert failed: vPortExitCritical port.c:618 (port_uxCriticalNesting[0] > 0)
```

The fix wraps **only** the `esp_zb_zcl_read_attr_cmd_req()` call with `esp_zb_lock_acquire/release` as it is normally done for all esp_zb_zcl_read_attr_cmd_req calls.

## Test Scenarios

Tested on **ESP32-H2** with **arduino-esp32 core v3.3.8**.

Zigbee coordinator: **ZHA** on **Home Assistant OS 17.3** (Core 2026.5.1).

- Reproduced the crash in ~1 out of 5–10 calls to `getTime()` / `getTimezone()` before the fix
- After applying the fix, no crashes observed across repeated calls

## Related links

No existing issue — the root cause was identified during investigation of the crash.