### PR TITLE
fix(httpclient): Replace emplace_back with push_back for headers

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1244,7 +1244,7 @@ int HTTPClient::handleHeaderResponse() {
         }
 
         if (_collectAllHeaders && headerName.length() > 0) {
-          _currentHeaders.emplace_back(headerName, headerValue);
+          _currentHeaders.push_back({headerName, headerValue});
         } else {
           for (size_t i = 0; i < _currentHeaders.size(); ++i) {
             if (_currentHeaders[i].key.equalsIgnoreCase(headerName)) {


### PR DESCRIPTION
## Description of Change

This PR implements the change described in https://github.com/espressif/arduino-esp32/pull/12597#issuecomment-4583213145

## Test Scenarios
CI only

## Related links
Closes https://github.com/espressif/arduino-esp32/pull/12597