### PR TITLE
fix(network): guard NetworkUDP::write() against NULL tx_buffer

### DIFF
--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -274,6 +274,13 @@ int NetworkUDP::endPacket() {
 }
 
 size_t NetworkUDP::write(uint8_t data) {
+  // tx_buffer is only allocated by begin()/beginPacket(). It is NULL before the
+  // first successful beginPacket(), after stop() frees it, or when beginPacket()
+  // failed (e.g. out of memory) and its return value was ignored. Guard against
+  // dereferencing a NULL buffer, which would otherwise crash the device.
+  if (tx_buffer == NULL) {
+    return 0;
+  }
   if (tx_buffer_len == 1460) {
     endPacket();
     tx_buffer_len = 0;


### PR DESCRIPTION
## Description of Change

`NetworkUDP::write(uint8_t)` dereferences `tx_buffer` without a NULL check:

```cpp
size_t NetworkUDP::write(uint8_t data) {
  if (tx_buffer_len == 1460) { endPacket(); tx_buffer_len = 0; }
  tx_buffer[tx_buffer_len++] = data;   // tx_buffer may be NULL
  return 1;
}
```

`tx_buffer` is only allocated by `begin()` / `beginPacket()`. It is `NULL`:

- before the first successful `beginPacket()`,
- after `stop()` (which `free()`s it and sets it to `NULL`),
- when `beginPacket()` failed (e.g. out of memory) and its return value was ignored.

Writing in any of those states dereferences a `NULL` pointer and the device panics (`Guru Meditation Error: StoreProhibited`) and reboots. `write(const uint8_t*, size_t)` loops over the single-byte `write()`, so it crashes on the first byte as well.

This change returns `0` when `tx_buffer == NULL`, matching the `Stream`/`Print` contract for a write that stored nothing. When `tx_buffer` is allocated (the normal path) the behavior is unchanged, so there is no regression.

## Tests scenarios

Reproduced and verified on hardware — **M5 Camera (ESP32)**, arduino-esp32 **3.3.8**, Arduino CLI 1.5.0.

Minimal sketch (no Wi-Fi/network connection required — the crash is purely the `NULL` `tx_buffer`):

```cpp
#include <WiFi.h>
#include <WiFiUdp.h>
WiFiUDP udp;
void setup() {
  Serial.begin(115200);
  delay(3000);
  Serial.println("Calling udp.write('A') without beginPacket()...");
  size_t n = udp.write('A');
  Serial.printf("write() returned %u -> NO CRASH\n", (unsigned)n);
}
void loop() {}
```

**Before this fix** (stock 3.3.8) — panics at `udp.write('A')` and boot-loops:

```
Calling udp.write('A') without beginPacket()...
Guru Meditation Error: Core  1 panic'ed (StoreProhibited). Exception was unhandled.
```

**After this fix** — `write()` returns `0` and the device stays alive (ran 98+ iterations of the call in a loop, no panic):

```
write() returned 0 -> NO CRASH
```

## Related links

None — found via source review of `libraries/Network/src/NetworkUdp.cpp`, reproduced on hardware as shown above.
