### PR TITLE
ci(tests): Skip publishing results if tests did not compile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,11 @@ name: Runtime Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_results:
+        description: 'Publish test results to gh-pages (report, badge, history)'
+        type: boolean
+        default: true
   pull_request:
     types: [opened, reopened, closed, synchronize, labeled, unlabeled]
     paths:

--- a/.github/workflows/tests_hw_wokwi.yml
+++ b/.github/workflows/tests_hw_wokwi.yml
@@ -166,6 +166,12 @@ jobs:
             push_time=""
           fi
 
+          # Non-security-critical: publish_results is only present for workflow_dispatch events
+          publish_results=$(jq -r '.inputs.publish_results // "true"' artifacts/event_file/event.json | tr -cd "[:alpha:]")
+          if [ "$publish_results" != "false" ]; then
+            publish_results="true"
+          fi
+
           # HW tests enablement
           if [ -n "$GITLAB_ACCESS_TOKEN" ]; then
             hw_tests_enabled="true"
@@ -232,7 +238,8 @@ jobs:
             "sha": "$WR_HEAD_SHA",
             "action": "$action",
             "run_id": "$WR_RUN_ID",
-            "conclusion": "$WR_CONCLUSION"
+            "conclusion": "$WR_CONCLUSION",
+            "publish_results": $publish_results
           }
           EOF
 

--- a/.github/workflows/tests_results.yml
+++ b/.github/workflows/tests_results.yml
@@ -15,6 +15,8 @@ jobs:
     name: Get artifacts
     runs-on: ubuntu-latest
     outputs:
+      artifacts_available: ${{ steps.check-artifacts.outputs.artifacts_available }}
+      publish_results: ${{ steps.get-info.outputs.publish_results }}
       original_event: ${{ steps.get-info.outputs.original_event }}
       original_action: ${{ steps.get-info.outputs.original_action }}
       original_sha: ${{ steps.get-info.outputs.original_sha }}
@@ -32,13 +34,25 @@ jobs:
       qemu_types: ${{ steps.get-info.outputs.qemu_types }}
     steps:
       - name: Download and Extract Artifacts
+        continue-on-error: true
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
         with:
           run_id: ${{ github.event.workflow_run.id }}
           path: ./artifacts
 
+      - name: Check if artifacts are available
+        id: check-artifacts
+        run: |
+          if [ -f ./artifacts/parent-artifacts/workflow_info.json ]; then
+            echo "artifacts_available=true" >> $GITHUB_OUTPUT
+          else
+            echo "artifacts_available=false" >> $GITHUB_OUTPUT
+            echo "No artifacts found. The triggering workflow may have been cancelled before uploading artifacts."
+          fi
+
       - name: Get original info
         id: get-info
+        if: steps.check-artifacts.outputs.artifacts_available == 'true'
         run: |
           # Inputs in workflow_info.json are already sanitized and safe to use
 
@@ -48,6 +62,7 @@ jobs:
           original_ref=$(jq -r '.ref' ./artifacts/parent-artifacts/workflow_info.json)
           original_conclusion=$(jq -r '.conclusion' ./artifacts/parent-artifacts/workflow_info.json)
           original_run_id=$(jq -r '.run_id' ./artifacts/parent-artifacts/workflow_info.json)
+          publish_results=$(jq -r '.publish_results // "true"' ./artifacts/parent-artifacts/workflow_info.json)
 
           hw_tests_enabled=$(jq -r '.hw_tests_enabled' ./artifacts/parent-artifacts/workflow_info.json)
           hw_targets=$(jq -c '.hw_targets' ./artifacts/parent-artifacts/workflow_info.json)
@@ -74,6 +89,7 @@ jobs:
           echo "original_ref=$original_ref" >> $GITHUB_OUTPUT
           echo "original_conclusion=$original_conclusion" >> $GITHUB_OUTPUT
           echo "original_run_id=$original_run_id" >> $GITHUB_OUTPUT
+          echo "publish_results=$publish_results" >> $GITHUB_OUTPUT
 
           echo "hw_tests_enabled = $hw_tests_enabled"
           echo "hw_targets = $hw_targets"
@@ -90,6 +106,7 @@ jobs:
           echo "original_ref = $original_ref"
           echo "original_conclusion = $original_conclusion"
           echo "original_run_id = $original_run_id"
+          echo "publish_results = $publish_results"
 
       - name: Print links to other runs
         env:
@@ -102,9 +119,11 @@ jobs:
     name: Unit Test Results
     needs: get-artifacts
     if: |
-      github.event.workflow_run.conclusion == 'success' ||
-      github.event.workflow_run.conclusion == 'failure' ||
-      github.event.workflow_run.conclusion == 'timed_out'
+      needs.get-artifacts.outputs.artifacts_available == 'true' && (
+        github.event.workflow_run.conclusion == 'success' ||
+        github.event.workflow_run.conclusion == 'failure' ||
+        github.event.workflow_run.conclusion == 'timed_out'
+      )
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -232,13 +251,26 @@ jobs:
             })).data;
             core.info(`${name} is ${state}`);
 
