### PR TITLE
feat(hosted): Add support for getting the target chip name

### DIFF
--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -69,6 +69,22 @@ void hostedGetSlaveVersion(uint32_t *major, uint32_t *minor, uint32_t *patch) {
   *patch = slave_version_struct.patch1;
 }
 
+const char * hostedGetSlaveTargetName() {
+#if ESP_HOSTED_VERSION_VAL(ESP_HOSTED_VERSION_MAJOR_1, ESP_HOSTED_VERSION_MINOR_1, ESP_HOSTED_VERSION_PATCH_1) < ESP_HOSTED_VERSION_VAL(2, 12, 2)
+  return CONFIG_IDF_SLAVE_TARGET;
+#else
+  uint32_t chip_id = 0;
+  char target_name[20] = {0};
+  size_t target_name_len = sizeof(target_name);
+  esp_err_t ret = esp_hosted_get_cp_info(&chip_id, target_name, target_name_len);
+  if (ret != ESP_OK) {
+    log_e("Could not get slave target name: %s", esp_err_to_name(ret));
+    return CONFIG_IDF_SLAVE_TARGET;
+  }
+  return target_name;
+#endif
+}
+
 bool hostedHasUpdate() {
   if (!hosted_initialized) {
     log_e("ESP-Hosted is not initialized");
@@ -104,11 +120,12 @@ bool hostedHasUpdate() {
   return false;
 }
 
-char *hostedGetUpdateURL() {
+const char *hostedGetUpdateURL() {
   // https://espressif.github.io/arduino-esp32/hosted/esp32c6-v1.2.3.bin
   static char url[92] = {0};
+  const char *target_name = hostedGetSlaveTargetName();
   snprintf(
-    url, 92, "https://espressif.github.io/arduino-esp32/hosted/%s-v%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".bin", CONFIG_ESP_HOSTED_IDF_SLAVE_TARGET,
+    url, 92, "https://espressif.github.io/arduino-esp32/hosted/%s-v%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".bin", target_name,
     host_version_struct.major1, host_version_struct.minor1, host_version_struct.patch1
   );
   return url;

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -74,7 +74,7 @@ const char * hostedGetSlaveTargetName() {
   return CONFIG_IDF_SLAVE_TARGET;
 #else
   uint32_t chip_id = 0;
-  char target_name[20] = {0};
+  static char target_name[20] = {0};
   size_t target_name_len = sizeof(target_name);
   esp_err_t ret = esp_hosted_get_cp_info(&chip_id, target_name, target_name_len);
   if (ret != ESP_OK) {
@@ -125,7 +125,7 @@ const char *hostedGetUpdateURL() {
   static char url[92] = {0};
   const char *target_name = hostedGetSlaveTargetName();
   snprintf(
-    url, 92, "https://espressif.github.io/arduino-esp32/hosted/%s-v%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".bin", target_name,
+    url, sizeof(url), "https://espressif.github.io/arduino-esp32/hosted/%s-v%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".bin", target_name,
     host_version_struct.major1, host_version_struct.minor1, host_version_struct.patch1
   );
   return url;

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -69,7 +69,7 @@ void hostedGetSlaveVersion(uint32_t *major, uint32_t *minor, uint32_t *patch) {
   *patch = slave_version_struct.patch1;
 }
 
-const char * hostedGetSlaveTargetName() {
+const char *hostedGetSlaveTargetName() {
 #if ESP_HOSTED_VERSION_VAL(ESP_HOSTED_VERSION_MAJOR_1, ESP_HOSTED_VERSION_MINOR_1, ESP_HOSTED_VERSION_PATCH_1) < ESP_HOSTED_VERSION_VAL(2, 12, 2)
   return CONFIG_IDF_SLAVE_TARGET;
 #else
@@ -125,8 +125,8 @@ const char *hostedGetUpdateURL() {
   static char url[92] = {0};
   const char *target_name = hostedGetSlaveTargetName();
   snprintf(
-    url, sizeof(url), "https://espressif.github.io/arduino-esp32/hosted/%s-v%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".bin", target_name,
-    host_version_struct.major1, host_version_struct.minor1, host_version_struct.patch1
+    url, sizeof(url), "https://espressif.github.io/arduino-esp32/hosted/%s-v%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".bin", target_name, host_version_struct.major1,
+    host_version_struct.minor1, host_version_struct.patch1
   );
   return url;
 }

--- a/cores/esp32/esp32-hal-hosted.h
+++ b/cores/esp32/esp32-hal-hosted.h
@@ -46,7 +46,7 @@ bool hostedSetPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8
 void hostedGetPins(int8_t *clk, int8_t *cmd, int8_t *d0, int8_t *d1, int8_t *d2, int8_t *d3, int8_t *rst);
 void hostedGetHostVersion(uint32_t *major, uint32_t *minor, uint32_t *patch);
 void hostedGetSlaveVersion(uint32_t *major, uint32_t *minor, uint32_t *patch);
-const char * hostedGetSlaveTargetName();
+const char *hostedGetSlaveTargetName();
 bool hostedHasUpdate();
 const char *hostedGetUpdateURL();
 bool hostedBeginUpdate();

--- a/cores/esp32/esp32-hal-hosted.h
+++ b/cores/esp32/esp32-hal-hosted.h
@@ -46,8 +46,9 @@ bool hostedSetPins(int8_t clk, int8_t cmd, int8_t d0, int8_t d1, int8_t d2, int8
 void hostedGetPins(int8_t *clk, int8_t *cmd, int8_t *d0, int8_t *d1, int8_t *d2, int8_t *d3, int8_t *rst);
 void hostedGetHostVersion(uint32_t *major, uint32_t *minor, uint32_t *patch);
 void hostedGetSlaveVersion(uint32_t *major, uint32_t *minor, uint32_t *patch);
+const char * hostedGetSlaveTargetName();
 bool hostedHasUpdate();
-char *hostedGetUpdateURL();
+const char *hostedGetUpdateURL();
 bool hostedBeginUpdate();
 bool hostedWriteUpdate(uint8_t *buf, uint32_t len);
 bool hostedEndUpdate();


### PR DESCRIPTION
This pull request updates the ESP-Hosted interface to improve how the slave target name is retrieved and used, and refines the update URL generation to be more robust and version-aware. The changes also update function signatures for better type safety.

### Improvements to slave target name retrieval

* Added a new function `hostedGetSlaveTargetName()` to dynamically retrieve the slave target name, using different logic depending on the ESP-Hosted version. For versions 2.12.2 and above, it queries the chip for its target name, with a fallback to the configuration value if the query fails.

### Update URL generation

* Modified `hostedGetUpdateURL()` to use the new `hostedGetSlaveTargetName()` function, ensuring the correct target name is always used in the update URL. Also changed its return type to `const char *` for consistency and safety. [[1]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bL107-R128) [[2]](diffhunk://#diff-d4db1cef3565d101085515c2368696512fbe57c542bdb638af7dc3d61fc2be64R49-R51)

### API changes

* Updated the declarations in `esp32-hal-hosted.h` for `hostedGetSlaveTargetName()` and `hostedGetUpdateURL()` to use `const char *` as the return type, reflecting the implementation changes and improving type correctness.