### PR TITLE
feat(openthread): fixes and improvements

### DIFF
--- a/docs/en/openthread/openthread.rst
+++ b/docs/en/openthread/openthread.rst
@@ -206,6 +206,12 @@ Common Issues
   * Check that OpenThread is started before applying the dataset
   * Verify the dataset parameters match the target network
 
+**Unexpected network after reboot**
+  * OpenThread persists the committed Active Operational Dataset in NVS
+  * After ``OpenThread::begin()`` returns, use ``OThread.hasActiveDataset()`` to check whether a dataset was restored from NVS
+  * If a dataset is present, bring the interface up and start Thread to resume the existing network
+  * If you want to apply changed dataset constants, clear the stored dataset first (for example with the OpenThread CLI ``factoryreset`` command)
+
 Initialization Order
 ********************
 

--- a/docs/en/openthread/openthread.rst
+++ b/docs/en/openthread/openthread.rst
@@ -7,8 +7,8 @@ About
 
 The OpenThread library provides support for creating Thread network devices using ESP32 SoCs with IEEE 802.15.4 radio support. The library offers two different programming interfaces for interacting with the OpenThread stack:
 
-* **Stream-based CLI enhanced with Helper Functions API**: Command-line interface helper functions that send OpenThread CLI commands and parse responses
-* **Classes API**: Object-oriented classes that directly call OpenThread API functions
+* **Stream-based CLI enhanced with Helper Functions API**: Command-line interface helper functions that send OpenThread CLI commands and parse responses.
+* **Classes API**: Object-oriented classes that directly call OpenThread API functions.
 
 The OpenThread library is built on top of `ESP OpenThread <https://github.com/espressif/esp-openthread>`_ and provides a high-level Arduino-style interface for creating Thread devices.
 
@@ -177,40 +177,40 @@ Common Issues
 *************
 
 **Thread network not starting**
-  * Ensure the device has IEEE 802.15.4 radio support (ESP32-H2, ESP32-C6, ESP32-C5)
-  * Check that Thread is enabled in ESP-IDF configuration (``CONFIG_OPENTHREAD_ENABLED``)
-  * Verify that ``OpenThread::begin()`` is called before using Thread functions
-  * Check Serial Monitor for initialization errors
+  * Ensure the device has IEEE 802.15.4 radio support (ESP32-H2, ESP32-C6, ESP32-C5).
+  * Check that Thread is enabled in ESP-IDF configuration (``CONFIG_OPENTHREAD_ENABLED``).
+  * Verify that ``OpenThread::begin()`` is called before using Thread functions.
+  * Check Serial Monitor for initialization errors.
 
 **Device not joining network**
-  * Verify the operational dataset parameters (network name, network key, channel, PAN ID)
-  * Ensure the device is within range of the Thread network
-  * Check that the network key and extended PAN ID match the network you're trying to join
-  * Verify the device role is not "Detached"
+  * Verify the operational dataset parameters (network name, network key, channel, PAN ID).
+  * Ensure the device is within range of the Thread network.
+  * Check that the network key and extended PAN ID match the network you're trying to join.
+  * Verify the device role is not "Detached".
 
 **CLI commands not working**
-  * Ensure ``OpenThreadCLI::begin()`` is called before using CLI functions
-  * Check that ``OpenThreadCLI::startConsole()`` is called with a valid Stream
-  * Verify the CLI is properly initialized and running
-  * Check Serial Monitor for CLI initialization errors
+  * Ensure ``OpenThreadCLI::begin()`` is called before using CLI functions.
+  * Check that ``OpenThreadCLI::startConsole()`` is called with a valid Stream.
+  * Verify the CLI is properly initialized and running.
+  * Check Serial Monitor for CLI initialization errors.
 
 **Address not available**
-  * Wait for the device to join the Thread network (role should be Child, Router, or Leader)
-  * Check that the network interface is up using ``networkInterfaceUp()``
-  * Verify the device has obtained a mesh-local address
-  * Check network connectivity using ``getRloc()`` or ``getMeshLocalEid()``
+  * Wait for the device to join the Thread network (role should be Child, Router, or Leader).
+  * Check that the network interface is up using ``networkInterfaceUp()``.
+  * Verify the device has obtained a mesh-local address.
+  * Check network connectivity using ``getRloc()`` or ``getMeshLocalEid()``.
 
 **Dataset not applying**
-  * Ensure all required dataset parameters are set (network name, network key, channel)
-  * Verify the dataset is valid before applying
-  * Check that OpenThread is started before applying the dataset
-  * Verify the dataset parameters match the target network
+  * Ensure all required dataset parameters are set (network name, network key, channel).
+  * Verify the dataset is valid before applying.
+  * Check that OpenThread is started before applying the dataset.
+  * Verify the dataset parameters match the target network.
 
 **Unexpected network after reboot**
-  * OpenThread persists the committed Active Operational Dataset in NVS
-  * After ``OpenThread::begin()`` returns, use ``OThread.hasActiveDataset()`` to check whether a dataset was restored from NVS
-  * If a dataset is present, bring the interface up and start Thread to resume the existing network
-  * If you want to apply changed dataset constants, clear the stored dataset first (for example with the OpenThread CLI ``factoryreset`` command)
+  * OpenThread persists the committed Active Operational Dataset in NVS.
+  * After ``OpenThread::begin()`` returns, use ``OThread.hasActiveDataset()`` to check whether a dataset was restored from NVS.
+  * If a dataset is present, bring the interface up and start Thread to resume the existing network.
+  * If you want to apply changed dataset constants, clear the stored dataset first (for example with the OpenThread CLI ``factoryreset`` command).
 
 Initialization Order
 ********************

