### PR TITLE
NetworkClient: keep flush from clearing RX data

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -380,7 +380,7 @@ int NetworkClient::read() {
 }
 
 void NetworkClient::flush() {
-  clear();
+  // NetworkClient has no TX buffer; clear() is the explicit RX discard API.
 }
 
 size_t NetworkClient::write(const uint8_t *buf, size_t size) {

--- a/libraries/Network/src/NetworkClient.h
+++ b/libraries/Network/src/NetworkClient.h
@@ -58,7 +58,6 @@ public:
   size_t write_P(PGM_P buf, size_t size);
   size_t write(Stream &stream);
   size_t write(Stream &stream, size_t length);
-  [[deprecated("Use clear() instead.")]]
   void flush();  // Print::flush tx
   int available();
   int read();


### PR DESCRIPTION
## Summary
- Make `NetworkClient::flush()` a Print-compatible no-op instead of discarding receive data.
- Remove the deprecated `Use clear() instead.` marker from `NetworkClient::flush()`; `clear()` remains the explicit RX discard API.

## Verification
- `git diff --check`
- `pio run` in `/tmp/arduino-esp32-flush-check` with this checkout as `framework-arduinoespressif32` and `-Werror=deprecated-declarations`

Closes #12544