### PR TITLE
change(esptool): Update esptool to 5.3 and adapt scripts to handle it

### DIFF
--- a/.github/scripts/update_esptool.py
+++ b/.github/scripts/update_esptool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # This script is used to re-package the esptool if needed and update the JSON file
-# for the Arduino ESP32 platform.
+# and tests/requirements.txt for the Arduino ESP32 platform.
 #
 # The script has only been tested on macOS.
 #
@@ -31,6 +31,7 @@
 import argparse
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -44,6 +45,26 @@ def ensure_v_prefix(version):
     if version.startswith("v"):
         return version
     return f"v{version}"
+
+def strip_v_prefix(version):
+    if version.startswith("v"):
+        return version[1:]
+    return version
+
+def update_tests_requirements(requirements_path, version):
+    version = strip_v_prefix(version)
+    requirements_path = Path(requirements_path)
+    content = requirements_path.read_text()
+    new_content, count = re.subn(
+        r"^esptool==\S+",
+        f"esptool=={version}",
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count == 0:
+        raise RuntimeError(f"No esptool== line found in {requirements_path}")
+    requirements_path.write_text(new_content)
 
 def compute_sha256(filepath):
     sha256 = hashlib.sha256()
@@ -207,7 +228,7 @@ def get_release_info(version):
     response.raise_for_status()
     return response.json()
 
-def create_branch_and_commit(version, json_path):
+def create_branch_and_commit(version, *paths):
     """Create a new branch and commit the changes to it."""
     branch_name = f"update-esptool-{version}"
     commit_message = f"change(esptool): Upgrade to version {version}"
@@ -217,9 +238,9 @@ def create_branch_and_commit(version, json_path):
         subprocess.run(["git", "checkout", "-b", branch_name], check=True, capture_output=True, text=True)
         print(f"Created and switched to new branch: {branch_name}")
 
-        # Stage the JSON file
-        subprocess.run(["git", "add", str(json_path)], check=True, capture_output=True, text=True)
-        print(f"Staged file: {json_path}")
+        for path in paths:
+            subprocess.run(["git", "add", str(path)], check=True, capture_output=True, text=True)
+            print(f"Staged file: {path}")
 
         # Commit the changes
         subprocess.run(["git", "commit", "-m", commit_message], check=True, capture_output=True, text=True)
@@ -234,11 +255,12 @@ def main():
     parser = argparse.ArgumentParser(description="Repack esptool and update JSON metadata.")
     parser.add_argument("version", help="Version of the esptool (e.g. 5.0.dev1)")
     parser.add_argument("-l", "--local", dest="base_folder", help="Enable local build mode and set the base folder with unpacked artifacts")
-    parser.add_argument("-c", "--commit", action="store_true", help="Automatically create a new branch and commit the JSON file changes")
+    parser.add_argument("-c", "--commit", action="store_true", help="Automatically create a new branch and commit the updated files")
     args = parser.parse_args()
 
     script_dir = Path(__file__).resolve().parent
     json_path = (script_dir / "../../package/package_esp32_index.template.json").resolve()
+    requirements_path = (script_dir / "../../tests/requirements.txt").resolve()
     tmp_json_path = Path(str(json_path) + ".tmp")
     shutil.copy(json_path, tmp_json_path)
 
@@ -262,10 +284,14 @@ def main():
     shutil.move(tmp_json_path, json_path)
     print(f"Done. JSON updated at {json_path}")
 
+    print(f"Updating esptool pin in {requirements_path}")
+    update_tests_requirements(requirements_path, args.version)
+    print(f"Done. requirements.txt updated at {requirements_path}")
+
     # Auto-commit if requested
     if args.commit:
         print("Auto-commit enabled. Creating branch and committing changes...")
-        create_branch_and_commit(args.version, json_path)
+        create_branch_and_commit(args.version, json_path, requirements_path)
 
 if __name__ == "__main__":
     main()

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -84,7 +84,7 @@
             {
               "packager": "esp32",
               "name": "esptool_py",
-              "version": "5.2.0"
+              "version": "5.3.0"
             },
             {
               "packager": "esp32",
@@ -472,56 +472,56 @@
         },
         {
           "name": "esptool_py",
-          "version": "5.2.0",
+          "version": "5.3.0",
           "systems": [
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-aarch64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-linux-aarch64.tar.gz",
-              "checksum": "SHA-256:a3a0fc13ada8d69dddbdfff1c765fa0b88fb578a83d02315be9c15fefa6ca58e",
-              "size": "66991044"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-aarch64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-linux-aarch64.tar.gz",
+              "checksum": "SHA-256:5a03918919f0b94222b639803e97e74d679d0fc3c5092cf27292f8e5a1430794",
+              "size": "75198819"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-linux-amd64.tar.gz",
-              "checksum": "SHA-256:0a9f6c913fccfacac9261eb2acd8060010db5933c18c8e47cb32377eaa7202a3",
-              "size": "73991509"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-linux-amd64.tar.gz",
+              "checksum": "SHA-256:46ca7b52c309790bc4d140990680f6088e8cad40b230fda6999661efc24845b6",
+              "size": "82516240"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-linux-armv7.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-linux-armv7.tar.gz",
-              "checksum": "SHA-256:dbf92966eb6ad5f4d068d8b2461f534b15219cb405083a38d26519284e91b73a",
-              "size": "57875713"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-linux-armv7.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-linux-armv7.tar.gz",
+              "checksum": "SHA-256:59fad3317798ec65567cb6fda49db081c778cf971e35155a06dde0919d4e7e96",
+              "size": "65340824"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-amd64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-macos-amd64.tar.gz",
-              "checksum": "SHA-256:dcb6c38cb10e1d7ca5ce658687e4abe47dfda22284857673b55cae010ff5f5ee",
-              "size": "58174910"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-macos-amd64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-macos-amd64.tar.gz",
+              "checksum": "SHA-256:ea33d15db3cc1f7aec1e6af0ed327ec13c82f139f442a100eca76d5b29094be9",
+              "size": "63866831"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-macos-arm64.tar.gz",
-              "archiveFileName": "esptool-v5.2.0-macos-arm64.tar.gz",
-              "checksum": "SHA-256:2b45270273ff96b6394bd6e317b153cf4a42869ca917d2bcebafc9a3cdac0e1e",
-              "size": "54970972"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-macos-arm64.tar.gz",
+              "archiveFileName": "esptool-v5.3.0-macos-arm64.tar.gz",
+              "checksum": "SHA-256:78369f963f1454ecc1b5516119e43aa5aa5cc1afeaca467458cbbeef02675dd4",
+              "size": "60740013"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
-              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
-              "size": "58319204"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.3.0-windows-amd64.zip",
+              "checksum": "SHA-256:c86e30586e559f0ae5b41a828f21b4c69a7fc11a194e09391f5a2e31952b2471",
+              "size": "63716106"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esptool/releases/download/v5.2.0/esptool-v5.2.0-windows-amd64.zip",
-              "archiveFileName": "esptool-v5.2.0-windows-amd64.zip",
-              "checksum": "SHA-256:ef0522120afb5e8e673d68726c32e0de416990fc62dc313191721edeb0a74fc6",
-              "size": "58319204"
+              "url": "https://github.com/espressif/esptool/releases/download/v5.3.0/esptool-v5.3.0-windows-amd64.zip",
+              "archiveFileName": "esptool-v5.3.0-windows-amd64.zip",
+              "checksum": "SHA-256:c86e30586e559f0ae5b41a828f21b4c69a7fc11a194e09391f5a2e31952b2471",
+              "size": "63716106"
             }
           ]
         },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,5 @@ pytest-embedded-serial-esp==2.5.0
 pytest-embedded-arduino==2.5.0
 pytest-embedded-wokwi==2.5.0
 pytest-embedded-qemu==2.5.0
