### PR TITLE
fix(zigbee): Guard reporting before stack start and fix multistate input state

### DIFF
--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -553,8 +553,11 @@ void ZigbeeCore::scanNetworks(u_int32_t channel_mask, u_int8_t scan_duration) {
     log_w("Scan already in progress, ignoring new scan request");
     return;
   }
-  log_v("Scanning Zigbee networks");
-  esp_zb_lock_acquire(portMAX_DELAY);
+  log_v("Starting to scan Zigbee networks");
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_e("Failed to start scanning Zigbee networks: failed to acquire Zigbee lock");
+    return;
+  }
   esp_zb_zdo_active_scan_request(channel_mask, scan_duration, scanCompleteCallback);
   esp_zb_lock_release();
   _scan_status = ZB_SCAN_RUNNING;
@@ -806,25 +809,6 @@ void ZigbeeCore::start() {
     _started = true;
   }
   return;
-}
-
-bool ZigbeeCore::updateReportingInfo(esp_zb_zcl_reporting_info_t *reporting_info) {
-  if (reporting_info == nullptr) {
-    log_e("Reporting info is null");
-    return false;
-  }
-  if (!started()) {
-    log_w("Cannot configure reporting: Zigbee stack not started");
-    return false;
-  }
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to update reporting info: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
 }
 
 // Function to convert enum value to string

--- a/libraries/Zigbee/src/ZigbeeCore.cpp
+++ b/libraries/Zigbee/src/ZigbeeCore.cpp
@@ -41,6 +41,7 @@ ZigbeeCore::ZigbeeCore() {
   _open_network = 0;
   _scan_status = ZB_SCAN_FAILED;
   _begin_timeout = ZB_BEGIN_TIMEOUT_DEFAULT;
+  _initialized = false;
   _started = false;
   _connected = false;
   _scan_duration = 3;  // default scan duration
@@ -61,11 +62,16 @@ static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id,
 bool zb_apsde_data_indication_handler(esp_zb_apsde_data_ind_t ind);
 
 bool ZigbeeCore::begin(esp_zb_cfg_t *role_cfg, bool erase_nvs) {
+  if (_initialized) {
+    log_w("Zigbee already initialized; begin() ignored (use start()/stop() to pause/resume)");
+    return false;
+  }
+
+  _role = (zigbee_role_t)role_cfg->esp_zb_role;
   if (!zigbeeInit(role_cfg, erase_nvs)) {
     log_e("ZigbeeCore begin failed");
     return false;
   }
-  _role = (zigbee_role_t)role_cfg->esp_zb_role;
   if (xSemaphoreTake(lock, _begin_timeout) != pdTRUE) {
     log_e("ZigbeeCore begin failed or timeout");
     if (_role != ZIGBEE_COORDINATOR) {  // Only End Device and Router can rejoin
@@ -76,6 +82,11 @@ bool ZigbeeCore::begin(esp_zb_cfg_t *role_cfg, bool erase_nvs) {
 }
 
 bool ZigbeeCore::begin(zigbee_role_t role, bool erase_nvs) {
+  if (_initialized) {
+    log_w("Zigbee already initialized; begin() ignored (use start()/stop() to pause/resume)");
+    return false;
+  }
+
   bool status = true;
   switch (role) {
     case ZIGBEE_COORDINATOR:
@@ -201,8 +212,12 @@ bool ZigbeeCore::zigbeeInit(esp_zb_cfg_t *zb_cfg, bool erase_nvs) {
   }
 
   // Create Zigbee task and start Zigbee stack
-  xTaskCreate(esp_zb_task, "Zigbee_main", 8192, NULL, 5, NULL);
+  if (xTaskCreate(esp_zb_task, "Zigbee_main", 8192, NULL, 5, NULL) != pdPASS) {
+    log_e("Failed to create Zigbee task");
+    return false;
+  }
 
+  _initialized = true;
   return true;
 }
 
@@ -791,6 +806,25 @@ void ZigbeeCore::start() {
     _started = true;
   }
   return;
+}
+
+bool ZigbeeCore::updateReportingInfo(esp_zb_zcl_reporting_info_t *reporting_info) {
+  if (reporting_info == nullptr) {
+    log_e("Reporting info is null");
+    return false;
+  }
+  if (!started()) {
+    log_w("Cannot configure reporting: Zigbee stack not started");
+    return false;
+  }
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_err_t ret = esp_zb_zcl_update_reporting_info(reporting_info);
+  esp_zb_lock_release();
+  if (ret != ESP_OK) {
+    log_e("Failed to update reporting info: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+  return true;
 }
 
 // Function to convert enum value to string

--- a/libraries/Zigbee/src/ZigbeeCore.h
+++ b/libraries/Zigbee/src/ZigbeeCore.h
@@ -143,6 +143,9 @@ public:
   void stop();
   void start();
 
+  bool initialized() {
+    return _initialized;
+  }
   bool started() {
     return _started;
   }
@@ -150,8 +153,6 @@ public:
     return _connected;
   }
 
-  // Configure ZCL attribute reporting (requires a running Zigbee stack).
-  bool updateReportingInfo(esp_zb_zcl_reporting_info_t *reporting_info);
   zigbee_role_t getRole() {
     return _role;
   }

--- a/libraries/Zigbee/src/ZigbeeCore.h
+++ b/libraries/Zigbee/src/ZigbeeCore.h
@@ -110,6 +110,7 @@ private:
 
   esp_zb_ep_list_t *_zb_ep_list;
   zigbee_role_t _role;
+  bool _initialized;
   bool _started;
   bool _connected;
 
@@ -148,6 +149,9 @@ public:
   bool connected() {
     return _connected;
   }
+
+  // Configure ZCL attribute reporting (requires a running Zigbee stack).
+  bool updateReportingInfo(esp_zb_zcl_reporting_info_t *reporting_info);
   zigbee_role_t getRole() {
     return _role;
   }

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -336,9 +336,8 @@ bool ZigbeeEP::setBatteryPercentage(uint8_t percentage) {
 }
 
 bool ZigbeeEP::setBatteryVoltage(uint8_t voltage) {
-  esp_zb_zcl_status_t ret = setClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_VOLTAGE_ID, &voltage, false
-  );
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_VOLTAGE_ID, &voltage, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set battery voltage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -74,6 +74,148 @@ ZigbeeEP::ZigbeeEP(uint8_t endpoint) {
   }
 }
 
+esp_zb_zcl_status_t ZigbeeEP::setClusterAttribute(uint16_t cluster_id, uint8_t cluster_role, uint16_t attr_id, void *value, bool check) {
+  if (!Zigbee.initialized()) {
+    log_w("Cannot set attribute: Zigbee stack not initialized");
+    return ESP_ZB_ZCL_STATUS_FAIL;
+  }
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_w("Cannot set attribute: failed to acquire Zigbee lock");
+    return ESP_ZB_ZCL_STATUS_FAIL;
+  }
+  esp_zb_zcl_status_t ret = esp_zb_zcl_set_attribute_val(_endpoint, cluster_id, cluster_role, attr_id, value, check);
+  esp_zb_lock_release();
+  return ret;
+}
+
+bool ZigbeeEP::getClusterAttribute(uint16_t cluster_id, uint8_t cluster_role, uint16_t attr_id, void *value, uint16_t value_size) {
+  if (value == nullptr || value_size == 0) {
+    log_e("Get attribute value buffer is invalid");
+    return false;
+  }
+  if (!Zigbee.initialized()) {
+    log_w("Cannot get attribute: Zigbee stack not initialized");
+    return false;
+  }
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_w("Cannot get attribute: failed to acquire Zigbee lock");
+    return false;
+  }
+  esp_zb_zcl_attr_t *attr = esp_zb_zcl_get_attribute(_endpoint, cluster_id, cluster_role, attr_id);
+  if (attr == nullptr || attr->data_p == nullptr) {
+    esp_zb_lock_release();
+    log_w("Cannot get attribute: attribute not found");
+    return false;
+  }
+  memcpy(value, attr->data_p, value_size);
+  esp_zb_lock_release();
+  return true;
+}
+
+bool ZigbeeEP::reportClusterAttribute(esp_zb_zcl_report_attr_cmd_t *report_attr_cmd) {
+  if (report_attr_cmd == nullptr) {
+    log_e("Report attribute command is null");
+    return false;
+  }
+  if (!Zigbee.started()) {
+    log_w("Cannot report attribute: Zigbee stack not started");
+    return false;
+  }
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_w("Cannot report attribute: failed to acquire Zigbee lock");
+    return false;
+  }
+  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(report_attr_cmd);
+  esp_zb_lock_release();
+  if (ret != ESP_OK) {
+    log_e("Failed to report attribute: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+  return true;
+}
+
+bool ZigbeeEP::readClusterAttribute(esp_zb_zcl_read_attr_cmd_t *read_req) {
+  if (read_req == nullptr) {
+    log_e("Read attribute command is null");
+    return false;
+  }
+  if (!Zigbee.started()) {
+    log_w("Cannot read attribute: Zigbee stack not started");
+    return false;
+  }
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_w("Cannot read attribute: failed to acquire Zigbee lock");
+    return false;
+  }
+  esp_err_t ret = esp_zb_zcl_read_attr_cmd_req(read_req);
+  esp_zb_lock_release();
+  if (ret != ESP_OK) {
+    log_e("Failed to read attribute: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+  return true;
+}
+
+bool ZigbeeEP::setClusterReporting(esp_zb_zcl_reporting_info_t *reporting_info) {
+  if (reporting_info == nullptr) {
+    log_e("Reporting info is null");
+    return false;
+  }
+  if (!Zigbee.initialized()) {
+    log_w("Cannot configure reporting: Zigbee stack not initialized");
+    return false;
+  }
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_w("Cannot configure reporting: failed to acquire Zigbee lock");
+    return false;
+  }
+  esp_err_t ret = esp_zb_zcl_update_reporting_info(reporting_info);
+  esp_zb_lock_release();
+  if (ret != ESP_OK) {
+    log_e("Failed to update reporting info: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+  return true;
+}
+
+bool ZigbeeEP::configureClusterReporting(esp_zb_zcl_config_report_cmd_t *report_cmd) {
+  if (report_cmd == nullptr) {
+    log_e("Configure report command is null");
+    return false;
+  }
+  if (!Zigbee.started()) {
+    log_w("Cannot configure cluster reporting: Zigbee stack not started");
+    return false;
+  }
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_w("Cannot configure cluster reporting: failed to acquire Zigbee lock");
+    return false;
+  }
+  esp_err_t ret = esp_zb_zcl_config_report_cmd_req(report_cmd);
+  esp_zb_lock_release();
+  if (ret != ESP_OK) {
+    log_e("Failed to configure cluster reporting: 0x%x: %s", ret, esp_err_to_name(ret));
+    return false;
+  }
+  return true;
+}
+
+bool ZigbeeEP::acquireCommandLock() {
+  if (!Zigbee.initialized()) {
+    log_w("Cannot send command: Zigbee stack not initialized");
+    return false;
+  }
+  if (!esp_zb_lock_acquire(portMAX_DELAY)) {
+    log_w("Cannot send command: failed to acquire Zigbee lock");
+    return false;
+  }
+  return true;
+}
+
+void ZigbeeEP::releaseCommandLock() {
+  esp_zb_lock_release();
+}
+
 void ZigbeeEP::setVersion(uint8_t version) {
   _ep_config.app_device_version = version;
 
@@ -182,12 +324,9 @@ bool ZigbeeEP::setBatteryPercentage(uint8_t percentage) {
     percentage = 100;
   }
   percentage = percentage * 2;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_PERCENTAGE_REMAINING_ID, &percentage,
-    false
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_PERCENTAGE_REMAINING_ID, &percentage, false
   );
-  esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set battery percentage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -197,12 +336,9 @@ bool ZigbeeEP::setBatteryPercentage(uint8_t percentage) {
 }
 
 bool ZigbeeEP::setBatteryVoltage(uint8_t voltage) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_VOLTAGE_ID, &voltage, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_POWER_CONFIG, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_POWER_CONFIG_BATTERY_VOLTAGE_ID, &voltage, false
   );
-  esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set battery voltage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -222,11 +358,7 @@ bool ZigbeeEP::reportBatteryPercentage() {
   report_attr_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
   report_attr_cmd.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to report battery percentage: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
     return false;
   }
   log_v("Battery percentage reported");
@@ -261,9 +393,9 @@ char *ZigbeeEP::readManufacturer(uint8_t endpoint, uint16_t short_addr, esp_zb_i
   }
   _read_manufacturer = NULL;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    return NULL;
+  }
 
   //Wait for response or timeout
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -300,9 +432,9 @@ char *ZigbeeEP::readModel(uint8_t endpoint, uint16_t short_addr, esp_zb_ieee_add
   }
   _read_model = NULL;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    return NULL;
+  }
 
   //Wait for response or timeout
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -435,9 +567,7 @@ bool ZigbeeEP::setTime(tm time) {
   }
   uint32_t zb_utctime = zb_utctime_from_unix(unix_ts);
   log_d("Setting ZCL UTCTime to %" PRIu32 " s since 2000-01-01 UTC", zb_utctime);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, &zb_utctime, false);
