### PR TITLE
feat(i2s): Add support for slave mode

### DIFF
--- a/docs/en/api/i2s.rst
+++ b/docs/en/api/i2s.rst
@@ -49,10 +49,10 @@ I2S Configuration
 Master / Slave Mode
 *******************
 
-In **Master mode** (default) the device is generating clock signal ``sck`` and word select signal on ``ws``.
+In **Master mode** (default), the device generates the clock signal ``sck`` and word select signal on ``ws``.
 
-In **Slave mode** the device listens on attached pins for the clock signal and word select - i.e. unless externally driven the pins will remain LOW.
-This mode is not supported yet.
+In **Slave mode**, the device listens on attached pins for the clock signal and word select driven by an external master.
+The role is selected via the ``role`` parameter of ``begin()`` (default ``I2S_ROLE_MASTER``).
 
 I2S Port
 ********
@@ -103,10 +103,21 @@ Data Bit Width
 This is the number of bits in a channel sample. The data bit width is set by function parameter ``bits_cfg``.
 The current supported values are:
 
-* ``I2S_DATA_BIT_WIDTH_8BIT``
+* ``I2S_DATA_BIT_WIDTH_8BIT`` (see note below)
 * ``I2S_DATA_BIT_WIDTH_16BIT``
 * ``I2S_DATA_BIT_WIDTH_24BIT``, requires the MCLK multiplier to be manually set to 384
 * ``I2S_DATA_BIT_WIDTH_32BIT``
+
+.. note::
+    **8-bit data width on ESP32 (HW v1):** The original ESP32's I2S peripheral uses
+    ``uint16_t``-aligned DMA words for 8-bit data, with only the high 8 bits valid.
+    The Arduino library handles this transparently: ``write()`` packs each ``int8_t``
+    sample into the high byte of a ``uint16_t``, and ``readBytes()`` unpacks it back.
+    For mono 8-bit, the existing stereo workaround is also applied (hardware runs in
+    stereo mode, software converts). This is fully automatic and requires no special
+    handling in application code. See the
+    `ESP-IDF I2S STD TX Mode documentation <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/i2s.html#std-tx-mode>`_
+    for background on the hardware behavior.
 
 Sample Rate
 ***********
@@ -120,11 +131,67 @@ The slot mode is set by function parameter ``ch``. The current supported values 
 
 * ``I2S_SLOT_MODE_MONO``
     I2S channel slot format mono. Transmit the same data in all slots for TX mode.
-    Only receive the data in the first slots for RX mode.
+    Only receive the data in the first slot for RX mode.
 
 * ``I2S_SLOT_MODE_STEREO``
     I2S channel slot format stereo. Transmit different data in different slots for TX mode.
     Receive the data in all slots for RX mode.
+
+.. note::
+    On the original ESP32 (I2S hardware version 1), 8-bit and 16-bit mono modes have a
+    known hardware limitation: the FIFO packing logic scrambles data during transmission
+    and reception. The library works around this automatically by configuring the hardware
+    in stereo mode and converting between mono and stereo in software. ``write()`` duplicates
+    each mono sample into both left and right slots, and ``readBytes()`` extracts the selected
+    channel to produce mono output. For 8-bit, the library also handles the ``uint16_t``
+    high-byte packing required by the hardware. This is fully transparent to application code.
+
+Slot Mask
+*********
+
+The ``slot_mask`` parameter selects which channel slot(s) to use. It is available in
+``begin()``, ``configureTX()``, and ``configureRX()``. When set to ``-1`` (default),
+the library chooses a sensible default based on the slot mode.
+
+The supported values are:
+
+* ``I2S_STD_SLOT_LEFT`` (1) -- Use the left slot only.
+* ``I2S_STD_SLOT_RIGHT`` (2) -- Use the right slot only.
+* ``I2S_STD_SLOT_BOTH`` (3) -- Use both left and right slots.
+
+**TX behavior (mono mode):**
+
+* ``LEFT`` -- Transmit mono data on the left wire slot; right is silent.
+* ``RIGHT`` -- Transmit mono data on the right wire slot; left is silent.
+* ``BOTH`` -- Transmit mono data on both wire slots. Useful for driving a stereo DAC
+  from a single-channel source.
+
+**TX behavior (stereo mode):**
+
+* ``LEFT`` -- Transmit only the left-channel data from the buffer on the left wire slot; right is silent.
+* ``RIGHT`` -- Transmit only the right-channel data from the buffer on the right wire slot; left is silent.
+* ``BOTH`` -- Transmit interleaved stereo data normally.
+
+**RX behavior (mono mode):**
+
+* ``LEFT`` -- Receive the left channel only.
+* ``RIGHT`` -- Receive the right channel only.
+* ``BOTH`` -- On the original ESP32 (HW v1), averages the left and right channels.
+  On other targets, causes sample duplication in the DMA buffer (not recommended).
+
+**RX behavior (stereo mode):**
+
+The library always forces ``slot_mask`` to ``BOTH`` for stereo RX, regardless of the
+value passed by the user. This is because the ESP-IDF does not reliably ignore
+``slot_mask`` in stereo RX mode on all targets — some hardware duplicates the selected
+channel instead of delivering normal interleaved data. The library overrides the mask
+to guarantee correct interleaved ``[L, R, L, R, ...]`` output.
+
+.. note::
+    On the original ESP32 (HW v1) with mono 8-bit or 16-bit mode, ``slot_mask`` controls
+    which channel the software workaround extracts: ``LEFT`` extracts the left channel,
+    ``RIGHT`` extracts the right channel, and ``BOTH`` averages the two channels.
+    This can be changed at runtime via ``configureRX()``.
 
 Arduino-ESP32 I2S API
 ---------------------
@@ -170,14 +237,14 @@ Before ``begin()``, this returns the configured controller value, such as ``I2S_
 
   i2s_port_t getPort()
 
-begin (Master Mode)
-^^^^^^^^^^^^^^^^^^^
+begin
+^^^^^
 
-Before usage choose which pins you want to use.
+Initialize the I2S driver. Before calling ``begin()``, choose which pins you want to use with ``setPins()`` or the PDM pin-setup functions.
 
 .. code-block:: arduino
 
-    bool begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask=-1)
+    bool begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask=-1, i2s_role_t role=I2S_ROLE_MASTER)
 
 Parameters:
 
@@ -189,9 +256,13 @@ Parameters:
 
 * [in] ``ch`` is the slot mode, for example ``I2S_SLOT_MODE_STEREO``.
 
-* [in] ``slot_mask`` is the slot mask, for example ``0b11``. This parameter is optional and defaults to ``-1`` (not used).
+* [in] ``slot_mask`` selects which slot(s) to use (see `Slot Mask`_ section).
+         This parameter is optional and defaults to ``-1`` (library default: LEFT for mono TX/RX, BOTH for stereo).
+         For stereo RX, the library always forces BOTH regardless of this value.
 
-This function will return ``true`` on success or ``fail`` in case of failure.
+* [in] ``role`` is the I2S role. Use ``I2S_ROLE_MASTER`` (default) to generate clock and word-select signals, or ``I2S_ROLE_SLAVE`` to receive them from an external master.
+
+This function will return ``true`` on success or ``false`` in case of failure.
 
 When failed, an error message will be printed if the correct log level is set.
 
@@ -320,20 +391,24 @@ Parameters:
 
 * [in] ``ch`` is the slot mode, for example ``I2S_SLOT_MODE_STEREO``.
 
-* [in] ``slot_mask`` is the slot mask, for example ``0b11``. This parameter is optional and defaults to ``-1`` (not used).
+* [in] ``slot_mask`` selects which slot(s) to use for TX (see `Slot Mask`_ section).
+         This parameter is optional and defaults to ``-1`` (library default).
 
-This function will return ``true`` on success or ``fail`` in case of failure.
+This function will return ``true`` on success or ``false`` in case of failure.
 
 When failed, an error message will be printed if the correct log level is set.
 
 configureRX
 ^^^^^^^^^^^
 
-Configure the I2S RX channel.
+Configure the I2S RX channel. This function can change the sample rate, bit width,
+slot mode, RX transform, and slot mask at runtime without calling ``end()``/``begin()``.
+If only the ``slot_mask`` changes (rate, bits, and channel mode remain the same), the
+library performs a lightweight slot-only reconfiguration.
 
 .. code-block:: arduino
 
-  bool configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform=I2S_RX_TRANSFORM_NONE)
+  bool configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform=I2S_RX_TRANSFORM_NONE, int8_t slot_mask=-1)
 
 Parameters:
 
@@ -348,8 +423,16 @@ Parameters:
          The supported values are: ``I2S_RX_TRANSFORM_NONE`` (no transformation),
          ``I2S_RX_TRANSFORM_32_TO_16`` (convert from 32 bits of data width to 16 bits) and
          ``I2S_RX_TRANSFORM_16_STEREO_TO_MONO`` (convert from stereo to mono when using 16 bits of data width).
+         When using ``I2S_RX_TRANSFORM_16_STEREO_TO_MONO``, the channel extracted depends on the configured
+         ``slot_mask``: ``LEFT`` extracts the left channel, ``RIGHT`` extracts the right channel, and ``BOTH``
+         averages both channels.
 
-This function will return ``true`` on success or ``fail`` in case of failure.
+* [in] ``slot_mask`` is the slot mask for RX channel selection (see `Slot Mask`_ section).
+         This parameter is optional and defaults to ``-1`` (use current setting).
+         In mono mode, this selects which channel to receive (LEFT, RIGHT, or BOTH).
+         In stereo mode, this parameter is ignored — the library always uses BOTH.
+
+This function will return ``true`` on success or ``false`` in case of failure.
 
 When failed, an error message will be printed if the correct log level is set.
 
@@ -573,6 +656,9 @@ When failed, an error message will be printed if the correct log level is set.
 Sample code
 -----------
 
+Master mode (default)
+*********************
+
 .. code-block:: arduino
 
   #include <ESP_I2S.h>
@@ -593,6 +679,27 @@ Sample code
       read_bytes = I2S.readBytes(buffer, buff_size);
     }
     I2S.write(buffer, read_bytes);
