### PR TITLE
fix(matter): Fix internal state synchronization

### DIFF
--- a/libraries/Matter/README.md
+++ b/libraries/Matter/README.md
@@ -1,0 +1,133 @@
+# Arduino Matter Library
+
+Arduino-friendly wrapper around [ESP-Matter](https://docs.espressif.com/projects/esp-matter/en/latest/) (Espressif's SDK for Matter), providing high-level endpoint classes for common Matter device types.
+
+## Architecture
+
+Each Matter device type is represented by a C++ class under `src/MatterEndpoints/` (e.g., `MatterOnOffLight`, `MatterTemperatureSensor`, `MatterFan`). These classes manage:
+
+- **Internal state variables** — C++ members that cache the device's current state (e.g., `onOffState`, `brightnessLevel`, `rawTemperature`).
+- **Matter attribute store** — The ESP-Matter SDK's attribute database, which is the protocol-level representation read by controllers and used for subscriptions/reporting.
+
+## Attribute Update Pattern
+
+This library is built on ESP-Matter, which uses an Ember-based attribute store. The attribute store is the protocol-level source of truth: when a Matter controller reads an attribute, it reads from this store.
+
+All endpoint setters and getters **must** follow one of the two patterns below.
+
+### Setter Pattern
+
+When the device application (Arduino sketch) wants to change state, the setter **must** update the attribute store first and only commit to internal state after the store confirms success.
+
+```cpp
+bool MyEndpoint::setValue(int newValue) {
+  if (internalValue == newValue) {
+    return true;  // No change needed
+  }
+
+  esp_matter_attr_val_t val = esp_matter_invalid(NULL);
+  if (!getAttributeVal(ClusterId, AttributeId, &val)) {
+    log_e("Failed to get attribute.");
+    return false;
+  }
+
+  if (val.val.i16 != newValue) {
+    val.val.i16 = newValue;
+    bool ret = updateAttributeVal(ClusterId, AttributeId, &val);
+    if (!ret) {
+      log_e("Failed to update attribute.");
+      return false;
+    }
+    // Internal state committed ONLY after attribute store update succeeds
+    internalValue = newValue;
+  }
+
+  return true;
+}
+```
+
+Key rules:
+- **Never assign internal state before the attribute store update.** If `updateAttributeVal()` fails and the function returns `false`, the internal state must remain unchanged.
+- **Internal state assignment goes inside the `if (value changed)` block**, after the successful update call.
+- When `updateAttributeVal()` may fail for nullable or dynamic attributes, a `setAttributeVal()` fallback can be used (see `MatterWindowCovering`, `MatterTemperatureControlledCabinet`). `setAttributeVal()` writes to the store without triggering the `PRE_UPDATE` callback chain or subscriber reporting.
+- For composite setters that update multiple attributes, attempt all sub-updates and return the combined result. Partial commits are possible (some attributes updated, others not) since true atomic rollback is not feasible with the current ESP-Matter API. Each sub-update independently follows the Ember pattern (internal state only after its own attribute store success).
+
+### Getter Pattern
+
+Getters return the internal state variable directly, without reading from the attribute store:
+
+```cpp
+int MyEndpoint::getValue() {
+  return internalValue;
+}
+```
+
+This is consistent across all endpoints. Since setters only update internal state after the attribute store succeeds, the getter always reflects the last successfully committed value.
+
+### Controller-Originated Changes (attributeChangeCB)
+
+When a Matter controller changes an attribute (e.g., turning a light on via an app), the flow is:
+
+1. ESP-Matter receives the write and fires a `PRE_UPDATE` callback.
+2. `app_attribute_update_cb()` in `Matter.cpp` calls the endpoint's virtual `attributeChangeCB()`.
+3. The endpoint's `attributeChangeCB()` updates internal state and, for endpoints that expose user callbacks (e.g., `MatterOnOffLight`, `MatterDimmableLight`, `MatterFan`), invokes `_onChangeCB`.
+4. If the callback returns `true` (or if no user callback is registered), internal state is updated and `ESP_OK` is returned, allowing the attribute store to commit the new value.
+5. If the callback returns `false`, the change is rejected (`ESP_FAIL`) and both internal state and attribute store remain unchanged.
+
+Note: Not all endpoints expose user callbacks. For example, `MatterTemperatureControlledCabinet::attributeChangeCB()` updates internal state directly and always returns success. Check individual endpoint headers for available `onChange` methods.
+
+### begin() Initialization
+
+The `begin()` method should initialize **both** the Matter config struct and internal state variables:
+
+```cpp
+bool MyEndpoint::begin(bool initialState, uint8_t brightness) {
+  my_endpoint::config_t config;
+  config.on_off.on_off = initialState;
+  onOffState = initialState;
+
+  config.level_control.current_level = brightness;
+  brightnessLevel = brightness;
+
+  endpoint_t *ep = my_endpoint::create(node::get(), &config, ENDPOINT_FLAG_NONE, (void *)this);
+  // ...
+}
+```
+
+### updateAttributeVal vs setAttributeVal
+
+| API | ESP-Matter function | Triggers PRE_UPDATE callback | Reports to subscribers | Use case |
+|-----|-------------------|------------------------------|----------------------|----------|
+| `updateAttributeVal()` | `attribute::update()` | Yes | Yes | Normal device-initiated state changes |
+| `setAttributeVal()` | `attribute::set_val()` | No | No | Fallback for nullable attributes, syncing related attributes inside callbacks, avoiding re-entrancy |
+
+## Endpoint Classes
+
+| Class | Device Type |
+|-------|-------------|
+| `MatterOnOffLight` | On/Off Light |
+| `MatterDimmableLight` | Dimmable Light |
+| `MatterColorLight` | Color Light (HSV) |
+| `MatterColorTemperatureLight` | Color Temperature Light |
+| `MatterEnhancedColorLight` | Enhanced Color Light |
+| `MatterOnOffPlugin` | On/Off Plug-in Unit |
+| `MatterDimmablePlugin` | Dimmable Plug-in Unit |
+| `MatterFan` | Fan |
+| `MatterGenericSwitch` | Generic Switch |
+| `MatterTemperatureSensor` | Temperature Sensor |
+| `MatterHumiditySensor` | Humidity Sensor |
+| `MatterPressureSensor` | Pressure Sensor |
+| `MatterContactSensor` | Contact Sensor |
+| `MatterOccupancySensor` | Occupancy Sensor |
+| `MatterWaterLeakDetector` | Water Leak Detector |
+| `MatterWaterFreezeDetector` | Water Freeze Detector |
+| `MatterRainSensor` | Rain Sensor |
+| `MatterThermostat` | Thermostat |
+| `MatterWindowCovering` | Window Covering |
+| `MatterTemperatureControlledCabinet` | Temperature Controlled Cabinet |
+
+## Further Reading
+
+- [ESP-Matter Programming Guide](https://docs.espressif.com/projects/esp-matter/en/latest/)
+- [Arduino-ESP32 Matter Documentation](https://docs.espressif.com/projects/arduino-esp32/en/latest/matter/index.html)
+- [Matter Specification (CSA)](https://csa-iot.org/developer-resource/specifications-download-request/)

--- a/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterEnhancedColorLight.cpp
@@ -191,6 +191,7 @@ bool MatterEnhancedColorLight::begin(bool initialState, espHsvColor_t _colorHSV,
 
   light_config.level_control.current_level = brightness;
   light_config.level_control.lighting.start_up_current_level = nullptr;
+  brightnessLevel = brightness;
 
   light_config.color_control.enhanced_color_mode = (uint8_t)ColorControl::ColorMode::kColorTemperature;
   light_config.color_control.color_temperature.color_temperature_mireds = ColorTemperature;

--- a/libraries/Matter/src/MatterEndpoints/MatterOccupancySensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterOccupancySensor.cpp
@@ -407,11 +407,6 @@ bool MatterOccupancySensor::setHoldTimeLimits(uint16_t _holdTimeMin_seconds, uin
     return false;
   }
 
-  // Update member variables immediately
-  holdTimeMin_seconds = _holdTimeMin_seconds;
-  holdTimeMax_seconds = _holdTimeMax_seconds;
-  holdTimeDefault_seconds = _holdTimeDefault_seconds;
-
   // Check if current HoldTime is outside the new limits and adjust if necessary
   uint16_t adjustedHoldTime = holdTime_seconds;
   bool holdTimeAdjusted = false;
@@ -429,13 +424,14 @@ bool MatterOccupancySensor::setHoldTimeLimits(uint16_t _holdTimeMin_seconds, uin
   uint16_t endpoint_id = getEndPointId();
   CHIP_ERROR schedule_err;
 
+  // Schedule the attribute store update on the Matter event loop.
+  // Lambdas capture all values by copy, so they don't depend on member state.
   if (holdTimeAdjusted) {
     // Schedule both limits and HoldTime updates together
     schedule_err = chip::DeviceLayer::SystemLayer().ScheduleLambda([endpoint_id, min = _holdTimeMin_seconds, max = _holdTimeMax_seconds,
                                                                     def = _holdTimeDefault_seconds, holdTime = adjustedHoldTime]() {
       SetHoldTimeLimitsAndHoldTimeInEventLoop(endpoint_id, min, max, def, holdTime);
     });
-    holdTime_seconds = adjustedHoldTime;
   } else {
     // No adjustment needed, just schedule the limits update
     schedule_err =
@@ -447,6 +443,15 @@ bool MatterOccupancySensor::setHoldTimeLimits(uint16_t _holdTimeMin_seconds, uin
   if (schedule_err != CHIP_NO_ERROR) {
     log_e("Failed to schedule HoldTimeLimits update: %" CHIP_ERROR_FORMAT, schedule_err.Format());
     return false;
+  }
+
+  // Commit to internal state only after scheduling succeeds,
+  // so that on failure the member variables remain unchanged (Ember pattern).
+  holdTimeMin_seconds = _holdTimeMin_seconds;
+  holdTimeMax_seconds = _holdTimeMax_seconds;
+  holdTimeDefault_seconds = _holdTimeDefault_seconds;
+  if (holdTimeAdjusted) {
+    holdTime_seconds = adjustedHoldTime;
   }
 
   log_v("HoldTimeLimits scheduled for update: Min=%u, Max=%u, Default=%u seconds", _holdTimeMin_seconds, _holdTimeMax_seconds, _holdTimeDefault_seconds);

--- a/libraries/Matter/src/MatterEndpoints/MatterTemperatureControlledCabinet.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterTemperatureControlledCabinet.cpp
@@ -364,8 +364,10 @@ bool MatterTemperatureControlledCabinet::setRawTemperatureSetpoint(int16_t _rawT
   }
   if (tempVal.val.i16 != _rawTemperature) {
     tempVal.val.i16 = _rawTemperature;
-    bool ret;
-    ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::TemperatureSetpoint::Id, &tempVal);
+    bool ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::TemperatureSetpoint::Id, &tempVal);
+    if (!ret) {
+      ret = setAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::TemperatureSetpoint::Id, &tempVal);
+    }
     if (!ret) {
       log_e("Failed to update Temperature Controlled Cabinet Temperature Setpoint Attribute.");
       return false;
@@ -388,10 +390,6 @@ double MatterTemperatureControlledCabinet::getTemperatureSetpoint() {
     return 0.0;
   }
 
-  esp_matter_attr_val_t tempVal = esp_matter_invalid(NULL);
-  if (getAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::TemperatureSetpoint::Id, &tempVal)) {
-    rawTempSetpoint = tempVal.val.i16;
-  }
   return (double)rawTempSetpoint / 100.0;
 }
 
@@ -417,8 +415,10 @@ bool MatterTemperatureControlledCabinet::setRawMinTemperature(int16_t _rawTemper
   }
   if (tempVal.val.i16 != _rawTemperature) {
     tempVal.val.i16 = _rawTemperature;
-    bool ret;
-    ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MinTemperature::Id, &tempVal);
+    bool ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MinTemperature::Id, &tempVal);
+    if (!ret) {
+      ret = setAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MinTemperature::Id, &tempVal);
+    }
     if (!ret) {
       log_e("Failed to update Temperature Controlled Cabinet Min Temperature Attribute.");
       return false;
@@ -441,10 +441,6 @@ double MatterTemperatureControlledCabinet::getMinTemperature() {
     return 0.0;
   }
 
-  esp_matter_attr_val_t tempVal = esp_matter_invalid(NULL);
-  if (getAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MinTemperature::Id, &tempVal)) {
-    rawMinTemperature = tempVal.val.i16;
-  }
   return (double)rawMinTemperature / 100.0;
 }
 
@@ -470,8 +466,10 @@ bool MatterTemperatureControlledCabinet::setRawMaxTemperature(int16_t _rawTemper
   }
   if (tempVal.val.i16 != _rawTemperature) {
     tempVal.val.i16 = _rawTemperature;
-    bool ret;
-    ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MaxTemperature::Id, &tempVal);
+    bool ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MaxTemperature::Id, &tempVal);
+    if (!ret) {
+      ret = setAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MaxTemperature::Id, &tempVal);
+    }
     if (!ret) {
       log_e("Failed to update Temperature Controlled Cabinet Max Temperature Attribute.");
       return false;
@@ -494,10 +492,6 @@ double MatterTemperatureControlledCabinet::getMaxTemperature() {
     return 0.0;
   }
 
-  esp_matter_attr_val_t tempVal = esp_matter_invalid(NULL);
-  if (getAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::MaxTemperature::Id, &tempVal)) {
-    rawMaxTemperature = tempVal.val.i16;
-  }
   return (double)rawMaxTemperature / 100.0;
 }
 