-  esp_zb_lock_release();
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ID, &zb_utctime, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set time: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -448,10 +578,7 @@ bool ZigbeeEP::setTime(tm time) {
 bool ZigbeeEP::setTimezone(int32_t gmt_offset) {
   esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_d("Setting timezone to %" PRId32, gmt_offset);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret =
-    esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ZONE_ID, &gmt_offset, false);
-  esp_zb_lock_release();
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_ZONE_ID, &gmt_offset, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set timezone: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -485,9 +612,9 @@ tm ZigbeeEP::getTime(uint8_t endpoint, int32_t short_addr, esp_zb_ieee_addr_t ie
   _read_time = 0;
 
   log_v("Reading time from endpoint %u", endpoint);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    return tm();
+  }
 
   //Wait for response or timeout
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -502,11 +629,7 @@ tm ZigbeeEP::getTime(uint8_t endpoint, int32_t short_addr, esp_zb_ieee_addr_t ie
     setTime(*timeinfo);
     // Update time status to synced
     _time_status |= 0x02;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_set_attribute_val(
-      _endpoint, ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_STATUS_ID, &_time_status, false
-    );
-    esp_zb_lock_release();
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_TIME, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TIME_TIME_STATUS_ID, &_time_status, false);
 
     return *timeinfo;
   } else {
@@ -541,9 +664,9 @@ int32_t ZigbeeEP::getTimezone(uint8_t endpoint, int32_t short_addr, esp_zb_ieee_
   _read_timezone = 0;
 
   log_v("Reading timezone from endpoint %u", endpoint);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    return 0;
+  }
 
   //Wait for response or timeout
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -647,11 +770,13 @@ void ZigbeeEP::requestOTAUpdate() {
   req.num_out_clusters = 0;
   req.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   req.cluster_list = cluster_list;
-  esp_zb_lock_acquire(portMAX_DELAY);
+  if (!acquireCommandLock()) {
+    return;
+  }
   if (esp_zb_bdb_dev_joined()) {
     esp_zb_zdo_match_cluster(&req, findOTAServer, &_endpoint);
   }
-  esp_zb_lock_release();
+  releaseCommandLock();
 }
 
 void ZigbeeEP::removeBoundDevice(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
@@ -712,9 +837,11 @@ void ZigbeeEP::zbDefaultResponse(const esp_zb_zcl_cmd_default_resp_message_t *me
 }
 
 void ZigbeeEP::addPrivilegeCommand(uint16_t cluster_id, uint16_t command_id) {
-  esp_zb_lock_acquire(portMAX_DELAY);
+  if (!acquireCommandLock()) {
+    return;
+  }
   esp_err_t ret = esp_zb_zcl_add_privilege_command(_endpoint, cluster_id, command_id);
-  esp_zb_lock_release();
+  releaseCommandLock();
   if (ret != ESP_OK) {
     log_e(
       "Failed to add privilege command for endpoint %u, cluster 0x%04x, command 0x%04x: 0x%x: %s", _endpoint, cluster_id, command_id, ret, esp_err_to_name(ret)

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -227,6 +227,18 @@ protected:
   zb_power_source_t _power_source;
   uint8_t _time_status;
 
+  // Thread-safe outgoing ZCL helpers (not related to stack callbacks).
+  esp_zb_zcl_status_t setClusterAttribute(uint16_t cluster_id, uint8_t cluster_role, uint16_t attr_id, void *value, bool check = false);
+  bool getClusterAttribute(uint16_t cluster_id, uint8_t cluster_role, uint16_t attr_id, void *value, uint16_t value_size);
+  bool reportClusterAttribute(esp_zb_zcl_report_attr_cmd_t *report_attr_cmd);
+  bool readClusterAttribute(esp_zb_zcl_read_attr_cmd_t *read_req);
+  bool setClusterReporting(esp_zb_zcl_reporting_info_t *reporting_info);
+  bool configureClusterReporting(esp_zb_zcl_config_report_cmd_t *report_cmd);
+
+  // Acquire/release pair for outgoing ZCL/ZDO commands (caller invokes SDK between them).
+  bool acquireCommandLock();
+  void releaseCommandLock();
+
   // Friend class declaration to allow access to protected members
   friend class ZigbeeCore;
 };

--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
@@ -193,17 +193,13 @@ void ZigbeeAnalog::analogOutputChanged() {
 }
 
 bool ZigbeeAnalog::setAnalogInput(float analog) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   if (!(_analog_clusters & ANALOG_INPUT)) {
     log_e("Analog Input cluster not added");
     return false;
   }
   log_d("Setting analog input to %.1f", analog);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ANALOG_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ANALOG_INPUT_PRESENT_VALUE_ID, &analog, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ANALOG_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ANALOG_INPUT_PRESENT_VALUE_ID, &analog, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set analog input: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -212,18 +208,13 @@ bool ZigbeeAnalog::setAnalogInput(float analog) {
 }
 
 bool ZigbeeAnalog::setAnalogOutput(float analog) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   _output_state = analog;
   analogOutputChanged();
 
   log_v("Updating analog output to %.2f", analog);
-  /* Update analog output */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ANALOG_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_PRESENT_VALUE_ID, &_output_state, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_ANALOG_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_PRESENT_VALUE_ID, &_output_state, false
   );
-  esp_zb_lock_release();
-
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set analog output: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -242,11 +233,8 @@ bool ZigbeeAnalog::reportAnalogInput() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send Analog Input report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send Analog Input report");
     return false;
   }
   log_v("Analog Input report sent");
@@ -264,11 +252,8 @@ bool ZigbeeAnalog::reportAnalogOutput() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send Analog Output report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send Analog Output report");
     return false;
   }
   log_v("Analog Output report sent");
@@ -291,7 +276,7 @@ bool ZigbeeAnalog::setAnalogInputReporting(uint16_t min_interval, uint16_t max_i
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
 
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeAnalog::setAnalogInputDescription(const char *description) {

--- a/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeAnalog.cpp
@@ -291,14 +291,7 @@ bool ZigbeeAnalog::setAnalogInputReporting(uint16_t min_interval, uint16_t max_i
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set Analog Input reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeAnalog::setAnalogInputDescription(const char *description) {

--- a/libraries/Zigbee/src/ep/ZigbeeBinary.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeBinary.cpp
@@ -127,17 +127,12 @@ bool ZigbeeBinary::setBinaryOutputApplication(uint32_t application_type) {
 }
 
 bool ZigbeeBinary::setBinaryInput(bool input) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   if (!(_binary_clusters & BINARY_INPUT)) {
     log_e("Binary Input cluster not added");
     return false;
   }
   log_d("Setting binary input to %d", input);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_BINARY_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_INPUT_PRESENT_VALUE_ID, &input, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_BINARY_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_INPUT_PRESENT_VALUE_ID, &input, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set binary input: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -156,11 +151,8 @@ bool ZigbeeBinary::reportBinaryInput() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send Binary Input report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send Binary Input report: 0x%x: %s");
     return false;
   }
   log_v("Binary Input report sent");
@@ -270,17 +262,12 @@ void ZigbeeBinary::binaryOutputChanged() {
 }
 
 bool ZigbeeBinary::setBinaryOutput(bool output) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   _output_state = output;
   binaryOutputChanged();
 
   log_v("Updating binary output to %d", output);
   /* Update binary output */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_BINARY_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_OUTPUT_PRESENT_VALUE_ID, &_output_state, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_BINARY_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_OUTPUT_PRESENT_VALUE_ID, &_output_state, false);
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set binary output: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
@@ -300,11 +287,8 @@ bool ZigbeeBinary::reportBinaryOutput() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send Binary Output report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send Binary Output report: 0x%x: %s");
     return false;
   }
   log_v("Binary Output report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeBinary.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeBinary.cpp
@@ -132,7 +132,8 @@ bool ZigbeeBinary::setBinaryInput(bool input) {
     return false;
   }
   log_d("Setting binary input to %d", input);
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_BINARY_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_INPUT_PRESENT_VALUE_ID, &input, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_BINARY_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_INPUT_PRESENT_VALUE_ID, &input, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set binary input: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -267,7 +268,9 @@ bool ZigbeeBinary::setBinaryOutput(bool output) {
 
   log_v("Updating binary output to %d", output);
   /* Update binary output */
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_BINARY_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_OUTPUT_PRESENT_VALUE_ID, &_output_state, false);
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_BINARY_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_BINARY_OUTPUT_PRESENT_VALUE_ID, &_output_state, false
+  );
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set binary output: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -100,21 +100,17 @@ bool ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max
   float delta_f = delta / 1000000.0f;
   memcpy(&reporting_info.u.send_info.delta.s32, &delta_f, sizeof(float));
 
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeCarbonDioxideSensor::setCarbonDioxide(float carbon_dioxide) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   float zb_carbon_dioxide = carbon_dioxide / 1000000.0f;
   log_v("Updating carbon dioxide sensor value...");
-  /* Update carbon dioxide sensor measured value */
   log_d("Setting carbon dioxide to %0.1f", carbon_dioxide);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID,
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_CARBON_DIOXIDE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_CARBON_DIOXIDE_MEASUREMENT_MEASURED_VALUE_ID,
     &zb_carbon_dioxide, false
   );
-  esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set carbon dioxide: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -133,11 +129,8 @@ bool ZigbeeCarbonDioxideSensor::report() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send carbon dioxide report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send carbon dioxide report");
     return false;
   }
   log_v("Carbon dioxide report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeCarbonDioxideSensor.cpp
@@ -100,14 +100,7 @@ bool ZigbeeCarbonDioxideSensor::setReporting(uint16_t min_interval, uint16_t max
   float delta_f = delta / 1000000.0f;
   memcpy(&reporting_info.u.send_info.delta.s32, &delta_f, sizeof(float));
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeCarbonDioxideSensor::setCarbonDioxide(float carbon_dioxide) {

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -61,38 +61,43 @@ ZigbeeColorDimmableLight::ZigbeeColorDimmableLight(uint8_t endpoint) : ZigbeeEP(
 }
 
 uint16_t ZigbeeColorDimmableLight::getCurrentColorX() {
-  return (*(uint16_t *)esp_zb_zcl_get_attribute(
-             _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID
-  )
-             ->data_p);
+  uint16_t value = 0;
+  getClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &value, sizeof(value)
+  );
+  return value;
 }
 
 uint16_t ZigbeeColorDimmableLight::getCurrentColorY() {
-  return (*(uint16_t *)esp_zb_zcl_get_attribute(
-             _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID
-  )
-             ->data_p);
+  uint16_t value = 0;
+  getClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &value, sizeof(value)
+  );
+  return value;
 }
 
 uint8_t ZigbeeColorDimmableLight::getCurrentColorHue() {
-  return (*(uint8_t *)esp_zb_zcl_get_attribute(
-             _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID
-  )
-             ->data_p);
+  uint8_t value = 0;
+  getClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &value, sizeof(value)
+  );
+  return value;
 }
 
 uint8_t ZigbeeColorDimmableLight::getCurrentColorSaturation() {
-  return (*(uint8_t *)esp_zb_zcl_get_attribute(
-             _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID
-  )
-             ->data_p);
+  uint8_t value = 0;
+  getClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &value, sizeof(value)
+  );
+  return value;
 }
 
 uint16_t ZigbeeColorDimmableLight::getCurrentColorTemperature() {
-  return (*(uint16_t *)esp_zb_zcl_get_attribute(
-             _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_TEMPERATURE_ID
-  )
-             ->data_p);
+  uint16_t value = 0;
+  getClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_TEMPERATURE_ID, &value, sizeof(value)
+  );
+  return value;
 }
 
 //set attribute method -> method overridden in child class
@@ -286,59 +291,37 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
   _current_hsv = hsv_color;
 
   log_v("Updating light state: %d, level: %u, color: %u, %u, %u", state, level, red, green, blue);