+    I2S.end();
+  }
+
+  void loop() {}
+
+Slave mode
+**********
+
+.. code-block:: arduino
+
+  #include <ESP_I2S.h>
+
+  const int buff_size = 128;
+  uint8_t buffer[buff_size];
+  I2SClass I2S;
+
+  void setup() {
+    I2S.setPins(5, 25, -1, 35); //SCK, WS, SDOUT (not used), SDIN
+    I2S.begin(I2S_MODE_STD, 16000, I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO, -1, I2S_ROLE_SLAVE);
+    size_t read_bytes = I2S.readBytes((char *)buffer, buff_size);
+    // process received data...
     I2S.end();
   }
 

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -1068,17 +1068,17 @@ bool I2SClass::configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slo
       if (ch == I2S_SLOT_MODE_STEREO) {
         i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
         _rx_slot_mask = I2S_STD_SLOT_BOTH;
+      } else if (slot_mask >= 0 && (i2s_std_slot_mask_t)slot_mask <= I2S_STD_SLOT_BOTH) {
+        i2s_config.slot_cfg.slot_mask = (i2s_std_slot_mask_t)slot_mask;
+        _rx_slot_mask = (i2s_std_slot_mask_t)slot_mask;
       } else {
-        if (slot_mask >= 0 && (i2s_std_slot_mask_t)slot_mask <= I2S_STD_SLOT_BOTH) {
-          i2s_config.slot_cfg.slot_mask = (i2s_std_slot_mask_t)slot_mask;
-        }
-        if (slot_mask == I2S_STD_SLOT_RIGHT) {
-          _rx_slot_mask = I2S_STD_SLOT_RIGHT;
-        } else if (slot_mask == I2S_STD_SLOT_BOTH) {
-          _rx_slot_mask = I2S_STD_SLOT_BOTH;
-        } else {
+        // slot_mask = -1 (default) in mono: preserve current _rx_slot_mask,
+        // but reset to LEFT if transitioning from stereo (where BOTH was forced).
+        if (rx_slot_mode != I2S_SLOT_MODE_MONO && _rx_slot_mask != I2S_STD_SLOT_LEFT) {
+          log_w("configureRX: switching from stereo to mono with no explicit slot_mask; defaulting to LEFT");
           _rx_slot_mask = I2S_STD_SLOT_LEFT;
         }
+        i2s_config.slot_cfg.slot_mask = _rx_slot_mask;
       }
 #if SOC_I2S_HW_VERSION_1
       _8bit_hw_packing = (bits_cfg == I2S_DATA_BIT_WIDTH_8BIT);
@@ -1089,10 +1089,6 @@ bool I2SClass::configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slo
         i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
       } else {
         _mono_hw_workaround = false;
-      }
-#else
-      if (ch == I2S_SLOT_MODE_MONO && slot_mask < 0) {
-        i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_LEFT;
       }
 #endif
       I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_disable(rx_chan));
@@ -1412,6 +1408,10 @@ bool I2SClass::transformRX(i2s_rx_transform_t transform) {
       break;
 
     case I2S_RX_TRANSFORM_16_STEREO_TO_MONO:
+      if (rx_data_bit_width != I2S_DATA_BIT_WIDTH_16BIT) {
+        log_e("I2S_RX_TRANSFORM_16_STEREO_TO_MONO requires 16-bit data width");
+        return false;
+      }
       if (rx_slot_mode != I2S_SLOT_MODE_STEREO) {
         log_e("Wrong slot mode. Should be Stereo");
         return false;
@@ -1431,6 +1431,10 @@ bool I2SClass::transformRX(i2s_rx_transform_t transform) {
 
     case I2S_RX_TRANSFORM_8_UNPACK:
 #if SOC_I2S_HW_VERSION_1
+      if (rx_data_bit_width != I2S_DATA_BIT_WIDTH_8BIT) {
+        log_e("I2S_RX_TRANSFORM_8_UNPACK requires 8-bit data width");
+        return false;
+      }
       if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
         return false;
       }
@@ -1438,7 +1442,7 @@ bool I2SClass::transformRX(i2s_rx_transform_t transform) {
       break;
 #else
       log_w("I2S_RX_TRANSFORM_8_UNPACK is only needed on ESP32 HW v1; ignoring on this target");
-      break;
+      return true;
 #endif
 
     default: log_e("Unknown RX Transform %d", transform); return false;

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -202,8 +202,75 @@ static esp_err_t i2s_channel_read_32_to_16(i2s_chan_handle_t handle, char *read_
   return ESP_OK;
 }
 
-// Resample the 16bit stereo microphone data into 16bit mono.
-static esp_err_t i2s_channel_read_16_stereo_to_mono(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
+// Unified stereo-to-mono extraction for the HW v1 mono workaround.
+// DMA always delivers interleaved uint16_t pairs (stereo). This function
+// de-interleaves by slot_offset (0=left, 1=right, 2=average) and optionally
+// unpacks the high byte for 8-bit mode.
+// 16-bit: DMA reads 2× user bytes;  output is int16_t per sample.
+//  8-bit: DMA reads 4× user bytes;  output is  int8_t per sample (high byte of uint16_t).
+static esp_err_t i2s_channel_read_stereo_to_mono(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
+                                                 uint32_t timeout_ms, size_t slot_offset, bool unpack_8bit) {
+  size_t out_len = 0;
+  size_t read_buff_len = len * (unpack_8bit ? 4 : 2);
+  if (read_buff == NULL) {
+    log_e("Temp buffer is NULL!");
+    return ESP_FAIL;
+  }
+  esp_err_t err = i2s_channel_read(handle, read_buff, read_buff_len, &out_len, timeout_ms);
+  if (err != ESP_OK) {
+    *bytes_read = 0;
+    return err;
+  }
+  size_t stereo_samples = out_len / 2;
+  int16_t *src = (int16_t *)read_buff;
+  size_t written = 0;
+
+  if (unpack_8bit) {
+    uint8_t *ds = (uint8_t *)dst;
+    if (slot_offset < 2) {
+      for (size_t i = slot_offset; i < stereo_samples; i += 2) {
+        ds[written++] = (uint8_t)((uint16_t)src[i] >> 8);
+      }
+    } else {
+      for (size_t i = 0; i < stereo_samples; i += 2) {
+        int16_t l = (int8_t)((uint16_t)src[i] >> 8);
+        int16_t r = (int8_t)((uint16_t)src[i + 1] >> 8);
+        ds[written++] = (int8_t)((l + r) / 2);
+      }
+    }
+    *bytes_read = written;
+  } else {
+    int16_t *ds = (int16_t *)dst;
+    if (slot_offset < 2) {
+      for (size_t i = slot_offset; i < stereo_samples; i += 2) {
+        ds[written++] = src[i];
+      }
+    } else {
+      for (size_t i = 0; i < stereo_samples; i += 2) {
+        ds[written++] = (int16_t)(((int32_t)src[i] + (int32_t)src[i + 1]) / 2);
+      }
+    }
+    *bytes_read = written * 2;
+  }
+  return ESP_OK;
+}
+
+// 16-bit wrappers (all targets — used by I2S_RX_TRANSFORM_16_STEREO_TO_MONO)
+static esp_err_t i2s_channel_read_16_stereo_to_mono_left(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
+  return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 0, false);
+}
+
+static esp_err_t i2s_channel_read_16_stereo_to_mono_right(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
+  return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 1, false);
+}
+
+static esp_err_t i2s_channel_read_16_stereo_to_mono_both(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
+  return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 2, false);
+}
+
+#if SOC_I2S_HW_VERSION_1
+// Unpack stereo 8-bit: each DMA uint16_t → one int8_t (high byte)
+static esp_err_t i2s_channel_read_8_unpack(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   size_t out_len = 0;
   size_t read_buff_len = len * 2;
   if (read_buff == NULL) {
@@ -215,15 +282,32 @@ static esp_err_t i2s_channel_read_16_stereo_to_mono(i2s_chan_handle_t handle, ch
     *bytes_read = 0;
     return err;
   }
-  out_len /= 2;
-  uint16_t *ds = (uint16_t *)dst;
+  size_t n_samples = out_len / 2;
+  uint8_t *ds = (uint8_t *)dst;
   uint16_t *src = (uint16_t *)read_buff;
-  for (size_t i = 0; i < out_len; i += 2) {
-    *ds++ = src[i];
+  for (size_t i = 0; i < n_samples; i++) {
+    ds[i] = (uint8_t)(src[i] >> 8);
   }
-  *bytes_read = out_len;
+  *bytes_read = n_samples;
   return ESP_OK;
 }
+
+// 8-bit mono wrappers (ESP32 HW v1 only — mono workaround + uint16_t packing)
+static esp_err_t i2s_channel_read_8_stereo_to_mono_left(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
+                                                        uint32_t timeout_ms) {
+  return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 0, true);
+}
+
+static esp_err_t i2s_channel_read_8_stereo_to_mono_right(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
+                                                         uint32_t timeout_ms) {
+  return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 1, true);
+}
+
+static esp_err_t i2s_channel_read_8_stereo_to_mono_both(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
+                                                        uint32_t timeout_ms) {
+  return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 2, true);
+}
+#endif  // SOC_I2S_HW_VERSION_1
 
 I2SClass::I2SClass(i2s_port_t port) {
   last_error = ESP_OK;
@@ -244,6 +328,13 @@ I2SClass::I2SClass(i2s_port_t port) {
   rx_sample_rate = 0;
   rx_data_bit_width = I2S_DATA_BIT_WIDTH_16BIT;
   rx_slot_mode = I2S_SLOT_MODE_STEREO;
+
+  _role = I2S_ROLE_MASTER;
+  _rx_slot_mask = I2S_STD_SLOT_LEFT;
+#if SOC_I2S_HW_VERSION_1
+  _mono_hw_workaround = false;
+  _8bit_hw_packing = false;
+#endif
 
   _mclk = -1;
   _bclk = -1;
@@ -405,6 +496,7 @@ bool I2SClass::initSTD(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mo
 
   // I2S configuration
   i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
+  chan_cfg.role = _role;
   if (_dout >= 0 && _din >= 0) {
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, &tx_chan, &rx_chan));
   } else if (_dout >= 0) {
@@ -417,6 +509,33 @@ bool I2SClass::initSTD(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mo
   if (slot_mask >= 0 && (i2s_std_slot_mask_t)slot_mask <= I2S_STD_SLOT_BOTH) {
     i2s_config.slot_cfg.slot_mask = (i2s_std_slot_mask_t)slot_mask;
   }
+  if (slot_mask == I2S_STD_SLOT_RIGHT) {
+    _rx_slot_mask = I2S_STD_SLOT_RIGHT;
+  } else if (slot_mask == I2S_STD_SLOT_BOTH || (ch == I2S_SLOT_MODE_STEREO && slot_mask < 0)) {
+    _rx_slot_mask = I2S_STD_SLOT_BOTH;
+  } else {
+    _rx_slot_mask = I2S_STD_SLOT_LEFT;
+  }
+#if SOC_I2S_HW_VERSION_1
+  // ESP32 HW v1: DMA uses 2 bytes per sample for 8-bit data (high byte valid).
+  // Mono FIFO packing is also broken for 8/16-bit.  Work around both issues by
+  // packing 8-bit in software and forcing stereo for mono.
+  _8bit_hw_packing = (bits_cfg == I2S_DATA_BIT_WIDTH_8BIT);
+  if (ch == I2S_SLOT_MODE_MONO && (bits_cfg == I2S_DATA_BIT_WIDTH_16BIT || bits_cfg == I2S_DATA_BIT_WIDTH_8BIT)) {
+    _mono_hw_workaround = true;
+    i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
+    i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+  } else {
+    _mono_hw_workaround = false;
+  }
+#else
+  // Newer targets default to SLOT_BOTH even in mono, which doubles each
+  // sample in the DMA buffer.  Force SLOT_LEFT for true mono unless the
+  // caller explicitly overrode slot_mask.
+  if (ch == I2S_SLOT_MODE_MONO && slot_mask < 0) {
+    i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_LEFT;
+  }
+#endif
   if (tx_chan != NULL) {
     tx_sample_rate = rate;
     tx_data_bit_width = bits_cfg;
@@ -425,11 +544,51 @@ bool I2SClass::initSTD(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mo
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_enable(tx_chan));
   }
   if (rx_chan != NULL) {
+    if (ch == I2S_SLOT_MODE_STEREO) {
+      i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+      _rx_slot_mask = I2S_STD_SLOT_BOTH;
+    }
     rx_sample_rate = rate;
     rx_data_bit_width = bits_cfg;
     rx_slot_mode = ch;
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_init_std_mode(rx_chan, &i2s_config));
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_enable(rx_chan));
+#if SOC_I2S_HW_VERSION_1
+    if (_mono_hw_workaround) {
+      if (_8bit_hw_packing) {
+        // 8-bit mono: DMA produces stereo uint16_t (4 bytes per mono sample)
+        if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 4)) {
+          goto err;
+        }
+        if (_rx_slot_mask == I2S_STD_SLOT_RIGHT) {
+          rx_fn = i2s_channel_read_8_stereo_to_mono_right;
+        } else if (_rx_slot_mask == I2S_STD_SLOT_BOTH) {
+          rx_fn = i2s_channel_read_8_stereo_to_mono_both;
+        } else {
+          rx_fn = i2s_channel_read_8_stereo_to_mono_left;
+        }
+      } else {
+        if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
+          goto err;
+        }
+        if (_rx_slot_mask == I2S_STD_SLOT_RIGHT) {
+          rx_fn = i2s_channel_read_16_stereo_to_mono_right;
+        } else if (_rx_slot_mask == I2S_STD_SLOT_BOTH) {
+          rx_fn = i2s_channel_read_16_stereo_to_mono_both;
+        } else {
+          rx_fn = i2s_channel_read_16_stereo_to_mono_left;
+        }
+      }
+      rx_transform = I2S_RX_TRANSFORM_16_STEREO_TO_MONO;
+    } else if (_8bit_hw_packing) {
+      // 8-bit stereo: DMA produces uint16_t per sample (2× user bytes)
+      if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
+        goto err;
+      }
+      rx_fn = i2s_channel_read_8_unpack;
+      rx_transform = I2S_RX_TRANSFORM_8_UNPACK;
+    }
+#endif
   }
 
   // Peripheral manager set bus type to I2S
