### PR TITLE
feat(hwcdc): Add stub for updateBaudRate to avoid crashes

### DIFF
--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2015-2026 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -469,6 +469,15 @@ void HWCDC::begin(unsigned long baud) {
 err:
   log_e("Serial JTAG Pin %u can't be set into Peripheral Manager.", pin);
   end();
+}
+
+void HWCDC::updateBaudRate(unsigned long baud) {
+  log_w("USB Serial/JTAG baud rate is set by the USB standard; updateBaudRate(%lu) has no effect", baud);
+}
+
+uint32_t HWCDC::baudRate() {
+  log_w("USB Serial/JTAG does not have a configurable baud rate");
+  return 115200;
 }
 
 void HWCDC::end() {

--- a/cores/esp32/HWCDC.h
+++ b/cores/esp32/HWCDC.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2015-2026 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,9 +103,8 @@ public:
   }
   operator bool() const;
   void setDebugOutput(bool);
-  uint32_t baudRate() {
-    return 115200;
-  }
+  void updateBaudRate(unsigned long baud);
+  uint32_t baudRate();
 };
 #if ARDUINO_USB_MODE && ARDUINO_USB_CDC_ON_BOOT  // Hardware JTAG CDC selected
 #ifndef HWCDC_SERIAL_IS_DEFINED


### PR DESCRIPTION
## Description of Change

This pull request updates the `HWCDC` class in the ESP32 core to clarify the handling of baud rate for USB Serial/JTAG and improves code clarity. The most important changes are:

**Baud Rate Handling Improvements:**

* Added a new `updateBaudRate(unsigned long baud)` method to `HWCDC` that logs a warning indicating baud rate changes have no effect for USB Serial/JTAG, since the baud rate is set by the USB standard. (`HWCDC.cpp`, `HWCDC.h`) [[1]](diffhunk://#diff-7249b9fe4e4776c9c695cecc060d2cbff5e34d655e70c9ce90735785d00e673dR474-R482) [[2]](diffhunk://#diff-fcdd8322b8f8607c19b05aca2c405b7460022aad4761e6dd6f6a63960fd2cf0bL106-R107)
* Modified the `baudRate()` method to log a warning when called, clarifying that the baud rate is not configurable, and returns a default value of `115200`. (`HWCDC.cpp`, `HWCDC.h`) [[1]](diffhunk://#diff-7249b9fe4e4776c9c695cecc060d2cbff5e34d655e70c9ce90735785d00e673dR474-R482) [[2]](diffhunk://#diff-fcdd8322b8f8607c19b05aca2c405b7460022aad4761e6dd6f6a63960fd2cf0bL106-R107)

**General Maintenance:**

* Updated the copyright year in `HWCDC.h`.

## Test Scenarios

Tested locally