+      - name: Check if results should be published
+        id: check-publish
+        if: always()
+        env:
+          ORIGINAL_CONCLUSION: ${{ needs.get-artifacts.outputs.original_conclusion }}
+          WR_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          PUBLISH_RESULTS: ${{ needs.get-artifacts.outputs.publish_results }}
+          ORIGINAL_EVENT: ${{ needs.get-artifacts.outputs.original_event }}
+        run: |
+          if [[ "$ORIGINAL_CONCLUSION" != "cancelled" && \
+                "$WR_CONCLUSION" != "cancelled" && \
+                "$PUBLISH_RESULTS" != "false" && \
+                ("$ORIGINAL_EVENT" == "schedule" || "$ORIGINAL_EVENT" == "workflow_dispatch") ]]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Generate report
-        if: |
-          (!cancelled() &&
-           needs.get-artifacts.outputs.original_conclusion != 'cancelled' &&
-           github.event.workflow_run.conclusion != 'cancelled') &&
-          (needs.get-artifacts.outputs.original_event == 'schedule' ||
-           needs.get-artifacts.outputs.original_event == 'workflow_dispatch')
+        if: ${{ !cancelled() && steps.check-publish.outputs.should_publish == 'true' }}
         env:
           HW_TESTS_ENABLED: ${{ needs.get-artifacts.outputs.hw_tests_enabled }}
           HW_TARGETS: ${{ needs.get-artifacts.outputs.hw_targets }}
@@ -279,12 +311,7 @@ jobs:
           rm -rf artifacts
 
       - name: Generate badge
-        if: |
-          (!cancelled() &&
-           needs.get-artifacts.outputs.original_conclusion != 'cancelled' &&
-           github.event.workflow_run.conclusion != 'cancelled') &&
-          (needs.get-artifacts.outputs.original_event == 'schedule' ||
-           needs.get-artifacts.outputs.original_event == 'workflow_dispatch')
+        if: ${{ !cancelled() && steps.check-publish.outputs.should_publish == 'true' }}
         uses: jaywcjlove/generated-badges@0e078ae4d4bab3777ea4f137de496ab44688f5ad # v1.0.13
         with:
           label: Runtime Tests
@@ -294,12 +321,7 @@ jobs:
           style: flat
 
       - name: Push badge
-        if: |
-          (!cancelled() &&
-           needs.get-artifacts.outputs.original_conclusion != 'cancelled' &&
-           github.event.workflow_run.conclusion != 'cancelled') &&
-          (needs.get-artifacts.outputs.original_event == 'schedule' ||
-           needs.get-artifacts.outputs.original_event == 'workflow_dispatch')
+        if: ${{ !cancelled() && steps.check-publish.outputs.should_publish == 'true' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Description of Change

This pull request enhances the test workflow automation by introducing a configurable option to control whether test results are published, and improves robustness in handling workflow artifacts and publishing conditions. The changes make the publishing of results more flexible and prevent errors when artifacts are missing or workflows are cancelled.

Key changes include:

**Configurable Publishing of Test Results**
* Added a `publish_results` boolean input to the `workflow_dispatch` trigger in `.github/workflows/tests.yml`, allowing manual control over whether test results are published.
* Updated `.github/workflows/tests_hw_wokwi.yml` to propagate the `publish_results` input through the workflow, ensuring it is available for downstream jobs and included in the workflow info artifact. [[1]](diffhunk://#diff-36b3dd47533746ca0ce7afb9e66f58fcfc45c44cde7ae2f0084b8ded49c8b29aR169-R174) [[2]](diffhunk://#diff-36b3dd47533746ca0ce7afb9e66f58fcfc45c44cde7ae2f0084b8ded49c8b29aL235-R242)

**Robust Artifact Handling**
* Modified `.github/workflows/tests_results.yml` to check for the presence of artifacts before proceeding, and to output an `artifacts_available` flag for use in job conditionals.
* Ensured that jobs dependent on artifacts only run when artifacts are available, preventing failures due to missing files.

**Conditional Publishing Logic**
* Refactored the logic for publishing reports, badges, and history: now, these steps only run if the workflow was not cancelled, artifacts are available, and `publish_results` is not set to `false`. This logic is centralized in a new "Check if results should be published" step. [[1]](diffhunk://#diff-07bda5b6dde334d5e7734781efbfe75a79dfdb9fd808786cc2dba65a35fea050R254-R273) [[2]](diffhunk://#diff-07bda5b6dde334d5e7734781efbfe75a79dfdb9fd808786cc2dba65a35fea050L282-R314) [[3]](diffhunk://#diff-07bda5b6dde334d5e7734781efbfe75a79dfdb9fd808786cc2dba65a35fea050L297-R324)

**Workflow Metadata Propagation**
* Ensured that the `publish_results` value is read from workflow info artifacts and made available as an output for downstream jobs, improving traceability and consistency. [[1]](diffhunk://#diff-07bda5b6dde334d5e7734781efbfe75a79dfdb9fd808786cc2dba65a35fea050R18-R19) [[2]](diffhunk://#diff-07bda5b6dde334d5e7734781efbfe75a79dfdb9fd808786cc2dba65a35fea050R65) [[3]](diffhunk://#diff-07bda5b6dde334d5e7734781efbfe75a79dfdb9fd808786cc2dba65a35fea050R92) [[4]](diffhunk://#diff-07bda5b6dde334d5e7734781efbfe75a79dfdb9fd808786cc2dba65a35fea050R109)

These improvements make the test result publishing process more flexible, reliable, and maintainable.
