### PR TITLE
fix(usb_cdc): Fix blocking write() when timeout is zero

### DIFF
--- a/cores/esp32/USBCDC.cpp
+++ b/cores/esp32/USBCDC.cpp
@@ -406,9 +406,10 @@ size_t USBCDC::write(const uint8_t *buffer, size_t size) {
   }
   size_t to_send = size, so_far = 0;
   // writeTimeout will prevent that TinyUSB failure locks the while(to_send) loop
+  bool non_blocking = tx_timeout_ms == 0;
   uint32_t writeTimeout = millis() + tx_timeout_ms;
   while (to_send) {
-    if (!tud_cdc_n_connected(itf) || (int32_t)(millis() - writeTimeout) >= 0) {
+    if (!tud_cdc_n_connected(itf) || (!non_blocking && (int32_t)(millis() - writeTimeout) >= 0)) {
       log_e("USB is disconnected or CDC writing has timed out.");
       size = so_far;
       break;
@@ -416,6 +417,10 @@ size_t USBCDC::write(const uint8_t *buffer, size_t size) {
     size_t space = tud_cdc_n_write_available(itf);
     if (!space) {
       tud_cdc_n_write_flush(itf);
+      if (non_blocking) {
+        size = so_far;
+        break;
+      }
       continue;
     }
     if (space > to_send) {


### PR DESCRIPTION
## Description of Change
With USB OTG CDC, when timeout is set to zero, the interface gets locked in an infinite loop.
This PR fixes it.

## Test Scenarios
ESP32-S3 | ESP32-S2 using USB OTG (TinyUSB) CDC.

```cpp
void setup() {
  Serial.begin();
  delay(2000);
  Serial.println("It will set timeout to 0 and try to print something...");
  Serial.setTxTimeoutMs(0);   // expect: non-blocking writes
  Serial.println("hello");    // blocks until USB host connects
}

void loop() {
  Serial.println("loop...");
  delay(1000);
}
```

## Related links
Fix #12634 
