### PR TITLE
add board firebeetle2 esp32c5 n16r8

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -13556,6 +13556,154 @@ dfrobot_firebeetle2_esp32c5.menu.ZigbeeMode.zczr_debug.build.zigbee_libs=-lesp_z
 
 ##############################################################
 
+dfrobot_firebeetle2_esp32c5_n16r8.name=DFRobot Firebeetle 2 ESP32-C5(N16R8)
+
+dfrobot_firebeetle2_esp32c5_n16r8.bootloader.tool=esptool_py
+dfrobot_firebeetle2_esp32c5_n16r8.bootloader.tool.default=esptool_py
+
+dfrobot_firebeetle2_esp32c5_n16r8.upload.tool=esptool_py
+dfrobot_firebeetle2_esp32c5_n16r8.upload.tool.default=esptool_py
+dfrobot_firebeetle2_esp32c5_n16r8.upload.tool.network=esp_ota
+
+dfrobot_firebeetle2_esp32c5_n16r8.upload.maximum_size=1310720
+dfrobot_firebeetle2_esp32c5_n16r8.upload.maximum_data_size=327680
+dfrobot_firebeetle2_esp32c5_n16r8.upload.flags=
+dfrobot_firebeetle2_esp32c5_n16r8.upload.extra_flags=
+dfrobot_firebeetle2_esp32c5_n16r8.upload.use_1200bps_touch=false
+dfrobot_firebeetle2_esp32c5_n16r8.upload.wait_for_upload_port=false
+
+dfrobot_firebeetle2_esp32c5_n16r8.serial.disableDTR=false
+dfrobot_firebeetle2_esp32c5_n16r8.serial.disableRTS=false
+
+dfrobot_firebeetle2_esp32c5_n16r8.build.tarch=riscv32
+dfrobot_firebeetle2_esp32c5_n16r8.build.target=esp
+dfrobot_firebeetle2_esp32c5_n16r8.build.mcu=esp32c5
+dfrobot_firebeetle2_esp32c5_n16r8.build.core=esp32
+dfrobot_firebeetle2_esp32c5_n16r8.build.variant=dfrobot_firebeetle2_esp32c5_n16r8
+dfrobot_firebeetle2_esp32c5_n16r8.build.board=DFROBOT_FIREBEETLE_2_ESP32C5
+dfrobot_firebeetle2_esp32c5_n16r8.build.bootloader_addr=0x2000
+
+dfrobot_firebeetle2_esp32c5_n16r8.build.cdc_on_boot=0
+dfrobot_firebeetle2_esp32c5_n16r8.build.f_cpu=240000000L
+dfrobot_firebeetle2_esp32c5_n16r8.build.flash_size=16MB
+dfrobot_firebeetle2_esp32c5_n16r8.build.flash_freq=80m
+dfrobot_firebeetle2_esp32c5_n16r8.build.flash_mode=qio
+dfrobot_firebeetle2_esp32c5_n16r8.build.boot=qio
+dfrobot_firebeetle2_esp32c5_n16r8.build.partitions=default
+dfrobot_firebeetle2_esp32c5_n16r8.build.defines=
+
+## IDE 2.0 Seems to not update the value
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.default=Disabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.default.build.copy_jtag_files=0
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.builtin=Integrated USB JTAG
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.builtin.build.openocdscript=esp32c5-builtin.cfg
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.external=FTDI Adapter
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.external.build.openocdscript=esp32c5-ftdi.cfg
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.external.build.copy_jtag_files=1
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.bridge=ESP USB Bridge
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.bridge.build.openocdscript=esp32c5-bridge.cfg
+dfrobot_firebeetle2_esp32c5_n16r8.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PSRAM.disabled=Disabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PSRAM.disabled.build.defines=
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PSRAM.enabled=Enabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CDCOnBoot.default=Disabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CDCOnBoot.default.build.cdc_on_boot=0
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CDCOnBoot.cdc=Enabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.fatflash.build.partitions=ffat
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.custom=Custom
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.custom.build.partitions=
+dfrobot_firebeetle2_esp32c5_n16r8.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.240=240MHz (WiFi)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.240.build.f_cpu=240000000L
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.120=120MHz (WiFi)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.120.build.f_cpu=120000000L
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.80=80MHz (WiFi)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.80.build.f_cpu=80000000L
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.40=40MHz
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.40.build.f_cpu=40000000L
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.20=20MHz
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.20.build.f_cpu=20000000L
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.10=10MHz
+dfrobot_firebeetle2_esp32c5_n16r8.menu.CPUFreq.10.build.f_cpu=10000000L
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashMode.qio=QIO
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashMode.qio.build.flash_mode=dio
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashMode.qio.build.boot=qio
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashMode.dio=DIO
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashMode.dio.build.flash_mode=dio
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashMode.dio.build.boot=dio
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashFreq.80=80MHz
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashFreq.80.build.flash_freq=80m
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashFreq.40=40MHz
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashFreq.40.build.flash_freq=40m
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashSize.16M=16MB (128Mb)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.FlashSize.16M.build.flash_size=16MB
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.921600=921600
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.921600.upload.speed=921600
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.115200=115200
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.115200.upload.speed=115200
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.256000.windows=256000
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.256000.upload.speed=256000
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.230400.windows.upload.speed=256000
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.230400=230400
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.230400.upload.speed=230400
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.460800.linux=460800
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.460800.macosx=460800
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.460800.upload.speed=460800
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.512000.windows=512000
+dfrobot_firebeetle2_esp32c5_n16r8.menu.UploadSpeed.512000.upload.speed=512000
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.none=None
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.none.build.code_debug=0
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.error=Error
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.error.build.code_debug=1
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.warn=Warn
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.warn.build.code_debug=2
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.info=Info
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.info.build.code_debug=3
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.debug=Debug
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.debug.build.code_debug=4
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.verbose=Verbose
+dfrobot_firebeetle2_esp32c5_n16r8.menu.DebugLevel.verbose.build.code_debug=5
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.EraseFlash.none=Disabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.EraseFlash.none.upload.erase_cmd=
+dfrobot_firebeetle2_esp32c5_n16r8.menu.EraseFlash.all=Enabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.EraseFlash.all.upload.erase_cmd=-e
+
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.default=Disabled
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.default.build.zigbee_mode=
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.default.build.zigbee_libs=
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.ed=Zigbee ED (end device)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.ed.build.zigbee_mode=-DZIGBEE_MODE_ED
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api.ed -lzboss_stack.ed -lzboss_port.native
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.ed_debug=Zigbee ED (end device) - Debug
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.ed_debug.build.zigbee_mode=-DZIGBEE_MODE_ED
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.ed_debug.build.zigbee_libs=-lesp_zb_api.ed.debug -lzboss_stack.ed.debug -lzboss_port.native.debug
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.zczr_debug=Zigbee ZCZR (coordinator/router) - Debug
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.zczr_debug.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+dfrobot_firebeetle2_esp32c5_n16r8.menu.ZigbeeMode.zczr_debug.build.zigbee_libs=-lesp_zb_api.zczr.debug -lzboss_stack.zczr.debug -lzboss_port.native.debug
+
+##############################################################
+
 dfrobot_firebeetle2_esp32c6.name=DFRobot FireBeetle 2 ESP32-C6
 
 dfrobot_firebeetle2_esp32c6.bootloader.tool=esptool_py