@@ -461,7 +620,7 @@ bool I2SClass::initSTD(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mo
 
   return true;
 err:
-  log_e("Failed to set all pins bus to I2S_STD");
+  log_e("I2S_STD initialization failed");
   I2SClass::i2sDetachBus((void *)(this));
   return false;
 }
@@ -514,6 +673,7 @@ bool I2SClass::initTDM(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mo
 
   // I2S configuration
   i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
+  chan_cfg.role = _role;
   if (_dout >= 0 && _din >= 0) {
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, &tx_chan, &rx_chan));
   } else if (_dout >= 0) {
@@ -605,6 +765,7 @@ bool I2SClass::initPDMtx(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_
 
   // I2S configuration
   i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
+  chan_cfg.role = _role;
   I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, &tx_chan, NULL));
 
   i2s_pdm_tx_config_t i2s_pdm_tx_config = I2S_PDM_TX_CHAN_CFG(rate, bits_cfg, ch);
@@ -689,6 +850,7 @@ bool I2SClass::initPDMrx(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_
 
   // I2S configuration
   i2s_chan_config_t chan_cfg = I2S_DEFAULT_CFG(_port);
+  chan_cfg.role = _role;
   I2S_ERROR_CHECK_RETURN_FALSE(i2s_new_channel(&chan_cfg, NULL, &rx_chan));
 
   i2s_pdm_rx_config_t i2s_pdf_rx_config = I2S_PDM_RX_CHAN_CFG(rate, bits_cfg, ch);
@@ -735,7 +897,7 @@ err:
 }
 #endif
 
-bool I2SClass::begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask) {
+bool I2SClass::begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask, i2s_role_t role) {
   /* Setup I2S peripheral */
   if (mode >= I2S_MODE_MAX) {
     log_e("Invalid I2S mode selected.");
@@ -746,6 +908,7 @@ bool I2SClass::begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_c
     return false;
   }
   _mode = mode;
+  _role = role;
 
   bool init = false;
   switch (_mode) {
@@ -795,6 +958,12 @@ bool I2SClass::end() {
     rx_transform_buf = NULL;
     rx_transform_buf_len = 0;
   }
+  rx_fn = i2s_channel_read_default;
+  rx_transform = I2S_RX_TRANSFORM_NONE;
+#if SOC_I2S_HW_VERSION_1
+  _mono_hw_workaround = false;
+  _8bit_hw_packing = false;
+#endif
 
   //Peripheral manager deinit used pins
   switch (mode) {
@@ -861,6 +1030,20 @@ bool I2SClass::configureTX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slo
     if (slot_mask >= 0 && (i2s_std_slot_mask_t)slot_mask <= I2S_STD_SLOT_BOTH) {
       i2s_config.slot_cfg.slot_mask = (i2s_std_slot_mask_t)slot_mask;
     }
+#if SOC_I2S_HW_VERSION_1
+    _8bit_hw_packing = (bits_cfg == I2S_DATA_BIT_WIDTH_8BIT);
+    if (ch == I2S_SLOT_MODE_MONO && (bits_cfg == I2S_DATA_BIT_WIDTH_16BIT || bits_cfg == I2S_DATA_BIT_WIDTH_8BIT)) {
+      _mono_hw_workaround = true;
+      i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
+      i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+    } else {
+      _mono_hw_workaround = false;
+    }
+#else
+    if (ch == I2S_SLOT_MODE_MONO && slot_mask < 0) {
+      i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_LEFT;
+    }
+#endif
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_disable(tx_chan));
     I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_reconfig_std_clock(tx_chan, &i2s_config.clk_cfg));
     tx_sample_rate = rate;
@@ -873,11 +1056,41 @@ bool I2SClass::configureTX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slo
   return false;
 }
 
-bool I2SClass::configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform) {
+bool I2SClass::configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform, int8_t slot_mask) {
   /* Setup I2S channels */
   if (rx_chan != NULL) {
     if (rx_sample_rate != rate || rx_data_bit_width != bits_cfg || rx_slot_mode != ch) {
       i2s_std_config_t i2s_config = I2S_STD_CHAN_CFG(rate, bits_cfg, ch);
+      if (ch == I2S_SLOT_MODE_STEREO) {
+        i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+        _rx_slot_mask = I2S_STD_SLOT_BOTH;
+      } else {
+        if (slot_mask >= 0 && (i2s_std_slot_mask_t)slot_mask <= I2S_STD_SLOT_BOTH) {
+          i2s_config.slot_cfg.slot_mask = (i2s_std_slot_mask_t)slot_mask;
+        }
+        if (slot_mask == I2S_STD_SLOT_RIGHT) {
+          _rx_slot_mask = I2S_STD_SLOT_RIGHT;
+        } else if (slot_mask == I2S_STD_SLOT_BOTH) {
+          _rx_slot_mask = I2S_STD_SLOT_BOTH;
+        } else {
+          _rx_slot_mask = I2S_STD_SLOT_LEFT;
+        }
+      }
+#if SOC_I2S_HW_VERSION_1
+      _8bit_hw_packing = (bits_cfg == I2S_DATA_BIT_WIDTH_8BIT);
+      bool new_workaround = (ch == I2S_SLOT_MODE_MONO && (bits_cfg == I2S_DATA_BIT_WIDTH_16BIT || bits_cfg == I2S_DATA_BIT_WIDTH_8BIT));
+      if (new_workaround) {
+        _mono_hw_workaround = true;
+        i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
+        i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+      } else {
+        _mono_hw_workaround = false;
+      }
+#else
+      if (ch == I2S_SLOT_MODE_MONO && slot_mask < 0) {
+        i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_LEFT;
+      }
+#endif
       I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_disable(rx_chan));
       I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_reconfig_std_clock(rx_chan, &i2s_config.clk_cfg));
       rx_sample_rate = rate;
@@ -885,7 +1098,95 @@ bool I2SClass::configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slo
       rx_data_bit_width = bits_cfg;
       rx_slot_mode = ch;
       I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_enable(rx_chan));
+#if SOC_I2S_HW_VERSION_1
+      if (_mono_hw_workaround) {
+        if (_8bit_hw_packing) {
+          if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 4)) {
+            return false;
+          }
+          if (_rx_slot_mask == I2S_STD_SLOT_RIGHT) {
+            rx_fn = i2s_channel_read_8_stereo_to_mono_right;
+          } else if (_rx_slot_mask == I2S_STD_SLOT_BOTH) {
+            rx_fn = i2s_channel_read_8_stereo_to_mono_both;
+          } else {
+            rx_fn = i2s_channel_read_8_stereo_to_mono_left;
+          }
+        } else {
+          if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
+            return false;
+          }
+          if (_rx_slot_mask == I2S_STD_SLOT_RIGHT) {
+            rx_fn = i2s_channel_read_16_stereo_to_mono_right;
+          } else if (_rx_slot_mask == I2S_STD_SLOT_BOTH) {
+            rx_fn = i2s_channel_read_16_stereo_to_mono_both;
+          } else {
+            rx_fn = i2s_channel_read_16_stereo_to_mono_left;
+          }
+        }
+        rx_transform = I2S_RX_TRANSFORM_16_STEREO_TO_MONO;
+        return true;
+      } else if (_8bit_hw_packing) {
+        if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
+          return false;
+        }
+        rx_fn = i2s_channel_read_8_unpack;
+        rx_transform = I2S_RX_TRANSFORM_8_UNPACK;
+        return true;
+      }
+#endif
       return transformRX(transform);
