### PR TITLE
feat(periman): Add esp-hosted to peripheral manager + minor updates to LDO 

### DIFF
--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -347,8 +347,8 @@ static bool hostedInit() {
   err = esp_hosted_connect_to_slave();
   if (err != ESP_OK) {
     log_e("esp_hosted_connect_to_slave failed: %s", esp_err_to_name(err));
+    esp_hosted_deinit();    
     hosted_initialized = false;
-    esp_hosted_deinit();
     hostedClearPinBuses();
     return false;
   }
@@ -363,13 +363,12 @@ static bool hostedDeinit() {
     return false;
   }
 
-  hosted_initialized = false;
-
   if (esp_hosted_deinit() != ESP_OK) {
     log_e("esp_hosted_deinit failed!");
     return false;
   }
-
+  
+  hosted_initialized = false;
   hostedClearPinBuses();
   return true;
 }

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -17,6 +17,7 @@
 
 #include "esp32-hal-hosted.h"
 #include "esp32-hal-log.h"
+#include "esp32-hal-periman.h"
 #include "esp32-hal.h"
 #include "pins_arduino.h"
 
@@ -56,6 +57,9 @@ static esp_hosted_coprocessor_fwver_t host_version_struct = {
 
 static bool hostedInit();
 static bool hostedDeinit();
+static bool hostedDetachBus(void *bus_pointer);
+static bool hostedClearPinBuses(void);
+static bool hostedAssignPinBuses(void);
 
 void hostedGetHostVersion(uint32_t *major, uint32_t *minor, uint32_t *patch) {
   *major = host_version_struct.major1;
@@ -214,54 +218,139 @@ bool hostedActivateUpdate() {
   return true;
 }
 
-static bool hostedInit() {
+static bool hostedClearPinBuses(void) {
+  if (!perimanClearPinBus((uint8_t)sdio_pin_config.pin_clk)) {
+    return false;
+  }
+  if (!perimanClearPinBus((uint8_t)sdio_pin_config.pin_cmd)) {
+    return false;
+  }
+  if (!perimanClearPinBus((uint8_t)sdio_pin_config.pin_d0)) {
+    return false;
+  }
+  if (!perimanClearPinBus((uint8_t)sdio_pin_config.pin_d1)) {
+    return false;
+  }
+  if (!perimanClearPinBus((uint8_t)sdio_pin_config.pin_d2)) {
+    return false;
+  }
+  if (!perimanClearPinBus((uint8_t)sdio_pin_config.pin_d3)) {
+    return false;
+  }
+  if (!perimanClearPinBus((uint8_t)sdio_pin_config.pin_reset)) {
+    return false;
+  }
+  return true;
+}
+
+static bool hostedAssignPinBuses(void) {
+  void *const bus = (void *)&sdio_pin_config;
+
+  if (!perimanSetPinBus((uint8_t)sdio_pin_config.pin_clk, ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CLK, bus, 0, -1)) {
+    return false;
+  }
+  if (!perimanSetPinBus((uint8_t)sdio_pin_config.pin_cmd, ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CMD, bus, 0, -1)) {
+    return false;
+  }
+  if (!perimanSetPinBus((uint8_t)sdio_pin_config.pin_d0, ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D0, bus, 0, -1)) {
+    return false;
+  }
+  if (!perimanSetPinBus((uint8_t)sdio_pin_config.pin_d1, ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D1, bus, 0, -1)) {
+    return false;
+  }
+  if (!perimanSetPinBus((uint8_t)sdio_pin_config.pin_d2, ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D2, bus, 0, -1)) {
+    return false;
+  }
+  if (!perimanSetPinBus((uint8_t)sdio_pin_config.pin_d3, ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D3, bus, 0, -1)) {
+    return false;
+  }
+  if (!perimanSetPinBus((uint8_t)sdio_pin_config.pin_reset, ESP32_BUS_TYPE_ESP_HOSTED_SDIO_RST, bus, 0, -1)) {
+    return false;
+  }
+  return true;
+}
+
+static bool hostedDetachBus(void *bus_pointer) {
+  if (bus_pointer != (void *)&sdio_pin_config) {
+    return false;
+  }
   if (!hosted_initialized) {
-    log_i("Initializing ESP-Hosted");
-    log_d(
-      "SDIO pins: clk=%d, cmd=%d, d0=%d, d1=%d, d2=%d, d3=%d, rst=%d", sdio_pin_config.pin_clk, sdio_pin_config.pin_cmd, sdio_pin_config.pin_d0,
-      sdio_pin_config.pin_d1, sdio_pin_config.pin_d2, sdio_pin_config.pin_d3, sdio_pin_config.pin_reset
-    );
-    hosted_initialized = true;
-    struct esp_hosted_sdio_config conf = INIT_DEFAULT_HOST_SDIO_CONFIG();
-    conf.pin_clk.pin = sdio_pin_config.pin_clk;
-    conf.pin_cmd.pin = sdio_pin_config.pin_cmd;
-    conf.pin_d0.pin = sdio_pin_config.pin_d0;
-    conf.pin_d1.pin = sdio_pin_config.pin_d1;
-    conf.pin_d2.pin = sdio_pin_config.pin_d2;
-    conf.pin_d3.pin = sdio_pin_config.pin_d3;
-    conf.pin_reset.pin = sdio_pin_config.pin_reset;
-    esp_err_t err = esp_hosted_sdio_set_config(&conf);
-    if (err != ESP_OK) {  //&& err != ESP_ERR_NOT_ALLOWED) { // uncomment when second init is fixed
-      log_e("esp_hosted_sdio_set_config failed: %s", esp_err_to_name(err));
-      return false;
-    }
-    err = esp_hosted_init();
-    if (err != ESP_OK) {
-      log_e("esp_hosted_init failed: %s", esp_err_to_name(err));
-      hosted_initialized = false;
-      return false;
-    }
-    log_i("ESP-Hosted initialized!");
-    err = esp_hosted_connect_to_slave();
-    if (err != ESP_OK) {
-      log_e("esp_hosted_connect_to_slave failed: %s", esp_err_to_name(err));
-      hosted_initialized = false;
-      return false;
-    }
-    hostedHasUpdate();
+    return true;
+  }
+  hosted_wifi_active = false;
+  hosted_ble_active = false;
+  return hostedDeinit();
+}
+
+static bool hostedInit() {
+  if (hosted_initialized) {
     return true;
   }
 
-  // Attach pins to PeriMan here
-  // Slave chip model is CONFIG_IDF_SLAVE_TARGET
-  // sdio_pin_config.pin_clk
-  // sdio_pin_config.pin_cmd
-  // sdio_pin_config.pin_d0
-  // sdio_pin_config.pin_d1
-  // sdio_pin_config.pin_d2
-  // sdio_pin_config.pin_d3
-  // sdio_pin_config.pin_reset
+  log_i("Initializing ESP-Hosted");
+  log_d(
+    "SDIO pins: clk=%d, cmd=%d, d0=%d, d1=%d, d2=%d, d3=%d, rst=%d", sdio_pin_config.pin_clk, sdio_pin_config.pin_cmd, sdio_pin_config.pin_d0,
+    sdio_pin_config.pin_d1, sdio_pin_config.pin_d2, sdio_pin_config.pin_d3, sdio_pin_config.pin_reset
+  );
 
+  perimanSetBusDeinit(ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CLK, hostedDetachBus);
+  perimanSetBusDeinit(ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CMD, hostedDetachBus);
+  perimanSetBusDeinit(ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D0, hostedDetachBus);
+  perimanSetBusDeinit(ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D1, hostedDetachBus);
+  perimanSetBusDeinit(ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D2, hostedDetachBus);
+  perimanSetBusDeinit(ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D3, hostedDetachBus);
+  perimanSetBusDeinit(ESP32_BUS_TYPE_ESP_HOSTED_SDIO_RST, hostedDetachBus);
+
+  if (!hostedClearPinBuses()) {
+    log_e("ESP-Hosted: failed to clear SDIO pins from peripheral manager");
+    return false;
+  }
+
+  // Assign before SDIO bring-up: periman auto-LDO (VO4) must be on for GPIO 39-48
+  // (e.g. core board D2/D3). ESP-Hosted does not enable it (SD_PWR_CTRL_LDO_INTERNAL_IO off).
+  if (!hostedAssignPinBuses()) {
+    log_e("ESP-Hosted: failed to assign SDIO pins to peripheral manager");
+    return false;
+  }
+
+  hosted_initialized = true;
+
+  struct esp_hosted_sdio_config conf = INIT_DEFAULT_HOST_SDIO_CONFIG();
+  conf.pin_clk.pin = sdio_pin_config.pin_clk;
+  conf.pin_cmd.pin = sdio_pin_config.pin_cmd;
+  conf.pin_d0.pin = sdio_pin_config.pin_d0;
+  conf.pin_d1.pin = sdio_pin_config.pin_d1;
+  conf.pin_d2.pin = sdio_pin_config.pin_d2;
+  conf.pin_d3.pin = sdio_pin_config.pin_d3;
+  conf.pin_reset.pin = sdio_pin_config.pin_reset;
+
+  esp_err_t err = esp_hosted_sdio_set_config(&conf);
+  if (err != ESP_OK) {  //&& err != ESP_ERR_NOT_ALLOWED) { // uncomment when second init is fixed
+    log_e("esp_hosted_sdio_set_config failed: %s", esp_err_to_name(err));
+    hosted_initialized = false;
+    hostedClearPinBuses();
+    return false;
+  }
+
+  err = esp_hosted_init();
+  if (err != ESP_OK) {
+    log_e("esp_hosted_init failed: %s", esp_err_to_name(err));
+    hosted_initialized = false;
+    hostedClearPinBuses();
+    return false;
+  }
+  log_i("ESP-Hosted initialized!");
+
+  err = esp_hosted_connect_to_slave();
+  if (err != ESP_OK) {
+    log_e("esp_hosted_connect_to_slave failed: %s", esp_err_to_name(err));
+    hosted_initialized = false;
+    esp_hosted_deinit();
+    hostedClearPinBuses();
+    return false;
+  }
+
+  hostedHasUpdate();
   return true;
 }
 
@@ -271,12 +360,14 @@ static bool hostedDeinit() {
     return false;
   }
 
+  hosted_initialized = false;
+
   if (esp_hosted_deinit() != ESP_OK) {
     log_e("esp_hosted_deinit failed!");
     return false;
   }
 
-  hosted_initialized = false;
+  hostedClearPinBuses();
   return true;
 }
 

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -61,8 +61,6 @@ static bool hostedDeinit();
 static bool hostedDetachBus(void *bus_pointer);
 static bool hostedClearPinBuses(void);
 static bool hostedAssignPinBuses(void);
-static bool hostedSdioPinValid(uint8_t pin);
-static bool hostedSdioPinsValid(void);
 
 void hostedGetHostVersion(uint32_t *major, uint32_t *minor, uint32_t *patch) {
   *major = host_version_struct.major1;

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -307,7 +307,6 @@ static bool hostedInit() {
   }
 
   // Assign before SDIO bring-up: periman auto-LDO (VO4) must be on for GPIO 39-48
-  // (e.g. core board D2/D3). ESP-Hosted does not enable it (SD_PWR_CTRL_LDO_INTERNAL_IO off).
   if (!hostedAssignPinBuses()) {
     log_e("ESP-Hosted: failed to assign SDIO pins to peripheral manager");
     return false;

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -275,12 +275,11 @@ static bool hostedDetachBus(void *bus_pointer) {
   if (bus_pointer != (void *)&sdio_pin_config) {
     return false;
   }
-  if (!hosted_initialized) {
-    return true;
+  if (hosted_initialized) {
+    log_e("ESP-Hosted: stop WiFi/BLE before removing SDIO pins from periman");
+    return false;
   }
-  hosted_wifi_active = false;
-  hosted_ble_active = false;
-  return hostedDeinit();
+  return true;
 }
 
 static bool hostedInit() {
@@ -326,7 +325,6 @@ static bool hostedInit() {
   esp_err_t err = esp_hosted_sdio_set_config(&conf);
   if (err != ESP_OK) {  //&& err != ESP_ERR_NOT_ALLOWED) { // uncomment when second init is fixed
     log_e("esp_hosted_sdio_set_config failed: %s", esp_err_to_name(err));
-    hosted_initialized = false;
     hostedClearPinBuses();
     return false;
   }
@@ -334,7 +332,6 @@ static bool hostedInit() {
   err = esp_hosted_init();
   if (err != ESP_OK) {
     log_e("esp_hosted_init failed: %s", esp_err_to_name(err));
-    hosted_initialized = false;
     hostedClearPinBuses();
     return false;
   }
@@ -342,7 +339,6 @@ static bool hostedInit() {
   if (err != ESP_OK) {
     log_e("esp_hosted_connect_to_slave failed: %s", esp_err_to_name(err));
     esp_hosted_deinit();
-    hosted_initialized = false;
     hostedClearPinBuses();
     return false;
   }
@@ -362,7 +358,6 @@ static bool hostedDeinit() {
     log_e("esp_hosted_deinit failed!");
     return false;
   }
-  
   hosted_initialized = false;
   hostedClearPinBuses();
   return true;

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -20,6 +20,7 @@
 #include "esp32-hal-periman.h"
 #include "esp32-hal.h"
 #include "pins_arduino.h"
+#include "soc/soc_caps.h"
 
 #include "esp_hosted.h"
 #include "esp_hosted_transport_config.h"
@@ -60,6 +61,8 @@ static bool hostedDeinit();
 static bool hostedDetachBus(void *bus_pointer);
 static bool hostedClearPinBuses(void);
 static bool hostedAssignPinBuses(void);
+static bool hostedSdioPinValid(uint8_t pin);
+static bool hostedSdioPinsValid(void);
 
 void hostedGetHostVersion(uint32_t *major, uint32_t *minor, uint32_t *patch) {
   *major = host_version_struct.major1;
@@ -287,11 +290,6 @@ static bool hostedInit() {
     return true;
   }
 
-  if (sdio_pin_config.pin_clk < 0 || sdio_pin_config.pin_cmd < 0 || sdio_pin_config.pin_d0 < 0 || sdio_pin_config.pin_d1 < 0 || sdio_pin_config.pin_d2 < 0 || sdio_pin_config.pin_d3 < 0 || sdio_pin_config.pin_reset < 0) {
-    log_e("ESP-Hosted: all SDIO pins must be defined");
-    return false;
-  }
-
   log_i("Initializing ESP-Hosted");
   log_d(
     "SDIO pins: clk=%d, cmd=%d, d0=%d, d1=%d, d2=%d, d3=%d, rst=%d", sdio_pin_config.pin_clk, sdio_pin_config.pin_cmd, sdio_pin_config.pin_d0,
@@ -311,12 +309,12 @@ static bool hostedInit() {
     return false;
   }
 
+  // Assign before SDIO pins before configuration to turn on LDO when needed
+  if (!hostedAssignPinBuses()) {
     log_e("ESP-Hosted: failed to assign SDIO pins to peripheral manager");
-    return false;
     hostedClearPinBuses();
+    return false;
   }
-
-  hosted_initialized = true;
 
   struct esp_hosted_sdio_config conf = INIT_DEFAULT_HOST_SDIO_CONFIG();
   conf.pin_clk.pin = sdio_pin_config.pin_clk;
@@ -342,17 +340,16 @@ static bool hostedInit() {
     hostedClearPinBuses();
     return false;
   }
-  log_i("ESP-Hosted initialized!");
-
   err = esp_hosted_connect_to_slave();
   if (err != ESP_OK) {
     log_e("esp_hosted_connect_to_slave failed: %s", esp_err_to_name(err));
-    esp_hosted_deinit();    
+    esp_hosted_deinit();
     hosted_initialized = false;
     hostedClearPinBuses();
     return false;
   }
 
+  hosted_initialized = true;
   hostedHasUpdate();
   return true;
 }

--- a/cores/esp32/esp32-hal-hosted.c
+++ b/cores/esp32/esp32-hal-hosted.c
@@ -287,6 +287,11 @@ static bool hostedInit() {
     return true;
   }
 
+  if (sdio_pin_config.pin_clk < 0 || sdio_pin_config.pin_cmd < 0 || sdio_pin_config.pin_d0 < 0 || sdio_pin_config.pin_d1 < 0 || sdio_pin_config.pin_d2 < 0 || sdio_pin_config.pin_d3 < 0 || sdio_pin_config.pin_reset < 0) {
+    log_e("ESP-Hosted: all SDIO pins must be defined");
+    return false;
+  }
+
   log_i("Initializing ESP-Hosted");
   log_d(
     "SDIO pins: clk=%d, cmd=%d, d0=%d, d1=%d, d2=%d, d3=%d, rst=%d", sdio_pin_config.pin_clk, sdio_pin_config.pin_cmd, sdio_pin_config.pin_d0,
@@ -306,10 +311,9 @@ static bool hostedInit() {
     return false;
   }
 
-  // Assign before SDIO bring-up: periman auto-LDO (VO4) must be on for GPIO 39-48
-  if (!hostedAssignPinBuses()) {
     log_e("ESP-Hosted: failed to assign SDIO pins to peripheral manager");
     return false;
+    hostedClearPinBuses();
   }
 
   hosted_initialized = true;

--- a/cores/esp32/esp32-hal-ldo.c
+++ b/cores/esp32/esp32-hal-ldo.c
@@ -45,10 +45,19 @@ esp_err_t ldoReleaseChannel(ldo_channel_handle_t handle) {
   return err;
 }
 
-static int8_t s_sdmmc_ldo_chan = -1;
+static int8_t s_claimed_ldo_chan = -1;
+static const char *s_claimed_ldo_owner = NULL;
 
-void ldoSdmmcDriverAttached(uint8_t chan_id) {
-  s_sdmmc_ldo_chan = (int8_t)chan_id;
+void ldoDriverClaimChannel(uint8_t chan_id, const char *owner) {
+  s_claimed_ldo_chan = (int8_t)chan_id;
+  s_claimed_ldo_owner = (owner != NULL && owner[0] != '\0') ? owner : "driver";
+}
+
+void ldoDriverReleaseChannel(uint8_t chan_id) {
+  if (s_claimed_ldo_chan == (int8_t)chan_id) {
+    s_claimed_ldo_chan = -1;
+    s_claimed_ldo_owner = NULL;
+  }
 }
 
 #if BOARD_PERIMAN_IO_LDO_AUTO
@@ -101,8 +110,8 @@ static void io_ldo_try_acquire(void) {
   if (s_io_ldo_slot.refcount <= 0 || s_io_ldo_slot.handle != NULL) {
     return;
   }
-  if (s_sdmmc_ldo_chan >= 0 && s_sdmmc_ldo_chan == s_io_ldo.chan_id) {
-    log_d("periman IO LDO auto: channel %d held by SDMMC; skip acquire", s_io_ldo.chan_id);
+  if (s_claimed_ldo_chan >= 0 && s_claimed_ldo_chan == s_io_ldo.chan_id) {
+    log_d("periman IO LDO auto: channel %d held by %s; skip acquire", s_io_ldo.chan_id, s_claimed_ldo_owner ? s_claimed_ldo_owner : "driver");
     return;
   }
   if (ldoAcquireChannel((uint8_t)s_io_ldo.chan_id, s_io_ldo.voltage_mv, false, &s_io_ldo_slot.handle) == ESP_OK) {
@@ -149,6 +158,11 @@ void ldoPerimanPinBusSet(uint8_t pin, peripheral_bus_type_t old_type, peripheral
 #endif
 }
 
+#if SOC_SDMMC_HOST_SUPPORTED
+void ldoSdmmcDriverAttached(uint8_t chan_id) {
+  ldoDriverClaimChannel(chan_id, "SDMMC");
+}
+
 void ldoSdmmcPrepareAcquire(uint8_t chan_id) {
 #if BOARD_PERIMAN_IO_LDO_AUTO
   if (io_ldo_channel_matches(chan_id)) {
@@ -160,9 +174,7 @@ void ldoSdmmcPrepareAcquire(uint8_t chan_id) {
 }
 
 void ldoSdmmcDriverDetached(uint8_t chan_id) {
-  if (s_sdmmc_ldo_chan == (int8_t)chan_id) {
-    s_sdmmc_ldo_chan = -1;
-  }
+  ldoDriverReleaseChannel(chan_id);
 #if BOARD_PERIMAN_IO_LDO_AUTO
   if (io_ldo_channel_matches(chan_id)) {
     io_ldo_try_acquire();
@@ -179,5 +191,6 @@ void ldoSdmmcDriverCreateFailed(uint8_t chan_id) {
   (void)chan_id;
 #endif
 }
+#endif /* SOC_SDMMC_HOST_SUPPORTED */
 
 #endif /* SOC_GP_LDO_SUPPORTED */

--- a/cores/esp32/esp32-hal-ldo.h
+++ b/cores/esp32/esp32-hal-ldo.h
@@ -44,7 +44,10 @@ esp_err_t ldoReleaseChannel(ldo_channel_handle_t handle);
 
 void ldoPerimanPinBusSet(uint8_t pin, peripheral_bus_type_t old_type, peripheral_bus_type_t new_type);
 
-/** Mark an on-chip LDO channel as already acquired (periman auto-LDO will skip re-acquire). */
+/** Mark an on-chip LDO channel as already acquired (periman auto-LDO will skip re-acquire).
+ *
+ * @param owner Must remain valid after the call (e.g. string literal / static storage); used for debug logging.
+ */
 void ldoDriverClaimChannel(uint8_t chan_id, const char *owner);
 void ldoDriverReleaseChannel(uint8_t chan_id);
 

--- a/cores/esp32/esp32-hal-ldo.h
+++ b/cores/esp32/esp32-hal-ldo.h
@@ -43,10 +43,17 @@ esp_err_t ldoReleaseChannel(ldo_channel_handle_t handle);
  */
 
 void ldoPerimanPinBusSet(uint8_t pin, peripheral_bus_type_t old_type, peripheral_bus_type_t new_type);
+
+/** Mark an on-chip LDO channel as already acquired (periman auto-LDO will skip re-acquire). */
+void ldoDriverClaimChannel(uint8_t chan_id, const char *owner);
+void ldoDriverReleaseChannel(uint8_t chan_id);
+
+#if SOC_SDMMC_HOST_SUPPORTED
 void ldoSdmmcPrepareAcquire(uint8_t chan_id);
 void ldoSdmmcDriverAttached(uint8_t chan_id);
 void ldoSdmmcDriverDetached(uint8_t chan_id);
 void ldoSdmmcDriverCreateFailed(uint8_t chan_id);
+#endif
 
 #endif /* SOC_GP_LDO_SUPPORTED */
 

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -112,6 +112,15 @@ const char *perimanGetTypeName(peripheral_bus_type_t type) {
     case ESP32_BUS_TYPE_PPP_RTS: return "PPP_MODEM_RTS";
     case ESP32_BUS_TYPE_PPP_CTS: return "PPP_MODEM_CTS";
 #endif
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE) || defined(CONFIG_ESP_WIFI_REMOTE_ENABLED)
+    case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CLK: return "ESP_HOSTED_SDIO_CLK";
+    case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CMD: return "ESP_HOSTED_SDIO_CMD";
+    case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D0:  return "ESP_HOSTED_SDIO_D0";
+    case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D1:  return "ESP_HOSTED_SDIO_D1";
+    case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D2:  return "ESP_HOSTED_SDIO_D2";
+    case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D3:  return "ESP_HOSTED_SDIO_D3";
+    case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_RST: return "ESP_HOSTED_SDIO_RST";
+#endif
     default: return "UNKNOWN";
   }
 }

--- a/cores/esp32/esp32-hal-periman.h
+++ b/cores/esp32/esp32-hal-periman.h
@@ -109,6 +109,15 @@ typedef enum {
   ESP32_BUS_TYPE_PPP_RTS,  // IO is used as PPP Modem RTS pin
   ESP32_BUS_TYPE_PPP_CTS,  // IO is used as PPP Modem CTS pin
 #endif
+#if defined(CONFIG_ESP_HOSTED_ENABLE_BT_NIMBLE) || defined(CONFIG_ESP_WIFI_REMOTE_ENABLED)
+  ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CLK,  // IO is used as ESP-Hosted SDIO CLK pin
+  ESP32_BUS_TYPE_ESP_HOSTED_SDIO_CMD,  // IO is used as ESP-Hosted SDIO CMD pin
+  ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D0,   // IO is used as ESP-Hosted SDIO D0 pin
+  ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D1,   // IO is used as ESP-Hosted SDIO D1 pin
+  ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D2,   // IO is used as ESP-Hosted SDIO D2 pin
+  ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D3,   // IO is used as ESP-Hosted SDIO D3 pin
+  ESP32_BUS_TYPE_ESP_HOSTED_SDIO_RST,  // IO is used as ESP-Hosted slave RESET pin
+#endif
   ESP32_BUS_TYPE_MAX
 } peripheral_bus_type_t;
 

--- a/variants/esp32p4_core_board/pins_arduino.h
+++ b/variants/esp32p4_core_board/pins_arduino.h
@@ -25,8 +25,9 @@ static const uint8_t RX = 38;
 static const uint8_t SDA = 7;
 static const uint8_t SCL = 8;
 
-// GPIO 36 and below: no extra on-chip LDO needed for the IO bank.
-// GPIO 39-48: LDO VO4 (channel 4). GPIO 37-38 (UART) are outside that VO4 range.
+// GPIO 36 and below: VDD_IO_4. GPIO 37-38 (UART): VDD_IO_4.
+// GPIO 39-48: VDD_IO_5 — board should tie VDD_IO_5 / SDIO pull-ups to VDDO_4 (VO4, chan 4).
+// GPIO 49-54: VDD_IO_6 (hosted CLK/CMD/D0/D1/RST on core board; no VO4).
 static const uint8_t SS = 30;
 static const uint8_t MOSI = 33;
 static const uint8_t MISO = 32;
@@ -62,10 +63,10 @@ static const uint8_t T11 = 13;
 static const uint8_t T12 = 14;
 static const uint8_t T13 = 15;
 
-// On-chip GP LDO: periman enables VO4 when a GPIO in the range is used (see esp32-hal-ldo.c).
+// On-chip GP LDO: periman/hosted enable VO4 for GPIO 39-48 (VDD_IO_5), e.g. hosted D2/D3 = 48/47.
 // No on-board SDMMC slot on this board (no BOARD_HAS_SDMMC / BOARD_SDMMC_POWER_*).
 #define BOARD_PERIMAN_IO_LDO_AUTO        1
-#define BOARD_PERIMAN_IO_LDO0_CHANNEL    4  // LDO_VO4 on ESP32-P4
+#define BOARD_PERIMAN_IO_LDO0_CHANNEL    4  // LDO_VO4 -> VDDO_4
 #define BOARD_PERIMAN_IO_LDO0_GPIO_MIN   39
 #define BOARD_PERIMAN_IO_LDO0_GPIO_MAX   48
 #define BOARD_PERIMAN_IO_LDO0_VOLTAGE_MV 3300


### PR DESCRIPTION
## Description of Change
This pull request introduces enhancements to the ESP32 peripheral management system, focusing on better coordination between the ESP-Hosted SDIO interface and the automatic on-chip LDO (Low Dropout Regulator) management. The changes ensure that SDIO pins are properly registered, cleared, and managed with the peripheral manager, and that LDO channels are correctly claimed and released to prevent conflicts between drivers and automatic LDO control. Additionally, new bus types for ESP-Hosted SDIO pins are defined and integrated.

### ESP-Hosted SDIO and Peripheral Manager Integration

* Added functions to assign, clear, and detach SDIO pins (`hostedAssignPinBuses`, `hostedClearPinBuses`, `hostedDetachBus`) from the peripheral manager, ensuring pins are properly managed during initialization and deinitialization (`esp32-hal-hosted.c`). [[1]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR60-R62) [[2]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bL217-R317) [[3]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR326-R353) [[4]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR363-R370)
* Registered SDIO pins with the peripheral manager before bring-up, and ensured cleanup on failure paths in initialization. [[1]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bL217-R317) [[2]](diffhunk://#diff-0298cc339c31036909370e2d07e215e8629992033bdb102ed2074818b99e533bR326-R353)
* Added new bus type enums for ESP-Hosted SDIO pins and provided type name mapping for logging/debugging (`esp32-hal-periman.h`, `esp32-hal-periman.c`). [[1]](diffhunk://#diff-c000debbd8a1f78bce815451cf47df688b77276d783a9a2f415a4381d18078bbR111-R119) [[2]](diffhunk://#diff-b13165e864af00ee872517324ae4929b78d0411fff6f4fb2b98114f241c00f22R114-R122)

### LDO Channel Ownership and Coordination

* Refactored LDO channel claiming: introduced generic `ldoDriverClaimChannel` and `ldoDriverReleaseChannel` to allow any driver (not just SDMMC) to claim an LDO channel, preventing the auto-LDO logic from interfering with claimed channels (`esp32-hal-ldo.c`, `esp32-hal-ldo.h`). [[1]](diffhunk://#diff-4bcfa5aa3980f1c3d827f44fee6112e988a3e5676d37f272cb6ae976d0e19d2aL48-R60) [[2]](diffhunk://#diff-ed681f5a70322f6589faec6aead17523440f35cb42b99fd7f4b74c660de09485R46-R56)
* Updated SDMMC-specific LDO claim/release to use the new generic functions, and improved logging to indicate which driver holds the channel. [[1]](diffhunk://#diff-4bcfa5aa3980f1c3d827f44fee6112e988a3e5676d37f272cb6ae976d0e19d2aR161-R165) [[2]](diffhunk://#diff-4bcfa5aa3980f1c3d827f44fee6112e988a3e5676d37f272cb6ae976d0e19d2aL163-R177) [[3]](diffhunk://#diff-4bcfa5aa3980f1c3d827f44fee6112e988a3e5676d37f272cb6ae976d0e19d2aL104-R114)

### Board Definition Clarification

* Clarified and updated comments in the core board pin definitions regarding which GPIOs require which LDO channels, reflecting the new SDIO and LDO management logic (`pins_arduino.h`). [[1]](diffhunk://#diff-e45f3f06ef8a5d6dd0b5ef71c16ae7243b2d29a0828b17fcb581398bd6a7bc75L28-R30) [[2]](diffhunk://#diff-e45f3f06ef8a5d6dd0b5ef71c16ae7243b2d29a0828b17fcb581398bd6a7bc75L65-R69)

## Test Scenarios
Tested using WifiScan example on ESP32-P4X-EV board and P4 Core board
## Related links
