### PR TITLE
refactor(ci): Merge env variables in a common file

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -1338,7 +1338,7 @@ bash .github/scripts/check_official_variants.sh \
 
 **Features:**
 - Sources `socs_config.sh` for targets
-- Builds tests with Arduino CLI
+- Builds tests with `arduino_cmake.py` by default, or Arduino CLI with `--arduino-cli`
 - Supports multiple test types
 
 #### `tests_run.sh`

--- a/.github/scripts/env.sh
+++ b/.github/scripts/env.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Common environment setup for build and test scripts
+# Sets: OS_IS_*, OS_NAME, ARDUINO_USR_PATH, ARDUINO_ESP32_PATH,
+#       GITHUB_WORKSPACE, REPO_ROOT, SDKCONFIG_DIR
+
+# Skip if already sourced
+[ -n "$ENV_SOURCED" ] && return 0
+ENV_SOURCED=1
+
+ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# OS detection
+OSBITS=$(uname -m)
+if [[ "$OSTYPE" == "linux"* ]]; then
+    export OS_IS_LINUX="1"
+    if [[ "$OSBITS" == "i686" ]]; then
+        OS_NAME="linux32"
+    elif [[ "$OSBITS" == "x86_64" ]]; then
+        OS_NAME="linux64"
+    elif [[ "$OSBITS" == "armv7l" || "$OSBITS" == "aarch64" ]]; then
+        OS_NAME="linuxarm"
+    else
+        OS_NAME="$OSTYPE-$OSBITS"
+        echo "Unknown OS '$OS_NAME'"
+        exit 1
+    fi
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    export OS_IS_MACOS="1"
+    OS_NAME="macosx"
+elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
+    export OS_IS_WINDOWS="1"
+    OS_NAME="windows"
+else
+    OS_NAME="$OSTYPE-$OSBITS"
+    echo "Unknown OS '$OS_NAME'"
+    exit 1
+fi
+export OS_NAME
+
+# Arduino paths
+if [ "$OS_IS_MACOS" == "1" ]; then
+    export ARDUINO_USR_PATH="$HOME/Documents/Arduino"
+elif [ "$OS_IS_WINDOWS" == "1" ]; then
+    export ARDUINO_USR_PATH="$HOME/Documents/Arduino"
+else
+    export ARDUINO_USR_PATH="$HOME/Arduino"
+fi
+
+export ARDUINO_ESP32_PATH="$ARDUINO_USR_PATH/hardware/espressif/esp32"
+
+# GITHUB_WORKSPACE fallback for local runs
+if [ -z "$GITHUB_WORKSPACE" ]; then
+    export GITHUB_WORKSPACE="$(cd "$ENV_DIR/../.." && pwd)"
+fi
+
+# Repository root and sdkconfig paths
+if [ -d "$ARDUINO_ESP32_PATH/tools/esp32-arduino-libs" ]; then
+    REPO_ROOT="$ARDUINO_ESP32_PATH"
+elif [ -d "$GITHUB_WORKSPACE/tools/esp32-arduino-libs" ]; then
+    REPO_ROOT="$GITHUB_WORKSPACE"
+else
+    REPO_ROOT="$(cd "$ENV_DIR/../.." && pwd)"
+fi
+
+export REPO_ROOT
+export SDKCONFIG_DIR="$REPO_ROOT/tools/esp32-arduino-libs"

--- a/.github/scripts/install-arduino-cli.sh
+++ b/.github/scripts/install-arduino-cli.sh
@@ -1,43 +1,9 @@
 #!/bin/bash
 
-OSBITS=$(uname -m)
-if [[ "$OSTYPE" == "linux"* ]]; then
-    export OS_IS_LINUX="1"
-    if [[ "$OSBITS" == "i686" ]]; then
-        OS_NAME="linux32"
-    elif [[ "$OSBITS" == "x86_64" ]]; then
-        OS_NAME="linux64"
-    elif [[ "$OSBITS" == "armv7l" || "$OSBITS" == "aarch64" ]]; then
-        OS_NAME="linuxarm"
-    else
-        OS_NAME="$OSTYPE-$OSBITS"
-        echo "Unknown OS '$OS_NAME'"
-        exit 1
-    fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    export OS_IS_MACOS="1"
-    OS_NAME="macosx"
-elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
-    export OS_IS_WINDOWS="1"
-    OS_NAME="windows"
-else
-    OS_NAME="$OSTYPE-$OSBITS"
-    echo "Unknown OS '$OS_NAME'"
-    exit 1
-fi
-export OS_NAME
+SCRIPTS_DIR_CLI="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTS_DIR_CLI}/env.sh"
 
