### PR TITLE
fix(btserial): Properly clear address set variable

### DIFF
--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -972,7 +972,7 @@ bool BluetoothSerial::connect(String remoteName) {
   }
   disconnect();
   _doConnect = true;
-  _isRemoteAddressSet = true;
+  _isRemoteAddressSet = false;
   _sec_mask = ESP_SPP_SEC_ENCRYPT | ESP_SPP_SEC_AUTHENTICATE;
   _role = ESP_SPP_ROLE_MASTER;
   strncpy(_remote_name, remoteName.c_str(), ESP_BT_GAP_MAX_BDNAME_LEN);

--- a/tests/validation/bt_classic/ci.yml
+++ b/tests/validation/bt_classic/ci.yml
@@ -1,0 +1,17 @@
+tags:
+  - two_duts
+
+multi_device:
+  device0: server
+  device1: client
+
+platforms:
+  wokwi: false
+  qemu: false
+
+fqbn_append: PartitionScheme=huge_app
+
+requires:
+  - CONFIG_BT_ENABLED=y
+  - CONFIG_BLUEDROID_ENABLED=y
+  - CONFIG_BT_SPP_ENABLED=y

--- a/tests/validation/bt_classic/client/client.ino
+++ b/tests/validation/bt_classic/client/client.ino
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * BT Classic SPP master for multi-DUT validation (pairs with server/).
+ */
+
+#include <Arduino.h>
+#include "BluetoothSerial.h"
+
+#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
+#error Bluetooth is not enabled
+#endif
+
+#if !defined(CONFIG_BT_SPP_ENABLED)
+#error BT Classic SPP is only available on ESP32
+#endif
+
+static BluetoothSerial SerialBT;
+static String slaveName;
+static const char *kMasterName = "BT_CLASSIC_MASTER";
+static const char *kPing = "BT_CLASSIC_PING";
+static const char *kPong = "BT_CLASSIC_PONG";
+
+static bool readSlaveNameFromHost() {
+  Serial.println("[CLIENT] Ready for slave name");
+  Serial.println("[CLIENT] Send slave name:");
+  while (slaveName.length() == 0) {
+    if (Serial.available()) {
+      slaveName = Serial.readStringUntil('\n');
+      slaveName.trim();
+    }
+    delay(50);
+  }
+  Serial.printf("[CLIENT] Slave name: %s\n", slaveName.c_str());
+  return true;
+}
+
+static bool waitForConnection() {
+  Serial.printf("[CLIENT] Connecting to %s\n", slaveName.c_str());
+
+  if (SerialBT.connect(slaveName)) {
+    return true;
+  }
+
+  const unsigned long deadline = millis() + 90000;
+  while (millis() < deadline) {
+    if (SerialBT.connected(10000)) {
+      return true;
+    }
+    Serial.println("[CLIENT] Waiting for slave...");
+  }
+  return false;
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  if (!readSlaveNameFromHost()) {
+    return;
+  }
+
+  if (!SerialBT.begin(kMasterName, true)) {
+    Serial.println("[CLIENT] ERROR: begin failed");
+    return;
+  }
+
+  if (!waitForConnection()) {
+    Serial.println("[CLIENT] ERROR: connect failed");
+    return;
+  }
+
+  Serial.println("[CLIENT] Connected");
+
+  SerialBT.println(kPing);
+
+  const unsigned long deadline = millis() + 30000;
+  while (!SerialBT.available() && millis() < deadline) {
+    delay(50);
+  }
+
+  if (!SerialBT.available()) {
+    Serial.println("[CLIENT] ERROR: no response from server");
+    return;
+  }
+
+  String response = SerialBT.readStringUntil('\n');
+  response.trim();
+  Serial.printf("[CLIENT] Received: %s\n", response.c_str());
+
+  if (response != kPong) {
+    Serial.println("[CLIENT] ERROR: unexpected response");
+    return;
+  }
+
+  Serial.println("[CLIENT] Test complete");
+}
+
+void loop() {}