-esptool==5.2.0
+esptool==5.3.0
 wokwi-client

--- a/tools/get.py
+++ b/tools/get.py
@@ -109,6 +109,43 @@ def mkdir_p(path):
             raise
 
 
+def is_archive_metadata_path(name):
+    """True for AppleDouble, __MACOSX, and other non-content archive entries."""
+    if not name:
+        return True
+    parts = name.replace("\\", "/").split("/")
+    if parts[0] in ("__MACOSX", "pax_global_header"):
+        return True
+    return any(part.startswith("._") for part in parts)
+
+
+def archive_root_dir(member_names):
+    """Return the top-level directory inside an archive, ignoring metadata entries."""
+    roots = set()
+    for name in member_names:
+        if is_archive_metadata_path(name):
+            continue
+        name = name.rstrip("/")
+        if not name:
+            continue
+        roots.add(name.split("/")[0])
+
+    if len(roots) == 1:
+        return roots.pop()
+
+    non_meta = [r for r in roots if not r.startswith(".")]
+    if len(non_meta) == 1:
+        return non_meta[0]
+
+    for name in member_names:
+        if is_archive_metadata_path(name):
+            continue
+        name = name.rstrip("/")
+        if name:
+            return name.split("/")[0]
+    return ""
+
+
 def format_time(seconds):
     minutes, seconds = divmod(seconds, 60)
     return "{:02}:{:05.2f}".format(int(minutes), seconds)
@@ -170,9 +207,10 @@ def verify_files(filename, destination, rename_to):
         raise NotImplementedError("Unsupported archive type")
 
     try:
