### PR TITLE
fix(release): Fix release script testing and tool packaging

### DIFF
--- a/.github/scripts/env.sh
+++ b/.github/scripts/env.sh
@@ -10,7 +10,10 @@ ENV_SOURCED=1
 ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # OS detection
+# $OSTYPE can be unset or report unexpected values when bash is launched from
+# PowerShell on Windows CI runners, so cross-check with uname -s as a fallback.
 OSBITS=$(uname -m)
+_UNAME_S=$(uname -s)
 if [[ "$OSTYPE" == "linux"* ]]; then
     export OS_IS_LINUX="1"
     if [[ "$OSBITS" == "i686" ]]; then
@@ -27,7 +30,8 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     export OS_IS_MACOS="1"
     OS_NAME="macosx"
-elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
+elif [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || \
+        "$_UNAME_S" == MINGW* || "$_UNAME_S" == CYGWIN* || "$_UNAME_S" == MSYS* ]]; then
     export OS_IS_WINDOWS="1"
     OS_NAME="windows"
 else
@@ -35,6 +39,7 @@ else
     echo "Unknown OS '$OS_NAME'"
     exit 1
 fi
+unset _UNAME_S
 export OS_NAME
 
 # Arduino paths

--- a/.github/scripts/on-release.sh
+++ b/.github/scripts/on-release.sh
@@ -184,15 +184,23 @@ cp -f  "$GITHUB_WORKSPACE/package.json"                     "$PKG_DIR/"
 cp -f  "$GITHUB_WORKSPACE/programmers.txt"                  "$PKG_DIR/"
 cp -Rf "$GITHUB_WORKSPACE/cores"                            "$PKG_DIR/"
 cp -Rf "$GITHUB_WORKSPACE/libraries"                        "$PKG_DIR/"
-cp -f  "$GITHUB_WORKSPACE/tools/espota.exe"                 "$PKG_DIR/tools/"
-cp -f  "$GITHUB_WORKSPACE/tools/espota.py"                  "$PKG_DIR/tools/"
-cp -f  "$GITHUB_WORKSPACE/tools/gen_esp32part.py"           "$PKG_DIR/tools/"
-cp -f  "$GITHUB_WORKSPACE/tools/gen_esp32part.exe"          "$PKG_DIR/tools/"
-cp -f  "$GITHUB_WORKSPACE/tools/gen_insights_package.py"    "$PKG_DIR/tools/"
-cp -f  "$GITHUB_WORKSPACE/tools/gen_insights_package.exe"   "$PKG_DIR/tools/"
+
+# Copy every tools/*.py and tools/*.exe at the repository root (not subdirs).
+# Dev-only scripts are skipped by name prefix (toolchain bootstrap / CI / unused).
+echo "Copying tools root scripts ..."
+shopt -s nullglob
+for tool_file in "$GITHUB_WORKSPACE"/tools/*.py "$GITHUB_WORKSPACE"/tools/*.exe; do
+    tool_base="${tool_file##*/}"
+    case "$tool_base" in
+        get.*|arduino_cmake.*) continue ;;
+        *) echo "Copying $tool_file" ;;
+    esac
+    cp -f "$tool_file" "$PKG_DIR/tools/"
+done
+shopt -u nullglob
+
 cp -Rf "$GITHUB_WORKSPACE/tools/partitions"                 "$PKG_DIR/tools/"
 cp -Rf "$GITHUB_WORKSPACE/tools/ide-debug"                  "$PKG_DIR/tools/"
-cp -f  "$GITHUB_WORKSPACE/tools/pioarduino-build.py"        "$PKG_DIR/tools/"
 
 # Remove unnecessary files in the package folder
 echo "Cleaning up folders ..."

--- a/.github/scripts/test-package-json.sh
+++ b/.github/scripts/test-package-json.sh
@@ -9,20 +9,20 @@ SCRIPTS_DIR="./.github/scripts"
 OUTPUT_DIR="$GITHUB_WORKSPACE/build"
 PACKAGE_JSON_DEV="package_esp32_dev_index.json"
 PACKAGE_JSON_REL="package_esp32_index.json"
-
-# Get release info
 RELEASE_PRE="${RELEASE_PRE:-false}"