-  /* Update light clusters */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  //set on/off state
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  //set level
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light level: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  //set x color
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &xy_color.x, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &xy_color.x, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light xy color: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  //set y color
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &xy_color.y, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &xy_color.y, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light y color: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  //set hue (for compatibility)
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &hue, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &hue, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light hue: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  //set saturation (for compatibility)
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light saturation: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 bool ZigbeeColorDimmableLight::setLightState(bool state) {
@@ -347,12 +330,7 @@ bool ZigbeeColorDimmableLight::setLightState(bool state) {
   }
 
   _current_state = state;
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
 
   if (ret == ESP_ZB_ZCL_STATUS_SUCCESS) {
     lightChangedByMode();  // Call appropriate callback based on current color mode
@@ -374,12 +352,7 @@ bool ZigbeeColorDimmableLight::setLightLevel(uint8_t level) {
     _current_hsv.v = level;
   }
 
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
 
   if (ret == ESP_ZB_ZCL_STATUS_SUCCESS) {
     lightChangedByMode();  // Call appropriate callback based on current color mode
@@ -420,35 +393,22 @@ bool ZigbeeColorDimmableLight::setLightColor(espHsvColor_t hsv_color) {
   uint8_t saturation = std::clamp((uint8_t)hsv_color.s, (uint8_t)0, (uint8_t)254);
 
   log_v("Updating light HSV: H=%u, S=%u, V=%u (level=%u)", hue, saturation, hsv_color.v, _current_level);
-  /* Update light clusters */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  //set level (brightness from HSV value component)
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light level: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  //set hue
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &hue, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &hue, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light hue: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  //set saturation
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light saturation: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 bool ZigbeeColorDimmableLight::setLightColorTemperature(uint16_t color_temperature) {
@@ -467,20 +427,14 @@ bool ZigbeeColorDimmableLight::setLightColorTemperature(uint16_t color_temperatu
 
   log_v("Updating light color temperature: %u", color_temperature);
 
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  /* Update light clusters */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_TEMPERATURE_ID,
-    &_current_color_temperature, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_TEMPERATURE_ID, &_current_color_temperature, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light color temperature: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 bool ZigbeeColorDimmableLight::isColorModeSupported(uint8_t color_mode) {
@@ -504,13 +458,8 @@ bool ZigbeeColorDimmableLight::setLightColorMode(uint8_t color_mode) {
     return false;
   }
 
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Setting color mode: %u", color_mode);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_MODE_ID, &color_mode, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_MODE_ID, &color_mode, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light color mode: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -100,6 +100,45 @@ uint16_t ZigbeeColorDimmableLight::getCurrentColorTemperature() {
   return value;
 }
 
+uint16_t ZigbeeColorDimmableLight::readColorAttributeU16(uint16_t attr_id) {
+  esp_zb_zcl_attr_t *attr =
+    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id);
+  if (attr == nullptr || attr->data_p == nullptr) {
+    log_w("Cannot read color attribute 0x%04x", attr_id);
+    return 0;
+  }
+  return *(uint16_t *)attr->data_p;
+}
+
+uint8_t ZigbeeColorDimmableLight::readColorAttributeU8(uint16_t attr_id) {
+  esp_zb_zcl_attr_t *attr =
+    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id);
+  if (attr == nullptr || attr->data_p == nullptr) {
+    log_w("Cannot read color attribute 0x%04x", attr_id);
+    return 0;
+  }
+  return *(uint8_t *)attr->data_p;
+}
+
+void ZigbeeColorDimmableLight::syncColorModeFromCallback(uint8_t color_mode) {
+  if (_current_color_mode == color_mode) {
+    return;
+  }
+  if (!isColorModeSupported(color_mode)) {
+    log_w("Color mode %u not supported by current capabilities: 0x%04x", color_mode, _color_capabilities);
+    return;
+  }
+  esp_zb_zcl_status_t ret = esp_zb_zcl_set_attribute_val(
+    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_MODE_ID, &color_mode, false
+  );
+  if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
+    log_e("Failed to set light color mode: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
+    return;
+  }
+  _current_color_mode = color_mode;
+  log_v("Color mode changed to: %u", _current_color_mode);
+}
+
 //set attribute method -> method overridden in child class
 void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message) {
   //check the data and call right method
@@ -153,11 +192,8 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
         return;
       }
       uint16_t light_color_x = (*(uint16_t *)message->attribute.data.value);
-      uint16_t light_color_y = getCurrentColorY();
-      // Update color mode to XY if not already
-      if (_current_color_mode != ZIGBEE_COLOR_MODE_CURRENT_X_Y) {
-        setLightColorMode(ZIGBEE_COLOR_MODE_CURRENT_X_Y);
-      }
+      uint16_t light_color_y = readColorAttributeU16(ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID);
+      syncColorModeFromCallback(ZIGBEE_COLOR_MODE_CURRENT_X_Y);
       //calculate RGB from XY and call RGB callback
       _current_color = espXYToRgbColor(255, light_color_x, light_color_y, false);
       lightChangedRgb();
@@ -169,12 +205,9 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
         log_w("XY color capability not enabled, but XY attribute received. Current capabilities: 0x%04x", _color_capabilities);
         return;
       }
-      uint16_t light_color_x = getCurrentColorX();
+      uint16_t light_color_x = readColorAttributeU16(ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID);
       uint16_t light_color_y = (*(uint16_t *)message->attribute.data.value);
-      // Update color mode to XY if not already
-      if (_current_color_mode != ZIGBEE_COLOR_MODE_CURRENT_X_Y) {
-        setLightColorMode(ZIGBEE_COLOR_MODE_CURRENT_X_Y);
-      }
+      syncColorModeFromCallback(ZIGBEE_COLOR_MODE_CURRENT_X_Y);
       //calculate RGB from XY and call RGB callback
       _current_color = espXYToRgbColor(255, light_color_x, light_color_y, false);
       lightChangedRgb();
@@ -186,13 +219,10 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
         return;
       }
       uint8_t light_color_hue = (*(uint8_t *)message->attribute.data.value);
-      // Update color mode to HS if not already
-      if (_current_color_mode != ZIGBEE_COLOR_MODE_HUE_SATURATION) {
-        setLightColorMode(ZIGBEE_COLOR_MODE_HUE_SATURATION);
-      }
+      syncColorModeFromCallback(ZIGBEE_COLOR_MODE_HUE_SATURATION);
       // Store HSV values and call HSV callback (don't convert to RGB)
       _current_hsv.h = light_color_hue;
-      _current_hsv.s = getCurrentColorSaturation();
+      _current_hsv.s = readColorAttributeU8(ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID);
       _current_hsv.v = _current_level;  // Use level as value
       lightChangedHsv();
       return;
@@ -203,12 +233,9 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
         return;
       }
       uint8_t light_color_saturation = (*(uint8_t *)message->attribute.data.value);
-      // Update color mode to HS if not already
-      if (_current_color_mode != ZIGBEE_COLOR_MODE_HUE_SATURATION) {
-        setLightColorMode(ZIGBEE_COLOR_MODE_HUE_SATURATION);
-      }
+      syncColorModeFromCallback(ZIGBEE_COLOR_MODE_HUE_SATURATION);
       // Store HSV values and call HSV callback (don't convert to RGB)
-      _current_hsv.h = getCurrentColorHue();
+      _current_hsv.h = readColorAttributeU8(ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID);
       _current_hsv.s = light_color_saturation;
       _current_hsv.v = _current_level;  // Use level as value
       lightChangedHsv();
@@ -220,10 +247,7 @@ void ZigbeeColorDimmableLight::zbAttributeSet(const esp_zb_zcl_set_attr_value_me
         return;
       }
       uint16_t light_color_temp = (*(uint16_t *)message->attribute.data.value);
-      // Update color mode to TEMP if not already
-      if (_current_color_mode != ZIGBEE_COLOR_MODE_TEMPERATURE) {
-        setLightColorMode(ZIGBEE_COLOR_MODE_TEMPERATURE);
-      }
+      syncColorModeFromCallback(ZIGBEE_COLOR_MODE_TEMPERATURE);
       if (_current_color_temperature != light_color_temp) {
         _current_color_temperature = light_color_temp;
         lightChangedTemp();

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
@@ -62,25 +62,19 @@ ZigbeeColorDimmableLight::ZigbeeColorDimmableLight(uint8_t endpoint) : ZigbeeEP(
 
 uint16_t ZigbeeColorDimmableLight::getCurrentColorX() {
   uint16_t value = 0;
-  getClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &value, sizeof(value)
-  );
+  getClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &value, sizeof(value));
   return value;
 }
 
 uint16_t ZigbeeColorDimmableLight::getCurrentColorY() {
   uint16_t value = 0;
-  getClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &value, sizeof(value)
-  );
+  getClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &value, sizeof(value));
   return value;
 }
 
 uint8_t ZigbeeColorDimmableLight::getCurrentColorHue() {
   uint8_t value = 0;
-  getClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &value, sizeof(value)
-  );
+  getClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, &value, sizeof(value));
   return value;
 }
 
@@ -101,8 +95,7 @@ uint16_t ZigbeeColorDimmableLight::getCurrentColorTemperature() {
 }
 
 uint16_t ZigbeeColorDimmableLight::readColorAttributeU16(uint16_t attr_id) {
-  esp_zb_zcl_attr_t *attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id);
+  esp_zb_zcl_attr_t *attr = esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id);
   if (attr == nullptr || attr->data_p == nullptr) {
     log_w("Cannot read color attribute 0x%04x", attr_id);
     return 0;
@@ -111,8 +104,7 @@ uint16_t ZigbeeColorDimmableLight::readColorAttributeU16(uint16_t attr_id) {
 }
 
 uint8_t ZigbeeColorDimmableLight::readColorAttributeU8(uint16_t attr_id) {
-  esp_zb_zcl_attr_t *attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id);
+  esp_zb_zcl_attr_t *attr = esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id);
   if (attr == nullptr || attr->data_p == nullptr) {
     log_w("Cannot read color attribute 0x%04x", attr_id);
     return 0;
@@ -320,17 +312,21 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
     log_e("Failed to set light state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
   }
-  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light level: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
   }
-  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &xy_color.x, false);
+  ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, &xy_color.x, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light xy color: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
   }
-  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &xy_color.y, false);
+  ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID, &xy_color.y, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light y color: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -340,7 +336,9 @@ bool ZigbeeColorDimmableLight::setLight(bool state, uint8_t level, uint8_t red, 
     log_e("Failed to set light hue: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
   }
-  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false);
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light saturation: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -354,7 +352,8 @@ bool ZigbeeColorDimmableLight::setLightState(bool state) {
   }
 
   _current_state = state;
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
 
   if (ret == ESP_ZB_ZCL_STATUS_SUCCESS) {
     lightChangedByMode();  // Call appropriate callback based on current color mode
@@ -376,7 +375,9 @@ bool ZigbeeColorDimmableLight::setLightLevel(uint8_t level) {
     _current_hsv.v = level;
   }
 
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
+  );
 
   if (ret == ESP_ZB_ZCL_STATUS_SUCCESS) {
     lightChangedByMode();  // Call appropriate callback based on current color mode
@@ -417,7 +418,9 @@ bool ZigbeeColorDimmableLight::setLightColor(espHsvColor_t hsv_color) {
   uint8_t saturation = std::clamp((uint8_t)hsv_color.s, (uint8_t)0, (uint8_t)254);
 
   log_v("Updating light HSV: H=%u, S=%u, V=%u (level=%u)", hue, saturation, hsv_color.v, _current_level);
-  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light level: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -427,7 +430,9 @@ bool ZigbeeColorDimmableLight::setLightColor(espHsvColor_t hsv_color) {
     log_e("Failed to set light hue: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
   }
-  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false);
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID, &saturation, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light saturation: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -483,7 +488,8 @@ bool ZigbeeColorDimmableLight::setLightColorMode(uint8_t color_mode) {
   }
 
   log_v("Setting color mode: %u", color_mode);
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_MODE_ID, &color_mode, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_COLOR_MODE_ID, &color_mode, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light color mode: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.h
@@ -165,6 +165,11 @@ private:
   uint8_t getCurrentColorSaturation();
   uint16_t getCurrentColorTemperature();
 
+  // Stack callback helpers (must not use Zigbee lock).
+  uint16_t readColorAttributeU16(uint16_t attr_id);
+  uint8_t readColorAttributeU8(uint16_t attr_id);
+  void syncColorModeFromCallback(uint8_t color_mode);
+
   void lightChangedRgb();
   void lightChangedHsv();
   void lightChangedTemp();

--- a/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
@@ -128,9 +128,11 @@ void ZigbeeColorDimmerSwitch::lightToggle() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -145,9 +147,11 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -163,9 +167,11 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint8_t endpoint, uint16_t short_addr)
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -184,9 +190,11 @@ void ZigbeeColorDimmerSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t i
       "Sending 'light toggle' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
       ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -200,9 +208,11 @@ void ZigbeeColorDimmerSwitch::lightOn() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -217,9 +227,11 @@ void ZigbeeColorDimmerSwitch::lightOn(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -235,9 +247,11 @@ void ZigbeeColorDimmerSwitch::lightOn(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -256,9 +270,11 @@ void ZigbeeColorDimmerSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_
       "Sending 'light on' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
       ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -272,9 +288,11 @@ void ZigbeeColorDimmerSwitch::lightOff() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -289,9 +307,11 @@ void ZigbeeColorDimmerSwitch::lightOff(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -307,9 +327,11 @@ void ZigbeeColorDimmerSwitch::lightOff(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -328,9 +350,11 @@ void ZigbeeColorDimmerSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee
       "Sending 'light off' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
       ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -345,9 +369,11 @@ void ZigbeeColorDimmerSwitch::lightOffWithEffect(uint8_t effect_id, uint8_t effe
     cmd_req.effect_id = effect_id;
     cmd_req.effect_variant = effect_variant;
     log_v("Sending 'light off with effect' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_off_with_effect_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -360,9 +386,11 @@ void ZigbeeColorDimmerSwitch::lightOnWithSceneRecall() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     log_v("Sending 'light on with scene recall' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_on_with_recall_global_scene_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -378,9 +406,11 @@ void ZigbeeColorDimmerSwitch::lightOnWithTimedOff(uint8_t on_off_control, uint16
     cmd_req.on_time = time_on;
     cmd_req.off_wait_time = time_off;
     log_v("Sending 'light on with time off' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_on_with_timed_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -395,9 +425,11 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level) {
     cmd_req.level = level;
     cmd_req.transition_time = 0xffff;
     log_v("Sending 'set light level' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -413,9 +445,11 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint16_t group_addr) 
     cmd_req.level = level;
     cmd_req.transition_time = 0xffff;
     log_v("Sending 'set light level' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -432,9 +466,11 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, uin
     cmd_req.level = level;
     cmd_req.transition_time = 0xffff;
     log_v("Sending 'set light level' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -454,9 +490,11 @@ void ZigbeeColorDimmerSwitch::setLightLevel(uint8_t level, uint8_t endpoint, esp
       "Sending 'set light level' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
       ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_move_to_level_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -474,9 +512,11 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
     cmd_req.color_y = xy_color.y;
     cmd_req.transition_time = 0;
     log_v("Sending 'set light color' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -495,9 +535,11 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
     cmd_req.color_y = xy_color.y;
     cmd_req.transition_time = 0;
     log_v("Sending 'set light color' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -517,9 +559,11 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
     cmd_req.color_y = xy_color.y;
     cmd_req.transition_time = 0;
     log_v("Sending 'set light color' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -542,9 +586,11 @@ void ZigbeeColorDimmerSwitch::setLightColor(uint8_t red, uint8_t green, uint8_t 
       "Sending 'set light color' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
       ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_color_move_to_color_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -560,9 +606,9 @@ void ZigbeeColorDimmerSwitch::getLightState() {
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 
@@ -577,9 +623,9 @@ void ZigbeeColorDimmerSwitch::getLightState(uint16_t group_addr) {
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 
@@ -595,9 +641,9 @@ void ZigbeeColorDimmerSwitch::getLightState(uint8_t endpoint, uint16_t short_add
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 
@@ -613,9 +659,9 @@ void ZigbeeColorDimmerSwitch::getLightState(uint8_t endpoint, esp_zb_ieee_addr_t
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 
@@ -629,9 +675,9 @@ void ZigbeeColorDimmerSwitch::getLightLevel() {
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light level command");
+    }
   }
 }
 
@@ -646,9 +692,9 @@ void ZigbeeColorDimmerSwitch::getLightLevel(uint16_t group_addr) {
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light level command");
+    }
   }
 }
 
@@ -664,9 +710,9 @@ void ZigbeeColorDimmerSwitch::getLightLevel(uint8_t endpoint, uint16_t short_add
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light level command");
+    }
   }
 }
 
@@ -682,9 +728,9 @@ void ZigbeeColorDimmerSwitch::getLightLevel(uint8_t endpoint, esp_zb_ieee_addr_t
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light level command");
+    }
   }
 }
 
@@ -698,9 +744,9 @@ void ZigbeeColorDimmerSwitch::getLightColor() {
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color command");
+    }
   }
 }
 
@@ -715,9 +761,9 @@ void ZigbeeColorDimmerSwitch::getLightColor(uint16_t group_addr) {
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color command");
+    }
   }
 }
 
@@ -733,9 +779,9 @@ void ZigbeeColorDimmerSwitch::getLightColor(uint8_t endpoint, uint16_t short_add
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color command");
+    }
   }
 }
 
@@ -751,9 +797,9 @@ void ZigbeeColorDimmerSwitch::getLightColor(uint8_t endpoint, esp_zb_ieee_addr_t
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_X_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_Y_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color command");
+    }
   }
 }
 
@@ -767,9 +813,9 @@ void ZigbeeColorDimmerSwitch::getLightColorHS() {
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color (hue/saturation) command");
+    }
   }
 }
 
@@ -784,9 +830,9 @@ void ZigbeeColorDimmerSwitch::getLightColorHS(uint16_t group_addr) {
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color (hue/saturation) command");
+    }
   }
 }
 