--- a/tests/validation/bt_classic/server/server.ino
+++ b/tests/validation/bt_classic/server/server.ino
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * BT Classic SPP slave for multi-DUT validation (pairs with client/).
+ */
+
+#include <Arduino.h>
+#include "BluetoothSerial.h"
+
+#if !defined(CONFIG_BT_ENABLED) || !defined(CONFIG_BLUEDROID_ENABLED)
+#error Bluetooth is not enabled
+#endif
+
+#if !defined(CONFIG_BT_SPP_ENABLED)
+#error BT Classic SPP is only available on ESP32
+#endif
+
+static BluetoothSerial SerialBT;
+static String serverName;
+
+static bool readNameFromHost() {
+  Serial.println("[SERVER] Ready for name");
+  Serial.println("[SERVER] Send name:");
+  while (serverName.length() == 0) {
+    if (Serial.available()) {
+      serverName = Serial.readStringUntil('\n');
+      serverName.trim();
+    }
+    delay(50);
+  }
+  Serial.printf("[SERVER] Name: %s\n", serverName.c_str());
+  return true;
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  if (!readNameFromHost()) {
+    return;
+  }
+
+  if (!SerialBT.begin(serverName)) {
+    Serial.println("[SERVER] ERROR: begin failed");
+    return;
+  }
+
+  Serial.println("[SERVER] SPP listening");
+
+  const unsigned long connectTimeoutMs = 90000;
+  unsigned long start = millis();
+  while (!SerialBT.hasClient() && (millis() - start) < connectTimeoutMs) {
+    delay(100);
+  }
+
+  if (!SerialBT.hasClient()) {
+    Serial.println("[SERVER] ERROR: client timeout");
+    return;
+  }
+
+  Serial.println("[SERVER] Client connected");
+
+  start = millis();
+  while (!SerialBT.available() && (millis() - start) < 30000) {
+    delay(50);
+  }
+
+  if (!SerialBT.available()) {
+    Serial.println("[SERVER] ERROR: no data from client");
+    return;
+  }
+
+  String msg = SerialBT.readStringUntil('\n');
+  msg.trim();
+  Serial.printf("[SERVER] Received: %s\n", msg.c_str());
+
+  if (msg != "BT_CLASSIC_PING") {
+    Serial.println("[SERVER] ERROR: unexpected payload");
+    return;
+  }
+
+  SerialBT.println("BT_CLASSIC_PONG");
+  Serial.println("[SERVER] Sent response");
+  Serial.println("[SERVER] Test complete");
+}
+
+void loop() {}

--- a/tests/validation/bt_classic/test_bt_classic.py
+++ b/tests/validation/bt_classic/test_bt_classic.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: CC0-1.0
+
+import logging
+
+from conftest import rand_str4
+
+
+def test_bt_classic(dut, ci_job_id):
+    logger = logging.getLogger(__name__)
+
+    server = dut[0]
+    client = dut[1]
+
+    slave_name = 'BT_SRV_' + ci_job_id if ci_job_id else 'BT_SRV_' + rand_str4()
+    logger.info('Slave name: %s', slave_name)
+
+    logger.info('Waiting for devices to be ready...')
+    server.expect_exact('[SERVER] Ready for name', timeout=120)
+    client.expect_exact('[CLIENT] Ready for slave name', timeout=120)
+
+    server.expect_exact('[SERVER] Send name:')
+    client.expect_exact('[CLIENT] Send slave name:')
+
+    logger.info('Sending slave name to both devices')
+    server.write(f'{slave_name}\n')
+    client.write(f'{slave_name}\n')
+
+    server.expect_exact(f'[SERVER] Name: {slave_name}')
+    client.expect_exact(f'[CLIENT] Slave name: {slave_name}')
+
+    logger.info('Waiting for SPP server...')
+    server.expect_exact('[SERVER] SPP listening', timeout=30)
+
+    logger.info('Waiting for client connection...')
+    client.expect_exact(f'[CLIENT] Connecting to {slave_name}', timeout=30)
+    server.expect_exact('[SERVER] Client connected', timeout=90)
+    client.expect_exact('[CLIENT] Connected', timeout=90)
+
+    logger.info('Verifying ping/pong over SPP...')
+    server.expect_exact('[SERVER] Received: BT_CLASSIC_PING', timeout=30)
+    server.expect_exact('[SERVER] Sent response', timeout=10)
+    client.expect_exact('[CLIENT] Received: BT_CLASSIC_PONG', timeout=30)
+
+    server.expect_exact('[SERVER] Test complete', timeout=10)
+    client.expect_exact('[CLIENT] Test complete', timeout=10)
+
+    logger.info('BT Classic test passed')

--- a/tests/validation/bt_classic/test_bt_classic.py
+++ b/tests/validation/bt_classic/test_bt_classic.py
@@ -13,37 +13,37 @@ def test_bt_classic(dut, ci_job_id):
     server = dut[0]
     client = dut[1]
 