+
+source "${SCRIPTS_DIR}/env.sh"
 
 # Convert path to absolute and handle Windows paths for file:// URLs
 function get_file_url {
     local file_path="$1"
 
-    # Get absolute path
-    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-        # On Windows, convert to absolute path and use forward slashes
-        abs_path=$(cd "$(dirname "$file_path")" && pwd -W)/$(basename "$file_path") 2>/dev/null || echo "$file_path"
-        # Ensure forward slashes and proper file:// format for Windows
-        abs_path="${abs_path//\\//}"
+    if [[ "$OS_IS_WINDOWS" == "1" ]]; then
+        # On Windows use cygpath to produce a proper Windows-style path that
+        # native binaries (arduino-cli) can open.  cygpath is always available
+        # in Git Bash / MSYS2 and handles every quirk of drive-letter paths.
+        local abs_path
+        abs_path=$(cygpath -m "$(realpath "$file_path" 2>/dev/null || echo "$file_path")")
         echo "file:///$abs_path"
     else
         # On Unix systems, just ensure absolute path
@@ -34,9 +34,31 @@ function get_file_url {
     fi
 }
 
+# Verify that the installed esp32 core version matches the release tag.
+# GITHUB_REF_NAME is set automatically by GitHub Actions for release events.
+# Strip a leading 'v' to normalise tags like v3.3.9 → 3.3.9.
+function verify_installed_version {
+    local expected_version="${GITHUB_REF_NAME#v}"
+
+    if [ -z "$expected_version" ]; then
+        echo "WARNING: GITHUB_REF_NAME is not set; skipping version check"
+        return 0
+    fi
+
+    local installed_version
+    installed_version=$(arduino-cli core list 2>/dev/null | awk '/^esp32:esp32[[:space:]]/{print $2}')
+
+    if [ "$installed_version" != "$expected_version" ]; then
+        echo "ERROR: Expected esp32:esp32@$expected_version but found esp32:esp32@${installed_version:-<none>}"
+        echo "       The local package JSON was likely not loaded properly."
+        return 1
+    fi
+    echo "✓ Verified esp32:esp32@$expected_version is installed"
+}
+
 echo "Installing arduino-cli ..."
 # Set up PATH based on OS
-if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+if [[ "$OS_IS_WINDOWS" == "1" ]]; then
     export PATH="$HOME/bin:$PATH"
 else
     export PATH="/home/runner/bin:$HOME/bin:$PATH"
@@ -60,6 +82,8 @@ if [ $? -ne 0 ]; then
     echo "ERROR: Failed to install esp32 ($?)"
     exit 1
 fi
+
+verify_installed_version || exit 1
 
 echo "Compiling example ..."
 arduino-cli compile --fqbn esp32:esp32:esp32 "$GITHUB_WORKSPACE"/libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino
@@ -91,6 +115,8 @@ if [ "$RELEASE_PRE" == "false" ]; then
         echo "ERROR: Failed to install esp32 ($?)"
         exit 1
     fi
+
+    verify_installed_version || exit 1
 
     echo "Compiling example ..."
     arduino-cli compile --fqbn esp32:esp32:esp32 "$GITHUB_WORKSPACE"/libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino


### PR DESCRIPTION
## Description of Change

This pull request improves the robustness and maintainability of the release and test automation scripts, with a focus on more reliable Windows detection, flexible tool copying, and enhanced validation of installed core versions.

**Script robustness and cross-platform improvements:**

* Enhanced Windows detection in `.github/scripts/test-package-json.sh` by checking both `$OSTYPE` and `uname -s`, ensuring reliable OS detection regardless of how Bash is invoked. (`[.github/scripts/test-package-json.shR16-R33](diffhunk://#diff-260ce37678883193000666183a31517eaf6162c139485287199e6a43b5b44db9R16-R33)`)
* Updated path handling for Windows in `.github/scripts/test-package-json.sh` to use `cygpath`, providing consistent and correct file paths for native binaries like `arduino-cli`. (`[.github/scripts/test-package-json.shR16-R33](diffhunk://#diff-260ce37678883193000666183a31517eaf6162c139485287199e6a43b5b44db9R16-R33)`)

**Validation and testing enhancements:**

* Added a `verify_installed_version` function in `.github/scripts/test-package-json.sh` to ensure the installed `esp32:esp32` core version matches the release tag, improving the reliability of release checks. This function is now called after core installation and before compiling examples. (`[[1]](diffhunk://#diff-260ce37678883193000666183a31517eaf6162c139485287199e6a43b5b44db9R45-R69)`, `[[2]](diffhunk://#diff-260ce37678883193000666183a31517eaf6162c139485287199e6a43b5b44db9R94-R95)`, `[[3]](diffhunk://#diff-260ce37678883193000666183a31517eaf6162c139485287199e6a43b5b44db9R127-R128)`)

**Release packaging improvements:**

* Refactored the tool copying logic in `.github/scripts/on-release.sh` to dynamically copy all `.py` and `.exe` files from the `tools` directory, skipping development-only scripts by name pattern, instead of hardcoding each file. This makes the script more maintainable and future-proof. (`[.github/scripts/on-release.shL187-L195](diffhunk://#diff-f6fb1aba88970cb53fc594d346daf15296b027a9c2c46d9af53b8952afdf3c5bL187-L195)`)

Closes https://github.com/espressif/arduino-esp32/issues/12652

## Test Scenarios

https://github.com/lucasssvaz/arduino-esp32/actions/runs/26928027142