@@ -802,9 +848,9 @@ void ZigbeeColorDimmerSwitch::getLightColorHS(uint8_t endpoint, uint16_t short_a
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color (hue/saturation) command");
+    }
   }
 }
 
@@ -820,9 +866,9 @@ void ZigbeeColorDimmerSwitch::getLightColorHS(uint8_t endpoint, esp_zb_ieee_addr
     read_req.attr_number = 2;
     uint16_t attr_id[] = {ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_HUE_ID, ESP_ZB_ZCL_ATTR_COLOR_CONTROL_CURRENT_SATURATION_ID};
     read_req.attr_field = attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light color (hue/saturation) command");
+    }
   }
 }
 
@@ -835,9 +881,11 @@ void ZigbeeColorDimmerSwitch::setLightLevelStep(ZigbeeLevelStepDirection directi
     cmd_req.step_mode = (uint8_t)direction;
     cmd_req.step_size = step_size;
     cmd_req.transition_time = transition_time;
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_step_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   }
 }
 
@@ -851,9 +899,11 @@ void ZigbeeColorDimmerSwitch::setLightLevelStep(ZigbeeLevelStepDirection directi
     cmd_req.step_mode = (uint8_t)direction;
     cmd_req.step_size = step_size;
     cmd_req.transition_time = transition_time;
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_step_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   }
 }
 
@@ -870,9 +920,11 @@ void ZigbeeColorDimmerSwitch::setLightLevelStep(
     cmd_req.step_mode = (uint8_t)direction;
     cmd_req.step_size = step_size;
     cmd_req.transition_time = transition_time;
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_step_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   }
 }
 
@@ -889,9 +941,11 @@ void ZigbeeColorDimmerSwitch::setLightLevelStep(
     cmd_req.step_mode = (uint8_t)direction;
     cmd_req.step_size = step_size;
     cmd_req.transition_time = transition_time;
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_level_step_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   }
 }
 