+    }
+    // Slot-only change: rate/bits/ch unchanged but slot_mask or transform changed.
+    // Stereo RX always uses BOTH — the IDF does not reliably ignore slot_mask
+    // in stereo mode, so slot changes are only meaningful for mono.
+    if (ch != I2S_SLOT_MODE_STEREO && slot_mask >= 0 && (i2s_std_slot_mask_t)slot_mask != _rx_slot_mask) {
+      i2s_std_config_t i2s_config = I2S_STD_CHAN_CFG(rate, bits_cfg, ch);
+      i2s_config.slot_cfg.slot_mask = (i2s_std_slot_mask_t)slot_mask;
+      if (slot_mask == I2S_STD_SLOT_RIGHT) {
+        _rx_slot_mask = I2S_STD_SLOT_RIGHT;
+      } else if (slot_mask == I2S_STD_SLOT_BOTH) {
+        _rx_slot_mask = I2S_STD_SLOT_BOTH;
+      } else {
+        _rx_slot_mask = I2S_STD_SLOT_LEFT;
+      }
+#if SOC_I2S_HW_VERSION_1
+      if (_mono_hw_workaround) {
+        i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
+        i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+      }
+#endif
+      I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_disable(rx_chan));
+      I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_reconfig_std_slot(rx_chan, &i2s_config.slot_cfg));
+      I2S_ERROR_CHECK_RETURN_FALSE(i2s_channel_enable(rx_chan));
+#if SOC_I2S_HW_VERSION_1
+      if (_mono_hw_workaround) {
+        if (_8bit_hw_packing) {
+          if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 4)) {
+            return false;
+          }
+          if (_rx_slot_mask == I2S_STD_SLOT_RIGHT) {
+            rx_fn = i2s_channel_read_8_stereo_to_mono_right;
+          } else if (_rx_slot_mask == I2S_STD_SLOT_BOTH) {
+            rx_fn = i2s_channel_read_8_stereo_to_mono_both;
+          } else {
+            rx_fn = i2s_channel_read_8_stereo_to_mono_left;
+          }
+        } else {
+          if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
+            return false;
+          }
+          if (_rx_slot_mask == I2S_STD_SLOT_RIGHT) {
+            rx_fn = i2s_channel_read_16_stereo_to_mono_right;
+          } else if (_rx_slot_mask == I2S_STD_SLOT_BOTH) {
+            rx_fn = i2s_channel_read_16_stereo_to_mono_both;
+          } else {
+            rx_fn = i2s_channel_read_16_stereo_to_mono_left;
+          }
+        }
+        rx_transform = I2S_RX_TRANSFORM_16_STEREO_TO_MONO;
+        return true;
+      }
+#endif
     }
     if (rx_transform != transform) {
       return transformRX(transform);
@@ -923,6 +1224,106 @@ size_t I2SClass::write(const uint8_t *buffer, size_t size) {
   if (tx_chan == NULL) {
     return written;
   }
+  size_t min_size = (tx_data_bit_width == I2S_DATA_BIT_WIDTH_8BIT) ? 1 : (tx_data_bit_width / 8);
+  if (size < min_size) {
+    last_error = ESP_OK;
+    return 0;
+  }
+#if SOC_I2S_HW_VERSION_1
+  if (_8bit_hw_packing && _mono_hw_workaround) {
+    // 8-bit mono on HW v1: pack each int8_t sample into the high byte of
+    // a uint16_t, then duplicate into L+R stereo for DMA.
+    const int8_t *src = (const int8_t *)buffer;
+    size_t mono_samples = size;
+    size_t mono_written = 0;
+    while (mono_written < mono_samples) {
+      const size_t MAX_CHUNK = 128;
+      uint16_t stereo_buf[MAX_CHUNK * 2];
+      size_t chunk = mono_samples - mono_written;
+      if (chunk > MAX_CHUNK) {
+        chunk = MAX_CHUNK;
+      }
+      for (size_t i = 0; i < chunk; i++) {
+        uint16_t packed = (uint16_t)((uint8_t)src[mono_written + i]) << 8;
+        stereo_buf[i * 2] = packed;
+        stereo_buf[i * 2 + 1] = packed;
+      }
+      size_t stereo_bytes = chunk * 2 * sizeof(uint16_t);
+      bytes_sent = 0;
+      esp_err_t err = i2s_channel_write(tx_chan, (char *)stereo_buf, stereo_bytes, &bytes_sent, _timeout);
+      setWriteError(err);
+      if (err != ESP_OK) {
+        last_error = err;
+        break;
+      }
+      mono_written += bytes_sent / (2 * sizeof(uint16_t));
+    }
+    if (mono_written == mono_samples) {
+      last_error = ESP_OK;
+    }
+    return mono_written;
+  }
+  if (_8bit_hw_packing && !_mono_hw_workaround) {
+    // 8-bit stereo on HW v1: pack each int8_t into the high byte of a uint16_t.
+    const int8_t *src = (const int8_t *)buffer;
+    size_t n_samples = size;
+    size_t samples_written = 0;
+    while (samples_written < n_samples) {
+      const size_t MAX_CHUNK = 256;
+      uint16_t pack_buf[MAX_CHUNK];
+      size_t chunk = n_samples - samples_written;
+      if (chunk > MAX_CHUNK) {
+        chunk = MAX_CHUNK;
+      }
+      for (size_t i = 0; i < chunk; i++) {
+        pack_buf[i] = (uint16_t)((uint8_t)src[samples_written + i]) << 8;
+      }
+      size_t pack_bytes = chunk * sizeof(uint16_t);
+      bytes_sent = 0;
+      esp_err_t err = i2s_channel_write(tx_chan, (char *)pack_buf, pack_bytes, &bytes_sent, _timeout);
+      setWriteError(err);
+      if (err != ESP_OK) {
+        last_error = err;
+        break;
+      }
+      samples_written += bytes_sent / sizeof(uint16_t);
+    }
+    if (samples_written == n_samples) {
+      last_error = ESP_OK;
+    }
+    return samples_written;
+  }
+  if (_mono_hw_workaround) {
+    const int16_t *src = (const int16_t *)buffer;
+    size_t mono_samples = size / sizeof(int16_t);
+    size_t mono_written = 0;
+    while (mono_written < mono_samples) {
+      const size_t MAX_CHUNK = 128;
+      int16_t stereo_buf[MAX_CHUNK * 2];
+      size_t chunk = mono_samples - mono_written;
+      if (chunk > MAX_CHUNK) {
+        chunk = MAX_CHUNK;
+      }
+      for (size_t i = 0; i < chunk; i++) {
+        stereo_buf[i * 2] = src[mono_written + i];
+        stereo_buf[i * 2 + 1] = src[mono_written + i];
+      }
+      size_t stereo_bytes = chunk * 2 * sizeof(int16_t);
+      bytes_sent = 0;
+      esp_err_t err = i2s_channel_write(tx_chan, (char *)stereo_buf, stereo_bytes, &bytes_sent, _timeout);
+      setWriteError(err);
+      if (err != ESP_OK) {
+        last_error = err;
+        break;
+      }
+      mono_written += bytes_sent / (2 * sizeof(int16_t));
+    }
+    if (mono_written == mono_samples) {
+      last_error = ESP_OK;
+    }
+    return mono_written * sizeof(int16_t);
+  }
+#endif
   while (written < size) {
     bytes_sent = 0;
     bytes_to_send = size - written;
@@ -1014,9 +1415,27 @@ bool I2SClass::transformRX(i2s_rx_transform_t transform) {
       if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
         return false;
       }
-      rx_fn = i2s_channel_read_16_stereo_to_mono;
+      if (_rx_slot_mask == I2S_STD_SLOT_RIGHT) {
+        rx_fn = i2s_channel_read_16_stereo_to_mono_right;
+      } else if (_rx_slot_mask == I2S_STD_SLOT_BOTH) {
+        rx_fn = i2s_channel_read_16_stereo_to_mono_both;
+      } else {
+        rx_fn = i2s_channel_read_16_stereo_to_mono_left;
+      }
       rx_slot_mode = I2S_SLOT_MODE_MONO;
       break;
+
+    case I2S_RX_TRANSFORM_8_UNPACK:
+#if SOC_I2S_HW_VERSION_1
+      if (!allocTranformRX(I2S_READ_CHUNK_SIZE * 2)) {
+        return false;
+      }
+      rx_fn = i2s_channel_read_8_unpack;
+      break;
+#else
+      log_w("I2S_RX_TRANSFORM_8_UNPACK is only needed on ESP32 HW v1; ignoring on this target");
+      break;
+#endif
 
     default: log_e("Unknown RX Transform %d", transform); return false;
   }

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -208,8 +208,9 @@ static esp_err_t i2s_channel_read_32_to_16(i2s_chan_handle_t handle, char *read_
 // unpacks the high byte for 8-bit mode.
 // 16-bit: DMA reads 2× user bytes;  output is int16_t per sample.
 //  8-bit: DMA reads 4× user bytes;  output is  int8_t per sample (high byte of uint16_t).
-static esp_err_t i2s_channel_read_stereo_to_mono(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
-                                                 uint32_t timeout_ms, size_t slot_offset, bool unpack_8bit) {
+static esp_err_t i2s_channel_read_stereo_to_mono(
+  i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms, size_t slot_offset, bool unpack_8bit
+) {
   size_t out_len = 0;
   size_t read_buff_len = len * (unpack_8bit ? 4 : 2);
   if (read_buff == NULL) {
@@ -256,15 +257,18 @@ static esp_err_t i2s_channel_read_stereo_to_mono(i2s_chan_handle_t handle, char 
 }
 
 // 16-bit wrappers (all targets — used by I2S_RX_TRANSFORM_16_STEREO_TO_MONO)
-static esp_err_t i2s_channel_read_16_stereo_to_mono_left(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
+static esp_err_t
+  i2s_channel_read_16_stereo_to_mono_left(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 0, false);
 }
 
-static esp_err_t i2s_channel_read_16_stereo_to_mono_right(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
+static esp_err_t
+  i2s_channel_read_16_stereo_to_mono_right(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 1, false);
 }
 
-static esp_err_t i2s_channel_read_16_stereo_to_mono_both(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
+static esp_err_t
+  i2s_channel_read_16_stereo_to_mono_both(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 2, false);
 }
 
@@ -293,18 +297,18 @@ static esp_err_t i2s_channel_read_8_unpack(i2s_chan_handle_t handle, char *read_
 }
 
 // 8-bit mono wrappers (ESP32 HW v1 only — mono workaround + uint16_t packing)
-static esp_err_t i2s_channel_read_8_stereo_to_mono_left(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
-                                                        uint32_t timeout_ms) {
+static esp_err_t
+  i2s_channel_read_8_stereo_to_mono_left(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 0, true);
 }
 
-static esp_err_t i2s_channel_read_8_stereo_to_mono_right(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
-                                                         uint32_t timeout_ms) {
+static esp_err_t
+  i2s_channel_read_8_stereo_to_mono_right(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 1, true);
 }
 
-static esp_err_t i2s_channel_read_8_stereo_to_mono_both(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read,
-                                                        uint32_t timeout_ms) {
+static esp_err_t
+  i2s_channel_read_8_stereo_to_mono_both(i2s_chan_handle_t handle, char *read_buff, void *dst, size_t len, size_t *bytes_read, uint32_t timeout_ms) {
   return i2s_channel_read_stereo_to_mono(handle, read_buff, dst, len, bytes_read, timeout_ms, 2, true);
 }
 #endif  // SOC_I2S_HW_VERSION_1

--- a/libraries/ESP_I2S/src/ESP_I2S.h
+++ b/libraries/ESP_I2S/src/ESP_I2S.h
@@ -70,7 +70,8 @@ public:
 
   bool begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask = -1, i2s_role_t role = I2S_ROLE_MASTER);
   bool configureTX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask = -1);
-  bool configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform = I2S_RX_TRANSFORM_NONE, int8_t slot_mask = -1);
+  bool
+    configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform = I2S_RX_TRANSFORM_NONE, int8_t slot_mask = -1);
   bool end();
 
   size_t readBytes(char *buffer, size_t size);

--- a/libraries/ESP_I2S/src/ESP_I2S.h
+++ b/libraries/ESP_I2S/src/ESP_I2S.h
@@ -68,7 +68,6 @@ public:
   void setInvertedPdm(bool clk);
 #endif
 
-  // TODO: swap slot_mask and role so that slave mode doesn't require an explicit slot_mask placeholder (API-breaking change)
   bool begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask = -1, i2s_role_t role = I2S_ROLE_MASTER);
   bool configureTX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask = -1);
   bool configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform = I2S_RX_TRANSFORM_NONE, int8_t slot_mask = -1);

