### PR TITLE
change(esptool): Rollback esptool to v5.2

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -84,7 +84,7 @@
             {
               "packager": "esp32",
               "name": "esptool_py",
-              "version": "5.3.0"
+              "version": "5.2.0"
             },
             {
               "packager": "esp32",
@@ -472,56 +472,56 @@
         },
         {
           "name": "esptool_py",
-          "version": "5.3.0",
+          "version": "5.2.0",
           "systems": [
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-aarch64.tar.gz",
-              "archiveFileName": "esptool-v5.3.0-linux-aarch64.tar.gz",
-              "checksum": "SHA-256:5a03918919f0b94222b639803e97e74d679d0fc3c5092cf27292f8e5a1430794",
-              "size": "75198819"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-aarch64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-linux-aarch64.tar.gz",
+              "checksum": "SHA-256:a3a0fc13ada8d69dddbdfff1c765fa0b88fb578a83d02315be9c15fefa6ca58e",
+              "size": "66991044"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.3.0-linux-amd64.tar.gz",
-              "checksum": "SHA-256:46ca7b52c309790bc4d140990680f6088e8cad40b230fda6999661efc24845b6",
-              "size": "82516240"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-linux-amd64.tar.gz",
+              "checksum": "SHA-256:0a9f6c913fccfacac9261eb2acd8060010db5933c18c8e47cb32377eaa7202a3",
+              "size": "73991509"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-armv7.tar.gz",
-              "archiveFileName": "esptool-v5.3.0-linux-armv7.tar.gz",
-              "checksum": "SHA-256:59fad3317798ec65567cb6fda49db081c778cf971e35155a06dde0919d4e7e96",
-              "size": "65340824"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-armv7.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-linux-armv7.tar.gz",
+              "checksum": "SHA-256:dbf92966eb6ad5f4d068d8b2461f534b15219cb405083a38d26519284e91b73a",
+              "size": "57875713"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-macos-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.3.0-macos-amd64.tar.gz",
-              "checksum": "SHA-256:e313df506a0e1e074ebc7dffb065993197881a2a5285e1b0dd20398ae67687ed",
-              "size": "63777562"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-macos-amd64.tar.gz",
+              "checksum": "SHA-256:dcb6c38cb10e1d7ca5ce658687e4abe47dfda22284857673b55cae010ff5f5ee",
+              "size": "58174910"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-macos-arm64.tar.gz",
-              "archiveFileName": "esptool-v5.3.0-macos-arm64.tar.gz",
-              "checksum": "SHA-256:58fc5415cadefde99bf282143c3aadfea139309fe56eba9bd6fa596c69d855b9",
-              "size": "60554760"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-arm64.tar.gz",
+              "archiveFileName": "esptool-v5.2.0-macos-arm64.tar.gz",
+              "checksum": "SHA-256:2b45270273ff96b6394bd6e317b153cf4a42869ca917d2bcebafc9a3cdac0e1e",
+              "size": "54970972"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.3.0-windows-amd64.zip",
-              "checksum": "SHA-256:c86e30586e559f0ae5b41a828f21b4c69a7fc11a194e09391f5a2e31952b2471",
-              "size": "63716106"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
+              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
+              "size": "58319204"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.3.0-windows-amd64.zip",
-              "checksum": "SHA-256:c86e30586e559f0ae5b41a828f21b4c69a7fc11a194e09391f5a2e31952b2471",
-              "size": "63716106"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
+              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
+              "size": "58319204"
             }
           ]
         },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,5 @@ pytest-embedded-serial-esp==2.5.0
 pytest-embedded-arduino==2.5.0
 pytest-embedded-wokwi==2.5.0
 pytest-embedded-qemu==2.5.0
-esptool==5.3.0
+esptool==5.2.0
 wokwi-client


### PR DESCRIPTION
## Description of Change

This pull request downgrades the `esptool` dependency from version 5.3.0 to 5.2.0 across both the Python test requirements and the ESP32 package index template. The main goal is to ensure consistency and compatibility with the earlier version of `esptool`. All related download URLs, checksums, and file sizes for different platforms in the package index have been updated accordingly.

Dependency version downgrade:

* Downgraded `esptool` from version 5.3.0 to 5.2.0 in the Python test requirements file (`tests/requirements.txt`).
* Updated the `esptool_py` package version from 5.3.0 to 5.2.0 in the ESP32 package index template (`package/package_esp32_index.template.json`).

Package index updates for all platforms:

* Updated all platform-specific download URLs, archive file names, checksums, and file sizes to reference `esptool` version 5.2.0 instead of 5.3.0 in `package/package_esp32_index.template.json`.