--- a/libraries/Zigbee/src/ep/ZigbeeContactSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeContactSwitch.cpp
@@ -45,14 +45,9 @@ void ZigbeeContactSwitch::setIASClientEndpoint(uint8_t ep_number) {
 }
 
 bool ZigbeeContactSwitch::setClosed() {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Setting Contact switch to closed");
   uint8_t closed = 0;  // ALARM1 = 0, ALARM2 = 0
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set contact switch to closed: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -62,14 +57,9 @@ bool ZigbeeContactSwitch::setClosed() {
 }
 
 bool ZigbeeContactSwitch::setOpen() {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Setting Contact switch to open");
   uint8_t open = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 | ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM2;  // ALARM1 = 1, ALARM2 = 1
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set contact switch to open: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -80,23 +70,29 @@ bool ZigbeeContactSwitch::setOpen() {
 
 bool ZigbeeContactSwitch::report() {
   /* Send IAS Zone status changed notification command */
+  if (_enrolled) {
+    esp_zb_zcl_ias_zone_status_change_notif_cmd_t status_change_notif_cmd;
+    status_change_notif_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    status_change_notif_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
+    status_change_notif_cmd.zcl_basic_cmd.dst_endpoint = _ias_cie_endpoint;  //default is 1
+    memcpy(status_change_notif_cmd.zcl_basic_cmd.dst_addr_u.addr_long, _ias_cie_addr, sizeof(esp_zb_ieee_addr_t));
 
-  esp_zb_zcl_ias_zone_status_change_notif_cmd_t status_change_notif_cmd;
-  status_change_notif_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
-  status_change_notif_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  status_change_notif_cmd.zcl_basic_cmd.dst_endpoint = _ias_cie_endpoint;  //default is 1
-  memcpy(status_change_notif_cmd.zcl_basic_cmd.dst_addr_u.addr_long, _ias_cie_addr, sizeof(esp_zb_ieee_addr_t));
+    status_change_notif_cmd.zone_status = _zone_status;
+    status_change_notif_cmd.extend_status = 0;
+    status_change_notif_cmd.zone_id = _zone_id;
+    status_change_notif_cmd.delay = 0;
 
-  status_change_notif_cmd.zone_status = _zone_status;
-  status_change_notif_cmd.extend_status = 0;
-  status_change_notif_cmd.zone_id = _zone_id;
-  status_change_notif_cmd.delay = 0;
-
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&status_change_notif_cmd);  //return transaction sequence number, ignore it
-  esp_zb_lock_release();
-  log_v("IAS Zone status changed notification sent");
-  return true;
+    if (!acquireCommandLock()) {
+      return false;
+    }
+    esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&status_change_notif_cmd);  //return transaction sequence number, ignore it
+    releaseCommandLock();
+    log_v("IAS Zone status changed notification sent");
+    return true;
+  } else {
+    log_e("Failed to report: IAS Zone not enrolled");
+    return false;
+  }
 }
 
 void ZigbeeContactSwitch::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enroll_response_message_t *message) {
@@ -104,15 +100,13 @@ void ZigbeeContactSwitch::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enro
     log_v("IAS Zone Enroll Response: zone id(%u), status(%u)", message->zone_id, message->response_code);
     if (message->response_code == ESP_ZB_ZCL_IAS_ZONE_ENROLL_RESPONSE_CODE_SUCCESS) {
       log_v("IAS Zone Enroll Response: success");
-      esp_zb_lock_acquire(portMAX_DELAY);
-      memcpy(
-        _ias_cie_addr,
-        (*(esp_zb_ieee_addr_t *)
-            esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID)
-              ->data_p),
-        sizeof(esp_zb_ieee_addr_t)
+      esp_zb_zcl_attr_t *ias_cie_attr = esp_zb_zcl_get_attribute(
+        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID
       );
-      esp_zb_lock_release();
+      if (ias_cie_attr == nullptr || ias_cie_attr->data_p == nullptr) {
+        return;
+      }
+      memcpy(_ias_cie_addr, ias_cie_attr->data_p, sizeof(_ias_cie_addr));
       _zone_id = message->zone_id;
       _enrolled = true;
     }
@@ -128,32 +122,28 @@ bool ZigbeeContactSwitch::requestIASZoneEnroll() {
   enroll_request.zone_type = ESP_ZB_ZCL_IAS_ZONE_ZONETYPE_CONTACT_SWITCH;
   enroll_request.manuf_code = 0;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
+  if (!acquireCommandLock()) {
+    return false;
+  }
   esp_zb_zcl_ias_zone_enroll_cmd_req(&enroll_request);  //return transaction sequence number, ignore it
-  esp_zb_lock_release();
+  releaseCommandLock();
   log_v("IAS Zone enroll request sent");
   return true;
 }
 
 bool ZigbeeContactSwitch::restoreIASZoneEnroll() {
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_attr_t *ias_cie_attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID);
-  esp_zb_zcl_attr_t *zone_id_attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID);
-  esp_zb_lock_release();
-
-  if (ias_cie_attr == NULL || ias_cie_attr->data_p == NULL) {
+  if (!getClusterAttribute(
+        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID, _ias_cie_addr, sizeof(_ias_cie_addr)
+      )) {
     log_e("Failed to restore IAS Zone enroll: ias cie address attribute not found");
     return false;
   }
-  if (zone_id_attr == NULL || zone_id_attr->data_p == NULL) {
+  if (!getClusterAttribute(
+        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id)
+      )) {
     log_e("Failed to restore IAS Zone enroll: zone id attribute not found");
     return false;
   }
-
-  memcpy(_ias_cie_addr, (esp_zb_ieee_addr_t *)ias_cie_attr->data_p, sizeof(esp_zb_ieee_addr_t));
-  _zone_id = (*(uint8_t *)zone_id_attr->data_p);
 
   log_d(
     "Restored IAS Zone enroll: zone id(%u), ias cie address(%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X)", _zone_id, _ias_cie_addr[0], _ias_cie_addr[1],

--- a/libraries/Zigbee/src/ep/ZigbeeContactSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeContactSwitch.cpp
@@ -47,7 +47,8 @@ void ZigbeeContactSwitch::setIASClientEndpoint(uint8_t ep_number) {
 bool ZigbeeContactSwitch::setClosed() {
   log_v("Setting Contact switch to closed");
   uint8_t closed = 0;  // ALARM1 = 0, ALARM2 = 0
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set contact switch to closed: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -59,7 +60,8 @@ bool ZigbeeContactSwitch::setClosed() {
 bool ZigbeeContactSwitch::setOpen() {
   log_v("Setting Contact switch to open");
   uint8_t open = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 | ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM2;  // ALARM1 = 1, ALARM2 = 1
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set contact switch to open: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -100,9 +102,8 @@ void ZigbeeContactSwitch::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enro
     log_v("IAS Zone Enroll Response: zone id(%u), status(%u)", message->zone_id, message->response_code);
     if (message->response_code == ESP_ZB_ZCL_IAS_ZONE_ENROLL_RESPONSE_CODE_SUCCESS) {
       log_v("IAS Zone Enroll Response: success");
-      esp_zb_zcl_attr_t *ias_cie_attr = esp_zb_zcl_get_attribute(
-        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID
-      );
+      esp_zb_zcl_attr_t *ias_cie_attr =
+        esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID);
       if (ias_cie_attr == nullptr || ias_cie_attr->data_p == nullptr) {
         return;
       }
@@ -138,9 +139,7 @@ bool ZigbeeContactSwitch::restoreIASZoneEnroll() {
     log_e("Failed to restore IAS Zone enroll: ias cie address attribute not found");
     return false;
   }
-  if (!getClusterAttribute(
-        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id)
-      )) {
+  if (!getClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id))) {
     log_e("Failed to restore IAS Zone enroll: zone id attribute not found");
     return false;
   }

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
@@ -74,27 +74,17 @@ bool ZigbeeDimmableLight::setLight(bool state, uint8_t level) {
   lightChanged();
 
   log_v("Updating on/off light state to %d", state);
-  /* Update light clusters */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  // set on/off state
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  // set level
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
-  );
+  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light level: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 bool ZigbeeDimmableLight::setLightState(bool state) {

--- a/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDimmableLight.cpp
@@ -79,7 +79,9 @@ bool ZigbeeDimmableLight::setLight(bool state, uint8_t level) {
     log_e("Failed to set light state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
   }
-  ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false);
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_LEVEL_CONTROL_CURRENT_LEVEL_ID, &_current_level, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light level: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;

--- a/libraries/Zigbee/src/ep/ZigbeeDoorWindowHandle.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDoorWindowHandle.cpp
@@ -47,7 +47,8 @@ void ZigbeeDoorWindowHandle::setIASClientEndpoint(uint8_t ep_number) {
 bool ZigbeeDoorWindowHandle::setClosed() {
   log_v("Setting Door/Window handle to closed");
   uint8_t closed = 0;  // ALARM1 = 0, ALARM2 = 0
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set door/window handle to closed: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -59,7 +60,8 @@ bool ZigbeeDoorWindowHandle::setClosed() {
 bool ZigbeeDoorWindowHandle::setOpen() {
   log_v("Setting Door/Window handle to open");
   uint8_t open = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 | ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM2;  // ALARM1 = 1, ALARM2 = 1
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set door/window handle to open: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -71,7 +73,8 @@ bool ZigbeeDoorWindowHandle::setOpen() {
 bool ZigbeeDoorWindowHandle::setTilted() {
   log_v("Setting Door/Window handle to tilted");
   uint8_t tilted = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1;  // ALARM1 = 1, ALARM2 = 0
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &tilted, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &tilted, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set door/window handle to tilted: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -105,7 +108,6 @@ bool ZigbeeDoorWindowHandle::report() {
     log_e("Failed to report: IAS Zone not enrolled");
     return false;
   }
-
 }
 
 void ZigbeeDoorWindowHandle::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enroll_response_message_t *message) {
@@ -113,9 +115,8 @@ void ZigbeeDoorWindowHandle::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_e
     log_v("IAS Zone Enroll Response: zone id(%u), status(%u)", message->zone_id, message->response_code);
     if (message->response_code == ESP_ZB_ZCL_IAS_ZONE_ENROLL_RESPONSE_CODE_SUCCESS) {
       log_v("IAS Zone Enroll Response: success");
-      esp_zb_zcl_attr_t *ias_cie_attr = esp_zb_zcl_get_attribute(
-        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID
-      );
+      esp_zb_zcl_attr_t *ias_cie_attr =
+        esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID);
       if (ias_cie_attr == nullptr || ias_cie_attr->data_p == nullptr) {
         return;
       }
@@ -151,9 +152,7 @@ bool ZigbeeDoorWindowHandle::restoreIASZoneEnroll() {
     log_e("Failed to restore IAS Zone enroll: ias cie address attribute not found");
     return false;
   }
-  if (!getClusterAttribute(
-        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id)
-      )) {
+  if (!getClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id))) {
     log_e("Failed to restore IAS Zone enroll: zone id attribute not found");
     return false;
   }

--- a/libraries/Zigbee/src/ep/ZigbeeDoorWindowHandle.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeDoorWindowHandle.cpp
@@ -45,14 +45,9 @@ void ZigbeeDoorWindowHandle::setIASClientEndpoint(uint8_t ep_number) {
 }
 
 bool ZigbeeDoorWindowHandle::setClosed() {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Setting Door/Window handle to closed");
   uint8_t closed = 0;  // ALARM1 = 0, ALARM2 = 0
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &closed, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set door/window handle to closed: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -62,14 +57,9 @@ bool ZigbeeDoorWindowHandle::setClosed() {
 }
 
 bool ZigbeeDoorWindowHandle::setOpen() {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Setting Door/Window handle to open");
   uint8_t open = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1 | ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM2;  // ALARM1 = 1, ALARM2 = 1
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &open, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set door/window handle to open: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -79,14 +69,9 @@ bool ZigbeeDoorWindowHandle::setOpen() {
 }
 
 bool ZigbeeDoorWindowHandle::setTilted() {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Setting Door/Window handle to tilted");
   uint8_t tilted = ESP_ZB_ZCL_IAS_ZONE_ZONE_STATUS_ALARM1;  // ALARM1 = 1, ALARM2 = 0
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &tilted, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &tilted, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set door/window handle to tilted: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -97,23 +82,30 @@ bool ZigbeeDoorWindowHandle::setTilted() {
 
 bool ZigbeeDoorWindowHandle::report() {
   /* Send IAS Zone status changed notification command */
+  if (_enrolled) {
+    esp_zb_zcl_ias_zone_status_change_notif_cmd_t status_change_notif_cmd;
+    status_change_notif_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    status_change_notif_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
+    status_change_notif_cmd.zcl_basic_cmd.dst_endpoint = _ias_cie_endpoint;  //default is 1
+    memcpy(status_change_notif_cmd.zcl_basic_cmd.dst_addr_u.addr_long, _ias_cie_addr, sizeof(esp_zb_ieee_addr_t));
 
-  esp_zb_zcl_ias_zone_status_change_notif_cmd_t status_change_notif_cmd;
-  status_change_notif_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
-  status_change_notif_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  status_change_notif_cmd.zcl_basic_cmd.dst_endpoint = _ias_cie_endpoint;  //default is 1
-  memcpy(status_change_notif_cmd.zcl_basic_cmd.dst_addr_u.addr_long, _ias_cie_addr, sizeof(esp_zb_ieee_addr_t));
+    status_change_notif_cmd.zone_status = _zone_status;
+    status_change_notif_cmd.extend_status = 0;
+    status_change_notif_cmd.zone_id = _zone_id;
+    status_change_notif_cmd.delay = 0;
 
-  status_change_notif_cmd.zone_status = _zone_status;
-  status_change_notif_cmd.extend_status = 0;
-  status_change_notif_cmd.zone_id = _zone_id;
-  status_change_notif_cmd.delay = 0;
+    if (!acquireCommandLock()) {
+      return false;
+    }
+    esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&status_change_notif_cmd);  //return transaction sequence number, ignore it
+    releaseCommandLock();
+    log_v("IAS Zone status changed notification sent");
+    return true;
+  } else {
+    log_e("Failed to report: IAS Zone not enrolled");
+    return false;
+  }
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&status_change_notif_cmd);  //return transaction sequence number, ignore it
-  esp_zb_lock_release();
-  log_v("IAS Zone status changed notification sent");
-  return true;
 }
 
 void ZigbeeDoorWindowHandle::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enroll_response_message_t *message) {
@@ -121,15 +113,13 @@ void ZigbeeDoorWindowHandle::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_e
     log_v("IAS Zone Enroll Response: zone id(%u), status(%u)", message->zone_id, message->response_code);
     if (message->response_code == ESP_ZB_ZCL_IAS_ZONE_ENROLL_RESPONSE_CODE_SUCCESS) {
       log_v("IAS Zone Enroll Response: success");
-      esp_zb_lock_acquire(portMAX_DELAY);
-      memcpy(
-        _ias_cie_addr,
-        (*(esp_zb_ieee_addr_t *)
-            esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID)
-              ->data_p),
-        sizeof(esp_zb_ieee_addr_t)
+      esp_zb_zcl_attr_t *ias_cie_attr = esp_zb_zcl_get_attribute(
+        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID
       );
-      esp_zb_lock_release();
+      if (ias_cie_attr == nullptr || ias_cie_attr->data_p == nullptr) {
+        return;
+      }
+      memcpy(_ias_cie_addr, ias_cie_attr->data_p, sizeof(_ias_cie_addr));
       _zone_id = message->zone_id;
       _enrolled = true;
     }
@@ -145,32 +135,28 @@ bool ZigbeeDoorWindowHandle::requestIASZoneEnroll() {
   enroll_request.zone_type = ESP_ZB_ZCL_IAS_ZONE_ZONETYPE_DOOR_WINDOW_HANDLE;
   enroll_request.manuf_code = 0;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
+  if (!acquireCommandLock()) {
+    return false;
+  }
   esp_zb_zcl_ias_zone_enroll_cmd_req(&enroll_request);  //return transaction sequence number, ignore it
-  esp_zb_lock_release();
+  releaseCommandLock();
   log_v("IAS Zone enroll request sent");
   return true;
 }
 
 bool ZigbeeDoorWindowHandle::restoreIASZoneEnroll() {
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_attr_t *ias_cie_attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID);
-  esp_zb_zcl_attr_t *zone_id_attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID);
-  esp_zb_lock_release();
-
-  if (ias_cie_attr == NULL || ias_cie_attr->data_p == NULL) {
+  if (!getClusterAttribute(
+        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID, _ias_cie_addr, sizeof(_ias_cie_addr)
+      )) {
     log_e("Failed to restore IAS Zone enroll: ias cie address attribute not found");
     return false;
   }
-  if (zone_id_attr == NULL || zone_id_attr->data_p == NULL) {
+  if (!getClusterAttribute(
+        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id)
+      )) {
     log_e("Failed to restore IAS Zone enroll: zone id attribute not found");
     return false;
   }
-
-  memcpy(_ias_cie_addr, (esp_zb_ieee_addr_t *)ias_cie_attr->data_p, sizeof(esp_zb_ieee_addr_t));
-  _zone_id = (*(uint8_t *)zone_id_attr->data_p);
 
   log_d(
     "Restored IAS Zone enroll: zone id(%u), ias cie address(%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X)", _zone_id, _ias_cie_addr[0], _ias_cie_addr[1],

--- a/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
@@ -245,12 +245,10 @@ bool ZigbeeElectricalMeasurement::setDCReporting(ZIGBEE_DC_MEASUREMENT_TYPE meas
   reporting_info.u.send_info.delta.s16 = delta;
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeElectricalMeasurement::setDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE measurement_type, int16_t measurement) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-
   esp_zb_zcl_electrical_measurement_attr_t attr_id = ESP_ZB_ZCL_ATTR_ELECTRICAL_MEASUREMENT_DC_VOLTAGE_ID;
   if (measurement_type == ZIGBEE_DC_MEASUREMENT_TYPE_CURRENT) {
     attr_id = ESP_ZB_ZCL_ATTR_ELECTRICAL_MEASUREMENT_DC_CURRENT_ID;
@@ -261,9 +259,7 @@ bool ZigbeeElectricalMeasurement::setDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE me
   log_v("Updating DC measurement value...");
   /* Update DC sensor measured value */
   log_d("Setting DC measurement to %d", measurement);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &measurement, false);
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &measurement, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set DC measurement: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -288,11 +284,8 @@ bool ZigbeeElectricalMeasurement::reportDC(ZIGBEE_DC_MEASUREMENT_TYPE measuremen
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send DC report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send DC report: 0x%x: %s");
     return false;
   }
   log_v("DC report sent");
@@ -745,7 +738,6 @@ bool ZigbeeElectricalMeasurement::setACPowerFactor(ZIGBEE_AC_PHASE_TYPE phase_ty
   return true;
 }
 bool ZigbeeElectricalMeasurement::setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, ZIGBEE_AC_PHASE_TYPE phase_type, int32_t value) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   uint16_t attr_id = 0;
 
   // Check value is valid for the measurement type
@@ -779,6 +771,7 @@ bool ZigbeeElectricalMeasurement::setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE me
   uint16_t uint16_value = (uint16_t)value;
   int16_t int16_value = (int16_t)value;
   int8_t int8_value = (int8_t)value;
+  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_FAIL;
 
   switch (measurement_type) {
     case ZIGBEE_AC_MEASUREMENT_TYPE_VOLTAGE:
@@ -792,10 +785,7 @@ bool ZigbeeElectricalMeasurement::setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE me
       // Use uint16_t for voltage
       log_v("Updating AC voltage measurement value...");
       log_d("Setting AC voltage to %u", uint16_value);
-      esp_zb_lock_acquire(portMAX_DELAY);
-      ret =
-        esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &uint16_value, false);
-      esp_zb_lock_release();
+      ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &uint16_value, false);
       break;
 
     case ZIGBEE_AC_MEASUREMENT_TYPE_CURRENT:
@@ -809,10 +799,7 @@ bool ZigbeeElectricalMeasurement::setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE me
       // Use uint16_t for current
       log_v("Updating AC current measurement value...");
       log_d("Setting AC current to %u", uint16_value);
-      esp_zb_lock_acquire(portMAX_DELAY);
-      ret =
-        esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &uint16_value, false);
-      esp_zb_lock_release();
+      ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &uint16_value, false);
       break;
 
     case ZIGBEE_AC_MEASUREMENT_TYPE_POWER:
@@ -826,9 +813,7 @@ bool ZigbeeElectricalMeasurement::setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE me
       // Use int16_t for power
       log_v("Updating AC power measurement value...");
       log_d("Setting AC power to %d", int16_value);
-      esp_zb_lock_acquire(portMAX_DELAY);
-      ret = esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &int16_value, false);
-      esp_zb_lock_release();
+      ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &int16_value, false);
       break;
 
     case ZIGBEE_AC_MEASUREMENT_TYPE_FREQUENCY:
@@ -836,10 +821,7 @@ bool ZigbeeElectricalMeasurement::setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE me
       // Use uint16_t for frequency
       log_v("Updating AC frequency measurement value...");
       log_d("Setting AC frequency to %u", uint16_value);
-      esp_zb_lock_acquire(portMAX_DELAY);
-      ret =
-        esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &uint16_value, false);
-      esp_zb_lock_release();
+      ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &uint16_value, false);
       break;
     case ZIGBEE_AC_MEASUREMENT_TYPE_POWER_FACTOR:
       switch (phase_type) {
@@ -852,9 +834,7 @@ bool ZigbeeElectricalMeasurement::setACMeasurement(ZIGBEE_AC_MEASUREMENT_TYPE me
       // Use int8_t for power factor
       log_v("Updating AC power factor measurement value...");
       log_d("Setting AC power factor to %d", int8_value);
-      esp_zb_lock_acquire(portMAX_DELAY);
-      ret = esp_zb_zcl_set_attribute_val(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &int8_value, false);
-      esp_zb_lock_release();
+      ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ELECTRICAL_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, attr_id, &int8_value, false);
       break;
     default: log_e("Invalid measurement type"); return false;
   }
@@ -926,7 +906,7 @@ bool ZigbeeElectricalMeasurement::setACReporting(
   }
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeElectricalMeasurement::reportAC(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, ZIGBEE_AC_PHASE_TYPE phase_type) {
@@ -974,11 +954,8 @@ bool ZigbeeElectricalMeasurement::reportAC(ZIGBEE_AC_MEASUREMENT_TYPE measuremen
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send AC report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send AC report: 0x%x: %s");
     return false;
   }
   log_v("AC report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeElectricalMeasurement.cpp
@@ -245,14 +245,7 @@ bool ZigbeeElectricalMeasurement::setDCReporting(ZIGBEE_DC_MEASUREMENT_TYPE meas
   reporting_info.u.send_info.delta.s16 = delta;
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeElectricalMeasurement::setDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE measurement_type, int16_t measurement) {
@@ -933,14 +926,7 @@ bool ZigbeeElectricalMeasurement::setACReporting(
   }
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeElectricalMeasurement::reportAC(ZIGBEE_AC_MEASUREMENT_TYPE measurement_type, ZIGBEE_AC_PHASE_TYPE phase_type) {

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
@@ -94,22 +94,15 @@ bool ZigbeeFlowSensor::setReporting(uint16_t min_interval, uint16_t max_interval
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
 
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeFlowSensor::setFlow(float flow) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   uint16_t zb_flow = (uint16_t)(flow * 10);
   log_v("Updating flow sensor value...");
-  /* Update temperature sensor measured value */
   log_d("Setting flow to %u", zb_flow);
-
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_VALUE_ID, &zb_flow, false
-  );
-  esp_zb_lock_release();
-
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_FLOW_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_FLOW_MEASUREMENT_VALUE_ID, &zb_flow, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set flow value: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -128,12 +121,8 @@ bool ZigbeeFlowSensor::report() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-
-  if (ret != ESP_OK) {
-    log_e("Failed to send flow report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send flow report");
     return false;
   }
   log_v("Flow report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeFlowSensor.cpp
@@ -94,15 +94,7 @@ bool ZigbeeFlowSensor::setReporting(uint16_t min_interval, uint16_t max_interval
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeFlowSensor::setFlow(float flow) {

--- a/libraries/Zigbee/src/ep/ZigbeeIlluminanceSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeIlluminanceSensor.cpp
@@ -78,20 +78,16 @@ bool ZigbeeIlluminanceSensor::setReporting(uint16_t min_interval, uint16_t max_i
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
 
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeIlluminanceSensor::setIlluminance(uint16_t illuminanceValue) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Updating Illuminance...");
-  /* Update illuminance sensor measured illuminance */
   log_d("Setting Illuminance to %u", illuminanceValue);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ILLUMINANCE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ILLUMINANCE_MEASUREMENT_MEASURED_VALUE_ID,
-    &illuminanceValue, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_ILLUMINANCE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ILLUMINANCE_MEASUREMENT_MEASURED_VALUE_ID, &illuminanceValue,
+    false
   );
-  esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set illuminance: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -110,11 +106,8 @@ bool ZigbeeIlluminanceSensor::report() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send illuminance report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send illuminance report");
     return false;
   }
   log_v("Illuminance report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeIlluminanceSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeIlluminanceSensor.cpp
@@ -78,15 +78,7 @@ bool ZigbeeIlluminanceSensor::setReporting(uint16_t min_interval, uint16_t max_i
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeIlluminanceSensor::setIlluminance(uint16_t illuminanceValue) {

--- a/libraries/Zigbee/src/ep/ZigbeeLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeLight.cpp
@@ -54,7 +54,8 @@ bool ZigbeeLight::setLight(bool state) {
 
   log_v("Updating on/off light state to %u", state);
   /* Update on/off light state */
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeeLight.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeLight.cpp
@@ -49,17 +49,12 @@ void ZigbeeLight::lightChanged() {
 }
 
 bool ZigbeeLight::setLight(bool state) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   _current_state = state;
   lightChanged();
 
   log_v("Updating on/off light state to %u", state);
   /* Update on/off light state */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set light state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
@@ -351,7 +351,13 @@ bool ZigbeeMultistate::setMultistateOutputStates(const char * const states[], ui
 
 //set attribute method -> method overridden in child class
 void ZigbeeMultistate::zbAttributeSet(const esp_zb_zcl_set_attr_value_message_t *message) {
-  if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_MULTI_OUTPUT) {
+  if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_MULTI_INPUT) {
+    if (message->attribute.id == ESP_ZB_ZCL_ATTR_MULTI_INPUT_PRESENT_VALUE_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U16) {
+      _input_state = *(uint16_t *)message->attribute.data.value;
+    } else {
+      log_w("Received message ignored. Attribute ID: %u not supported for Multistate Input", message->attribute.id);
+    }
+  } else if (message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_MULTI_OUTPUT) {
     if (message->attribute.id == ESP_ZB_ZCL_ATTR_MULTI_OUTPUT_PRESENT_VALUE_ID && message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_U16) {
       _output_state = *(uint16_t *)message->attribute.data.value;
       multistateOutputChanged();
@@ -387,6 +393,7 @@ bool ZigbeeMultistate::setMultistateInput(uint16_t state) {
     log_e("Failed to set multistate input: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
   }
+  _input_state = state;
   return true;
 }
 

--- a/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
@@ -378,17 +378,12 @@ void ZigbeeMultistate::multistateOutputChanged() {
 }
 
 bool ZigbeeMultistate::setMultistateInput(uint16_t state) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   if (!(_multistate_clusters & MULTISTATE_INPUT)) {
     log_e("Multistate Input cluster not added");
     return false;
   }
   log_d("Setting multistate input to %u", state);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_MULTI_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_INPUT_PRESENT_VALUE_ID, &state, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_MULTI_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_INPUT_PRESENT_VALUE_ID, &state, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set multistate input: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -398,17 +393,12 @@ bool ZigbeeMultistate::setMultistateInput(uint16_t state) {
 }
 
 bool ZigbeeMultistate::setMultistateOutput(uint16_t state) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   _output_state = state;
   multistateOutputChanged();
 
   log_v("Updating multistate output to %u", state);
   /* Update multistate output */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_MULTI_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_OUTPUT_PRESENT_VALUE_ID, &_output_state, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_MULTI_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_OUTPUT_PRESENT_VALUE_ID, &_output_state, false);
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set multistate output: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
@@ -428,11 +418,8 @@ bool ZigbeeMultistate::reportMultistateInput() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send Multistate Input report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send Multistate Input report: 0x%x: %s");
     return false;
   }
   log_v("Multistate Input report sent");
@@ -450,11 +437,8 @@ bool ZigbeeMultistate::reportMultistateOutput() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send Multistate Output report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send Multistate Output report: 0x%x: %s");
     return false;
   }
   log_v("Multistate Output report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeMultistate.cpp
@@ -383,7 +383,8 @@ bool ZigbeeMultistate::setMultistateInput(uint16_t state) {
     return false;
   }
   log_d("Setting multistate input to %u", state);
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_MULTI_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_INPUT_PRESENT_VALUE_ID, &state, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_MULTI_INPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_INPUT_PRESENT_VALUE_ID, &state, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set multistate input: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -398,7 +399,9 @@ bool ZigbeeMultistate::setMultistateOutput(uint16_t state) {
 
   log_v("Updating multistate output to %u", state);
   /* Update multistate output */
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_MULTI_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_OUTPUT_PRESENT_VALUE_ID, &_output_state, false);
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_MULTI_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_MULTI_OUTPUT_PRESENT_VALUE_ID, &_output_state, false
+  );
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set multistate output: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
@@ -54,15 +54,10 @@ bool ZigbeeOccupancySensor::setSensorType(uint8_t sensor_type) {
 }
 
 bool ZigbeeOccupancySensor::setOccupancy(bool occupied) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Updating occupancy sensor value...");
   /* Update occupancy sensor value */
   log_d("Setting occupancy to %d", occupied);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID, &occupied, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID, &occupied, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set occupancy: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -81,11 +76,8 @@ bool ZigbeeOccupancySensor::report() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send occupancy report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send occupancy report: 0x%x: %s");
     return false;
   }
   log_v("Occupancy report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeOccupancySensor.cpp
@@ -57,7 +57,9 @@ bool ZigbeeOccupancySensor::setOccupancy(bool occupied) {
   log_v("Updating occupancy sensor value...");
   /* Update occupancy sensor value */
   log_d("Setting occupancy to %d", occupied);
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID, &occupied, false);
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID, &occupied, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set occupancy: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;

--- a/libraries/Zigbee/src/ep/ZigbeePM25Sensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePM25Sensor.cpp
@@ -92,19 +92,15 @@ bool ZigbeePM25Sensor::setReporting(uint16_t min_interval, uint16_t max_interval
   float delta_f = delta;
   memcpy(&reporting_info.u.send_info.delta.s32, &delta_f, sizeof(float));
 
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeePM25Sensor::setPM25(float pm25) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Updating PM2.5 sensor value...");
-  /* Update PM2.5 sensor measured value */
   log_d("Setting PM2.5 to %0.1f", pm25);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_PM2_5_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PM2_5_MEASUREMENT_MEASURED_VALUE_ID, &pm25, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_PM2_5_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PM2_5_MEASUREMENT_MEASURED_VALUE_ID, &pm25, false
   );
-  esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set PM2.5: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -123,11 +119,8 @@ bool ZigbeePM25Sensor::report() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send PM2.5 report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send PM2.5 report");
     return false;
   }
   log_v("PM2.5 report sent");

--- a/libraries/Zigbee/src/ep/ZigbeePM25Sensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePM25Sensor.cpp
@@ -92,14 +92,7 @@ bool ZigbeePM25Sensor::setReporting(uint16_t min_interval, uint16_t max_interval
   float delta_f = delta;
   memcpy(&reporting_info.u.send_info.delta.s32, &delta_f, sizeof(float));
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeePM25Sensor::setPM25(float pm25) {

--- a/libraries/Zigbee/src/ep/ZigbeePowerOutlet.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePowerOutlet.cpp
@@ -51,17 +51,12 @@ void ZigbeePowerOutlet::stateChanged() {
 }
 
 bool ZigbeePowerOutlet::setState(bool state) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   _current_state = state;
   stateChanged();
 
   log_v("Updating on/off outlet state to %d", state);
   /* Update on/off outlet state */
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set outlet state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeePowerOutlet.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePowerOutlet.cpp
@@ -56,7 +56,8 @@ bool ZigbeePowerOutlet::setState(bool state) {
 
   log_v("Updating on/off outlet state to %d", state);
   /* Update on/off outlet state */
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_ON_OFF, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID, &_current_state, false);
 
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set outlet state: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -88,19 +88,14 @@ bool ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_inte
   reporting_info.u.send_info.delta.u16 = delta;  // x hPa
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeePressureSensor::setPressure(int16_t pressure) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Updating pressure sensor value...");
-  /* Update pressure sensor measured value */
   log_d("Setting pressure to %d hPa", pressure);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &pressure, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &pressure, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set pressure: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -119,11 +114,8 @@ bool ZigbeePressureSensor::report() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send pressure report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send pressure report");
     return false;
   }
   log_v("Pressure report sent");

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -88,14 +88,7 @@ bool ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_inte
   reporting_info.u.send_info.delta.u16 = delta;  // x hPa
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeePressureSensor::setPressure(int16_t pressure) {

--- a/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeePressureSensor.cpp
@@ -94,8 +94,9 @@ bool ZigbeePressureSensor::setReporting(uint16_t min_interval, uint16_t max_inte
 bool ZigbeePressureSensor::setPressure(int16_t pressure) {
   log_v("Updating pressure sensor value...");
   log_d("Setting pressure to %d hPa", pressure);
-  esp_zb_zcl_status_t ret =
-    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &pressure, false);
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_PRESSURE_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_PRESSURE_MEASUREMENT_VALUE_ID, &pressure, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set pressure: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;

--- a/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
@@ -117,9 +117,11 @@ void ZigbeeSwitch::lightToggle() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -134,9 +136,11 @@ void ZigbeeSwitch::lightToggle(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -152,9 +156,11 @@ void ZigbeeSwitch::lightToggle(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_TOGGLE_ID;
     log_v("Sending 'light toggle' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -173,9 +179,11 @@ void ZigbeeSwitch::lightToggle(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
       "Sending 'light toggle' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
       ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -189,9 +197,11 @@ void ZigbeeSwitch::lightOn() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -206,9 +216,11 @@ void ZigbeeSwitch::lightOn(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -224,9 +236,11 @@ void ZigbeeSwitch::lightOn(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_ON_ID;
     log_v("Sending 'light on' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -245,9 +259,11 @@ void ZigbeeSwitch::lightOn(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
       "Sending 'light on' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
       ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -261,9 +277,11 @@ void ZigbeeSwitch::lightOff() {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -278,9 +296,11 @@ void ZigbeeSwitch::lightOff(uint16_t group_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_GROUP_ENDP_NOT_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to group address 0x%x", group_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -296,9 +316,11 @@ void ZigbeeSwitch::lightOff(uint8_t endpoint, uint16_t short_addr) {
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
     cmd_req.on_off_cmd_id = ESP_ZB_ZCL_CMD_ON_OFF_OFF_ID;
     log_v("Sending 'light off' command to endpoint %u, address 0x%x", endpoint, short_addr);
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -317,9 +339,11 @@ void ZigbeeSwitch::lightOff(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
       "Sending 'light off' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
       ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
     );
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -334,9 +358,11 @@ void ZigbeeSwitch::lightOffWithEffect(uint8_t effect_id, uint8_t effect_variant)
     cmd_req.effect_id = effect_id;
     cmd_req.effect_variant = effect_variant;
     log_v("Sending 'light off with effect' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_off_with_effect_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -349,9 +375,11 @@ void ZigbeeSwitch::lightOnWithSceneRecall() {
     cmd_req.zcl_basic_cmd.src_endpoint = _endpoint;
     cmd_req.address_mode = ESP_ZB_APS_ADDR_MODE_DST_ADDR_ENDP_NOT_PRESENT;
     log_v("Sending 'light on with scene recall' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_on_with_recall_global_scene_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -367,9 +395,11 @@ void ZigbeeSwitch::lightOnWithTimedOff(uint8_t on_off_control, uint16_t time_on,
     cmd_req.on_time = time_on;
     cmd_req.off_wait_time = time_off;
     log_v("Sending 'light on with time off' command");
-    esp_zb_lock_acquire(portMAX_DELAY);
+    if (!acquireCommandLock()) {
+      return;
+    }
     esp_zb_zcl_on_off_on_with_timed_off_cmd_req(&cmd_req);
-    esp_zb_lock_release();
+    releaseCommandLock();
   } else {
     log_e("Light not bound");
   }
@@ -385,9 +415,9 @@ void ZigbeeSwitch::getLightState() {
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 
@@ -402,9 +432,9 @@ void ZigbeeSwitch::getLightState(uint16_t group_addr) {
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 
@@ -420,9 +450,9 @@ void ZigbeeSwitch::getLightState(uint8_t endpoint, uint16_t short_addr) {
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 
@@ -438,9 +468,9 @@ void ZigbeeSwitch::getLightState(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr)
     read_req.attr_number = 1;
     uint16_t attr_id = ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID;
     read_req.attr_field = &attr_id;
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_read_attr_cmd_req(&read_req);
-    esp_zb_lock_release();
+    if (!readClusterAttribute(&read_req)) {
+      log_e("Failed to send read light state command");
+    }
   }
 }
 

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -92,20 +92,15 @@ bool ZigbeeTempSensor::setReporting(uint16_t min_interval, uint16_t max_interval
   reporting_info.u.send_info.delta.u16 = (uint16_t)(delta * 100);  // Convert delta to ZCL uint16_t
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeTempSensor::setTemperature(float temperature) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   int16_t zb_temperature = zb_float_to_s16(temperature);
   log_v("Updating temperature sensor value...");
-  /* Update temperature sensor measured value */
   log_d("Setting temperature to %d", zb_temperature);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &zb_temperature, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &zb_temperature, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set temperature: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -124,11 +119,8 @@ bool ZigbeeTempSensor::reportTemperature() {
   report_attr_cmd.manuf_specific = 0x00U;    //Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  //Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send temperature report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send temperature report");
     return false;
   }
   log_v("Temperature report sent");
@@ -150,17 +142,12 @@ void ZigbeeTempSensor::addHumiditySensor(float min, float max, float tolerance, 
 }
 
 bool ZigbeeTempSensor::setHumidity(float humidity) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   uint16_t zb_humidity = (uint16_t)(humidity * 100);
   log_v("Updating humidity sensor value...");
-  /* Update humidity sensor measured value */
   log_d("Setting humidity to %u", zb_humidity);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID, &zb_humidity,
-    false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID, &zb_humidity, false
   );
-  esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set humidity: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -179,11 +166,8 @@ bool ZigbeeTempSensor::reportHumidity() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send humidity report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send humidity report");
     return false;
   }
   log_v("Humidity report sent");
@@ -205,7 +189,7 @@ bool ZigbeeTempSensor::setHumidityReporting(uint16_t min_interval, uint16_t max_
   reporting_info.u.send_info.delta.u16 = (uint16_t)(delta * 100);  // Convert delta to ZCL uint16_t
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeTempSensor::report() {

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -99,8 +99,9 @@ bool ZigbeeTempSensor::setTemperature(float temperature) {
   int16_t zb_temperature = zb_float_to_s16(temperature);
   log_v("Updating temperature sensor value...");
   log_d("Setting temperature to %d", zb_temperature);
-  esp_zb_zcl_status_t ret =
-    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &zb_temperature, false);
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID, &zb_temperature, false
+  );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set temperature: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;

--- a/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
@@ -92,14 +92,7 @@ bool ZigbeeTempSensor::setReporting(uint16_t min_interval, uint16_t max_interval
   reporting_info.u.send_info.delta.u16 = (uint16_t)(delta * 100);  // Convert delta to ZCL uint16_t
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeTempSensor::setTemperature(float temperature) {
@@ -212,14 +205,7 @@ bool ZigbeeTempSensor::setHumidityReporting(uint16_t min_interval, uint16_t max_
   reporting_info.u.send_info.delta.u16 = (uint16_t)(delta * 100);  // Convert delta to ZCL uint16_t
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set humidity reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeTempSensor::report() {

--- a/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
@@ -232,9 +232,9 @@ void ZigbeeThermostat::getTemperature() {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read temperature' command");
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read temperature command");
+  }
 }
 
 void ZigbeeThermostat::getTemperature(uint16_t group_addr) {
@@ -251,9 +251,9 @@ void ZigbeeThermostat::getTemperature(uint16_t group_addr) {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read temperature' command to group address 0x%x", group_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read temperature command");
+  }
 }
 
 void ZigbeeThermostat::getTemperature(uint8_t endpoint, uint16_t short_addr) {
@@ -271,9 +271,9 @@ void ZigbeeThermostat::getTemperature(uint8_t endpoint, uint16_t short_addr) {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read temperature' command to endpoint %u, address 0x%x", endpoint, short_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read temperature command");
+  }
 }
 
 void ZigbeeThermostat::getTemperature(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
@@ -294,9 +294,9 @@ void ZigbeeThermostat::getTemperature(uint8_t endpoint, esp_zb_ieee_addr_t ieee_
     "Sending 'read temperature' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
     ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
   );
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read temperature command");
+  }
 }
 
 void ZigbeeThermostat::getTemperatureSettings() {
@@ -314,9 +314,10 @@ void ZigbeeThermostat::getTemperatureSettings() {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read sensor settings' command");
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read sensor settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -344,9 +345,10 @@ void ZigbeeThermostat::getTemperatureSettings(uint16_t group_addr) {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read sensor settings' command to group address 0x%x", group_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read sensor settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -375,9 +377,10 @@ void ZigbeeThermostat::getTemperatureSettings(uint8_t endpoint, uint16_t short_a
   read_req.attr_field = attributes;
 
   log_i("Sending 'read sensor settings' command to endpoint %u, address 0x%x", endpoint, short_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read sensor settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -409,9 +412,10 @@ void ZigbeeThermostat::getTemperatureSettings(uint8_t endpoint, esp_zb_ieee_addr
     "Sending 'read sensor settings' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
     ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
   );
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read sensor settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -446,9 +450,7 @@ void ZigbeeThermostat::setTemperatureReporting(uint16_t min_interval, uint16_t m
   report_cmd.record_field = records;
 
   log_i("Sending 'configure temperature reporting' command");
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 
 void ZigbeeThermostat::setTemperatureReporting(uint16_t group_addr, uint16_t min_interval, uint16_t max_interval, float delta) {
@@ -475,9 +477,7 @@ void ZigbeeThermostat::setTemperatureReporting(uint16_t group_addr, uint16_t min
   report_cmd.record_field = records;
 
   log_i("Sending 'configure temperature reporting' command to group address 0x%x", group_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 
 void ZigbeeThermostat::setTemperatureReporting(uint8_t endpoint, uint16_t short_addr, uint16_t min_interval, uint16_t max_interval, float delta) {
@@ -505,9 +505,7 @@ void ZigbeeThermostat::setTemperatureReporting(uint8_t endpoint, uint16_t short_
   report_cmd.record_field = records;
 
   log_i("Sending 'configure temperature reporting' command to endpoint %u, address 0x%x", endpoint, short_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 
 void ZigbeeThermostat::setTemperatureReporting(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr, uint16_t min_interval, uint16_t max_interval, float delta) {
@@ -538,9 +536,7 @@ void ZigbeeThermostat::setTemperatureReporting(uint8_t endpoint, esp_zb_ieee_add
     "Sending 'configure temperature reporting' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7],
     ieee_addr[6], ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
   );
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 
 // Humidity measuring methods
@@ -558,9 +554,9 @@ void ZigbeeThermostat::getHumidity() {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read humidity' command");
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity command");
+  }
 }
 
 void ZigbeeThermostat::getHumidity(uint16_t group_addr) {
@@ -577,9 +573,9 @@ void ZigbeeThermostat::getHumidity(uint16_t group_addr) {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read humidity' command to group address 0x%x", group_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity command");
+  }
 }
 
 void ZigbeeThermostat::getHumidity(uint8_t endpoint, uint16_t short_addr) {
@@ -597,9 +593,9 @@ void ZigbeeThermostat::getHumidity(uint8_t endpoint, uint16_t short_addr) {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read humidity' command to endpoint %u, address 0x%x", endpoint, short_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity command");
+  }
 }
 
 void ZigbeeThermostat::getHumidity(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr) {
@@ -620,9 +616,9 @@ void ZigbeeThermostat::getHumidity(uint8_t endpoint, esp_zb_ieee_addr_t ieee_add
     "Sending 'read humidity' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6], ieee_addr[5],
     ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
   );
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity command");
+  }
 }
 
 void ZigbeeThermostat::getHumiditySettings() {
@@ -640,9 +636,10 @@ void ZigbeeThermostat::getHumiditySettings() {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read humidity settings' command");
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -670,9 +667,10 @@ void ZigbeeThermostat::getHumiditySettings(uint16_t group_addr) {
   read_req.attr_field = attributes;
 
   log_i("Sending 'read humidity settings' command to group address 0x%x", group_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -701,9 +699,10 @@ void ZigbeeThermostat::getHumiditySettings(uint8_t endpoint, uint16_t short_addr
   read_req.attr_field = attributes;
 
   log_i("Sending 'read humidity settings' command to endpoint %u, address 0x%x", endpoint, short_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -735,9 +734,10 @@ void ZigbeeThermostat::getHumiditySettings(uint8_t endpoint, esp_zb_ieee_addr_t 
     "Sending 'read humidity settings' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
     ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
   );
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_read_attr_cmd_req(&read_req);
-  esp_zb_lock_release();
+  if (!readClusterAttribute(&read_req)) {
+    log_e("Failed to send read humidity settings command");
+    return;
+  }
 
   //Take semaphore to wait for response of all attributes
   if (xSemaphoreTake(lock, ZB_CMD_TIMEOUT) != pdTRUE) {
@@ -772,9 +772,7 @@ void ZigbeeThermostat::setHumidityReporting(uint16_t min_interval, uint16_t max_
   report_cmd.record_field = records;
 
   log_i("Sending 'configure humidity reporting' command");
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 
 void ZigbeeThermostat::setHumidityReporting(uint16_t group_addr, uint16_t min_interval, uint16_t max_interval, float delta) {
@@ -801,9 +799,7 @@ void ZigbeeThermostat::setHumidityReporting(uint16_t group_addr, uint16_t min_in
   report_cmd.record_field = records;
 
   log_i("Sending 'configure humidity reporting' command to group address 0x%x", group_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 
 void ZigbeeThermostat::setHumidityReporting(uint8_t endpoint, uint16_t short_addr, uint16_t min_interval, uint16_t max_interval, float delta) {
@@ -831,9 +827,7 @@ void ZigbeeThermostat::setHumidityReporting(uint8_t endpoint, uint16_t short_add
   report_cmd.record_field = records;
 
   log_i("Sending 'configure humidity reporting' command to endpoint %u, address 0x%x", endpoint, short_addr);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 
 void ZigbeeThermostat::setHumidityReporting(uint8_t endpoint, esp_zb_ieee_addr_t ieee_addr, uint16_t min_interval, uint16_t max_interval, float delta) {
@@ -864,8 +858,6 @@ void ZigbeeThermostat::setHumidityReporting(uint8_t endpoint, esp_zb_ieee_addr_t
     "Sending 'configure humidity reporting' command to endpoint %u, ieee address %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", endpoint, ieee_addr[7], ieee_addr[6],
     ieee_addr[5], ieee_addr[4], ieee_addr[3], ieee_addr[2], ieee_addr[1], ieee_addr[0]
   );
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_config_report_cmd_req(&report_cmd);
-  esp_zb_lock_release();
+  configureClusterReporting(&report_cmd);
 }
 #endif  // CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeVibrationSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeVibrationSensor.cpp
@@ -45,14 +45,9 @@ void ZigbeeVibrationSensor::setIASClientEndpoint(uint8_t ep_number) {
 }
 
 bool ZigbeeVibrationSensor::setVibration(bool sensed) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   log_v("Setting Vibration sensor to %s", sensed ? "sensed" : "not sensed");
   uint8_t vibration = (uint8_t)sensed;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &vibration, false
-  );
-  esp_zb_lock_release();
+  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &vibration, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set vibration status: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -63,22 +58,28 @@ bool ZigbeeVibrationSensor::setVibration(bool sensed) {
 
 bool ZigbeeVibrationSensor::report() {
   /* Send IAS Zone status changed notification command */
+  if (_enrolled) {
+    esp_zb_zcl_ias_zone_status_change_notif_cmd_t status_change_notif_cmd;
+    status_change_notif_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
+    status_change_notif_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
+    status_change_notif_cmd.zcl_basic_cmd.dst_endpoint = _ias_cie_endpoint;  //default is 1
+    memcpy(status_change_notif_cmd.zcl_basic_cmd.dst_addr_u.addr_long, _ias_cie_addr, sizeof(esp_zb_ieee_addr_t));
+    status_change_notif_cmd.zone_status = _zone_status;
+    status_change_notif_cmd.extend_status = 0;
+    status_change_notif_cmd.zone_id = _zone_id;
+    status_change_notif_cmd.delay = 0;
 
-  esp_zb_zcl_ias_zone_status_change_notif_cmd_t status_change_notif_cmd;
-  status_change_notif_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_64_ENDP_PRESENT;
-  status_change_notif_cmd.zcl_basic_cmd.src_endpoint = _endpoint;
-  status_change_notif_cmd.zcl_basic_cmd.dst_endpoint = _ias_cie_endpoint;  //default is 1
-  memcpy(status_change_notif_cmd.zcl_basic_cmd.dst_addr_u.addr_long, _ias_cie_addr, sizeof(esp_zb_ieee_addr_t));
-  status_change_notif_cmd.zone_status = _zone_status;
-  status_change_notif_cmd.extend_status = 0;
-  status_change_notif_cmd.zone_id = _zone_id;
-  status_change_notif_cmd.delay = 0;
-
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&status_change_notif_cmd);  //return transaction sequence number, ignore it
-  esp_zb_lock_release();
-  log_v("IAS Zone status changed notification sent");
-  return true;
+    if (!acquireCommandLock()) {
+      return false;
+    }
+    esp_zb_zcl_ias_zone_status_change_notif_cmd_req(&status_change_notif_cmd);  //return transaction sequence number, ignore it
+    releaseCommandLock();
+    log_v("IAS Zone status changed notification sent");
+    return true;
+  } else {
+    log_e("Failed to report: IAS Zone not enrolled");
+    return false;
+  }
 }
 
 void ZigbeeVibrationSensor::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enroll_response_message_t *message) {
@@ -86,15 +87,13 @@ void ZigbeeVibrationSensor::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_en
     log_v("IAS Zone Enroll Response: zone id(%u), status(%u)", message->zone_id, message->response_code);
     if (message->response_code == ESP_ZB_ZCL_IAS_ZONE_ENROLL_RESPONSE_CODE_SUCCESS) {
       log_v("IAS Zone Enroll Response: success");
-      esp_zb_lock_acquire(portMAX_DELAY);
-      memcpy(
-        _ias_cie_addr,
-        (*(esp_zb_ieee_addr_t *)
-            esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID)
-              ->data_p),
-        sizeof(esp_zb_ieee_addr_t)
+      esp_zb_zcl_attr_t *ias_cie_attr = esp_zb_zcl_get_attribute(
+        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID
       );
-      esp_zb_lock_release();
+      if (ias_cie_attr == nullptr || ias_cie_attr->data_p == nullptr) {
+        return;
+      }
+      memcpy(_ias_cie_addr, ias_cie_attr->data_p, sizeof(_ias_cie_addr));
       _zone_id = message->zone_id;
       _enrolled = true;
     }
@@ -110,32 +109,28 @@ bool ZigbeeVibrationSensor::requestIASZoneEnroll() {
   enroll_request.zone_type = ESP_ZB_ZCL_IAS_ZONE_ZONETYPE_VIBRATION_MOVEMENT;
   enroll_request.manuf_code = 0;
 
-  esp_zb_lock_acquire(portMAX_DELAY);
+  if (!acquireCommandLock()) {
+    return false;
+  }
   esp_zb_zcl_ias_zone_enroll_cmd_req(&enroll_request);  //return transaction sequence number, ignore it
-  esp_zb_lock_release();
+  releaseCommandLock();
   log_v("IAS Zone enroll request sent");
   return true;
 }
 
 bool ZigbeeVibrationSensor::restoreIASZoneEnroll() {
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_zb_zcl_attr_t *ias_cie_attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID);
-  esp_zb_zcl_attr_t *zone_id_attr =
-    esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID);
-  esp_zb_lock_release();
-
-  if (ias_cie_attr == NULL || ias_cie_attr->data_p == NULL) {
+  if (!getClusterAttribute(
+        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID, _ias_cie_addr, sizeof(_ias_cie_addr)
+      )) {
     log_e("Failed to restore IAS Zone enroll: ias cie address attribute not found");
     return false;
   }
-  if (zone_id_attr == NULL || zone_id_attr->data_p == NULL) {
+  if (!getClusterAttribute(
+        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id)
+      )) {
     log_e("Failed to restore IAS Zone enroll: zone id attribute not found");
     return false;
   }
-
-  memcpy(_ias_cie_addr, (esp_zb_ieee_addr_t *)ias_cie_attr->data_p, sizeof(esp_zb_ieee_addr_t));
-  _zone_id = (*(uint8_t *)zone_id_attr->data_p);
 
   log_d(
     "Restored IAS Zone enroll: zone id(%u), ias cie address(%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X)", _zone_id, _ias_cie_addr[0], _ias_cie_addr[1],

--- a/libraries/Zigbee/src/ep/ZigbeeVibrationSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeVibrationSensor.cpp
@@ -47,7 +47,8 @@ void ZigbeeVibrationSensor::setIASClientEndpoint(uint8_t ep_number) {
 bool ZigbeeVibrationSensor::setVibration(bool sensed) {
   log_v("Setting Vibration sensor to %s", sensed ? "sensed" : "not sensed");
   uint8_t vibration = (uint8_t)sensed;
-  esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &vibration, false);
+  esp_zb_zcl_status_t ret =
+    setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONESTATUS_ID, &vibration, false);
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set vibration status: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -87,9 +88,8 @@ void ZigbeeVibrationSensor::zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_en
     log_v("IAS Zone Enroll Response: zone id(%u), status(%u)", message->zone_id, message->response_code);
     if (message->response_code == ESP_ZB_ZCL_IAS_ZONE_ENROLL_RESPONSE_CODE_SUCCESS) {
       log_v("IAS Zone Enroll Response: success");
-      esp_zb_zcl_attr_t *ias_cie_attr = esp_zb_zcl_get_attribute(
-        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID
-      );
+      esp_zb_zcl_attr_t *ias_cie_attr =
+        esp_zb_zcl_get_attribute(_endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID);
       if (ias_cie_attr == nullptr || ias_cie_attr->data_p == nullptr) {
         return;
       }
@@ -125,9 +125,7 @@ bool ZigbeeVibrationSensor::restoreIASZoneEnroll() {
     log_e("Failed to restore IAS Zone enroll: ias cie address attribute not found");
     return false;
   }
-  if (!getClusterAttribute(
-        ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id)
-      )) {
+  if (!getClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &_zone_id, sizeof(_zone_id))) {
     log_e("Failed to restore IAS Zone enroll: zone id attribute not found");
     return false;
   }

--- a/libraries/Zigbee/src/ep/ZigbeeWindSpeedSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeWindSpeedSensor.cpp
@@ -101,21 +101,16 @@ bool ZigbeeWindSpeedSensor::setReporting(uint16_t min_interval, uint16_t max_int
   reporting_info.u.send_info.delta.u16 = (uint16_t)(delta * 100);  // Convert delta to ZCL uint16_t
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  return Zigbee.updateReportingInfo(&reporting_info);
+  return setClusterReporting(&reporting_info);
 }
 
 bool ZigbeeWindSpeedSensor::setWindSpeed(float windspeed) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
   uint16_t zb_windspeed = zb_windspeed_to_u16(windspeed);
   log_v("Updating windspeed sensor value...");
-  /* Update windspeed sensor measured value */
   log_d("Setting windspeed to %u", zb_windspeed);
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WIND_SPEED_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WIND_SPEED_MEASUREMENT_MEASURED_VALUE_ID,
-    &zb_windspeed, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WIND_SPEED_MEASUREMENT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WIND_SPEED_MEASUREMENT_MEASURED_VALUE_ID, &zb_windspeed, false
   );
-  esp_zb_lock_release();
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set wind speed: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
     return false;
@@ -134,11 +129,8 @@ bool ZigbeeWindSpeedSensor::reportWindSpeed() {
   report_attr_cmd.manuf_specific = 0x00U;    // Standard profile command. Manufacturer code field shall not be included into ZCL frame header.
   report_attr_cmd.dis_default_resp = 0x00U;  // Default response is enabled.
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_attr_cmd);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to send wind speed report: 0x%x: %s", ret, esp_err_to_name(ret));
+  if (!reportClusterAttribute(&report_attr_cmd)) {
+    log_e("Failed to send wind speed report");
     return false;
   }
   log_v("Wind speed measurement report sent");

--- a/libraries/Zigbee/src/ep/ZigbeeWindSpeedSensor.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeWindSpeedSensor.cpp
@@ -101,14 +101,7 @@ bool ZigbeeWindSpeedSensor::setReporting(uint16_t min_interval, uint16_t max_int
   reporting_info.u.send_info.delta.u16 = (uint16_t)(delta * 100);  // Convert delta to ZCL uint16_t
   reporting_info.dst.profile_id = ESP_ZB_AF_HA_PROFILE_ID;
   reporting_info.manuf_code = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC;
-  esp_zb_lock_acquire(portMAX_DELAY);
-  esp_err_t ret = esp_zb_zcl_update_reporting_info(&reporting_info);
-  esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to set reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
-  return true;
+  return Zigbee.updateReportingInfo(&reporting_info);
 }
 
 bool ZigbeeWindSpeedSensor::setWindSpeed(float windspeed) {

--- a/libraries/Zigbee/src/ep/ZigbeeWindowCovering.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeWindowCovering.cpp
@@ -207,7 +207,7 @@ void ZigbeeWindowCovering::zbAttributeSet(const esp_zb_zcl_set_attr_value_messag
         maintenance_mode, leds_on
       );
       setMode(motor_reversed, calibration_mode, maintenance_mode, leds_on);
-      //Update Configuration status with motor reversed status
+      // Update configuration status with motor reversed status (stack callback: no Zigbee lock).
       uint8_t config_status;
       config_status = (*(uint8_t *)esp_zb_zcl_get_attribute(
                           _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_STATUS_ID
@@ -216,12 +216,7 @@ void ZigbeeWindowCovering::zbAttributeSet(const esp_zb_zcl_set_attr_value_messag
       config_status = motor_reversed ? config_status | ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_REVERSE_COMMANDS
                                      : config_status & ~ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_REVERSE_COMMANDS;
       log_v("Updating window covering config status to %u", config_status);
-      esp_zb_lock_acquire(portMAX_DELAY);
-      esp_zb_zcl_set_attribute_val(
-        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_STATUS_ID, &config_status,
-        false
-      );
-      esp_zb_lock_release();
+      esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_STATUS_ID, &config_status, false);
       return;
     }
   } else {
@@ -293,121 +288,95 @@ void ZigbeeWindowCovering::stop() {
 
 // Methods to control window covering from user application
 bool ZigbeeWindowCovering::setLiftPosition(uint16_t lift_position) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  // Update both lift attributes
   _current_lift_position = lift_position;
   _current_lift_percentage = ((lift_position - _installed_open_limit_lift) * 100) / (_installed_closed_limit_lift - _installed_open_limit_lift);
   log_v("Updating window covering lift position to %u (%u%)", _current_lift_position, _current_lift_percentage);
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID,
-    &_current_lift_position, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID, &_current_lift_position, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set lift position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_PERCENTAGE_ID,
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_PERCENTAGE_ID,
     &_current_lift_percentage, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set lift percentage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 bool ZigbeeWindowCovering::setLiftPercentage(uint8_t lift_percentage) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  // Update both lift attributes
   _current_lift_percentage = lift_percentage;
   _current_lift_position = _installed_open_limit_lift + ((_installed_closed_limit_lift - _installed_open_limit_lift) * lift_percentage) / 100;
   log_v("Updating window covering lift percentage to %u%% (%u)", _current_lift_percentage, _current_lift_position);
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID,
-    &_current_lift_position, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID, &_current_lift_position, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set lift position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_PERCENTAGE_ID,
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_PERCENTAGE_ID,
     &_current_lift_percentage, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set lift percentage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 bool ZigbeeWindowCovering::setTiltPosition(uint16_t tilt_position) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  // Update both tilt attributes
   _current_tilt_position = tilt_position;
   _current_tilt_percentage = ((tilt_position - _installed_open_limit_tilt) * 100) / (_installed_closed_limit_tilt - _installed_open_limit_tilt);
-
   log_v("Updating window covering tilt position to %u (%u%)", _current_tilt_position, _current_tilt_percentage);
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID,
-    &_current_tilt_position, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID, &_current_tilt_position, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set tilt position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_PERCENTAGE_ID,
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_PERCENTAGE_ID,
     &_current_tilt_percentage, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set tilt percentage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 bool ZigbeeWindowCovering::setTiltPercentage(uint8_t tilt_percentage) {
-  esp_zb_zcl_status_t ret = ESP_ZB_ZCL_STATUS_SUCCESS;
-  // Update both tilt attributes
   _current_tilt_percentage = tilt_percentage;
   _current_tilt_position = _installed_open_limit_tilt + ((_installed_closed_limit_tilt - _installed_open_limit_tilt) * tilt_percentage) / 100;
-
   log_v("Updating window covering tilt percentage to %u%% (%u)", _current_tilt_percentage, _current_tilt_position);
 
-  esp_zb_lock_acquire(portMAX_DELAY);
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID,
-    &_current_tilt_position, false
+  esp_zb_zcl_status_t ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID, &_current_tilt_position, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set tilt position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-  ret = esp_zb_zcl_set_attribute_val(
-    _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_PERCENTAGE_ID,
+  ret = setClusterAttribute(
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_PERCENTAGE_ID,
     &_current_tilt_percentage, false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set tilt percentage: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
-    goto unlock_and_return;
+    return false;
   }
-unlock_and_return:
-  esp_zb_lock_release();
-  return ret == ESP_ZB_ZCL_STATUS_SUCCESS;
+  return true;
 }
 
 #endif  // CONFIG_ZB_ENABLED

--- a/libraries/Zigbee/src/ep/ZigbeeWindowCovering.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeWindowCovering.cpp
@@ -217,7 +217,8 @@ void ZigbeeWindowCovering::zbAttributeSet(const esp_zb_zcl_set_attr_value_messag
                                      : config_status & ~ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_REVERSE_COMMANDS;
       log_v("Updating window covering config status to %u", config_status);
       esp_zb_zcl_status_t ret = esp_zb_zcl_set_attribute_val(
-        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_STATUS_ID, &config_status, false
+        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_STATUS_ID, &config_status,
+        false
       );
       if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
         log_e("Failed to set window covering config status: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
@@ -298,7 +299,8 @@ bool ZigbeeWindowCovering::setLiftPosition(uint16_t lift_position) {
   log_v("Updating window covering lift position to %u (%u%)", _current_lift_position, _current_lift_percentage);
 
   esp_zb_zcl_status_t ret = setClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID, &_current_lift_position, false
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID, &_current_lift_position,
+    false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set lift position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
@@ -321,7 +323,8 @@ bool ZigbeeWindowCovering::setLiftPercentage(uint8_t lift_percentage) {
   log_v("Updating window covering lift percentage to %u%% (%u)", _current_lift_percentage, _current_lift_position);
 
   esp_zb_zcl_status_t ret = setClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID, &_current_lift_position, false
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_LIFT_ID, &_current_lift_position,
+    false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set lift position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
@@ -344,7 +347,8 @@ bool ZigbeeWindowCovering::setTiltPosition(uint16_t tilt_position) {
   log_v("Updating window covering tilt position to %u (%u%)", _current_tilt_position, _current_tilt_percentage);
 
   esp_zb_zcl_status_t ret = setClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID, &_current_tilt_position, false
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID, &_current_tilt_position,
+    false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set tilt position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
@@ -367,7 +371,8 @@ bool ZigbeeWindowCovering::setTiltPercentage(uint8_t tilt_percentage) {
   log_v("Updating window covering tilt percentage to %u%% (%u)", _current_tilt_percentage, _current_tilt_position);
 
   esp_zb_zcl_status_t ret = setClusterAttribute(
-    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID, &_current_tilt_position, false
+    ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CURRENT_POSITION_TILT_ID, &_current_tilt_position,
+    false
   );
   if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
     log_e("Failed to set tilt position: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));

--- a/libraries/Zigbee/src/ep/ZigbeeWindowCovering.cpp
+++ b/libraries/Zigbee/src/ep/ZigbeeWindowCovering.cpp
@@ -216,7 +216,12 @@ void ZigbeeWindowCovering::zbAttributeSet(const esp_zb_zcl_set_attr_value_messag
       config_status = motor_reversed ? config_status | ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_REVERSE_COMMANDS
                                      : config_status & ~ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_REVERSE_COMMANDS;
       log_v("Updating window covering config status to %u", config_status);
-      esp_zb_zcl_status_t ret = setClusterAttribute(ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_STATUS_ID, &config_status, false);
+      esp_zb_zcl_status_t ret = esp_zb_zcl_set_attribute_val(
+        _endpoint, ESP_ZB_ZCL_CLUSTER_ID_WINDOW_COVERING, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_WINDOW_COVERING_CONFIG_STATUS_ID, &config_status, false
+      );
+      if (ret != ESP_ZB_ZCL_STATUS_SUCCESS) {
+        log_e("Failed to set window covering config status: 0x%x: %s", ret, esp_zb_zcl_status_to_name(ret));
+      }
       return;
     }
   } else {


### PR DESCRIPTION
## Description of Change

This PR hardens Zigbee stack initialization and reporting configuration, and fixes multistate input state handling.
- **Safe reporting configuration** — Add `ZigbeeCore::updateReportingInfo()` so all `setReporting()` / `setHumidityReporting()` / `setDCReporting()` / `setACReporting()` / `setAnalogInputReporting()` paths verify the stack is started before calling `esp_zb_zcl_update_reporting_info()`. Calling them before `begin()` logs a warning and returns `false` instead of crashing.
- **Guard duplicate `Zigbee.begin()`** — Track `_initialized` and return `false` with a warning on a second `begin()`, instead of re-initializing the stack (e.g. “Zigbee lock has already been initialized”). Pause/resume remains `stop()` / `start()`.
- **Fix `ZigbeeMultistate` input state** — `setMultistateInput()` updates `_input_state` only after a successful ZCL set; `zbAttributeSet()` handles `MULT_INPUT` present value so `getMultistateInput()` stays aligned with the attribute after local sets and remote writes.
- **Init robustness** — Set `_role` before `zigbeeInit()` in `begin(esp_zb_cfg_t*)` so `esp_zb_task` never reads a stale role; check `xTaskCreate()` before setting `_initialized` so a failed task creation does not block retry.

## Test Scenarios

Tested locally in WIP Zigbee test suite.