--- a/libraries/ESP_I2S/src/ESP_I2S.h
+++ b/libraries/ESP_I2S/src/ESP_I2S.h
@@ -41,6 +41,7 @@ typedef enum {
   I2S_RX_TRANSFORM_NONE,
   I2S_RX_TRANSFORM_32_TO_16,
   I2S_RX_TRANSFORM_16_STEREO_TO_MONO,
+  I2S_RX_TRANSFORM_8_UNPACK,
   I2S_RX_TRANSFORM_MAX
 } i2s_rx_transform_t;
 
@@ -67,9 +68,10 @@ public:
   void setInvertedPdm(bool clk);
 #endif
 
-  bool begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask = -1);
+  // TODO: swap slot_mask and role so that slave mode doesn't require an explicit slot_mask placeholder (API-breaking change)
+  bool begin(i2s_mode_t mode, uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask = -1, i2s_role_t role = I2S_ROLE_MASTER);
   bool configureTX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, int8_t slot_mask = -1);
-  bool configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform = I2S_RX_TRANSFORM_NONE);
+  bool configureRX(uint32_t rate, i2s_data_bit_width_t bits_cfg, i2s_slot_mode_t ch, i2s_rx_transform_t transform = I2S_RX_TRANSFORM_NONE, int8_t slot_mask = -1);
   bool end();
 
   size_t readBytes(char *buffer, size_t size);
@@ -120,6 +122,13 @@ private:
   uint32_t rx_sample_rate;
   i2s_data_bit_width_t rx_data_bit_width;
   i2s_slot_mode_t rx_slot_mode;
+
+  i2s_role_t _role;
+  i2s_std_slot_mask_t _rx_slot_mask;
+#if SOC_I2S_HW_VERSION_1
+  bool _mono_hw_workaround;
+  bool _8bit_hw_packing;
+#endif
 
   //STD and TDM mode
   int8_t _mclk, _bclk, _ws, _dout, _din;


### PR DESCRIPTION
## Description of Change

This pull request adds support for I2S slave mode, implements comprehensive workarounds for ESP32 (I2S HW v1) hardware limitations affecting mono and 8-bit modes, and significantly improves the `slot_mask` API surface for both TX and RX channels.

### I2S Slave Mode Support
- Added a `role` parameter to `I2SClass::begin()`, enabling configuration as either I2S master (default) or slave via `I2S_ROLE_MASTER` / `I2S_ROLE_SLAVE`.
- Updated documentation with master/slave descriptions and sample code.

### ESP32 I2S v1 Mono Workaround (8-bit and 16-bit)
The original ESP32's I2S FIFO packing logic scrambles data in mono mode for both 8-bit and 16-bit widths. The library now automatically:

- **TX:** Configures the hardware as stereo and duplicates each mono sample into both L/R slots before writing to DMA.
- **RX:** Reads stereo DMA data and extracts the selected channel (left, right, or averaged both) in software.

This is fully transparent to application code and respects the user's `slot_mask` selection.

### ESP32 I2S v1 8-bit Data Packing
On ESP32 HW v1, the I2S DMA uses `uint16_t`-aligned words for 8-bit data (only the high 8 bits are valid). The library now transparently handles this:

- **TX (`write()`):** Packs each `int8_t` sample into the high byte of a `uint16_t` before writing to DMA. For mono, also duplicates into L+R stereo.
- **RX (`readBytes()`):** Unpacks the high byte from each `uint16_t` DMA word back to `int8_t`. For mono, also de-interleaves from the stereo stream.

This enables full 8-bit support on ESP32, which was previously broken.


## Test Scenarios

Tested with WIP I2S test suite.

<details>
<summary>ESP32</summary>