-if [ "$OS_IS_MACOS" == "1" ]; then
-    export ARDUINO_IDE_PATH="$HOME/bin"
-    export ARDUINO_USR_PATH="$HOME/Documents/Arduino"
-elif [ "$OS_IS_WINDOWS" == "1" ]; then
-    export ARDUINO_IDE_PATH="$HOME/bin"
-    export ARDUINO_USR_PATH="$HOME/Documents/Arduino"
-else
-    export ARDUINO_IDE_PATH="$HOME/bin"
-    export ARDUINO_USR_PATH="$HOME/Arduino"
-fi
-
+export ARDUINO_IDE_PATH="$HOME/bin"
 if [ ! -d "$ARDUINO_IDE_PATH" ] || [ ! -f "$ARDUINO_IDE_PATH/arduino-cli" ]; then
     echo "Installing Arduino CLI on $OS_NAME ..."
     mkdir -p "$ARDUINO_IDE_PATH"

--- a/.github/scripts/install-arduino-core-esp32.sh
+++ b/.github/scripts/install-arduino-core-esp32.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-export ARDUINO_ESP32_PATH="$ARDUINO_USR_PATH/hardware/espressif/esp32"
+SCRIPTS_DIR_CORE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTS_DIR_CORE}/env.sh"
+
 if [ ! -d "$ARDUINO_ESP32_PATH" ]; then
     echo "Installing ESP32 Arduino Core ..."
     script_init_path="$PWD"

--- a/.github/scripts/install-arduino-ide.sh
+++ b/.github/scripts/install-arduino-ide.sh
@@ -4,45 +4,23 @@
 #OSTYPE: 'msys', ARCH: 'x86_64' => win32
 #OSTYPE: 'darwin18', ARCH: 'i386' => macos
 
-OSBITS=$(uname -m)
-if [[ "$OSTYPE" == "linux"* ]]; then
-    export OS_IS_LINUX="1"
+SCRIPTS_DIR_IDE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTS_DIR_IDE}/env.sh"
+
+if [ "$OS_IS_LINUX" == "1" ]; then
     ARCHIVE_FORMAT="tar.xz"
-    if [[ "$OSBITS" == "i686" ]]; then
-        OS_NAME="linux32"
-    elif [[ "$OSBITS" == "x86_64" ]]; then
-        OS_NAME="linux64"
-    elif [[ "$OSBITS" == "armv7l" || "$OSBITS" == "aarch64" ]]; then
-        OS_NAME="linuxarm"
-    else
-        OS_NAME="$OSTYPE-$OSBITS"
-        echo "Unknown OS '$OS_NAME'"
-        exit 1
-    fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    export OS_IS_MACOS="1"
+elif [ "$OS_IS_WINDOWS" == "1" ]; then
     ARCHIVE_FORMAT="zip"
-    OS_NAME="macosx"
-elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
-    export OS_IS_WINDOWS="1"
-    ARCHIVE_FORMAT="zip"
-    OS_NAME="windows"
 else
-    OS_NAME="$OSTYPE-$OSBITS"
-    echo "Unknown OS '$OS_NAME'"
-    exit 1
+    ARCHIVE_FORMAT="zip"
 fi
-export OS_NAME
 
 if [ "$OS_IS_MACOS" == "1" ]; then
     export ARDUINO_IDE_PATH="/Applications/Arduino.app/Contents/Java"
-    export ARDUINO_USR_PATH="$HOME/Documents/Arduino"
 elif [ "$OS_IS_WINDOWS" == "1" ]; then
     export ARDUINO_IDE_PATH="$HOME/arduino_ide"
-    export ARDUINO_USR_PATH="$HOME/Documents/Arduino"
 else
     export ARDUINO_IDE_PATH="$HOME/arduino_ide"
-    export ARDUINO_USR_PATH="$HOME/Arduino"
 fi
 
 # Updated as of Nov 3rd 2020