@@ -523,8 +517,10 @@ bool MatterTemperatureControlledCabinet::setRawStep(int16_t _rawStep) {
   }
   if (stepVal.val.i16 != _rawStep) {
     stepVal.val.i16 = _rawStep;
-    bool ret;
-    ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::Step::Id, &stepVal);
+    bool ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::Step::Id, &stepVal);
+    if (!ret) {
+      ret = setAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::Step::Id, &stepVal);
+    }
     if (!ret) {
       log_e("Failed to update Temperature Controlled Cabinet Step Attribute.");
       return false;
@@ -547,12 +543,6 @@ double MatterTemperatureControlledCabinet::getStep() {
     return 0.0;
   }
 
-  // Read from attribute (should always exist after begin() due to workaround)
-  // If read fails, use stored rawStep value from begin()
-  esp_matter_attr_val_t stepVal = esp_matter_invalid(NULL);
-  if (getAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::Step::Id, &stepVal)) {
-    rawStep = stepVal.val.i16;
-  }
   return (double)rawStep / 100.0;
 }
 
@@ -590,8 +580,10 @@ bool MatterTemperatureControlledCabinet::setSelectedTemperatureLevel(uint8_t lev
   }
   if (levelVal.val.u8 != level) {
     levelVal.val.u8 = level;
-    bool ret;
-    ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::SelectedTemperatureLevel::Id, &levelVal);
+    bool ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::SelectedTemperatureLevel::Id, &levelVal);
+    if (!ret) {
+      ret = setAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::SelectedTemperatureLevel::Id, &levelVal);
+    }
     if (!ret) {
       log_e("Failed to update Temperature Controlled Cabinet Selected Temperature Level Attribute.");
       return false;
@@ -609,10 +601,6 @@ uint8_t MatterTemperatureControlledCabinet::getSelectedTemperatureLevel() {
     return 0;
   }
 
-  esp_matter_attr_val_t levelVal = esp_matter_invalid(NULL);
-  if (getAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::SelectedTemperatureLevel::Id, &levelVal)) {
-    selectedTempLevel = levelVal.val.u8;
-  }
   return selectedTempLevel;
 }
 
