### PR TITLE
fix(ticker): Fix race condition and warnings

### DIFF
--- a/libraries/Ticker/src/Ticker.h
+++ b/libraries/Ticker/src/Ticker.h
@@ -61,19 +61,25 @@ public:
   // restriction applies, but keep TArg small to avoid a std::function heap allocation.
   template<typename TArg> void attach(float seconds, void (*callback)(TArg), TArg arg) {
     detach();
-    _callback_function = [callback, arg]() { callback(arg); };
+    _callback_function = [callback, arg]() {
+      callback(arg);
+    };
     _attach_us(1000000ULL * seconds, true, _static_callback, this);
   }
 
   template<typename TArg> void attach_ms(uint64_t milliseconds, void (*callback)(TArg), TArg arg) {
     detach();
-    _callback_function = [callback, arg]() { callback(arg); };
+    _callback_function = [callback, arg]() {
+      callback(arg);
+    };
     _attach_us(1000ULL * milliseconds, true, _static_callback, this);
   }
 
   template<typename TArg> void attach_us(uint64_t micros, void (*callback)(TArg), TArg arg) {
     detach();
-    _callback_function = [callback, arg]() { callback(arg); };
+    _callback_function = [callback, arg]() {
+      callback(arg);
+    };
     _attach_us(micros, true, _static_callback, this);
   }
 
@@ -98,19 +104,25 @@ public:
   // Same as attach typed-argument overloads above, but one-shot.
   template<typename TArg> void once(float seconds, void (*callback)(TArg), TArg arg) {
     detach();
-    _callback_function = [callback, arg]() { callback(arg); };
+    _callback_function = [callback, arg]() {
+      callback(arg);
+    };
     _attach_us(1000000ULL * seconds, false, _static_callback, this);
   }
 
   template<typename TArg> void once_ms(uint64_t milliseconds, void (*callback)(TArg), TArg arg) {
     detach();
-    _callback_function = [callback, arg]() { callback(arg); };
+    _callback_function = [callback, arg]() {
+      callback(arg);
+    };
     _attach_us(1000ULL * milliseconds, false, _static_callback, this);
   }
 
   template<typename TArg> void once_us(uint64_t micros, void (*callback)(TArg), TArg arg) {
     detach();
-    _callback_function = [callback, arg]() { callback(arg); };
+    _callback_function = [callback, arg]() {
+      callback(arg);
+    };
     _attach_us(micros, false, _static_callback, this);
   }
 

--- a/libraries/Ticker/src/Ticker.h
+++ b/libraries/Ticker/src/Ticker.h
@@ -39,66 +39,79 @@ public:
   typedef std::function<void(void)> callback_function_t;
 
   void attach(float seconds, callback_function_t callback) {
+    detach();
     _callback_function = std::move(callback);
     _attach_us(1000000ULL * seconds, true, _static_callback, this);
   }
 
   void attach_ms(uint64_t milliseconds, callback_function_t callback) {
+    detach();
     _callback_function = std::move(callback);
     _attach_us(1000ULL * milliseconds, true, _static_callback, this);
   }
 
   void attach_us(uint64_t micros, callback_function_t callback) {
+    detach();
     _callback_function = std::move(callback);
     _attach_us(micros, true, _static_callback, this);
   }
 