-        first_dir = file_list[0].split("/")[0]
-        total_files = len(file_list)
-        for i, zipped_file in enumerate(file_list, 1):
+        first_dir = archive_root_dir(file_list)
+        entries_to_verify = [f for f in file_list if not is_archive_metadata_path(f)]
+        total_files = len(entries_to_verify)
+        for i, zipped_file in enumerate(entries_to_verify, 1):
             local_path = os.path.join(extracted_dir_path, zipped_file.replace(first_dir, rename_to, 1))
             if not os.path.exists(local_path):
                 if verbose:
@@ -231,21 +269,21 @@ def unpack(filename, destination, force_extract, checksum):  # noqa: C901
         if filename.endswith("tar.gz"):
             if tarfile.is_tarfile(filename):
                 cfile = tarfile.open(filename, "r:gz")
-                dirname = cfile.getnames()[0].split("/")[0]
+                dirname = archive_root_dir(cfile.getnames())
             else:
                 print("File corrupted!")
                 file_is_corrupted = True
         elif filename.endswith("tar.xz"):
             if tarfile.is_tarfile(filename):
                 cfile = tarfile.open(filename, "r:xz")
-                dirname = cfile.getnames()[0].split("/")[0]
+                dirname = archive_root_dir(cfile.getnames())
             else:
                 print("File corrupted!")
                 file_is_corrupted = True
         elif filename.endswith("zip"):
             if zipfile.is_zipfile(filename):
                 cfile = zipfile.ZipFile(filename)
-                dirname = cfile.namelist()[0].split("/")[0]
+                dirname = archive_root_dir(cfile.namelist())
             else:
                 print("File corrupted!")
                 file_is_corrupted = True
@@ -268,7 +306,8 @@ def unpack(filename, destination, force_extract, checksum):  # noqa: C901
         return False
 
     # A little trick to rename tool directories so they don't contain version number
-    rename_to = re.match(r"^([a-z][^\-]*\-*)+", dirname).group(0).strip("-")
+    match = re.match(r"^([a-z][^\-]*\-*)+", dirname)
+    rename_to = match.group(0).strip("-") if match else dirname
     if rename_to == dirname and dirname.startswith("esp32-arduino-libs-"):
         rename_to = "esp32-arduino-libs"
     elif rename_to == dirname and dirname.startswith("esptool-"):


### PR DESCRIPTION
## Description of Change

This pull request updates the ESP32 platform to use esptool version 5.3.0 and improves the robustness of archive extraction in the build tools. It also enhances the update script to ensure `tests/requirements.txt` is kept in sync with the esptool version and improves handling of archive metadata during extraction.

**esptool version upgrade and automation:**

* Upgraded esptool from version 5.2.0 to 5.3.0 in both `package/package_esp32_index.template.json` and `tests/requirements.txt`, updating all relevant URLs, checksums, and sizes for the new release. [[1]](diffhunk://#diff-5cc2de46219528ecaffa00a28b18719ca62cbebebe50bfbee8d49c98cee14fa6L87-R87) [[2]](diffhunk://#diff-5cc2de46219528ecaffa00a28b18719ca62cbebebe50bfbee8d49c98cee14fa6L475-R524) [[3]](diffhunk://#diff-27c5febcc9ce93e8e5341f263b7d68962733b8a2a86c583723d025a1db39d7a3L8-R8)
* Enhanced `.github/scripts/update_esptool.py` to automatically update `tests/requirements.txt` with the correct esptool version and include it in the commit when the `--commit` flag is used. [[1]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebL4-R4) [[2]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebR34) [[3]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebR49-R68) [[4]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebL210-R231) [[5]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebL220-R243) [[6]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebL237-R263) [[7]](diffhunk://#diff-2834cfb960b1ada86cfd87ed7fb62dba1c6a89f5e8e9772d3272653f287930ebR287-R294)

**Archive extraction robustness:**

* Added functions `is_archive_metadata_path` and `archive_root_dir` to `tools/get.py` to better detect and ignore archive metadata entries (such as `__MACOSX` and AppleDouble files), improving reliability when extracting and verifying archives.
* Updated archive extraction and verification logic in `tools/get.py` to use the new functions, ensuring only relevant files are processed and improving compatibility with various archive formats. [[1]](diffhunk://#diff-8802003f42303622bc2d8b0ca79e2a43e530119e3a0a700182e23fd9039eaa19L173-R209) [[2]](diffhunk://#diff-8802003f42303622bc2d8b0ca79e2a43e530119e3a0a700182e23fd9039eaa19L234-R282)

**Other improvements:**

* Made the directory renaming logic during archive extraction more robust in `tools/get.py`, handling cases where the expected directory name pattern is not matched.

## Test Scenarios

Tested locally