--- a/docs/en/openthread/openthread_core.rst
+++ b/docs/en/openthread/openthread_core.rst
@@ -40,7 +40,7 @@ Initializes the OpenThread stack.
 
 This function initializes the OpenThread stack and creates the OpenThread task. If ``OThreadAutoStart`` is ``true``, it will attempt to start Thread using the active dataset from NVS or ESP-IDF default settings.
 
-``begin()`` returns only after the worker task has finished OpenThread stack initialization and reloaded any persisted Active Operational Dataset from NVS. After it returns successfully, APIs such as ``hasActiveDataset()`` can reliably query the stack state without an additional delay loop.
+``begin()`` returns only after the worker task has finished initializing the OpenThread stack and reloaded any persisted Active Operational Dataset from NVS. After it returns successfully, APIs such as ``hasActiveDataset()`` can reliably query the stack state without an additional delay loop.
 
 **Note:** This is a static function and should be called before creating an ``OpenThread`` instance.
 

--- a/docs/en/openthread/openthread_core.rst
+++ b/docs/en/openthread/openthread_core.rst
@@ -40,6 +40,8 @@ Initializes the OpenThread stack.
 
 This function initializes the OpenThread stack and creates the OpenThread task. If ``OThreadAutoStart`` is ``true``, it will attempt to start Thread using the active dataset from NVS or ESP-IDF default settings.
 
+``begin()`` returns only after the worker task has finished OpenThread stack initialization and reloaded any persisted Active Operational Dataset from NVS. After it returns successfully, APIs such as ``hasActiveDataset()`` can reliably query the stack state without an additional delay loop.
+
 **Note:** This is a static function and should be called before creating an ``OpenThread`` instance.
 
 end
@@ -130,6 +132,36 @@ This function sets the active operational dataset for the Thread network. The da
     dataset.setChannel(15);
     dataset.setNetworkKey(networkKey);
     OThread.commitDataSet(dataset);
+
+hasActiveDataset
+^^^^^^^^^^^^^^^^
+
+Checks whether OpenThread has a committed Active Operational Dataset.
+
+.. code-block:: arduino
+
+    bool hasActiveDataset() const;
+
+This function returns ``true`` when an Active Operational Dataset is available in the OpenThread stack. The dataset may have been loaded from NVS during ``OpenThread::begin()`` or committed by the application with ``commitDataSet()``.
+
+This is useful when a sketch needs to decide whether to resume an existing Thread network or provision a new one:
+
+.. code-block:: arduino
+
+    OpenThread::begin(false);
+
+    if (OThread.hasActiveDataset()) {
+        OThread.networkInterfaceUp();
+        OThread.start();
+    } else {
+        DataSet dataset;
+        dataset.initNew();
+        dataset.setNetworkName("MyThreadNetwork");
+        dataset.setChannel(15);
+        OThread.commitDataSet(dataset);
+        OThread.networkInterfaceUp();
+        OThread.start();
+    }
 
 getCurrentDataSet
 ^^^^^^^^^^^^^^^^^
@@ -447,7 +479,7 @@ Gets the OpenThread instance pointer.
 
 This function returns a pointer to the underlying OpenThread instance. This allows direct access to OpenThread API functions for advanced use cases.
 
-**Warning:** Direct use of the OpenThread instance requires knowledge of the OpenThread API. Use with caution.
+**Warning:** Direct use of the OpenThread instance requires knowledge of the OpenThread API. Use with caution. The Arduino wrapper methods acquire the ESP OpenThread stack lock internally, but raw ``ot*`` calls made through this pointer are outside that protection and must follow the ESP-IDF OpenThread locking rules.
 
 Operators
 *********

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -27,8 +27,17 @@ static esp_openthread_platform_config_t ot_native_config;
 static esp_netif_t *openthread_netif = NULL;
 
 // RAII helper for the OpenThread stack lock. The mainloop runs on the worker
-// task, so any otXxx() call made from another task must hold this lock. Acquire
-// on construction, release on destruction; evaluate as bool to check success.
+// task (ot_task_worker), so any otXxx()/esp_openthread_* call made from another
+// task races that mainloop and must be serialized with this lock. Acquire on
+// construction, release on destruction; evaluate as bool to check success.
+//
+// Policy for this file: every OpenThread/DataSet method that calls into the
+// stack from the caller's task (all the start/stop/interface/dataset calls and
+// every getter below) takes an OtLock for the duration of the ot* call. The
+// underlying mutex is recursive, so methods that call one another (or call into
+// helpers that also lock) are safe on the same task and will not self-deadlock.
+// Do NOT hold an OtLock across a call to end(), which deinitializes the stack
+// and destroys this very mutex.
 struct OtLock {
   bool mLocked;
   OtLock() : mLocked(esp_openthread_lock_acquire(portMAX_DELAY)) {}
@@ -166,6 +175,11 @@ void DataSet::initNew() {
     return;
   }
   clear();
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock for dataset init");
+    return;
+  }
   otDatasetCreateNewNetwork(mInstance, &mDataset);
 }
 
@@ -232,6 +246,11 @@ uint16_t DataSet::getPanId() const {
 }
 
 void DataSet::apply(otInstance *instance) {
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock for dataset apply");
+    return;
+  }
   otDatasetSetActive(instance, &mDataset);
 }
 
@@ -386,6 +405,11 @@ void OpenThread::start() {
     log_w("Error: OpenThread instance not initialized");
     return;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return;
+  }
   clearAllAddressCache();  // Clear cache when starting network
   otThreadSetEnabled(mInstance, true);
   log_d("Thread network started");