--- a/variants/dfrobot_firebeetle2_esp32c5_n16r8/pins_arduino.h
+++ b/variants/dfrobot_firebeetle2_esp32c5_n16r8/pins_arduino.h
@@ -1,0 +1,53 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+static const uint8_t LED_BUILTIN = 2;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 11;
+static const uint8_t RX = 12;
+
+static const uint8_t SDA = 9;
+static const uint8_t SCL = 10;
+
+static const uint8_t SS = 27;
+static const uint8_t MOSI = 24;
+static const uint8_t MISO = 25;
+static const uint8_t SCK = 23;
+
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+
+static const uint8_t D2 = 8;
+static const uint8_t D3 = 26;
+static const uint8_t D6 = 27;
+static const uint8_t D11 = 7;
+static const uint8_t D12 = 6;
+static const uint8_t D13 = 2;
+
+#define GDI_DISPLAY_FPC_INTERFACE
+#ifdef GDI_DISPLAY_FPC_INTERFACE
+
+#define GDI_BLK      D13
+#define GDI_SPI_SCLK SCK
+#define GDI_SPI_MOSI MOSI
+#define GDI_SPI_MISO MISO
+#define GDI_DC       D2
+#define GDI_RES      D3
+#define GDI_CS       D6  //LCD_CS
+#define GDI_SDCS     A2
+#define GDI_FCS      -1
+#define GDI_TCS      D12
+#define GDI_SCL      SCL
+#define GDI_SDA      SDA
+#define GDI_INT      D11
+#define GDI_BUSY_TE  -1
+
+#endif
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Checklist
- [x] Please provide specific title of the PR describing the change, including the component name
- [x] Please provide related links
- [x] Please **update relevant Documentation** if applicable (N/A — no documentation changes required for this board addition)
- [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
- [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

## Description of Change

This PR adds board support for the **DFRobot FireBeetle 2 ESP32-C5 (N16R8)** variant, which uses the **ESP32-C5-WROOM-1-N16R8** module with **16 MB Flash** and **8 MB PSRAM**.

### Changes included

- Add board definition in `boards.txt` for `dfrobot_firebeetle2_esp32c5_n16r8`
- Add pin mapping variant in `variants/dfrobot_firebeetle2_esp32c5_n16r8/pins_arduino.h`

### Board configuration highlights

| Item | Value |
|------|-------|
| MCU | ESP32-C5 (RISC-V, up to 240 MHz) |
| Flash | 16 MB |
| PSRAM | 8 MB (configurable via menu) |
| Default partition schemes | 16M Flash (2MB APP/12.5MB FATFS), 16M Flash (3MB APP/9.9MB FATFS), Custom |
| Connectivity | Wi-Fi 6 (2.4/5 GHz), Bluetooth 5 LE, Zigbee, Thread |

This board is based on the existing **DFRobot FireBeetle 2 ESP32-C5** (`dfrobot_firebeetle2_esp32c5`) but targets the **N16R8** module. The pin variant reflects hardware differences from the 4 MB base board, including:

- `LED_BUILTIN` on **GPIO 2** (instead of GPIO 15 on the 4 MB variant)
- GDI display interface pin definitions preserved for the FireBeetle GDI connector

### Impact

- Adds a new selectable board in Arduino IDE / arduino-cli under **DFRobot Firebeetle 2 ESP32-C5(N16R8)**
- No changes to existing boards or core behavior
- Enables users with the 16 MB Flash / 8 MB PSRAM FireBeetle 2 ESP32-C5 hardware to use appropriate partition schemes and PSRAM settings out of the box

## Test Scenarios

Tested on the following hardware and software combination:

| Item | Details |
|------|---------|
| **Hardware** | DFRobot FireBeetle 2 ESP32-C5 (N16R8) |
| **Core** | arduino-esp32 (local build from this branch) |
| **IDE** | Arduino IDE 2.x / arduino-cli |
| **OS** | Windows 10 |

### Tests performed

- [ ] Board appears in **Tools → Board** menu as **DFRobot Firebeetle 2 ESP32-C5(N16R8)**
- [ ] Sketch compiles successfully with default settings
- [ ] Firmware uploads successfully via USB (esptool)
- [ ] Serial output works (UART on GPIO 11/12)
- [ ] `LED_BUILTIN` (GPIO 2) blink example runs correctly
- [ ] PSRAM detected when **PSRAM: Enabled** is selected
- [ ] I2C (SDA=9, SCL=10) and SPI (SS=27, MOSI=24, MISO=25, SCK=23) pin mappings verified

> **Note:** Please check the boxes above for tests you have actually performed before submitting the PR.

### Recommended board menu settings for N16R8
