### PR TITLE
fix(ledc): Avoid busy-wait WDT timeout and release locks on fail

### DIFF
--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -435,6 +435,7 @@ uint32_t ledcWriteTone(uint8_t pin, uint32_t freq) {
     }
     bus->channel_resolution = 10;
 
+    bus->freq_hz = freq;
     uint32_t res_freq = ledc_get_freq(group, bus->timer_num);
     ledcWrite(pin, 0x1FF);
     return res_freq;
@@ -491,6 +492,7 @@ uint32_t ledcChangeFrequency(uint8_t pin, uint32_t freq, uint8_t resolution) {
       return 0;
     }
     bus->channel_resolution = resolution;
+    bus->freq_hz = freq;
     return ledc_get_freq(group, bus->timer_num);
   }
   return 0;
@@ -583,22 +585,31 @@ static bool ledcFadeConfig(uint8_t pin, uint32_t start_duty, uint32_t target_dut
     ledc_fade_stop(group, channel);
 #endif
 
-    if (ledc_set_duty_and_update(group, channel, start_duty, 0) != ESP_OK) {
+    bool success = (ledc_set_duty_and_update(group, channel, start_duty, 0) == ESP_OK);
+    if (!success) {
       log_e("ledc_set_duty_and_update failed");
-      return false;
+    } else {
+      // The new duty takes effect on the next PWM cycle (TRM §35.3.3).
+      // Wait one full period so the start duty is applied before fading.
+      delay(1000 / bus->freq_hz + 1);
+      success = (ledc_set_fade_time_and_start(group, channel, target_duty, max_fade_time_ms, LEDC_FADE_NO_WAIT) == ESP_OK);
+      if (!success) {
+        log_e("ledc_set_fade_time_and_start failed");
+      }
     }
-    // Wait for LEDCs next PWM cycle to update duty (~ 1-2 ms)
-    while (ledc_get_duty(group, channel) != start_duty);
 
-    if (ledc_set_fade_time_and_start(group, channel, target_duty, max_fade_time_ms, LEDC_FADE_NO_WAIT) != ESP_OK) {
-      log_e("ledc_set_fade_time_and_start failed");
-      return false;
+#ifndef SOC_LEDC_SUPPORT_FADE_STOP
+#if !CONFIG_DISABLE_HAL_LOCKS
+    if (!success && bus->lock != NULL) {
+      xSemaphoreGive(bus->lock);
     }
-  } else {
-    log_e("Pin %u is not attached to LEDC. Call ledcAttach first!", pin);
-    return false;
+#endif
+#endif
+    return success;
   }
-  return true;
+
+  log_e("Pin %u is not attached to LEDC. Call ledcAttach first!", pin);
+  return false;
 }
 
 bool ledcFade(uint8_t pin, uint32_t start_duty, uint32_t target_duty, int max_fade_time_ms) {

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -591,7 +591,13 @@ static bool ledcFadeConfig(uint8_t pin, uint32_t start_duty, uint32_t target_dut
     } else {
       // The new duty takes effect on the next PWM cycle (TRM §35.3.3).
       // Wait one full period so the start duty is applied before fading.
-      delay(1000 / bus->freq_hz + 1);
+      // Use the actual hardware frequency (not the cached field) to handle
+      // clock-division rounding, shared timers, and already-used channels.
+      uint32_t actual_freq = ledc_get_freq(group, bus->timer_num);
+      if (actual_freq == 0) {
+        actual_freq = 1;  // guard against division by zero; should not happen
+      }
+      delay((1000 + actual_freq - 1) / actual_freq);
       success = (ledc_set_fade_time_and_start(group, channel, target_duty, max_fade_time_ms, LEDC_FADE_NO_WAIT) == ESP_OK);
       if (!success) {
         log_e("ledc_set_fade_time_and_start failed");

--- a/cores/esp32/esp32-hal-ledc.c
+++ b/cores/esp32/esp32-hal-ledc.c
@@ -590,17 +590,20 @@ static bool ledcFadeConfig(uint8_t pin, uint32_t start_duty, uint32_t target_dut
       log_e("ledc_set_duty_and_update failed");
     } else {
       // The new duty takes effect on the next PWM cycle (TRM §35.3.3).
-      // Wait one full period so the start duty is applied before fading.
-      // Use the actual hardware frequency (not the cached field) to handle
-      // clock-division rounding, shared timers, and already-used channels.
+      // Wait one full period (ceil ms) so the start duty is applied before fading.
+      // Read from hardware so the delay is correct regardless of clock-division
+      // rounding, shared timers, or already-used channels where bus->freq_hz
+      // may not match the actual timer frequency.
       uint32_t actual_freq = ledc_get_freq(group, bus->timer_num);
       if (actual_freq == 0) {
-        actual_freq = 1;  // guard against division by zero; should not happen
-      }
-      delay((1000 + actual_freq - 1) / actual_freq);
-      success = (ledc_set_fade_time_and_start(group, channel, target_duty, max_fade_time_ms, LEDC_FADE_NO_WAIT) == ESP_OK);
-      if (!success) {
-        log_e("ledc_set_fade_time_and_start failed");
+        log_e("LEDC timer not running on pin %u", pin);
+        success = false;
+      } else {
+        delay((1000U + actual_freq - 1U) / actual_freq);
+        success = (ledc_set_fade_time_and_start(group, channel, target_duty, max_fade_time_ms, LEDC_FADE_NO_WAIT) == ESP_OK);
+        if (!success) {
+          log_e("ledc_set_fade_time_and_start failed");
+        }
       }
     }
 


### PR DESCRIPTION
## Description of Change

This pull request improves the handling of frequency and duty cycle updates in the ESP32 LEDC (LED Controller) HAL, ensuring that the internal state accurately reflects hardware changes and that PWM fades are applied more reliably. The most important changes are grouped below:

**Synchronization of Frequency State:**

* The `freq_hz` member of the `bus` structure is now updated whenever the frequency is changed via `ledcWriteTone` and `ledcChangeFrequency`, ensuring the software state matches the hardware configuration. [[1]](diffhunk://#diff-8aa24b38fba6deb89114becd58eb802831146ffe0447c10266db1d19b82e6882R438) [[2]](diffhunk://#diff-8aa24b38fba6deb89114becd58eb802831146ffe0447c10266db1d19b82e6882R495)

**Improvements to Fade Operation Reliability:**

* The `ledcFadeConfig` function now waits for one full PWM period after setting the start duty before initiating a fade. This ensures the start duty is applied before fading begins, making fades more predictable and robust, especially when timers are shared or frequencies are changed.
* Additional error handling and logging have been added to check for timer operation and fade command success, with appropriate semaphore release when failures occur and locks are in use.

## Test Scenarios

Tested in WIP PWM test
