### PR TITLE
feat(board): Add support for Waveshare ESP32-P4 POE ETH

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -44436,6 +44436,182 @@ Geekble_Nano_ESP32S3.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+waveshare_p4_poe_eth.name=Waveshare ESP32-P4-POE-ETH
+
+waveshare_p4_poe_eth.bootloader.tool=esptool_py
+waveshare_p4_poe_eth.bootloader.tool.default=esptool_py
+
+waveshare_p4_poe_eth.upload.tool=esptool_py
+waveshare_p4_poe_eth.upload.tool.default=esptool_py
+waveshare_p4_poe_eth.upload.tool.network=esp_ota
+
+waveshare_p4_poe_eth.upload.maximum_size=1310720
+waveshare_p4_poe_eth.upload.maximum_data_size=327680
+waveshare_p4_poe_eth.upload.flags=
+waveshare_p4_poe_eth.upload.extra_flags=
+waveshare_p4_poe_eth.upload.use_1200bps_touch=false
+waveshare_p4_poe_eth.upload.wait_for_upload_port=false
+
+waveshare_p4_poe_eth.serial.disableDTR=false
+waveshare_p4_poe_eth.serial.disableRTS=false
+
+waveshare_p4_poe_eth.build.tarch=riscv32
+waveshare_p4_poe_eth.build.target=esp
+waveshare_p4_poe_eth.build.mcu=esp32p4
+waveshare_p4_poe_eth.build.core=esp32
+waveshare_p4_poe_eth.build.variant=esp32p4
+waveshare_p4_poe_eth.build.chip_variant=waveshare_p4_poe_eth
+waveshare_p4_poe_eth.build.board=WAVESHARE_ESP32P4_POE_ETH
+waveshare_p4_poe_eth.build.bootloader_addr=0x2000
+
+waveshare_p4_poe_eth.build.usb_mode=0
+waveshare_p4_poe_eth.build.cdc_on_boot=0
+waveshare_p4_poe_eth.build.msc_on_boot=0
+waveshare_p4_poe_eth.build.dfu_on_boot=0
+waveshare_p4_poe_eth.build.f_cpu=360000000L
+waveshare_p4_poe_eth.build.flash_size=32MB
+waveshare_p4_poe_eth.build.flash_freq=80m
+waveshare_p4_poe_eth.build.img_freq=80m
+waveshare_p4_poe_eth.build.flash_mode=dio
+waveshare_p4_poe_eth.build.boot=qio
+waveshare_p4_poe_eth.build.partitions=default
+waveshare_p4_poe_eth.build.defines=-DBOARD_HAS_PSRAM
+
+waveshare_p4_poe_eth.menu.ChipVariant.prev3=Before v3.00
+waveshare_p4_poe_eth.menu.ChipVariant.prev3.build.chip_variant=esp32p4_es
+waveshare_p4_poe_eth.menu.ChipVariant.prev3.build.f_cpu=360000000L
+waveshare_p4_poe_eth.menu.ChipVariant.postv3=v3.00 or newer
+waveshare_p4_poe_eth.menu.ChipVariant.postv3.build.chip_variant=esp32p4
+waveshare_p4_poe_eth.menu.ChipVariant.postv3.build.f_cpu=400000000L
+
+## IDE 2.0 Seems to not update the value
+waveshare_p4_poe_eth.menu.JTAGAdapter.default=Disabled
+waveshare_p4_poe_eth.menu.JTAGAdapter.default.build.copy_jtag_files=0
+waveshare_p4_poe_eth.menu.JTAGAdapter.builtin=Integrated USB JTAG
+waveshare_p4_poe_eth.menu.JTAGAdapter.builtin.build.openocdscript=esp32p4-builtin.cfg
+waveshare_p4_poe_eth.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+waveshare_p4_poe_eth.menu.JTAGAdapter.external=FTDI Adapter
+waveshare_p4_poe_eth.menu.JTAGAdapter.external.build.openocdscript=esp32p4-ftdi.cfg
+waveshare_p4_poe_eth.menu.JTAGAdapter.external.build.copy_jtag_files=1
+waveshare_p4_poe_eth.menu.JTAGAdapter.bridge=ESP USB Bridge
+waveshare_p4_poe_eth.menu.JTAGAdapter.bridge.build.openocdscript=esp32p4-bridge.cfg
+waveshare_p4_poe_eth.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+waveshare_p4_poe_eth.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_p4_poe_eth.menu.USBMode.default.build.usb_mode=0
+waveshare_p4_poe_eth.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_p4_poe_eth.menu.USBMode.hwcdc.build.usb_mode=1
+
+waveshare_p4_poe_eth.menu.CDCOnBoot.default=Disabled
+waveshare_p4_poe_eth.menu.CDCOnBoot.default.build.cdc_on_boot=0
+waveshare_p4_poe_eth.menu.CDCOnBoot.cdc=Enabled
+waveshare_p4_poe_eth.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+waveshare_p4_poe_eth.menu.MSCOnBoot.default=Disabled
+waveshare_p4_poe_eth.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_p4_poe_eth.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_p4_poe_eth.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_p4_poe_eth.menu.DFUOnBoot.default=Disabled
+waveshare_p4_poe_eth.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_p4_poe_eth.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_p4_poe_eth.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_p4_poe_eth.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_p4_poe_eth.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_p4_poe_eth.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_p4_poe_eth.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_p4_poe_eth.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_p4_poe_eth.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_p4_poe_eth.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.default.build.partitions=default
+waveshare_p4_poe_eth.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_p4_poe_eth.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+waveshare_p4_poe_eth.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+waveshare_p4_poe_eth.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.minimal.build.partitions=minimal
+waveshare_p4_poe_eth.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
+waveshare_p4_poe_eth.menu.PartitionScheme.no_fs.build.partitions=no_fs
+waveshare_p4_poe_eth.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
+waveshare_p4_poe_eth.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_p4_poe_eth.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_p4_poe_eth.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_p4_poe_eth.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_p4_poe_eth.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_p4_poe_eth.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_p4_poe_eth.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_p4_poe_eth.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_p4_poe_eth.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_p4_poe_eth.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_p4_poe_eth.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+waveshare_p4_poe_eth.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
+waveshare_p4_poe_eth.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
+waveshare_p4_poe_eth.menu.PartitionScheme.app5M_little24M_32MB=32M Flash (4.8MB APP/22MB LittleFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.app5M_little24M_32MB.build.partitions=large_littlefs_32MB
+waveshare_p4_poe_eth.menu.PartitionScheme.app5M_little24M_32MB.upload.maximum_size=4718592
+waveshare_p4_poe_eth.menu.PartitionScheme.app13M_data7M_32MB=32M Flash (13MB APP/6.75MB SPIFFS)
+waveshare_p4_poe_eth.menu.PartitionScheme.app13M_data7M_32MB.build.partitions=default_32MB
+waveshare_p4_poe_eth.menu.PartitionScheme.app13M_data7M_32MB.upload.maximum_size=13107200
+waveshare_p4_poe_eth.menu.PartitionScheme.esp_sr_16=ESP SR 16M (3MB APP/6MB SPIFFS/3.9MB MODEL)
+waveshare_p4_poe_eth.menu.PartitionScheme.esp_sr_16.upload.maximum_size=3145728
+waveshare_p4_poe_eth.menu.PartitionScheme.esp_sr_16.upload.extra_flags=0xC10000 {build.path}/srmodels.bin
+waveshare_p4_poe_eth.menu.PartitionScheme.esp_sr_16.build.partitions=esp_sr_16
+waveshare_p4_poe_eth.menu.PartitionScheme.custom=Custom
+waveshare_p4_poe_eth.menu.PartitionScheme.custom.build.partitions=
+waveshare_p4_poe_eth.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_p4_poe_eth.menu.UploadSpeed.921600=921600
+waveshare_p4_poe_eth.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_p4_poe_eth.menu.UploadSpeed.115200=115200
+waveshare_p4_poe_eth.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_p4_poe_eth.menu.UploadSpeed.256000.windows=256000
+waveshare_p4_poe_eth.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_p4_poe_eth.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_p4_poe_eth.menu.UploadSpeed.230400=230400
+waveshare_p4_poe_eth.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_p4_poe_eth.menu.UploadSpeed.460800.linux=460800
+waveshare_p4_poe_eth.menu.UploadSpeed.460800.macosx=460800
+waveshare_p4_poe_eth.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_p4_poe_eth.menu.UploadSpeed.512000.windows=512000
+waveshare_p4_poe_eth.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_p4_poe_eth.menu.DebugLevel.none=None
+waveshare_p4_poe_eth.menu.DebugLevel.none.build.code_debug=0
+waveshare_p4_poe_eth.menu.DebugLevel.error=Error
+waveshare_p4_poe_eth.menu.DebugLevel.error.build.code_debug=1
+waveshare_p4_poe_eth.menu.DebugLevel.warn=Warn
+waveshare_p4_poe_eth.menu.DebugLevel.warn.build.code_debug=2
+waveshare_p4_poe_eth.menu.DebugLevel.info=Info
+waveshare_p4_poe_eth.menu.DebugLevel.info.build.code_debug=3
+waveshare_p4_poe_eth.menu.DebugLevel.debug=Debug
+waveshare_p4_poe_eth.menu.DebugLevel.debug.build.code_debug=4
+waveshare_p4_poe_eth.menu.DebugLevel.verbose=Verbose
+waveshare_p4_poe_eth.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_p4_poe_eth.menu.EraseFlash.none=Disabled
+waveshare_p4_poe_eth.menu.EraseFlash.none.upload.erase_cmd=
+waveshare_p4_poe_eth.menu.EraseFlash.all=Enabled
+waveshare_p4_poe_eth.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 waveshare_esp32_s3_zero.name=Waveshare ESP32-S3-Zero
 waveshare_esp32_s3_zero.vid.0=0x303a
 waveshare_esp32_s3_zero.pid.0=0x822B

--- a/boards.txt
+++ b/boards.txt
@@ -44575,7 +44575,7 @@ waveshare_p4_poe_eth.menu.PartitionScheme.esp_sr_16.upload.extra_flags=0xC10000 
 waveshare_p4_poe_eth.menu.PartitionScheme.esp_sr_16.build.partitions=esp_sr_16
 waveshare_p4_poe_eth.menu.PartitionScheme.custom=Custom
 waveshare_p4_poe_eth.menu.PartitionScheme.custom.build.partitions=
-waveshare_p4_poe_eth.menu.PartitionScheme.custom.upload.maximum_size=16777216
+waveshare_p4_poe_eth.menu.PartitionScheme.custom.upload.maximum_size=33554432
 
 waveshare_p4_poe_eth.menu.UploadSpeed.921600=921600
 waveshare_p4_poe_eth.menu.UploadSpeed.921600.upload.speed=921600

--- a/boards.txt
+++ b/boards.txt
@@ -44459,8 +44459,8 @@ waveshare_p4_poe_eth.build.tarch=riscv32
 waveshare_p4_poe_eth.build.target=esp
 waveshare_p4_poe_eth.build.mcu=esp32p4
 waveshare_p4_poe_eth.build.core=esp32
-waveshare_p4_poe_eth.build.variant=esp32p4
-waveshare_p4_poe_eth.build.chip_variant=waveshare_p4_poe_eth
+waveshare_p4_poe_eth.build.variant=waveshare_p4_poe_eth
+waveshare_p4_poe_eth.build.chip_variant=esp32p4_es
 waveshare_p4_poe_eth.build.board=WAVESHARE_ESP32P4_POE_ETH
 waveshare_p4_poe_eth.build.bootloader_addr=0x2000
 

--- a/variants/waveshare_p4_poe_eth/pins_arduino.h
+++ b/variants/waveshare_p4_poe_eth/pins_arduino.h
@@ -1,0 +1,80 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+// BOOT_MODE 35
+// BOOT_MODE2 36 pullup
+
+static const uint8_t TX = 37;
+static const uint8_t RX = 38;
+
+static const uint8_t SDA = 7;
+static const uint8_t SCL = 8;
+
+// GPIO 36 and below: no extra on-chip LDO needed for the IO bank.
+// GPIO 39-48: LDO VO4 (channel 4). GPIO 37-38 (UART) are outside that VO4 range.
+static const uint8_t SS = 46;
+static const uint8_t MOSI = 32;
+static const uint8_t MISO = 33;
+static const uint8_t SCK = 27;
+
+static const uint8_t A0 = 16;
+static const uint8_t A1 = 17;
+static const uint8_t A2 = 18;
+static const uint8_t A3 = 19;
+static const uint8_t A4 = 20;
+static const uint8_t A5 = 21;
+static const uint8_t A6 = 22;
+static const uint8_t A7 = 23;
+static const uint8_t A13 = 54;
+
+static const uint8_t T0 = 2;
+static const uint8_t T1 = 3;
+static const uint8_t T2 = 4;
+static const uint8_t T3 = 5;
+static const uint8_t T4 = 6;
+static const uint8_t T12 = 14;
+static const uint8_t T13 = 15;
+
+/* ESP32-P4 EV Function board specific definitions */
+//ETH
+#define ETH_PHY_TYPE    ETH_PHY_TLK110
+#define ETH_PHY_ADDR    1
+#define ETH_PHY_MDC     31
+#define ETH_PHY_MDIO    52
+#define ETH_PHY_POWER   51
+#define ETH_RMII_TX_EN  49
+#define ETH_RMII_TX0    34
+#define ETH_RMII_TX1    35
+#define ETH_RMII_RX0    29
+#define ETH_RMII_RX1_EN 30
+#define ETH_RMII_CRS_DV 28
+#define ETH_RMII_CLK    50
+#define ETH_CLK_MODE    EMAC_CLK_EXT_IN
+
+//SDMMC
+#define BOARD_HAS_SDMMC
+#define BOARD_SDMMC_SLOT           0
+#define BOARD_SDMMC_POWER_CHANNEL  4
+#define BOARD_SDMMC_POWER_PIN      45
+#define BOARD_SDMMC_POWER_ON_LEVEL LOW
+
+// On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
+#define BOARD_PERIMAN_IO_LDO_AUTO        1
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL    4   // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MIN   39  // Function EV: GPIO 39-48 on VO4
+#define BOARD_PERIMAN_IO_LDO0_GPIO_MAX   48
+#define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV 3300
+
+// I2S
+#define BOARD_HAS_ES8311
+#define I2S_MCLK 13
+#define I2S_BCLK 12
+#define I2S_LRCLK 10
+#define I2S_DOUT 11
+#define I2S_DIN 9
+#define PA_POWER 53
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_p4_poe_eth/pins_arduino.h
+++ b/variants/waveshare_p4_poe_eth/pins_arduino.h
@@ -70,11 +70,11 @@ static const uint8_t T13 = 15;
 
 // I2S
 #define BOARD_HAS_ES8311
-#define I2S_MCLK 13
-#define I2S_BCLK 12
+#define I2S_MCLK  13
+#define I2S_BCLK  12
 #define I2S_LRCLK 10
-#define I2S_DOUT 11
-#define I2S_DIN 9
-#define PA_POWER 53
+#define I2S_DOUT  11
+#define I2S_DIN   9
+#define PA_POWER  53
 
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
This pull request adds support for the Waveshare ESP32-P4-POE-ETH board to the project. The main changes include updating the `boards.txt` file to define the new board's configuration and adding a new `pins_arduino.h` header file that specifies the pin mappings and hardware features for this board.

**New board support:**

* Added configuration for the `waveshare_p4_poe_eth` board in `boards.txt`, including upload settings, build options, partition schemes, USB/JTAG/Debug options, and menu customizations.

**Board variant definition:**

* Introduced `variants/waveshare_p4_poe_eth/pins_arduino.h` to define pin mappings (e.g., `TX`, `RX`, `SDA`, `SCL`, analog pins, touch pins), Ethernet PHY settings, SDMMC, LDO configuration, and I2S audio support for the new board.