@@ -638,19 +626,21 @@ bool MatterTemperatureControlledCabinet::setSupportedTemperatureLevels(uint8_t *
     return false;
   }
 
-  // Copy the array into internal buffer
-  memcpy(supportedLevelsArray, levels, count * sizeof(uint8_t));
-  supportedLevelsCount = count;
-
-  // Use internal copy for Matter attribute update
-  // Use esp_matter_array helper function which properly initializes the structure
-  esp_matter_attr_val_t levelsVal = esp_matter_array(supportedLevelsArray, sizeof(uint8_t), count);
+  // Use caller's buffer directly for the attribute update — the pointer is read
+  // synchronously by updateAttributeVal, so the caller's buffer is safe to use here.
+  // Use esp_matter_array helper function which properly initializes the structure.
+  esp_matter_attr_val_t levelsVal = esp_matter_array(levels, sizeof(uint8_t), count);
 
   bool ret = updateAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::SupportedTemperatureLevels::Id, &levelsVal);
   if (!ret) {
     log_e("Failed to update Temperature Controlled Cabinet Supported Temperature Levels Attribute.");
     return false;
   }
+
+  // Copy into internal buffer only after the attribute store update succeeds,
+  // so that on failure the internal state remains unchanged (Ember pattern).
+  memcpy(supportedLevelsArray, levels, count * sizeof(uint8_t));
+  supportedLevelsCount = count;
   log_v("Temperature Controlled Cabinet supported temperature levels updated, count: %u", count);
 
   return true;