```
lucassvaz@Lucas--MacBook-Pro esp32 % ./.github/scripts/tests_run.sh -s i2s -t esp32  
Supplied port [ESPPORT1]: /dev/cu.usbserial-2140
Supplied port [ESPPORT2]: /dev/cu.usbserial-2130
Sketch i2s test type: validation
Running for target: esp32
  Running sketch: i2s
Running multi-device test: i2s
Running multi-device test: i2s -- Config: Default
pytest -s /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/test_i2s.py --count 2 --build-dir /Users/lucassvaz/.arduino/tests/esp32/i2s/sender/build.tmp|/Users/lucassvaz/.arduino/tests/esp32/i2s/receiver/build.tmp --port /dev/cu.usbserial-2140|/dev/cu.usbserial-2130 --target esp32 --junit-xml=/Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/esp32/i2s.xml -o junit_suite_name=validation_hardware_esp32_i2s0 --embedded-services esp,arduino|esp,arduino --wifi-ssid Kovaz_2.4GHz --wifi-password R@mmstein1604
=========================================== test session starts ===========================================
platform darwin -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests
configfile: pytest.ini
plugins: cov-5.0.0, anyio-4.12.0, embedded-2.8.0
collected 1 item                                                                                          

tests/validation/i2s/test_i2s.py::test_i2s 2026-05-29 09:28:18 [dut-0] Serial port /dev/cu.usbserial-2140:
2026-05-29 09:28:18 [dut-0] Connecting.....

--------------------------------------------- live log setup ----------------------------------------------
2026-05-29 09:28:19 INFO Target: esp32, Port: /dev/cu.usbserial-2140
2026-05-29 09:28:19 [dut-0] Connecting....
2026-05-29 09:28:20 [dut-0] esptool v5.2.0
                            Connected to ESP32 on /dev/cu.usbserial-2140:
2026-05-29 09:28:20 [dut-0] Chip type:          ESP32-D0WD-V3 (revision v3.0)
2026-05-29 09:28:20 [dut-0] Features:           Wi-Fi, BT, Dual Core + LP Core, 240MHz, Vref calibration in eFuse, Coding Scheme None
2026-05-29 09:28:20 [dut-0] Crystal frequency:  40MHz
2026-05-29 09:28:20 [dut-0] MAC:                c0:49:ef:44:85:04
2026-05-29 09:28:20 [dut-0] 
                            Stub flasher running.
2026-05-29 09:28:20 [dut-0] 
2026-05-29 09:28:20 [dut-0] Configuring flash size...
2026-05-29 09:28:20 [dut-0] Flash will be erased from 0x00000000 to 0x003fffff...
                            Wrote 4194304 bytes (216493 compressed) at 0x00000000 in 34.6 seconds (970.7 kbit/s).
                            Hash of data verified.
2026-05-29 09:29:00 [dut-0] 
2026-05-29 09:29:00 [dut-0] Hard resetting via RTS pin...
2026-05-29 09:29:00 [dut-1] Serial port /dev/cu.usbserial-2130:
2026-05-29 09:29:00 [dut-0] ets Jul 29 2019 12:21:46
2026-05-29 09:29:00 [dut-0] 
2026-05-29 09:29:00 [dut-0] rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
2026-05-29 09:29:00 [dut-0] configsip: 0, SPIWP:0xee
2026-05-29 09:29:00 [dut-0] clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
2026-05-29 09:29:00 [dut-0] mode:DIO, clock div:1
2026-05-29 09:29:00 [dut-0] load:0x3fff0030,len:4876
2026-05-29 09:29:00 [dut-0] ho 0 tail 12 room 4
2026-05-29 09:29:00 [dut-0] load:0x40078000,len:16560
2026-05-29 09:29:00 [dut-0] load:0x40080400,len:3500
2026-05-29 09:29:00 [dut-0] entry 0x400805b4
2026-05-29 09:29:00 [dut-1] Connecting....
2026-05-29 09:29:01 INFO Target: esp32, Port: /dev/cu.usbserial-2130
2026-05-29 09:29:01 [dut-0] [SENDER] Ready
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:788:test_i2s_begin_end:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:789:test_i2s_sample_rate_8k:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:790:test_i2s_sample_rate_44k:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:791:test_i2s_sample_rate_48k:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:792:test_i2s_32bit:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:793:test_i2s_8bit:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:794:test_i2s_mono:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:795:test_i2s_reopen:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:796:test_i2s_slave_mode_begin_end:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:797:test_i2s_mono_aligned_write:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:798:test_i2s_mono_subbyte_write_no_error:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:799:test_i2s_configure_tx_after_mono_begin:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:800:test_i2s_configure_rx_after_mono_begin:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:801:test_i2s_configure_rx_slot_mask:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:802:test_i2s_configure_rx_slot_mask_32bit:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:803:test_i2s_mono_left_slot_write:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:804:test_i2s_mono_right_slot_write:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:805:test_i2s_mono_both_slot_write:PASS
2026-05-29 09:29:01 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:806:test_i2s_stereo_left_slot_write:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:807:test_i2s_stereo_right_slot_write:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:808:test_i2s_mono_32bit_write:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:809:test_i2s_mono_right_subbyte_write_no_error:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:810:test_i2s_configure_tx_stereo_to_mono:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:811:test_i2s_configure_tx_mono_to_stereo:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:812:test_i2s_configure_tx_mono_left_to_right:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:813:test_i2s_stereo_rx_left_slot:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:814:test_i2s_stereo_rx_right_slot:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:815:test_i2s_configure_rx_stereo_slot_change:PASS
2026-05-29 09:29:02 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:816:test_i2s_configure_rx_mono_both_slot:PASS
2026-05-29 09:29:02 [dut-0] 
2026-05-29 09:29:02 [dut-0] -----------------------
2026-05-29 09:29:02 [dut-0] 29 Tests 0 Failures 0 Ignored 
2026-05-29 09:29:02 [dut-0] OK
2026-05-29 09:29:02 [dut-0] [SENDER] TX_READY
2026-05-29 09:29:01 [dut-1] Connecting.........
2026-05-29 09:29:03 [dut-1] esptool v5.2.0
                            Connected to ESP32 on /dev/cu.usbserial-2130:
2026-05-29 09:29:03 [dut-1] Chip type:          ESP32-D0WD-V3 (revision v3.0)
2026-05-29 09:29:03 [dut-1] Features:           Wi-Fi, BT, Dual Core + LP Core, 240MHz, Vref calibration in eFuse, Coding Scheme None
2026-05-29 09:29:03 [dut-1] Crystal frequency:  40MHz
2026-05-29 09:29:03 [dut-1] MAC:                c0:49:ef:44:83:ac
2026-05-29 09:29:03 [dut-1] 
                            Stub flasher running.
2026-05-29 09:29:03 [dut-1] 
2026-05-29 09:29:04 [dut-1] Configuring flash size...
2026-05-29 09:29:04 [dut-1] Flash will be erased from 0x00000000 to 0x003fffff...
                            Wrote 4194304 bytes (212818 compressed) at 0x00000000 in 34.5 seconds (971.3 kbit/s).
                            Hash of data verified.
2026-05-29 09:29:44 [dut-1] 
2026-05-29 09:29:44 [dut-1] Hard resetting via RTS pin...
---------------------------------------------- live log call ----------------------------------------------
2026-05-29 09:29:44 INFO Waiting for devices to be ready...
2026-05-29 09:29:44 [dut-1] ets Jul 29 2019 12:21:46
2026-05-29 09:29:44 [dut-1] 
2026-05-29 09:29:44 [dut-1] rst:0x1 (POWERON_RESET),boot:0x17 (SPI_FAST_FLASH_BOOT)
2026-05-29 09:29:44 [dut-1] configsip: 0, SPIWP:0xee
2026-05-29 09:29:44 [dut-1] clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
2026-05-29 09:29:44 [dut-1] mode:DIO, clock div:1
2026-05-29 09:29:44 [dut-1] load:0x3fff0030,len:4876
2026-05-29 09:29:44 [dut-1] ho 0 tail 12 room 4
2026-05-29 09:29:44 [dut-1] load:0x40078000,len:16560
2026-05-29 09:29:44 [dut-1] load:0x40080400,len:3500
2026-05-29 09:29:44 [dut-1] entry 0x400805b4
2026-05-29 09:29:45 [dut-1] [RECEIVER] Ready
2026-05-29 09:29:45 INFO Waiting for sender Unity tests...
2026-05-29 09:29:45 INFO Querying HW version...
2026-05-29 09:29:45 [dut-0] [SENDER] HW_V1_YES
2026-05-29 09:29:45 INFO HW v1: True
2026-05-29 09:29:45 INFO Phase 1: mono 16kHz/16-bit (default slot)...
2026-05-29 09:29:45 [dut-0] [SENDER] TX_CLOCKING
2026-05-29 09:29:45 [dut-1] [RECEIVER] RX_LISTENING
2026-05-29 09:29:45 [dut-1] [RECEIVER] RX_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:45 [dut-0] [SENDER] TX_DONE 16384
2026-05-29 09:29:45 INFO Phase 1: mono 16kHz/16-bit (default slot): matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:45 INFO Phase 2: stereo→mono right-slot...
2026-05-29 09:29:45 [dut-0] [SENDER] TX_STEREO_CLOCKING
2026-05-29 09:29:45 [dut-1] [RECEIVER] RX_RIGHT_LISTENING
2026-05-29 09:29:46 [dut-1] [RECEIVER] RX_RIGHT_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:46 [dut-0] [SENDER] TX_STEREO_DONE 65536
2026-05-29 09:29:46 INFO Phase 2: stereo→mono right-slot: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:46 INFO Phase 3: stereo→mono left-slot...
2026-05-29 09:29:47 [dut-0] [SENDER] TX_LEFT_CLOCKING
2026-05-29 09:29:47 [dut-1] [RECEIVER] RX_LEFT_LISTENING
2026-05-29 09:29:47 [dut-1] [RECEIVER] RX_LEFT_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:48 [dut-0] [SENDER] TX_LEFT_DONE 65536
2026-05-29 09:29:48 INFO Phase 3: stereo→mono left-slot: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:48 INFO Phase 4: mono RIGHT TX→RIGHT RX...
2026-05-29 09:29:48 [dut-0] [SENDER] TX_MONO_RIGHT_CLOCKING
2026-05-29 09:29:48 [dut-1] [RECEIVER] RX_RIGHT_LISTENING
2026-05-29 09:29:48 [dut-1] [RECEIVER] RX_RIGHT_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:48 [dut-0] [SENDER] TX_MONO_RIGHT_DONE 16384
2026-05-29 09:29:48 INFO Phase 4: mono RIGHT TX→RIGHT RX: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:48 INFO Phase 5: mono 8000Hz/8-bit...
2026-05-29 09:29:49 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:49 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:49 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:50 [dut-0] [SENDER] TX_PARAM_DONE 10048
2026-05-29 09:29:50 INFO Phase 5: mono 8000Hz/8-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:50 INFO Phase 6: stereo 8000Hz/8-bit...
2026-05-29 09:29:50 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:50 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:50 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:51 [dut-0] [SENDER] TX_PARAM_DONE 20096
2026-05-29 09:29:51 INFO Phase 6: stereo 8000Hz/8-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:51 INFO Phase 7: mono 8000Hz/16-bit...
2026-05-29 09:29:51 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:51 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:52 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:52 [dut-0] [SENDER] TX_PARAM_DONE 20096
2026-05-29 09:29:52 INFO Phase 7: mono 8000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:52 INFO Phase 8: stereo 8000Hz/16-bit...
2026-05-29 09:29:53 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:53 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:53 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:54 [dut-0] [SENDER] TX_PARAM_DONE 40192
2026-05-29 09:29:54 INFO Phase 8: stereo 8000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:54 INFO Phase 9: mono 8000Hz/32-bit...
2026-05-29 09:29:54 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:54 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:54 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:55 [dut-0] [SENDER] TX_PARAM_DONE 40192
2026-05-29 09:29:55 INFO Phase 9: mono 8000Hz/32-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:55 INFO Phase 10: stereo 8000Hz/32-bit...
2026-05-29 09:29:56 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:56 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:56 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=15 zeros=16 total=1024
2026-05-29 09:29:57 [dut-0] [SENDER] TX_PARAM_DONE 80384
2026-05-29 09:29:57 INFO Phase 10: stereo 8000Hz/32-bit: matches=64/64 full_ramps=15 zeros=16/1024 (1%)
2026-05-29 09:29:57 INFO Phase 11: mono 96000Hz/8-bit...
2026-05-29 09:29:57 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:57 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:57 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:58 [dut-0] [SENDER] TX_PARAM_DONE 98048
2026-05-29 09:29:58 INFO Phase 11: mono 96000Hz/8-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:58 INFO Phase 12: stereo 96000Hz/8-bit...
2026-05-29 09:29:58 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:58 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:58 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:29:59 [dut-0] [SENDER] TX_PARAM_DONE 196096
2026-05-29 09:29:59 INFO Phase 12: stereo 96000Hz/8-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:29:59 INFO Phase 13: mono 96000Hz/16-bit...
2026-05-29 09:29:59 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:29:59 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:29:59 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:00 [dut-0] [SENDER] TX_PARAM_DONE 196096
2026-05-29 09:30:00 INFO Phase 13: mono 96000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:00 INFO Phase 14: stereo 96000Hz/16-bit...
2026-05-29 09:30:00 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:00 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:00 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:01 [dut-0] [SENDER] TX_PARAM_DONE 392192
2026-05-29 09:30:01 INFO Phase 14: stereo 96000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:01 INFO Phase 15: mono 96000Hz/32-bit...
2026-05-29 09:30:01 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:01 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:01 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:02 [dut-0] [SENDER] TX_PARAM_DONE 392192
2026-05-29 09:30:02 INFO Phase 15: mono 96000Hz/32-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:02 INFO Phase 16: stereo 96000Hz/32-bit...
2026-05-29 09:30:02 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:03 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:03 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=15 zeros=16 total=1024
2026-05-29 09:30:04 [dut-0] [SENDER] TX_PARAM_DONE 784384
2026-05-29 09:30:04 INFO Phase 16: stereo 96000Hz/32-bit: matches=64/64 full_ramps=15 zeros=16/1024 (1%)
2026-05-29 09:30:04 INFO Phase 17: mono 16-bit slot=LEFT...
2026-05-29 09:30:04 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:04 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:04 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:05 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:30:05 INFO Phase 17: mono 16-bit slot=LEFT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:05 INFO Phase 18: mono 16-bit slot=RIGHT...
2026-05-29 09:30:05 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:05 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:05 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:06 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:30:06 INFO Phase 18: mono 16-bit slot=RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:06 INFO Phase 19: mono 32-bit slot=LEFT...
2026-05-29 09:30:06 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:06 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:06 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:07 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:30:07 INFO Phase 19: mono 32-bit slot=LEFT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:07 INFO Phase 20: mono 32-bit slot=RIGHT...
2026-05-29 09:30:08 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:08 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:08 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:09 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:30:09 INFO Phase 20: mono 32-bit slot=RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:09 INFO Phase 21: stereo 16-bit TX=LEFT → mono RX=LEFT...
2026-05-29 09:30:09 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:09 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:09 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:10 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:30:10 INFO Phase 21: stereo 16-bit TX=LEFT → mono RX=LEFT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:10 INFO Phase 22: stereo 16-bit TX=RIGHT → mono RX=RIGHT (R ramp)...
2026-05-29 09:30:10 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:10 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:10 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=0 total=2048
2026-05-29 09:30:11 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:30:11 INFO Phase 22: stereo 16-bit TX=RIGHT → mono RX=RIGHT (R ramp): matches=64/64 full_ramps=31 zeros=0/2048 (0%)
2026-05-29 09:30:11 INFO Phase 23: mono 16-bit TX=BOTH RX=LEFT...
2026-05-29 09:30:11 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:11 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:12 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:12 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:30:12 INFO Phase 23: mono 16-bit TX=BOTH RX=LEFT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:12 INFO Phase 24: mono 16-bit TX=BOTH RX=RIGHT...
2026-05-29 09:30:13 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:13 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:30:13 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:14 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:30:14 INFO Phase 24: mono 16-bit TX=BOTH RX=RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:14 INFO Phase 25: configureRX 16-bit LEFT→RIGHT...
2026-05-29 09:30:14 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:14 [dut-1] [RECEIVER] RX_RECONFIG_LISTENING
2026-05-29 09:30:14 [dut-1] [RECEIVER] RX_RECONFIG_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:15 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:30:15 INFO Phase 25: configureRX 16-bit LEFT→RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:15 INFO Phase 26: configureRX 16-bit RIGHT→LEFT...
2026-05-29 09:30:15 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:15 [dut-1] [RECEIVER] RX_RECONFIG_LISTENING
2026-05-29 09:30:15 [dut-1] [RECEIVER] RX_RECONFIG_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:16 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:30:16 INFO Phase 26: configureRX 16-bit RIGHT→LEFT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:16 INFO Phase 27: configureRX 32-bit LEFT→RIGHT...
2026-05-29 09:30:16 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:16 [dut-1] [RECEIVER] RX_RECONFIG_LISTENING
2026-05-29 09:30:17 [dut-1] [RECEIVER] RX_RECONFIG_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:30:18 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:30:18 INFO Phase 27: configureRX 32-bit LEFT→RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:30:18 INFO Phase 28: HW v1 mono BOTH begin (averaged ramp)...
2026-05-29 09:30:18 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:18 [dut-1] [RECEIVER] RX_MONO_BOTH_LISTENING
2026-05-29 09:30:18 [dut-1] [RECEIVER] RX_MONO_BOTH_DONE matches=64 full_ramps=31 zeros=0 total=2048
2026-05-29 09:30:19 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:30:19 INFO Phase 28: HW v1 mono BOTH begin (averaged ramp): matches=64/64 full_ramps=31 zeros=0/2048 (0%)
2026-05-29 09:30:19 INFO Phase 29: HW v1 configureRX BOTH (averaged ramp)...
2026-05-29 09:30:19 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:30:19 [dut-1] [RECEIVER] RX_RECONFIG_BOTH_LISTENING
2026-05-29 09:30:19 [dut-1] [RECEIVER] RX_RECONFIG_BOTH_DONE matches=64 full_ramps=32 zeros=0 total=2048
2026-05-29 09:30:20 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:30:20 INFO Phase 29: HW v1 configureRX BOTH (averaged ramp): matches=64/64 full_ramps=32 zeros=0/2048 (0%)
2026-05-29 09:30:20 INFO Querying TDM support...
2026-05-29 09:30:20 [dut-0] [SENDER] TDM_NOT_SUPPORTED
2026-05-29 09:30:20 INFO TDM not supported on this target — skipping Phase 30
2026-05-29 09:30:20 [dut-0] [SENDER] DONE
2026-05-29 09:30:20 [dut-1] [RECEIVER] DONE
2026-05-29 09:30:20 INFO I2S multi-DUT test passed!
PASSED
-------------------------------------------- live log teardown --------------------------------------------
2026-05-29 09:30:20 INFO Created unity output junit report: /private/var/folders/vp/g9wctsvn7b91k3pv_7cwpt_h0000gn/T/pytest-embedded/2026-05-29_12-28-18-735827/test_i2s/dut-0.xml


- generated xml file: /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/esp32/i2s.xml -
====================================== 1 passed in 122.29s (0:02:02) ======================================

```