+  // Typed-argument overloads: the lambda captures callback and arg by value, so
+  // TArg is passed directly without casting through void*. No pointer-size
+  // restriction applies, but keep TArg small to avoid a std::function heap allocation.
   template<typename TArg> void attach(float seconds, void (*callback)(TArg), TArg arg) {
-    static_assert(sizeof(TArg) <= sizeof(void *), "attach() callback argument size must be <= sizeof(void*)");
-    // C-cast serves two purposes:
-    // static_cast for smaller integer types,
-    // reinterpret_cast + const_cast for pointer types
-    _attach_us(1000000ULL * seconds, true, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
+    detach();
+    _callback_function = [callback, arg]() { callback(arg); };
+    _attach_us(1000000ULL * seconds, true, _static_callback, this);
   }
 
   template<typename TArg> void attach_ms(uint64_t milliseconds, void (*callback)(TArg), TArg arg) {
-    static_assert(sizeof(TArg) <= sizeof(void *), "attach() callback argument size must be <= sizeof(void*)");
-    _attach_us(1000ULL * milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
+    detach();
+    _callback_function = [callback, arg]() { callback(arg); };
+    _attach_us(1000ULL * milliseconds, true, _static_callback, this);
   }
 
   template<typename TArg> void attach_us(uint64_t micros, void (*callback)(TArg), TArg arg) {
-    static_assert(sizeof(TArg) <= sizeof(void *), "attach() callback argument size must be <= sizeof(void*)");
-    _attach_us(micros, true, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
+    detach();
+    _callback_function = [callback, arg]() { callback(arg); };
+    _attach_us(micros, true, _static_callback, this);
   }
 
   void once(float seconds, callback_function_t callback) {
+    detach();
     _callback_function = std::move(callback);
     _attach_us(1000000ULL * seconds, false, _static_callback, this);
   }
 
   void once_ms(uint64_t milliseconds, callback_function_t callback) {
+    detach();
     _callback_function = std::move(callback);
     _attach_us(1000ULL * milliseconds, false, _static_callback, this);
   }
 
   void once_us(uint64_t micros, callback_function_t callback) {
+    detach();
     _callback_function = std::move(callback);
     _attach_us(micros, false, _static_callback, this);
   }
 
+  // Same as attach typed-argument overloads above, but one-shot.
   template<typename TArg> void once(float seconds, void (*callback)(TArg), TArg arg) {
-    static_assert(sizeof(TArg) <= sizeof(void *), "attach() callback argument size must be <= sizeof(void*)");
-    _attach_us(1000000ULL * seconds, false, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
+    detach();
+    _callback_function = [callback, arg]() { callback(arg); };
+    _attach_us(1000000ULL * seconds, false, _static_callback, this);
   }
 
   template<typename TArg> void once_ms(uint64_t milliseconds, void (*callback)(TArg), TArg arg) {
-    static_assert(sizeof(TArg) <= sizeof(void *), "attach() callback argument size must be <= sizeof(void*)");
-    _attach_us(1000ULL * milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
+    detach();
+    _callback_function = [callback, arg]() { callback(arg); };
+    _attach_us(1000ULL * milliseconds, false, _static_callback, this);
   }
 
   template<typename TArg> void once_us(uint64_t micros, void (*callback)(TArg), TArg arg) {
-    static_assert(sizeof(TArg) <= sizeof(void *), "attach() callback argument size must be <= sizeof(void*)");
-    _attach_us(micros, false, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
+    detach();
+    _callback_function = [callback, arg]() { callback(arg); };
+    _attach_us(micros, false, _static_callback, this);
   }
 
   void restart(float seconds);


### PR DESCRIPTION
## Description of Change

This pull request refactors the callback attachment logic in the `Ticker` class to improve safety and flexibility. The main changes remove pointer-size restrictions on callback arguments and ensure that any existing callback is detached before attaching a new one. This update leverages modern C++ features for safer and more intuitive code.

**Callback management improvements:**

* All `attach` and `once` methods now call `detach()` before setting a new callback, ensuring that previously set callbacks are properly cleared and preventing potential conflicts or resource leaks.

**Typed callback overload enhancements:**

* The typed-argument overloads for `attach` and `once` methods have been rewritten to use lambda captures instead of pointer casting. This removes the previous restriction that callback argument types must be no larger than a pointer, making the API more flexible and type-safe.
* The static assertions and pointer casting logic have been removed from these overloads, simplifying their implementation and reducing the risk of subtle bugs.

**General code modernization:**

* The use of `std::function` and lambda expressions in the callback management makes the code more idiomatic and easier to maintain.

## Test Scenarios

Tested locally