@@ -662,11 +652,7 @@ uint16_t MatterTemperatureControlledCabinet::getSupportedTemperatureLevelsCount(
     return 0;
   }
 
-  esp_matter_attr_val_t levelsVal = esp_matter_invalid(NULL);
-  if (getAttributeVal(TemperatureControl::Id, TemperatureControl::Attributes::SupportedTemperatureLevels::Id, &levelsVal)) {
-    return levelsVal.val.a.n;  // a.n is the count (number of elements)
-  }
-  return 0;
+  return supportedLevelsCount;
 }
 
 #endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterEndpoints/MatterWindowCovering.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWindowCovering.cpp
@@ -361,11 +361,15 @@ bool MatterWindowCovering::setLiftPosition(uint16_t liftPosition) {
   if (val.val.u16 != liftPosition) {
     val.val.u16 = liftPosition;
     bool ret = updateAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionLift::Id, &val);
+    if (!ret) {
+      ret = setAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionLift::Id, &val);
+    }
     if (ret) {
       currentLiftPosition = liftPosition;
-      // Also update CurrentPositionLiftPercent100ths to keep attributes in sync
-      // This matches ESP-Matter's LiftPositionSet() behavior
-      setLiftPercentage((uint8_t)(liftPercent100ths / 100));
+      if (!setLiftPercentage((uint8_t)(liftPercent100ths / 100))) {
+        log_e("Failed to sync Lift Percentage from Lift Position.");
+        return false;
+      }
     }
     return ret;
   }
