### PR TITLE
change(esptool): Update esptool to 5.3

### DIFF
--- a/.github/scripts/update_esptool.py
+++ b/.github/scripts/update_esptool.py
@@ -40,6 +40,11 @@ import hashlib
 import requests
 from pathlib import Path
 
+def ensure_v_prefix(version):
+    if version.startswith("v"):
+        return version
+    return f"v{version}"
+
 def compute_sha256(filepath):
     sha256 = hashlib.sha256()
     with open(filepath, "rb") as f:
@@ -122,7 +127,7 @@ def create_archives(version, base_folder):
         base = dirpath.name[len("esptool-"):]
 
         if "windows" in dirpath.name:
-            zipfile_name = f"esptool-v{version}-{base}.zip"
+            zipfile_name = f"esptool-{ensure_v_prefix(version)}-{base}.zip"
             print(f"Creating {zipfile_name} from {dirpath} ...")
             with zipfile.ZipFile(zipfile_name, "w", zipfile.ZIP_DEFLATED) as zipf:
                 for root, _, files in os.walk(dirpath):
@@ -131,7 +136,7 @@ def create_archives(version, base_folder):
                         zipf.write(full_path, os.path.relpath(full_path, start=dirpath))
             archive_files.append(zipfile_name)
         else:
-            tarfile_name = f"esptool-v{version}-{base}.tar.gz"
+            tarfile_name = f"esptool-{ensure_v_prefix(version)}-{base}.tar.gz"
             print(f"Creating {tarfile_name} from {dirpath} ...")
             for root, dirs, files in os.walk(dirpath):
                 for name in dirs + files:
@@ -197,7 +202,7 @@ def update_json_from_release(tmp_json_path, version, release_info):
                 update_json_for_host(tmp_json_path, version, host, asset_url, asset_fname, asset_checksum, asset_size)
 
 def get_release_info(version):
-    url = f"https://api.github.com/repos/espressif/esptool/releases/tags/v{version}"
+    url = f"https://api.github.com/repos/espressif/esptool/releases/tags/{ensure_v_prefix(version)}"
     response = requests.get(url)
     response.raise_for_status()
     return response.json()

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Ignore toolchain directories
 tools/esp32-arduino-libs
 tools/xtensa-esp-elf
 tools/xtensa-esp32-elf
@@ -20,8 +21,9 @@ tools/openocd-esp32
 .*.swo
 *~
 
-# Ignore build folder
+# Ignore build and temporary files
 /build
+*.tmp
 
 # Ignore files built by Visual Studio/Visual Micro and other IDEs
 [Dd]ebug/

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -84,7 +84,7 @@
             {
               "packager": "esp32",
               "name": "esptool_py",
-              "version": "5.2.0"
+              "version": "5.3.0"
             },
             {
               "packager": "esp32",
@@ -472,56 +472,56 @@
         },
         {
           "name": "esptool_py",
-          "version": "5.2.0",
+          "version": "5.3.0",
           "systems": [
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-aarch64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-linux-aarch64.tar.gz",
-              "checksum": "SHA-256:a3a0fc13ada8d69dddbdfff1c765fa0b88fb578a83d02315be9c15fefa6ca58e",
-              "size": "66991044"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-aarch64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-linux-aarch64.tar.gz",
+              "checksum": "SHA-256:5a03918919f0b94222b639803e97e74d679d0fc3c5092cf27292f8e5a1430794",
+              "size": "75198819"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-linux-amd64.tar.gz",
-              "checksum": "SHA-256:0a9f6c913fccfacac9261eb2acd8060010db5933c18c8e47cb32377eaa7202a3",
-              "size": "73991509"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-linux-amd64.tar.gz",
+              "checksum": "SHA-256:46ca7b52c309790bc4d140990680f6088e8cad40b230fda6999661efc24845b6",
+              "size": "82516240"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-armv7.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-linux-armv7.tar.gz",
-              "checksum": "SHA-256:dbf92966eb6ad5f4d068d8b2461f534b15219cb405083a38d26519284e91b73a",
-              "size": "57875713"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-armv7.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-linux-armv7.tar.gz",
+              "checksum": "SHA-256:59fad3317798ec65567cb6fda49db081c778cf971e35155a06dde0919d4e7e96",
+              "size": "65340824"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-macos-amd64.tar.gz",
-              "checksum": "SHA-256:dcb6c38cb10e1d7ca5ce658687e4abe47dfda22284857673b55cae010ff5f5ee",
-              "size": "58174910"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-macos-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-macos-amd64.tar.gz",
+              "checksum": "SHA-256:e313df506a0e1e074ebc7dffb065993197881a2a5285e1b0dd20398ae67687ed",
+              "size": "63777562"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-arm64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-macos-arm64.tar.gz",
-              "checksum": "SHA-256:2b45270273ff96b6394bd6e317b153cf4a42869ca917d2bcebafc9a3cdac0e1e",
-              "size": "54970972"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-macos-arm64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-macos-arm64.tar.gz",
+              "checksum": "SHA-256:58fc5415cadefde99bf282143c3aadfea139309fe56eba9bd6fa596c69d855b9",
+              "size": "60554760"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
-              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
-              "size": "58319204"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.3.0-windows-amd64.zip",
+              "checksum": "SHA-256:c86e30586e559f0ae5b41a828f21b4c69a7fc11a194e09391f5a2e31952b2471",
+              "size": "63716106"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
-              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
-              "size": "58319204"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.3.0-windows-amd64.zip",
+              "checksum": "SHA-256:c86e30586e559f0ae5b41a828f21b4c69a7fc11a194e09391f5a2e31952b2471",
+              "size": "63716106"
             }
           ]
         },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,5 @@ pytest-embedded-serial-esp==2.5.0
 pytest-embedded-arduino==2.5.0
 pytest-embedded-wokwi==2.5.0
 pytest-embedded-qemu==2.5.0
-esptool==5.2.0
+esptool==5.3.0
 wokwi-client


### PR DESCRIPTION
## Description of Change

This pull request updates the ESP32 toolchain to use `esptool` version 5.3.0 and improves version string handling in the update script. The changes ensure consistent version formatting and update all relevant metadata, URLs, checksums, and file sizes for the new release.

**esptool version update:**

* Updated the `esptool_py` version from `5.2.0` to `5.3.0` in `package_esp32_index.template.json`, including all associated URLs, archive file names, checksums, and file sizes for each supported platform. [[1]](diffhunk://#diff-5cc2de46219528ecaffa00a28b18719ca62cbebebe50bfbee8d49c98cee14fa6L87-R87) [[2]](diffhunk://#diff-5cc2de46219528ecaffa00a28b18719ca62cbebebe50bfbee8d49c98cee14fa6L475-R524)

**Script improvements:**

* Added a new `ensure_v_prefix` function in `.github/scripts/update_esptool.py` to guarantee that version strings are always prefixed with `v`, ensuring consistency across archive naming and API requests.
* Updated archive creation and release info fetching in `.github/scripts/update_esptool.py` to use the new `ensure_v_prefix` function, preventing errors from missing or duplicated `v` prefixes in version strings. [[1]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebL125-R130) [[2]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebL134-R139) [[3]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebL200-R205)
