### PR TITLE
fix(ble): Use only one app_id per client

### DIFF
--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -516,8 +516,11 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
   rc = m_semaphoreRegEvt.wait("connect");
 
   if (rc != ESP_GATT_OK) {
-    // fixes ESP_GATT_NO_RESOURCES error mostly
     log_e("esp_ble_gattc_app_register_error: rc=%d", rc);
+    if (m_gattc_if != ESP_GATT_IF_NONE) {
+      esp_ble_gattc_app_unregister(m_gattc_if);
+      m_gattc_if = ESP_GATT_IF_NONE;
+    }
     return false;
   }
 
@@ -668,11 +671,7 @@ void BLEClient::gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t
     case ESP_GATTC_SRVC_CHG_EVT: log_i("SERVICE CHANGED"); break;
 
     case ESP_GATTC_CLOSE_EVT:
-    {
-      // esp_ble_gattc_app_unregister(m_gattAppId);
-      // BLEDevice::removePeerDevice(m_gattc_if, true);
       break;
-    }
 
     //
     // ESP_GATTC_DISCONNECT_EVT

--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -111,9 +111,11 @@ BLEClient::BLEClient() {
   m_conn_id = ESP_GATT_IF_NONE;
   m_haveServices = false;
   m_isConnected = false;  // Initially, we are flagged as not connected.
+  m_gattAppId = BLEDevice::getNextAppId();
 
 #if defined(CONFIG_BLUEDROID_ENABLED)
   m_gattc_if = ESP_GATT_IF_NONE;
+  BLEDevice::addPeerDevice(this, true, m_gattAppId);
 #endif
 
 #if defined(CONFIG_NIMBLE_ENABLED)
@@ -137,8 +139,24 @@ BLEClient::BLEClient() {
  * @brief Destructor.
  */
 BLEClient::~BLEClient() {
-  // We may have allocated service references associated with this client.  Before we are finished
-  // with the client, we must release resources.
+#if defined(CONFIG_BLUEDROID_ENABLED)
+  BLEDevice::removePeerDevice(m_gattAppId, true);
+  if (m_gattc_if != ESP_GATT_IF_NONE) {
+    esp_ble_gattc_app_unregister(m_gattc_if);
+    m_gattc_if = ESP_GATT_IF_NONE;
+  }
+#elif defined(CONFIG_NIMBLE_ENABLED)
+  // NimBLE passes `this` directly to ble_gap_connect as the callback arg.
+  // We must keep the object alive until the disconnect event has been delivered.
+  if (m_isConnected) {
+    ble_gap_terminate(m_conn_id, BLE_ERR_REM_USER_CONN_TERM);
+  }
+  unsigned long start = millis();
+  while (m_conn_id != BLE_HS_CONN_HANDLE_NONE && (millis() - start < 2000)) {
+    delay(10);
+  }
+  BLEDevice::removePeerDevice(m_gattAppId, true);
+#endif
   for (auto &myPair : m_servicesMap) {
     delete myPair.second;
   }
@@ -484,18 +502,14 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
     delay(50);  // Give the BLE stack time to settle after stopping scan
   }
 
-  // We need the connection handle that we get from registering the application.  We register the app
-  // and then block on its completion.  When the event has arrived, we will have the handle.
-  m_appId = BLEDevice::m_appId++;
-  BLEDevice::addPeerDevice(this, true, m_appId);
+  // Register the GATT client application to get a gattc_if for this connection.
+  // m_gattAppId was assigned once in the constructor and is stable for the lifetime of this client.
   m_semaphoreRegEvt.take("connect");
-
-  // clearServices(); // we dont need to delete services since every client is unique?
-  log_d("Registering GATT client app (appId=%u)...", m_appId);
-  errRc = ::esp_ble_gattc_app_register(m_appId);
+  log_d("Registering GATT client app (appId=%u)...", m_gattAppId);
+  errRc = ::esp_ble_gattc_app_register(m_gattAppId);
   if (errRc != ESP_OK) {
     log_e("esp_ble_gattc_app_register: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
-    BLEDevice::removePeerDevice(m_appId, true);
+    m_semaphoreRegEvt.give(ESP_GATT_ERROR);
     return false;
   }
 
@@ -504,10 +518,6 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
   if (rc != ESP_GATT_OK) {
     // fixes ESP_GATT_NO_RESOURCES error mostly
     log_e("esp_ble_gattc_app_register_error: rc=%d", rc);
-    BLEDevice::removePeerDevice(m_appId, true);
-    // not sure if this is needed here
-    // esp_ble_gattc_app_unregister(m_gattc_if);
-    // m_gattc_if = ESP_GATT_IF_NONE;
     return false;
   }
 
@@ -542,7 +552,6 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
       // Other errors, don't retry
       log_e("esp_ble_gattc_open: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
       m_semaphoreOpenEvt.give(ESP_GATT_ERROR);  // Release semaphore before cleanup
-      BLEDevice::removePeerDevice(m_appId, true);
       esp_ble_gattc_app_unregister(m_gattc_if);
       m_gattc_if = ESP_GATT_IF_NONE;
       return false;
@@ -553,7 +562,6 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
   if (errRc != ESP_OK) {
     log_e("esp_ble_gattc_open failed after %d retries: rc=%d %s", maxRetries, errRc, GeneralUtils::errorToString(errRc));
     m_semaphoreOpenEvt.give(ESP_GATT_ERROR);  // Release semaphore before cleanup
-    BLEDevice::removePeerDevice(m_appId, true);
     esp_ble_gattc_app_unregister(m_gattc_if);
     m_gattc_if = ESP_GATT_IF_NONE;
     return false;
@@ -568,7 +576,6 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
     log_e("Connection timeout after %" PRIu32 " ms to %s (no OPEN event received)", timeoutMs, address.toString().c_str());
     // Cancel any pending connection attempt
     esp_ble_gap_disconnect(getPeerAddress().getNative());
-    BLEDevice::removePeerDevice(m_appId, true);
     esp_ble_gattc_app_unregister(m_gattc_if);
     m_gattc_if = ESP_GATT_IF_NONE;
     return false;
@@ -576,7 +583,6 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
 
   if (rc != ESP_GATT_OK) {
     log_e("Connection failed to %s, status=%d %s", address.toString().c_str(), rc, GeneralUtils::errorToString(rc));
-    BLEDevice::removePeerDevice(m_appId, true);
     esp_ble_gattc_app_unregister(m_gattc_if);
     m_gattc_if = ESP_GATT_IF_NONE;
     return false;
@@ -663,7 +669,7 @@ void BLEClient::gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t
 
     case ESP_GATTC_CLOSE_EVT:
     {
-      // esp_ble_gattc_app_unregister(m_appId);
+      // esp_ble_gattc_app_unregister(m_gattAppId);
       // BLEDevice::removePeerDevice(m_gattc_if, true);
       break;
     }
@@ -686,10 +692,11 @@ void BLEClient::gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t
       m_isConnected = false;
       esp_ble_gattc_app_unregister(m_gattc_if);
       m_gattc_if = ESP_GATT_IF_NONE;
+      m_conn_id = ESP_GATT_IF_NONE;
       m_semaphoreOpenEvt.give(ESP_GATT_IF_NONE);
       m_semaphoreRssiCmplEvt.give();
       m_semaphoreSearchCmplEvt.give(1);
-      BLEDevice::removePeerDevice(m_appId, true);
+      // Client stays in the peer map until the object is destroyed.
       // Reset security state on disconnect
       BLESecurity::resetSecurity();
       if (m_wasConnected && m_pClientCallbacks != nullptr) {
@@ -751,7 +758,6 @@ void BLEClient::gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t
       if (evtParam->connect.conn_id != getConnId()) {
         break;
       }
-      BLEDevice::updatePeerDevice(this, true, m_appId);
       esp_err_t errRc = esp_ble_gattc_send_mtu_req(gattc_if, evtParam->connect.conn_id);
       if (errRc != ESP_OK) {
         log_e("esp_ble_gattc_send_mtu_req: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
@@ -946,7 +952,6 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
     return false;
   }
 
-  m_appId = BLEDevice::m_appId++;
   m_peerAddress = address;
 
   int rc = 0;
@@ -1019,7 +1024,7 @@ bool BLEClient::connect(BLEAddress address, uint8_t type, uint32_t timeoutMs) {
 
   log_i("<< connect()");
 
-  BLEDevice::addPeerDevice(this, true, m_appId);
+  BLEDevice::addPeerDevice(this, true, m_gattAppId);
   // Check if still connected before returning
   return isConnected();
 }
@@ -1140,7 +1145,7 @@ int BLEClient::handleGAPEvent(struct ble_gap_event *event, void *arg) {
 
       log_i("BLEClient", "disconnect; reason=%d, %s", rc, BLEUtils::returnCodeToString(rc));
 
-      BLEDevice::removePeerDevice(client->m_appId, true);
+      BLEDevice::removePeerDevice(client->m_gattAppId, true);
       client->m_isConnected = false;
       // Reset security state on disconnect
       BLESecurity::resetSecurity();

--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -670,8 +670,7 @@ void BLEClient::gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t
 
     case ESP_GATTC_SRVC_CHG_EVT: log_i("SERVICE CHANGED"); break;
 
-    case ESP_GATTC_CLOSE_EVT:
-      break;
+    case ESP_GATTC_CLOSE_EVT: break;
 
     //
     // ESP_GATTC_DISCONNECT_EVT

--- a/libraries/BLE/src/BLEClient.h
+++ b/libraries/BLE/src/BLEClient.h
@@ -97,7 +97,8 @@ public:
    *                            Common public properties                     *
    ***************************************************************************/
 
-  uint16_t m_appId;
+  /** GATT application id passed to esp_ble_gattc_app_register / used as peer map key. */
+  uint16_t m_gattAppId;
 
   /***************************************************************************
    *                           Common public declarations                    *

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -1047,15 +1047,8 @@ uint16_t BLEDevice::getNextAppId() {
   portENTER_CRITICAL(&mux);
   uint16_t id = m_appId++;
 #if defined(CONFIG_BLUEDROID_ENABLED)
-  if (m_appId == ESP_GATT_IF_NONE) {
-    m_appId++;
-  }
   if (m_appId > ESP_APP_ID_MAX) {
     m_appId = 0;
-  }
-#elif defined(CONFIG_NIMBLE_ENABLED)
-  if (m_appId == ESP_GATT_IF_NONE) {
-    m_appId++;
   }
 #endif
   portEXIT_CRITICAL(&mux);

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -193,7 +193,7 @@ BLEServer *BLEDevice::createServer() {
 
   if (m_pServer == nullptr) {
     m_pServer = new BLEServer();
-    m_pServer->createApp(m_appId++);
+    m_pServer->createApp(getNextAppId());
 #if defined(CONFIG_NIMBLE_ENABLED)
     ble_gatts_reset();
     ble_svc_gap_init();
@@ -1043,20 +1043,23 @@ BLEClient *BLEDevice::getClientByAddress(BLEAddress address) {
   return nullptr;
 }
 
-void BLEDevice::updatePeerDevice(void *peer, bool _client, uint16_t conn_id) {
-  log_d("update conn_id: %u, GATT role: %s", conn_id, _client ? "client" : "server");
-  std::map<uint16_t, conn_status_t>::iterator it = m_connectedClientsMap.find(ESP_GATT_IF_NONE);
-  if (it != m_connectedClientsMap.end()) {
-    std::swap(m_connectedClientsMap[conn_id], it->second);
-    m_connectedClientsMap.erase(it);
-  } else {
-    it = m_connectedClientsMap.find(conn_id);
-    if (it != m_connectedClientsMap.end()) {
-      conn_status_t _st = it->second;
-      _st.peer_device = peer;
-      std::swap(m_connectedClientsMap[conn_id], _st);
-    }
+uint16_t BLEDevice::getNextAppId() {
+  portENTER_CRITICAL(&mux);
+  uint16_t id = m_appId++;
+#if defined(CONFIG_BLUEDROID_ENABLED)
+  if (m_appId == ESP_GATT_IF_NONE) {
+    m_appId++;
   }
+  if (m_appId > ESP_APP_ID_MAX) {
+    m_appId = 0;
+  }
+#elif defined(CONFIG_NIMBLE_ENABLED)
+  if (m_appId == ESP_GATT_IF_NONE) {
+    m_appId++;
+  }
+#endif
+  portEXIT_CRITICAL(&mux);
+  return id;
 }
 
 void BLEDevice::addPeerDevice(void *peer, bool _client, uint16_t conn_id) {
@@ -1271,10 +1274,16 @@ void BLEDevice::gattClientEventHandler(esp_gattc_cb_event_t event, esp_gatt_if_t
     default: break;
   }  // switch
   for (auto &myPair : BLEDevice::getPeerDevices(true)) {
-    conn_status_t conn_status = (conn_status_t)myPair.second;
-    if (((BLEClient *)conn_status.peer_device)->getGattcIf() == gattc_if || ((BLEClient *)conn_status.peer_device)->getGattcIf() == ESP_GATT_IF_NONE
-        || gattc_if == ESP_GATT_IF_NONE) {
-      ((BLEClient *)conn_status.peer_device)->gattClientEventHandler(event, gattc_if, param);
+    BLEClient *client = (BLEClient *)myPair.second.peer_device;
+    esp_gatt_if_t client_if = client->getGattcIf();
+    bool dispatch = false;
+    if (client_if != ESP_GATT_IF_NONE && client_if == gattc_if) {
+      dispatch = true;
+    } else if (event == ESP_GATTC_REG_EVT && myPair.first == param->reg.app_id) {
+      dispatch = true;
+    }
+    if (dispatch) {
+      client->gattClientEventHandler(event, gattc_if, param);
     }
   }
 

--- a/libraries/BLE/src/BLEDevice.h
+++ b/libraries/BLE/src/BLEDevice.h
@@ -224,7 +224,6 @@ public:
   static void stopAdvertising();
   static std::map<uint16_t, conn_status_t> getPeerDevices(bool client);
   static void addPeerDevice(void *peer, bool is_client, uint16_t conn_id);
-  static void updatePeerDevice(void *peer, bool _client, uint16_t conn_id);
   static void removePeerDevice(uint16_t conn_id, bool client);
   static BLEClient *getClientByID(uint16_t conn_id);
   static BLEClient *getClientByAddress(BLEAddress address);
@@ -283,6 +282,7 @@ private:
   static std::map<uint16_t, conn_status_t> m_connectedClientsMap;
   static portMUX_TYPE mux;
   static String m_deviceName;
+  static uint16_t getNextAppId();
 
   /***************************************************************************
    *                        NimBLE private properties                        *

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -93,7 +93,7 @@ BLEServer::BLEServer() {
   m_advertiseOnDisconnect = false;
 #endif
 
-  m_appId = ESP_GATT_IF_NONE;
+  m_gattAppId = ESP_GATT_IF_NONE;
   m_gattsStarted = false;
   m_connectedCount = 0;
   m_connId = ESP_GATT_IF_NONE;
@@ -101,7 +101,7 @@ BLEServer::BLEServer() {
 }  // BLEServer
 
 void BLEServer::createApp(uint16_t appId) {
-  m_appId = appId;
+  m_gattAppId = appId;
 #ifdef CONFIG_BLUEDROID_ENABLED
   registerApp(appId);
 #endif
@@ -654,10 +654,10 @@ void BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t 
  *
  * @return N/A
  */
-void BLEServer::registerApp(uint16_t m_appId) {
-  log_v(">> registerApp - %u", m_appId);
+void BLEServer::registerApp(uint16_t m_gattAppId) {
+  log_v(">> registerApp - %u", m_gattAppId);
   m_semaphoreRegisterAppEvt.take("registerApp");  // Take the mutex, will be released by ESP_GATTS_REG_EVT event.
-  ::esp_ble_gatts_app_register(m_appId);
+  ::esp_ble_gatts_app_register(m_gattAppId);
   m_semaphoreRegisterAppEvt.wait("registerApp");
   log_v("<< registerApp");
 }  // registerApp

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -654,10 +654,10 @@ void BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t 
  *
  * @return N/A
  */
-void BLEServer::registerApp(uint16_t m_gattAppId) {
-  log_v(">> registerApp - %u", m_gattAppId);
+void BLEServer::registerApp(uint16_t appId) {
+  log_v(">> registerApp - %u", appId);
   m_semaphoreRegisterAppEvt.take("registerApp");  // Take the mutex, will be released by ESP_GATTS_REG_EVT event.
-  ::esp_ble_gatts_app_register(m_gattAppId);
+  ::esp_ble_gatts_app_register(appId);
   m_semaphoreRegisterAppEvt.wait("registerApp");
   log_v("<< registerApp");
 }  // registerApp

--- a/libraries/BLE/src/BLEServer.h
+++ b/libraries/BLE/src/BLEServer.h
@@ -133,7 +133,8 @@ public:
    *                        Common public properties                         *
    ***************************************************************************/
 
-  uint16_t m_appId;
+  /** GATT application id passed to esp_ble_gatts_app_register. */
+  uint16_t m_gattAppId;
 
   /***************************************************************************
    *                       Common public declarations                        *

--- a/tests/validation/ble/client/client.ino
+++ b/tests/validation/ble/client/client.ino
@@ -7,6 +7,9 @@ static BLEUUID serviceUUID("4fafc201-1fb5-459e-8fcc-c5c9c331914b");
 static BLEUUID insecureCharUUID("beb5483e-36e1-4688-b7f5-ea07361b26a8");
 static BLEUUID secureCharUUID("ff1d2614-e2d6-4c87-9154-6625d39ca7f8");
 
+static const int RECONNECT_CYCLES = 10;
+static const uint16_t APPID_PRESEED_GATT_IF_NONE = 250;  // crosses ESP_GATT_IF_NONE (0xFF on Bluedroid)
+
 String targetServerName = "";
 static boolean doConnect = false;
 static boolean connected = false;
@@ -162,6 +165,43 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
   }
 };
 
+bool runReconnectPhase(uint16_t preseed, const char *label) {
+  Serial.printf("[CLIENT] Reconnect phase: crossing %s (preseed=%u)\n", label, preseed);
+  BLEDevice::m_appId = preseed;
+
+  for (int i = 0; i < RECONNECT_CYCLES; i++) {
+    Serial.printf("[CLIENT] Reconnect cycle %d/%d starting\n", i + 1, RECONNECT_CYCLES);
+
+    BLEClient *pReconnectClient = BLEDevice::createClient();
+    if (pReconnectClient == nullptr) {
+      Serial.printf("[CLIENT] Reconnect cycle %d/%d FAILED: createClient returned null\n", i + 1, RECONNECT_CYCLES);
+      return false;
+    }
+
+    if (!pReconnectClient->connect(myDevice->getAddress(), myDevice->getAddressType(), 10000)) {
+      Serial.printf("[CLIENT] Reconnect cycle %d/%d FAILED: connect failed\n", i + 1, RECONNECT_CYCLES);
+      delete pReconnectClient;
+      return false;
+    }
+
+    BLERemoteService *pSvc = pReconnectClient->getService(serviceUUID);
+    if (pSvc != nullptr) {
+      BLERemoteCharacteristic *pChr = pSvc->getCharacteristic(insecureCharUUID);
+      if (pChr != nullptr && pChr->canRead()) {
+        String val = pChr->readValue();
+        Serial.printf("[CLIENT] Reconnect cycle %d/%d read: %s\n", i + 1, RECONNECT_CYCLES, val.c_str());
+      }
+    }
+
+    pReconnectClient->disconnect();
+    delete pReconnectClient;
+    Serial.printf("[CLIENT] Reconnect cycle %d/%d OK\n", i + 1, RECONNECT_CYCLES);
+  }
+
+  Serial.printf("[CLIENT] Reconnect phase %s PASSED\n", label);
+  return true;
+}
+
 void readServerName() {
   Serial.println("[CLIENT] Waiting for server name...");
   Serial.println("[CLIENT] Send server name:");
@@ -262,6 +302,23 @@ void loop() {
     }
 
     Serial.println("[CLIENT] Test operations completed");
+
+    // --- Reconnection stress test (app_id collision regression) ---
+    // Disconnect from the current connection first
+    Serial.println("[CLIENT] Starting reconnection stress test");
+    pClient->disconnect();
+    delay(1000);
+
+    // Cross ESP_GATT_IF_NONE boundary (0xFF on Bluedroid, 0xFFFF on NimBLE).
+    // Each new BLEClient gets its ID from the global counter, so pre-seeding the
+    // counter to 250 forces the first few clients to cross the 0xFF boundary.
+    bool passed = runReconnectPhase(APPID_PRESEED_GATT_IF_NONE, "ESP_GATT_IF_NONE");
+
+    if (passed) {
+      Serial.println("[CLIENT] Reconnection stress test PASSED");
+    } else {
+      Serial.println("[CLIENT] Reconnection stress test FAILED");
+    }
   }
 
   delay(1000);

--- a/tests/validation/ble/server/server.ino
+++ b/tests/validation/ble/server/server.ino
@@ -11,17 +11,18 @@
 
 String serverName = "";
 static bool deviceConnected = false;
+static int connectionCount = 0;
 
 class MyServerCallbacks : public BLEServerCallbacks {
   void onConnect(BLEServer *pServer) {
     deviceConnected = true;
-    Serial.println("[SERVER] Client connected");
+    connectionCount++;
+    Serial.printf("[SERVER] Client connected (count: %d)\n", connectionCount);
   }
 
   void onDisconnect(BLEServer *pServer) {
     deviceConnected = false;
-    Serial.println("[SERVER] Client disconnected");
-    // Restart advertising after disconnect
+    Serial.printf("[SERVER] Client disconnected (count: %d)\n", connectionCount);
     BLEDevice::startAdvertising();
     Serial.println("[SERVER] Advertising restarted");
   }

--- a/tests/validation/ble/test_ble.py
+++ b/tests/validation/ble/test_ble.py
@@ -140,8 +140,29 @@ def test_ble(dut, ci_job_id):
     client.expect_exact("[CLIENT] Test operations completed", timeout=10)
     LOGGER.info("All characteristic operations completed successfully")
 
-    # Verify connection status
-    LOGGER.info("Verifying connection status...")
-    server.expect_exact("[SERVER] Status: Connected", timeout=5)
+    LOGGER.info("Security and characteristic test passed!")
+
+    # --- Reconnection stress test (app_id collision regression, issue #12625) ---
+    # The client disconnects, pre-seeds the allocator, and reconnects in a loop.
+    # We only rely on client-side messages for synchronization since server periodic
+    # "Status" messages can interleave and cause pexpect buffer position issues.
+    LOGGER.info("Starting reconnection stress test (app_id boundary crossing)...")
+    client.expect_exact("[CLIENT] Starting reconnection stress test", timeout=15)
+
+    reconnect_cycles = 10
+
+    # Crossing ESP_GATT_IF_NONE boundary (0xFF on Bluedroid, 0xFFFF on NimBLE)
+    LOGGER.info("Crossing ESP_GATT_IF_NONE boundary...")
+    client.expect(r"\[CLIENT\] Reconnect phase: crossing ESP_GATT_IF_NONE", timeout=10)
+
+    for i in range(1, reconnect_cycles + 1):
+        LOGGER.info(f"Reconnect cycle {i}/{reconnect_cycles}...")
+        client.expect_exact(f"[CLIENT] Reconnect cycle {i}/{reconnect_cycles} OK", timeout=20)
+
+    client.expect(r"\[CLIENT\] Reconnect phase ESP_GATT_IF_NONE PASSED", timeout=10)
+    LOGGER.info("Reconnect phase passed")
+
+    client.expect_exact("[CLIENT] Reconnection stress test PASSED", timeout=10)
+    LOGGER.info("Reconnection stress test passed")
 
     LOGGER.info("BLE test passed!")


### PR DESCRIPTION
## Description of Change

This pull request refactors the management of GATT application IDs (`appId`) for both BLE client and server objects, ensuring correct handling of ID assignment, especially across boundary values like `ESP_GATT_IF_NONE`. It introduces a new method for generating application IDs, updates the peer device management logic, and adds a reconnection stress test to validate the robustness of these changes. The changes help prevent resource leaks and potential collisions in BLE client/server connections.

**GATT Application ID Management and Refactoring:**

- Introduced `getNextAppId()` in `BLEDevice` to safely generate unique GATT application IDs, handling wrap-around and avoiding reserved values like `ESP_GATT_IF_NONE`. Both `BLEClient` and `BLEServer` now use `m_gattAppId` instead of `m_appId`, and all related code and method signatures have been updated accordingly. [[1]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8L1046-R1062) [[2]](diffhunk://#diff-076e56fe388d1558bb95fedc1f0b1e8bceb94d61d8380da286518c165833a591L100-R101) [[3]](diffhunk://#diff-3ca371b1423c263a68afe4b35292964b3b9abbf5ffe96c8d1c7aad36d84c7ab5L96-R104) [[4]](diffhunk://#diff-3ca371b1423c263a68afe4b35292964b3b9abbf5ffe96c8d1c7aad36d84c7ab5L657-R660) [[5]](diffhunk://#diff-af84440118c6afb89da33a7e9a448071718aa7ae01c4dc2e82166ac2cc931f93L136-R137) [[6]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aR114-R118) [[7]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8L196-R196)

- Removed the `updatePeerDevice` method and refactored peer device management to use the new application ID approach, ensuring clients remain tracked until destruction and simplifying cleanup logic. [[1]](diffhunk://#diff-7d54983ed6d61fa10de96e316460c65092dacd07e0d18042d0bdefa5bd699886L227) [[2]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL754) [[3]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aR695-R699) [[4]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL140-R159) [[5]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL487-R512) [[6]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL507-L510) [[7]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL545) [[8]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL556) [[9]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL571-L579) [[10]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL949) [[11]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL1022-R1027) [[12]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL1143-R1148)

**Event Handling and Dispatch Improvements:**

- Updated event handler logic in `BLEDevice::gattClientEventHandler` to correctly dispatch events to the appropriate `BLEClient` based on the new application ID system, especially during registration events. [[1]](diffhunk://#diff-beb1fd7ad661682624af589b256695f8022e4c44567282cb748ddbc3893541e8L1274-R1286) [[2]](diffhunk://#diff-f70eb436d84697da8592a35b11b350bc18ff8962bb1214860b97dbeae287da3aL666-R672)

**Testing and Validation Enhancements:**

- Added a reconnection stress test in `tests/validation/ble/client/client.ino` that pre-seeds the application ID counter near the reserved boundary, repeatedly creates and destroys clients, and verifies correct operation across the boundary value. This helps catch regressions related to app ID collisions. [[1]](diffhunk://#diff-3a6ffb6ae7c472687175ba46332e4d5f89fc6c471b9caf36fa8bae0b646d4cc7R10-R12) [[2]](diffhunk://#diff-3a6ffb6ae7c472687175ba46332e4d5f89fc6c471b9caf36fa8bae0b646d4cc7R168-R204) [[3]](diffhunk://#diff-3a6ffb6ae7c472687175ba46332e4d5f89fc6c471b9caf36fa8bae0b646d4cc7R305-R321)

**Minor Improvements:**

- Enhanced server connection logging in `server.ino` to include a connection count for better traceability during tests.

These changes collectively improve BLE client/server stability, prevent resource leaks, and ensure robust handling of GATT application IDs across their full range.

## Test Scenarios

Tested locally

## Related links

Closes #12625