@@ -396,6 +420,11 @@ void OpenThread::stop() {
     log_w("Error: OpenThread instance not initialized");
     return;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return;
+  }
   clearAllAddressCache();  // Clear cache when stopping network
   otThreadSetEnabled(mInstance, false);
   log_d("Thread network stopped");
@@ -404,6 +433,11 @@ void OpenThread::stop() {
 void OpenThread::networkInterfaceUp() {
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
+    return;
+  }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     return;
   }
   // Enable the Thread interface (equivalent to CLI Command "ifconfig up")
@@ -418,6 +452,11 @@ void OpenThread::networkInterfaceUp() {
 void OpenThread::networkInterfaceDown() {
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
+    return;
+  }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     return;
   }
   // Disable the Thread interface (equivalent to CLI Command "ifconfig down")
@@ -469,6 +508,11 @@ ot_device_role_t OpenThread::otGetDeviceRole() {
     log_w("Error: OpenThread instance not initialized");
     return OT_ROLE_DISABLED;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return OT_ROLE_DISABLED;
+  }
   return (ot_device_role_t)otThreadGetDeviceRole(mInstance);
 }
 
@@ -479,6 +523,12 @@ const char *OpenThread::otGetStringDeviceRole() {
 void OpenThread::otPrintNetworkInformation(Stream &output) {
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
+    return;
+  }
+
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     return;
   }
 
@@ -515,6 +565,11 @@ String OpenThread::getNetworkName() const {
     log_w("Error: OpenThread instance not initialized");
     return String();  // Return empty String, not nullptr
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return String();
+  }
   const char *networkName = otThreadGetNetworkName(mInstance);
   return networkName ? String(networkName) : String();
 }
@@ -523,6 +578,11 @@ String OpenThread::getNetworkName() const {
 const uint8_t *OpenThread::getExtendedPanId() const {
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
+    return nullptr;
+  }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     return nullptr;
   }
   const otExtendedPanId *extPanId = otThreadGetExtendedPanId(mInstance);
@@ -535,6 +595,11 @@ const uint8_t *OpenThread::getNetworkKey() const {
     log_w("Error: OpenThread instance not initialized");
     return nullptr;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return nullptr;
+  }
   otThreadGetNetworkKey(mInstance, &mNetworkKey);
   return mNetworkKey.m8;
 }
@@ -545,6 +610,11 @@ uint8_t OpenThread::getChannel() const {
     log_w("Error: OpenThread instance not initialized");
     return 0;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return 0;
+  }
   return otLinkGetChannel(mInstance);
 }
 
@@ -552,6 +622,11 @@ uint8_t OpenThread::getChannel() const {
 uint16_t OpenThread::getPanId() const {
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
+    return 0;
+  }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     return 0;
   }
   return otLinkGetPanId(mInstance);
@@ -571,6 +646,13 @@ const DataSet &OpenThread::getCurrentDataSet() const {
 
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
+    mCurrentDataset.clear();
+    return mCurrentDataset;
+  }
+
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     mCurrentDataset.clear();
     return mCurrentDataset;
   }
@@ -610,6 +692,11 @@ const otMeshLocalPrefix *OpenThread::getMeshLocalPrefix() const {
     log_w("Error: OpenThread instance not initialized");
     return nullptr;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return nullptr;
+  }
   return otThreadGetMeshLocalPrefix(mInstance);
 }
 