-    slave_name = 'BT_SRV_' + ci_job_id if ci_job_id else 'BT_SRV_' + rand_str4()
-    logger.info('Slave name: %s', slave_name)
+    slave_name = "BT_SRV_" + ci_job_id if ci_job_id else "BT_SRV_" + rand_str4()
+    logger.info("Slave name: %s", slave_name)
 
-    logger.info('Waiting for devices to be ready...')
-    server.expect_exact('[SERVER] Ready for name', timeout=120)
-    client.expect_exact('[CLIENT] Ready for slave name', timeout=120)
+    logger.info("Waiting for devices to be ready...")
+    server.expect_exact("[SERVER] Ready for name", timeout=120)
+    client.expect_exact("[CLIENT] Ready for slave name", timeout=120)
 
-    server.expect_exact('[SERVER] Send name:')
-    client.expect_exact('[CLIENT] Send slave name:')
+    server.expect_exact("[SERVER] Send name:")
+    client.expect_exact("[CLIENT] Send slave name:")
 
-    logger.info('Sending slave name to both devices')
-    server.write(f'{slave_name}\n')
-    client.write(f'{slave_name}\n')
+    logger.info("Sending slave name to both devices")
+    server.write(f"{slave_name}\n")
+    client.write(f"{slave_name}\n")
 
-    server.expect_exact(f'[SERVER] Name: {slave_name}')
-    client.expect_exact(f'[CLIENT] Slave name: {slave_name}')
+    server.expect_exact(f"[SERVER] Name: {slave_name}")
+    client.expect_exact(f"[CLIENT] Slave name: {slave_name}")
 
-    logger.info('Waiting for SPP server...')
-    server.expect_exact('[SERVER] SPP listening', timeout=30)
+    logger.info("Waiting for SPP server...")
+    server.expect_exact("[SERVER] SPP listening", timeout=30)
 
-    logger.info('Waiting for client connection...')
-    client.expect_exact(f'[CLIENT] Connecting to {slave_name}', timeout=30)
-    server.expect_exact('[SERVER] Client connected', timeout=90)
-    client.expect_exact('[CLIENT] Connected', timeout=90)
+    logger.info("Waiting for client connection...")
+    client.expect_exact(f"[CLIENT] Connecting to {slave_name}", timeout=30)
+    server.expect_exact("[SERVER] Client connected", timeout=90)
+    client.expect_exact("[CLIENT] Connected", timeout=90)
 
-    logger.info('Verifying ping/pong over SPP...')
-    server.expect_exact('[SERVER] Received: BT_CLASSIC_PING', timeout=30)
-    server.expect_exact('[SERVER] Sent response', timeout=10)
-    client.expect_exact('[CLIENT] Received: BT_CLASSIC_PONG', timeout=30)
+    logger.info("Verifying ping/pong over SPP...")
+    server.expect_exact("[SERVER] Received: BT_CLASSIC_PING", timeout=30)
+    server.expect_exact("[SERVER] Sent response", timeout=10)
+    client.expect_exact("[CLIENT] Received: BT_CLASSIC_PONG", timeout=30)
 
-    server.expect_exact('[SERVER] Test complete', timeout=10)
-    client.expect_exact('[CLIENT] Test complete', timeout=10)
+    server.expect_exact("[SERVER] Test complete", timeout=10)
+    client.expect_exact("[CLIENT] Test complete", timeout=10)
 
-    logger.info('BT Classic test passed')
+    logger.info("BT Classic test passed")


### PR DESCRIPTION
## Description of Change

This pull request introduces a new multi-device validation test for Bluetooth Classic SPP (Serial Port Profile) communication, including both Arduino client and server implementations, a Python test script for automation, and supporting configuration. Additionally, it fixes a bug in the `BluetoothSerial::connect` method regarding remote address state management.

**Bluetooth Classic SPP Multi-Device Validation**

* Adds an Arduino-based SPP client example (`client.ino`) that connects to a remote SPP server, sends a ping, and expects a pong response, designed for automated multi-device testing.
* Adds an Arduino-based SPP server example (`server.ino`) that listens for incoming connections, receives a ping message, and responds with a pong, also for automated test scenarios.
* Introduces a Python test script (`test_bt_classic.py`) to orchestrate and validate the SPP ping/pong exchange between two devices, ensuring correct setup, connection, and data exchange.
* Adds a test configuration file (`ci.yml`) specifying requirements for running the new multi-device Bluetooth Classic test, including platform and build flags.

**Bug Fix**

* Fixes the initialization of `_isRemoteAddressSet` in the `BluetoothSerial::connect` method to ensure the remote address state is correctly reset before attempting a connection.

## Test Scenarios

Tested locally

## Related links

Closes #11217