@@ -373,10 +377,6 @@ bool MatterWindowCovering::setLiftPosition(uint16_t liftPosition) {
 }
 
 uint16_t MatterWindowCovering::getLiftPosition() {
-  esp_matter_attr_val_t val = esp_matter_invalid(NULL);
-  if (getAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionLift::Id, &val)) {
-    currentLiftPosition = val.val.u16;
-  }
   return currentLiftPosition;
 }
 
@@ -409,6 +409,9 @@ bool MatterWindowCovering::setLiftPercentage(uint8_t liftPercent) {
   if (currentVal.val.u16 != liftPercent100ths) {
     currentVal.val.u16 = liftPercent100ths;
     bool ret = updateAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id, &currentVal);
+    if (!ret) {
+      ret = setAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id, &currentVal);
+    }
     if (ret) {
       currentLiftPercent = liftPercent;
     }
@@ -418,10 +421,6 @@ bool MatterWindowCovering::setLiftPercentage(uint8_t liftPercent) {
 }
 
 uint8_t MatterWindowCovering::getLiftPercentage() {
-  esp_matter_attr_val_t val = esp_matter_invalid(NULL);
-  if (getAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionLiftPercent100ths::Id, &val)) {
-    currentLiftPercent = (uint8_t)(val.val.u16 / 100);
-  }
   return currentLiftPercent;
 }
 