@@ -618,6 +705,11 @@ IPAddress OpenThread::getMeshLocalEid() const {
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
     return IPAddress(IPv6);  // Return empty IPv6 address
+  }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return IPAddress(IPv6);
   }
   const otIp6Address *otAddr = otThreadGetMeshLocalEid(mInstance);
   if (!otAddr) {
@@ -632,6 +724,11 @@ IPAddress OpenThread::getLeaderRloc() const {
   if (!mInstance) {
     log_w("Error: OpenThread instance not initialized");
     return IPAddress(IPv6);  // Return empty IPv6 address
+  }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return IPAddress(IPv6);
   }
   otIp6Address otAddr;
   otError error = otThreadGetLeaderRloc(mInstance, &otAddr);
@@ -648,6 +745,11 @@ IPAddress OpenThread::getRloc() const {
     log_w("Error: OpenThread instance not initialized");
     return IPAddress(IPv6);  // Return empty IPv6 address
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return IPAddress(IPv6);
+  }
   const otIp6Address *otAddr = otThreadGetRloc(mInstance);
   if (!otAddr) {
     log_w("Failed to get Node RLOC");
@@ -662,12 +764,23 @@ uint16_t OpenThread::getRloc16() const {
     log_w("Error: OpenThread instance not initialized");
     return 0;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return 0;
+  }
   return otThreadGetRloc16(mInstance);
 }
 
 // Populate unicast address cache from OpenThread
 void OpenThread::populateUnicastAddressCache() const {
   if (!mInstance) {
+    return;
+  }
+
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     return;
   }
 
@@ -687,6 +800,12 @@ void OpenThread::populateUnicastAddressCache() const {
 // Populate multicast address cache from OpenThread
 void OpenThread::populateMulticastAddressCache() const {
   if (!mInstance) {
+    return;
+  }
+
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
     return;
   }
 

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -24,8 +24,28 @@
 #include <openthread/commissioner.h>
 #include <openthread/platform/radio.h>
 
+#include "esp_openthread_lock.h"
+
 static esp_openthread_platform_config_t ot_native_config;
 static esp_netif_t *openthread_netif = NULL;
+
+// RAII helper for the OpenThread stack lock. The mainloop runs on the worker
+// task, so any otXxx() call made from another task must hold this lock. Acquire
+// on construction, release on destruction; evaluate as bool to check success.
+struct OtLock {
+  bool mLocked;
+  OtLock() : mLocked(esp_openthread_lock_acquire(portMAX_DELAY)) {}
+  ~OtLock() {
+    if (mLocked) {
+      esp_openthread_lock_release();
+    }
+  }
+  explicit operator bool() const {
+    return mLocked;
+  }
+  OtLock(const OtLock &) = delete;
+  OtLock &operator=(const OtLock &) = delete;
+};
 
 const char *otRoleString[] = {
   "Disabled",  ///< The Thread stack is disabled.

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -66,6 +66,11 @@ static TaskHandle_t s_ot_task = NULL;
 // Signaled by ot_task_worker() once the stack finished (or failed) initializing.
 // Mirrors the s_ot_syn_semaphore handshake done by IDF's esp_openthread_start().
 static SemaphoreHandle_t s_ot_init_done = NULL;
+// Result of that initialization, written by ot_task_worker() BEFORE it gives
+// s_ot_init_done. The semaphore only says "init finished"; this says whether it
+// succeeded, so begin() can abort if a later init step failed (in which case the
+// worker never launches the mainloop and just suspends itself).
+static volatile bool s_ot_init_ok = false;
 #if CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM
 static struct netif *ot_lwip_netif = NULL;
 #endif
@@ -133,11 +138,14 @@ static void ot_task_worker(void *aContext) {
     log_e("Failed to set default OpenThread esp_netif");
     err = true;
   }
-  // Tell begin() that initialization is finished (whether it succeeded or not)
-  // BEFORE entering the mainloop, which never returns. This matches IDF's
-  // esp_openthread_start(), where the worker task releases the sync semaphore
-  // only after esp_openthread_init() + netif setup are complete, so the caller
-  // can safely touch the instance/dataset (NVS already loaded) afterwards.
+  // Publish the init result, then tell begin() that initialization is finished
+  // (whether it succeeded or not) BEFORE entering the mainloop, which never
+  // returns. This matches IDF's esp_openthread_start(), where the worker task
+  // releases the sync semaphore only after esp_openthread_init() + netif setup
+  // are complete, so the caller can safely touch the instance/dataset (NVS
+  // already loaded) afterwards. s_ot_init_ok MUST be set before the give so
+  // begin() reads a stable value once xSemaphoreTake() returns.
+  s_ot_init_ok = !err;
   if (s_ot_init_done != NULL) {
     xSemaphoreGive(s_ot_init_done);
   }
@@ -319,6 +327,17 @@ void OpenThread::begin(bool OThreadAutoStart) {
   // the init handshake and the mutex only for protecting API calls.
   if (xSemaphoreTake(s_ot_init_done, pdMS_TO_TICKS(5000)) != pdTRUE) {
     log_e("Error: Timed out waiting for OpenThread stack initialization");
+    otStarted = true;  // force end() to run the full teardown below
+    end();
+    return;
+  }
+
+  // The handshake only tells us init finished, not whether it succeeded. If a
+  // later init step failed (e.g. netif attach/set-default), the worker never
+  // launched the mainloop and is now suspended, so we must NOT proceed even
+  // though the instance may look initialized. Tear down instead.
+  if (!s_ot_init_ok) {
+    log_e("Error: OpenThread stack initialization failed in the worker task");
     otStarted = true;  // force end() to run the full teardown below
     end();
     return;
@@ -526,33 +545,54 @@ void OpenThread::otPrintNetworkInformation(Stream &output) {
     return;
   }
 
-  OtLock lock;
-  if (!lock) {
-    log_e("Error: Failed to acquire OpenThread lock");
-    return;
+  // Snapshot all OpenThread state under the lock, then release it before doing
+  // any Stream output. Stream writes can block on backpressure (e.g. Serial),
+  // and holding the stack lock across them would stall the OpenThread mainloop.
+  otDeviceRole role = OT_DEVICE_ROLE_DISABLED;
+  uint16_t rloc16 = 0;
+  char networkName[OT_NETWORK_NAME_MAX_SIZE + 1] = {0};
+  uint8_t channel = 0;
+  uint16_t panId = 0;
+  otExtendedPanId extPanId = {0};
+  otNetworkKey networkKey = {0};
+  {
+    OtLock lock;
+    if (!lock) {
+      log_e("Error: Failed to acquire OpenThread lock");
+      return;
+    }
+    role = otThreadGetDeviceRole(mInstance);
+    rloc16 = otThreadGetRloc16(mInstance);
+    const char *name = otThreadGetNetworkName(mInstance);
+    if (name) {
+      strncpy(networkName, name, sizeof(networkName) - 1);
+    }
+    channel = otLinkGetChannel(mInstance);
+    panId = otLinkGetPanId(mInstance);
+    const otExtendedPanId *extPanIdPtr = otThreadGetExtendedPanId(mInstance);
+    if (extPanIdPtr) {
+      extPanId = *extPanIdPtr;
+    }
+    otThreadGetNetworkKey(mInstance, &networkKey);
   }
 
-  const otDeviceRole role = otThreadGetDeviceRole(mInstance);
   output.printf("Role: %s", (role <= OT_DEVICE_ROLE_LEADER) ? otRoleString[role] : otRoleString[5]);
   output.println();
-  output.printf("RLOC16: 0x%04x", otThreadGetRloc16(mInstance));  // RLOC16
+  output.printf("RLOC16: 0x%04x", rloc16);
   output.println();
-  output.printf("Network Name: %s", otThreadGetNetworkName(mInstance));
+  output.printf("Network Name: %s", networkName);
   output.println();
-  output.printf("Channel: %u", otLinkGetChannel(mInstance));
+  output.printf("Channel: %u", channel);
   output.println();
-  output.printf("PAN ID: 0x%04x", otLinkGetPanId(mInstance));
+  output.printf("PAN ID: 0x%04x", panId);
   output.println();
 
-  const otExtendedPanId *extPanId = otThreadGetExtendedPanId(mInstance);
   output.print("Extended PAN ID: ");
   for (int i = 0; i < OT_EXT_PAN_ID_SIZE; i++) {
-    output.printf("%02x", extPanId->m8[i]);
+    output.printf("%02x", extPanId.m8[i]);
   }
   output.println();
 
-  otNetworkKey networkKey;
-  otThreadGetNetworkKey(mInstance, &networkKey);
   output.print("Network Key: ");
   for (int i = 0; i < OT_NETWORK_KEY_SIZE; i++) {
     output.printf("%02x", networkKey.m8[i]);

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -20,9 +20,6 @@
 #include "lwip/netif.h"
 
 #include <openthread/instance.h>
-#include <openthread/joiner.h>
-#include <openthread/commissioner.h>
-#include <openthread/platform/radio.h>
 
 #include "esp_openthread_lock.h"
 
@@ -139,11 +136,18 @@ static void ot_task_worker(void *aContext) {
     // only returns in case there is an OpenThread Stack failure...
     esp_openthread_launch_mainloop();
   }
-  // Clean up
-  esp_openthread_netif_glue_deinit();
-  esp_netif_destroy(openthread_netif);
-  esp_vfs_eventfd_unregister();
-  vTaskDelete(NULL);
+
+  // We only get here on an init failure, or if the mainloop returned because of
+  // a stack failure. Do NOT tear down the netif/glue/eventfd or self-delete from
+  // this task: teardown and deletion of this task handle are owned exclusively
+  // by end() (which begin() also invokes when a start fails). Cleaning up here
+  // would race end() and leave openthread_netif / s_ot_task pointing at freed
+  // resources, causing a double esp_netif_destroy() or a vTaskDelete() on an
+  // already-deleted task. Park instead and let end() release everything and
+  // delete this (still valid) task handle.
+  while (true) {
+    vTaskDelay(portMAX_DELAY);
+  }
 }
 
 // DataSet Implementation

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -284,6 +284,11 @@ void OpenThread::begin(bool OThreadAutoStart) {
   xTaskCreate(ot_task_worker, "ot_main_loop", 10240, NULL, 20, &s_ot_task);
   if (s_ot_task == NULL) {
     log_e("Error: Failed to create OpenThread task");
+    // otStarted is still false, so end() will not run to clean this up. Delete
+    // the handshake semaphore here so its handle is not leaked and a later
+    // begin() starts from a clean state.
+    vSemaphoreDelete(s_ot_init_done);
+    s_ot_init_done = NULL;
     return;
   }
   log_d("OpenThread task created successfully");

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -145,8 +145,8 @@ static void ot_task_worker(void *aContext) {
   // resources, causing a double esp_netif_destroy() or a vTaskDelete() on an
   // already-deleted task. Park instead and let end() release everything and
   // delete this (still valid) task handle.
-  while (true) {
-    vTaskDelay(portMAX_DELAY);
+  for (;;) {
+    vTaskSuspend(NULL);
   }
 }
 

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -19,6 +19,11 @@
 #include "esp_openthread_netif_glue.h"
 #include "lwip/netif.h"
 
+#include <openthread/instance.h>
+#include <openthread/joiner.h>
+#include <openthread/commissioner.h>
+#include <openthread/platform/radio.h>
+
 static esp_openthread_platform_config_t ot_native_config;
 static esp_netif_t *openthread_netif = NULL;
 
@@ -32,6 +37,9 @@ const char *otRoleString[] = {
 };
 
 static TaskHandle_t s_ot_task = NULL;
+// Signaled by ot_task_worker() once the stack finished (or failed) initializing.
+// Mirrors the s_ot_syn_semaphore handshake done by IDF's esp_openthread_start().
+static SemaphoreHandle_t s_ot_init_done = NULL;
 #if CONFIG_LWIP_HOOK_IP6_INPUT_CUSTOM
 static struct netif *ot_lwip_netif = NULL;
 #endif
@@ -98,6 +106,14 @@ static void ot_task_worker(void *aContext) {
   if (!err && ESP_OK != esp_netif_set_default_netif(openthread_netif)) {
     log_e("Failed to set default OpenThread esp_netif");
     err = true;
+  }
+  // Tell begin() that initialization is finished (whether it succeeded or not)
+  // BEFORE entering the mainloop, which never returns. This matches IDF's
+  // esp_openthread_start(), where the worker task releases the sync semaphore
+  // only after esp_openthread_init() + netif setup are complete, so the caller
+  // can safely touch the instance/dataset (NVS already loaded) afterwards.
+  if (s_ot_init_done != NULL) {
+    xSemaphoreGive(s_ot_init_done);
   }
   if (!err) {
     // only returns in case there is an OpenThread Stack failure...
@@ -230,6 +246,16 @@ void OpenThread::begin(bool OThreadAutoStart) {
   ot_native_config.port_config.netif_queue_size = 10;
   ot_native_config.port_config.task_queue_size = 10;
 
+  // Handshake semaphore so begin() can block until the worker task has finished
+  // initializing the stack (mirrors IDF's esp_openthread_start()).
+  if (s_ot_init_done == NULL) {
+    s_ot_init_done = xSemaphoreCreateBinary();
+    if (s_ot_init_done == NULL) {
+      log_e("Error: Failed to create OpenThread init semaphore");
+      return;
+    }
+  }
+
   // Initialize OpenThread stack
   xTaskCreate(ot_task_worker, "ot_main_loop", 10240, NULL, 20, &s_ot_task);
   if (s_ot_task == NULL) {
@@ -238,30 +264,51 @@ void OpenThread::begin(bool OThreadAutoStart) {
   }
   log_d("OpenThread task created successfully");
 
-  // starts Thread with default dataset from NVS or from IDF default settings
-  if (OThreadAutoStart) {
-    otOperationalDatasetTlvs dataset;
-    otError error = otDatasetGetActiveTlvs(esp_openthread_get_instance(), &dataset);
-    //    error = OT_ERROR_FAILED; // teste para forçar NULL dataset
-    if (error != OT_ERROR_NONE) {
-      log_i("Failed to get active NVS dataset from OpenThread");
-    } else {
-      log_i("Got active NVS dataset from OpenThread");
-    }
-    esp_err_t err = esp_openthread_auto_start((error == OT_ERROR_NONE) ? &dataset : NULL);
-    if (err != ESP_OK) {
-      log_i("Failed to AUTO start OpenThread");
-    } else {
-      log_i("AUTO start OpenThread done");
-    }
-  }
-
-  // get the OpenThread instance that will be used for all operations
-  mInstance = esp_openthread_get_instance();
-  if (!mInstance) {
-    log_e("Error: Failed to initialize OpenThread instance");
+  // Wait for the worker task to finish initializing the stack before touching
+  // the instance or any otXxx() API. We must NOT hold the OpenThread lock here:
+  // esp_openthread_init() acquires that same lock on the worker task, so holding
+  // it would deadlock. This is exactly why the IDF uses a separate semaphore for
+  // the init handshake and the mutex only for protecting API calls.
+  if (xSemaphoreTake(s_ot_init_done, pdMS_TO_TICKS(5000)) != pdTRUE) {
+    log_e("Error: Timed out waiting for OpenThread stack initialization");
+    otStarted = true;  // force end() to run the full teardown below
     end();
     return;
+  }
+
+  // get the OpenThread instance that will be used for all operations. After the
+  // handshake above the stack is fully up and the persisted dataset (if any) has
+  // already been loaded from NVS, so this check is now reliable.
+  mInstance = esp_openthread_get_instance();
+  if (mInstance == nullptr || !otInstanceIsInitialized(mInstance)) {
+    log_e("Error: Failed to initialize OpenThread instance");
+    otStarted = true;  // force end() to run the full teardown below
+    end();
+    return;
+  }
+
+  // starts Thread with default dataset from NVS or from IDF default settings
+  if (OThreadAutoStart) {
+    // The mainloop is already running on the worker task, so every otXxx() call
+    // from this (non-OT) task must be made while holding the stack lock.
+    OtLock lock;
+    if (!lock) {
+      log_e("Failed to acquire OpenThread lock for auto start");
+    } else {
+      otOperationalDatasetTlvs dataset;
+      otError error = otDatasetGetActiveTlvs(mInstance, &dataset);
+      if (error != OT_ERROR_NONE) {
+        log_i("Failed to get active NVS dataset from OpenThread");
+      } else {
+        log_i("Got active NVS dataset from OpenThread");
+      }
+      esp_err_t err = esp_openthread_auto_start((error == OT_ERROR_NONE) ? &dataset : NULL);
+      if (err != ESP_OK) {
+        log_i("Failed to AUTO start OpenThread");
+      } else {
+        log_i("AUTO start OpenThread done");
+      }
+    }
   }
 
   otStarted = true;
@@ -276,6 +323,14 @@ void OpenThread::end() {
   if (s_ot_task != NULL) {
     vTaskDelete(s_ot_task);
     s_ot_task = NULL;
+  }
+
+  // Delete the init-handshake semaphore only AFTER the worker task is gone, so
+  // it can no longer xSemaphoreGive() a freed handle. Setting it back to NULL
+  // lets a subsequent begin() recreate it cleanly.
+  if (s_ot_init_done != NULL) {
+    vSemaphoreDelete(s_ot_init_done);
+    s_ot_init_done = NULL;
   }
 
   // Clean up in reverse order of initialization
@@ -349,6 +404,11 @@ void OpenThread::commitDataSet(const DataSet &dataset) {
     log_w("Error: OpenThread instance not initialized");
     return;
   }
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return;
+  }
   // Commit the dataset as the active dataset
   otError error = otDatasetSetActive(mInstance, &(dataset.getDataset()));
   if (error != OT_ERROR_NONE) {
@@ -357,6 +417,22 @@ void OpenThread::commitDataSet(const DataSet &dataset) {
   }
   clearAllAddressCache();  // Clear cache when dataset changes
   log_d("Dataset committed successfully");
+}
+
+bool OpenThread::hasActiveDataset() const {
+  if (!mInstance) {
+    log_w("Error: OpenThread instance not initialized");
+    return false;
+  }
+
+  OtLock lock;
+  if (!lock) {
+    log_e("Error: Failed to acquire OpenThread lock");
+    return false;
+  }
+
+  otOperationalDatasetTlvs datasetTlvs;
+  return otDatasetGetActiveTlvs(mInstance, &datasetTlvs) == OT_ERROR_NONE;
 }
 
 ot_device_role_t OpenThread::otGetDeviceRole() {

--- a/libraries/OpenThread/src/OThread.cpp
+++ b/libraries/OpenThread/src/OThread.cpp
@@ -532,7 +532,8 @@ void OpenThread::otPrintNetworkInformation(Stream &output) {
     return;
   }
 
-  output.printf("Role: %s", otGetStringDeviceRole());
+  const otDeviceRole role = otThreadGetDeviceRole(mInstance);
+  output.printf("Role: %s", (role <= OT_DEVICE_ROLE_LEADER) ? otRoleString[role] : otRoleString[5]);
   output.println();
   output.printf("RLOC16: 0x%04x", otThreadGetRloc16(mInstance));  // RLOC16
   output.println();

--- a/libraries/OpenThread/src/OThread.h
+++ b/libraries/OpenThread/src/OThread.h
@@ -98,6 +98,12 @@ public:
   // Set the dataset
   void commitDataSet(const DataSet &dataset);
 
+  // Returns true when OpenThread has a committed Active Operational Dataset.
+  // The dataset may have been loaded from NVS during begin(), or committed by
+  // the application. This is useful when deciding whether to resume an existing
+  // Thread network or provision a new one.
+  bool hasActiveDataset() const;
+
   // Get the Node Network Name
   String getNetworkName() const;
 

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -256,7 +256,10 @@ void OpenThreadCLI::begin() {
     }
   }
 
-  xTaskCreate(ot_cli_loop, "ot_cli", 4096, xTaskGetCurrentTaskHandle(), 2, &s_cli_task);
+  if (xTaskCreate(ot_cli_loop, "ot_cli", 4096, xTaskGetCurrentTaskHandle(), 2, &s_cli_task) != pdPASS || s_cli_task == NULL) {
+    log_e("Error: Failed to create OpenThread CLI task");
+    return;
+  }
   // Initialize the OpenThread CLI. The OpenThread mainloop is already running on
   // its worker task (begin() is only allowed after OpenThread::otStarted), so
   // this direct otCliInit() call must hold the stack lock to avoid racing the

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -266,12 +266,15 @@ void OpenThreadCLI::begin() {
   // mainloop. Note: CLI command *input* later flows through
   // esp_openthread_cli_input(), which is already thread-safe on its own (it
   // marshals the line onto the OpenThread task queue), so it needs no lock here.
-  if (esp_openthread_lock_acquire(portMAX_DELAY)) {
-    otCliInit(esp_openthread_get_instance(), ot_cli_output_callback, NULL);
-    esp_openthread_lock_release();
-  } else {
+  if (!esp_openthread_lock_acquire(portMAX_DELAY)) {
     log_e("Failed to acquire OpenThread lock to initialize the CLI");
+    vTaskDelete(s_cli_task);
+    s_cli_task = NULL;
+    return;
   }
+
+  otCliInit(esp_openthread_get_instance(), ot_cli_output_callback, NULL);
+  esp_openthread_lock_release();
 
   otCLIStarted = true;
   return;

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -81,11 +81,13 @@ static void ot_cli_loop(void *context) {
 
 // process the CLI responses received from the OpenThread stack
 static int ot_cli_output_callback(void *context, const char *format, va_list args) {
-  char prompt_check[3];
-  int ret = 0;
+  char buf[OT_CLI_MAX_LINE_LENGTH];
+  int ret = vsnprintf(buf, sizeof(buf), format, args);
+  if (ret <= 0) {
+    return ret;
+  }
 
-  vsnprintf(prompt_check, sizeof(prompt_check), format, args);
-  if (!strncmp(prompt_check, "> ", sizeof(prompt_check))) {
+  if (!strncmp(buf, "> ", 2)) {
     if (s_cli_task) {
       xTaskNotifyGive(s_cli_task);
     }
@@ -93,27 +95,24 @@ static int ot_cli_output_callback(void *context, const char *format, va_list arg
       xTaskNotifyGive(s_console_cli_task);
     }
   } else {
-    char buf[OT_CLI_MAX_LINE_LENGTH];
-    ret = vsnprintf(buf, sizeof(buf), format, args);
-    if (ret) {
-      // store received data in the RX buffer
-      if (rx_queue != NULL) {
-        size_t freeSpace = uxQueueSpacesAvailable(rx_queue);
-        if (freeSpace < ret) {
-          // Drop the oldest data to make room for the new data
-          for (int i = 0; i < (ret - freeSpace); i++) {
-            uint8_t c;
-            xQueueReceive(rx_queue, &c, 0);
-          }
+    // store received data in the RX buffer
+    if (rx_queue != NULL) {
+      size_t len = (ret < (int)sizeof(buf)) ? (size_t)ret : sizeof(buf) - 1;
+      size_t freeSpace = uxQueueSpacesAvailable(rx_queue);
+      if (freeSpace < len) {
+        // Drop the oldest data to make room for the new data
+        for (size_t i = 0; i < (len - freeSpace); i++) {
+          uint8_t c;
+          xQueueReceive(rx_queue, &c, 0);
         }
-        for (int i = 0; i < ret; i++) {
-          xQueueSend(rx_queue, &buf[i], 0);
-        }
-        // if there is a user callback function in place, it shall have the priority
-        // to process/consume the Stream data received from OpenThread CLI, which is available in its RX Buffer
-        if (otConsole.responseCallBack != nullptr) {
-          otConsole.responseCallBack();
-        }
+      }
+      for (size_t i = 0; i < len; i++) {
+        xQueueSend(rx_queue, &buf[i], 0);
+      }
+      // if there is a user callback function in place, it shall have the priority
+      // to process/consume the Stream data received from OpenThread CLI, which is available in its RX Buffer
+      if (otConsole.responseCallBack != nullptr) {
+        otConsole.responseCallBack();
       }
     }
   }

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -257,8 +257,18 @@ void OpenThreadCLI::begin() {
   }
 
   xTaskCreate(ot_cli_loop, "ot_cli", 4096, xTaskGetCurrentTaskHandle(), 2, &s_cli_task);
-  // Initialize the OpenThread cli
-  otCliInit(esp_openthread_get_instance(), ot_cli_output_callback, NULL);
+  // Initialize the OpenThread CLI. The OpenThread mainloop is already running on
+  // its worker task (begin() is only allowed after OpenThread::otStarted), so
+  // this direct otCliInit() call must hold the stack lock to avoid racing the
+  // mainloop. Note: CLI command *input* later flows through
+  // esp_openthread_cli_input(), which is already thread-safe on its own (it
+  // marshals the line onto the OpenThread task queue), so it needs no lock here.
+  if (esp_openthread_lock_acquire(portMAX_DELAY)) {
+    otCliInit(esp_openthread_get_instance(), ot_cli_output_callback, NULL);
+    esp_openthread_lock_release();
+  } else {
+    log_e("Failed to acquire OpenThread lock to initialize the CLI");
+  }
 
   otCLIStarted = true;
   return;

--- a/libraries/OpenThread/src/OThreadCLI.cpp
+++ b/libraries/OpenThread/src/OThreadCLI.cpp
@@ -97,14 +97,14 @@ static int ot_cli_output_callback(void *context, const char *format, va_list arg
   } else {
     // store received data in the RX buffer
     if (rx_queue != NULL) {
+      const size_t capacity = uxQueueMessagesWaiting(rx_queue) + uxQueueSpacesAvailable(rx_queue);
       size_t len = (ret < (int)sizeof(buf)) ? (size_t)ret : sizeof(buf) - 1;
-      size_t freeSpace = uxQueueSpacesAvailable(rx_queue);
-      if (freeSpace < len) {
-        // Drop the oldest data to make room for the new data
-        for (size_t i = 0; i < (len - freeSpace); i++) {
-          uint8_t c;
-          xQueueReceive(rx_queue, &c, 0);
-        }
+      if (len > capacity) {
+        len = capacity;
+      }
+      while (uxQueueSpacesAvailable(rx_queue) < len) {
+        uint8_t c;
+        xQueueReceive(rx_queue, &c, 0);
       }
       for (size_t i = 0; i < len; i++) {
         xQueueSend(rx_queue, &buf[i], 0);

--- a/libraries/OpenThread/src/OThreadCLI_Util.cpp
+++ b/libraries/OpenThread/src/OThreadCLI_Util.cpp
@@ -81,7 +81,11 @@ bool otExecCommand(const char *cmd, const char *arg, ot_cmd_return_t *returnCode
       cliResp[i] = '\0';
     }
   }
-  log_d("CMD[%s %s] Resp[%s]", cmd, arg, cliResp);
+  if (arg == NULL) {
+    log_d("CMD[%s] Resp[%s]", cmd, cliResp);
+  } else {
+    log_d("CMD[%s %s] Resp[%s]", cmd, arg, cliResp);
+  }
   // initial returnCode is success values
   if (returnCode) {
     returnCode->errorCode = 0;


### PR DESCRIPTION
## Description of Change

This pull request significantly improves thread safety and initialization reliability in the OpenThread integration by introducing a recursive lock (RAII-style) for all OpenThread stack interactions, and by synchronizing stack initialization with a dedicated semaphore. These changes ensure that OpenThread API calls from multiple tasks are properly serialized, prevent race conditions, and avoid resource leaks or double-free errors during initialization and teardown.

The most important changes are:

**Thread Safety and Locking:**

* Introduced the `OtLock` RAII helper struct to acquire and release the OpenThread stack lock automatically, ensuring all OpenThread/DataSet methods that interact with the stack are thread-safe. The lock is now used throughout the codebase for all otXxx()/esp_openthread_* calls made outside the mainloop task.
* Updated all relevant methods (e.g., `start`, `stop`, `networkInterfaceUp`, `networkInterfaceDown`, dataset operations, and various getters) to use `OtLock`, logging errors and aborting the operation if the lock cannot be acquired.

**Initialization and Resource Management:**

* Added a dedicated semaphore (`s_ot_init_done`) to synchronize between the main thread and the OpenThread worker task, ensuring that `begin()` waits until the stack is fully initialized (or failed) before proceeding. This prevents premature access to the instance or dataset and mirrors the behavior of the ESP-IDF implementation.

* Modified the worker task (`ot_task_worker`) to only signal initialization completion and to suspend itself on failure, leaving all resource cleanup and task deletion to `end()`. This avoids double-free or use-after-free errors.
* Ensured the handshake semaphore is created and deleted at the correct points in `begin()` and `end()`, preventing resource leaks and ensuring correct state for repeated start/stop cycles. 

These changes greatly improve the robustness and safety of OpenThread stack usage in a multitasking environment.
 
* Modified `OpenThread::begin()` to wait for the worker task to finish stack initialization before accessing the OpenThread instance or APIs, preventing race conditions and ensuring NVS data is loaded. 

**API enhancements:**

* Added `OpenThread::hasActiveDataset()` to check for a committed active operational dataset, which is useful for deciding whether to resume or provision a Thread network. 

**CLI command and output handling:**

* Improved `ot_cli_output_callback()` to use a single buffer for prompt detection and output, fixed buffer length handling, and ensured correct queue management when storing CLI responses.
* Enhanced CLI command logging in `otExecCommand()` to handle commands with or without arguments more robustly. 


## Test Scenarios
Tested with ESP32-C5, ESP32-C6 and ESP32-H2 using the library examples

## Related links
None