### PR TITLE
feat(esp32p4): add LDO HAL with periman auto-rail and SDMMC handover

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(CORE_SRCS
   cores/esp32/esp32-hal-matrix.c
   cores/esp32/esp32-hal-misc.c
   cores/esp32/esp32-hal-periman.c
+  cores/esp32/esp32-hal-ldo.c
   cores/esp32/esp32-hal-psram.c
   cores/esp32/esp32-hal-rgb-led.c
   cores/esp32/esp32-hal-sigmadelta.c

--- a/cores/esp32/esp32-hal-ldo.c
+++ b/cores/esp32/esp32-hal-ldo.c
@@ -21,10 +21,11 @@ esp_err_t ldoAcquireChannel(uint8_t chan_id, int voltage_mv, bool adjustable, ld
   esp_ldo_channel_config_t cfg = {
     .chan_id = (int)chan_id,
     .voltage_mv = voltage_mv,
-    .flags = {
-      .adjustable = adjustable ? 1u : 0u,
-      .owned_by_hw = 0u,
-    },
+    .flags =
+      {
+        .adjustable = adjustable ? 1u : 0u,
+        .owned_by_hw = 0u,
+      },
   };
   esp_err_t err = esp_ldo_acquire_channel(&cfg, out_handle);
   if (err != ESP_OK) {

--- a/cores/esp32/esp32-hal-ldo.c
+++ b/cores/esp32/esp32-hal-ldo.c
@@ -28,7 +28,7 @@ esp_err_t ldoAcquireChannel(uint8_t chan_id, int voltage_mv, bool adjustable, ld
   };
   esp_err_t err = esp_ldo_acquire_channel(&cfg, out_handle);
   if (err != ESP_OK) {
-    log_w("ldoAcquireChannel: chan=%u %dmV adj=%d failed: %s", (unsigned)chan_id, voltage_mv, adjustable, esp_err_to_name(err));
+    log_e("ldoAcquireChannel: chan=%u %dmV adj=%d failed: %s", (unsigned)chan_id, voltage_mv, adjustable, esp_err_to_name(err));
   }
   return err;
 }

--- a/cores/esp32/esp32-hal-ldo.c
+++ b/cores/esp32/esp32-hal-ldo.c
@@ -129,8 +129,8 @@ void ldoPerimanPinBusSet(uint8_t pin, int old_type_as_int, int new_type_as_int) 
   if (!io_ldo_pin_in_range(pin)) {
     return;
   }
-  const bool old_active = (old_type_as_int != 0);
-  const bool new_active = (new_type_as_int != 0);
+  const bool old_active = (old_type_as_int != (int)ESP32_BUS_TYPE_INIT);
+  const bool new_active = (new_type_as_int != (int)ESP32_BUS_TYPE_INIT);
 
   if (!old_active && new_active) {
     s_io_ldo_slot.refcount++;

--- a/cores/esp32/esp32-hal-ldo.c
+++ b/cores/esp32/esp32-hal-ldo.c
@@ -124,13 +124,13 @@ static bool io_ldo_channel_matches(uint8_t chan_id) {
 
 #endif /* BOARD_PERIMAN_IO_LDO_AUTO */
 
-void ldoPerimanPinBusSet(uint8_t pin, int old_type_as_int, int new_type_as_int) {
+void ldoPerimanPinBusSet(uint8_t pin, peripheral_bus_type_t old_type, peripheral_bus_type_t new_type) {
 #if BOARD_PERIMAN_IO_LDO_AUTO
   if (!io_ldo_pin_in_range(pin)) {
     return;
   }
-  const bool old_active = (old_type_as_int != (int)ESP32_BUS_TYPE_INIT);
-  const bool new_active = (new_type_as_int != (int)ESP32_BUS_TYPE_INIT);
+  const bool old_active = (old_type != ESP32_BUS_TYPE_INIT);
+  const bool new_active = (new_type != ESP32_BUS_TYPE_INIT);
 
   if (!old_active && new_active) {
     s_io_ldo_slot.refcount++;
@@ -143,8 +143,8 @@ void ldoPerimanPinBusSet(uint8_t pin, int old_type_as_int, int new_type_as_int) 
   }
 #else
   (void)pin;
-  (void)old_type_as_int;
-  (void)new_type_as_int;
+  (void)old_type;
+  (void)new_type;
 #endif
 }
 

--- a/cores/esp32/esp32-hal-ldo.c
+++ b/cores/esp32/esp32-hal-ldo.c
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp32-hal-ldo.h"
+
+#if SOC_GP_LDO_SUPPORTED
+
+#include "esp32-hal-log.h"
+#include "pins_arduino.h"
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+esp_err_t ldoAcquireChannel(uint8_t chan_id, int voltage_mv, bool adjustable, ldo_channel_handle_t *out_handle) {
+  if (out_handle == NULL) {
+    return ESP_ERR_INVALID_ARG;
+  }
+  *out_handle = NULL;
+  esp_ldo_channel_config_t cfg = {
+    .chan_id = (int)chan_id,
+    .voltage_mv = voltage_mv,
+    .flags = {
+      .adjustable = adjustable ? 1u : 0u,
+      .owned_by_hw = 0u,
+    },
+  };
+  esp_err_t err = esp_ldo_acquire_channel(&cfg, out_handle);
+  if (err != ESP_OK) {
+    log_w("ldoAcquireChannel: chan=%u %dmV adj=%d failed: %s", (unsigned)chan_id, voltage_mv, adjustable, esp_err_to_name(err));
+  }
+  return err;
+}
+
+esp_err_t ldoReleaseChannel(ldo_channel_handle_t handle) {
+  if (handle == NULL) {
+    return ESP_ERR_INVALID_ARG;
+  }
+  esp_err_t err = esp_ldo_release_channel(handle);
+  if (err != ESP_OK) {
+    log_e("ldoReleaseChannel: %s", esp_err_to_name(err));
+  }
+  return err;
+}
+
+static int8_t s_sdmmc_ldo_chan = -1;
+
+void ldoSdmmcDriverAttached(uint8_t chan_id) {
+  s_sdmmc_ldo_chan = (int8_t)chan_id;
+}
+
+#if BOARD_PERIMAN_IO_LDO_AUTO
+
+#ifndef BOARD_PERIMAN_IO_LDO0_CHANNEL
+#error "BOARD_PERIMAN_IO_LDO0_CHANNEL required when BOARD_PERIMAN_IO_LDO_AUTO is 1"
+#endif
+#ifndef BOARD_PERIMAN_IO_LDO0_GPIO_MIN
+#error "BOARD_PERIMAN_IO_LDO0_GPIO_MIN required when BOARD_PERIMAN_IO_LDO_AUTO is 1"
+#endif
+#ifndef BOARD_PERIMAN_IO_LDO0_GPIO_MAX
+#error "BOARD_PERIMAN_IO_LDO0_GPIO_MAX required when BOARD_PERIMAN_IO_LDO_AUTO is 1"
+#endif
+#ifndef BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV 3300
+#endif
+
+static const struct {
+  int chan_id;
+  uint8_t gpio_min;
+  uint8_t gpio_max;
+  int voltage_mv;
+} s_io_ldo = {
+  .chan_id = BOARD_PERIMAN_IO_LDO0_CHANNEL,
+  .gpio_min = BOARD_PERIMAN_IO_LDO0_GPIO_MIN,
+  .gpio_max = BOARD_PERIMAN_IO_LDO0_GPIO_MAX,
+  .voltage_mv = BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV,
+};
+
+static struct {
+  int refcount;
+  ldo_channel_handle_t handle;
+} s_io_ldo_slot;
+
+static bool io_ldo_pin_in_range(uint8_t pin) {
+  return (SOC_GPIO_VALID_DIGITAL_IO_PAD_MASK & (1ULL << pin)) != 0ULL && pin >= s_io_ldo.gpio_min && pin <= s_io_ldo.gpio_max;
+}
+
+static void io_ldo_release_handle(void) {
+  if (s_io_ldo_slot.handle == NULL) {
+    return;
+  }
+  if (ldoReleaseChannel(s_io_ldo_slot.handle) == ESP_OK) {
+    log_i("periman IO LDO auto: released channel %d", s_io_ldo.chan_id);
+  }
+  s_io_ldo_slot.handle = NULL;
+}
+
+static void io_ldo_try_acquire(void) {
+  if (s_io_ldo_slot.refcount <= 0 || s_io_ldo_slot.handle != NULL) {
+    return;
+  }
+  if (s_sdmmc_ldo_chan >= 0 && s_sdmmc_ldo_chan == s_io_ldo.chan_id) {
+    log_d("periman IO LDO auto: channel %d held by SDMMC; skip acquire", s_io_ldo.chan_id);
+    return;
+  }
+  if (ldoAcquireChannel((uint8_t)s_io_ldo.chan_id, s_io_ldo.voltage_mv, false, &s_io_ldo_slot.handle) == ESP_OK) {
+    log_i("periman IO LDO auto: enabled channel %d @ %d mV", s_io_ldo.chan_id, s_io_ldo.voltage_mv);
+  } else {
+    s_io_ldo_slot.handle = NULL;
+  }
+}
+
+static void io_ldo_try_release(void) {
+  if (s_io_ldo_slot.refcount != 0 || s_io_ldo_slot.handle == NULL) {
+    return;
+  }
+  io_ldo_release_handle();
+}
+
+static bool io_ldo_channel_matches(uint8_t chan_id) {
+  return (int)chan_id == s_io_ldo.chan_id;
+}
+
+#endif /* BOARD_PERIMAN_IO_LDO_AUTO */
+
+void ldoPerimanPinBusSet(uint8_t pin, int old_type_as_int, int new_type_as_int) {
+#if BOARD_PERIMAN_IO_LDO_AUTO
+  if (!io_ldo_pin_in_range(pin)) {
+    return;
+  }
+  const bool old_active = (old_type_as_int != 0);
+  const bool new_active = (new_type_as_int != 0);
+
+  if (!old_active && new_active) {
+    s_io_ldo_slot.refcount++;
+    io_ldo_try_acquire();
+  } else if (old_active && !new_active) {
+    if (s_io_ldo_slot.refcount > 0) {
+      s_io_ldo_slot.refcount--;
+    }
+    io_ldo_try_release();
+  }
+#else
+  (void)pin;
+  (void)old_type_as_int;
+  (void)new_type_as_int;
+#endif
+}
+
+void ldoSdmmcPrepareAcquire(uint8_t chan_id) {
+#if BOARD_PERIMAN_IO_LDO_AUTO
+  if (io_ldo_channel_matches(chan_id)) {
+    io_ldo_release_handle();
+  }
+#else
+  (void)chan_id;
+#endif
+}
+
+void ldoSdmmcDriverDetached(uint8_t chan_id) {
+  if (s_sdmmc_ldo_chan == (int8_t)chan_id) {
+    s_sdmmc_ldo_chan = -1;
+  }
+#if BOARD_PERIMAN_IO_LDO_AUTO
+  if (io_ldo_channel_matches(chan_id)) {
+    io_ldo_try_acquire();
+  }
+#endif
+}
+
+void ldoSdmmcDriverCreateFailed(uint8_t chan_id) {
+#if BOARD_PERIMAN_IO_LDO_AUTO
+  if (io_ldo_channel_matches(chan_id)) {
+    io_ldo_try_acquire();
+  }
+#else
+  (void)chan_id;
+#endif
+}
+
+#endif /* SOC_GP_LDO_SUPPORTED */

--- a/cores/esp32/esp32-hal-ldo.h
+++ b/cores/esp32/esp32-hal-ldo.h
@@ -27,7 +27,9 @@ typedef esp_ldo_channel_handle_t ldo_channel_handle_t;
  * Manual LDO control (any board with SOC_GP_LDO_SUPPORTED).
  *
  * @param chan_id    Datasheet channel ID (e.g. ESP32-P4 LDO_VO4 -> 4).
+ * @param voltage_mv Requested output voltage in millivolts.
  * @param adjustable false = fixed voltage, shareable; true = exclusive (example: SDMMC variable voltage: 1.8V / 3.3V).
+ * @param out_handle Output pointer that receives the acquired LDO channel handle.
  */
 esp_err_t ldoAcquireChannel(uint8_t chan_id, int voltage_mv, bool adjustable, ldo_channel_handle_t *out_handle);
 esp_err_t ldoReleaseChannel(ldo_channel_handle_t handle);

--- a/cores/esp32/esp32-hal-ldo.h
+++ b/cores/esp32/esp32-hal-ldo.h
@@ -20,6 +20,7 @@ extern "C" {
 #if SOC_GP_LDO_SUPPORTED
 
 #include "esp_ldo_regulator.h"
+#include "esp32-hal-periman.h"
 
 typedef esp_ldo_channel_handle_t ldo_channel_handle_t;
 
@@ -41,7 +42,7 @@ esp_err_t ldoReleaseChannel(ldo_channel_handle_t handle);
  *   BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV (default 3300 in .c if omitted)
  */
 
-void ldoPerimanPinBusSet(uint8_t pin, int old_type_as_int, int new_type_as_int);
+void ldoPerimanPinBusSet(uint8_t pin, peripheral_bus_type_t old_type, peripheral_bus_type_t new_type);
 void ldoSdmmcPrepareAcquire(uint8_t chan_id);
 void ldoSdmmcDriverAttached(uint8_t chan_id);
 void ldoSdmmcDriverDetached(uint8_t chan_id);

--- a/cores/esp32/esp32-hal-ldo.h
+++ b/cores/esp32/esp32-hal-ldo.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "sdkconfig.h"
+#include "soc/soc_caps.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "esp_err.h"
+
+#if SOC_GP_LDO_SUPPORTED
+
+#include "esp_ldo_regulator.h"
+
+typedef esp_ldo_channel_handle_t ldo_channel_handle_t;
+
+/**
+ * Manual LDO control (any board with SOC_GP_LDO_SUPPORTED).
+ *
+ * @param chan_id    Datasheet channel ID (e.g. ESP32-P4 LDO_VO4 -> 4).
+ * @param adjustable false = fixed voltage, shareable; true = exclusive (example: SDMMC variable voltage: 1.8V / 3.3V).
+ */
+esp_err_t ldoAcquireChannel(uint8_t chan_id, int voltage_mv, bool adjustable, ldo_channel_handle_t *out_handle);
+esp_err_t ldoReleaseChannel(ldo_channel_handle_t handle);
+
+/*
+ * Optional periman auto-LDO (board opt-in via pins_arduino.h):
+ *   BOARD_PERIMAN_IO_LDO_AUTO = 1
+ *   BOARD_PERIMAN_IO_LDO0_CHANNEL, BOARD_PERIMAN_IO_LDO0_GPIO_MIN/MAX
+ *   BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV (default 3300 in .c if omitted)
+ */
+
+void ldoPerimanPinBusSet(uint8_t pin, int old_type_as_int, int new_type_as_int);
+void ldoSdmmcPrepareAcquire(uint8_t chan_id);
+void ldoSdmmcDriverAttached(uint8_t chan_id);
+void ldoSdmmcDriverDetached(uint8_t chan_id);
+void ldoSdmmcDriverCreateFailed(uint8_t chan_id);
+
+#endif /* SOC_GP_LDO_SUPPORTED */
+
+#ifdef __cplusplus
+}
+#endif

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -6,6 +6,7 @@
 
 #include "esp32-hal-log.h"
 #include "esp32-hal-periman.h"
+#include "esp32-hal-ldo.h"
 #include "esp_bit_defs.h"
 
 typedef struct ATTR_PACKED {
@@ -157,6 +158,9 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void *bus, int8_t
   pins[pin].bus_num = bus_num;
   pins[pin].bus_channel = bus_channel;
   pins[pin].extra_type = NULL;
+#if defined(SOC_GP_LDO_SUPPORTED) && SOC_GP_LDO_SUPPORTED
+  ldoPerimanPinBusSet(pin, (int)otype, (int)type);
+#endif
   log_v("Pin %u successfully set to type %s (%u) with bus %p", pin, perimanGetTypeName(type), (unsigned int)type, bus);
   return true;
 }

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -159,7 +159,7 @@ bool perimanSetPinBus(uint8_t pin, peripheral_bus_type_t type, void *bus, int8_t
   pins[pin].bus_channel = bus_channel;
   pins[pin].extra_type = NULL;
 #if defined(SOC_GP_LDO_SUPPORTED) && SOC_GP_LDO_SUPPORTED
-  ldoPerimanPinBusSet(pin, (int)otype, (int)type);
+  ldoPerimanPinBusSet(pin, otype, type);
 #endif
   log_v("Pin %u successfully set to type %s (%u) with bus %p", pin, perimanGetTypeName(type), (unsigned int)type, bus);
   return true;

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -38,11 +38,6 @@
 #include "esp_system.h"
 #include "esp_intr_alloc.h"
 
-#ifdef SOC_SDMMC_IO_POWER_EXTERNAL  //ESP32-P4
-#include "sd_pwr_ctrl_by_on_chip_ldo.h"
-#include "soc/sdmmc_pins.h"
-#endif
-
 #if CONFIG_IDF_TARGET_ESP32  // ESP32/PICO-D4
 #include "soc/dport_reg.h"
 #include "esp32/rom/ets_sys.h"
@@ -273,44 +268,6 @@ static bool spiDetachBus_SS(void *bus) {
   return true;
 }
 
-#ifdef SOC_SDMMC_IO_POWER_EXTERNAL  //ESP32-P4
-static void setLDOPower(int8_t pin) {
-  if (pin < 0) {
-    return;
-  }
-
-#ifdef BOARD_SDMMC_POWER_PIN
-  if (perimanPinIsValid(BOARD_SDMMC_POWER_PIN) && perimanGetPinBusType(BOARD_SDMMC_POWER_PIN)) {
-    if (strcmp(perimanGetPinBusExtraType(BOARD_SDMMC_POWER_PIN), "SDMMC POWER") == 0) {
-      return;
-    }
-  }
-#endif
-
-  int8_t ldo_ctrld[] = {SDMMC_SLOT0_IOMUX_PIN_NUM_CLK, SDMMC_SLOT0_IOMUX_PIN_NUM_CMD, SDMMC_SLOT0_IOMUX_PIN_NUM_D0, SDMMC_SLOT0_IOMUX_PIN_NUM_D1,
-                        SDMMC_SLOT0_IOMUX_PIN_NUM_D2,  SDMMC_SLOT0_IOMUX_PIN_NUM_D3,  SDMMC_SLOT0_IOMUX_PIN_NUM_D4, SDMMC_SLOT0_IOMUX_PIN_NUM_D5,
-                        SDMMC_SLOT0_IOMUX_PIN_NUM_D6,  SDMMC_SLOT0_IOMUX_PIN_NUM_D7};
-  for (int j = 0; j < 10; j++) {
-    if (pin == ldo_ctrld[j]) {
-#ifdef BOARD_SDMMC_POWER_PIN
-      pinMode(BOARD_SDMMC_POWER_PIN, OUTPUT);
-      digitalWrite(BOARD_SDMMC_POWER_PIN, BOARD_SDMMC_POWER_ON_LEVEL);
-      perimanSetPinBusExtraType(BOARD_SDMMC_POWER_PIN, "SDMMC POWER");
-#endif
-      sd_pwr_ctrl_ldo_config_t ldo_config;
-      ldo_config.ldo_chan_id = BOARD_SDMMC_POWER_CHANNEL;
-      sd_pwr_ctrl_handle_t pwr_ctrl_handle = NULL;
-      sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle);
-      if (sd_pwr_ctrl_set_io_voltage(pwr_ctrl_handle, 3300)) {
-        log_e("Unable to set power control to 3V3");
-        return;
-      }
-      break;
-    }
-  }
-}
-#endif
-
 bool spiAttachSCK(spi_t *spi, int8_t sck) {
   if (!spi || sck < 0) {
     return false;
@@ -319,9 +276,6 @@ bool spiAttachSCK(spi_t *spi, int8_t sck) {
   if (bus != NULL && !perimanClearPinBus(sck)) {
     return false;
   }
-#ifdef SOC_SDMMC_IO_POWER_EXTERNAL  //ESP32-P4
-  setLDOPower(sck);
-#endif
   pinMode(sck, OUTPUT);
   pinMatrixOutAttach(sck, SPI_CLK_IDX(spi->num), false, false);
   spi->sck = sck;
@@ -341,9 +295,6 @@ bool spiAttachMISO(spi_t *spi, int8_t miso) {
   if (bus != NULL && !perimanClearPinBus(miso)) {
     return false;
   }
-#ifdef SOC_SDMMC_IO_POWER_EXTERNAL  //ESP32-P4
-  setLDOPower(miso);
-#endif
   pinMode(miso, INPUT);
   pinMatrixInAttach(miso, SPI_MISO_IDX(spi->num), false);
   spi->miso = miso;
@@ -363,9 +314,6 @@ bool spiAttachMOSI(spi_t *spi, int8_t mosi) {
   if (bus != NULL && !perimanClearPinBus(mosi)) {
     return false;
   }
-#ifdef SOC_SDMMC_IO_POWER_EXTERNAL  //ESP32-P4
-  setLDOPower(mosi);
-#endif
   pinMode(mosi, OUTPUT);
   pinMatrixOutAttach(mosi, SPI_MOSI_IDX(spi->num), false, false);
   spi->mosi = mosi;
@@ -424,9 +372,6 @@ bool spiAttachSS(spi_t *spi, uint8_t ss_num, int8_t ss) {
   if (bus != NULL && !perimanClearPinBus(ss)) {
     return false;
   }
-#ifdef SOC_SDMMC_IO_POWER_EXTERNAL  //ESP32-P4
-  setLDOPower(ss);
-#endif
   pinMode(ss, OUTPUT);
   pinMatrixOutAttach(ss, SPI_SS_IDX(spi->num, ss_num), spi->ss_invert, false);
   spiEnableSSPins(spi, (1 << ss_num));

--- a/cores/esp32/esp32-hal.h
+++ b/cores/esp32/esp32-hal.h
@@ -113,6 +113,7 @@ void yield(void);
 #include "esp32-hal-matrix.h"
 #include "esp32-hal-uart.h"
 #include "esp32-hal-gpio.h"
+#include "esp32-hal-ldo.h"
 #include "esp32-hal-touch.h"
 #include "esp32-hal-touch-ng.h"
 #include "esp32-hal-dac.h"

--- a/libraries/SD_MMC/src/SD_MMC.cpp
+++ b/libraries/SD_MMC/src/SD_MMC.cpp
@@ -31,6 +31,7 @@
 #include "soc/sdmmc_pins.h"
 #include "ff.h"
 #include "esp32-hal-periman.h"
+#include "esp32-hal-ldo.h"
 
 #if SOC_SDMMC_IO_POWER_EXTERNAL
 #include "sd_pwr_ctrl_by_on_chip_ldo.h"
@@ -268,11 +269,15 @@ bool SDMMCFS::begin(const char *mountpoint, bool mode1bit, bool format_if_mount_
     };
     sd_pwr_ctrl_handle_t pwr_ctrl_handle = NULL;
 
+    ldoSdmmcPrepareAcquire((uint8_t)_power_channel);
     if (sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle) != ESP_OK) {
       log_e("Failed to create a new on-chip LDO power control driver");
+      ldoSdmmcDriverCreateFailed((uint8_t)_power_channel);
       return false;
     }
     host.pwr_ctrl_handle = pwr_ctrl_handle;
+    _pwr_ctrl_handle = pwr_ctrl_handle;
+    ldoSdmmcDriverAttached((uint8_t)_power_channel);
   }
 #endif
 
@@ -306,6 +311,14 @@ bool SDMMCFS::begin(const char *mountpoint, bool mode1bit, bool format_if_mount_
     } else {
       log_e("Failed to initialize the card (0x%x). Make sure SD card lines have pull-up resistors in place.", ret);
     }
+#ifdef SOC_SDMMC_IO_POWER_EXTERNAL
+    if (_power_channel != -1 && host.pwr_ctrl_handle != NULL) {
+      sd_pwr_ctrl_del_on_chip_ldo(host.pwr_ctrl_handle);
+      host.pwr_ctrl_handle = NULL;
+      _pwr_ctrl_handle = nullptr;
+      ldoSdmmcDriverDetached((uint8_t)_power_channel);
+    }
+#endif
     _card = NULL;
     return false;
   }
@@ -342,6 +355,12 @@ err:
 
 void SDMMCFS::end() {
   if (_card) {
+#ifdef SOC_SDMMC_IO_POWER_EXTERNAL
+    sd_pwr_ctrl_handle_t pwr_ctrl = (sd_pwr_ctrl_handle_t)_pwr_ctrl_handle;
+    if (pwr_ctrl == NULL && _power_channel != -1) {
+      pwr_ctrl = _card->host.pwr_ctrl_handle;
+    }
+#endif
     esp_vfs_fat_sdcard_unmount(_impl->mountpoint(), _card);
     _impl->mountpoint(NULL);
     _card = NULL;
@@ -355,6 +374,13 @@ void SDMMCFS::end() {
     }
 #if defined(BOARD_SDMMC_POWER_PIN)
     perimanClearPinBus(BOARD_SDMMC_POWER_PIN);
+#endif
+#ifdef SOC_SDMMC_IO_POWER_EXTERNAL
+    if (_power_channel != -1 && pwr_ctrl != NULL) {
+      sd_pwr_ctrl_del_on_chip_ldo(pwr_ctrl);
+      _pwr_ctrl_handle = nullptr;
+      ldoSdmmcDriverDetached((uint8_t)_power_channel);
+    }
 #endif
   }
 }

--- a/libraries/SD_MMC/src/SD_MMC.h
+++ b/libraries/SD_MMC/src/SD_MMC.h
@@ -42,6 +42,7 @@ protected:
   int8_t _pin_d3 = -1;
 #ifdef SOC_SDMMC_IO_POWER_EXTERNAL
   int8_t _power_channel = -1;
+  void *_pwr_ctrl_handle = nullptr;  // sd_pwr_ctrl; IDF unmount does not delete this
 #endif
   uint8_t _pdrv = 0xFF;
   bool _mode1bit = false;

--- a/variants/esp32p4/pins_arduino.h
+++ b/variants/esp32p4/pins_arduino.h
@@ -74,11 +74,11 @@ static const uint8_t T13 = 15;
 #define BOARD_SDMMC_POWER_ON_LEVEL LOW
 
 // On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
-#define BOARD_PERIMAN_IO_LDO_AUTO           1
-#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39  // Function EV: GPIO 39-48 on VO4
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
-#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
+#define BOARD_PERIMAN_IO_LDO_AUTO        1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL    4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN   39  // Function EV: GPIO 39-48 on VO4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX   48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV 3300
 
 //WIFI - ESP32C6
 #define BOARD_HAS_SDIO_ESP_HOSTED

--- a/variants/esp32p4/pins_arduino.h
+++ b/variants/esp32p4/pins_arduino.h
@@ -13,7 +13,8 @@ static const uint8_t RX = 38;
 static const uint8_t SDA = 7;
 static const uint8_t SCL = 8;
 
-// Use GPIOs 36 or lower on the P4 DevKit to avoid LDO power issues with high numbered GPIOs.
+// GPIO 36 and below: no extra on-chip LDO needed for the IO bank.
+// GPIO 39-48: LDO VO4 (channel 4). GPIO 37-38 (UART) are outside that VO4 range.
 static const uint8_t SS = 26;
 static const uint8_t MOSI = 32;
 static const uint8_t MISO = 33;
@@ -71,6 +72,13 @@ static const uint8_t T13 = 15;
 #define BOARD_SDMMC_POWER_CHANNEL  4
 #define BOARD_SDMMC_POWER_PIN      45
 #define BOARD_SDMMC_POWER_ON_LEVEL LOW
+
+// On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
+#define BOARD_PERIMAN_IO_LDO_AUTO           1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39  // Function EV: GPIO 39-48 on VO4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
 
 //WIFI - ESP32C6
 #define BOARD_HAS_SDIO_ESP_HOSTED

--- a/variants/esp32p4_4ds_mipi/pins_arduino.h
+++ b/variants/esp32p4_4ds_mipi/pins_arduino.h
@@ -71,10 +71,10 @@ static const uint8_t T4 = 2;   // careful, also used as I2C SDA pin
 #define BOARD_SDMMC_POWER_ON_LEVEL LOW
 
 // On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
-#define BOARD_PERIMAN_IO_LDO_AUTO           1
-#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39  // Function EV: GPIO 39-48 on VO4
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
-#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
+#define BOARD_PERIMAN_IO_LDO_AUTO        1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL    4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN   39  // Function EV: GPIO 39-48 on VO4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX   48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV 3300
 
 #endif /* Pins_Arduino_h */

--- a/variants/esp32p4_4ds_mipi/pins_arduino.h
+++ b/variants/esp32p4_4ds_mipi/pins_arduino.h
@@ -70,4 +70,11 @@ static const uint8_t T4 = 2;   // careful, also used as I2C SDA pin
 #define BOARD_SDMMC_POWER_PIN      45
 #define BOARD_SDMMC_POWER_ON_LEVEL LOW
 
+// On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
+#define BOARD_PERIMAN_IO_LDO_AUTO           1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39  // Function EV: GPIO 39-48 on VO4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
+
 #endif /* Pins_Arduino_h */

--- a/variants/esp32p4_4ds_mipi_round/pins_arduino.h
+++ b/variants/esp32p4_4ds_mipi_round/pins_arduino.h
@@ -71,10 +71,10 @@ static const uint8_t T4 = 2;   // careful, also used as I2C SDA pin
 #define BOARD_SDMMC_POWER_ON_LEVEL LOW
 
 // On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
-#define BOARD_PERIMAN_IO_LDO_AUTO           1
-#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39  // Function EV: GPIO 39-48 on VO4
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
-#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
+#define BOARD_PERIMAN_IO_LDO_AUTO        1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL    4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN   39  // Function EV: GPIO 39-48 on VO4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX   48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV 3300
 
 #endif /* Pins_Arduino_h */

--- a/variants/esp32p4_4ds_mipi_round/pins_arduino.h
+++ b/variants/esp32p4_4ds_mipi_round/pins_arduino.h
@@ -70,4 +70,11 @@ static const uint8_t T4 = 2;   // careful, also used as I2C SDA pin
 #define BOARD_SDMMC_POWER_PIN      45
 #define BOARD_SDMMC_POWER_ON_LEVEL LOW
 
+// On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
+#define BOARD_PERIMAN_IO_LDO_AUTO           1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39  // Function EV: GPIO 39-48 on VO4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
+
 #endif /* Pins_Arduino_h */

--- a/variants/esp32p4_core_board/pins_arduino.h
+++ b/variants/esp32p4_core_board/pins_arduino.h
@@ -25,7 +25,8 @@ static const uint8_t RX = 38;
 static const uint8_t SDA = 7;
 static const uint8_t SCL = 8;
 
-// Use GPIOs 36 or lower on the P4 DevKit to avoid LDO power issues with high numbered GPIOs.
+// GPIO 36 and below: no extra on-chip LDO needed for the IO bank.
+// GPIO 39-48: LDO VO4 (channel 4). GPIO 37-38 (UART) are outside that VO4 range.
 static const uint8_t SS = 30;
 static const uint8_t MOSI = 33;
 static const uint8_t MISO = 32;
@@ -60,6 +61,14 @@ static const uint8_t T10 = 12;
 static const uint8_t T11 = 13;
 static const uint8_t T12 = 14;
 static const uint8_t T13 = 15;
+
+// On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
+// No on-board SDMMC slot on this board (no BOARD_HAS_SDMMC / BOARD_SDMMC_POWER_*).
+#define BOARD_PERIMAN_IO_LDO_AUTO           1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
 
 //WIFI - ESP32C6
 #define BOARD_HAS_SDIO_ESP_HOSTED

--- a/variants/esp32p4_core_board/pins_arduino.h
+++ b/variants/esp32p4_core_board/pins_arduino.h
@@ -64,11 +64,11 @@ static const uint8_t T13 = 15;
 
 // On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
 // No on-board SDMMC slot on this board (no BOARD_HAS_SDMMC / BOARD_SDMMC_POWER_*).
-#define BOARD_PERIMAN_IO_LDO_AUTO           1
-#define BOARD_PERIMAN_IO_LDO0_CHANNEL       4   // LDO_VO4 on ESP32-P4
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN      39
-#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX      48
-#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV    3300
+#define BOARD_PERIMAN_IO_LDO_AUTO        1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL    4  // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN   39
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX   48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV 3300
 
 //WIFI - ESP32C6
 #define BOARD_HAS_SDIO_ESP_HOSTED


### PR DESCRIPTION
## Description of Change
This pull request introduces a new LDO (Low Dropout Regulator) management layer for ESP32 platforms with on-chip LDO support, and refactors SD/MMC and SPI peripheral power management to use this new abstraction. It also adds automatic LDO channel management for certain GPIO ranges on supported boards, improving reliability and simplifying board definitions.

The most important changes are:

**LDO Management Abstraction:**
* Added new files `esp32-hal-ldo.c` and `esp32-hal-ldo.h` providing an abstraction for LDO channel acquisition and release, as well as hooks for SDMMC and automatic periman-based LDO management. [[1]](diffhunk://#diff-4bcfa5aa3980f1c3d827f44fee6112e988a3e5676d37f272cb6ae976d0e19d2aR1-R182) [[2]](diffhunk://#diff-ed681f5a70322f6589faec6aead17523440f35cb42b99fd7f4b74c660de09485R1-R52)
* Integrated the new LDO API into the core build process and headers (`CMakeLists.txt`, `esp32-hal.h`). [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR44) [[2]](diffhunk://#diff-098866efd38dff35e3590a4071469b34b93a37194f86fc63670b14b199e5e3b6R116)

**Automatic Periman LDO Handling:**
* Implemented optional automatic LDO channel enable/disable in `esp32-hal-ldo.c` for GPIOs in a board-defined range, with board opt-in via macros in `pins_arduino.h`. [[1]](diffhunk://#diff-4bcfa5aa3980f1c3d827f44fee6112e988a3e5676d37f272cb6ae976d0e19d2aR1-R182) [[2]](diffhunk://#diff-51adfb7b07a2d90124b0e3a8e68ce074572c2f496fcb142153810f65b871e6b4R76-R82)
* Updated `esp32-hal-periman.c` to call `ldoPerimanPinBusSet()` when pin bus types change, ensuring LDO power is managed transparently. [[1]](diffhunk://#diff-b13165e864af00ee872517324ae4929b78d0411fff6f4fb2b98114f241c00f22R161-R163) [[2]](diffhunk://#diff-b13165e864af00ee872517324ae4929b78d0411fff6f4fb2b98114f241c00f22R9)

**SD/MMC Power Control Refactor:**
* Updated `SD_MMC.cpp` to use the new LDO hooks for SDMMC power channel handling, including correct cleanup on driver attach/detach and error cases. [[1]](diffhunk://#diff-189709f5c8480d98e34da66c324549596307584cbc87b4d480debe833e04217dR34) [[2]](diffhunk://#diff-189709f5c8480d98e34da66c324549596307584cbc87b4d480debe833e04217dR272-R280) [[3]](diffhunk://#diff-189709f5c8480d98e34da66c324549596307584cbc87b4d480debe833e04217dR314-R321) [[4]](diffhunk://#diff-189709f5c8480d98e34da66c324549596307584cbc87b4d480debe833e04217dR358-R363) [[5]](diffhunk://#diff-189709f5c8480d98e34da66c324549596307584cbc87b4d480debe833e04217dR377-R383) [[6]](diffhunk://#diff-702576768b8885ce77b01a90976126ed307010ab6a8868f81776c90cfaed8605R45)
* Updated the ESP32-P4 board definition to enable automatic LDO management for GPIOs 39-48 (VO4), clarifying which pins require LDO power. [[1]](diffhunk://#diff-51adfb7b07a2d90124b0e3a8e68ce074572c2f496fcb142153810f65b871e6b4L16-R17) [[2]](diffhunk://#diff-51adfb7b07a2d90124b0e3a8e68ce074572c2f496fcb142153810f65b871e6b4R76-R82)

**SPI Power Control Simplification:**
* Removed the legacy `setLDOPower()` logic from `esp32-hal-spi.c`, as LDO management is now handled by the new abstraction and periman. [[1]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL41-L45) [[2]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL276-L313) [[3]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL322-L324) [[4]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL344-L346) [[5]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL366-L368) [[6]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL427-L429)

These changes make LDO power management more robust, less error-prone, and easier to configure for new boards.

## Test Scenarios
Tested on P4X-EV 1.6 and P4 Core board with SDMMC/GPIO LDO switching.

## Related links
Closes #12540
Might be related #12598