</details>

<details>
<summary>ESP32-S3</summary>

```
lucassvaz@Lucas--MacBook-Pro esp32 % ./.github/scripts/tests_run.sh -s i2s -t esp32s3  
Supplied port [ESPPORT1]: /dev/cu.usbserial-2140
Supplied port [ESPPORT2]: /dev/cu.usbserial-2130
Sketch i2s test type: validation
Running for target: esp32s3
  Running sketch: i2s
Running multi-device test: i2s
Running multi-device test: i2s -- Config: Default
pytest -s /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/test_i2s.py --count 2 --build-dir /Users/lucassvaz/.arduino/tests/esp32s3/i2s/sender/build.tmp|/Users/lucassvaz/.arduino/tests/esp32s3/i2s/receiver/build.tmp --port /dev/cu.usbserial-2140|/dev/cu.usbserial-2130 --target esp32s3 --junit-xml=/Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/esp32s3/i2s.xml -o junit_suite_name=validation_hardware_esp32s3_i2s0 --embedded-services esp,arduino|esp,arduino --wifi-ssid Kovaz_2.4GHz --wifi-password R@mmstein1604
=========================================== test session starts ===========================================
platform darwin -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests
configfile: pytest.ini
plugins: cov-5.0.0, anyio-4.12.0, embedded-2.8.0
collected 1 item                                                                                          

tests/validation/i2s/test_i2s.py::test_i2s 2026-05-29 09:24:51 [dut-0] Serial port /dev/cu.usbserial-2140:
2026-05-29 09:24:51 [dut-0] Connecting....

--------------------------------------------- live log setup ----------------------------------------------
2026-05-29 09:24:51 INFO Target: esp32s3, Port: /dev/cu.usbserial-2140
2026-05-29 09:24:51 [dut-0] Connecting....
2026-05-29 09:24:51 [dut-0] esptool v5.2.0
                            Connected to ESP32-S3 on /dev/cu.usbserial-2140:
2026-05-29 09:24:52 [dut-0] Chip type:          ESP32-S3 (QFN56) (revision v0.1)
2026-05-29 09:24:52 [dut-0] Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz
2026-05-29 09:24:52 [dut-0] Crystal frequency:  40MHz
2026-05-29 09:24:52 [dut-0] MAC:                f4:12:fa:40:64:4c
2026-05-29 09:24:52 [dut-0] 
                            Stub flasher running.
2026-05-29 09:24:52 [dut-0] 
2026-05-29 09:24:52 [dut-0] Configuring flash size...
2026-05-29 09:24:52 [dut-0] SHA digest in image updated.
2026-05-29 09:24:52 [dut-0] Flash will be erased from 0x00000000 to 0x003fffff...
                            Wrote 4194304 bytes (213107 compressed) at 0x00000000 in 43.2 seconds (775.9 kbit/s).
                            Hash of data verified.
2026-05-29 09:25:49 [dut-0] 
2026-05-29 09:25:49 [dut-0] Hard resetting via RTS pin...
2026-05-29 09:25:49 [dut-1] Serial port /dev/cu.usbserial-2130:
2026-05-29 09:25:49 [dut-0] ESP-ROM:esp32s3-20210327
2026-05-29 09:25:49 [dut-0] Build:Mar 27 2021
2026-05-29 09:25:49 [dut-0] rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
2026-05-29 09:25:49 [dut-0] SPIWP:0xee
2026-05-29 09:25:49 [dut-0] mode:DIO, clock div:1
2026-05-29 09:25:49 [dut-0] load:0x3fce2820,len:0x10cc
2026-05-29 09:25:49 [dut-0] load:0x403c8700,len:0xc2c
2026-05-29 09:25:49 [dut-0] load:0x403cb700,len:0x30c0
2026-05-29 09:25:49 [dut-0] entry 0x403c88b8
2026-05-29 09:25:49 [dut-0] E (93) octal_psram: PSRAM chip is not connected, or wrong PSRAM line mode
2026-05-29 09:25:49 [dut-0] E (93) esp_psram: PSRAM enabled but initialization failed. Bailing out.
2026-05-29 09:25:49 [dut-0] E cpu_start: Failed to init external RAM; continuing without it.
2026-05-29 09:25:49 [dut-0] E (100) octal_psram: PSRAM chip is not connected, or wrong PSRAM line mode
2026-05-29 09:25:49 [dut-0] E (107) esp_psram: PSRAM enabled but initialization failed. Bailing out.
2026-05-29 09:25:49 [dut-0] [SENDER] Ready
2026-05-29 09:25:49 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:788:test_i2s_begin_end:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:789:test_i2s_sample_rate_8k:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:790:test_i2s_sample_rate_44k:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:791:test_i2s_sample_rate_48k:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:792:test_i2s_32bit:PASS
2026-05-29 09:25:49 [dut-1] Connecting....
2026-05-29 09:25:50 INFO Target: esp32s3, Port: /dev/cu.usbserial-2130
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:793:test_i2s_8bit:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:794:test_i2s_mono:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:795:test_i2s_reopen:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:796:test_i2s_slave_mode_begin_end:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:797:test_i2s_mono_aligned_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:798:test_i2s_mono_subbyte_write_no_error:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:799:test_i2s_configure_tx_after_mono_begin:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:800:test_i2s_configure_rx_after_mono_begin:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:801:test_i2s_configure_rx_slot_mask:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:802:test_i2s_configure_rx_slot_mask_32bit:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:803:test_i2s_mono_left_slot_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:804:test_i2s_mono_right_slot_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:805:test_i2s_mono_both_slot_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:806:test_i2s_stereo_left_slot_write:PASS
2026-05-29 09:25:50 [dut-1] Connecting....
2026-05-29 09:25:50 [dut-1] esptool v5.2.0
                            Connected to ESP32-S3 on /dev/cu.usbserial-2130:
2026-05-29 09:25:50 [dut-1] Chip type:          ESP32-S3 (QFN56) (revision v0.1)
2026-05-29 09:25:50 [dut-1] Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz
2026-05-29 09:25:50 [dut-1] Crystal frequency:  40MHz
2026-05-29 09:25:50 [dut-1] MAC:                f4:12:fa:42:b6:e8
2026-05-29 09:25:50 [dut-1] 
2026-05-29 09:25:50 [dut-1] Uploading stub flasher...
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:807:test_i2s_stereo_right_slot_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:808:test_i2s_mono_32bit_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:809:test_i2s_mono_right_subbyte_write_no_error:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:810:test_i2s_configure_tx_stereo_to_mono:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:811:test_i2s_configure_tx_mono_to_stereo:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:812:test_i2s_configure_tx_mono_left_to_right:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:813:test_i2s_stereo_rx_left_slot:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:814:test_i2s_stereo_rx_right_slot:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:815:test_i2s_configure_rx_stereo_slot_change:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:816:test_i2s_configure_rx_mono_both_slot:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:818:test_i2s_tdm_begin_end:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:819:test_i2s_tdm_stereo_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:820:test_i2s_tdm_mono_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:821:test_i2s_tdm_32bit_write:PASS
2026-05-29 09:25:50 [dut-0] /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/sender/sender.ino:822:test_i2s_tdm_slave_begin_end:PASS
2026-05-29 09:25:50 [dut-0] 
2026-05-29 09:25:50 [dut-0] -----------------------
2026-05-29 09:25:50 [dut-0] 34 Tests 0 Failures 0 Ignored 
2026-05-29 09:25:50 [dut-0] OK
                            Stub flasher running.
2026-05-29 09:25:51 [dut-1] 
2026-05-29 09:25:51 [dut-1] Configuring flash size...
2026-05-29 09:25:51 [dut-1] SHA digest in image updated.
2026-05-29 09:25:51 [dut-1] Flash will be erased from 0x00000000 to 0x003fffff...
                            Wrote 4194304 bytes (209085 compressed) at 0x00000000 in 42.8 seconds (783.6 kbit/s).
                            Hash of data verified.
2026-05-29 09:26:47 [dut-1] 
2026-05-29 09:26:47 [dut-1] Hard resetting via RTS pin...
---------------------------------------------- live log call ----------------------------------------------
2026-05-29 09:26:47 INFO Waiting for devices to be ready...
2026-05-29 09:26:48 [dut-1] ESP-ROM:esp32s3-20210327
2026-05-29 09:26:48 [dut-1] Build:Mar 27 2021
2026-05-29 09:26:48 [dut-1] rst:0x1 (POWERON),boot:0x2b (SPI_FAST_FLASH_BOOT)
2026-05-29 09:26:48 [dut-1] SPIWP:0xee
2026-05-29 09:26:48 [dut-1] mode:DIO, clock div:1
2026-05-29 09:26:48 [dut-1] load:0x3fce2820,len:0x10cc
2026-05-29 09:26:48 [dut-1] load:0x403c8700,len:0xc2c
2026-05-29 09:26:48 [dut-1] load:0x403cb700,len:0x30c0
2026-05-29 09:26:48 [dut-1] entry 0x403c88b8
2026-05-29 09:26:48 [dut-1] E (91) octal_psram: PSRAM chip is not connected, or wrong PSRAM line mode
2026-05-29 09:26:48 [dut-1] E (92) esp_psram: PSRAM enabled but initialization failed. Bailing out.
2026-05-29 09:26:48 [dut-1] E cpu_start: Failed to init external RAM; continuing without it.
2026-05-29 09:26:48 [dut-1] E (99) octal_psram: PSRAM chip is not connected, or wrong PSRAM line mode
2026-05-29 09:26:48 [dut-1] E (105) esp_psram: PSRAM enabled but initialization failed. Bailing out.
2026-05-29 09:26:48 [dut-1] [RECEIVER] Ready
2026-05-29 09:26:48 INFO Waiting for sender Unity tests...
2026-05-29 09:26:48 INFO Querying HW version...
2026-05-29 09:26:48 [dut-0] [SENDER] HW_V1_NO
2026-05-29 09:26:48 INFO HW v1: False
2026-05-29 09:26:48 INFO Phase 1: mono 16kHz/16-bit (default slot)...
2026-05-29 09:26:48 [dut-0] [SENDER] TX_CLOCKING
2026-05-29 09:26:48 [dut-1] [RECEIVER] RX_LISTENING
2026-05-29 09:26:48 [dut-1] [RECEIVER] RX_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:26:48 [dut-0] [SENDER] TX_DONE 16384
2026-05-29 09:26:48 INFO Phase 1: mono 16kHz/16-bit (default slot): matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:26:48 INFO Phase 2: stereo→mono right-slot...
2026-05-29 09:26:48 [dut-0] [SENDER] TX_STEREO_CLOCKING
2026-05-29 09:26:49 [dut-1] [RECEIVER] RX_RIGHT_LISTENING
2026-05-29 09:26:49 [dut-1] [RECEIVER] RX_RIGHT_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:26:50 [dut-0] [SENDER] TX_STEREO_DONE 65536
2026-05-29 09:26:50 INFO Phase 2: stereo→mono right-slot: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:26:50 INFO Phase 3: stereo→mono left-slot...
2026-05-29 09:26:50 [dut-0] [SENDER] TX_LEFT_CLOCKING
2026-05-29 09:26:50 [dut-1] [RECEIVER] RX_LEFT_LISTENING
2026-05-29 09:26:50 [dut-1] [RECEIVER] RX_LEFT_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:26:51 [dut-0] [SENDER] TX_LEFT_DONE 65536
2026-05-29 09:26:51 INFO Phase 3: stereo→mono left-slot: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:26:51 INFO Phase 4: mono RIGHT TX→RIGHT RX...
2026-05-29 09:26:51 [dut-0] [SENDER] TX_MONO_RIGHT_CLOCKING
2026-05-29 09:26:51 [dut-1] [RECEIVER] RX_RIGHT_LISTENING
2026-05-29 09:26:51 [dut-1] [RECEIVER] RX_RIGHT_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:26:51 [dut-0] [SENDER] TX_MONO_RIGHT_DONE 16384
2026-05-29 09:26:51 INFO Phase 4: mono RIGHT TX→RIGHT RX: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:26:51 INFO Phase 5: mono 8000Hz/8-bit...
2026-05-29 09:26:52 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:26:52 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:26:52 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:26:53 [dut-0] [SENDER] TX_PARAM_DONE 10048
2026-05-29 09:26:53 INFO Phase 5: mono 8000Hz/8-bit: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:26:53 INFO Phase 6: stereo 8000Hz/8-bit...
2026-05-29 09:26:53 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:26:53 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:26:53 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:26:54 [dut-0] [SENDER] TX_PARAM_DONE 20096
2026-05-29 09:26:54 INFO Phase 6: stereo 8000Hz/8-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:26:54 INFO Phase 7: mono 8000Hz/16-bit...
2026-05-29 09:26:54 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:26:54 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:26:55 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:26:55 [dut-0] [SENDER] TX_PARAM_DONE 20096
2026-05-29 09:26:55 INFO Phase 7: mono 8000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:26:55 INFO Phase 8: stereo 8000Hz/16-bit...
2026-05-29 09:26:56 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:26:56 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:26:56 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:26:57 [dut-0] [SENDER] TX_PARAM_DONE 40192
2026-05-29 09:26:57 INFO Phase 8: stereo 8000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:26:57 INFO Phase 9: mono 8000Hz/32-bit...
2026-05-29 09:26:57 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:26:57 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:26:58 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:26:58 [dut-0] [SENDER] TX_PARAM_DONE 40192
2026-05-29 09:26:58 INFO Phase 9: mono 8000Hz/32-bit: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:26:58 INFO Phase 10: stereo 8000Hz/32-bit...
2026-05-29 09:26:59 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:26:59 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:26:59 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=15 zeros=16 total=1024
2026-05-29 09:27:00 [dut-0] [SENDER] TX_PARAM_DONE 80384
2026-05-29 09:27:00 INFO Phase 10: stereo 8000Hz/32-bit: matches=64/64 full_ramps=15 zeros=16/1024 (1%)
2026-05-29 09:27:00 INFO Phase 11: mono 96000Hz/8-bit...
2026-05-29 09:27:00 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:00 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:00 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:27:01 [dut-0] [SENDER] TX_PARAM_DONE 98048
2026-05-29 09:27:01 INFO Phase 11: mono 96000Hz/8-bit: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:27:01 INFO Phase 12: stereo 96000Hz/8-bit...
2026-05-29 09:27:01 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:01 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:01 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:02 [dut-0] [SENDER] TX_PARAM_DONE 196096
2026-05-29 09:27:02 INFO Phase 12: stereo 96000Hz/8-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:02 INFO Phase 13: mono 96000Hz/16-bit...
2026-05-29 09:27:02 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:02 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:02 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:03 [dut-0] [SENDER] TX_PARAM_DONE 196096
2026-05-29 09:27:03 INFO Phase 13: mono 96000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:03 INFO Phase 14: stereo 96000Hz/16-bit...
2026-05-29 09:27:03 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:03 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:03 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:04 [dut-0] [SENDER] TX_PARAM_DONE 392192
2026-05-29 09:27:04 INFO Phase 14: stereo 96000Hz/16-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:04 INFO Phase 15: mono 96000Hz/32-bit...
2026-05-29 09:27:04 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:04 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:04 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:05 [dut-0] [SENDER] TX_PARAM_DONE 392192
2026-05-29 09:27:05 INFO Phase 15: mono 96000Hz/32-bit: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:05 INFO Phase 16: stereo 96000Hz/32-bit...
2026-05-29 09:27:05 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:06 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:06 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=15 zeros=16 total=1024
2026-05-29 09:27:07 [dut-0] [SENDER] TX_PARAM_DONE 784384
2026-05-29 09:27:07 INFO Phase 16: stereo 96000Hz/32-bit: matches=64/64 full_ramps=15 zeros=16/1024 (1%)
2026-05-29 09:27:07 INFO Phase 17: mono 16-bit slot=LEFT...
2026-05-29 09:27:07 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:07 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:07 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:08 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:27:08 INFO Phase 17: mono 16-bit slot=LEFT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:08 INFO Phase 18: mono 16-bit slot=RIGHT...
2026-05-29 09:27:08 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:08 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:08 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:09 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:27:09 INFO Phase 18: mono 16-bit slot=RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:09 INFO Phase 19: mono 32-bit slot=LEFT...
2026-05-29 09:27:09 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:09 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:10 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:27:10 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:27:10 INFO Phase 19: mono 32-bit slot=LEFT: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:27:10 INFO Phase 20: mono 32-bit slot=RIGHT...
2026-05-29 09:27:11 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:11 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:11 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:12 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:27:12 INFO Phase 20: mono 32-bit slot=RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:12 INFO Phase 21: stereo 16-bit TX=LEFT → mono RX=LEFT...
2026-05-29 09:27:12 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:12 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:12 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:27:13 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:27:13 INFO Phase 21: stereo 16-bit TX=LEFT → mono RX=LEFT: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:27:13 INFO Phase 22: stereo 16-bit TX=RIGHT → mono RX=RIGHT (R ramp)...
2026-05-29 09:27:13 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:13 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:13 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=1 total=2048
2026-05-29 09:27:14 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:27:14 INFO Phase 22: stereo 16-bit TX=RIGHT → mono RX=RIGHT (R ramp): matches=64/64 full_ramps=31 zeros=1/2048 (0%)
2026-05-29 09:27:14 INFO Phase 23: mono 16-bit TX=BOTH RX=LEFT...
2026-05-29 09:27:14 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:14 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:15 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:27:16 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:27:16 INFO Phase 23: mono 16-bit TX=BOTH RX=LEFT: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:27:16 INFO Phase 24: mono 16-bit TX=BOTH RX=RIGHT...
2026-05-29 09:27:16 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:16 [dut-1] [RECEIVER] RX_PARAM_LISTENING
2026-05-29 09:27:16 [dut-1] [RECEIVER] RX_PARAM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:17 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:27:17 INFO Phase 24: mono 16-bit TX=BOTH RX=RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:17 INFO Phase 25: configureRX 16-bit LEFT→RIGHT...
2026-05-29 09:27:17 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:17 [dut-1] [RECEIVER] RX_RECONFIG_LISTENING
2026-05-29 09:27:17 [dut-1] [RECEIVER] RX_RECONFIG_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:18 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:27:18 INFO Phase 25: configureRX 16-bit LEFT→RIGHT: matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:18 INFO Phase 26: configureRX 16-bit RIGHT→LEFT...
2026-05-29 09:27:18 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:18 [dut-1] [RECEIVER] RX_RECONFIG_LISTENING
2026-05-29 09:27:18 [dut-1] [RECEIVER] RX_RECONFIG_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:27:19 [dut-0] [SENDER] TX_PARAM_DONE 36096
2026-05-29 09:27:19 INFO Phase 26: configureRX 16-bit RIGHT→LEFT: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:27:19 INFO Phase 27: configureRX 32-bit LEFT→RIGHT...
2026-05-29 09:27:20 [dut-0] [SENDER] TX_PARAM_CLOCKING
2026-05-29 09:27:20 [dut-1] [RECEIVER] RX_RECONFIG_LISTENING
2026-05-29 09:27:20 [dut-1] [RECEIVER] RX_RECONFIG_DONE matches=64 full_ramps=31 zeros=33 total=2048
2026-05-29 09:27:21 [dut-0] [SENDER] TX_PARAM_DONE 72192
2026-05-29 09:27:21 INFO Phase 27: configureRX 32-bit LEFT→RIGHT: matches=64/64 full_ramps=31 zeros=33/2048 (1%)
2026-05-29 09:27:21 INFO Not HW v1 — skipping BOTH averaging tests
2026-05-29 09:27:21 INFO Querying TDM support...
2026-05-29 09:27:21 [dut-0] [SENDER] TDM_SUPPORTED
2026-05-29 09:27:21 INFO Phase 28: TDM mono SLOT0...
2026-05-29 09:27:21 [dut-0] [SENDER] TX_TDM_CLOCKING
2026-05-29 09:27:21 [dut-1] [RECEIVER] RX_TDM_LISTENING
2026-05-29 09:27:21 [dut-1] [RECEIVER] RX_TDM_DONE matches=64 full_ramps=31 zeros=32 total=2048
2026-05-29 09:27:21 [dut-0] [SENDER] TX_TDM_DONE 16384
2026-05-29 09:27:21 INFO Phase 28 (TDM): matches=64/64 full_ramps=31 zeros=32/2048 (1%)
2026-05-29 09:27:21 [dut-0] [SENDER] DONE
2026-05-29 09:27:21 [dut-1] [RECEIVER] DONE
2026-05-29 09:27:21 INFO I2S multi-DUT test passed!
PASSED
-------------------------------------------- live log teardown --------------------------------------------
2026-05-29 09:27:21 INFO Created unity output junit report: /private/var/folders/vp/g9wctsvn7b91k3pv_7cwpt_h0000gn/T/pytest-embedded/2026-05-29_12-24-51-214964/test_i2s/dut-0.xml


- generated xml file: /Users/lucassvaz/Espressif/Arduino/hardware/espressif/esp32/tests/validation/i2s/esp32s3/i2s.xml -
====================================== 1 passed in 151.02s (0:02:31) ======================================

```

</details>