--- a/.github/scripts/on-push.sh
+++ b/.github/scripts/on-push.sh
@@ -21,7 +21,7 @@ function build {
     local BUILD_SKETCH="${SCRIPTS_DIR}/sketch_utils.sh build"
     local BUILD_SKETCHES="${SCRIPTS_DIR}/sketch_utils.sh chunk_build"
 
-    local args=("-ai" "$ARDUINO_IDE_PATH" "-au" "$ARDUINO_USR_PATH" "-t" "$target")
+    local args=("-au" "$ARDUINO_USR_PATH" "-t" "$target")
 
     if [ "$OS_IS_LINUX" == "1" ]; then
         args+=("-p" "$ARDUINO_ESP32_PATH/libraries" "-i" "$chunk_index" "-m" "$chunks_cnt" "-d" "$log_level")
@@ -51,8 +51,7 @@ function build {
     fi
 }
 
-if [ -z "$GITHUB_WORKSPACE" ]; then
-    export GITHUB_WORKSPACE="$PWD"
+if [ -z "$GITHUB_REPOSITORY" ]; then
     export GITHUB_REPOSITORY="espressif/arduino-esp32"
 fi
 
@@ -75,7 +74,7 @@ fi
 #echo "Updating submodules ..."
 #git -C "$GITHUB_WORKSPACE" submodule update --init --recursive > /dev/null 2>&1
 
-source "${SCRIPTS_DIR}/install-arduino-cli.sh"
+source "${SCRIPTS_DIR}/env.sh"
 source "${SCRIPTS_DIR}/install-arduino-core-esp32.sh"
 
 SKETCHES_ESP32=(

--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 
-if [ -d "$ARDUINO_ESP32_PATH/tools/esp32-arduino-libs" ]; then
-    REPO_ROOT="$ARDUINO_ESP32_PATH"
-elif [ -d "$GITHUB_WORKSPACE/tools/esp32-arduino-libs" ]; then
-    REPO_ROOT="$GITHUB_WORKSPACE"
-else
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-fi
-
-SDKCONFIG_DIR="$REPO_ROOT/tools/esp32-arduino-libs"
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTS_DIR}/env.sh"
 
 function check_requirements { # check_requirements <sketchdir> <sdkconfig_path>
     local sketchdir=$1
@@ -641,7 +634,7 @@ print_err_warnings() {
     fi
 }
 
-function install_libs { # install_libs <ide_path> <sketchdir> [-v]
+function install_libs { # install_libs [-ai <cli_path>] -s <sketchdir> [-v]
     local ide_path=""
     local sketchdir=""
     local verbose=false
@@ -653,25 +646,16 @@ function install_libs { # install_libs <ide_path> <sketchdir> [-v]
         -v  ) verbose=true ;;
         * )
             echo "ERROR: Unknown argument: $1" >&2
-            echo "USAGE: install_libs -ai <ide_path> -s <sketchdir> [-v]" >&2
+            echo "USAGE: install_libs [-ai <cli_path>] -s <sketchdir> [-v]" >&2
             return 1
             ;;
         esac
         shift
     done
 
-    if [ -z "$ide_path" ]; then
-        echo "ERROR: IDE path not provided" >&2
-        echo "USAGE: install_libs -ai <ide_path> -s <sketchdir> [-v]" >&2
-        return 1
-    fi
     if [ -z "$sketchdir" ]; then
         echo "ERROR: Sketch directory not provided" >&2
-        echo "USAGE: install_libs -ai <ide_path> -s <sketchdir> [-v]" >&2
-        return 1
-    fi
-    if [ ! -f "$ide_path/arduino-cli" ]; then
-        echo "ERROR: arduino-cli not found at $ide_path/arduino-cli" >&2
+        echo "USAGE: install_libs [-ai <cli_path>] -s <sketchdir> [-v]" >&2
         return 1
     fi
 
@@ -699,6 +683,16 @@ function install_libs { # install_libs <ide_path> <sketchdir> [-v]
     if [ "$libs_count" -eq 0 ]; then
         [ "$verbose" = true ] && echo "libs array is empty in ci.yml, skipping library installation"
         return 0
+    fi
+
+    if [ -z "$ide_path" ] || [ ! -f "$ide_path/arduino-cli" ]; then
+        echo "arduino-cli not found, installing for library support..."
+        source "${SCRIPTS_DIR}/install-arduino-cli.sh"
+        ide_path="$ARDUINO_IDE_PATH"
+        if [ ! -f "$ide_path/arduino-cli" ]; then
+            echo "ERROR: Failed to install arduino-cli" >&2
+            return 1
+        fi
     fi
 
     echo "Installing $libs_count libraries from $sketchdir/ci.yml"

--- a/.github/scripts/tests_build.sh
+++ b/.github/scripts/tests_build.sh
@@ -176,14 +176,17 @@ while [ -n "$1" ]; do
 done
 
 set -e
-source "${SCRIPTS_DIR}/install-arduino-cli.sh"
+source "${SCRIPTS_DIR}/env.sh"
+if [ "${use_arduino_cli:-0}" -eq 1 ]; then
+    source "${SCRIPTS_DIR}/install-arduino-cli.sh"
+fi
 source "${SCRIPTS_DIR}/install-arduino-core-esp32.sh"
 source "${SCRIPTS_DIR}/tests_utils.sh"
 set +e
 
-args=("-ai" "$ARDUINO_IDE_PATH" "-au" "$ARDUINO_USR_PATH")
+args=("-au" "$ARDUINO_USR_PATH")
 if [ "${use_arduino_cli:-0}" -eq 1 ]; then
-    args+=("--arduino-cli")
+    args+=("-ai" "$ARDUINO_IDE_PATH" "--arduino-cli")
 fi
 
 # Parse comma-separated targets


### PR DESCRIPTION
## Description of Change

This pull request refactors and streamlines the environment setup and script logic for CI build and test workflows. The main focus is on centralizing environment detection and variable initialization into a new shared script, reducing code duplication and improving maintainability across all CI scripts. Additionally, the changes clarify the usage of build tools and enhance robustness in library installation.

**Centralized environment setup:**

* Added a new `env.sh` script to handle OS detection, path setup, and key environment variables. All build and test scripts now source this file, removing duplicated environment logic from individual scripts.
* Updated `install-arduino-cli.sh`, `install-arduino-core-esp32.sh`, `install-arduino-ide.sh`, `sketch_utils.sh`, `on-push.sh`, and `tests_build.sh` to source `env.sh` for consistent environment setup. [[1]](diffhunk://#diff-4502af5f8dbd3fec5b513c592ca6fa29adcfbbc03d203885fa60885efc3a510fL3-L40) [[2]](diffhunk://#diff-564574e752a998613b7df404ff69157f411a33c2002385546ffb462edf4ee4e2L3-R5) [[3]](diffhunk://#diff-7395fcab4ca3631645fe042dfdef606c281b024a79555623ffd42db004d83512L7-L45) [[4]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L3-R4) [[5]](diffhunk://#diff-69e60b602c9704198a3cf61eea0e6673e3ced88c6279d830c31c2a15a63c3154L78-R77) [[6]](diffhunk://#diff-d950f68457d32f433b4b052cc4a3c92ef2b41c1301e72492cccb5d0c3894e24eR179-R189)

**Build and test script improvements:**

* Modified build and test scripts to clarify that `arduino_cmake.py` is now the default build tool, with Arduino CLI available via a flag. Updated documentation to reflect this.
* Simplified argument passing in build and test scripts by removing unnecessary IDE path arguments when not using Arduino CLI. [[1]](diffhunk://#diff-69e60b602c9704198a3cf61eea0e6673e3ced88c6279d830c31c2a15a63c3154L24-R24) [[2]](diffhunk://#diff-d950f68457d32f433b4b052cc4a3c92ef2b41c1301e72492cccb5d0c3894e24eR179-R189)

**Robustness and maintainability:**

* Improved `install_libs` logic in `sketch_utils.sh` to automatically install Arduino CLI if not present, ensuring required tools are always available for library installation. [[1]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L663-L676) [[2]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5R688-R697)
* Cleaned up redundant or obsolete code, such as removing duplicate GITHUB_WORKSPACE fallback logic and unnecessary checks.

These changes make the CI scripts more modular, easier to maintain, and less error-prone by consolidating environment logic and clarifying tool usage.

## Test Scenarios

Locally and CI


