### PR TITLE
fix(tests): Fixed issue with uart validation due to delayed message

### DIFF
--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -449,6 +449,14 @@ void auto_baudrate_test(void) {
 
   TEST_ASSERT_UINT_WITHIN(2304, 115200, baudrate);
 
+  // Drain and assert the message that was used for baudrate detection
+  // This validates that the data was received correctly AND prevents the
+  // bytes from leaking into subsequent tests.
+  String received = selected_serial->readStringUntil('\n');
+  received.trim();
+  TEST_ASSERT_EQUAL_STRING("Hello to detect baudrate", received.c_str());
+  log_d("UART%d received message: %s\n", uart_num, recv_msg.c_str());
+  
   Serial.println("Auto baudrate test successful");
 }
 #endif


### PR DESCRIPTION
## Description of Change
`same_uart_pin_swap_test` is failing with:

```
Expected 'Hello from Serial1 after pin swap'
Was 'Hello to detect baudrateHello from Serial1 after pin swap'
```
Root cause: `auto_baudrate_test` spawns a `task_delayed_msg` task that sends `"Hello to detect baudrate\r\n"` over the selected_serial UART with delay(1500).
`selected_serial->begin(0)` blocks until the baudrate is detected from those incoming bytes, but the bytes themselves are **never read or asserted** - they remain sitting in the FIFO.
Because the UART has `uart_internal_loopback()` active, those stale bytes are later picked up by the `onReceive` callback in the next test (`same_uart_pin_swap_test`), corrupting its `recv_msg` buffer.

Fix: After the baudrate assertion in `auto_baudrate_test`, drain and validate the received message using `readStringUntil('\n')` (which stops at the `\r\n` from `println` without waiting for the full `Stream` timeout) followed by `trim()`.

This:
1. Adds a missing assertion - the content of the auto-baudrate message was never validated, only the detected baudrate was.
2. Drains the RX FIFO - prevents the stale bytes from leaking into subsequent tests.


## Test Scenarios
Tested on Wokwi simulation targeting ESP32 via the existing CI pipeline (`tests/validation/uart`).
The failing test `same_uart_pin_swap_test` now passes without corrupting `recv_msg`, and `auto_baudrate_test` additionally validates the full received string.