@@ -516,11 +515,15 @@ bool MatterWindowCovering::setTiltPosition(uint16_t tiltPosition) {
   if (val.val.u16 != tiltPosition) {
     val.val.u16 = tiltPosition;
     bool ret = updateAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionTilt::Id, &val);
+    if (!ret) {
+      ret = setAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionTilt::Id, &val);
+    }
     if (ret) {
       currentTiltPosition = tiltPosition;
-      // Also update CurrentPositionTiltPercent100ths to keep attributes in sync
-      // This matches ESP-Matter's TiltPositionSet() behavior
-      setTiltPercentage((uint8_t)(tiltPercent100ths / 100));
+      if (!setTiltPercentage((uint8_t)(tiltPercent100ths / 100))) {
+        log_e("Failed to sync Tilt Percentage from Tilt Position.");
+        return false;
+      }
     }
     return ret;
   }
@@ -528,10 +531,6 @@ bool MatterWindowCovering::setTiltPosition(uint16_t tiltPosition) {
 }
 
 uint16_t MatterWindowCovering::getTiltPosition() {
-  esp_matter_attr_val_t val = esp_matter_invalid(NULL);
-  if (getAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionTilt::Id, &val)) {
-    currentTiltPosition = val.val.u16;
-  }
   return currentTiltPosition;
 }
 
@@ -564,6 +563,9 @@ bool MatterWindowCovering::setTiltPercentage(uint8_t tiltPercent) {
   if (currentVal.val.u16 != tiltPercent100ths) {
     currentVal.val.u16 = tiltPercent100ths;
     bool ret = updateAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionTiltPercent100ths::Id, &currentVal);
+    if (!ret) {
+      ret = setAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionTiltPercent100ths::Id, &currentVal);
+    }
     if (ret) {
       currentTiltPercent = tiltPercent;
     }
@@ -573,10 +575,6 @@ bool MatterWindowCovering::setTiltPercentage(uint8_t tiltPercent) {
 }
 
 uint8_t MatterWindowCovering::getTiltPercentage() {
-  esp_matter_attr_val_t val = esp_matter_invalid(NULL);
-  if (getAttributeVal(WindowCovering::Id, WindowCovering::Attributes::CurrentPositionTiltPercent100ths::Id, &val)) {
-    currentTiltPercent = (uint8_t)(val.val.u16 / 100);
-  }
   return currentTiltPercent;
 }
 


### PR DESCRIPTION
## Description of Change

This pull request improves the reliability and clarity of attribute and internal state management for Matter endpoints, aligning all endpoint setters with the "Ember pattern" described in the new documentation. The changes ensure that internal state variables are only updated after successfully updating the Matter attribute store, preventing inconsistencies between device state and protocol state. The PR also adds a comprehensive developer guide to document these patterns and clarifies the use of attribute update APIs.

**Documentation and Developer Guidance**

* Added a detailed `README.md` explaining the architecture, state management patterns, setter/getter rules, attribute update APIs, and endpoint class inventory for the Arduino Matter library. This guides developers in implementing robust and consistent endpoint classes.

**Consistent Ember Pattern for State Updates**

* Refactored all endpoint setter methods (e.g., in `MatterTemperatureControlledCabinet`, `MatterWindowCovering`, `MatterOccupancySensor`) to update internal state variables only after the attribute store update succeeds. This prevents internal state from diverging from the protocol-level attribute store. [[1]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L367-R370) [[2]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L420-R421) [[3]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L473-R472) [[4]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L526-R523) [[5]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L593-R586) [[6]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L641-R643) [[7]](diffhunk://#diff-daf0d19ced10da9bb9246b8f84beee1fa5c19106af3a7327c11ba4f0832bdddfR364-L379) [[8]](diffhunk://#diff-daf0d19ced10da9bb9246b8f84beee1fa5c19106af3a7327c11ba4f0832bdddfR412-R414) [[9]](diffhunk://#diff-53209a569e471fcf1c819c32ab80fb1c1837f89109e3d10df671fd07ec323521R448-R456) [[10]](diffhunk://#diff-6220b46c8a219ee62f6c140cb9fe2a2e93b0be5bc391fea262da16ed848d0f6fR194)

* For attributes that may fail to update via `updateAttributeVal()` (e.g., nullable or dynamic attributes), added a fallback to `setAttributeVal()` as documented in the new guide. [[1]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L367-R370) [[2]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L420-R421) [[3]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L473-R472) [[4]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L526-R523) [[5]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L593-R586) [[6]](diffhunk://#diff-daf0d19ced10da9bb9246b8f84beee1fa5c19106af3a7327c11ba4f0832bdddfR364-L379) [[7]](diffhunk://#diff-daf0d19ced10da9bb9246b8f84beee1fa5c19106af3a7327c11ba4f0832bdddfR412-R414)

**Getter and Internal State Simplification**

* Simplified getter methods for affected endpoints to always return the internal state variable, removing unnecessary reads from the attribute store, since the internal state now reliably reflects the last committed value. [[1]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L391-L394) [[2]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L444-L447) [[3]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L497-L500) [[4]](diffhunk://#diff-8c96ca12e0bcc01959c9eab72a617864e544bbe017d457a3c49b54e6365acec3L612-L615) [[5]](diffhunk://#diff-daf0d19ced10da9bb9246b8f84beee1fa5c19106af3a7327c11ba4f0832bdddfR364-L379) [[6]](diffhunk://#diff-daf0d19ced10da9bb9246b8f84beee1fa5c19106af3a7327c11ba4f0832bdddfL421-L424)

**Atomicity and Buffer Handling Improvements**

* In setters that update arrays (e.g., `setSupportedTemperatureLevels`), now copy data into internal buffers only after successfully updating the attribute store, ensuring the internal buffer is not modified on failure.

**Event Loop Scheduling and State Commit**

* For `MatterOccupancySensor`, internal state for hold time limits is now updated only after successfully scheduling the attribute update on the Matter event loop, further aligning with the Ember pattern. [[1]](diffhunk://#diff-53209a569e471fcf1c819c32ab80fb1c1837f89109e3d10df671fd07ec323521L410-L414) [[2]](diffhunk://#diff-53209a569e471fcf1c819c32ab80fb1c1837f89109e3d10df671fd07ec323521R427-L438) [[3]](diffhunk://#diff-53209a569e471fcf1c819c32ab80fb1c1837f89109e3d10df671fd07ec323521R448-R456)

These changes collectively make endpoint implementations more robust and maintainable, and the new documentation provides a clear reference for future development.

## Test Scenarios

Tested locally with WIP Matter test. All 33 Phase 0 unit tests pass (previously 2 failures in  test_matter_window_covering` and `test_matter_cabinet`). Phase 1 controller-driven tests (commissioning, multi-endpoint control) also pass.
