### PR TITLE
ci(upload): Fix platform.txt and add upload tests

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -8,6 +8,7 @@ This document explains how the Continuous Integration and Continuous Deployment 
 - [Centralized SoC Configuration](#centralized-soc-configuration)
 - [Workflows](#workflows)
   - [Compilation Tests](#compilation-tests-pushyml)
+  - [Mock Upload Tests](#mock-upload-tests-upload-testsyml)
   - [Runtime Tests](#runtime-tests)
   - [Multi-Device (Multi-DUT) Tests](#multi-device-multi-dut-tests)
   - [IDF Component Build](#idf-component-build-build_componentyml)
@@ -171,6 +172,66 @@ Workflows source the configuration in their setup steps and use the arrays to dy
 
 **SoC Config Usage:**
 The script sources `socs_config.sh` and uses `BUILD_TEST_TARGETS` to determine which variants are considered official.
+
+### Mock Upload Tests (`upload-tests.yml`)
+
+**Trigger:**
+- Push to `master` or `release/*` branches
+- Pull requests modifying upload-related paths (`platform.txt`, `boards.txt`, `tools/flasher.py`, mock upload scripts, `CIBoardsTest/**`, etc.)
+- Manual workflow dispatch
+
+**Purpose:** Validate `upload.pattern` → `flasher.py` → esptool on every supported SoC, using a mock bootloader. Each tool uploads the same sketch **twice** per SoC (second flash exercises `--diff-with`).
+
+| Tool | Underlying | Install script |
+|------|------------|----------------|
+| `cli` | `arduino-cli` | `install-arduino-cli.sh` |
+| `builder` | arduino-nightly `processing.app.Base --upload` | `install-arduino-builder.sh` |
+
+The checked-out core is installed via `install-arduino-core-esp32.sh` (symlink + `get.py`), not Board Manager.
+
+**Jobs:**
+
+#### `mock-upload`
+**Matrix:** `ubuntu-latest`, `windows-latest`, `macos-26-intel` (3 parallel jobs)
+
+Each job loops all `CORE_SOCS` (8 chips): `start_mock_bootloader` (chip auto-detect by default) → cli twice → builder twice → `stop_mock_bootloader`.
+
+**Per-job setup:** Python + pyserial, `pip install esp32-mock-bootloader==$(cat .github/esp32-mock-bootloader-version)` ([PyPI package](https://pypi.org/project/esp32-mock-bootloader/)), libs cache (same key as `push.yml`), xvfb on Linux, `pip install esptool` + `MOCK_ESPTOOL_OVERRIDE=1` on all matrix OSes until bundled esptool supports `socket://`.
+
+The mock listens on TCP and upload tools use `socket://127.0.0.1:9876` on every OS (same as `test_mock_bootloader.py`). Older bundled esptool builds may lack `socket://` in vendored pyserial; `MOCK_ESPTOOL_OVERRIDE` routes `flasher.py` through pip esptool until the esptool packaging fix is released and picked up by the core.
+
+**CI entry script:** `.github/scripts/test-mock-upload.sh` (sources `mock_upload_lib.sh`; no args in GHA).
+
+**Libraries:** `mock_upload_lib.sh` (bootloader, esptool override, twice-upload helpers) and `arduino_headless.sh` (headless IDE 1.x / arduino-nightly builder). Headless JVM noise (log4j StatusLogger, macOS launcher dumps, jmdns `dns[query]`/`dns[response]` spam on cloud hostnames) is suppressed via `arduino-headless-logging.properties` plus a grep filter on all OSes (default on; set `ARDUINO_HEADLESS_LOG_FILTER=0` for raw IDE output).
+
+**Local commands:**
+
+```bash
+# Install mock bootloader (see https://github.com/espressif/esp32-mock-bootloader):
+pip install esp32-mock-bootloader
+
+# flasher.py integration only (protocol tests live in esp32-mock-bootloader repo):
+python3 .github/scripts/ci_testing/test_mock_bootloader.py
+
+# Full upload pipeline locally (requires pip esptool until bundled fix lands):
+MOCK_ESPTOOL_OVERRIDE=1 bash .github/scripts/test-mock-upload.sh cli esp32
+
+# Full matrix locally (all SoCs, cli + builder):
+bash .github/scripts/test-mock-upload.sh
+
+# Filter by tool and/or SoC:
+bash .github/scripts/test-mock-upload.sh cli esp32c3
+bash .github/scripts/test-mock-upload.sh builder esp32s3
+
+# Thin local wrapper (not used by GHA):
+bash .github/scripts/ci_testing/mock_upload_validation.sh
+```
+
+`MOCK_ESPTOOL_OVERRIDE=1` replaces bundled `tools/esptool/esptool` with pip `esptool` for the duration of the run (restored on exit). GHA sets this on all matrix OSes; remove that workflow step once bundled esptool supports `socket://`.
+
+FQBNs are resolved at runtime via `default_upload_test_fqbn()` in `sketch_utils.sh` (compile CI defaults + `UploadSpeed=115200`).
+
+**Note:** Scripts under `.github/scripts/ci_testing/` are for local validation only; GHA does not run them.
 
 #### 2. `build-arduino-linux`
 **Runs on:** Ubuntu-latest (matrix of chunks)

--- a/.github/scripts/arduino-headless-logging.properties
+++ b/.github/scripts/arduino-headless-logging.properties
@@ -1,0 +1,6 @@
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=INFO
+javax.jmdns.level=OFF
+javax.jmdns.impl.level=OFF
+javax.jmdns.impl.JmDNSImpl.level=OFF
+javax.jmdns.impl.tasks.level=OFF

--- a/.github/scripts/arduino_headless.sh
+++ b/.github/scripts/arduino_headless.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# Headless Arduino IDE 1.x / arduino-nightly builder for CI (upload, board install).
+
+[ -n "$ARDUINO_HEADLESS_SOURCED" ] && return 0
+ARDUINO_HEADLESS_SOURCED=1
+
+_HEADLESS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPTS_DIR:-$_HEADLESS_LIB_DIR}"
+
+function run_with_timeout {
+    local seconds="$1" pid elapsed rc
+    shift
+    "$@" &
+    pid=$!
+    elapsed=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if [ "$elapsed" -ge "$seconds" ]; then
+            echo "ERROR: timed out after ${seconds}s" >&2
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            return 124
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    wait "$pid"
+    rc=$?
+    return "$rc"
+}
+
+function _arduino_headless_log_filter_enabled {
+    case "${ARDUINO_HEADLESS_LOG_FILTER:-1}" in
+        0 | n | N | no | NO | false | FALSE | off | OFF) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+function _filter_arduino_headless_log_noise {
+    # arduino-nightly mDNS (jmdns) spams WARN + hex dumps on cloud VM hostnames; not actionable in CI.
+    LC_ALL=C grep -aEv \
+        -e '^(DEBUG|TRACE|INFO) StatusLogger' \
+        -e '^Picked up JAVA_TOOL_OPTIONS:' \
+        -e 'Arduino\[[0-9]+:[0-9]+\] ' \
+        -e '\[JRSAppKitAWT markAppIsDaemon\]' \
+        -e '^[[:space:]]+"-' \
+        -e '^[[:space:]]*[{}][[:space:]]*$' \
+        -e '^[[:space:]]*\)' \
+        -e '^JVM(Runtime|Options|Arguments|Classpath|DefaultOptions|MainClassName)' \
+        -e '^(CFBundleName|SearchSystemJVM|Command line passed|WorkingDirectory)=' \
+        -e 'javax\.jmdns' \
+        -e 'dns\[(query|response),' \
+        -e '^questions:$' \
+        -e 'questions=' \
+        -e '[[:space:]]*question:' \
+        -e 'DNSQuestion@' \
+        -e 'TYPE_IGNORE' \
+        -e 'CLASS_UNKNOWN' \
+        -e 'flags=0x[0-9a-fA-F]+:' \
+        -e 'bx-internal-cloud' \
+        -e '\.local' \
+        -e '^[[:space:]]*\[[[:space:]]*DNSQuestion@' \
+        -e '^[[:space:]]*[0-9a-fA-F]+: [0-9a-fA-F ]' \
+        -e '\]\]' \
+    | python3 -u -c 'import sys
+for raw in sys.stdin.buffer:
+    try:
+        sys.stdout.write(raw.decode("ascii"))
+    except UnicodeDecodeError:
+        pass'
+}
+
+function _run_arduino_headless_filtered {
+    local rc
+    if _arduino_headless_log_filter_enabled; then
+        set -o pipefail
+        "$@" 2>&1 | _filter_arduino_headless_log_noise
+        rc=${PIPESTATUS[0]}
+    else
+        "$@"
+        rc=$?
+    fi
+    return "$rc"
+}
+
+function _arduino_headless_java_bin {
+    local appdir="$1"
+    if [ -x "$appdir/java/bin/java" ]; then
+        echo "$appdir/java/bin/java"
+        return 0
+    fi
+    command -v java
+}
+
+function _arduino_headless_classpath {
+    local appdir="$1" cp
+    cp=$(printf '%s:' "$appdir"/lib/*.jar)
+    echo "${cp%:}"
+}
+
+function _arduino_headless_jul_config {
+    local props="$_HEADLESS_LIB_DIR/arduino-headless-logging.properties"
+    [ -f "$props" ] || return 1
+    printf '%s' "$props"
+}
+
+function _run_arduino_headless {
+    local appdir="$1"
+    shift
+    local java_bin classpath jul_config
+    local -a java_props=() java_cmd=()
+    [ -d "$appdir" ] || { echo "ERROR: Arduino tree not found at $appdir" >&2; return 1; }
+
+    jul_config="$(_arduino_headless_jul_config || true)"
+    if [ -n "$jul_config" ]; then
+        export JAVA_TOOL_OPTIONS="-Djava.awt.headless=true -Djava.util.logging.config.file=$jul_config"
+        java_props=(-Djava.awt.headless=true "-Djava.util.logging.config.file=$jul_config")
+    else
+        export JAVA_TOOL_OPTIONS="-Djava.awt.headless=true"
+        java_props=(-Djava.awt.headless=true)
+    fi
+
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        MSYS2_ARG_CONV_EXCL="*" MSYS_NO_PATHCONV=1 \
+            _run_arduino_headless_filtered "$appdir/arduino_debug.exe" "$@"
+        return
+    fi
+
+    if [[ "${OS_IS_MACOS:-0}" == "1" ]]; then
+        local app_bundle launcher
+        app_bundle="$(cd "$appdir/../.." && pwd)"
+        launcher="$app_bundle/Contents/MacOS/Arduino"
+        [ -x "$launcher" ] || { echo "ERROR: Arduino launcher not found at $launcher" >&2; return 1; }
+        if [ -n "$jul_config" ]; then
+            export JAVA_TOOL_OPTIONS="-Djava.awt.headless=true -Dapple.awt.UIElement=true -Djava.util.logging.config.file=$jul_config"
+        else
+            export JAVA_TOOL_OPTIONS="-Djava.awt.headless=true -Dapple.awt.UIElement=true"
+        fi
+        if [[ "$(uname -m)" == "arm64" ]]; then
+            _run_arduino_headless_filtered arch -x86_64 "$launcher" "$@"
+        else
+            _run_arduino_headless_filtered "$launcher" "$@"
+        fi
+        return
+    fi
+
+    java_bin="$(_arduino_headless_java_bin "$appdir")"
+    [ -n "$java_bin" ] || { echo "ERROR: java not found for $appdir" >&2; return 1; }
+    classpath="$(_arduino_headless_classpath "$appdir")"
+    java_cmd=("$java_bin" "${java_props[@]}" -DAPP_DIR="$appdir" -cp "$classpath" processing.app.Base "$@")
+    if [[ "${OS_IS_LINUX:-0}" == "1" ]] && command -v xvfb-run >/dev/null 2>&1; then
+        _run_arduino_headless_filtered xvfb-run -a "${java_cmd[@]}"
+    else
+        _run_arduino_headless_filtered "${java_cmd[@]}"
+    fi
+}
+
+function run_arduino_ide_v1 {
+    _run_arduino_headless "${ARDUINO_IDE_PATH:?ARDUINO_IDE_PATH required — source install-arduino-ide.sh first}" "$@"
+}
+
+function run_arduino_builder {
+    _run_arduino_headless "${ARDUINO_BUILDER_PATH:?ARDUINO_BUILDER_PATH required — source install-arduino-builder.sh first}" "$@"
+}

--- a/.github/scripts/ci_testing/mock_upload_validation.sh
+++ b/.github/scripts/ci_testing/mock_upload_validation.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Local convenience wrapper for mock upload CI (not used by GHA).
+# Usage: bash .github/scripts/ci_testing/mock_upload_validation.sh [cli|builder|all] [soc]
+#
+# Until bundled esptool supports socket://, use pip esptool for local runs:
+#   MOCK_ESPTOOL_OVERRIDE=1 bash .github/scripts/ci_testing/mock_upload_validation.sh cli esp32
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/../test-mock-upload.sh" "$@"

--- a/.github/scripts/ci_testing/test_ide1_upload_pattern.py
+++ b/.github/scripts/ci_testing/test_ide1_upload_pattern.py
@@ -3,14 +3,48 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 PLATFORM_TXT = ROOT / "platform.txt"
+BOARDS_TXT = ROOT / "boards.txt"
+SOCS_CONFIG = ROOT / ".github" / "scripts" / "socs_config.sh"
+
+_PLACEHOLDER_RE = re.compile(r"\{[^}]+\}")
+_ARRAY_LINE_RE = re.compile(r'^"([^"]+)"\s*,?\s*$')
 
 
-def load_platform_txt(path: Path) -> dict[str, str]:
+def load_bash_array(config_text: str, array_name: str) -> list[str]:
+    """Parse a simple NAME=( \"a\" \"b\" ) array from socs_config.sh."""
+    values: list[str] = []
+    in_array = False
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"{array_name}=("):
+            in_array = True
+            continue
+        if in_array:
+            if stripped == ")":
+                break
+            match = _ARRAY_LINE_RE.match(stripped)
+            if match:
+                values.append(match.group(1))
+    if not values:
+        raise SystemExit(f"could not parse {array_name} from {SOCS_CONFIG}")
+    return values
+
+
+def load_core_soc_boards() -> list[str]:
+    """CORE_SOCS from socs_config.sh (ALL_SOCS minus SKIP_LIB_BUILD_SOCS)."""
+    config_text = SOCS_CONFIG.read_text(encoding="utf-8")
+    all_socs = load_bash_array(config_text, "ALL_SOCS")
+    skip_socs = set(load_bash_array(config_text, "SKIP_LIB_BUILD_SOCS"))
+    return [soc for soc in all_socs if soc not in skip_socs]
+
+
+def load_properties(path: Path) -> dict[str, str]:
     props: dict[str, str] = {}
     for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
@@ -24,7 +58,6 @@ def load_platform_txt(path: Path) -> dict[str, str]:
 
 
 def collapse_os(props: dict[str, str], os_name: str) -> dict[str, str]:
-    """Strip .windows/.linux/.macosx suffixes like PreferencesMap.load()."""
     suffix = {
         "linux": ".linux",
         "windows": ".windows",
@@ -50,6 +83,31 @@ def get_tool_prefs(props: dict[str, str], tool: str) -> dict[str, str]:
     return out
 
 
+def board_upload_prefs(boards: dict[str, str], board_id: str) -> dict[str, str]:
+    upload_prefix = f"{board_id}.upload."
+    build_prefix = f"{board_id}.build."
+    out: dict[str, str] = {}
+    for key, value in boards.items():
+        if key.startswith(upload_prefix):
+            out["upload." + key[len(upload_prefix) :]] = value
+        elif key.startswith(build_prefix):
+            out["build." + key[len(build_prefix) :]] = value
+    return out
+
+
+def merge_menu_prefs(
+    boards: dict[str, str],
+    board_id: str,
+    menu_id: str,
+    option_id: str,
+    prefs: dict[str, str],
+) -> None:
+    prefix = f"{board_id}.menu.{menu_id}.{option_id}."
+    for key, value in boards.items():
+        if key.startswith(prefix):
+            prefs[key[len(f"{board_id}.menu.{menu_id}.{option_id}.") :]] = value
+
+
 def replace_from_mapping(src: str, mapping: dict[str, str], rounds: int = 10) -> str:
     for _ in range(rounds):
         prev = src
@@ -68,6 +126,7 @@ def simulate_upload_pattern(
     platform_path: str = "/plat",
     build_path: str = "/tmp/build",
     serial_port: str = "/dev/ttyUSB0",
+    board_prefs: dict[str, str] | None = None,
 ) -> str:
     props = collapse_os(props, os_name)
     prefs: dict[str, str] = {
@@ -75,13 +134,19 @@ def simulate_upload_pattern(
         "build.path": build_path,
         "build.project_name": "Sk",
         "serial.port": serial_port,
+        "path": f"{platform_path}/tools/esptool",
+        "cmd": "esptool",
         "upload.speed": "921600",
         "upload.flags": "",
-        "upload.erase_cmd": "",
         "upload.extra_flags": "",
         "build.mcu": "esp32",
-        "build.bootloader_addr": "0x1000",
+        "build.flash_mode": "dio",
+        "build.flash_freq": "80m",
+        "build.flash_size": "4MB",
+        "build.flash_offset": "0x10000",
     }
+    if board_prefs:
+        prefs.update(board_prefs)
     prefs.update(get_tool_prefs(props, tool))
     pattern = prefs.get("upload.pattern", "")
     if not pattern:
@@ -89,14 +154,111 @@ def simulate_upload_pattern(
     return replace_from_mapping(pattern, prefs)
 
 
+def flash_pairs(cmd: str) -> list[tuple[str, str]]:
+    import shlex
+
+    parts = shlex.split(cmd)
+    wf = parts.index("write-flash")
+    tokens = parts[wf + 1 :]
+    i = 0
+    while i < len(tokens) and not tokens[i].startswith("0x"):
+        i += 1
+    pairs: list[tuple[str, str]] = []
+    while i < len(tokens):
+        if tokens[i].startswith("0x") and i + 1 < len(tokens) and not tokens[i + 1].startswith("0x"):
+            pairs.append((tokens[i], tokens[i + 1]))
+            i += 2
+        else:
+            i += 1
+    return pairs
+
+
+def unexpanded_placeholders(cmd: str) -> list[str]:
+    return _PLACEHOLDER_RE.findall(cmd)
+
+
 def main() -> int:
-    props = load_platform_txt(PLATFORM_TXT)
-    for tool in ("esptool_py", "esptool_py_app_only"):
+    platform = load_properties(PLATFORM_TXT)
+    boards = load_properties(BOARDS_TXT)
+    core_soc_boards = load_core_soc_boards()
+
+    for board_id in core_soc_boards:
+        board_prefs = board_upload_prefs(boards, board_id)
+        if board_prefs.get("upload.tool") not in (None, "esptool_py"):
+            continue
+        if "build.bootloader_addr" not in board_prefs:
+            print(f"FAIL ({board_id}): missing build.bootloader_addr", file=sys.stderr)
+            return 1
+        if "upload.erase_cmd" not in board_prefs:
+            print(
+                f"FAIL ({board_id}): missing board-level upload.erase_cmd= "
+                "(required for IDE 1.x SerialUploader prefs)",
+                file=sys.stderr,
+            )
+            return 1
+
+        for tool in ("esptool_py",):
+            for os_name in ("linux", "windows"):
+                cmd = simulate_upload_pattern(
+                    platform,
+                    tool=tool,
+                    os_name=os_name,
+                    board_prefs=board_prefs,
+                )
+                leftovers = unexpanded_placeholders(cmd)
+                if leftovers:
+                    print(
+                        f"FAIL ({board_id}/{tool}/{os_name}): unexpanded placeholders {leftovers}:\n  {cmd}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                if "flasher" not in cmd:
+                    print(
+                        f"FAIL ({board_id}/{tool}/{os_name}): flasher not in command:\n  {cmd}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                pairs = flash_pairs(cmd)
+                if len(pairs) != 4:
+                    print(
+                        f"FAIL ({board_id}/{tool}/{os_name}): expected 4 flash pairs, got {len(pairs)}:\n  {pairs}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                print(f"OK ({board_id}/{os_name}): {cmd[:100]}...")
+
+    erase_board = next(
+        (
+            board_id
+            for board_id in core_soc_boards
+            if f"{board_id}.menu.EraseFlash.all.upload.erase_cmd" in boards
+        ),
+        None,
+    )
+    if erase_board is None:
+        print("FAIL: no CORE_SOC board defines EraseFlash.all.upload.erase_cmd", file=sys.stderr)
+        return 1
+
+    erase_all = board_upload_prefs(boards, erase_board)
+    merge_menu_prefs(boards, erase_board, "EraseFlash", "all", erase_all)
+    erase_cmd = simulate_upload_pattern(platform, board_prefs=erase_all)
+    if " write-flash -e -z " not in f" {erase_cmd} ":
+        print(f"FAIL: EraseFlash=all should pass -e after write-flash:\n  {erase_cmd}", file=sys.stderr)
+        return 1
+
+    for tool in ("esptool_py_app_only",):
+        app_only_runtime = {"runtime.tools.esptool_py.path": "/plat/tools/esptool"}
         for os_name in ("linux", "windows"):
-            cmd = simulate_upload_pattern(props, tool=tool, os_name=os_name)
-            if "{upload.flash_prefix}" in cmd:
+            cmd = simulate_upload_pattern(
+                platform,
+                tool=tool,
+                os_name=os_name,
+                board_prefs=app_only_runtime,
+            )
+            leftovers = unexpanded_placeholders(cmd)
+            if leftovers:
                 print(
-                    f"FAIL ({tool}/{os_name}): unexpanded {{upload.flash_prefix}} in:\n  {cmd}",
+                    f"FAIL ({tool}/{os_name}): unexpanded placeholders {leftovers}:\n  {cmd}",
                     file=sys.stderr,
                 )
                 return 1
@@ -107,6 +269,7 @@ def main() -> int:
                 )
                 return 1
             print(f"OK ({tool}/{os_name}): {cmd[:120]}...")
+
     return 0
 
 

--- a/.github/scripts/ci_testing/test_ide_v1_docker.sh
+++ b/.github/scripts/ci_testing/test_ide_v1_docker.sh
@@ -1,0 +1,393 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+#
+# Docker-based Arduino IDE v1 testing across multiple platforms.
+# (Renamed from test_ide_v1.sh — use ci_testing/release_validation.sh for native local validation.)
+#
+# This script detects the host OS/architecture and Docker capabilities,
+# then runs IDE v1 install+compile tests in containers for each feasible
+# platform. Platforms that cannot be tested are reported as SKIPPED.
+#
+# Usage:
+#   bash .github/scripts/ci_testing/test_ide_v1_docker.sh [package_json_path]
+#
+# Arguments:
+#   package_json_path  Path to package JSON file to test (default: build/package_esp32_dev_index.json)
+#
+# Environment:
+#   RELEASE_VERSION    Version to install (e.g. 3.3.9). Auto-detected from JSON if unset.
+#   SKETCH_PATH        Path to sketch to compile (default: libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PACKAGE_JSON="${1:-$REPO_ROOT/package/package_esp32_index.template.json}"
+SKETCH_PATH="${SKETCH_PATH:-libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino}"
+ARDUINO_IDE_VERSION="1.8.19"
+
+# Results tracking (plain variables for Bash 3.x compat on macOS)
+RESULT_linux64="PENDING"
+RESULT_linuxarm="PENDING"
+RESULT_windows="PENDING"
+RESULT_macos="PENDING"
+
+HOST_OS="$(uname -s)"
+HOST_ARCH="$(uname -m)"
+
+echo "==========================================="
+echo "  IDE v1 Docker Test Runner"
+echo "==========================================="
+echo "Host: $HOST_OS ($HOST_ARCH)"
+echo "Package JSON: $PACKAGE_JSON"
+echo ""
+
+if [ ! -f "$PACKAGE_JSON" ]; then
+    echo "ERROR: Package JSON not found at $PACKAGE_JSON"
+    exit 1
+fi
+
+# Check Docker availability
+if ! command -v docker &>/dev/null; then
+    echo "ERROR: Docker is not installed or not in PATH"
+    echo "Install Docker to run IDE v1 platform tests"
+    exit 1
+fi
+
+if ! docker info &>/dev/null; then
+    echo "ERROR: Docker daemon is not running or not accessible"
+    exit 1
+fi
+
+# Detect Docker capabilities
+can_run_linux_amd64() {
+    local host_arch="$HOST_ARCH"
+    if [[ "$host_arch" == "x86_64" ]]; then
+        return 0
+    fi
+    # Check buildx/QEMU for cross-arch
+    if docker buildx ls 2>/dev/null | grep -q "linux/amd64"; then
+        return 0
+    fi
+    return 1
+}
+
+can_run_linux_arm64() {
+    local host_arch="$HOST_ARCH"
+    if [[ "$host_arch" == "aarch64" || "$host_arch" == "arm64" ]]; then
+        return 0
+    fi
+    if docker buildx ls 2>/dev/null | grep -q "linux/arm64"; then
+        return 0
+    fi
+    return 1
+}
+
+can_run_windows() {
+    if [[ "$HOST_OS" != "MINGW"* && "$HOST_OS" != "MSYS"* && "$HOST_OS" != "CYGWIN"* && "$HOST_OS" != *"NT"* ]]; then
+        return 1
+    fi
+    # Check if Windows containers are enabled
+    if docker info 2>/dev/null | grep -q "OSType: windows"; then
+        return 0
+    fi
+    return 1
+}
+
+# The test script run inside Linux containers
+LINUX_TEST_SCRIPT='#!/bin/bash
+set -e
+
+ARDUINO_IDE_VERSION="$1"
+PACKAGE_JSON_PATH="$2"
+SKETCH_PATH="$3"
+RELEASE_VERSION="$4"
+
+echo "=== Installing dependencies ==="
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq wget xz-utils xvfb libxrender1 libxtst6 libxi6 libfreetype6 libfontconfig1 python3 python3-serial > /dev/null 2>&1
+
+echo "=== Downloading Arduino IDE $ARDUINO_IDE_VERSION ==="
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+    IDE_URL="https://downloads.arduino.cc/arduino-${ARDUINO_IDE_VERSION}-linux64.tar.xz"
+elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+    IDE_URL="https://downloads.arduino.cc/arduino-${ARDUINO_IDE_VERSION}-linuxaarch64.tar.xz"
+else
+    echo "ERROR: Unsupported architecture $ARCH"
+    exit 1
+fi
+
+wget -q -O /tmp/arduino.tar.xz "$IDE_URL"
+tar xf /tmp/arduino.tar.xz -C /opt/
+rm /tmp/arduino.tar.xz
+
+ARDUINO_DIR="/opt/arduino-${ARDUINO_IDE_VERSION}"
+ARDUINO_CMD="$ARDUINO_DIR/arduino"
+
+if [ ! -f "$ARDUINO_CMD" ]; then
+    echo "ERROR: Arduino binary not found at $ARDUINO_CMD"
+    ls -la /opt/
+    exit 1
+fi
+
+echo "=== Installing ESP32 core via IDE v1 ==="
+PACKAGE_URL="file://${PACKAGE_JSON_PATH}"
+VERSION_ARG=""
+if [ -n "$RELEASE_VERSION" ]; then
+    VERSION_ARG=":${RELEASE_VERSION}"
+fi
+
+# Use xvfb for headless operation (IDE v1 GUI requires a display even in CLI mode)
+# "Platform is already installed!" is treated as success
+xvfb-run "$ARDUINO_CMD" \
+    --pref "boardsmanager.additional.urls=$PACKAGE_URL" \
+    --install-boards "esp32:esp32${VERSION_ARG}" 2>&1 | tee /tmp/install_output.txt
+install_rc=${PIPESTATUS[0]}
+
+if [ $install_rc -ne 0 ]; then
+    if grep -q "Platform is already installed" /tmp/install_output.txt; then
+        echo "Core already installed, skipping installation"
+    else
+        echo "ERROR: Failed to install ESP32 core"
+        exit 1
+    fi
+fi
+
+echo "=== Compiling test sketch ==="
+xvfb-run "$ARDUINO_CMD" \
+    --pref "boardsmanager.additional.urls=$PACKAGE_URL" \
+    --verify \
+    --board esp32:esp32:esp32 \
+    "/workspace/${SKETCH_PATH}"
+
+if [ $? -ne 0 ]; then
+    echo "ERROR: Compilation failed"
+    exit 1
+fi
+
+echo "=== SUCCESS ==="
+'
+
+# Run test in a Linux x86_64 container
+run_linux_amd64_test() {
+    echo "--- Testing: linux64 (x86_64) ---"
+
+    local platform_flag=""
+    if [[ "$HOST_ARCH" != "x86_64" ]]; then
+        platform_flag="--platform linux/amd64"
+    fi
+
+    docker run --rm \
+        $platform_flag \
+        -v "$REPO_ROOT:/workspace:ro" \
+        -v "$PACKAGE_JSON:/test_package.json:ro" \
+        ubuntu:22.04 \
+        bash -c "$LINUX_TEST_SCRIPT" -- \
+            "$ARDUINO_IDE_VERSION" \
+            "/test_package.json" \
+            "$SKETCH_PATH" \
+            "${RELEASE_VERSION:-}"
+
+    return $?
+}
+
+# Run test in a Linux arm64 container
+run_linux_arm64_test() {
+    echo "--- Testing: linuxarm (arm64/aarch64) ---"
+
+    local platform_flag=""
+    if [[ "$HOST_ARCH" != "aarch64" && "$HOST_ARCH" != "arm64" ]]; then
+        platform_flag="--platform linux/arm64"
+    fi
+
+    docker run --rm \
+        $platform_flag \
+        -v "$REPO_ROOT:/workspace:ro" \
+        -v "$PACKAGE_JSON:/test_package.json:ro" \
+        ubuntu:22.04 \
+        bash -c "$LINUX_TEST_SCRIPT" -- \
+            "$ARDUINO_IDE_VERSION" \
+            "/test_package.json" \
+            "$SKETCH_PATH" \
+            "${RELEASE_VERSION:-}"
+
+    return $?
+}
+
+# Run test in a Windows container
+run_windows_test() {
+    echo "--- Testing: windows ---"
+
+    docker run --rm \
+        -v "$REPO_ROOT:C:\\workspace:ro" \
+        -v "$PACKAGE_JSON:C:\\test_package.json:ro" \
+        mcr.microsoft.com/windows/servercore:ltsc2022 \
+        powershell -Command "
+            Write-Host '=== Downloading Arduino IDE $ARDUINO_IDE_VERSION ==='
+            \$url = 'https://downloads.arduino.cc/arduino-${ARDUINO_IDE_VERSION}-windows.zip'
+            Invoke-WebRequest -Uri \$url -OutFile C:\\arduino.zip -UseBasicParsing
+            Expand-Archive -Path C:\\arduino.zip -DestinationPath C:\\
+            Remove-Item C:\\arduino.zip
+
+            \$arduinoCmd = 'C:\\arduino-${ARDUINO_IDE_VERSION}\\arduino_debug.exe'
+
+            Write-Host '=== Installing ESP32 core via IDE v1 ==='
+            \$packageUrl = 'file:///C:/test_package.json'
+            & \$arduinoCmd --pref \"boardsmanager.additional.urls=\$packageUrl\" --install-boards 'esp32:esp32${RELEASE_VERSION:+:$RELEASE_VERSION}'
+            if (\$LASTEXITCODE -ne 0) { exit 1 }
+
+            Write-Host '=== Compiling test sketch ==='
+            & \$arduinoCmd --pref \"boardsmanager.additional.urls=\$packageUrl\" --verify --board esp32:esp32:esp32 'C:\\workspace\\${SKETCH_PATH//\//\\}'
+            if (\$LASTEXITCODE -ne 0) { exit 1 }
+
+            Write-Host '=== SUCCESS ==='
+        "
+
+    return $?
+}
+
+# Run test natively on macOS
+run_macos_native_test() {
+    echo "--- Testing: macos (native) ---"
+
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap "rm -rf '$tmp_dir'" RETURN
+
+    echo "=== Downloading Arduino IDE $ARDUINO_IDE_VERSION ==="
+    local ide_url="https://downloads.arduino.cc/arduino-${ARDUINO_IDE_VERSION}-macosx.zip"
+    curl -sL -o "$tmp_dir/arduino.zip" "$ide_url"
+    unzip -q "$tmp_dir/arduino.zip" -d "$tmp_dir/"
+    rm "$tmp_dir/arduino.zip"
+
+    local arduino_app="$tmp_dir/Arduino.app"
+    local arduino_cmd="$arduino_app/Contents/MacOS/Arduino"
+
+    if [ ! -f "$arduino_cmd" ]; then
+        echo "ERROR: Arduino binary not found at $arduino_cmd"
+        ls -la "$tmp_dir/"
+        return 1
+    fi
+
+    echo "=== Installing ESP32 core via IDE v1 ==="
+    local package_url="file://${PACKAGE_JSON}"
+    local version_arg=""
+    if [ -n "${RELEASE_VERSION:-}" ]; then
+        version_arg=":${RELEASE_VERSION}"
+    fi
+
+    "$arduino_cmd" \
+        --pref "boardsmanager.additional.urls=$package_url" \
+        --install-boards "esp32:esp32${version_arg}" 2>&1 | tee /tmp/install_output.txt
+    local install_rc=${PIPESTATUS[0]}
+
+    if [ $install_rc -ne 0 ]; then
+        if grep -q "Platform is already installed" /tmp/install_output.txt; then
+            echo "Core already installed, skipping installation"
+        else
+            echo "ERROR: Failed to install ESP32 core"
+            return 1
+        fi
+    fi
+
+    echo "=== Compiling test sketch ==="
+    "$arduino_cmd" \
+        --pref "boardsmanager.additional.urls=$package_url" \
+        --verify \
+        --board esp32:esp32:esp32 \
+        "$REPO_ROOT/${SKETCH_PATH}"
+
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Compilation failed"
+        return 1
+    fi
+
+    echo "=== SUCCESS ==="
+    return 0
+}
+
+# Execute tests for each platform
+echo ""
+echo "==========================================="
+echo "  Running Platform Tests"
+echo "==========================================="
+echo ""
+
+# Linux x86_64
+if can_run_linux_amd64; then
+    if run_linux_amd64_test; then
+        RESULT_linux64="PASS"
+    else
+        RESULT_linux64="FAIL"
+    fi
+else
+    RESULT_linux64="SKIPPED (no x86_64 support - host is $HOST_ARCH, no QEMU/buildx)"
+fi
+
+echo ""
+
+# Linux arm64
+if can_run_linux_arm64; then
+    if run_linux_arm64_test; then
+        RESULT_linuxarm="PASS"
+    else
+        RESULT_linuxarm="FAIL"
+    fi
+else
+    RESULT_linuxarm="SKIPPED (no arm64 support - host is $HOST_ARCH, no QEMU/buildx)"
+fi
+
+echo ""
+
+# Windows
+if can_run_windows; then
+    if run_windows_test; then
+        RESULT_windows="PASS"
+    else
+        RESULT_windows="FAIL"
+    fi
+else
+    RESULT_windows="SKIPPED (not a Windows host or Windows containers not enabled)"
+fi
+
+# macOS – run natively on the host if we're on macOS
+if [[ "$HOST_OS" == "Darwin" ]]; then
+    if run_macos_native_test; then
+        RESULT_macos="PASS"
+    else
+        RESULT_macos="FAIL"
+    fi
+else
+    RESULT_macos="SKIPPED (not a macOS host)"
+fi
+
+# Print results
+echo ""
+echo "==========================================="
+echo "  IDE v1 Test Matrix Results"
+echo "==========================================="
+echo ""
+
+has_failure=0
+for platform in linux64 linuxarm windows macos; do
+    eval "result=\$RESULT_${platform}"
+    printf "  %-10s %s\n" "$platform:" "$result"
+    if [[ "$result" == "FAIL" ]]; then
+        has_failure=1
+    fi
+done
+
+echo ""
+echo "==========================================="
+
+if [ "$has_failure" -eq 1 ]; then
+    echo "  RESULT: Some tests FAILED"
+    exit 1
+else
+    echo "  RESULT: All testable platforms passed"
+    exit 0
+fi

--- a/.github/scripts/ci_testing/test_mock_bootloader.py
+++ b/.github/scripts/ci_testing/test_mock_bootloader.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+arduino-esp32 integration test: flasher.py + socket:// + platform upload recipe.
+
+Protocol and esptool validation live in the esp32-mock-bootloader package:
+https://github.com/espressif/esp32-mock-bootloader
+
+Usage:
+    pip install esp32-mock-bootloader
+    python3 .github/scripts/ci_testing/test_mock_bootloader.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+FLASHER_SCRIPT = REPO_ROOT / 'tools' / 'flasher.py'
+
+PASS = '\033[32mPASS\033[0m'
+FAIL = '\033[31mFAIL\033[0m'
+
+
+def _esptool_available() -> bool:
+    if shutil.which('esptool'):
+        return True
+    try:
+        subprocess.run(
+            [sys.executable, '-m', 'esptool', 'version'],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        return True
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def _create_fake_binary(path: Path, size: int = 4096) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b'\x00' * size)
+    return path
+
+
+def _start_mock(port: int) -> None:
+    subprocess.run(
+        [
+            'esp32-mock-bootloader', 'start',
+            '--port', str(port),
+            '--chip', 'esp32',
+            '--startup-timeout', '60',
+        ],
+        check=True,
+    )
+
+
+def _stop_mock(port: int) -> None:
+    subprocess.run(
+        ['esp32-mock-bootloader', 'stop', '--port', str(port)],
+        check=False,
+    )
+
+
+def test_flasher_socket_platform_recipe() -> bool:
+    print('=' * 60)
+    print('  Test – flasher.py + socket:// + platform upload recipe (twice)')
+    print('=' * 60)
+
+    if not FLASHER_SCRIPT.is_file():
+        print('  SKIPPED (flasher.py not found)')
+        return True
+    if not _esptool_available():
+        print('  SKIPPED (esptool not installed)')
+        return True
+
+    esptool = shutil.which('esptool')
+    if not esptool:
+        print('  SKIPPED (esptool binary not on PATH)')
+        return True
+
+    if not shutil.which('esp32-mock-bootloader'):
+        print('  SKIPPED (esp32-mock-bootloader not installed)')
+        return True
+
+    port = 19824
+    _start_mock(port)
+    try:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            build_dir = Path(tmp)
+            bin_file = _create_fake_binary(build_dir / 'sketch.bin', 4096)
+            port_url = f'socket://127.0.0.1:{port}'
+            flasher_cmd = [
+                sys.executable, str(FLASHER_SCRIPT),
+                '--esptool', esptool,
+                '--build-dir', str(build_dir),
+                '--chip', 'esp32',
+                '--port', port_url,
+                '--baud', '115200',
+                '--before', 'default-reset',
+                '--after', 'hard-reset',
+                'write-flash', '-z',
+                '--flash-mode', 'keep', '--flash-freq', 'keep', '--flash-size', 'keep',
+                '0x10000', str(bin_file),
+            ]
+            first = subprocess.run(
+                flasher_cmd, capture_output=True, text=True, timeout=60,
+            )
+            ok = first.returncode == 0
+            if not ok:
+                print(f'  {FAIL}  first flasher upload')
+                print(f'         rc={first.returncode}\nstdout: {first.stdout[-500:]}\n'
+                      f'stderr: {first.stderr[-300:]}')
+                return False
+            print(f'  {PASS}  first flasher upload')
+
+            time.sleep(0.5)
+            second = subprocess.run(
+                flasher_cmd, capture_output=True, text=True, timeout=60,
+            )
+            ok = second.returncode == 0
+            if not ok:
+                print(f'  {FAIL}  second flasher upload (diff-with path)')
+                print(f'         rc={second.returncode}\nstdout: {second.stdout[-500:]}\n'
+                      f'stderr: {second.stderr[-300:]}')
+                return False
+            print(f'  {PASS}  second flasher upload (diff-with path)')
+            return True
+    finally:
+        _stop_mock(port)
+
+
+if __name__ == '__main__':
+    ok = test_flasher_socket_platform_recipe()
+    print()
+    if ok:
+        print(f'{PASS} flasher integration test passed')
+        sys.exit(0)
+    print(f'{FAIL} flasher integration test failed')
+    sys.exit(1)

--- a/.github/scripts/install-arduino-builder.sh
+++ b/.github/scripts/install-arduino-builder.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Slim arduino-nightly tree for headless builder upload CI (not full Arduino IDE 1.8.19).
+
+SCRIPTS_DIR_BUILDER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPTS_DIR_BUILDER}/env.sh"
+
+ARDUINO_NIGHTLY_VERSION="${ARDUINO_NIGHTLY_VERSION:-1.0.4}"
+ARDUINO_BUILDER_URL="https://github.com/espressif/arduino-esp32/releases/download/${ARDUINO_NIGHTLY_VERSION}/arduino-nightly-"
+
+if [ "$OS_IS_LINUX" == "1" ]; then
+    ARCHIVE_FORMAT="tar.xz"
+elif [ "$OS_IS_WINDOWS" == "1" ] || [ "$OS_IS_MACOS" == "1" ]; then
+    ARCHIVE_FORMAT="zip"
+else
+    echo "ERROR: Unsupported OS for arduino-builder installation"
+    exit 1
+fi
+
+if [ "$OS_IS_MACOS" == "1" ]; then
+    export ARDUINO_BUILDER_PATH="$HOME/arduino_nightly/Arduino.app/Contents/Java"
+else
+    export ARDUINO_BUILDER_PATH="$HOME/arduino_ide"
+fi
+
+if [ ! -d "$ARDUINO_BUILDER_PATH" ]; then
+    echo "Installing arduino-nightly builder on $OS_NAME ..."
+    archive="arduino.${ARCHIVE_FORMAT}"
+    echo "Downloading '${ARDUINO_BUILDER_URL}${OS_NAME}.${ARCHIVE_FORMAT}' ..."
+    if [ "$OS_IS_LINUX" == "1" ]; then
+        wget -q -O "$archive" "${ARDUINO_BUILDER_URL}${OS_NAME}.${ARCHIVE_FORMAT}"
+        echo "Extracting '$archive' ..."
+        tar xf "$archive"
+        mv arduino-nightly "$ARDUINO_BUILDER_PATH"
+    else
+        curl -fsSL -o "$archive" -L "${ARDUINO_BUILDER_URL}${OS_NAME}.${ARCHIVE_FORMAT}"
+        echo "Extracting '$archive' ..."
+        unzip -q "$archive"
+        if [ "$OS_IS_MACOS" == "1" ]; then
+            mkdir -p "$HOME/arduino_nightly"
+            mv "Arduino.app" "$HOME/arduino_nightly/Arduino.app"
+        else
+            mv arduino-nightly "$ARDUINO_BUILDER_PATH"
+        fi
+    fi
+    rm -f "$archive"
+
+    mkdir -p "$ARDUINO_USR_PATH/libraries"
+    mkdir -p "$ARDUINO_USR_PATH/hardware"
+
+    echo "arduino-nightly builder installed in '$ARDUINO_BUILDER_PATH'"
+    echo ""
+fi

--- a/.github/scripts/install-arduino-core-esp32.sh
+++ b/.github/scripts/install-arduino-core-esp32.sh
@@ -12,31 +12,38 @@ if [ ! -d "$ARDUINO_ESP32_PATH" ]; then
     echo "Installing Python Serial ..."
     pip install pyserial > /dev/null
 
-    if [ "$OS_IS_WINDOWS" == "1" ]; then
+    if [ "${OS_IS_WINDOWS:-0}" == "1" ]; then
         echo "Installing Python Requests ..."
         pip install requests > /dev/null
     fi
 
-    if [ -n "$GITHUB_REPOSITORY" ];  then
+    if [ -n "${GITHUB_REPOSITORY:-}" ]; then
         echo "Linking Core..."
-        ln -s "$GITHUB_WORKSPACE" esp32
+        ln -sfn "$GITHUB_WORKSPACE" esp32
     else
         echo "Cloning Core Repository..."
         git clone https://github.com/espressif/arduino-esp32.git esp32 > /dev/null 2>&1
     fi
 
-    #echo "Updating Submodules ..."
     cd esp32 || exit
-    #git submodule update --init --recursive > /dev/null 2>&1
-
     echo "Installing Platform Tools ..."
-    if [ "$OS_IS_WINDOWS" == "1" ]; then
-        cd tools && ./get.exe
+    if [ "${OS_IS_WINDOWS:-0}" == "1" ]; then
+        (cd tools && ./get.exe)
     else
-        cd tools && python get.py
+        (cd tools && python get.py)
     fi
     cd "$script_init_path" || exit
 
     echo "ESP32 Arduino has been installed in '$ARDUINO_ESP32_PATH'"
     echo ""
+elif [ ! -d "$ARDUINO_ESP32_PATH/tools/xtensa-esp-elf" ] && \
+     [ ! -d "$ARDUINO_ESP32_PATH/tools/riscv32-esp-elf" ]; then
+    echo "ESP32 core linked but toolchains missing; running get.py ..."
+    script_init_path="$PWD"
+    if [ "${OS_IS_WINDOWS:-0}" == "1" ]; then
+        (cd "$ARDUINO_ESP32_PATH/tools" && ./get.exe)
+    else
+        (cd "$ARDUINO_ESP32_PATH/tools" && python get.py)
+    fi
+    cd "$script_init_path" || exit
 fi

--- a/.github/scripts/install-arduino-ide.sh
+++ b/.github/scripts/install-arduino-ide.sh
@@ -1,57 +1,61 @@
 #!/bin/bash
 
-#OSTYPE: 'linux-gnu', ARCH: 'x86_64' => linux64
-#OSTYPE: 'msys', ARCH: 'x86_64' => win32
-#OSTYPE: 'darwin18', ARCH: 'i386' => macos
-
 SCRIPTS_DIR_IDE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPTS_DIR_IDE}/env.sh"
 
+ARDUINO_IDE_VERSION="1.8.19"
+
 if [ "$OS_IS_LINUX" == "1" ]; then
     ARCHIVE_FORMAT="tar.xz"
+    ARDUINO_IDE_URL="https://downloads.arduino.cc/arduino-${ARDUINO_IDE_VERSION}-linux64.tar.xz"
 elif [ "$OS_IS_WINDOWS" == "1" ]; then
     ARCHIVE_FORMAT="zip"
-else
+    ARDUINO_IDE_URL="https://downloads.arduino.cc/arduino-${ARDUINO_IDE_VERSION}-windows.zip"
+elif [ "$OS_IS_MACOS" == "1" ]; then
     ARCHIVE_FORMAT="zip"
+    ARDUINO_IDE_URL="https://downloads.arduino.cc/arduino-${ARDUINO_IDE_VERSION}-macosx.zip"
+else
+    echo "ERROR: Unsupported OS for Arduino IDE installation"
+    exit 1
 fi
 
 if [ "$OS_IS_MACOS" == "1" ]; then
-    export ARDUINO_IDE_PATH="/Applications/Arduino.app/Contents/Java"
+    if [ -d "/Applications/Arduino.app/Contents/Java" ]; then
+        export ARDUINO_IDE_PATH="/Applications/Arduino.app/Contents/Java"
+    else
+        export ARDUINO_IDE_PATH="$HOME/arduino-ide-${ARDUINO_IDE_VERSION}/Arduino.app/Contents/Java"
+    fi
 elif [ "$OS_IS_WINDOWS" == "1" ]; then
     export ARDUINO_IDE_PATH="$HOME/arduino_ide"
 else
     export ARDUINO_IDE_PATH="$HOME/arduino_ide"
 fi
 
-# Updated as of Nov 3rd 2020
-ARDUINO_IDE_URL="https://github.com/espressif/arduino-esp32/releases/download/1.0.4/arduino-nightly-"
-
-# Currently not working
-#ARDUINO_IDE_URL="https://www.arduino.cc/download.php?f=/arduino-nightly-"
-
 if [ ! -d "$ARDUINO_IDE_PATH" ]; then
-    echo "Installing Arduino IDE on $OS_NAME ..."
-    echo "Downloading '$ARDUINO_IDE_URL$OS_NAME.$ARCHIVE_FORMAT' to 'arduino.$ARCHIVE_FORMAT' ..."
+    echo "Installing Arduino IDE ${ARDUINO_IDE_VERSION} on $OS_NAME ..."
+    echo "Downloading '$ARDUINO_IDE_URL' ..."
     if [ "$OS_IS_LINUX" == "1" ]; then
-        wget -O "arduino.$ARCHIVE_FORMAT" "$ARDUINO_IDE_URL$OS_NAME.$ARCHIVE_FORMAT" > /dev/null 2>&1
+        wget -q -O "arduino.$ARCHIVE_FORMAT" "$ARDUINO_IDE_URL"
         echo "Extracting 'arduino.$ARCHIVE_FORMAT' ..."
-        tar xf "arduino.$ARCHIVE_FORMAT" > /dev/null
-        mv arduino-nightly "$ARDUINO_IDE_PATH"
+        tar xf "arduino.$ARCHIVE_FORMAT"
+        mv "arduino-${ARDUINO_IDE_VERSION}" "$ARDUINO_IDE_PATH"
+    elif [ "$OS_IS_MACOS" == "1" ]; then
+        mkdir -p "$HOME/arduino-ide-${ARDUINO_IDE_VERSION}"
+        curl -fsSL -o "arduino.$ARCHIVE_FORMAT" "$ARDUINO_IDE_URL"
+        echo "Extracting 'arduino.$ARCHIVE_FORMAT' ..."
+        unzip -q "arduino.$ARCHIVE_FORMAT"
+        mv "Arduino.app" "$HOME/arduino-ide-${ARDUINO_IDE_VERSION}/Arduino.app"
     else
-        curl -o "arduino.$ARCHIVE_FORMAT" -L "$ARDUINO_IDE_URL$OS_NAME.$ARCHIVE_FORMAT" > /dev/null 2>&1
+        curl -fsSL -o "arduino.$ARCHIVE_FORMAT" "$ARDUINO_IDE_URL"
         echo "Extracting 'arduino.$ARCHIVE_FORMAT' ..."
-        unzip "arduino.$ARCHIVE_FORMAT" > /dev/null
-        if [ "$OS_IS_MACOS" == "1" ]; then
-            mv "Arduino.app" "/Applications/Arduino.app"
-        else
-            mv arduino-nightly "$ARDUINO_IDE_PATH"
-        fi
+        unzip -q "arduino.$ARCHIVE_FORMAT" > /dev/null
+        mv "arduino-${ARDUINO_IDE_VERSION}" "$ARDUINO_IDE_PATH"
     fi
     rm -rf "arduino.$ARCHIVE_FORMAT"
 
     mkdir -p "$ARDUINO_USR_PATH/libraries"
     mkdir -p "$ARDUINO_USR_PATH/hardware"
 
-    echo "Arduino IDE Installed in '$ARDUINO_IDE_PATH'"
+    echo "Arduino IDE ${ARDUINO_IDE_VERSION} installed in '$ARDUINO_IDE_PATH'"
     echo ""
 fi

--- a/.github/scripts/mock_upload_lib.sh
+++ b/.github/scripts/mock_upload_lib.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+# Mock upload CI helpers: TCP bootloader, esptool override, twice-upload, logging.
+
+[ -n "$MOCK_UPLOAD_LIB_SOURCED" ] && return 0
+MOCK_UPLOAD_LIB_SOURCED=1
+
+_MOCK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPTS_DIR:-$_MOCK_LIB_DIR}"
+
+source "${SCRIPTS_DIR}/env.sh"
+source "${SCRIPTS_DIR}/arduino_headless.sh"
+
+if [ -n "${GITHUB_ACTIONS:-}" ] || [ -t 1 ]; then
+    _MOCK_C_RESET=$'\033[0m'
+    _MOCK_C_HEADER=$'\033[95m'
+    _MOCK_C_STEP=$'\033[96m'
+    _MOCK_C_PASS=$'\033[32m'
+    _MOCK_C_FAIL=$'\033[31m'
+    _MOCK_C_DIM=$'\033[90m'
+else
+    _MOCK_C_RESET=
+    _MOCK_C_HEADER=
+    _MOCK_C_STEP=
+    _MOCK_C_PASS=
+    _MOCK_C_FAIL=
+    _MOCK_C_DIM=
+fi
+
+function _native_path_for_java {
+    local p="$1"
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]] && command -v cygpath >/dev/null 2>&1; then
+        cygpath -m "$p"
+    else
+        echo "$p"
+    fi
+}
+
+function _windows_long_path {
+    local target="$1" dir base
+    if [ -d "$target" ]; then
+        (cd "$target" && pwd -W | sed 's|\\|/|g')
+    else
+        dir="$(dirname "$target")"
+        base="$(basename "$target")"
+        echo "$(_windows_long_path "$dir")/$base"
+    fi
+}
+
+function _windows_path_for_ide_pref {
+    local p="$1" unix
+    if [[ "$p" == [A-Za-z]:/* ]]; then
+        unix="$(cygpath -u "$p" 2>/dev/null || echo "$p")"
+    else
+        unix="$p"
+    fi
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -w "$unix"
+    else
+        echo "$p" | sed 's|/|\\|g'
+    fi
+}
+
+function _mock_arduino_packages_dir {
+    if [[ "${OS_IS_MACOS:-0}" == "1" ]]; then
+        echo "$HOME/Library/Arduino15"
+    elif [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        echo "${LOCALAPPDATA:-$HOME/AppData/Local}/Arduino15"
+    else
+        echo "$HOME/.arduino15"
+    fi
+}
+
+function mock_upload_mktemp_build_dir {
+    local dir
+    dir="$(mktemp -d)"
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        _windows_long_path "$dir"
+    else
+        echo "$dir"
+    fi
+}
+
+function mock_upload_prepare_windows_builder_paths {
+    local sketch="$1" staging sketch_name sketch_dir src_dir
+    sketch_name="$(basename "$sketch")"
+    sketch_dir="$(basename "$sketch" .ino)"
+    src_dir="$(dirname "$sketch")"
+    staging="$(mktemp -d)"
+    mkdir -p "$staging/$sketch_dir/build"
+    cp -a "$src_dir/." "$staging/$sketch_dir/"
+    MOCK_UPLOAD_WINDOWS_STAGING="$staging"
+    export MOCK_UPLOAD_WINDOWS_STAGING
+    printf '%s\n' \
+        "$(_windows_long_path "$staging/$sketch_dir")/$sketch_name" \
+        "$(_windows_long_path "$staging/$sketch_dir/build")"
+}
+
+function _dump_arduino_app_log {
+    local -a candidates=() log
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        candidates+=(
+            "$(_mock_arduino_packages_dir)/logs/application.log"
+            "${LOCALAPPDATA}/Arduino15/logs/application.log"
+            "${HOME}/AppData/Local/Arduino15/logs/application.log"
+            "${ARDUINO_USR_PATH:-}/logs/application.log"
+            "${ARDUINO_BUILDER_PATH:-}/portable/logs/application.log"
+        )
+    else
+        candidates+=("${HOME}/.arduino15/logs/application.log")
+    fi
+    for log in "${candidates[@]}"; do
+        [ -n "$log" ] || continue
+        if [ ! -f "$log" ] && command -v cygpath >/dev/null 2>&1; then
+            log="$(cygpath -u "$log" 2>/dev/null || echo "$log")"
+        fi
+        [ -f "$log" ] || continue
+        echo "--- Arduino application.log (last 80 lines): $log ---" >&2
+        tail -n 80 "$log" >&2
+        return 0
+    done
+}
+
+function _resolve_bundled_esptool_path {
+    local ext="" candidate hw_dir tools_dir
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        ext=".exe"
+    fi
+
+    candidate="${ARDUINO_ESP32_PATH}/tools/esptool/esptool${ext}"
+    if [ -f "$candidate" ]; then
+        echo "$candidate"
+        return 0
+    fi
+
+    hw_dir="$(_mock_arduino_packages_dir)/packages/esp32/hardware/esp32"
+    if [ -d "$hw_dir" ]; then
+        candidate=$(find "$hw_dir" -path "*/tools/esptool/esptool${ext}" -type f 2>/dev/null | sort -V | tail -1)
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    fi
+
+    # Release platform.txt uses {runtime.tools.esptool_py.path} (board-manager tool).
+    tools_dir="$(_mock_arduino_packages_dir)/packages/esp32/tools/esptool_py"
+    if [ -d "$tools_dir" ]; then
+        candidate=$(find "$tools_dir" -name "esptool${ext}" -type f 2>/dev/null | sort -V | tail -1)
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+function _mock_esptool_pip_binary {
+    local candidate py_scripts
+
+    if command -v python >/dev/null 2>&1; then
+        py_scripts="$(python -c 'import os, sys; print(os.path.join(os.path.dirname(sys.executable), "Scripts"))' 2>/dev/null || true)"
+        if [[ "${OS_IS_WINDOWS:-0}" == "1" ]] && [ -n "$py_scripts" ]; then
+            candidate="$py_scripts/esptool.exe"
+            if [ -f "$candidate" ]; then
+                echo "$candidate"
+                return 0
+            fi
+        fi
+    fi
+    candidate="$(command -v esptool.exe 2>/dev/null || true)"
+    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+        echo "$candidate"
+        return 0
+    fi
+    candidate="$(command -v esptool 2>/dev/null || true)"
+    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+        echo "$candidate"
+        return 0
+    fi
+    if [ -n "${py_scripts:-}" ]; then
+        candidate="$py_scripts/esptool"
+        if [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+function install_mock_esptool_override {
+    local bundled wrapped
+    [ -n "${MOCK_ESPTOOL_OVERRIDE:-}" ] || return 0
+
+    bundled="$(_resolve_bundled_esptool_path || true)"
+    [ -n "$bundled" ] || {
+        echo "ERROR: bundled esptool not found (checked dev tree, platform bundle, and esptool_py tool)" >&2
+        return 1
+    }
+
+    wrapped="$(_mock_esptool_pip_binary || true)"
+    [ -n "$wrapped" ] || {
+        echo "ERROR: MOCK_ESPTOOL_OVERRIDE set but pip esptool not found (PATH or Python Scripts)" >&2
+        return 1
+    }
+
+    export MOCK_ESPTOOL_BUNDLED="$bundled"
+    export MOCK_ESPTOOL_ORIGINAL="${bundled}.mock-upload-original"
+    if [ ! -f "$MOCK_ESPTOOL_ORIGINAL" ]; then
+        cp -a "$bundled" "$MOCK_ESPTOOL_ORIGINAL"
+    fi
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        cp -a "$wrapped" "$bundled"
+    else
+        printf '#!/bin/sh\nexec %q "$@"\n' "$wrapped" >"$bundled"
+        chmod +x "$bundled"
+    fi
+    echo "Using pip esptool ($wrapped) via $bundled (MOCK_ESPTOOL_OVERRIDE)"
+}
+
+function restore_mock_esptool_override {
+    local bundled="${MOCK_ESPTOOL_BUNDLED:-}"
+    [ -n "${MOCK_ESPTOOL_ORIGINAL:-}" ] || return 0
+    [ -f "$MOCK_ESPTOOL_ORIGINAL" ] || return 0
+    [ -n "$bundled" ] || return 0
+
+    mv -f "$MOCK_ESPTOOL_ORIGINAL" "$bundled"
+    unset MOCK_ESPTOOL_ORIGINAL MOCK_ESPTOOL_BUNDLED
+}
+
+function start_mock_bootloader {
+    local chip="${1:-}"
+    MOCK_BOOTLOADER_PORT=""
+    MOCK_BOOTLOADER_CLI_PORT=""
+    MOCK_BOOTLOADER_SERIAL_PORT=""
+
+    local tcp_port="${MOCK_BOOTLOADER_TCP_PORT:-9876}"
+    local mock_timeout="${MOCK_BOOTLOADER_TIMEOUT:-600}"
+    local -a chip_args=()
+
+    command -v esp32-mock-bootloader >/dev/null 2>&1 || {
+        echo "ERROR: esp32-mock-bootloader not found (pip install esp32-mock-bootloader)" >&2
+        return 1
+    }
+
+    if [ -n "$chip" ]; then
+        chip_args=(--chip "$chip")
+    fi
+
+    esp32-mock-bootloader start --port "$tcp_port" --startup-timeout "$mock_timeout" "${chip_args[@]}" || {
+        echo "ERROR: mock bootloader failed to start" >&2
+        return 1
+    }
+
+    MOCK_BOOTLOADER_PORT="$(esp32-mock-bootloader url --port "$tcp_port")"
+    MOCK_BOOTLOADER_CLI_PORT="$MOCK_BOOTLOADER_PORT"
+    MOCK_BOOTLOADER_SERIAL_PORT="$MOCK_BOOTLOADER_PORT"
+}
+
+function stop_mock_bootloader {
+    local tcp_port="${MOCK_BOOTLOADER_TCP_PORT:-9876}"
+    command -v esp32-mock-bootloader >/dev/null 2>&1 && \
+        esp32-mock-bootloader stop --port "$tcp_port" 2>/dev/null || true
+    unset MOCK_BOOTLOADER_PORT MOCK_BOOTLOADER_CLI_PORT MOCK_BOOTLOADER_SERIAL_PORT
+}
+
+function mock_upload_soc_banner {
+    local soc="$1"
+    echo ""
+    printf '%s########################################%s\n' "$_MOCK_C_HEADER" "$_MOCK_C_RESET"
+    printf '%s# SoC: %s%s\n' "$_MOCK_C_HEADER" "$soc" "$_MOCK_C_RESET"
+    printf '%s# mock bootloader: TCP socket (esptool socket://)%s\n' "$_MOCK_C_HEADER" "$_MOCK_C_RESET"
+    printf '%s########################################%s\n' "$_MOCK_C_HEADER" "$_MOCK_C_RESET"
+}
+
+function mock_upload_tool_header {
+    local tool_label="$1" soc="$2"
+    echo ""
+    printf '%s=== [%s] SoC: %s ===%s\n' "$_MOCK_C_HEADER" "$tool_label" "$soc" "$_MOCK_C_RESET"
+}
+
+function mock_upload_tool_meta {
+    printf '%s    %s%s\n' "$_MOCK_C_DIM" "$*" "$_MOCK_C_RESET"
+}
+
+function mock_upload_result {
+    local tool_label="$1" soc="$2" status="$3"
+    if [ "$status" = "PASS" ]; then
+        printf '%s--- [%s] %s: PASS (both uploads) ---%s\n' "$_MOCK_C_PASS" "$tool_label" "$soc" "$_MOCK_C_RESET"
+    else
+        printf '%s--- [%s] %s: FAIL (see upload step above) ---%s\n' "$_MOCK_C_FAIL" "$tool_label" "$soc" "$_MOCK_C_RESET" >&2
+    fi
+}
+
+function mock_upload_log_step {
+    local tool="$1" step="$2" total="$3" detail="$4"
+    echo ""
+    printf '%s>>> [%s] upload %s/%s: %s%s\n' "$_MOCK_C_STEP" "$tool" "$step" "$total" "$detail" "$_MOCK_C_RESET"
+}
+
+function mock_upload_twice_cli {
+    local fqbn="$1" sketch="$2" build_dir="$3"
+    local cli="${ARDUINO_CLI_PATH:-${ARDUINO_IDE_PATH:?}/arduino-cli}"
+    local curroptions currcli_fqbn port
+    local tool="arduino-cli"
+
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        sketch="$(_native_path_for_java "$sketch")"
+        build_dir="$(_native_path_for_java "$build_dir")"
+    fi
+
+    port="${MOCK_BOOTLOADER_CLI_PORT:-$MOCK_BOOTLOADER_PORT}"
+    [ -n "$port" ] || { echo "ERROR: mock bootloader port not set" >&2; return 1; }
+    [ -x "$cli" ] || { echo "ERROR: arduino-cli not found at $cli" >&2; return 1; }
+    mkdir -p "$build_dir"
+
+    curroptions=$(echo "$fqbn" | cut -d':' -f4-)
+    currcli_fqbn=$(echo "$fqbn" | cut -d':' -f1-3)
+
+    mock_upload_log_step "$tool" 1 2 "compile + upload (full flash, no flasher cache yet)"
+    "$cli" compile --fqbn "$currcli_fqbn" --board-options "$curroptions" \
+        --build-path "$build_dir" -p "$port" --upload "$sketch" || return 1
+    mock_upload_log_step "$tool" 2 2 "upload only (fast reflash via flasher --diff-with)"
+    "$cli" upload --fqbn "$currcli_fqbn" --board-options "$curroptions" \
+        --input-dir "$build_dir" -p "$port" "$sketch" || return 1
+}
+
+function mock_upload_twice_headless {
+    local fqbn="$1" sketch="$2" build_dir="$3" runner="$4" tool_label="$5"
+    shift 5
+    local -a prefix_args=("$@") args port project_name build_path_pref
+
+    port="${MOCK_BOOTLOADER_SERIAL_PORT:-$MOCK_BOOTLOADER_PORT}"
+    [ -n "$port" ] || { echo "ERROR: mock bootloader serial port not set" >&2; return 1; }
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        local -a win_paths=()
+        mapfile -t win_paths < <(mock_upload_prepare_windows_builder_paths "$sketch")
+        sketch="${win_paths[0]}"
+        build_dir="${win_paths[1]}"
+    fi
+    project_name="$(basename "$sketch")"
+    mkdir -p "$build_dir"
+    build_path_pref="$build_dir"
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        build_path_pref="$(_windows_path_for_ide_pref "$build_dir")"
+    fi
+    args=(
+        "${prefix_args[@]}"
+        --board "$fqbn"
+        --pref "build.path=$build_path_pref"
+        --pref "build.project_name=$project_name"
+        --pref "serial.port=$port"
+        --port "$port"
+        --upload
+        "$sketch"
+    )
+    mock_upload_log_step "$tool_label" 1 2 "compile + upload (full flash, IDE 1.x upload path)"
+    if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+        echo "    sketch (staged): $sketch" >&2
+        echo "    build.path (pref): $build_path_pref" >&2
+    fi
+    if ! run_with_timeout 900 "$runner" "${args[@]}"; then
+        _dump_arduino_app_log
+        return 1
+    fi
+    mock_upload_log_step "$tool_label" 2 2 "compile + upload again (fast reflash via flasher --diff-with)"
+    if ! run_with_timeout 900 "$runner" "${args[@]}"; then
+        _dump_arduino_app_log
+        return 1
+    fi
+}
+
+function mock_upload_twice_builder {
+    mock_upload_twice_headless "$1" "$2" "$3" run_arduino_builder "arduino-builder"
+}
+
+function mock_upload_twice_ide_v1 {
+    mock_upload_twice_headless "$1" "$2" "$3" run_arduino_ide_v1 "arduino-ide-v1" "${@:4}"
+}

--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -51,7 +51,83 @@ function check_requirements { # check_requirements <sketchdir> <sdkconfig_path>
         fi
     fi
 
-    echo $has_requirements
+    echo "$has_requirements"
+}
+
+function _normalize_fqbn_opts {
+    echo "$1" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g'
+}
+
+function default_fqbn_for_target {
+    local target="$1"
+    local options_override="${2:-}"
+    local debug_level="${3:-}"
+    local extra_opts="${4:-}"
+    local pkg="${5:-espressif:esp32}"
+    local fqbn_append="${6:-}"
+
+    local opt=""
+    local merged
+    merged=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
+
+    local esp32_opts esp32s2_opts esp32s3_opts esp32c3_opts esp32c6_opts esp32h2_opts esp32p4_opts esp32c5_opts
+    esp32_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${debug_level},${fqbn_append},${extra_opts}")
+    esp32s2_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${debug_level},${fqbn_append},${extra_opts}")
+    esp32s3_opts=$(_normalize_fqbn_opts "PSRAM=opi,USBMode=default,${debug_level},${fqbn_append},${extra_opts}")
+    esp32c3_opts=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
+    esp32c6_opts=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
+    esp32h2_opts=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
+    esp32p4_opts=$(_normalize_fqbn_opts "PSRAM=enabled,USBMode=default,ChipVariant=postv3,${debug_level},${fqbn_append},${extra_opts}")
+    esp32c5_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${debug_level},${fqbn_append},${extra_opts}")
+
+    case "$target" in
+        esp32)
+            [ -n "${options_override:-$esp32_opts}" ] && opt=":${options_override:-$esp32_opts}"
+            echo "${pkg}:esp32${opt}"
+            ;;
+        esp32s2)
+            [ -n "${options_override:-$esp32s2_opts}" ] && opt=":${options_override:-$esp32s2_opts}"
+            echo "${pkg}:esp32s2${opt}"
+            ;;
+        esp32c3)
+            [ -n "${options_override:-$esp32c3_opts}" ] && opt=":${options_override:-$esp32c3_opts}"
+            echo "${pkg}:esp32c3${opt}"
+            ;;
+        esp32s3)
+            [ -n "${options_override:-$esp32s3_opts}" ] && opt=":${options_override:-$esp32s3_opts}"
+            echo "${pkg}:esp32s3${opt}"
+            ;;
+        esp32c6)
+            [ -n "${options_override:-$esp32c6_opts}" ] && opt=":${options_override:-$esp32c6_opts}"
+            echo "${pkg}:esp32c6${opt}"
+            ;;
+        esp32h2)
+            [ -n "${options_override:-$esp32h2_opts}" ] && opt=":${options_override:-$esp32h2_opts}"
+            echo "${pkg}:esp32h2${opt}"
+            ;;
+        esp32p4)
+            [ -n "${options_override:-$esp32p4_opts}" ] && opt=":${options_override:-$esp32p4_opts}"
+            echo "${pkg}:esp32p4${opt}"
+            ;;
+        esp32c5)
+            [ -n "${options_override:-$esp32c5_opts}" ] && opt=":${options_override:-$esp32c5_opts}"
+            echo "${pkg}:esp32c5${opt}"
+            ;;
+        *)
+            echo "ERROR: Invalid chip: $target" >&2
+            return 1
+            ;;
+    esac
+}
+
+function default_upload_test_fqbn {
+    default_fqbn_for_target "$1" "" "" "UploadSpeed=115200" "${2:-espressif:esp32}"
+}
+
+function split_fqbn_for_cli {
+    local fqbn="$1"
+    CLI_FQBN_OPTIONS=$(echo "$fqbn" | cut -d':' -f4-)
+    CLI_FQBN_BASE=$(echo "$fqbn" | cut -d':' -f1-3)
 }
 
 function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [extra-options]
@@ -167,65 +243,7 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
                 fi
             fi
 
-            # Default FQBN options if none were passed in the command line.
-            # Replace any double commas with a single one and strip leading and
-            # trailing commas.
-
-            esp32_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32s2_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32s3_opts=$(echo "PSRAM=opi,USBMode=default,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32c3_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32c6_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32h2_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32p4_opts=$(echo "PSRAM=enabled,USBMode=default,ChipVariant=postv3,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-            esp32c5_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
-
-            # Select the common part of the FQBN based on the target.  The rest will be
-            # appended depending on the passed options.
-
-            opt=""
-
-            case "$target" in
-                "esp32")
-                    [ -n "${options:-$esp32_opts}" ] && opt=":${options:-$esp32_opts}"
-                    fqbn="espressif:esp32:esp32$opt"
-                ;;
-                "esp32s2")
-                    [ -n "${options:-$esp32s2_opts}" ] && opt=":${options:-$esp32s2_opts}"
-                    fqbn="espressif:esp32:esp32s2$opt"
-                ;;
-                "esp32c3")
-                    [ -n "${options:-$esp32c3_opts}" ] && opt=":${options:-$esp32c3_opts}"
-                    fqbn="espressif:esp32:esp32c3$opt"
-                ;;
-                "esp32s3")
-                    [ -n "${options:-$esp32s3_opts}" ] && opt=":${options:-$esp32s3_opts}"
-                    fqbn="espressif:esp32:esp32s3$opt"
-                ;;
-                "esp32c6")
-                    [ -n "${options:-$esp32c6_opts}" ] && opt=":${options:-$esp32c6_opts}"
-                    fqbn="espressif:esp32:esp32c6$opt"
-                ;;
-                "esp32h2")
-                    [ -n "${options:-$esp32h2_opts}" ] && opt=":${options:-$esp32h2_opts}"
-                    fqbn="espressif:esp32:esp32h2$opt"
-                ;;
-                "esp32p4")
-                    [ -n "${options:-$esp32p4_opts}" ] && opt=":${options:-$esp32p4_opts}"
-                    fqbn="espressif:esp32:esp32p4$opt"
-                ;;
-                "esp32c5")
-                    [ -n "${options:-$esp32c5_opts}" ] && opt=":${options:-$esp32c5_opts}"
-                    fqbn="espressif:esp32:esp32c5$opt"
-                ;;
-                *)
-                    echo "ERROR: Invalid chip: $target"
-                    exit 1
-                ;;
-            esac
-
-            # Make it look like a JSON array.
-
+            fqbn=$(default_fqbn_for_target "$target" "$options" "${debug_level:-}" "" "espressif:esp32" "$fqbn_append") || exit 1
             fqbn="[\"$fqbn\"]"
         fi
     else
@@ -296,10 +314,9 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
 
         if [ "${use_arduino_cli:-0}" -eq 1 ] && [ -f "$ide_path/arduino-cli" ]; then
             echo "Building $sketchname with arduino-cli and FQBN=$currfqbn"
-            local curroptions
-            local currcli_fqbn
-            curroptions=$(echo "$currfqbn" | cut -d':' -f4)
-            currcli_fqbn=$(echo "$currfqbn" | cut -d':' -f1-3)
+            split_fqbn_for_cli "$currfqbn"
+            local curroptions="$CLI_FQBN_OPTIONS"
+            local currcli_fqbn="$CLI_FQBN_BASE"
             "$ide_path"/arduino-cli compile \
                 --fqbn "$currcli_fqbn" \
                 --board-options "$curroptions" \
@@ -355,7 +372,7 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
             ram_bytes=$(grep -oE 'Global variables use ([0-9]+) bytes' "$output_file" | awk '{print $4}')
             ram_percentage=$(grep -oE 'Global variables use ([0-9]+) bytes \(([0-9]+)%\)' "$output_file" | awk '{print $6}' | tr -d '(%)')
 
-            directory_path=$(dirname "$sketch")
+            directory_path=$(dirname "$sketchdir")
             constant_part="/home/runner/Arduino/hardware/espressif/esp32/libraries/"
             lib_sketch_name="${directory_path#"$constant_part"}"
             echo "{\"name\": \"$lib_sketch_name\",
@@ -781,6 +798,7 @@ Available commands:
     chunk_build: Build a chunk of sketches.
     check_requirements: Check if target meets sketch requirements.
     install_libs: Install libraries from ci.yml file.
+    default_upload_test_fqbn: Print default mock-upload FQBN for a SoC (target [pkg_prefix]).
 "
 
 cmd=$1
@@ -802,8 +820,10 @@ case "$cmd" in
     ;;
     "install_libs") install_libs "$@"
     ;;
+    "default_upload_test_fqbn") default_upload_test_fqbn "$@"
+    ;;
     *)
         echo "ERROR: Unrecognized command"
         echo "$USAGE"
         exit 2
-esac
+    esac

--- a/.github/scripts/test-mock-upload.sh
+++ b/.github/scripts/test-mock-upload.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# PR/push mock upload CI entry: arduino-cli and arduino-nightly builder, twice per SoC.
+# Usage: test-mock-upload.sh [cli|builder|all] [soc]
+# Default: all tools, all CORE_SOCS.
+
+set -eo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Mock uploads always need pip esptool (socket://); default on so local runs work too.
+export MOCK_ESPTOOL_OVERRIDE="${MOCK_ESPTOOL_OVERRIDE:-1}"
+source "${SCRIPTS_DIR}/socs_config.sh"
+source "${SCRIPTS_DIR}/mock_upload_lib.sh"
+
+printf '%s=== Mock upload test setup (%s/%s) ===%s\n' \
+    "$_MOCK_C_HEADER" "$(uname -s)" "$(uname -m)" "$_MOCK_C_RESET"
+
+SKETCH_UTILS="${SCRIPTS_DIR}/sketch_utils.sh"
+
+TOOL_FILTER="${1:-all}"
+SOC_FILTER="${2:-}"
+
+GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
+SKETCH="$GITHUB_WORKSPACE/libraries/ESP32/examples/CI/CIBoardsTest/CIBoardsTest.ino"
+if [[ "${OS_IS_WINDOWS:-0}" == "1" ]] && command -v cygpath >/dev/null 2>&1; then
+    SKETCH="$(cygpath -m "$SKETCH")"
+fi
+
+declare -a TEST_RESULTS=()
+TEST_FAILURES=0
+
+if [[ "${OS_IS_WINDOWS:-0}" == "1" ]]; then
+    export PATH="$HOME/bin:$PATH"
+else
+    export PATH="/home/runner/bin:$HOME/bin:$PATH"
+fi
+
+echo "Installing arduino-cli ..."
+source "${SCRIPTS_DIR}/install-arduino-cli.sh"
+echo "Installing arduino-nightly builder ..."
+source "${SCRIPTS_DIR}/install-arduino-builder.sh"
+echo "Installing ESP32 core (symlink + tools) ..."
+source "${SCRIPTS_DIR}/install-arduino-core-esp32.sh"
+install_mock_esptool_override || exit 1
+echo "Setup complete. Sketch: $SKETCH"
+
+record_test() {
+    TEST_RESULTS+=("$1|$2")
+    [ "$1" = "FAIL" ] && TEST_FAILURES=$((TEST_FAILURES + 1))
+    return 0
+}
+
+run_soc_tool_test() {
+    local tool="$1" soc="$2" fqbn="$3"
+    local name="${tool}:${soc}"
+    local build_dir rc=0 tool_label
+
+    case "$tool" in
+        cli) tool_label="arduino-cli" ;;
+        builder) tool_label="arduino-builder" ;;
+        *)
+            echo "ERROR: unknown tool: $tool" >&2
+            return 1
+            ;;
+    esac
+
+    mock_upload_tool_header "$tool_label" "$soc"
+    mock_upload_tool_meta "FQBN: $fqbn"
+    mock_upload_tool_meta "sketch: $SKETCH"
+
+    build_dir="$(mock_upload_mktemp_build_dir)"
+    mock_upload_tool_meta "build dir: $build_dir"
+
+    case "$tool" in
+        cli)
+            mock_upload_twice_cli "$fqbn" "$SKETCH" "$build_dir" || rc=$?
+            ;;
+        builder)
+            mock_upload_twice_builder "$fqbn" "$SKETCH" "$build_dir" || rc=$?
+            ;;
+    esac
+    rm -rf "$build_dir"
+    if [ -n "${MOCK_UPLOAD_WINDOWS_STAGING:-}" ]; then
+        rm -rf "$MOCK_UPLOAD_WINDOWS_STAGING"
+        unset MOCK_UPLOAD_WINDOWS_STAGING
+    fi
+
+    if [ "$rc" -eq 0 ]; then
+        mock_upload_result "$tool_label" "$soc" PASS
+        record_test PASS "$name"
+    else
+        mock_upload_result "$tool_label" "$soc" FAIL
+        record_test FAIL "$name"
+    fi
+    return 0
+}
+
+print_summary() {
+    local pass=0 entry status name
+    echo ""
+    printf '%s=== Mock upload summary (%s, tool=%s) ===%s\n' \
+        "$_MOCK_C_HEADER" "$(uname -s)" "$TOOL_FILTER" "$_MOCK_C_RESET"
+    for entry in "${TEST_RESULTS[@]}"; do
+        status="${entry%%|*}"
+        name="${entry#*|}"
+        case "$status" in
+            PASS)
+                pass=$((pass + 1))
+                printf '  %s✓ PASS%s  %s\n' "$_MOCK_C_PASS" "$_MOCK_C_RESET" "$name"
+                ;;
+            FAIL)
+                printf '  %s✗ FAIL%s  %s\n' "$_MOCK_C_FAIL" "$_MOCK_C_RESET" "$name"
+                ;;
+        esac
+    done
+    echo ""
+    if [ "$TEST_FAILURES" -eq 0 ]; then
+        printf '%sResult: PASSED (%s passed)%s\n' "$_MOCK_C_PASS" "$pass" "$_MOCK_C_RESET"
+    else
+        printf '%sResult: FAILED (%s failed, %s passed)%s\n' "$_MOCK_C_FAIL" "$TEST_FAILURES" "$pass" "$_MOCK_C_RESET"
+    fi
+}
+
+case "$TOOL_FILTER" in
+    cli|builder|all) ;;
+    *)
+        echo "Usage: $0 [cli|builder|all] [soc]" >&2
+        exit 1
+        ;;
+esac
+
+declare -a SOCS_TO_RUN=()
+if [ -n "$SOC_FILTER" ]; then
+    SOCS_TO_RUN=("$SOC_FILTER")
+else
+    SOCS_TO_RUN=("${CORE_SOCS[@]}")
+fi
+
+finish_tests() {
+    restore_mock_esptool_override
+    print_summary
+    exit $((TEST_FAILURES > 0 ? 1 : 0))
+}
+trap finish_tests EXIT
+
+for soc in "${SOCS_TO_RUN[@]}"; do
+    fqbn="$("$SKETCH_UTILS" default_upload_test_fqbn "$soc")"
+    mock_upload_soc_banner "$soc"
+    start_mock_bootloader "$soc" || {
+        record_test FAIL "mock:${soc}"
+        continue
+    }
+
+    if [ "$TOOL_FILTER" = "cli" ] || [ "$TOOL_FILTER" = "all" ]; then
+        run_soc_tool_test cli "$soc" "$fqbn"
+    fi
+    if [ "$TOOL_FILTER" = "builder" ] || [ "$TOOL_FILTER" = "all" ]; then
+        run_soc_tool_test builder "$soc" "$fqbn"
+    fi
+
+    stop_mock_bootloader
+done

--- a/.github/scripts/validate_board.sh
+++ b/.github/scripts/validate_board.sh
@@ -3,10 +3,10 @@
 # Board validation script for ESP32 Arduino Core
 # This script validates board definitions in boards.txt
 
-set -e
+set -eo pipefail
 
 # Required properties for all boards
-REQUIRED_PROPERTIES=("upload.flags" "upload.extra_flags")
+REQUIRED_PROPERTIES=("upload.flags" "upload.extra_flags" "upload.erase_cmd")
 
 # Function to print output
 print_error() {
@@ -21,10 +21,10 @@ print_success() {
 validate_board() {
     local board_name="$1"
     local boards_file="boards.txt"
-    
+
     echo "Validating board: $board_name"
     echo ""
-    
+
     # Rule 1: Check build.board format
     echo "Rule 1: Build Board Format Validation"
     echo "====================================="
@@ -71,16 +71,16 @@ validate_board() {
 validate_build_board_format() {
     local board_name="$1"
     local boards_file="$2"
-    
+
     # Get the build.board value
     local build_board_value
     build_board_value=$(grep "^$board_name.build.board=" "$boards_file" | cut -d'=' -f2)
-    
+
     if [ -z "$build_board_value" ]; then
         print_error "build.board property not found for '$board_name'"
         exit 1
     fi
-    
+
     # Check for invalid characters (anything that's not uppercase letter, number, or underscore)
     if echo "$build_board_value" | grep -q '[^A-Z0-9_]'; then
         local invalid_chars
@@ -88,13 +88,13 @@ validate_build_board_format() {
         print_error "$board_name.build.board contains invalid characters: '$invalid_chars' (only A-Z, 0-9, and _ are allowed)"
         exit 1
     fi
-    
+
     # Check if it's all uppercase
     if echo "$build_board_value" | grep -q '[a-z]'; then
         print_error "build.board must be uppercase: '$build_board_value' (found lowercase letters)"
         exit 1
     fi
-    
+
     echo "  ✓ build.board is valid: '$build_board_value'"
 }
 
@@ -102,15 +102,15 @@ validate_build_board_format() {
 validate_required_properties() {
     local board_name="$1"
     local boards_file="$2"
-    
+
     local missing_props=()
-    
+
     for prop in "${REQUIRED_PROPERTIES[@]}"; do
         if ! grep -q "^$board_name.$prop=" "$boards_file"; then
             missing_props+=("$prop")
         fi
     done
-    
+
     if [ ${#missing_props[@]} -gt 0 ]; then
         print_error "Missing required properties for board '$board_name':"
         printf '  - %s\n' "${missing_props[@]}"
@@ -125,17 +125,17 @@ validate_required_properties() {
 validate_partition_schemes() {
     local board_name="$1"
     local boards_file="$2"
-    
+
     # Get all available flash sizes for this board
     local flash_sizes
     flash_sizes=$(grep "^$board_name.menu.FlashSize\." "$boards_file" | grep "\.build\.flash_size=" | cut -d'=' -f2 | sort -V)
-    
+
     # Check if board has menu.FlashSize entries
     if [ -z "$flash_sizes" ]; then
         # If no menu.FlashSize entries, check if board has build.flash_size entry at least
         local has_flash_size
         has_flash_size=$(grep "^$board_name\." "$boards_file" | grep "\.build\.flash_size=" | head -1)
-        
+
         if [ -z "$has_flash_size" ]; then
             print_error "No flash size options found for board '$board_name' (needs build.flash_size entry at least)"
             exit 1
@@ -146,7 +146,7 @@ validate_partition_schemes() {
             flash_sizes="$flash_size_value"
         fi
     fi
-    
+
     # Convert flash sizes to MB for comparison
     local flash_sizes_mb=()
     while IFS= read -r size; do
@@ -154,7 +154,7 @@ validate_partition_schemes() {
             flash_sizes_mb+=("${BASH_REMATCH[1]}")
         fi
     done <<< "$flash_sizes"
-    
+
     # Find the maximum flash size available
     local max_flash_mb=0
     for size_mb in "${flash_sizes_mb[@]}"; do
@@ -162,21 +162,21 @@ validate_partition_schemes() {
             max_flash_mb="$size_mb"
         fi
     done
-    
+
     echo "  ✓ Flash configuration found - maximum size: ${max_flash_mb}MB"
-    
+
     # Find all partition schemes for this board
     local partition_schemes
     partition_schemes=$(grep "^$board_name.menu.PartitionScheme\." "$boards_file" | grep -v "\.build\." | grep -v "\.upload\." | sed 's/.*\.PartitionScheme\.\([^=]*\)=.*/\1/' | sort -u)
-    
+
     if [ -n "$partition_schemes" ]; then
         # Validate each partition scheme against the maximum flash size
         while IFS= read -r scheme; do
             validate_partition_scheme_size "$scheme" "$max_flash_mb" "$board_name" "$boards_file"
         done <<< "$partition_schemes"
     fi
-    
-    
+
+
     echo "  ✓ Partition scheme validation completed"
 }
 
@@ -186,11 +186,11 @@ validate_partition_scheme_size() {
     local max_flash_mb="$2"
     local board_name="$3"
     local boards_file="$4"
-    
+
     # Extract size from partition scheme name (e.g., "default_8MB" -> 8)
     if [[ "$scheme" =~ _([0-9]+)MB$ ]]; then
         local scheme_size_mb="${BASH_REMATCH[1]}"
-        
+
         if [ "$scheme_size_mb" -gt "$max_flash_mb" ]; then
             print_error "Partition scheme '$scheme' (${scheme_size_mb}MB) exceeds available flash size (${max_flash_mb}MB) for board '$board_name'"
             exit 1
@@ -200,7 +200,7 @@ validate_partition_scheme_size() {
     elif [[ "$scheme" =~ _([0-9]+)M$ ]]; then
         # Handle cases like "default_8M" (without B)
         local scheme_size_mb="${BASH_REMATCH[1]}"
-        
+
         if [ "$scheme_size_mb" -gt "$max_flash_mb" ]; then
             print_error "Partition scheme '$scheme' (${scheme_size_mb}MB) exceeds available flash size (${max_flash_mb}MB) for board '$board_name'"
             exit 1
@@ -210,7 +210,7 @@ validate_partition_scheme_size() {
     elif [[ "$scheme" =~ _([0-9]+)$ ]]; then
         # Handle cases like "esp_sr_16" (just number at end)
         local scheme_size_mb="${BASH_REMATCH[1]}"
-        
+
         if [ "$scheme_size_mb" -gt "$max_flash_mb" ]; then
             print_error "Partition scheme '$scheme' (${scheme_size_mb}MB) exceeds available flash size (${max_flash_mb}MB) for board '$board_name'"
             exit 1
@@ -221,22 +221,22 @@ validate_partition_scheme_size() {
         # For schemes without size in name, check description for size indicators
         local description_text
         description_text=$(grep "^$board_name.menu.PartitionScheme\.$scheme=" "$boards_file" | cut -d'=' -f2)
-        
+
         # First check main description for size indicators (before brackets)
         # Look for the largest size indicator in the main description
         local main_description_size_mb=0
         local main_description_size_text=""
-        
+
         # Check for MB and M values in main description (before brackets)
         local main_part=$(echo "$description_text" | sed 's/(.*//')  # Remove bracket content
-        
+
         # Extract M values (not followed by B) and MB values
         local m_values=$(echo "$main_part" | grep -oE '([0-9]+\.?[0-9]*)M' | grep -v 'MB' | sed 's/M$//')
         local mb_values=$(echo "$main_part" | grep -oE '([0-9]+\.?[0-9]*)MB' | sed 's/MB//')
-        
+
         # Combine both M and MB values
         local all_mb_values=$(echo -e "$m_values\n$mb_values" | grep -v '^$')
-        
+
         # Find the largest MB value in main description
         local largest_mb_int=0
         while IFS= read -r value; do
@@ -249,13 +249,13 @@ validate_partition_scheme_size() {
             else
                 continue
             fi
-            
+
             if [ "$value_int" -gt "$largest_mb_int" ]; then
                 largest_mb_int=$value_int
                 main_description_size_text="${value}M"
             fi
         done <<< "$all_mb_values"
-        
+
         if [ "$largest_mb_int" -gt 0 ]; then
             # Found size in main description
             if [ "$largest_mb_int" -gt $((max_flash_mb * 10)) ]; then
@@ -268,26 +268,31 @@ validate_partition_scheme_size() {
             # No size in main description, check bracket content
             local bracket_content
             bracket_content=$(echo "$description_text" | grep -oE '\([^)]+\)' | head -1)
-            
+
             if [ -n "$bracket_content" ]; then
                 # Calculate total size from all components in brackets
                 local total_size_mb=0
-                
+
                 # Extract and sum MB values
                 local mb_sum=0
                 while IFS= read -r value; do
                     if [[ "$value" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
                         local whole="${BASH_REMATCH[1]}"
                         local decimal="${BASH_REMATCH[2]}"
-                        # Convert decimal to integer (e.g., 1.3 -> 13, 6.93 -> 69)
-                        # Handle multi-digit decimals: 6.93 -> 6*10 + 9 = 69 (round down)
-                        local decimal_int=$((decimal / 10))
+                        # Convert to tenths of MB (e.g., 1.3 -> 13, 6.93 -> 69)
+                        # Normalize decimal to single digit (first decimal place only)
+                        local decimal_int
+                        if [ ${#decimal} -eq 1 ]; then
+                            decimal_int=$((10#$decimal))
+                        else
+                            decimal_int=$((10#$decimal / 10))
+                        fi
                         mb_sum=$((mb_sum + whole * 10 + decimal_int))
                     elif [[ "$value" =~ ^([0-9]+)$ ]]; then
                         mb_sum=$((mb_sum + value * 10))
                     fi
                 done < <(echo "$bracket_content" | grep -oE '([0-9]+\.?[0-9]*)MB' | sed 's/MB//')
-                
+
                 # Extract and sum KB values (convert to MB tenths)
                 local kb_sum=0
                 while IFS= read -r value; do
@@ -302,10 +307,10 @@ validate_partition_scheme_size() {
                         kb_sum=$((kb_sum + (value * 10 + 512) / 1024))
                     fi
                 done < <(echo "$bracket_content" | grep -oE '([0-9]+\.?[0-9]*)KB' | sed 's/KB//')
-                
+
                 # Sum all values and convert back to MB (divide by 10, rounded)
                 total_size_mb=$(( (mb_sum + kb_sum + 5) / 10 ))
-                
+
                 if [ "$total_size_mb" -gt 0 ]; then
                     # Found size in description
                     if [ "$total_size_mb" -gt "$max_flash_mb" ]; then
@@ -332,26 +337,26 @@ validate_scheme_upload_size() {
     local board_name="$2"
     local boards_file="$3"
     local max_flash_mb="$4"
-    
+
     # Get upload maximum size for this specific scheme
     local upload_size
     upload_size=$(grep "^$board_name.menu.PartitionScheme\.$scheme\." "$boards_file" | grep "\.upload\.maximum_size=" | head -1 | cut -d'=' -f2)
-    
+
     if [ -z "$upload_size" ]; then
         echo "    ✓ Partition scheme '$scheme' is valid for ${max_flash_mb}MB flash (no upload size limit)"
         return 0
     fi
-    
+
     # Convert flash size to bytes for comparison
     local max_flash_bytes=$((max_flash_mb * 1024 * 1024))
-    
+
     # Check upload size against maximum flash size
     if [ "$upload_size" -gt "$max_flash_bytes" ]; then
         local upload_mb=$(( (upload_size + 524288) / 1048576 ))
         print_error "Partition scheme '$scheme' upload size (${upload_mb}MB, ${upload_size} bytes) exceeds available flash size (${max_flash_mb}MB) for board '$board_name'"
         exit 1
     fi
-    
+
     local upload_mb=$(( (upload_size + 524288) / 1048576 ))
     echo "    ✓ Partition scheme '$scheme' is valid for ${max_flash_mb}MB flash (upload size: ${upload_mb}MB)"
 }
@@ -360,78 +365,78 @@ validate_scheme_upload_size() {
 validate_vid_pid_consistency() {
     local board_name="$1"
     local boards_file="$2"
-    
+
     # Get all VID and PID entries for this board (including upload_port entries)
     local vid_entries
     local pid_entries
-    
+
     vid_entries=$(grep "^$board_name\.vid\." "$boards_file" | sort)
     pid_entries=$(grep "^$board_name\.pid\." "$boards_file" | sort)
-    
+
     # Also get upload_port VID and PID entries
     local upload_port_vid_entries
     local upload_port_pid_entries
-    
+
     upload_port_vid_entries=$(grep "^$board_name\.upload_port\..*\.vid=" "$boards_file" | sort)
     upload_port_pid_entries=$(grep "^$board_name\.upload_port\..*\.pid=" "$boards_file" | sort)
-    
+
     # Check for duplicate VID entries with same index but different values
     local all_vid_entries="$vid_entries"
     if [ -n "$upload_port_vid_entries" ]; then
         all_vid_entries="$all_vid_entries
 $upload_port_vid_entries"
     fi
-    
+
     local vid_duplicates
     vid_duplicates=$(echo "$all_vid_entries" | cut -d'=' -f1 | sort | uniq -d)
-    
+
     if [ -n "$vid_duplicates" ]; then
         print_error "Found duplicate VID entries with different values for board '$board_name':"
         echo "$vid_duplicates"
         exit 1
     fi
-    
+
     # Check for duplicate PID entries with same index but different values
     local all_pid_entries="$pid_entries"
     if [ -n "$upload_port_pid_entries" ]; then
         all_pid_entries="$all_pid_entries
 $upload_port_pid_entries"
     fi
-    
+
     local pid_duplicates
     pid_duplicates=$(echo "$all_pid_entries" | cut -d'=' -f1 | sort | uniq -d)
-    
+
     if [ -n "$pid_duplicates" ]; then
         print_error "Found duplicate PID entries with different values for board '$board_name':"
         echo "$pid_duplicates"
         exit 1
     fi
-    
+
     # Check for missing corresponding PID for each VID (and vice versa)
     local vid_indices
     local pid_indices
-    
+
     # Get indices from regular vid/pid entries
     local regular_vid_indices=$(echo "$vid_entries" | cut -d'=' -f1 | sed "s/^$board_name\.vid\.//" | sort -n)
     local regular_pid_indices=$(echo "$pid_entries" | cut -d'=' -f1 | sed "s/^$board_name\.pid\.//" | sort -n)
-    
+
     # Get indices from upload_port entries
     local upload_vid_indices=$(echo "$upload_port_vid_entries" | cut -d'=' -f1 | sed "s/^$board_name\.upload_port\.//" | sed "s/\.vid$//" | sort -n)
     local upload_pid_indices=$(echo "$upload_port_pid_entries" | cut -d'=' -f1 | sed "s/^$board_name\.upload_port\.//" | sed "s/\.pid$//" | sort -n)
-    
+
     # Combine indices
     vid_indices="$regular_vid_indices"
     if [ -n "$upload_vid_indices" ]; then
         vid_indices="$vid_indices
 $upload_vid_indices"
     fi
-    
+
     pid_indices="$regular_pid_indices"
     if [ -n "$upload_pid_indices" ]; then
         pid_indices="$pid_indices
 $upload_pid_indices"
     fi
-    
+
     # Check if VID and PID indices match
     if [ "$vid_indices" != "$pid_indices" ]; then
         print_error "VID and PID indices don't match for board '$board_name'"
@@ -439,22 +444,22 @@ $upload_pid_indices"
         echo "PID indices: $pid_indices"
         exit 1
     fi
-    
+
     # Check that no VID/PID combination matches esp32_family (0x303a/0x1001)
     local esp32_family_vid="0x303a"
     local esp32_family_pid="0x1001"
-    
+
     # Check regular vid/pid entries
     if [ -n "$vid_entries" ] && [ -n "$pid_entries" ]; then
         while IFS= read -r vid_line; do
             if [ -n "$vid_line" ]; then
                 local vid_index=$(echo "$vid_line" | cut -d'=' -f1 | sed "s/^$board_name\.vid\.//")
                 local vid_value=$(echo "$vid_line" | cut -d'=' -f2)
-                
+
                 # Find corresponding PID
                 local pid_value
                 pid_value=$(grep "^$board_name\.pid\.$vid_index=" "$boards_file" | cut -d'=' -f2)
-                
+
                 if [ "$vid_value" = "$esp32_family_vid" ] && [ "$pid_value" = "$esp32_family_pid" ]; then
                     print_error "Board '$board_name' VID/PID combination ($vid_value/$pid_value) matches esp32_family VID/PID (0x303a/0x1001) - this is not allowed"
                     exit 1
@@ -462,18 +467,18 @@ $upload_pid_indices"
             fi
         done <<< "$vid_entries"
     fi
-    
+
     # Check upload_port vid/pid entries
     if [ -n "$upload_port_vid_entries" ] && [ -n "$upload_port_pid_entries" ]; then
         while IFS= read -r vid_line; do
             if [ -n "$vid_line" ]; then
                 local vid_index=$(echo "$vid_line" | cut -d'=' -f1 | sed "s/^$board_name\.upload_port\.//" | sed "s/\.vid$//")
                 local vid_value=$(echo "$vid_line" | cut -d'=' -f2)
-                
+
                 # Find corresponding PID
                 local pid_value
                 pid_value=$(grep "^$board_name\.upload_port\.$vid_index\.pid=" "$boards_file" | cut -d'=' -f2)
-                
+
                 if [ "$vid_value" = "$esp32_family_vid" ] && [ "$pid_value" = "$esp32_family_pid" ]; then
                     print_error "Board '$board_name' upload_port VID/PID combination ($vid_value/$pid_value) matches esp32_family VID/PID (0x303a/0x1001) - this is not allowed"
                     exit 1
@@ -481,7 +486,7 @@ $upload_pid_indices"
             fi
         done <<< "$upload_port_vid_entries"
     fi
-    
+
     echo "  ✓ VID and PID consistency check passed"
 }
 
@@ -489,47 +494,47 @@ $upload_pid_indices"
 validate_debug_level_menu() {
     local board_name="$1"
     local boards_file="$2"
-    
+
     # Required DebugLevel menu options
     local required_debug_levels=("none" "error" "warn" "info" "debug" "verbose")
     local missing_levels=()
-    
+
     # Check if DebugLevel menu exists
     if ! grep -q "^$board_name.menu.DebugLevel\." "$boards_file"; then
         print_error "Missing DebugLevel menu for board '$board_name'"
         exit 1
     fi
-    
+
     # Check each required debug level
     for level in "${required_debug_levels[@]}"; do
         if ! grep -q "^$board_name.menu.DebugLevel.$level=" "$boards_file"; then
             missing_levels+=("$level")
         fi
     done
-    
+
     if [ ${#missing_levels[@]} -gt 0 ]; then
         print_error "Missing DebugLevel menu options for board '$board_name':"
         printf '  - %s\n' "${missing_levels[@]}"
         exit 1
     fi
-    
+
     # Check that each debug level has the correct build.code_debug value
     local code_debug_values=("0" "1" "2" "3" "4" "5")
     local debug_level_index=0
-    
+
     for level in "${required_debug_levels[@]}"; do
         local expected_value="${code_debug_values[$debug_level_index]}"
         local actual_value
         actual_value=$(grep "^$board_name.menu.DebugLevel.$level.build.code_debug=" "$boards_file" | cut -d'=' -f2)
-        
+
         if [ "$actual_value" != "$expected_value" ]; then
             print_error "Invalid code_debug value for DebugLevel '$level' in board '$board_name': expected '$expected_value', found '$actual_value'"
             exit 1
         fi
-        
+
         debug_level_index=$((debug_level_index + 1))
     done
-    
+
     echo "  ✓ DebugLevel menu validation completed"
 }
 
@@ -537,24 +542,24 @@ validate_debug_level_menu() {
 validate_no_duplicates() {
     local board_name="$1"
     local boards_file="$2"
-    
+
     # Get all lines for this board
     local board_lines
     board_lines=$(grep "^$board_name\." "$boards_file")
-    
+
     # Extract just the property names (before =)
     local property_names
     property_names=$(echo "$board_lines" | cut -d'=' -f1)
-    
+
     # Find duplicates
     local duplicate_lines
     duplicate_lines=$(echo "$property_names" | sort | uniq -d)
-    
+
     if [ -n "$duplicate_lines" ]; then
         print_error "Found duplicate lines for board '$board_name':"
         echo "Duplicate line keys:"
         echo "$duplicate_lines"
-        
+
         echo "Duplicate content details:"
         while IFS= read -r line_key; do
             if [ -n "$line_key" ]; then
@@ -569,7 +574,7 @@ validate_no_duplicates() {
         done <<< "$duplicate_lines"
         exit 1
     fi
-    
+
     echo "  ✓ No duplicate lines found"
 }
 
@@ -580,15 +585,15 @@ main() {
         echo "Example: $0 esp32s3"
         exit 1
     fi
-    
+
     local board_name="$1"
     local boards_file="boards.txt"
-    
+
     if [ ! -f "$boards_file" ]; then
         print_error "Boards file '$boards_file' not found"
         exit 1
     fi
-    
+
     validate_board "$board_name"
 }
 

--- a/.github/workflows/upload-tests.yml
+++ b/.github/workflows/upload-tests.yml
@@ -1,0 +1,76 @@
+name: Upload Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - release/*
+  pull_request:
+    paths:
+      - "platform.txt"
+      - "programmers.txt"
+      - "boards.txt"
+      - "tools/flasher.py"
+      - "package/package_esp32_index.template.json"
+      - ".github/esp32-mock-bootloader-version"
+      - ".github/scripts/arduino_headless.sh"
+      - ".github/scripts/mock_upload_lib.sh"
+      - ".github/scripts/test-mock-upload.sh"
+      - ".github/scripts/install-arduino-builder.sh"
+      - ".github/scripts/sketch_utils.sh"
+      - ".github/scripts/socs_config.sh"
+      - ".github/workflows/upload-tests.yml"
+
+concurrency:
+  group: mock-upload-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mock-upload:
+    name: Mock upload on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    env:
+      # Job env avoids PowerShell vs bash $GITHUB_ENV differences on Windows runners.
+      MOCK_ESPTOOL_OVERRIDE: "1"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-26-intel]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.0.4
+        with:
+          python-version: "3.x"
+
+      - name: Install python dependencies
+        run: pip install pyserial esptool esp32-mock-bootloader
+
+      - name: Install xvfb (Linux builder upload)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Get libs cache
+        if: runner.os == 'Linux'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          key: libs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package/package_esp32_index.template.json', 'tools/get.py') }}
+          path: |
+            ./tools/dist
+            ./tools/esp32-arduino-libs
+            ./tools/esptool
+            ./tools/mk*
+            ./tools/openocd-esp32
+            ./tools/riscv32-*
+            ./tools/xtensa-*
+
+      - name: Run mock upload tests
+        shell: bash
+        run: bash ./.github/scripts/test-mock-upload.sh

--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,13 @@ tools/openocd-esp32
 
 # Ignore build and temporary files
 /build
+tmp/
 *.tmp
 
 # Ignore files built by Visual Studio/Visual Micro and other IDEs
 [Dd]ebug/
 [Rr]elease/
+!.github/scripts/release
 .vs/
 __vm/
 *.vcxproj*

--- a/boards.txt
+++ b/boards.txt
@@ -62,6 +62,7 @@ esp32c2.upload.tool.network=esp_ota
 esp32c2.upload.maximum_size=1310720
 esp32c2.upload.maximum_data_size=327680
 esp32c2.upload.flags=
+esp32c2.upload.erase_cmd=
 esp32c2.upload.extra_flags=
 esp32c2.upload.use_1200bps_touch=false
 esp32c2.upload.wait_for_upload_port=false
@@ -160,7 +161,6 @@ esp32c2.menu.DebugLevel.verbose=Verbose
 esp32c2.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c2.menu.EraseFlash.none=Disabled
-esp32c2.menu.EraseFlash.none.upload.erase_cmd=
 esp32c2.menu.EraseFlash.all=Enabled
 esp32c2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -178,6 +178,7 @@ esp32c5.upload.tool.network=esp_ota
 esp32c5.upload.maximum_size=1310720
 esp32c5.upload.maximum_data_size=327680
 esp32c5.upload.flags=
+esp32c5.upload.erase_cmd=
 esp32c5.upload.extra_flags=
 esp32c5.upload.use_1200bps_touch=false
 esp32c5.upload.wait_for_upload_port=false
@@ -355,7 +356,6 @@ esp32c5.menu.DebugLevel.verbose=Verbose
 esp32c5.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c5.menu.EraseFlash.none=Disabled
-esp32c5.menu.EraseFlash.none.upload.erase_cmd=
 esp32c5.menu.EraseFlash.all=Enabled
 esp32c5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -389,6 +389,7 @@ esp32p4.upload.tool.network=esp_ota
 esp32p4.upload.maximum_size=1310720
 esp32p4.upload.maximum_data_size=327680
 esp32p4.upload.flags=
+esp32p4.upload.erase_cmd=
 esp32p4.upload.extra_flags=
 esp32p4.upload.use_1200bps_touch=false
 esp32p4.upload.wait_for_upload_port=false
@@ -577,7 +578,6 @@ esp32p4.menu.DebugLevel.verbose=Verbose
 esp32p4.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32p4.menu.EraseFlash.none=Disabled
-esp32p4.menu.EraseFlash.none.upload.erase_cmd=
 esp32p4.menu.EraseFlash.all=Enabled
 esp32p4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -595,6 +595,7 @@ esp32h2.upload.tool.network=esp_ota
 esp32h2.upload.maximum_size=1310720
 esp32h2.upload.maximum_data_size=327680
 esp32h2.upload.flags=
+esp32h2.upload.erase_cmd=
 esp32h2.upload.extra_flags=
 esp32h2.upload.use_1200bps_touch=false
 esp32h2.upload.wait_for_upload_port=false
@@ -760,7 +761,6 @@ esp32h2.menu.DebugLevel.verbose=Verbose
 esp32h2.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32h2.menu.EraseFlash.none=Disabled
-esp32h2.menu.EraseFlash.none.upload.erase_cmd=
 esp32h2.menu.EraseFlash.all=Enabled
 esp32h2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -794,6 +794,7 @@ esp32c6.upload.tool.network=esp_ota
 esp32c6.upload.maximum_size=1310720
 esp32c6.upload.maximum_data_size=327680
 esp32c6.upload.flags=
+esp32c6.upload.erase_cmd=
 esp32c6.upload.extra_flags=
 esp32c6.upload.use_1200bps_touch=false
 esp32c6.upload.wait_for_upload_port=false
@@ -966,7 +967,6 @@ esp32c6.menu.DebugLevel.verbose=Verbose
 esp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c6.menu.EraseFlash.none=Disabled
-esp32c6.menu.EraseFlash.none.upload.erase_cmd=
 esp32c6.menu.EraseFlash.all=Enabled
 esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -1001,6 +1001,7 @@ esp32c61.upload.tool.network=esp_ota
 esp32c61.upload.maximum_size=1310720
 esp32c61.upload.maximum_data_size=327680
 esp32c61.upload.flags=
+esp32c61.upload.erase_cmd=
 esp32c61.upload.extra_flags=
 esp32c61.upload.use_1200bps_touch=false
 esp32c61.upload.wait_for_upload_port=false
@@ -1152,7 +1153,6 @@ esp32c61.menu.DebugLevel.verbose=Verbose
 esp32c61.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c61.menu.EraseFlash.none=Disabled
-esp32c61.menu.EraseFlash.none.upload.erase_cmd=
 esp32c61.menu.EraseFlash.all=Enabled
 esp32c61.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -1170,6 +1170,7 @@ esp32s3.upload.tool.network=esp_ota
 esp32s3.upload.maximum_size=1310720
 esp32s3.upload.maximum_data_size=327680
 esp32s3.upload.flags=
+esp32s3.upload.erase_cmd=
 esp32s3.upload.extra_flags=
 esp32s3.upload.use_1200bps_touch=false
 esp32s3.upload.wait_for_upload_port=false
@@ -1402,7 +1403,6 @@ esp32s3.menu.DebugLevel.verbose=Verbose
 esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s3.menu.EraseFlash.none=Disabled
-esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 esp32s3.menu.EraseFlash.all=Enabled
 esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -1427,6 +1427,7 @@ esp32c3.upload.tool.network=esp_ota
 esp32c3.upload.maximum_size=1310720
 esp32c3.upload.maximum_data_size=327680
 esp32c3.upload.flags=
+esp32c3.upload.erase_cmd=
 esp32c3.upload.extra_flags=
 esp32c3.upload.use_1200bps_touch=false
 esp32c3.upload.wait_for_upload_port=false
@@ -1585,7 +1586,6 @@ esp32c3.menu.DebugLevel.verbose=Verbose
 esp32c3.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c3.menu.EraseFlash.none=Disabled
-esp32c3.menu.EraseFlash.none.upload.erase_cmd=
 esp32c3.menu.EraseFlash.all=Enabled
 esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -1614,6 +1614,7 @@ esp32s2.upload.tool.network=esp_ota
 esp32s2.upload.maximum_size=1310720
 esp32s2.upload.maximum_data_size=327680
 esp32s2.upload.flags=
+esp32s2.upload.erase_cmd=
 esp32s2.upload.extra_flags=
 esp32s2.upload.use_1200bps_touch=false
 esp32s2.upload.wait_for_upload_port=false
@@ -1795,7 +1796,6 @@ esp32s2.menu.DebugLevel.verbose=Verbose
 esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s2.menu.EraseFlash.none=Disabled
-esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 esp32s2.menu.EraseFlash.all=Enabled
 esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -1820,6 +1820,7 @@ esp32.upload.tool.network=esp_ota
 esp32.upload.maximum_size=1310720
 esp32.upload.maximum_data_size=327680
 esp32.upload.flags=
+esp32.upload.erase_cmd=
 esp32.upload.extra_flags=
 
 esp32.serial.disableDTR=true
@@ -1995,7 +1996,6 @@ esp32.menu.DebugLevel.verbose=Verbose
 esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32.menu.EraseFlash.none=Disabled
-esp32.menu.EraseFlash.none.upload.erase_cmd=
 esp32.menu.EraseFlash.all=Enabled
 esp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2020,6 +2020,7 @@ esp32da.upload.tool.network=esp_ota
 esp32da.upload.maximum_size=1310720
 esp32da.upload.maximum_data_size=327680
 esp32da.upload.flags=
+esp32da.upload.erase_cmd=
 esp32da.upload.extra_flags=
 
 esp32da.serial.disableDTR=true
@@ -2167,7 +2168,6 @@ esp32da.menu.DebugLevel.verbose=Verbose
 esp32da.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32da.menu.EraseFlash.none=Disabled
-esp32da.menu.EraseFlash.none.upload.erase_cmd=
 esp32da.menu.EraseFlash.all=Enabled
 esp32da.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2185,6 +2185,7 @@ esp32wrover.upload.tool.network=esp_ota
 esp32wrover.upload.maximum_size=1310720
 esp32wrover.upload.maximum_data_size=327680
 esp32wrover.upload.flags=
+esp32wrover.upload.erase_cmd=
 esp32wrover.upload.extra_flags=
 
 esp32wrover.serial.disableDTR=true
@@ -2282,7 +2283,6 @@ esp32wrover.menu.DebugLevel.verbose=Verbose
 esp32wrover.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32wrover.menu.EraseFlash.none=Disabled
-esp32wrover.menu.EraseFlash.none.upload.erase_cmd=
 esp32wrover.menu.EraseFlash.all=Enabled
 esp32wrover.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2300,6 +2300,7 @@ pico32.upload.tool.network=esp_ota
 pico32.upload.maximum_size=1310720
 pico32.upload.maximum_data_size=327680
 pico32.upload.flags=
+pico32.upload.erase_cmd=
 pico32.upload.extra_flags=
 
 pico32.serial.disableDTR=true
@@ -2362,7 +2363,6 @@ pico32.menu.DebugLevel.verbose=Verbose
 pico32.menu.DebugLevel.verbose.build.code_debug=5
 
 pico32.menu.EraseFlash.none=Disabled
-pico32.menu.EraseFlash.none.upload.erase_cmd=
 pico32.menu.EraseFlash.all=Enabled
 pico32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2379,6 +2379,7 @@ esp32s3-octal.upload.tool.network=esp_ota
 esp32s3-octal.upload.maximum_size=1310720
 esp32s3-octal.upload.maximum_data_size=327680
 esp32s3-octal.upload.flags=
+esp32s3-octal.upload.erase_cmd=
 esp32s3-octal.upload.extra_flags=
 esp32s3-octal.upload.use_1200bps_touch=false
 esp32s3-octal.upload.wait_for_upload_port=false
@@ -2595,7 +2596,6 @@ esp32s3-octal.menu.DebugLevel.verbose=Verbose
 esp32s3-octal.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s3-octal.menu.EraseFlash.none=Disabled
-esp32s3-octal.menu.EraseFlash.none.upload.erase_cmd=
 esp32s3-octal.menu.EraseFlash.all=Enabled
 esp32s3-octal.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2614,6 +2614,7 @@ esp32s3box.upload.maximum_size=3145728
 esp32s3box.upload.maximum_data_size=327680
 esp32s3box.upload.speed=921600
 esp32s3box.upload.flags=
+esp32s3box.upload.erase_cmd=
 esp32s3box.upload.extra_flags=
 esp32s3box.upload.use_1200bps_touch=false
 esp32s3box.upload.wait_for_upload_port=false
@@ -2694,7 +2695,6 @@ esp32s3box.menu.DebugLevel.verbose=Verbose
 esp32s3box.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s3box.menu.EraseFlash.none=Disabled
-esp32s3box.menu.EraseFlash.none.upload.erase_cmd=
 esp32s3box.menu.EraseFlash.all=Enabled
 esp32s3box.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2713,6 +2713,7 @@ esp32s3usbotg.upload.maximum_size=1310720
 esp32s3usbotg.upload.maximum_data_size=327680
 esp32s3usbotg.upload.speed=921600
 esp32s3usbotg.upload.flags=
+esp32s3usbotg.upload.erase_cmd=
 esp32s3usbotg.upload.extra_flags=
 esp32s3usbotg.upload.use_1200bps_touch=false
 esp32s3usbotg.upload.wait_for_upload_port=false
@@ -2800,7 +2801,6 @@ esp32s3usbotg.menu.DebugLevel.verbose=Verbose
 esp32s3usbotg.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s3usbotg.menu.EraseFlash.none=Disabled
-esp32s3usbotg.menu.EraseFlash.none.upload.erase_cmd=
 esp32s3usbotg.menu.EraseFlash.all=Enabled
 esp32s3usbotg.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2818,6 +2818,7 @@ esp32s3camlcd.upload.tool.network=esp_ota
 esp32s3camlcd.upload.maximum_size=1310720
 esp32s3camlcd.upload.maximum_data_size=327680
 esp32s3camlcd.upload.flags=
+esp32s3camlcd.upload.erase_cmd=
 esp32s3camlcd.upload.extra_flags=
 esp32s3camlcd.upload.use_1200bps_touch=false
 esp32s3camlcd.upload.wait_for_upload_port=false
@@ -2912,7 +2913,6 @@ esp32s3camlcd.menu.DebugLevel.verbose=Verbose
 esp32s3camlcd.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s3camlcd.menu.EraseFlash.none=Disabled
-esp32s3camlcd.menu.EraseFlash.none.upload.erase_cmd=
 esp32s3camlcd.menu.EraseFlash.all=Enabled
 esp32s3camlcd.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -2934,6 +2934,7 @@ esp32s2usb.upload.tool.network=esp_ota
 esp32s2usb.upload.maximum_size=1310720
 esp32s2usb.upload.maximum_data_size=327680
 esp32s2usb.upload.flags=
+esp32s2usb.upload.erase_cmd=
 esp32s2usb.upload.extra_flags=
 esp32s2usb.upload.use_1200bps_touch=true
 esp32s2usb.upload.wait_for_upload_port=true
@@ -3021,7 +3022,6 @@ esp32s2usb.menu.DebugLevel.verbose=Verbose
 esp32s2usb.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s2usb.menu.EraseFlash.none=Disabled
-esp32s2usb.menu.EraseFlash.none.upload.erase_cmd=
 esp32s2usb.menu.EraseFlash.all=Enabled
 esp32s2usb.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -3039,6 +3039,7 @@ esp32wroverkit.upload.tool.network=esp_ota
 esp32wroverkit.upload.maximum_size=1310720
 esp32wroverkit.upload.maximum_data_size=327680
 esp32wroverkit.upload.flags=
+esp32wroverkit.upload.erase_cmd=
 esp32wroverkit.upload.extra_flags=
 
 esp32wroverkit.serial.disableDTR=true
@@ -3173,7 +3174,6 @@ esp32wroverkit.menu.DebugLevel.verbose=Verbose
 esp32wroverkit.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32wroverkit.menu.EraseFlash.none=Disabled
-esp32wroverkit.menu.EraseFlash.none.upload.erase_cmd=
 esp32wroverkit.menu.EraseFlash.all=Enabled
 esp32wroverkit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -3191,6 +3191,7 @@ esp32p4_core_board.upload.tool.network=esp_ota
 esp32p4_core_board.upload.maximum_size=1310720
 esp32p4_core_board.upload.maximum_data_size=327680
 esp32p4_core_board.upload.flags=
+esp32p4_core_board.upload.erase_cmd=
 esp32p4_core_board.upload.extra_flags=
 esp32p4_core_board.upload.use_1200bps_touch=false
 esp32p4_core_board.upload.wait_for_upload_port=false
@@ -3340,7 +3341,6 @@ esp32p4_core_board.menu.DebugLevel.verbose=Verbose
 esp32p4_core_board.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32p4_core_board.menu.EraseFlash.none=Disabled
-esp32p4_core_board.menu.EraseFlash.none.upload.erase_cmd=
 esp32p4_core_board.menu.EraseFlash.all=Enabled
 esp32p4_core_board.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -3359,6 +3359,7 @@ aventen_s3_sync.upload.tool.network=esp_ota
 aventen_s3_sync.upload.maximum_size=1310720
 aventen_s3_sync.upload.maximum_data_size=327680
 aventen_s3_sync.upload.flags=
+aventen_s3_sync.upload.erase_cmd=
 aventen_s3_sync.upload.extra_flags=
 aventen_s3_sync.upload.use_1200bps_touch=false
 aventen_s3_sync.upload.wait_for_upload_port=false
@@ -3560,7 +3561,6 @@ aventen_s3_sync.menu.DebugLevel.verbose=Verbose
 aventen_s3_sync.menu.DebugLevel.verbose.build.code_debug=5
 
 aventen_s3_sync.menu.EraseFlash.none=Disabled
-aventen_s3_sync.menu.EraseFlash.none.upload.erase_cmd=
 aventen_s3_sync.menu.EraseFlash.all=Enabled
 aventen_s3_sync.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -3578,6 +3578,7 @@ BharatPi-Node-Wifi.upload.tool.network=esp_ota
 BharatPi-Node-Wifi.upload.maximum_size=1310720
 BharatPi-Node-Wifi.upload.maximum_data_size=327680
 BharatPi-Node-Wifi.upload.flags=
+BharatPi-Node-Wifi.upload.erase_cmd=
 BharatPi-Node-Wifi.upload.extra_flags=
 
 BharatPi-Node-Wifi.serial.disableDTR=true
@@ -3717,7 +3718,6 @@ BharatPi-Node-Wifi.menu.DebugLevel.verbose=Verbose
 BharatPi-Node-Wifi.menu.DebugLevel.verbose.build.code_debug=5
 
 BharatPi-Node-Wifi.menu.EraseFlash.none=Disabled
-BharatPi-Node-Wifi.menu.EraseFlash.none.upload.erase_cmd=
 BharatPi-Node-Wifi.menu.EraseFlash.all=Enabled
 BharatPi-Node-Wifi.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -3736,6 +3736,7 @@ BharatPi-A7672S-4G.upload.tool.network=esp_ota
 BharatPi-A7672S-4G.upload.maximum_size=1310720
 BharatPi-A7672S-4G.upload.maximum_data_size=327680
 BharatPi-A7672S-4G.upload.flags=
+BharatPi-A7672S-4G.upload.erase_cmd=
 BharatPi-A7672S-4G.upload.extra_flags=
 
 BharatPi-A7672S-4G.serial.disableDTR=true
@@ -3875,7 +3876,6 @@ BharatPi-A7672S-4G.menu.DebugLevel.verbose=Verbose
 BharatPi-A7672S-4G.menu.DebugLevel.verbose.build.code_debug=5
 
 BharatPi-A7672S-4G.menu.EraseFlash.none=Disabled
-BharatPi-A7672S-4G.menu.EraseFlash.none.upload.erase_cmd=
 BharatPi-A7672S-4G.menu.EraseFlash.all=Enabled
 BharatPi-A7672S-4G.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -3894,6 +3894,7 @@ BharatPi-LoRa.upload.tool.network=esp_ota
 BharatPi-LoRa.upload.maximum_size=1310720
 BharatPi-LoRa.upload.maximum_data_size=327680
 BharatPi-LoRa.upload.flags=
+BharatPi-LoRa.upload.erase_cmd=
 BharatPi-LoRa.upload.extra_flags=
 
 BharatPi-LoRa.serial.disableDTR=true
@@ -4033,7 +4034,6 @@ BharatPi-LoRa.menu.DebugLevel.verbose=Verbose
 BharatPi-LoRa.menu.DebugLevel.verbose.build.code_debug=5
 
 BharatPi-LoRa.menu.EraseFlash.none=Disabled
-BharatPi-LoRa.menu.EraseFlash.none.upload.erase_cmd=
 BharatPi-LoRa.menu.EraseFlash.all=Enabled
 BharatPi-LoRa.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -4055,6 +4055,7 @@ um_bling.upload.tool.network=esp_ota
 um_bling.upload.maximum_size=1310720
 um_bling.upload.maximum_data_size=327680
 um_bling.upload.flags=
+um_bling.upload.erase_cmd=
 um_bling.upload.extra_flags=
 um_bling.upload.use_1200bps_touch=false
 um_bling.upload.wait_for_upload_port=false
@@ -4187,7 +4188,6 @@ um_bling.menu.DebugLevel.verbose=Verbose
 um_bling.menu.DebugLevel.verbose.build.code_debug=5
 
 um_bling.menu.EraseFlash.none=Disabled
-um_bling.menu.EraseFlash.none.upload.erase_cmd=
 um_bling.menu.EraseFlash.all=Enabled
 um_bling.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -4209,6 +4209,7 @@ um_edges3_d.upload.tool.network=esp_ota
 um_edges3_d.upload.maximum_size=1310720
 um_edges3_d.upload.maximum_data_size=327680
 um_edges3_d.upload.flags=
+um_edges3_d.upload.erase_cmd=
 um_edges3_d.upload.extra_flags=
 um_edges3_d.upload.use_1200bps_touch=false
 um_edges3_d.upload.wait_for_upload_port=false
@@ -4336,7 +4337,6 @@ um_edges3_d.menu.DebugLevel.verbose=Verbose
 um_edges3_d.menu.DebugLevel.verbose.build.code_debug=5
 
 um_edges3_d.menu.EraseFlash.none=Disabled
-um_edges3_d.menu.EraseFlash.none.upload.erase_cmd=
 um_edges3_d.menu.EraseFlash.all=Enabled
 um_edges3_d.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -4358,6 +4358,7 @@ um_feathers2.upload.tool.network=esp_ota
 um_feathers2.upload.maximum_size=1310720
 um_feathers2.upload.maximum_data_size=327680
 um_feathers2.upload.flags=
+um_feathers2.upload.erase_cmd=
 um_feathers2.upload.extra_flags=
 um_feathers2.upload.use_1200bps_touch=true
 um_feathers2.upload.wait_for_upload_port=true
@@ -4487,7 +4488,6 @@ um_feathers2.menu.DebugLevel.verbose=Verbose
 um_feathers2.menu.DebugLevel.verbose.build.code_debug=5
 
 um_feathers2.menu.EraseFlash.none=Disabled
-um_feathers2.menu.EraseFlash.none.upload.erase_cmd=
 um_feathers2.menu.EraseFlash.all=Enabled
 um_feathers2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -4509,6 +4509,7 @@ um_feathers2neo.upload.tool.network=esp_ota
 um_feathers2neo.upload.maximum_size=1310720
 um_feathers2neo.upload.maximum_data_size=327680
 um_feathers2neo.upload.flags=
+um_feathers2neo.upload.erase_cmd=
 um_feathers2neo.upload.extra_flags=
 um_feathers2neo.upload.use_1200bps_touch=true
 um_feathers2neo.upload.wait_for_upload_port=true
@@ -4625,7 +4626,6 @@ um_feathers2neo.menu.DebugLevel.verbose=Verbose
 um_feathers2neo.menu.DebugLevel.verbose.build.code_debug=5
 
 um_feathers2neo.menu.EraseFlash.none=Disabled
-um_feathers2neo.menu.EraseFlash.none.upload.erase_cmd=
 um_feathers2neo.menu.EraseFlash.all=Enabled
 um_feathers2neo.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -4647,6 +4647,7 @@ um_feathers3.upload.tool.network=esp_ota
 um_feathers3.upload.maximum_size=1310720
 um_feathers3.upload.maximum_data_size=327680
 um_feathers3.upload.flags=
+um_feathers3.upload.erase_cmd=
 um_feathers3.upload.extra_flags=
 um_feathers3.upload.use_1200bps_touch=false
 um_feathers3.upload.wait_for_upload_port=false
@@ -4788,7 +4789,6 @@ um_feathers3.menu.DebugLevel.verbose=Verbose
 um_feathers3.menu.DebugLevel.verbose.build.code_debug=5
 
 um_feathers3.menu.EraseFlash.none=Disabled
-um_feathers3.menu.EraseFlash.none.upload.erase_cmd=
 um_feathers3.menu.EraseFlash.all=Enabled
 um_feathers3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -4810,6 +4810,7 @@ um_feathers3neo.upload.tool.network=esp_ota
 um_feathers3neo.upload.maximum_size=1310720
 um_feathers3neo.upload.maximum_data_size=327680
 um_feathers3neo.upload.flags=
+um_feathers3neo.upload.erase_cmd=
 um_feathers3neo.upload.extra_flags=
 um_feathers3neo.upload.use_1200bps_touch=false
 um_feathers3neo.upload.wait_for_upload_port=false
@@ -4957,7 +4958,6 @@ um_feathers3neo.menu.DebugLevel.verbose=Verbose
 um_feathers3neo.menu.DebugLevel.verbose.build.code_debug=5
 
 um_feathers3neo.menu.EraseFlash.none=Disabled
-um_feathers3neo.menu.EraseFlash.none.upload.erase_cmd=
 um_feathers3neo.menu.EraseFlash.all=Enabled
 um_feathers3neo.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -4979,6 +4979,7 @@ um_nanos3.upload.tool.network=esp_ota
 um_nanos3.upload.maximum_size=1310720
 um_nanos3.upload.maximum_data_size=327680
 um_nanos3.upload.flags=
+um_nanos3.upload.erase_cmd=
 um_nanos3.upload.extra_flags=
 um_nanos3.upload.use_1200bps_touch=false
 um_nanos3.upload.wait_for_upload_port=false
@@ -5111,7 +5112,6 @@ um_nanos3.menu.DebugLevel.verbose=Verbose
 um_nanos3.menu.DebugLevel.verbose.build.code_debug=5
 
 um_nanos3.menu.EraseFlash.none=Disabled
-um_nanos3.menu.EraseFlash.none.upload.erase_cmd=
 um_nanos3.menu.EraseFlash.all=Enabled
 um_nanos3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -5133,6 +5133,7 @@ um_omgs3.upload.tool.network=esp_ota
 um_omgs3.upload.maximum_size=1310720
 um_omgs3.upload.maximum_data_size=327680
 um_omgs3.upload.flags=
+um_omgs3.upload.erase_cmd=
 um_omgs3.upload.extra_flags=
 um_omgs3.upload.use_1200bps_touch=false
 um_omgs3.upload.wait_for_upload_port=false
@@ -5265,7 +5266,6 @@ um_omgs3.menu.DebugLevel.verbose=Verbose
 um_omgs3.menu.DebugLevel.verbose.build.code_debug=5
 
 um_omgs3.menu.EraseFlash.none=Disabled
-um_omgs3.menu.EraseFlash.none.upload.erase_cmd=
 um_omgs3.menu.EraseFlash.all=Enabled
 um_omgs3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -5287,6 +5287,7 @@ um_pros3.upload.tool.network=esp_ota
 um_pros3.upload.maximum_size=1310720
 um_pros3.upload.maximum_data_size=327680
 um_pros3.upload.flags=
+um_pros3.upload.erase_cmd=
 um_pros3.upload.extra_flags=
 um_pros3.upload.use_1200bps_touch=false
 um_pros3.upload.wait_for_upload_port=false
@@ -5428,7 +5429,6 @@ um_pros3.menu.DebugLevel.verbose=Verbose
 um_pros3.menu.DebugLevel.verbose.build.code_debug=5
 
 um_pros3.menu.EraseFlash.none=Disabled
-um_pros3.menu.EraseFlash.none.upload.erase_cmd=
 um_pros3.menu.EraseFlash.all=Enabled
 um_pros3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -5450,6 +5450,7 @@ um_squixl.upload.tool.network=esp_ota
 um_squixl.upload.maximum_size=1310720
 um_squixl.upload.maximum_data_size=327680
 um_squixl.upload.flags=
+um_squixl.upload.erase_cmd=
 um_squixl.upload.extra_flags=
 um_squixl.upload.use_1200bps_touch=false
 um_squixl.upload.wait_for_upload_port=false
@@ -5585,7 +5586,6 @@ um_squixl.menu.DebugLevel.verbose=Verbose
 um_squixl.menu.DebugLevel.verbose.build.code_debug=5
 
 um_squixl.menu.EraseFlash.none=Disabled
-um_squixl.menu.EraseFlash.none.upload.erase_cmd=
 um_squixl.menu.EraseFlash.all=Enabled
 um_squixl.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -5603,6 +5603,7 @@ um_tinypico.upload.tool.network=esp_ota
 um_tinypico.upload.maximum_size=1310720
 um_tinypico.upload.maximum_data_size=327680
 um_tinypico.upload.flags=
+um_tinypico.upload.erase_cmd=
 um_tinypico.upload.extra_flags=
 
 um_tinypico.serial.disableDTR=true
@@ -5681,7 +5682,6 @@ um_tinypico.menu.DebugLevel.verbose=Verbose
 um_tinypico.menu.DebugLevel.verbose.build.code_debug=5
 
 um_tinypico.menu.EraseFlash.none=Disabled
-um_tinypico.menu.EraseFlash.none.upload.erase_cmd=
 um_tinypico.menu.EraseFlash.all=Enabled
 um_tinypico.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -5699,6 +5699,7 @@ um_tinyc6.upload.tool.network=esp_ota
 um_tinyc6.upload.maximum_size=1310720
 um_tinyc6.upload.maximum_data_size=327680
 um_tinyc6.upload.flags=
+um_tinyc6.upload.erase_cmd=
 um_tinyc6.upload.extra_flags=
 um_tinyc6.upload.use_1200bps_touch=false
 um_tinyc6.upload.wait_for_upload_port=false
@@ -5818,7 +5819,6 @@ um_tinyc6.menu.DebugLevel.verbose=Verbose
 um_tinyc6.menu.DebugLevel.verbose.build.code_debug=5
 
 um_tinyc6.menu.EraseFlash.none=Disabled
-um_tinyc6.menu.EraseFlash.none.upload.erase_cmd=
 um_tinyc6.menu.EraseFlash.all=Enabled
 um_tinyc6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -5850,6 +5850,7 @@ um_tinys2.upload.tool.network=esp_ota
 um_tinys2.upload.maximum_size=1310720
 um_tinys2.upload.maximum_data_size=327680
 um_tinys2.upload.flags=
+um_tinys2.upload.erase_cmd=
 um_tinys2.upload.extra_flags=
 um_tinys2.upload.use_1200bps_touch=true
 um_tinys2.upload.wait_for_upload_port=true
@@ -5966,7 +5967,6 @@ um_tinys2.menu.DebugLevel.verbose=Verbose
 um_tinys2.menu.DebugLevel.verbose.build.code_debug=5
 
 um_tinys2.menu.EraseFlash.none=Disabled
-um_tinys2.menu.EraseFlash.none.upload.erase_cmd=
 um_tinys2.menu.EraseFlash.all=Enabled
 um_tinys2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -5988,6 +5988,7 @@ um_tinys3.upload.tool.network=esp_ota
 um_tinys3.upload.maximum_size=1310720
 um_tinys3.upload.maximum_data_size=327680
 um_tinys3.upload.flags=
+um_tinys3.upload.erase_cmd=
 um_tinys3.upload.extra_flags=
 um_tinys3.upload.use_1200bps_touch=false
 um_tinys3.upload.wait_for_upload_port=false
@@ -6120,7 +6121,6 @@ um_tinys3.menu.DebugLevel.verbose=Verbose
 um_tinys3.menu.DebugLevel.verbose.build.code_debug=5
 
 um_tinys3.menu.EraseFlash.none=Disabled
-um_tinys3.menu.EraseFlash.none.upload.erase_cmd=
 um_tinys3.menu.EraseFlash.all=Enabled
 um_tinys3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -6139,6 +6139,7 @@ S_ODI_Ultra.upload.maximum_size=1310720
 S_ODI_Ultra.upload.maximum_data_size=327680
 S_ODI_Ultra.upload.wait_for_upload_port=true
 S_ODI_Ultra.upload.flags=
+S_ODI_Ultra.upload.erase_cmd=
 S_ODI_Ultra.upload.extra_flags=
 
 S_ODI_Ultra.serial.disableDTR=true
@@ -6193,7 +6194,6 @@ S_ODI_Ultra.menu.DebugLevel.verbose=Verbose
 S_ODI_Ultra.menu.DebugLevel.verbose.build.code_debug=5
 
 S_ODI_Ultra.menu.EraseFlash.none=Disabled
-S_ODI_Ultra.menu.EraseFlash.none.upload.erase_cmd=
 S_ODI_Ultra.menu.EraseFlash.all=Enabled
 S_ODI_Ultra.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -6209,6 +6209,7 @@ lilygo_t_display.upload.maximum_data_size=327680
 lilygo_t_display.upload.wait_for_upload_port=true
 lilygo_t_display.upload.speed=460800
 lilygo_t_display.upload.flags=
+lilygo_t_display.upload.erase_cmd=
 lilygo_t_display.upload.extra_flags=
 
 lilygo_t_display.bootloader.tool=esptool_py
@@ -6342,7 +6343,6 @@ lilygo_t_display.menu.DebugLevel.verbose=Verbose
 lilygo_t_display.menu.DebugLevel.verbose.build.code_debug=5
 
 lilygo_t_display.menu.EraseFlash.none=Disabled
-lilygo_t_display.menu.EraseFlash.none.upload.erase_cmd=
 lilygo_t_display.menu.EraseFlash.all=Enabled
 lilygo_t_display.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -6361,6 +6361,7 @@ lilygo_t_display_s3.upload.maximum_size=3145728
 lilygo_t_display_s3.upload.maximum_data_size=327680
 lilygo_t_display_s3.upload.speed=921600
 lilygo_t_display_s3.upload.flags=
+lilygo_t_display_s3.upload.erase_cmd=
 lilygo_t_display_s3.upload.extra_flags=
 lilygo_t_display_s3.upload.use_1200bps_touch=false
 lilygo_t_display_s3.upload.wait_for_upload_port=false
@@ -6464,7 +6465,6 @@ lilygo_t_display_s3.menu.DebugLevel.verbose=Verbose
 lilygo_t_display_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 lilygo_t_display_s3.menu.EraseFlash.none=Disabled
-lilygo_t_display_s3.menu.EraseFlash.none.upload.erase_cmd=
 lilygo_t_display_s3.menu.EraseFlash.all=Enabled
 lilygo_t_display_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -6483,6 +6483,7 @@ lilygo_t_eth_lite.upload.maximum_size=3145728
 lilygo_t_eth_lite.upload.maximum_data_size=327680
 lilygo_t_eth_lite.upload.speed=921600
 lilygo_t_eth_lite.upload.flags=
+lilygo_t_eth_lite.upload.erase_cmd=
 lilygo_t_eth_lite.upload.extra_flags=
 lilygo_t_eth_lite.upload.use_1200bps_touch=false
 lilygo_t_eth_lite.upload.wait_for_upload_port=false
@@ -6586,7 +6587,6 @@ lilygo_t_eth_lite.menu.DebugLevel.verbose=Verbose
 lilygo_t_eth_lite.menu.DebugLevel.verbose.build.code_debug=5
 
 lilygo_t_eth_lite.menu.EraseFlash.none=Disabled
-lilygo_t_eth_lite.menu.EraseFlash.none.upload.erase_cmd=
 lilygo_t_eth_lite.menu.EraseFlash.all=Enabled
 lilygo_t_eth_lite.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -6603,6 +6603,7 @@ lilygo_t3s3.upload.maximum_data_size=327680
 lilygo_t3s3.upload.wait_for_upload_port=false
 lilygo_t3s3.upload.speed=460800
 lilygo_t3s3.upload.flags=
+lilygo_t3s3.upload.erase_cmd=
 lilygo_t3s3.upload.extra_flags=
 
 lilygo_t3s3.bootloader.tool=esptool_py
@@ -6747,7 +6748,6 @@ lilygo_t3s3.menu.DebugLevel.verbose=Verbose
 lilygo_t3s3.menu.DebugLevel.verbose.build.code_debug=5
 
 lilygo_t3s3.menu.EraseFlash.none=Disabled
-lilygo_t3s3.menu.EraseFlash.none.upload.erase_cmd=
 lilygo_t3s3.menu.EraseFlash.all=Enabled
 lilygo_t3s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -6789,6 +6789,7 @@ twatchs3.upload.tool.network=esp_ota
 twatchs3.upload.maximum_size=1310720
 twatchs3.upload.maximum_data_size=327680
 twatchs3.upload.flags=
+twatchs3.upload.erase_cmd=
 twatchs3.upload.extra_flags=
 twatchs3.upload.use_1200bps_touch=false
 twatchs3.upload.wait_for_upload_port=false
@@ -6924,7 +6925,6 @@ twatchs3.menu.DebugLevel.verbose=Verbose
 twatchs3.menu.DebugLevel.verbose.build.code_debug=5
 
 twatchs3.menu.EraseFlash.none=Disabled
-twatchs3.menu.EraseFlash.none.upload.erase_cmd=
 twatchs3.menu.EraseFlash.all=Enabled
 twatchs3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -6954,6 +6954,7 @@ twatch_ultra.upload.tool.network=esp_ota
 twatch_ultra.upload.maximum_size=1310720
 twatch_ultra.upload.maximum_data_size=327680
 twatch_ultra.upload.flags=
+twatch_ultra.upload.erase_cmd=
 twatch_ultra.upload.extra_flags=
 twatch_ultra.upload.use_1200bps_touch=false
 twatch_ultra.upload.wait_for_upload_port=false
@@ -7089,7 +7090,6 @@ twatch_ultra.menu.DebugLevel.verbose=Verbose
 twatch_ultra.menu.DebugLevel.verbose.build.code_debug=5
 
 twatch_ultra.menu.EraseFlash.none=Disabled
-twatch_ultra.menu.EraseFlash.none.upload.erase_cmd=
 twatch_ultra.menu.EraseFlash.all=Enabled
 twatch_ultra.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7118,6 +7118,7 @@ tlora_pager.upload.tool.network=esp_ota
 tlora_pager.upload.maximum_size=1310720
 tlora_pager.upload.maximum_data_size=327680
 tlora_pager.upload.flags=
+tlora_pager.upload.erase_cmd=
 tlora_pager.upload.extra_flags=
 tlora_pager.upload.use_1200bps_touch=false
 tlora_pager.upload.wait_for_upload_port=false
@@ -7253,7 +7254,6 @@ tlora_pager.menu.DebugLevel.verbose=Verbose
 tlora_pager.menu.DebugLevel.verbose.build.code_debug=5
 
 tlora_pager.menu.EraseFlash.none=Disabled
-tlora_pager.menu.EraseFlash.none.upload.erase_cmd=
 tlora_pager.menu.EraseFlash.all=Enabled
 tlora_pager.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7285,6 +7285,7 @@ micros2.upload.tool.network=esp_ota
 micros2.upload.maximum_size=1310720
 micros2.upload.maximum_data_size=327680
 micros2.upload.flags=
+micros2.upload.erase_cmd=
 micros2.upload.extra_flags=
 micros2.upload.use_1200bps_touch=true
 micros2.upload.wait_for_upload_port=true
@@ -7414,7 +7415,6 @@ micros2.menu.DebugLevel.verbose=Verbose
 micros2.menu.DebugLevel.verbose.build.code_debug=5
 
 micros2.menu.EraseFlash.none=Disabled
-micros2.menu.EraseFlash.none.upload.erase_cmd=
 micros2.menu.EraseFlash.all=Enabled
 micros2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7432,6 +7432,7 @@ magicbit.upload.tool.network=esp_ota
 magicbit.upload.maximum_size=1310720
 magicbit.upload.maximum_data_size=327680
 magicbit.upload.flags=
+magicbit.upload.erase_cmd=
 magicbit.upload.extra_flags=
 
 magicbit.serial.disableDTR=true
@@ -7479,7 +7480,6 @@ magicbit.menu.DebugLevel.verbose=Verbose
 magicbit.menu.DebugLevel.verbose.build.code_debug=5
 
 magicbit.menu.EraseFlash.none=Disabled
-magicbit.menu.EraseFlash.none.upload.erase_cmd=
 magicbit.menu.EraseFlash.all=Enabled
 magicbit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7497,6 +7497,7 @@ turta_iot_node.upload.tool.network=esp_ota
 turta_iot_node.upload.maximum_size=1310720
 turta_iot_node.upload.maximum_data_size=327680
 turta_iot_node.upload.flags=
+turta_iot_node.upload.erase_cmd=
 turta_iot_node.upload.extra_flags=
 
 turta_iot_node.serial.disableDTR=true
@@ -7537,7 +7538,6 @@ turta_iot_node.menu.DebugLevel.verbose=Verbose
 turta_iot_node.menu.DebugLevel.verbose.build.code_debug=5
 
 turta_iot_node.menu.EraseFlash.none=Disabled
-turta_iot_node.menu.EraseFlash.none.upload.erase_cmd=
 turta_iot_node.menu.EraseFlash.all=Enabled
 turta_iot_node.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7555,6 +7555,7 @@ ttgo-lora32.upload.tool.network=esp_ota
 ttgo-lora32.upload.maximum_size=1310720
 ttgo-lora32.upload.maximum_data_size=294912
 ttgo-lora32.upload.flags=
+ttgo-lora32.upload.erase_cmd=
 ttgo-lora32.upload.extra_flags=
 
 ttgo-lora32.serial.disableDTR=true
@@ -7619,7 +7620,6 @@ ttgo-lora32.menu.DebugLevel.verbose=Verbose
 ttgo-lora32.menu.DebugLevel.verbose.build.code_debug=5
 
 ttgo-lora32.menu.EraseFlash.none=Disabled
-ttgo-lora32.menu.EraseFlash.none.upload.erase_cmd=
 ttgo-lora32.menu.EraseFlash.all=Enabled
 ttgo-lora32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7637,6 +7637,7 @@ ttgo-t1.upload.tool.network=esp_ota
 ttgo-t1.upload.maximum_size=1310720
 ttgo-t1.upload.maximum_data_size=327680
 ttgo-t1.upload.flags=
+ttgo-t1.upload.erase_cmd=
 ttgo-t1.upload.extra_flags=
 
 ttgo-t1.serial.disableDTR=true
@@ -7748,7 +7749,6 @@ ttgo-t1.menu.DebugLevel.verbose=Verbose
 ttgo-t1.menu.DebugLevel.verbose.build.code_debug=5
 
 ttgo-t1.menu.EraseFlash.none=Disabled
-ttgo-t1.menu.EraseFlash.none.upload.erase_cmd=
 ttgo-t1.menu.EraseFlash.all=Enabled
 ttgo-t1.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7767,6 +7767,7 @@ ttgo-t7-v13-mini32.upload.maximum_size=1310720
 ttgo-t7-v13-mini32.upload.maximum_data_size=327680
 ttgo-t7-v13-mini32.upload.wait_for_upload_port=true
 ttgo-t7-v13-mini32.upload.flags=
+ttgo-t7-v13-mini32.upload.erase_cmd=
 ttgo-t7-v13-mini32.upload.extra_flags=
 
 ttgo-t7-v13-mini32.serial.disableDTR=true
@@ -7874,7 +7875,6 @@ ttgo-t7-v13-mini32.menu.DebugLevel.verbose=Verbose
 ttgo-t7-v13-mini32.menu.DebugLevel.verbose.build.code_debug=5
 
 ttgo-t7-v13-mini32.menu.EraseFlash.none=Disabled
-ttgo-t7-v13-mini32.menu.EraseFlash.none.upload.erase_cmd=
 ttgo-t7-v13-mini32.menu.EraseFlash.all=Enabled
 ttgo-t7-v13-mini32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -7893,6 +7893,7 @@ ttgo-t7-v14-mini32.upload.maximum_size=1310720
 ttgo-t7-v14-mini32.upload.maximum_data_size=327680
 ttgo-t7-v14-mini32.upload.wait_for_upload_port=true
 ttgo-t7-v14-mini32.upload.flags=
+ttgo-t7-v14-mini32.upload.erase_cmd=
 ttgo-t7-v14-mini32.upload.extra_flags=
 
 ttgo-t7-v14-mini32.serial.disableDTR=true
@@ -8000,7 +8001,6 @@ ttgo-t7-v14-mini32.menu.DebugLevel.verbose=Verbose
 ttgo-t7-v14-mini32.menu.DebugLevel.verbose.build.code_debug=5
 
 ttgo-t7-v14-mini32.menu.EraseFlash.none=Disabled
-ttgo-t7-v14-mini32.menu.EraseFlash.none.upload.erase_cmd=
 ttgo-t7-v14-mini32.menu.EraseFlash.all=Enabled
 ttgo-t7-v14-mini32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8018,6 +8018,7 @@ ttgo-t-oi-plus.upload.tool.network=esp_ota
 ttgo-t-oi-plus.upload.maximum_size=1310720
 ttgo-t-oi-plus.upload.maximum_data_size=327680
 ttgo-t-oi-plus.upload.flags=
+ttgo-t-oi-plus.upload.erase_cmd=
 ttgo-t-oi-plus.upload.extra_flags=
 
 ttgo-t-oi-plus.serial.disableDTR=false
@@ -8120,7 +8121,6 @@ ttgo-t-oi-plus.menu.DebugLevel.verbose=Verbose
 ttgo-t-oi-plus.menu.DebugLevel.verbose.build.code_debug=5
 
 ttgo-t-oi-plus.menu.EraseFlash.none=Disabled
-ttgo-t-oi-plus.menu.EraseFlash.none.upload.erase_cmd=
 ttgo-t-oi-plus.menu.EraseFlash.all=Enabled
 ttgo-t-oi-plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8138,6 +8138,7 @@ cw02.upload.tool.network=esp_ota
 cw02.upload.maximum_size=1310720
 cw02.upload.maximum_data_size=294912
 cw02.upload.flags=
+cw02.upload.erase_cmd=
 cw02.upload.extra_flags=
 
 cw02.serial.disableDTR=true
@@ -8204,7 +8205,6 @@ cw02.menu.DebugLevel.verbose=Verbose
 cw02.menu.DebugLevel.verbose.build.code_debug=5
 
 cw02.menu.EraseFlash.none=Disabled
-cw02.menu.EraseFlash.none.upload.erase_cmd=
 cw02.menu.EraseFlash.all=Enabled
 cw02.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8222,6 +8222,7 @@ esp32thing.upload.tool.network=esp_ota
 esp32thing.upload.maximum_size=1310720
 esp32thing.upload.maximum_data_size=327680
 esp32thing.upload.flags=
+esp32thing.upload.erase_cmd=
 esp32thing.upload.extra_flags=
 
 esp32thing.serial.disableDTR=true
@@ -8285,7 +8286,6 @@ esp32thing.menu.DebugLevel.verbose=Verbose
 esp32thing.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32thing.menu.EraseFlash.none=Disabled
-esp32thing.menu.EraseFlash.none.upload.erase_cmd=
 esp32thing.menu.EraseFlash.all=Enabled
 esp32thing.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8304,6 +8304,7 @@ esp32thing_plus.upload.maximum_size=1310720
 esp32thing_plus.upload.maximum_data_size=327680
 esp32thing_plus.upload.wait_for_upload_port=true
 esp32thing_plus.upload.flags=
+esp32thing_plus.upload.erase_cmd=
 esp32thing_plus.upload.extra_flags=
 
 esp32thing_plus.serial.disableDTR=true
@@ -8365,7 +8366,6 @@ esp32thing_plus.menu.DebugLevel.verbose=Verbose
 esp32thing_plus.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32thing_plus.menu.EraseFlash.none=Disabled
-esp32thing_plus.menu.EraseFlash.none.upload.erase_cmd=
 esp32thing_plus.menu.EraseFlash.all=Enabled
 esp32thing_plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8384,6 +8384,7 @@ esp32thing_plus_c.upload.maximum_size=1310720
 esp32thing_plus_c.upload.maximum_data_size=327680
 esp32thing_plus_c.upload.wait_for_upload_port=true
 esp32thing_plus_c.upload.flags=
+esp32thing_plus_c.upload.erase_cmd=
 esp32thing_plus_c.upload.extra_flags=
 
 esp32thing_plus_c.serial.disableDTR=true
@@ -8445,7 +8446,6 @@ esp32thing_plus_c.menu.DebugLevel.verbose=Verbose
 esp32thing_plus_c.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32thing_plus_c.menu.EraseFlash.none=Disabled
-esp32thing_plus_c.menu.EraseFlash.none.upload.erase_cmd=
 esp32thing_plus_c.menu.EraseFlash.all=Enabled
 esp32thing_plus_c.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8465,6 +8465,7 @@ sparkfun_esp32s2_thing_plus.upload.tool.network=esp_ota
 sparkfun_esp32s2_thing_plus.upload.maximum_size=1310720
 sparkfun_esp32s2_thing_plus.upload.maximum_data_size=327680
 sparkfun_esp32s2_thing_plus.upload.flags=
+sparkfun_esp32s2_thing_plus.upload.erase_cmd=
 sparkfun_esp32s2_thing_plus.upload.extra_flags=
 sparkfun_esp32s2_thing_plus.upload.use_1200bps_touch=true
 sparkfun_esp32s2_thing_plus.upload.wait_for_upload_port=true
@@ -8608,7 +8609,6 @@ sparkfun_esp32s2_thing_plus.menu.DebugLevel.verbose=Verbose
 sparkfun_esp32s2_thing_plus.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_esp32s2_thing_plus.menu.EraseFlash.none=Disabled
-sparkfun_esp32s2_thing_plus.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_esp32s2_thing_plus.menu.EraseFlash.all=Enabled
 sparkfun_esp32s2_thing_plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8626,6 +8626,7 @@ sparkfun_esp32s3_thing_plus.upload.tool.network=esp_ota
 sparkfun_esp32s3_thing_plus.upload.maximum_size=1310720
 sparkfun_esp32s3_thing_plus.upload.maximum_data_size=327680
 sparkfun_esp32s3_thing_plus.upload.flags=
+sparkfun_esp32s3_thing_plus.upload.erase_cmd=
 sparkfun_esp32s3_thing_plus.upload.extra_flags=
 sparkfun_esp32s3_thing_plus.upload.use_1200bps_touch=false
 sparkfun_esp32s3_thing_plus.upload.wait_for_upload_port=false
@@ -8818,7 +8819,6 @@ sparkfun_esp32s3_thing_plus.menu.DebugLevel.verbose=Verbose
 sparkfun_esp32s3_thing_plus.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_esp32s3_thing_plus.menu.EraseFlash.none=Disabled
-sparkfun_esp32s3_thing_plus.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_esp32s3_thing_plus.menu.EraseFlash.all=Enabled
 sparkfun_esp32s3_thing_plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -8843,6 +8843,7 @@ sparkfun_esp32c5_thing_plus.upload.tool.network=esp_ota
 sparkfun_esp32c5_thing_plus.upload.maximum_size=1310720
 sparkfun_esp32c5_thing_plus.upload.maximum_data_size=327680
 sparkfun_esp32c5_thing_plus.upload.flags=
+sparkfun_esp32c5_thing_plus.upload.erase_cmd=
 sparkfun_esp32c5_thing_plus.upload.extra_flags=
 sparkfun_esp32c5_thing_plus.upload.use_1200bps_touch=false
 sparkfun_esp32c5_thing_plus.upload.wait_for_upload_port=false
@@ -9008,7 +9009,6 @@ sparkfun_esp32c5_thing_plus.menu.DebugLevel.verbose=Verbose
 sparkfun_esp32c5_thing_plus.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_esp32c5_thing_plus.menu.EraseFlash.none=Disabled
-sparkfun_esp32c5_thing_plus.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_esp32c5_thing_plus.menu.EraseFlash.all=Enabled
 sparkfun_esp32c5_thing_plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -9042,6 +9042,7 @@ sparkfun_esp32c6_thing_plus.upload.tool.network=esp_ota
 sparkfun_esp32c6_thing_plus.upload.maximum_size=1310720
 sparkfun_esp32c6_thing_plus.upload.maximum_data_size=327680
 sparkfun_esp32c6_thing_plus.upload.flags=
+sparkfun_esp32c6_thing_plus.upload.erase_cmd=
 sparkfun_esp32c6_thing_plus.upload.extra_flags=
 sparkfun_esp32c6_thing_plus.upload.use_1200bps_touch=false
 sparkfun_esp32c6_thing_plus.upload.wait_for_upload_port=false
@@ -9197,7 +9198,6 @@ sparkfun_esp32c6_thing_plus.menu.DebugLevel.verbose=Verbose
 sparkfun_esp32c6_thing_plus.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_esp32c6_thing_plus.menu.EraseFlash.none=Disabled
-sparkfun_esp32c6_thing_plus.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_esp32c6_thing_plus.menu.EraseFlash.all=Enabled
 sparkfun_esp32c6_thing_plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -9226,6 +9226,7 @@ esp32micromod.upload.maximum_size=1310720
 esp32micromod.upload.maximum_data_size=327680
 esp32micromod.upload.wait_for_upload_port=true
 esp32micromod.upload.flags=
+esp32micromod.upload.erase_cmd=
 esp32micromod.upload.extra_flags=
 
 esp32micromod.serial.disableDTR=true
@@ -9353,7 +9354,6 @@ esp32micromod.menu.DebugLevel.verbose=Verbose
 esp32micromod.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32micromod.menu.EraseFlash.none=Disabled
-esp32micromod.menu.EraseFlash.none.upload.erase_cmd=
 esp32micromod.menu.EraseFlash.all=Enabled
 esp32micromod.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -9371,6 +9371,7 @@ sparkfun_lora_gateway_1-channel.upload.tool.network=esp_ota
 sparkfun_lora_gateway_1-channel.upload.maximum_size=1310720
 sparkfun_lora_gateway_1-channel.upload.maximum_data_size=294912
 sparkfun_lora_gateway_1-channel.upload.flags=
+sparkfun_lora_gateway_1-channel.upload.erase_cmd=
 sparkfun_lora_gateway_1-channel.upload.extra_flags=
 
 sparkfun_lora_gateway_1-channel.serial.disableDTR=true
@@ -9446,7 +9447,6 @@ sparkfun_lora_gateway_1-channel.menu.DebugLevel.verbose=Verbose
 sparkfun_lora_gateway_1-channel.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_lora_gateway_1-channel.menu.EraseFlash.none=Disabled
-sparkfun_lora_gateway_1-channel.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_lora_gateway_1-channel.menu.EraseFlash.all=Enabled
 sparkfun_lora_gateway_1-channel.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -9464,6 +9464,7 @@ sparkfun_esp32_iot_redboard.upload.tool.network=esp_ota
 sparkfun_esp32_iot_redboard.upload.maximum_size=1310720
 sparkfun_esp32_iot_redboard.upload.maximum_data_size=327680
 sparkfun_esp32_iot_redboard.upload.flags=
+sparkfun_esp32_iot_redboard.upload.erase_cmd=
 sparkfun_esp32_iot_redboard.upload.extra_flags=
 
 sparkfun_esp32_iot_redboard.serial.disableDTR=true
@@ -9614,7 +9615,6 @@ sparkfun_esp32_iot_redboard.menu.DebugLevel.verbose=Verbose
 sparkfun_esp32_iot_redboard.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_esp32_iot_redboard.menu.EraseFlash.none=Disabled
-sparkfun_esp32_iot_redboard.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_esp32_iot_redboard.menu.EraseFlash.all=Enabled
 sparkfun_esp32_iot_redboard.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -9632,6 +9632,7 @@ sparkfun_esp32c6_qwiic_pocket.upload.tool.network=esp_ota
 sparkfun_esp32c6_qwiic_pocket.upload.maximum_size=1310720
 sparkfun_esp32c6_qwiic_pocket.upload.maximum_data_size=327680
 sparkfun_esp32c6_qwiic_pocket.upload.flags=
+sparkfun_esp32c6_qwiic_pocket.upload.erase_cmd=
 sparkfun_esp32c6_qwiic_pocket.upload.extra_flags=
 sparkfun_esp32c6_qwiic_pocket.upload.use_1200bps_touch=false
 sparkfun_esp32c6_qwiic_pocket.upload.wait_for_upload_port=false
@@ -9787,7 +9788,6 @@ sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.verbose=Verbose
 sparkfun_esp32c6_qwiic_pocket.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.none=Disabled
-sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.all=Enabled
 sparkfun_esp32c6_qwiic_pocket.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -9819,6 +9819,7 @@ sparkfun_pro_micro_esp32c3.upload.tool.network=esp_ota
 sparkfun_pro_micro_esp32c3.upload.maximum_size=1310720
 sparkfun_pro_micro_esp32c3.upload.maximum_data_size=327680
 sparkfun_pro_micro_esp32c3.upload.flags=
+sparkfun_pro_micro_esp32c3.upload.erase_cmd=
 sparkfun_pro_micro_esp32c3.upload.extra_flags=
 sparkfun_pro_micro_esp32c3.upload.use_1200bps_touch=false
 sparkfun_pro_micro_esp32c3.upload.wait_for_upload_port=false
@@ -9946,7 +9947,6 @@ sparkfun_pro_micro_esp32c3.menu.DebugLevel.verbose=Verbose
 sparkfun_pro_micro_esp32c3.menu.DebugLevel.verbose.build.code_debug=5
 
 sparkfun_pro_micro_esp32c3.menu.EraseFlash.none=Disabled
-sparkfun_pro_micro_esp32c3.menu.EraseFlash.none.upload.erase_cmd=
 sparkfun_pro_micro_esp32c3.menu.EraseFlash.all=Enabled
 sparkfun_pro_micro_esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -9964,6 +9964,7 @@ nina_w10.upload.tool.network=esp_ota
 nina_w10.upload.maximum_size=1310720
 nina_w10.upload.maximum_data_size=327680
 nina_w10.upload.flags=
+nina_w10.upload.erase_cmd=
 nina_w10.upload.extra_flags=
 
 nina_w10.serial.disableDTR=true
@@ -10092,7 +10093,6 @@ nina_w10.menu.DebugLevel.verbose=Verbose
 nina_w10.menu.DebugLevel.verbose.build.code_debug=5
 
 nina_w10.menu.EraseFlash.none=Disabled
-nina_w10.menu.EraseFlash.none.upload.erase_cmd=
 nina_w10.menu.EraseFlash.all=Enabled
 nina_w10.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10110,6 +10110,7 @@ nora_w10.upload.tool.network=esp_ota
 nora_w10.upload.maximum_size=1310720
 nora_w10.upload.maximum_data_size=327680
 nora_w10.upload.flags=
+nora_w10.upload.erase_cmd=
 nora_w10.upload.extra_flags=
 nora_w10.upload.use_1200bps_touch=false
 nora_w10.upload.wait_for_upload_port=false
@@ -10304,7 +10305,6 @@ nora_w10.menu.DebugLevel.verbose=Verbose
 nora_w10.menu.DebugLevel.verbose.build.code_debug=5
 
 nora_w10.menu.EraseFlash.none=Disabled
-nora_w10.menu.EraseFlash.none.upload.erase_cmd=
 nora_w10.menu.EraseFlash.all=Enabled
 nora_w10.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10322,6 +10322,7 @@ widora-air.upload.tool.network=esp_ota
 widora-air.upload.maximum_size=1310720
 widora-air.upload.maximum_data_size=327680
 widora-air.upload.flags=
+widora-air.upload.erase_cmd=
 widora-air.upload.extra_flags=
 
 widora-air.serial.disableDTR=true
@@ -10376,7 +10377,6 @@ widora-air.menu.DebugLevel.verbose=Verbose
 widora-air.menu.DebugLevel.verbose.build.code_debug=5
 
 widora-air.menu.EraseFlash.none=Disabled
-widora-air.menu.EraseFlash.none.upload.erase_cmd=
 widora-air.menu.EraseFlash.all=Enabled
 widora-air.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10394,6 +10394,7 @@ esp320.upload.tool.network=esp_ota
 esp320.upload.maximum_size=1310720
 esp320.upload.maximum_data_size=327680
 esp320.upload.flags=
+esp320.upload.erase_cmd=
 esp320.upload.extra_flags=
 
 esp320.serial.disableDTR=true
@@ -10448,7 +10449,6 @@ esp320.menu.DebugLevel.verbose=Verbose
 esp320.menu.DebugLevel.verbose.build.code_debug=5
 
 esp320.menu.EraseFlash.none=Disabled
-esp320.menu.EraseFlash.none.upload.erase_cmd=
 esp320.menu.EraseFlash.all=Enabled
 esp320.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10466,6 +10466,7 @@ nano32.upload.tool.network=esp_ota
 nano32.upload.maximum_size=1310720
 nano32.upload.maximum_data_size=327680
 nano32.upload.flags=
+nano32.upload.erase_cmd=
 nano32.upload.extra_flags=
 
 nano32.serial.disableDTR=true
@@ -10520,7 +10521,6 @@ nano32.menu.DebugLevel.verbose=Verbose
 nano32.menu.DebugLevel.verbose.build.code_debug=5
 
 nano32.menu.EraseFlash.none=Disabled
-nano32.menu.EraseFlash.none.upload.erase_cmd=
 nano32.menu.EraseFlash.all=Enabled
 nano32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10538,6 +10538,7 @@ d32.upload.tool.network=esp_ota
 d32.upload.maximum_size=1310720
 d32.upload.maximum_data_size=327680
 d32.upload.flags=
+d32.upload.erase_cmd=
 d32.upload.extra_flags=
 
 d32.serial.disableDTR=true
@@ -10604,7 +10605,6 @@ d32.menu.DebugLevel.verbose=Verbose
 d32.menu.DebugLevel.verbose.build.code_debug=5
 
 d32.menu.EraseFlash.none=Disabled
-d32.menu.EraseFlash.none.upload.erase_cmd=
 d32.menu.EraseFlash.all=Enabled
 d32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10622,6 +10622,7 @@ d32_pro.upload.tool.network=esp_ota
 d32_pro.upload.maximum_size=1310720
 d32_pro.upload.maximum_data_size=327680
 d32_pro.upload.flags=
+d32_pro.upload.erase_cmd=
 d32_pro.upload.extra_flags=
 
 d32_pro.serial.disableDTR=true
@@ -10697,7 +10698,6 @@ d32_pro.menu.DebugLevel.verbose=Verbose
 d32_pro.menu.DebugLevel.verbose.build.code_debug=5
 
 d32_pro.menu.EraseFlash.none=Disabled
-d32_pro.menu.EraseFlash.none.upload.erase_cmd=
 d32_pro.menu.EraseFlash.all=Enabled
 d32_pro.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10715,6 +10715,7 @@ lolin_c3_mini.upload.tool.network=esp_ota
 lolin_c3_mini.upload.maximum_size=1310720
 lolin_c3_mini.upload.maximum_data_size=327680
 lolin_c3_mini.upload.flags=
+lolin_c3_mini.upload.erase_cmd=
 lolin_c3_mini.upload.extra_flags=
 lolin_c3_mini.upload.use_1200bps_touch=false
 lolin_c3_mini.upload.wait_for_upload_port=false
@@ -10812,7 +10813,6 @@ lolin_c3_mini.menu.DebugLevel.verbose=Verbose
 lolin_c3_mini.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_c3_mini.menu.EraseFlash.none=Disabled
-lolin_c3_mini.menu.EraseFlash.none.upload.erase_cmd=
 lolin_c3_mini.menu.EraseFlash.all=Enabled
 lolin_c3_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10830,6 +10830,7 @@ lolin_c3_pico.upload.tool.network=esp_ota
 lolin_c3_pico.upload.maximum_size=1310720
 lolin_c3_pico.upload.maximum_data_size=327680
 lolin_c3_pico.upload.flags=
+lolin_c3_pico.upload.erase_cmd=
 lolin_c3_pico.upload.extra_flags=
 lolin_c3_pico.upload.use_1200bps_touch=false
 lolin_c3_pico.upload.wait_for_upload_port=false
@@ -10924,7 +10925,6 @@ lolin_c3_pico.menu.DebugLevel.verbose=Verbose
 lolin_c3_pico.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_c3_pico.menu.EraseFlash.none=Disabled
-lolin_c3_pico.menu.EraseFlash.none.upload.erase_cmd=
 lolin_c3_pico.menu.EraseFlash.all=Enabled
 lolin_c3_pico.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -10944,6 +10944,7 @@ lolin_s2_mini.upload.tool.network=esp_ota
 lolin_s2_mini.upload.maximum_size=1310720
 lolin_s2_mini.upload.maximum_data_size=327680
 lolin_s2_mini.upload.flags=
+lolin_s2_mini.upload.erase_cmd=
 lolin_s2_mini.upload.extra_flags=
 lolin_s2_mini.upload.use_1200bps_touch=true
 lolin_s2_mini.upload.wait_for_upload_port=true
@@ -11020,7 +11021,6 @@ lolin_s2_mini.menu.DebugLevel.verbose=Verbose
 lolin_s2_mini.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_s2_mini.menu.EraseFlash.none=Disabled
-lolin_s2_mini.menu.EraseFlash.none.upload.erase_cmd=
 lolin_s2_mini.menu.EraseFlash.all=Enabled
 lolin_s2_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11040,6 +11040,7 @@ lolin_s2_pico.upload.tool.network=esp_ota
 lolin_s2_pico.upload.maximum_size=1310720
 lolin_s2_pico.upload.maximum_data_size=327680
 lolin_s2_pico.upload.flags=
+lolin_s2_pico.upload.erase_cmd=
 lolin_s2_pico.upload.extra_flags=
 lolin_s2_pico.upload.use_1200bps_touch=true
 lolin_s2_pico.upload.wait_for_upload_port=true
@@ -11116,7 +11117,6 @@ lolin_s2_pico.menu.DebugLevel.verbose=Verbose
 lolin_s2_pico.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_s2_pico.menu.EraseFlash.none=Disabled
-lolin_s2_pico.menu.EraseFlash.none.upload.erase_cmd=
 lolin_s2_pico.menu.EraseFlash.all=Enabled
 lolin_s2_pico.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11134,6 +11134,7 @@ lolin_s3.upload.tool.network=esp_ota
 lolin_s3.upload.maximum_size=1310720
 lolin_s3.upload.maximum_data_size=327680
 lolin_s3.upload.flags=
+lolin_s3.upload.erase_cmd=
 lolin_s3.upload.extra_flags=
 lolin_s3.upload.use_1200bps_touch=false
 lolin_s3.upload.wait_for_upload_port=false
@@ -11272,7 +11273,6 @@ lolin_s3.menu.DebugLevel.verbose=Verbose
 lolin_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_s3.menu.EraseFlash.none=Disabled
-lolin_s3.menu.EraseFlash.none.upload.erase_cmd=
 lolin_s3.menu.EraseFlash.all=Enabled
 lolin_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11292,6 +11292,7 @@ lolin_s3_mini.upload.tool.network=esp_ota
 lolin_s3_mini.upload.maximum_size=1310720
 lolin_s3_mini.upload.maximum_data_size=327680
 lolin_s3_mini.upload.flags=
+lolin_s3_mini.upload.erase_cmd=
 lolin_s3_mini.upload.extra_flags=
 lolin_s3_mini.upload.use_1200bps_touch=false
 lolin_s3_mini.upload.wait_for_upload_port=false
@@ -11443,7 +11444,6 @@ lolin_s3_mini.menu.DebugLevel.verbose=Verbose
 lolin_s3_mini.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_s3_mini.menu.EraseFlash.none=Disabled
-lolin_s3_mini.menu.EraseFlash.none.upload.erase_cmd=
 lolin_s3_mini.menu.EraseFlash.all=Enabled
 lolin_s3_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11463,6 +11463,7 @@ lolin_s3_mini_pro.upload.tool.network=esp_ota
 lolin_s3_mini_pro.upload.maximum_size=1310720
 lolin_s3_mini_pro.upload.maximum_data_size=327680
 lolin_s3_mini_pro.upload.flags=
+lolin_s3_mini_pro.upload.erase_cmd=
 lolin_s3_mini_pro.upload.extra_flags=
 lolin_s3_mini_pro.upload.use_1200bps_touch=false
 lolin_s3_mini_pro.upload.wait_for_upload_port=false
@@ -11614,7 +11615,6 @@ lolin_s3_mini_pro.menu.DebugLevel.verbose=Verbose
 lolin_s3_mini_pro.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_s3_mini_pro.menu.EraseFlash.none=Disabled
-lolin_s3_mini_pro.menu.EraseFlash.none.upload.erase_cmd=
 lolin_s3_mini_pro.menu.EraseFlash.all=Enabled
 lolin_s3_mini_pro.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11634,6 +11634,7 @@ lolin_s3_pro.upload.tool.network=esp_ota
 lolin_s3_pro.upload.maximum_size=1310720
 lolin_s3_pro.upload.maximum_data_size=327680
 lolin_s3_pro.upload.flags=
+lolin_s3_pro.upload.erase_cmd=
 lolin_s3_pro.upload.extra_flags=
 lolin_s3_pro.upload.use_1200bps_touch=false
 lolin_s3_pro.upload.wait_for_upload_port=false
@@ -11772,7 +11773,6 @@ lolin_s3_pro.menu.DebugLevel.verbose=Verbose
 lolin_s3_pro.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin_s3_pro.menu.EraseFlash.none=Disabled
-lolin_s3_pro.menu.EraseFlash.none.upload.erase_cmd=
 lolin_s3_pro.menu.EraseFlash.all=Enabled
 lolin_s3_pro.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11790,6 +11790,7 @@ lolin32.upload.tool.network=esp_ota
 lolin32.upload.maximum_size=1310720
 lolin32.upload.maximum_data_size=327680
 lolin32.upload.flags=
+lolin32.upload.erase_cmd=
 lolin32.upload.extra_flags=
 
 lolin32.serial.disableDTR=true
@@ -11870,7 +11871,6 @@ lolin32.menu.DebugLevel.verbose=Verbose
 lolin32.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin32.menu.EraseFlash.none=Disabled
-lolin32.menu.EraseFlash.none.upload.erase_cmd=
 lolin32.menu.EraseFlash.all=Enabled
 lolin32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11888,6 +11888,7 @@ viralink32g01.upload.tool.network=esp_ota
 viralink32g01.upload.maximum_size=1310720
 viralink32g01.upload.maximum_data_size=327680
 viralink32g01.upload.flags=
+viralink32g01.upload.erase_cmd=
 viralink32g01.upload.extra_flags=
 
 viralink32g01.serial.disableDTR=true
@@ -11968,7 +11969,6 @@ viralink32g01.menu.DebugLevel.verbose=Verbose
 viralink32g01.menu.DebugLevel.verbose.build.code_debug=5
 
 viralink32g01.menu.EraseFlash.none=Disabled
-viralink32g01.menu.EraseFlash.none.upload.erase_cmd=
 viralink32g01.menu.EraseFlash.all=Enabled
 viralink32g01.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -11986,6 +11986,7 @@ viralink32g11.upload.tool.network=esp_ota
 viralink32g11.upload.maximum_size=1310720
 viralink32g11.upload.maximum_data_size=327680
 viralink32g11.upload.flags=
+viralink32g11.upload.erase_cmd=
 viralink32g11.upload.extra_flags=
 
 viralink32g11.serial.disableDTR=true
@@ -12066,7 +12067,6 @@ viralink32g11.menu.DebugLevel.verbose=Verbose
 viralink32g11.menu.DebugLevel.verbose.build.code_debug=5
 
 viralink32g11.menu.EraseFlash.none=Disabled
-viralink32g11.menu.EraseFlash.none.upload.erase_cmd=
 viralink32g11.menu.EraseFlash.all=Enabled
 viralink32g11.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12085,6 +12085,7 @@ lolin32-lite.upload.maximum_size=1310720
 lolin32-lite.upload.maximum_data_size=327680
 lolin32-lite.upload.wait_for_upload_port=true
 lolin32-lite.upload.flags=
+lolin32-lite.upload.erase_cmd=
 lolin32-lite.upload.extra_flags=
 
 lolin32-lite.serial.disableDTR=true
@@ -12165,7 +12166,6 @@ lolin32-lite.menu.DebugLevel.verbose=Verbose
 lolin32-lite.menu.DebugLevel.verbose.build.code_debug=5
 
 lolin32-lite.menu.EraseFlash.none=Disabled
-lolin32-lite.menu.EraseFlash.none.upload.erase_cmd=
 lolin32-lite.menu.EraseFlash.all=Enabled
 lolin32-lite.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12183,6 +12183,7 @@ pocket_32.upload.tool.network=esp_ota
 pocket_32.upload.maximum_size=1310720
 pocket_32.upload.maximum_data_size=327680
 pocket_32.upload.flags=
+pocket_32.upload.erase_cmd=
 pocket_32.upload.extra_flags=
 
 pocket_32.serial.disableDTR=true
@@ -12237,7 +12238,6 @@ pocket_32.menu.DebugLevel.verbose=Verbose
 pocket_32.menu.DebugLevel.verbose.build.code_debug=5
 
 pocket_32.menu.EraseFlash.none=Disabled
-pocket_32.menu.EraseFlash.none.upload.erase_cmd=
 pocket_32.menu.EraseFlash.all=Enabled
 pocket_32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12255,6 +12255,7 @@ WeMosBat.upload.tool.network=esp_ota
 WeMosBat.upload.maximum_size=1310720
 WeMosBat.upload.maximum_data_size=327680
 WeMosBat.upload.flags=
+WeMosBat.upload.erase_cmd=
 WeMosBat.upload.extra_flags=
 
 WeMosBat.serial.disableDTR=true
@@ -12349,7 +12350,6 @@ WeMosBat.menu.DebugLevel.verbose=Verbose
 WeMosBat.menu.DebugLevel.verbose.build.code_debug=5
 
 WeMosBat.menu.EraseFlash.none=Disabled
-WeMosBat.menu.EraseFlash.none.upload.erase_cmd=
 WeMosBat.menu.EraseFlash.all=Enabled
 WeMosBat.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12367,6 +12367,7 @@ espea32.upload.tool.network=esp_ota
 espea32.upload.maximum_size=1310720
 espea32.upload.maximum_data_size=327680
 espea32.upload.flags=
+espea32.upload.erase_cmd=
 espea32.upload.extra_flags=
 
 espea32.serial.disableDTR=true
@@ -12421,7 +12422,6 @@ espea32.menu.DebugLevel.verbose=Verbose
 espea32.menu.DebugLevel.verbose.build.code_debug=5
 
 espea32.menu.EraseFlash.none=Disabled
-espea32.menu.EraseFlash.none.upload.erase_cmd=
 espea32.menu.EraseFlash.all=Enabled
 espea32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12439,6 +12439,7 @@ quantum.upload.tool.network=esp_ota
 quantum.upload.maximum_size=1310720
 quantum.upload.maximum_data_size=327680
 quantum.upload.flags=
+quantum.upload.erase_cmd=
 quantum.upload.extra_flags=
 
 quantum.serial.disableDTR=true
@@ -12493,7 +12494,6 @@ quantum.menu.DebugLevel.verbose=Verbose
 quantum.menu.DebugLevel.verbose.build.code_debug=5
 
 quantum.menu.EraseFlash.none=Disabled
-quantum.menu.EraseFlash.none.upload.erase_cmd=
 quantum.menu.EraseFlash.all=Enabled
 quantum.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12511,6 +12511,7 @@ node32s.upload.tool.network=esp_ota
 node32s.upload.maximum_size=1310720
 node32s.upload.maximum_data_size=327680
 node32s.upload.flags=
+node32s.upload.erase_cmd=
 node32s.upload.extra_flags=
 
 node32s.serial.disableDTR=true
@@ -12574,7 +12575,6 @@ node32s.menu.DebugLevel.verbose=Verbose
 node32s.menu.DebugLevel.verbose.build.code_debug=5
 
 node32s.menu.EraseFlash.none=Disabled
-node32s.menu.EraseFlash.none.upload.erase_cmd=
 node32s.menu.EraseFlash.all=Enabled
 node32s.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12592,6 +12592,7 @@ hornbill32dev.upload.tool.network=esp_ota
 hornbill32dev.upload.maximum_size=1310720
 hornbill32dev.upload.maximum_data_size=327680
 hornbill32dev.upload.flags=
+hornbill32dev.upload.erase_cmd=
 hornbill32dev.upload.extra_flags=
 
 hornbill32dev.serial.disableDTR=true
@@ -12646,7 +12647,6 @@ hornbill32dev.menu.DebugLevel.verbose=Verbose
 hornbill32dev.menu.DebugLevel.verbose.build.code_debug=5
 
 hornbill32dev.menu.EraseFlash.none=Disabled
-hornbill32dev.menu.EraseFlash.none.upload.erase_cmd=
 hornbill32dev.menu.EraseFlash.all=Enabled
 hornbill32dev.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12664,6 +12664,7 @@ hornbill32minima.upload.tool.network=esp_ota
 hornbill32minima.upload.maximum_size=1310720
 hornbill32minima.upload.maximum_data_size=327680
 hornbill32minima.upload.flags=
+hornbill32minima.upload.erase_cmd=
 hornbill32minima.upload.extra_flags=
 
 hornbill32minima.serial.disableDTR=true
@@ -12717,7 +12718,6 @@ hornbill32minima.menu.DebugLevel.verbose=Verbose
 hornbill32minima.menu.DebugLevel.verbose.build.code_debug=5
 
 hornbill32minima.menu.EraseFlash.none=Disabled
-hornbill32minima.menu.EraseFlash.none.upload.erase_cmd=
 hornbill32minima.menu.EraseFlash.all=Enabled
 hornbill32minima.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12734,6 +12734,7 @@ dfrobot_beetle_esp32c3.upload.tool.network=esp_ota
 dfrobot_beetle_esp32c3.upload.maximum_size=1310720
 dfrobot_beetle_esp32c3.upload.maximum_data_size=327680
 dfrobot_beetle_esp32c3.upload.flags=
+dfrobot_beetle_esp32c3.upload.erase_cmd=
 dfrobot_beetle_esp32c3.upload.extra_flags=
 dfrobot_beetle_esp32c3.upload.use_1200bps_touch=false
 dfrobot_beetle_esp32c3.upload.wait_for_upload_port=false
@@ -12850,7 +12851,6 @@ dfrobot_beetle_esp32c3.menu.DebugLevel.verbose=Verbose
 dfrobot_beetle_esp32c3.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_beetle_esp32c3.menu.EraseFlash.none=Disabled
-dfrobot_beetle_esp32c3.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_beetle_esp32c3.menu.EraseFlash.all=Enabled
 dfrobot_beetle_esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -12868,6 +12868,7 @@ dfrobot_beetle_esp32c6.upload.tool.network=esp_ota
 dfrobot_beetle_esp32c6.upload.maximum_size=1310720
 dfrobot_beetle_esp32c6.upload.maximum_data_size=327680
 dfrobot_beetle_esp32c6.upload.flags=
+dfrobot_beetle_esp32c6.upload.erase_cmd=
 dfrobot_beetle_esp32c6.upload.extra_flags=
 dfrobot_beetle_esp32c6.upload.use_1200bps_touch=false
 dfrobot_beetle_esp32c6.upload.wait_for_upload_port=false
@@ -13005,7 +13006,6 @@ dfrobot_beetle_esp32c6.menu.DebugLevel.verbose=Verbose
 dfrobot_beetle_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_beetle_esp32c6.menu.EraseFlash.none=Disabled
-dfrobot_beetle_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_beetle_esp32c6.menu.EraseFlash.all=Enabled
 dfrobot_beetle_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -13028,6 +13028,7 @@ dfrobot_firebeetle2_esp32e.upload.tool.default=esptool_py
 dfrobot_firebeetle2_esp32e.upload.maximum_size=1310720
 dfrobot_firebeetle2_esp32e.upload.maximum_data_size=327680
 dfrobot_firebeetle2_esp32e.upload.flags=
+dfrobot_firebeetle2_esp32e.upload.erase_cmd=
 dfrobot_firebeetle2_esp32e.upload.extra_flags=
 
 dfrobot_firebeetle2_esp32e.serial.disableDTR=true
@@ -13178,7 +13179,6 @@ dfrobot_firebeetle2_esp32e.menu.DebugLevel.verbose=Verbose
 dfrobot_firebeetle2_esp32e.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_firebeetle2_esp32e.menu.EraseFlash.none=Disabled
-dfrobot_firebeetle2_esp32e.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_firebeetle2_esp32e.menu.EraseFlash.all=Enabled
 dfrobot_firebeetle2_esp32e.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -13196,6 +13196,7 @@ dfrobot_firebeetle2_esp32s3.upload.tool.network=esp_ota
 dfrobot_firebeetle2_esp32s3.upload.maximum_size=1310720
 dfrobot_firebeetle2_esp32s3.upload.maximum_data_size=327680
 dfrobot_firebeetle2_esp32s3.upload.flags=
+dfrobot_firebeetle2_esp32s3.upload.erase_cmd=
 dfrobot_firebeetle2_esp32s3.upload.extra_flags=
 dfrobot_firebeetle2_esp32s3.upload.use_1200bps_touch=false
 dfrobot_firebeetle2_esp32s3.upload.wait_for_upload_port=false
@@ -13396,7 +13397,6 @@ dfrobot_firebeetle2_esp32s3.menu.DebugLevel.verbose=Verbose
 dfrobot_firebeetle2_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_firebeetle2_esp32s3.menu.EraseFlash.none=Disabled
-dfrobot_firebeetle2_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_firebeetle2_esp32s3.menu.EraseFlash.all=Enabled
 dfrobot_firebeetle2_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -13416,6 +13416,7 @@ dfrobot_firebeetle2_esp32c5.upload.tool.network=esp_ota
 dfrobot_firebeetle2_esp32c5.upload.maximum_size=1310720
 dfrobot_firebeetle2_esp32c5.upload.maximum_data_size=327680
 dfrobot_firebeetle2_esp32c5.upload.flags=
+dfrobot_firebeetle2_esp32c5.upload.erase_cmd=
 dfrobot_firebeetle2_esp32c5.upload.extra_flags=
 dfrobot_firebeetle2_esp32c5.upload.use_1200bps_touch=false
 dfrobot_firebeetle2_esp32c5.upload.wait_for_upload_port=false
@@ -13534,7 +13535,6 @@ dfrobot_firebeetle2_esp32c5.menu.DebugLevel.verbose=Verbose
 dfrobot_firebeetle2_esp32c5.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_firebeetle2_esp32c5.menu.EraseFlash.none=Disabled
-dfrobot_firebeetle2_esp32c5.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_firebeetle2_esp32c5.menu.EraseFlash.all=Enabled
 dfrobot_firebeetle2_esp32c5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -13568,6 +13568,7 @@ dfrobot_firebeetle2_esp32c6.upload.tool.network=esp_ota
 dfrobot_firebeetle2_esp32c6.upload.maximum_size=1310720
 dfrobot_firebeetle2_esp32c6.upload.maximum_data_size=327680
 dfrobot_firebeetle2_esp32c6.upload.flags=
+dfrobot_firebeetle2_esp32c6.upload.erase_cmd=
 dfrobot_firebeetle2_esp32c6.upload.extra_flags=
 dfrobot_firebeetle2_esp32c6.upload.use_1200bps_touch=false
 dfrobot_firebeetle2_esp32c6.upload.wait_for_upload_port=false
@@ -13705,7 +13706,6 @@ dfrobot_firebeetle2_esp32c6.menu.DebugLevel.verbose=Verbose
 dfrobot_firebeetle2_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_firebeetle2_esp32c6.menu.EraseFlash.none=Disabled
-dfrobot_firebeetle2_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_firebeetle2_esp32c6.menu.EraseFlash.all=Enabled
 dfrobot_firebeetle2_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -13733,6 +13733,7 @@ dfrobot_firebeetle2_esp32p4.upload.tool.network=esp_ota
 dfrobot_firebeetle2_esp32p4.upload.maximum_size=1310720
 dfrobot_firebeetle2_esp32p4.upload.maximum_data_size=327680
 dfrobot_firebeetle2_esp32p4.upload.flags=
+dfrobot_firebeetle2_esp32p4.upload.erase_cmd=
 dfrobot_firebeetle2_esp32p4.upload.extra_flags=
 dfrobot_firebeetle2_esp32p4.upload.use_1200bps_touch=false
 dfrobot_firebeetle2_esp32p4.upload.wait_for_upload_port=false
@@ -13855,7 +13856,6 @@ dfrobot_firebeetle2_esp32p4.menu.DebugLevel.verbose=Verbose
 dfrobot_firebeetle2_esp32p4.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_firebeetle2_esp32p4.menu.EraseFlash.none=Disabled
-dfrobot_firebeetle2_esp32p4.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_firebeetle2_esp32p4.menu.EraseFlash.all=Enabled
 dfrobot_firebeetle2_esp32p4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -13874,6 +13874,7 @@ dfrobot_romeo_esp32s3.upload.tool.network=esp_ota
 dfrobot_romeo_esp32s3.upload.maximum_size=1310720
 dfrobot_romeo_esp32s3.upload.maximum_data_size=327680
 dfrobot_romeo_esp32s3.upload.flags=
+dfrobot_romeo_esp32s3.upload.erase_cmd=
 dfrobot_romeo_esp32s3.upload.extra_flags=
 dfrobot_romeo_esp32s3.upload.use_1200bps_touch=false
 dfrobot_romeo_esp32s3.upload.wait_for_upload_port=false
@@ -14052,7 +14053,6 @@ dfrobot_romeo_esp32s3.menu.DebugLevel.verbose=Verbose
 dfrobot_romeo_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_romeo_esp32s3.menu.EraseFlash.none=Disabled
-dfrobot_romeo_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_romeo_esp32s3.menu.EraseFlash.all=Enabled
 dfrobot_romeo_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -14069,10 +14069,10 @@ dfrobot_lorawan_esp32s3.upload.tool.default=esptool_py
 dfrobot_lorawan_esp32s3.upload.tool.network=esp_ota
 
 dfrobot_lorawan_esp32s3.upload.speed=921600
-dfrobot_lorawan_esp32s3.upload.erase_cmd=
 dfrobot_lorawan_esp32s3.upload.maximum_size=1310720
 dfrobot_lorawan_esp32s3.upload.maximum_data_size=327680
 dfrobot_lorawan_esp32s3.upload.flags=
+dfrobot_lorawan_esp32s3.upload.erase_cmd=
 dfrobot_lorawan_esp32s3.upload.extra_flags=
 dfrobot_lorawan_esp32s3.upload.use_1200bps_touch=false
 dfrobot_lorawan_esp32s3.upload.wait_for_upload_port=false
@@ -14237,7 +14237,6 @@ dfrobot_lorawan_esp32s3.menu.DebugLevel.verbose=Verbose
 dfrobot_lorawan_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 dfrobot_lorawan_esp32s3.menu.EraseFlash.none=Disabled
-dfrobot_lorawan_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 dfrobot_lorawan_esp32s3.menu.EraseFlash.all=Enabled
 dfrobot_lorawan_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -14276,6 +14275,7 @@ firebeetle32.upload.tool.network=esp_ota
 firebeetle32.upload.maximum_size=1310720
 firebeetle32.upload.maximum_data_size=327680
 firebeetle32.upload.flags=
+firebeetle32.upload.erase_cmd=
 firebeetle32.upload.extra_flags=
 
 firebeetle32.serial.disableDTR=true
@@ -14330,7 +14330,6 @@ firebeetle32.menu.DebugLevel.verbose=Verbose
 firebeetle32.menu.DebugLevel.verbose.build.code_debug=5
 
 firebeetle32.menu.EraseFlash.none=Disabled
-firebeetle32.menu.EraseFlash.none.upload.erase_cmd=
 firebeetle32.menu.EraseFlash.all=Enabled
 firebeetle32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -14348,6 +14347,7 @@ intorobot-fig.upload.tool.network=esp_ota
 intorobot-fig.upload.maximum_size=1310720
 intorobot-fig.upload.maximum_data_size=327680
 intorobot-fig.upload.flags=
+intorobot-fig.upload.erase_cmd=
 intorobot-fig.upload.extra_flags=
 
 intorobot-fig.serial.disableDTR=true
@@ -14402,7 +14402,6 @@ intorobot-fig.menu.DebugLevel.verbose=Verbose
 intorobot-fig.menu.DebugLevel.verbose.build.code_debug=5
 
 intorobot-fig.menu.EraseFlash.none=Disabled
-intorobot-fig.menu.EraseFlash.none.upload.erase_cmd=
 intorobot-fig.menu.EraseFlash.all=Enabled
 intorobot-fig.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -14420,6 +14419,7 @@ onehorse32dev.upload.tool.network=esp_ota
 onehorse32dev.upload.maximum_size=1310720
 onehorse32dev.upload.maximum_data_size=327680
 onehorse32dev.upload.flags=
+onehorse32dev.upload.erase_cmd=
 onehorse32dev.upload.extra_flags=
 
 onehorse32dev.serial.disableDTR=true
@@ -14474,7 +14474,6 @@ onehorse32dev.menu.DebugLevel.verbose=Verbose
 onehorse32dev.menu.DebugLevel.verbose.build.code_debug=5
 
 onehorse32dev.menu.EraseFlash.none=Disabled
-onehorse32dev.menu.EraseFlash.none.upload.erase_cmd=
 onehorse32dev.menu.EraseFlash.all=Enabled
 onehorse32dev.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -14505,6 +14504,7 @@ adafruit_metro_esp32s2.upload.tool.network=esp_ota
 adafruit_metro_esp32s2.upload.maximum_size=1310720
 adafruit_metro_esp32s2.upload.maximum_data_size=327680
 adafruit_metro_esp32s2.upload.flags=
+adafruit_metro_esp32s2.upload.erase_cmd=
 adafruit_metro_esp32s2.upload.extra_flags=
 adafruit_metro_esp32s2.upload.use_1200bps_touch=true
 adafruit_metro_esp32s2.upload.wait_for_upload_port=true
@@ -14650,7 +14650,6 @@ adafruit_metro_esp32s2.menu.DebugLevel.verbose=Verbose
 adafruit_metro_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_metro_esp32s2.menu.EraseFlash.none=Disabled
-adafruit_metro_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_metro_esp32s2.menu.EraseFlash.all=Enabled
 adafruit_metro_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -14688,6 +14687,7 @@ adafruit_metro_esp32s3.upload.tool.network=esp_ota
 adafruit_metro_esp32s3.upload.maximum_size=1310720
 adafruit_metro_esp32s3.upload.maximum_data_size=327680
 adafruit_metro_esp32s3.upload.flags=
+adafruit_metro_esp32s3.upload.erase_cmd=
 adafruit_metro_esp32s3.upload.extra_flags=
 adafruit_metro_esp32s3.upload.use_1200bps_touch=true
 adafruit_metro_esp32s3.upload.wait_for_upload_port=true
@@ -14853,7 +14853,6 @@ adafruit_metro_esp32s3.menu.DebugLevel.verbose=Verbose
 adafruit_metro_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_metro_esp32s3.menu.EraseFlash.none=Disabled
-adafruit_metro_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_metro_esp32s3.menu.EraseFlash.all=Enabled
 adafruit_metro_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -14891,6 +14890,7 @@ adafruit_magtag29_esp32s2.upload.tool.network=esp_ota
 adafruit_magtag29_esp32s2.upload.maximum_size=1310720
 adafruit_magtag29_esp32s2.upload.maximum_data_size=327680
 adafruit_magtag29_esp32s2.upload.flags=
+adafruit_magtag29_esp32s2.upload.erase_cmd=
 adafruit_magtag29_esp32s2.upload.extra_flags=
 adafruit_magtag29_esp32s2.upload.use_1200bps_touch=true
 adafruit_magtag29_esp32s2.upload.wait_for_upload_port=true
@@ -15036,7 +15036,6 @@ adafruit_magtag29_esp32s2.menu.DebugLevel.verbose=Verbose
 adafruit_magtag29_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_magtag29_esp32s2.menu.EraseFlash.none=Disabled
-adafruit_magtag29_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_magtag29_esp32s2.menu.EraseFlash.all=Enabled
 adafruit_magtag29_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -15074,6 +15073,7 @@ adafruit_funhouse_esp32s2.upload.tool.network=esp_ota
 adafruit_funhouse_esp32s2.upload.maximum_size=1310720
 adafruit_funhouse_esp32s2.upload.maximum_data_size=327680
 adafruit_funhouse_esp32s2.upload.flags=
+adafruit_funhouse_esp32s2.upload.erase_cmd=
 adafruit_funhouse_esp32s2.upload.extra_flags=
 adafruit_funhouse_esp32s2.upload.use_1200bps_touch=true
 adafruit_funhouse_esp32s2.upload.wait_for_upload_port=true
@@ -15219,7 +15219,6 @@ adafruit_funhouse_esp32s2.menu.DebugLevel.verbose=Verbose
 adafruit_funhouse_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_funhouse_esp32s2.menu.EraseFlash.none=Disabled
-adafruit_funhouse_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_funhouse_esp32s2.menu.EraseFlash.all=Enabled
 adafruit_funhouse_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -15245,6 +15244,7 @@ featheresp32.upload.tool.network=esp_ota
 featheresp32.upload.maximum_size=1310720
 featheresp32.upload.maximum_data_size=327680
 featheresp32.upload.flags=
+featheresp32.upload.erase_cmd=
 featheresp32.upload.extra_flags=
 
 featheresp32.serial.disableDTR=true
@@ -15353,7 +15353,6 @@ featheresp32.menu.DebugLevel.verbose=Verbose
 featheresp32.menu.DebugLevel.verbose.build.code_debug=5
 
 featheresp32.menu.EraseFlash.none=Disabled
-featheresp32.menu.EraseFlash.none.upload.erase_cmd=
 featheresp32.menu.EraseFlash.all=Enabled
 featheresp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -15379,6 +15378,7 @@ adafruit_feather_esp32_v2.upload.tool.network=esp_ota
 adafruit_feather_esp32_v2.upload.maximum_size=1310720
 adafruit_feather_esp32_v2.upload.maximum_data_size=327680
 adafruit_feather_esp32_v2.upload.flags=
+adafruit_feather_esp32_v2.upload.erase_cmd=
 adafruit_feather_esp32_v2.upload.extra_flags=
 
 adafruit_feather_esp32_v2.serial.disableDTR=true
@@ -15474,7 +15474,6 @@ adafruit_feather_esp32_v2.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32_v2.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32_v2.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32_v2.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32_v2.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32_v2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -15512,6 +15511,7 @@ adafruit_feather_esp32s2.upload.tool.network=esp_ota
 adafruit_feather_esp32s2.upload.maximum_size=1310720
 adafruit_feather_esp32s2.upload.maximum_data_size=327680
 adafruit_feather_esp32s2.upload.flags=
+adafruit_feather_esp32s2.upload.erase_cmd=
 adafruit_feather_esp32s2.upload.extra_flags=
 adafruit_feather_esp32s2.upload.use_1200bps_touch=true
 adafruit_feather_esp32s2.upload.wait_for_upload_port=true
@@ -15657,7 +15657,6 @@ adafruit_feather_esp32s2.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32s2.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32s2.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -15695,6 +15694,7 @@ adafruit_feather_esp32s2_tft.upload.tool.network=esp_ota
 adafruit_feather_esp32s2_tft.upload.maximum_size=1310720
 adafruit_feather_esp32s2_tft.upload.maximum_data_size=327680
 adafruit_feather_esp32s2_tft.upload.flags=
+adafruit_feather_esp32s2_tft.upload.erase_cmd=
 adafruit_feather_esp32s2_tft.upload.extra_flags=
 adafruit_feather_esp32s2_tft.upload.use_1200bps_touch=true
 adafruit_feather_esp32s2_tft.upload.wait_for_upload_port=true
@@ -15840,7 +15840,6 @@ adafruit_feather_esp32s2_tft.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32s2_tft.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32s2_tft.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32s2_tft.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32s2_tft.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s2_tft.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -15878,6 +15877,7 @@ adafruit_feather_esp32s2_reversetft.upload.tool.network=esp_ota
 adafruit_feather_esp32s2_reversetft.upload.maximum_size=1310720
 adafruit_feather_esp32s2_reversetft.upload.maximum_data_size=327680
 adafruit_feather_esp32s2_reversetft.upload.flags=
+adafruit_feather_esp32s2_reversetft.upload.erase_cmd=
 adafruit_feather_esp32s2_reversetft.upload.extra_flags=
 adafruit_feather_esp32s2_reversetft.upload.use_1200bps_touch=true
 adafruit_feather_esp32s2_reversetft.upload.wait_for_upload_port=true
@@ -16023,7 +16023,6 @@ adafruit_feather_esp32s2_reversetft.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32s2_reversetft.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32s2_reversetft.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32s2_reversetft.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32s2_reversetft.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s2_reversetft.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -16061,6 +16060,7 @@ adafruit_feather_esp32s3.upload.tool.network=esp_ota
 adafruit_feather_esp32s3.upload.maximum_size=1310720
 adafruit_feather_esp32s3.upload.maximum_data_size=327680
 adafruit_feather_esp32s3.upload.flags=
+adafruit_feather_esp32s3.upload.erase_cmd=
 adafruit_feather_esp32s3.upload.extra_flags=
 adafruit_feather_esp32s3.upload.use_1200bps_touch=true
 adafruit_feather_esp32s3.upload.wait_for_upload_port=true
@@ -16241,7 +16241,6 @@ adafruit_feather_esp32s3.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32s3.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32s3.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -16279,6 +16278,7 @@ adafruit_feather_esp32s3_nopsram.upload.tool.network=esp_ota
 adafruit_feather_esp32s3_nopsram.upload.maximum_size=1310720
 adafruit_feather_esp32s3_nopsram.upload.maximum_data_size=327680
 adafruit_feather_esp32s3_nopsram.upload.flags=
+adafruit_feather_esp32s3_nopsram.upload.erase_cmd=
 adafruit_feather_esp32s3_nopsram.upload.extra_flags=
 adafruit_feather_esp32s3_nopsram.upload.use_1200bps_touch=true
 adafruit_feather_esp32s3_nopsram.upload.wait_for_upload_port=true
@@ -16428,7 +16428,6 @@ adafruit_feather_esp32s3_nopsram.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32s3_nopsram.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32s3_nopsram.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32s3_nopsram.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32s3_nopsram.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s3_nopsram.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -16466,6 +16465,7 @@ adafruit_feather_esp32s3_tft.upload.tool.network=esp_ota
 adafruit_feather_esp32s3_tft.upload.maximum_size=1310720
 adafruit_feather_esp32s3_tft.upload.maximum_data_size=327680
 adafruit_feather_esp32s3_tft.upload.flags=
+adafruit_feather_esp32s3_tft.upload.erase_cmd=
 adafruit_feather_esp32s3_tft.upload.extra_flags=
 adafruit_feather_esp32s3_tft.upload.use_1200bps_touch=true
 adafruit_feather_esp32s3_tft.upload.wait_for_upload_port=true
@@ -16646,7 +16646,6 @@ adafruit_feather_esp32s3_tft.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32s3_tft.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32s3_tft.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32s3_tft.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32s3_tft.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s3_tft.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -16684,6 +16683,7 @@ adafruit_feather_esp32s3_reversetft.upload.tool.network=esp_ota
 adafruit_feather_esp32s3_reversetft.upload.maximum_size=1310720
 adafruit_feather_esp32s3_reversetft.upload.maximum_data_size=327680
 adafruit_feather_esp32s3_reversetft.upload.flags=
+adafruit_feather_esp32s3_reversetft.upload.erase_cmd=
 adafruit_feather_esp32s3_reversetft.upload.extra_flags=
 adafruit_feather_esp32s3_reversetft.upload.use_1200bps_touch=true
 adafruit_feather_esp32s3_reversetft.upload.wait_for_upload_port=true
@@ -16864,7 +16864,6 @@ adafruit_feather_esp32s3_reversetft.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32s3_reversetft.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32s3_reversetft.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32s3_reversetft.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32s3_reversetft.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32s3_reversetft.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -16891,6 +16890,7 @@ adafruit_feather_esp32c6.upload.tool.network=esp_ota
 adafruit_feather_esp32c6.upload.maximum_size=1310720
 adafruit_feather_esp32c6.upload.maximum_data_size=327680
 adafruit_feather_esp32c6.upload.flags=
+adafruit_feather_esp32c6.upload.erase_cmd=
 adafruit_feather_esp32c6.upload.extra_flags=
 adafruit_feather_esp32c6.upload.use_1200bps_touch=false
 adafruit_feather_esp32c6.upload.wait_for_upload_port=false
@@ -17027,7 +17027,6 @@ adafruit_feather_esp32c6.menu.DebugLevel.verbose=Verbose
 adafruit_feather_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_feather_esp32c6.menu.EraseFlash.none=Disabled
-adafruit_feather_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_feather_esp32c6.menu.EraseFlash.all=Enabled
 adafruit_feather_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -17056,6 +17055,7 @@ adafruit_qtpy_esp32_pico.upload.tool.network=esp_ota
 adafruit_qtpy_esp32_pico.upload.maximum_size=1310720
 adafruit_qtpy_esp32_pico.upload.maximum_data_size=327680
 adafruit_qtpy_esp32_pico.upload.flags=
+adafruit_qtpy_esp32_pico.upload.erase_cmd=
 adafruit_qtpy_esp32_pico.upload.extra_flags=
 
 adafruit_qtpy_esp32_pico.serial.disableDTR=true
@@ -17151,7 +17151,6 @@ adafruit_qtpy_esp32_pico.menu.DebugLevel.verbose=Verbose
 adafruit_qtpy_esp32_pico.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_qtpy_esp32_pico.menu.EraseFlash.none=Disabled
-adafruit_qtpy_esp32_pico.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_qtpy_esp32_pico.menu.EraseFlash.all=Enabled
 adafruit_qtpy_esp32_pico.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -17177,6 +17176,7 @@ adafruit_qtpy_esp32c3.upload.tool.network=esp_ota
 adafruit_qtpy_esp32c3.upload.maximum_size=1310720
 adafruit_qtpy_esp32c3.upload.maximum_data_size=327680
 adafruit_qtpy_esp32c3.upload.flags=
+adafruit_qtpy_esp32c3.upload.erase_cmd=
 adafruit_qtpy_esp32c3.upload.extra_flags=
 adafruit_qtpy_esp32c3.upload.use_1200bps_touch=false
 adafruit_qtpy_esp32c3.upload.wait_for_upload_port=false
@@ -17286,7 +17286,6 @@ adafruit_qtpy_esp32c3.menu.DebugLevel.verbose=Verbose
 adafruit_qtpy_esp32c3.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_qtpy_esp32c3.menu.EraseFlash.none=Disabled
-adafruit_qtpy_esp32c3.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_qtpy_esp32c3.menu.EraseFlash.all=Enabled
 adafruit_qtpy_esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -17324,6 +17323,7 @@ adafruit_qtpy_esp32s2.upload.tool.network=esp_ota
 adafruit_qtpy_esp32s2.upload.maximum_size=1310720
 adafruit_qtpy_esp32s2.upload.maximum_data_size=327680
 adafruit_qtpy_esp32s2.upload.flags=
+adafruit_qtpy_esp32s2.upload.erase_cmd=
 adafruit_qtpy_esp32s2.upload.extra_flags=
 adafruit_qtpy_esp32s2.upload.use_1200bps_touch=true
 adafruit_qtpy_esp32s2.upload.wait_for_upload_port=true
@@ -17469,7 +17469,6 @@ adafruit_qtpy_esp32s2.menu.DebugLevel.verbose=Verbose
 adafruit_qtpy_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_qtpy_esp32s2.menu.EraseFlash.none=Disabled
-adafruit_qtpy_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_qtpy_esp32s2.menu.EraseFlash.all=Enabled
 adafruit_qtpy_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -17507,6 +17506,7 @@ adafruit_qtpy_esp32s3_nopsram.upload.tool.network=esp_ota
 adafruit_qtpy_esp32s3_nopsram.upload.maximum_size=1310720
 adafruit_qtpy_esp32s3_nopsram.upload.maximum_data_size=327680
 adafruit_qtpy_esp32s3_nopsram.upload.flags=
+adafruit_qtpy_esp32s3_nopsram.upload.erase_cmd=
 adafruit_qtpy_esp32s3_nopsram.upload.extra_flags=
 adafruit_qtpy_esp32s3_nopsram.upload.use_1200bps_touch=true
 adafruit_qtpy_esp32s3_nopsram.upload.wait_for_upload_port=true
@@ -17656,7 +17656,6 @@ adafruit_qtpy_esp32s3_nopsram.menu.DebugLevel.verbose=Verbose
 adafruit_qtpy_esp32s3_nopsram.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_qtpy_esp32s3_nopsram.menu.EraseFlash.none=Disabled
-adafruit_qtpy_esp32s3_nopsram.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_qtpy_esp32s3_nopsram.menu.EraseFlash.all=Enabled
 adafruit_qtpy_esp32s3_nopsram.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -17694,6 +17693,7 @@ adafruit_qtpy_esp32s3_n4r2.upload.tool.network=esp_ota
 adafruit_qtpy_esp32s3_n4r2.upload.maximum_size=1310720
 adafruit_qtpy_esp32s3_n4r2.upload.maximum_data_size=327680
 adafruit_qtpy_esp32s3_n4r2.upload.flags=
+adafruit_qtpy_esp32s3_n4r2.upload.erase_cmd=
 adafruit_qtpy_esp32s3_n4r2.upload.extra_flags=
 adafruit_qtpy_esp32s3_n4r2.upload.use_1200bps_touch=true
 adafruit_qtpy_esp32s3_n4r2.upload.wait_for_upload_port=true
@@ -17874,7 +17874,6 @@ adafruit_qtpy_esp32s3_n4r2.menu.DebugLevel.verbose=Verbose
 adafruit_qtpy_esp32s3_n4r2.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_qtpy_esp32s3_n4r2.menu.EraseFlash.none=Disabled
-adafruit_qtpy_esp32s3_n4r2.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_qtpy_esp32s3_n4r2.menu.EraseFlash.all=Enabled
 adafruit_qtpy_esp32s3_n4r2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -17900,6 +17899,7 @@ adafruit_itsybitsy_esp32.upload.tool.network=esp_ota
 adafruit_itsybitsy_esp32.upload.maximum_size=1310720
 adafruit_itsybitsy_esp32.upload.maximum_data_size=327680
 adafruit_itsybitsy_esp32.upload.flags=
+adafruit_itsybitsy_esp32.upload.erase_cmd=
 adafruit_itsybitsy_esp32.upload.extra_flags=
 
 adafruit_itsybitsy_esp32.serial.disableDTR=true
@@ -17992,7 +17992,6 @@ adafruit_itsybitsy_esp32.menu.DebugLevel.verbose=Verbose
 adafruit_itsybitsy_esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_itsybitsy_esp32.menu.EraseFlash.none=Disabled
-adafruit_itsybitsy_esp32.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_itsybitsy_esp32.menu.EraseFlash.all=Enabled
 adafruit_itsybitsy_esp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -18030,6 +18029,7 @@ adafruit_matrixportal_esp32s3.upload.tool.network=esp_ota
 adafruit_matrixportal_esp32s3.upload.maximum_size=1310720
 adafruit_matrixportal_esp32s3.upload.maximum_data_size=327680
 adafruit_matrixportal_esp32s3.upload.flags=
+adafruit_matrixportal_esp32s3.upload.erase_cmd=
 adafruit_matrixportal_esp32s3.upload.extra_flags=
 adafruit_matrixportal_esp32s3.upload.use_1200bps_touch=true
 adafruit_matrixportal_esp32s3.upload.wait_for_upload_port=true
@@ -18189,7 +18189,6 @@ adafruit_matrixportal_esp32s3.menu.DebugLevel.verbose=Verbose
 adafruit_matrixportal_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_matrixportal_esp32s3.menu.EraseFlash.none=Disabled
-adafruit_matrixportal_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_matrixportal_esp32s3.menu.EraseFlash.all=Enabled
 adafruit_matrixportal_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -18227,6 +18226,7 @@ adafruit_camera_esp32s3.upload.tool.network=esp_ota
 adafruit_camera_esp32s3.upload.maximum_size=1310720
 adafruit_camera_esp32s3.upload.maximum_data_size=327680
 adafruit_camera_esp32s3.upload.flags=
+adafruit_camera_esp32s3.upload.erase_cmd=
 adafruit_camera_esp32s3.upload.extra_flags=
 adafruit_camera_esp32s3.upload.use_1200bps_touch=true
 adafruit_camera_esp32s3.upload.wait_for_upload_port=true
@@ -18407,7 +18407,6 @@ adafruit_camera_esp32s3.menu.DebugLevel.verbose=Verbose
 adafruit_camera_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_camera_esp32s3.menu.EraseFlash.none=Disabled
-adafruit_camera_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_camera_esp32s3.menu.EraseFlash.all=Enabled
 adafruit_camera_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -18445,6 +18444,7 @@ adafruit_qualia_s3_rgb666.upload.tool.network=esp_ota
 adafruit_qualia_s3_rgb666.upload.maximum_size=1310720
 adafruit_qualia_s3_rgb666.upload.maximum_data_size=327680
 adafruit_qualia_s3_rgb666.upload.flags=
+adafruit_qualia_s3_rgb666.upload.erase_cmd=
 adafruit_qualia_s3_rgb666.upload.extra_flags=
 adafruit_qualia_s3_rgb666.upload.use_1200bps_touch=true
 adafruit_qualia_s3_rgb666.upload.wait_for_upload_port=true
@@ -18610,7 +18610,6 @@ adafruit_qualia_s3_rgb666.menu.DebugLevel.verbose=Verbose
 adafruit_qualia_s3_rgb666.menu.DebugLevel.verbose.build.code_debug=5
 
 adafruit_qualia_s3_rgb666.menu.EraseFlash.none=Disabled
-adafruit_qualia_s3_rgb666.menu.EraseFlash.none.upload.erase_cmd=
 adafruit_qualia_s3_rgb666.menu.EraseFlash.all=Enabled
 adafruit_qualia_s3_rgb666.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -18636,6 +18635,7 @@ sparklemotion.upload.tool.network=esp_ota
 sparklemotion.upload.maximum_size=1310720
 sparklemotion.upload.maximum_data_size=327680
 sparklemotion.upload.flags=
+sparklemotion.upload.erase_cmd=
 sparklemotion.upload.extra_flags=
 
 sparklemotion.serial.disableDTR=true
@@ -18744,7 +18744,6 @@ sparklemotion.menu.DebugLevel.verbose=Verbose
 sparklemotion.menu.DebugLevel.verbose.build.code_debug=5
 
 sparklemotion.menu.EraseFlash.none=Disabled
-sparklemotion.menu.EraseFlash.none.upload.erase_cmd=
 sparklemotion.menu.EraseFlash.all=Enabled
 sparklemotion.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -18770,6 +18769,7 @@ sparklemotionmini.upload.tool.network=esp_ota
 sparklemotionmini.upload.maximum_size=1310720
 sparklemotionmini.upload.maximum_data_size=327680
 sparklemotionmini.upload.flags=
+sparklemotionmini.upload.erase_cmd=
 sparklemotionmini.upload.extra_flags=
 
 sparklemotionmini.serial.disableDTR=true
@@ -18878,7 +18878,6 @@ sparklemotionmini.menu.DebugLevel.verbose=Verbose
 sparklemotionmini.menu.DebugLevel.verbose.build.code_debug=5
 
 sparklemotionmini.menu.EraseFlash.none=Disabled
-sparklemotionmini.menu.EraseFlash.none.upload.erase_cmd=
 sparklemotionmini.menu.EraseFlash.all=Enabled
 sparklemotionmini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -18904,6 +18903,7 @@ sparklemotionstick.upload.tool.network=esp_ota
 sparklemotionstick.upload.maximum_size=1310720
 sparklemotionstick.upload.maximum_data_size=327680
 sparklemotionstick.upload.flags=
+sparklemotionstick.upload.erase_cmd=
 sparklemotionstick.upload.extra_flags=
 
 sparklemotionstick.serial.disableDTR=true
@@ -19012,7 +19012,6 @@ sparklemotionstick.menu.DebugLevel.verbose=Verbose
 sparklemotionstick.menu.DebugLevel.verbose.build.code_debug=5
 
 sparklemotionstick.menu.EraseFlash.none=Disabled
-sparklemotionstick.menu.EraseFlash.none.upload.erase_cmd=
 sparklemotionstick.menu.EraseFlash.all=Enabled
 sparklemotionstick.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19037,6 +19036,7 @@ nodemcu-32s.upload.tool.network=esp_ota
 nodemcu-32s.upload.maximum_size=1310720
 nodemcu-32s.upload.maximum_data_size=327680
 nodemcu-32s.upload.flags=
+nodemcu-32s.upload.erase_cmd=
 nodemcu-32s.upload.extra_flags=
 
 nodemcu-32s.serial.disableDTR=true
@@ -19091,7 +19091,6 @@ nodemcu-32s.menu.DebugLevel.verbose=Verbose
 nodemcu-32s.menu.DebugLevel.verbose.build.code_debug=5
 
 nodemcu-32s.menu.EraseFlash.none=Disabled
-nodemcu-32s.menu.EraseFlash.none.upload.erase_cmd=
 nodemcu-32s.menu.EraseFlash.all=Enabled
 nodemcu-32s.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19105,6 +19104,7 @@ nologo_esp32c3_super_mini.upload.tool.network=esp_ota
 nologo_esp32c3_super_mini.upload.maximum_size=1310720
 nologo_esp32c3_super_mini.upload.maximum_data_size=327680
 nologo_esp32c3_super_mini.upload.flags=
+nologo_esp32c3_super_mini.upload.erase_cmd=
 nologo_esp32c3_super_mini.upload.extra_flags=
 nologo_esp32c3_super_mini.upload.use_1200bps_touch=false
 nologo_esp32c3_super_mini.upload.wait_for_upload_port=false
@@ -19226,7 +19226,6 @@ nologo_esp32c3_super_mini.menu.DebugLevel.verbose=Verbose
 nologo_esp32c3_super_mini.menu.DebugLevel.verbose.build.code_debug=5
 
 nologo_esp32c3_super_mini.menu.EraseFlash.none=Disabled
-nologo_esp32c3_super_mini.menu.EraseFlash.none.upload.erase_cmd=
 nologo_esp32c3_super_mini.menu.EraseFlash.all=Enabled
 nologo_esp32c3_super_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19244,6 +19243,7 @@ nologo_esp32s3_pico.upload.tool.network=esp_ota
 nologo_esp32s3_pico.upload.maximum_size=1310720
 nologo_esp32s3_pico.upload.maximum_data_size=327680
 nologo_esp32s3_pico.upload.flags=
+nologo_esp32s3_pico.upload.erase_cmd=
 nologo_esp32s3_pico.upload.extra_flags=
 nologo_esp32s3_pico.upload.use_1200bps_touch=false
 nologo_esp32s3_pico.upload.wait_for_upload_port=false
@@ -19457,7 +19457,6 @@ nologo_esp32s3_pico.menu.DebugLevel.verbose=Verbose
 nologo_esp32s3_pico.menu.DebugLevel.verbose.build.code_debug=5
 
 nologo_esp32s3_pico.menu.EraseFlash.none=Disabled
-nologo_esp32s3_pico.menu.EraseFlash.none.upload.erase_cmd=
 nologo_esp32s3_pico.menu.EraseFlash.all=Enabled
 nologo_esp32s3_pico.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19482,6 +19481,7 @@ mhetesp32devkit.upload.tool.network=esp_ota
 mhetesp32devkit.upload.maximum_size=1310720
 mhetesp32devkit.upload.maximum_data_size=327680
 mhetesp32devkit.upload.flags=
+mhetesp32devkit.upload.erase_cmd=
 mhetesp32devkit.upload.extra_flags=
 
 mhetesp32devkit.serial.disableDTR=true
@@ -19545,7 +19545,6 @@ mhetesp32devkit.menu.DebugLevel.verbose=Verbose
 mhetesp32devkit.menu.DebugLevel.verbose.build.code_debug=5
 
 mhetesp32devkit.menu.EraseFlash.none=Disabled
-mhetesp32devkit.menu.EraseFlash.none.upload.erase_cmd=
 mhetesp32devkit.menu.EraseFlash.all=Enabled
 mhetesp32devkit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19563,6 +19562,7 @@ mhetesp32minikit.upload.tool.network=esp_ota
 mhetesp32minikit.upload.maximum_size=1310720
 mhetesp32minikit.upload.maximum_data_size=327680
 mhetesp32minikit.upload.flags=
+mhetesp32minikit.upload.erase_cmd=
 mhetesp32minikit.upload.extra_flags=
 
 mhetesp32minikit.serial.disableDTR=true
@@ -19628,7 +19628,6 @@ mhetesp32minikit.menu.DebugLevel.verbose=Verbose
 mhetesp32minikit.menu.DebugLevel.verbose.build.code_debug=5
 
 mhetesp32minikit.menu.EraseFlash.none=Disabled
-mhetesp32minikit.menu.EraseFlash.none.upload.erase_cmd=
 mhetesp32minikit.menu.EraseFlash.all=Enabled
 mhetesp32minikit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19646,6 +19645,7 @@ esp32vn-iot-uno.upload.tool.network=esp_ota
 esp32vn-iot-uno.upload.maximum_size=1310720
 esp32vn-iot-uno.upload.maximum_data_size=327680
 esp32vn-iot-uno.upload.flags=
+esp32vn-iot-uno.upload.erase_cmd=
 esp32vn-iot-uno.upload.extra_flags=
 
 esp32vn-iot-uno.serial.disableDTR=true
@@ -19700,7 +19700,6 @@ esp32vn-iot-uno.menu.DebugLevel.verbose=Verbose
 esp32vn-iot-uno.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32vn-iot-uno.menu.EraseFlash.none=Disabled
-esp32vn-iot-uno.menu.EraseFlash.none.upload.erase_cmd=
 esp32vn-iot-uno.menu.EraseFlash.all=Enabled
 esp32vn-iot-uno.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19718,6 +19717,7 @@ esp32doit-devkit-v1.upload.tool.network=esp_ota
 esp32doit-devkit-v1.upload.maximum_size=1310720
 esp32doit-devkit-v1.upload.maximum_data_size=327680
 esp32doit-devkit-v1.upload.flags=
+esp32doit-devkit-v1.upload.erase_cmd=
 esp32doit-devkit-v1.upload.extra_flags=
 
 esp32doit-devkit-v1.serial.disableDTR=true
@@ -19772,7 +19772,6 @@ esp32doit-devkit-v1.menu.DebugLevel.verbose=Verbose
 esp32doit-devkit-v1.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32doit-devkit-v1.menu.EraseFlash.none=Disabled
-esp32doit-devkit-v1.menu.EraseFlash.none.upload.erase_cmd=
 esp32doit-devkit-v1.menu.EraseFlash.all=Enabled
 esp32doit-devkit-v1.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19791,6 +19790,7 @@ esp32doit-espduino.upload.maximum_size=1310720
 esp32doit-espduino.upload.maximum_data_size=327680
 esp32doit-espduino.upload.wait_for_upload_port=true
 esp32doit-espduino.upload.flags=
+esp32doit-espduino.upload.erase_cmd=
 esp32doit-espduino.upload.extra_flags=
 
 esp32doit-espduino.serial.disableDTR=true
@@ -19871,7 +19871,6 @@ esp32doit-espduino.menu.DebugLevel.verbose=Verbose
 esp32doit-espduino.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32doit-espduino.menu.EraseFlash.none=Disabled
-esp32doit-espduino.menu.EraseFlash.none.upload.erase_cmd=
 esp32doit-espduino.menu.EraseFlash.all=Enabled
 esp32doit-espduino.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19889,6 +19888,7 @@ esp32-evb.upload.tool.network=esp_ota
 esp32-evb.upload.maximum_size=1310720
 esp32-evb.upload.maximum_data_size=327680
 esp32-evb.upload.flags=
+esp32-evb.upload.erase_cmd=
 esp32-evb.upload.extra_flags=
 
 esp32-evb.serial.disableDTR=true
@@ -19952,7 +19952,6 @@ esp32-evb.menu.DebugLevel.verbose=Verbose
 esp32-evb.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-evb.menu.EraseFlash.none=Disabled
-esp32-evb.menu.EraseFlash.none.upload.erase_cmd=
 esp32-evb.menu.EraseFlash.all=Enabled
 esp32-evb.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -19970,6 +19969,7 @@ esp32-gateway.upload.tool.network=esp_ota
 esp32-gateway.upload.maximum_size=1310720
 esp32-gateway.upload.maximum_data_size=327680
 esp32-gateway.upload.flags=
+esp32-gateway.upload.erase_cmd=
 esp32-gateway.upload.extra_flags=
 
 esp32-gateway.serial.disableDTR=true
@@ -20029,7 +20029,6 @@ esp32-gateway.menu.DebugLevel.verbose=Verbose
 esp32-gateway.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-gateway.menu.EraseFlash.none=Disabled
-esp32-gateway.menu.EraseFlash.none.upload.erase_cmd=
 esp32-gateway.menu.EraseFlash.all=Enabled
 esp32-gateway.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -20047,6 +20046,7 @@ esp32-poe.upload.tool.network=esp_ota
 esp32-poe.upload.maximum_size=1310720
 esp32-poe.upload.maximum_data_size=327680
 esp32-poe.upload.flags=
+esp32-poe.upload.erase_cmd=
 esp32-poe.upload.extra_flags=
 
 esp32-poe.serial.disableDTR=true
@@ -20172,7 +20172,6 @@ esp32-poe.menu.DebugLevel.verbose=Verbose
 esp32-poe.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-poe.menu.EraseFlash.none=Disabled
-esp32-poe.menu.EraseFlash.none.upload.erase_cmd=
 esp32-poe.menu.EraseFlash.all=Enabled
 esp32-poe.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -20190,6 +20189,7 @@ esp32-poe-iso.upload.tool.network=esp_ota
 esp32-poe-iso.upload.maximum_size=1310720
 esp32-poe-iso.upload.maximum_data_size=327680
 esp32-poe-iso.upload.flags=
+esp32-poe-iso.upload.erase_cmd=
 esp32-poe-iso.upload.extra_flags=
 
 esp32-poe-iso.serial.disableDTR=true
@@ -20315,7 +20315,6 @@ esp32-poe-iso.menu.DebugLevel.verbose=Verbose
 esp32-poe-iso.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-poe-iso.menu.EraseFlash.none=Disabled
-esp32-poe-iso.menu.EraseFlash.none.upload.erase_cmd=
 esp32-poe-iso.menu.EraseFlash.all=Enabled
 esp32-poe-iso.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -20333,6 +20332,7 @@ esp32-devkitlipo.upload.tool.network=esp_ota
 esp32-devkitlipo.upload.maximum_size=1310720
 esp32-devkitlipo.upload.maximum_data_size=327680
 esp32-devkitlipo.upload.flags=
+esp32-devkitlipo.upload.erase_cmd=
 esp32-devkitlipo.upload.extra_flags=
 
 esp32-devkitlipo.serial.disableDTR=true
@@ -20416,7 +20416,6 @@ esp32-devkitlipo.menu.DebugLevel.verbose=Verbose
 esp32-devkitlipo.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-devkitlipo.menu.EraseFlash.none=Disabled
-esp32-devkitlipo.menu.EraseFlash.none.upload.erase_cmd=
 esp32-devkitlipo.menu.EraseFlash.all=Enabled
 esp32-devkitlipo.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -20434,6 +20433,7 @@ esp32s2-devkitlipo.upload.tool.network=esp_ota
 esp32s2-devkitlipo.upload.maximum_size=1310720
 esp32s2-devkitlipo.upload.maximum_data_size=327680
 esp32s2-devkitlipo.upload.flags=
+esp32s2-devkitlipo.upload.erase_cmd=
 esp32s2-devkitlipo.upload.extra_flags=
 esp32s2-devkitlipo.upload.use_1200bps_touch=false
 esp32s2-devkitlipo.upload.wait_for_upload_port=false
@@ -20611,7 +20611,6 @@ esp32s2-devkitlipo.menu.DebugLevel.verbose=Verbose
 esp32s2-devkitlipo.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s2-devkitlipo.menu.EraseFlash.none=Disabled
-esp32s2-devkitlipo.menu.EraseFlash.none.upload.erase_cmd=
 esp32s2-devkitlipo.menu.EraseFlash.all=Enabled
 esp32s2-devkitlipo.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -20629,6 +20628,7 @@ esp32s2-devkitlipo-usb.upload.tool.network=esp_ota
 esp32s2-devkitlipo-usb.upload.maximum_size=1310720
 esp32s2-devkitlipo-usb.upload.maximum_data_size=327680
 esp32s2-devkitlipo-usb.upload.flags=
+esp32s2-devkitlipo-usb.upload.erase_cmd=
 esp32s2-devkitlipo-usb.upload.extra_flags=
 esp32s2-devkitlipo-usb.upload.use_1200bps_touch=false
 esp32s2-devkitlipo-usb.upload.wait_for_upload_port=false
@@ -20806,7 +20806,6 @@ esp32s2-devkitlipo-usb.menu.DebugLevel.verbose=Verbose
 esp32s2-devkitlipo-usb.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s2-devkitlipo-usb.menu.EraseFlash.none=Disabled
-esp32s2-devkitlipo-usb.menu.EraseFlash.none.upload.erase_cmd=
 esp32s2-devkitlipo-usb.menu.EraseFlash.all=Enabled
 esp32s2-devkitlipo-usb.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -20824,6 +20823,7 @@ esp32s3-devkitlipo.upload.tool.network=esp_ota
 esp32s3-devkitlipo.upload.maximum_size=1310720
 esp32s3-devkitlipo.upload.maximum_data_size=327680
 esp32s3-devkitlipo.upload.flags=
+esp32s3-devkitlipo.upload.erase_cmd=
 esp32s3-devkitlipo.upload.extra_flags=
 esp32s3-devkitlipo.upload.use_1200bps_touch=false
 esp32s3-devkitlipo.upload.wait_for_upload_port=false
@@ -21044,7 +21044,6 @@ esp32s3-devkitlipo.menu.DebugLevel.verbose=Verbose
 esp32s3-devkitlipo.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s3-devkitlipo.menu.EraseFlash.none=Disabled
-esp32s3-devkitlipo.menu.EraseFlash.none.upload.erase_cmd=
 esp32s3-devkitlipo.menu.EraseFlash.all=Enabled
 esp32s3-devkitlipo.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -21062,6 +21061,7 @@ esp32c3-devkitlipo.upload.tool.network=esp_ota
 esp32c3-devkitlipo.upload.maximum_size=1310720
 esp32c3-devkitlipo.upload.maximum_data_size=327680
 esp32c3-devkitlipo.upload.flags=
+esp32c3-devkitlipo.upload.erase_cmd=
 esp32c3-devkitlipo.upload.extra_flags=
 esp32c3-devkitlipo.upload.use_1200bps_touch=false
 esp32c3-devkitlipo.upload.wait_for_upload_port=false
@@ -21217,7 +21217,6 @@ esp32c3-devkitlipo.menu.DebugLevel.verbose=Verbose
 esp32c3-devkitlipo.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c3-devkitlipo.menu.EraseFlash.none=Disabled
-esp32c3-devkitlipo.menu.EraseFlash.none.upload.erase_cmd=
 esp32c3-devkitlipo.menu.EraseFlash.all=Enabled
 esp32c3-devkitlipo.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -21235,6 +21234,7 @@ esp32c6-evb.upload.tool.network=esp_ota
 esp32c6-evb.upload.maximum_size=1310720
 esp32c6-evb.upload.maximum_data_size=327680
 esp32c6-evb.upload.flags=
+esp32c6-evb.upload.erase_cmd=
 esp32c6-evb.upload.extra_flags=
 esp32c6-evb.upload.use_1200bps_touch=false
 esp32c6-evb.upload.wait_for_upload_port=false
@@ -21390,7 +21390,6 @@ esp32c6-evb.menu.DebugLevel.verbose=Verbose
 esp32c6-evb.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c6-evb.menu.EraseFlash.none=Disabled
-esp32c6-evb.menu.EraseFlash.none.upload.erase_cmd=
 esp32c6-evb.menu.EraseFlash.all=Enabled
 esp32c6-evb.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -21418,6 +21417,7 @@ esp32h2-devkitlipo.upload.tool.network=esp_ota
 esp32h2-devkitlipo.upload.maximum_size=1310720
 esp32h2-devkitlipo.upload.maximum_data_size=327680
 esp32h2-devkitlipo.upload.flags=
+esp32h2-devkitlipo.upload.erase_cmd=
 esp32h2-devkitlipo.upload.extra_flags=
 esp32h2-devkitlipo.upload.use_1200bps_touch=false
 esp32h2-devkitlipo.upload.wait_for_upload_port=false
@@ -21567,7 +21567,6 @@ esp32h2-devkitlipo.menu.DebugLevel.verbose=Verbose
 esp32h2-devkitlipo.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32h2-devkitlipo.menu.EraseFlash.none=Disabled
-esp32h2-devkitlipo.menu.EraseFlash.none.upload.erase_cmd=
 esp32h2-devkitlipo.menu.EraseFlash.all=Enabled
 esp32h2-devkitlipo.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -21595,6 +21594,7 @@ esp32-sbc-fabgl.upload.tool.network=esp_ota
 esp32-sbc-fabgl.upload.maximum_size=1310720
 esp32-sbc-fabgl.upload.maximum_data_size=327680
 esp32-sbc-fabgl.upload.flags=
+esp32-sbc-fabgl.upload.erase_cmd=
 esp32-sbc-fabgl.upload.extra_flags=
 
 esp32-sbc-fabgl.serial.disableDTR=true
@@ -21761,7 +21761,6 @@ esp32-sbc-fabgl.menu.DebugLevel.verbose=Verbose
 esp32-sbc-fabgl.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-sbc-fabgl.menu.EraseFlash.none=Disabled
-esp32-sbc-fabgl.menu.EraseFlash.none.upload.erase_cmd=
 esp32-sbc-fabgl.menu.EraseFlash.all=Enabled
 esp32-sbc-fabgl.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -21786,6 +21785,7 @@ espino32.upload.tool.network=esp_ota
 espino32.upload.maximum_size=1310720
 espino32.upload.maximum_data_size=327680
 espino32.upload.flags=
+espino32.upload.erase_cmd=
 espino32.upload.extra_flags=
 
 espino32.serial.disableDTR=true
@@ -21840,7 +21840,6 @@ espino32.menu.DebugLevel.verbose=Verbose
 espino32.menu.DebugLevel.verbose.build.code_debug=5
 
 espino32.menu.EraseFlash.none=Disabled
-espino32.menu.EraseFlash.none.upload.erase_cmd=
 espino32.menu.EraseFlash.all=Enabled
 espino32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -21858,6 +21857,7 @@ m5stack_core.upload.tool.network=esp_ota
 m5stack_core.upload.maximum_size=1310720
 m5stack_core.upload.maximum_data_size=327680
 m5stack_core.upload.flags=
+m5stack_core.upload.erase_cmd=
 m5stack_core.upload.extra_flags=
 
 m5stack_core.serial.disableDTR=true
@@ -22005,7 +22005,6 @@ m5stack_core.menu.DebugLevel.verbose=Verbose
 m5stack_core.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_core.menu.EraseFlash.none=Disabled
-m5stack_core.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_core.menu.EraseFlash.all=Enabled
 m5stack_core.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -22023,6 +22022,7 @@ m5stack_fire.upload.tool.network=esp_ota
 m5stack_fire.upload.maximum_size=6553600
 m5stack_fire.upload.maximum_data_size=4521984
 m5stack_fire.upload.flags=
+m5stack_fire.upload.erase_cmd=
 m5stack_fire.upload.extra_flags=
 
 m5stack_fire.serial.disableDTR=true
@@ -22179,7 +22179,6 @@ m5stack_fire.menu.DebugLevel.verbose=Verbose
 m5stack_fire.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_fire.menu.EraseFlash.none=Disabled
-m5stack_fire.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_fire.menu.EraseFlash.all=Enabled
 m5stack_fire.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -22197,6 +22196,7 @@ m5stack_core2.upload.tool.network=esp_ota
 m5stack_core2.upload.maximum_size=6553600
 m5stack_core2.upload.maximum_data_size=4521984
 m5stack_core2.upload.flags=
+m5stack_core2.upload.erase_cmd=
 m5stack_core2.upload.extra_flags=
 
 m5stack_core2.serial.disableDTR=true
@@ -22353,7 +22353,6 @@ m5stack_core2.menu.DebugLevel.verbose=Verbose
 m5stack_core2.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_core2.menu.EraseFlash.none=Disabled
-m5stack_core2.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_core2.menu.EraseFlash.all=Enabled
 m5stack_core2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -22371,6 +22370,7 @@ m5stack_tough.upload.tool.network=esp_ota
 m5stack_tough.upload.maximum_size=6553600
 m5stack_tough.upload.maximum_data_size=4521984
 m5stack_tough.upload.flags=
+m5stack_tough.upload.erase_cmd=
 m5stack_tough.upload.extra_flags=
 
 m5stack_tough.serial.disableDTR=true
@@ -22527,7 +22527,6 @@ m5stack_tough.menu.DebugLevel.verbose=Verbose
 m5stack_tough.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_tough.menu.EraseFlash.none=Disabled
-m5stack_tough.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_tough.menu.EraseFlash.all=Enabled
 m5stack_tough.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -22545,6 +22544,7 @@ m5stack_station.upload.tool.network=esp_ota
 m5stack_station.upload.maximum_size=6553600
 m5stack_station.upload.maximum_data_size=4521984
 m5stack_station.upload.flags=
+m5stack_station.upload.erase_cmd=
 m5stack_station.upload.extra_flags=
 
 m5stack_station.serial.disableDTR=true
@@ -22694,7 +22694,6 @@ m5stack_station.menu.DebugLevel.verbose=Verbose
 m5stack_station.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_station.menu.EraseFlash.none=Disabled
-m5stack_station.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_station.menu.EraseFlash.all=Enabled
 m5stack_station.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -22712,6 +22711,7 @@ m5stack_stickc.upload.tool.network=esp_ota
 m5stack_stickc.upload.maximum_size=1310720
 m5stack_stickc.upload.maximum_data_size=327680
 m5stack_stickc.upload.flags=
+m5stack_stickc.upload.erase_cmd=
 m5stack_stickc.upload.extra_flags=
 
 m5stack_stickc.serial.disableDTR=true
@@ -22842,7 +22842,6 @@ m5stack_stickc.menu.DebugLevel.verbose=Verbose
 m5stack_stickc.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_stickc.menu.EraseFlash.none=Disabled
-m5stack_stickc.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_stickc.menu.EraseFlash.all=Enabled
 m5stack_stickc.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -22861,6 +22860,7 @@ m5stack_stickc_plus.upload.tool.network=esp_ota
 m5stack_stickc_plus.upload.maximum_size=1310720
 m5stack_stickc_plus.upload.maximum_data_size=327680
 m5stack_stickc_plus.upload.flags=
+m5stack_stickc_plus.upload.erase_cmd=
 m5stack_stickc_plus.upload.extra_flags=
 
 m5stack_stickc_plus.serial.disableDTR=true
@@ -22991,7 +22991,6 @@ m5stack_stickc_plus.menu.DebugLevel.verbose=Verbose
 m5stack_stickc_plus.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_stickc_plus.menu.EraseFlash.none=Disabled
-m5stack_stickc_plus.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_stickc_plus.menu.EraseFlash.all=Enabled
 m5stack_stickc_plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -23009,6 +23008,7 @@ m5stack_stickc_plus2.upload.tool.network=esp_ota
 m5stack_stickc_plus2.upload.maximum_size=3342336
 m5stack_stickc_plus2.upload.maximum_data_size=327680
 m5stack_stickc_plus2.upload.flags=
+m5stack_stickc_plus2.upload.erase_cmd=
 m5stack_stickc_plus2.upload.extra_flags=
 
 m5stack_stickc_plus2.serial.disableDTR=true
@@ -23152,7 +23152,6 @@ m5stack_stickc_plus2.menu.DebugLevel.verbose=Verbose
 m5stack_stickc_plus2.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_stickc_plus2.menu.EraseFlash.none=Disabled
-m5stack_stickc_plus2.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_stickc_plus2.menu.EraseFlash.all=Enabled
 m5stack_stickc_plus2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -23170,6 +23169,7 @@ m5stack_atom.upload.tool.network=esp_ota
 m5stack_atom.upload.maximum_size=1310720
 m5stack_atom.upload.maximum_data_size=327680
 m5stack_atom.upload.flags=
+m5stack_atom.upload.erase_cmd=
 m5stack_atom.upload.extra_flags=
 
 m5stack_atom.serial.disableDTR=true
@@ -23300,7 +23300,6 @@ m5stack_atom.menu.DebugLevel.verbose=Verbose
 m5stack_atom.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_atom.menu.EraseFlash.none=Disabled
-m5stack_atom.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_atom.menu.EraseFlash.all=Enabled
 m5stack_atom.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -23317,6 +23316,7 @@ m5stack_atoms3.upload.tool.network=esp_ota
 m5stack_atoms3.upload.maximum_size=1310720
 m5stack_atoms3.upload.maximum_data_size=327680
 m5stack_atoms3.upload.flags=
+m5stack_atoms3.upload.erase_cmd=
 m5stack_atoms3.upload.extra_flags=
 m5stack_atoms3.upload.use_1200bps_touch=false
 m5stack_atoms3.upload.wait_for_upload_port=false
@@ -23516,7 +23516,6 @@ m5stack_atoms3.menu.DebugLevel.verbose=Verbose
 m5stack_atoms3.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_atoms3.menu.EraseFlash.none=Disabled
-m5stack_atoms3.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_atoms3.menu.EraseFlash.all=Enabled
 m5stack_atoms3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -23533,6 +23532,7 @@ m5stack_cores3.upload.tool.network=esp_ota
 m5stack_cores3.upload.maximum_size=1310720
 m5stack_cores3.upload.maximum_data_size=327680
 m5stack_cores3.upload.flags=
+m5stack_cores3.upload.erase_cmd=
 m5stack_cores3.upload.extra_flags=
 m5stack_cores3.upload.use_1200bps_touch=false
 m5stack_cores3.upload.wait_for_upload_port=false
@@ -23756,7 +23756,6 @@ m5stack_cores3.menu.DebugLevel.verbose=Verbose
 m5stack_cores3.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_cores3.menu.EraseFlash.none=Disabled
-m5stack_cores3.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_cores3.menu.EraseFlash.all=Enabled
 m5stack_cores3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -23774,6 +23773,7 @@ m5stack_tab5.upload.tool.network=esp_ota
 m5stack_tab5.upload.maximum_size=1310720
 m5stack_tab5.upload.maximum_data_size=327680
 m5stack_tab5.upload.flags=
+m5stack_tab5.upload.erase_cmd=
 m5stack_tab5.upload.extra_flags=
 m5stack_tab5.upload.use_1200bps_touch=false
 m5stack_tab5.upload.wait_for_upload_port=false
@@ -23944,7 +23944,6 @@ m5stack_tab5.menu.DebugLevel.verbose=Verbose
 m5stack_tab5.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_tab5.menu.EraseFlash.none=Disabled
-m5stack_tab5.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_tab5.menu.EraseFlash.all=Enabled
 m5stack_tab5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -23964,6 +23963,7 @@ m5stack_timer_cam.upload.maximum_size=1310720
 m5stack_timer_cam.upload.maximum_data_size=327680
 
 m5stack_timer_cam.upload.flags=
+m5stack_timer_cam.upload.erase_cmd=
 m5stack_timer_cam.upload.extra_flags=
 
 m5stack_timer_cam.serial.disableDTR=true
@@ -24092,7 +24092,6 @@ m5stack_timer_cam.menu.DebugLevel.verbose=Verbose
 m5stack_timer_cam.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_timer_cam.menu.EraseFlash.none=Disabled
-m5stack_timer_cam.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_timer_cam.menu.EraseFlash.all=Enabled
 m5stack_timer_cam.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -24112,6 +24111,7 @@ m5stack_unit_cam.upload.maximum_size=1310720
 m5stack_unit_cam.upload.maximum_data_size=327680
 
 m5stack_unit_cam.upload.flags=
+m5stack_unit_cam.upload.erase_cmd=
 m5stack_unit_cam.upload.extra_flags=
 
 m5stack_unit_cam.serial.disableDTR=true
@@ -24240,7 +24240,6 @@ m5stack_unit_cam.menu.DebugLevel.verbose=Verbose
 m5stack_unit_cam.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_unit_cam.menu.EraseFlash.none=Disabled
-m5stack_unit_cam.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_unit_cam.menu.EraseFlash.all=Enabled
 m5stack_unit_cam.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -24258,6 +24257,7 @@ m5stack_unit_cams3.upload.tool.network=esp_ota
 m5stack_unit_cams3.upload.maximum_size=1310720
 m5stack_unit_cams3.upload.maximum_data_size=327680
 m5stack_unit_cams3.upload.flags=
+m5stack_unit_cams3.upload.erase_cmd=
 m5stack_unit_cams3.upload.extra_flags=
 m5stack_unit_cams3.upload.use_1200bps_touch=false
 m5stack_unit_cams3.upload.wait_for_upload_port=false
@@ -24474,7 +24474,6 @@ m5stack_unit_cams3.menu.DebugLevel.verbose=Verbose
 m5stack_unit_cams3.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_unit_cams3.menu.EraseFlash.none=Disabled
-m5stack_unit_cams3.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_unit_cams3.menu.EraseFlash.all=Enabled
 m5stack_unit_cams3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -24493,6 +24492,7 @@ m5stack_poe_cam.upload.maximum_size=1310720
 m5stack_poe_cam.upload.maximum_data_size=327680
 
 m5stack_poe_cam.upload.flags=
+m5stack_poe_cam.upload.erase_cmd=
 m5stack_poe_cam.upload.extra_flags=
 
 m5stack_poe_cam.serial.disableDTR=true
@@ -24621,7 +24621,6 @@ m5stack_poe_cam.menu.DebugLevel.verbose=Verbose
 m5stack_poe_cam.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_poe_cam.menu.EraseFlash.none=Disabled
-m5stack_poe_cam.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_poe_cam.menu.EraseFlash.all=Enabled
 m5stack_poe_cam.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -24639,6 +24638,7 @@ m5stack_paper.upload.tool.network=esp_ota
 m5stack_paper.upload.maximum_size=6553600
 m5stack_paper.upload.maximum_data_size=4521984
 m5stack_paper.upload.flags=
+m5stack_paper.upload.erase_cmd=
 m5stack_paper.upload.extra_flags=
 
 m5stack_paper.serial.disableDTR=true
@@ -24795,7 +24795,6 @@ m5stack_paper.menu.DebugLevel.verbose=Verbose
 m5stack_paper.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_paper.menu.EraseFlash.none=Disabled
-m5stack_paper.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_paper.menu.EraseFlash.all=Enabled
 m5stack_paper.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -24813,6 +24812,7 @@ m5stack_coreink.upload.tool.network=esp_ota
 m5stack_coreink.upload.maximum_size=1310720
 m5stack_coreink.upload.maximum_data_size=327680
 m5stack_coreink.upload.flags=
+m5stack_coreink.upload.erase_cmd=
 m5stack_coreink.upload.extra_flags=
 
 m5stack_coreink.serial.disableDTR=true
@@ -24943,7 +24943,6 @@ m5stack_coreink.menu.DebugLevel.verbose=Verbose
 m5stack_coreink.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_coreink.menu.EraseFlash.none=Disabled
-m5stack_coreink.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_coreink.menu.EraseFlash.all=Enabled
 m5stack_coreink.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -24961,6 +24960,7 @@ m5stack_stamp_pico.upload.tool.network=esp_ota
 m5stack_stamp_pico.upload.maximum_size=1310720
 m5stack_stamp_pico.upload.maximum_data_size=327680
 m5stack_stamp_pico.upload.flags=
+m5stack_stamp_pico.upload.erase_cmd=
 m5stack_stamp_pico.upload.extra_flags=
 
 m5stack_stamp_pico.serial.disableDTR=true
@@ -25091,7 +25091,6 @@ m5stack_stamp_pico.menu.DebugLevel.verbose=Verbose
 m5stack_stamp_pico.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_stamp_pico.menu.EraseFlash.none=Disabled
-m5stack_stamp_pico.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_stamp_pico.menu.EraseFlash.all=Enabled
 m5stack_stamp_pico.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -25110,6 +25109,7 @@ m5stack_stamp_c3.upload.maximum_size=1310720
 m5stack_stamp_c3.upload.maximum_data_size=327680
 m5stack_stamp_c3.upload.wait_for_upload_port=false
 m5stack_stamp_c3.upload.flags=
+m5stack_stamp_c3.upload.erase_cmd=
 m5stack_stamp_c3.upload.extra_flags=
 
 m5stack_stamp_c3.serial.disableDTR=false
@@ -25237,7 +25237,6 @@ m5stack_stamp_c3.menu.DebugLevel.verbose=Verbose
 m5stack_stamp_c3.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_stamp_c3.menu.EraseFlash.none=Disabled
-m5stack_stamp_c3.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_stamp_c3.menu.EraseFlash.all=Enabled
 m5stack_stamp_c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -25254,6 +25253,7 @@ m5stack_stamp_s3.upload.tool.network=esp_ota
 m5stack_stamp_s3.upload.maximum_size=1310720
 m5stack_stamp_s3.upload.maximum_data_size=327680
 m5stack_stamp_s3.upload.flags=
+m5stack_stamp_s3.upload.erase_cmd=
 m5stack_stamp_s3.upload.extra_flags=
 m5stack_stamp_s3.upload.use_1200bps_touch=false
 m5stack_stamp_s3.upload.wait_for_upload_port=false
@@ -25474,7 +25474,6 @@ m5stack_stamp_s3.menu.DebugLevel.verbose=Verbose
 m5stack_stamp_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_stamp_s3.menu.EraseFlash.none=Disabled
-m5stack_stamp_s3.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_stamp_s3.menu.EraseFlash.all=Enabled
 m5stack_stamp_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -25491,6 +25490,7 @@ m5stack_capsule.upload.tool.network=esp_ota
 m5stack_capsule.upload.maximum_size=1310720
 m5stack_capsule.upload.maximum_data_size=327680
 m5stack_capsule.upload.flags=
+m5stack_capsule.upload.erase_cmd=
 m5stack_capsule.upload.extra_flags=
 m5stack_capsule.upload.use_1200bps_touch=false
 m5stack_capsule.upload.wait_for_upload_port=false
@@ -25714,7 +25714,6 @@ m5stack_capsule.menu.DebugLevel.verbose=Verbose
 m5stack_capsule.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_capsule.menu.EraseFlash.none=Disabled
-m5stack_capsule.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_capsule.menu.EraseFlash.all=Enabled
 m5stack_capsule.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -25731,6 +25730,7 @@ m5stack_cardputer.upload.tool.network=esp_ota
 m5stack_cardputer.upload.maximum_size=1310720
 m5stack_cardputer.upload.maximum_data_size=327680
 m5stack_cardputer.upload.flags=
+m5stack_cardputer.upload.erase_cmd=
 m5stack_cardputer.upload.extra_flags=
 m5stack_cardputer.upload.use_1200bps_touch=false
 m5stack_cardputer.upload.wait_for_upload_port=false
@@ -25951,7 +25951,6 @@ m5stack_cardputer.menu.DebugLevel.verbose=Verbose
 m5stack_cardputer.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_cardputer.menu.EraseFlash.none=Disabled
-m5stack_cardputer.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_cardputer.menu.EraseFlash.all=Enabled
 m5stack_cardputer.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -25968,6 +25967,7 @@ m5stack_dial.upload.tool.network=esp_ota
 m5stack_dial.upload.maximum_size=1310720
 m5stack_dial.upload.maximum_data_size=327680
 m5stack_dial.upload.flags=
+m5stack_dial.upload.erase_cmd=
 m5stack_dial.upload.extra_flags=
 m5stack_dial.upload.use_1200bps_touch=false
 m5stack_dial.upload.wait_for_upload_port=false
@@ -26188,7 +26188,6 @@ m5stack_dial.menu.DebugLevel.verbose=Verbose
 m5stack_dial.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_dial.menu.EraseFlash.none=Disabled
-m5stack_dial.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_dial.menu.EraseFlash.all=Enabled
 m5stack_dial.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -26205,6 +26204,7 @@ m5stack_dinmeter.upload.tool.network=esp_ota
 m5stack_dinmeter.upload.maximum_size=1310720
 m5stack_dinmeter.upload.maximum_data_size=327680
 m5stack_dinmeter.upload.flags=
+m5stack_dinmeter.upload.erase_cmd=
 m5stack_dinmeter.upload.extra_flags=
 m5stack_dinmeter.upload.use_1200bps_touch=false
 m5stack_dinmeter.upload.wait_for_upload_port=false
@@ -26425,7 +26425,6 @@ m5stack_dinmeter.menu.DebugLevel.verbose=Verbose
 m5stack_dinmeter.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_dinmeter.menu.EraseFlash.none=Disabled
-m5stack_dinmeter.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_dinmeter.menu.EraseFlash.all=Enabled
 m5stack_dinmeter.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -26443,6 +26442,7 @@ m5stack_nanoc6.upload.tool.network=esp_ota
 m5stack_nanoc6.upload.maximum_size=1310720
 m5stack_nanoc6.upload.maximum_data_size=327680
 m5stack_nanoc6.upload.flags=
+m5stack_nanoc6.upload.erase_cmd=
 m5stack_nanoc6.upload.extra_flags=
 m5stack_nanoc6.upload.use_1200bps_touch=false
 m5stack_nanoc6.upload.wait_for_upload_port=false
@@ -26566,7 +26566,6 @@ m5stack_nanoc6.menu.DebugLevel.verbose=Verbose
 m5stack_nanoc6.menu.DebugLevel.verbose.build.code_debug=5
 
 m5stack_nanoc6.menu.EraseFlash.none=Disabled
-m5stack_nanoc6.menu.EraseFlash.none.upload.erase_cmd=
 m5stack_nanoc6.menu.EraseFlash.all=Enabled
 m5stack_nanoc6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -26594,6 +26593,7 @@ odroid_esp32.upload.tool.network=esp_ota
 odroid_esp32.upload.maximum_size=1310720
 odroid_esp32.upload.maximum_data_size=327680
 odroid_esp32.upload.flags=
+odroid_esp32.upload.erase_cmd=
 odroid_esp32.upload.extra_flags=
 
 odroid_esp32.serial.disableDTR=true
@@ -26665,7 +26665,6 @@ odroid_esp32.menu.DebugLevel.verbose=Verbose
 odroid_esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 odroid_esp32.menu.EraseFlash.none=Disabled
-odroid_esp32.menu.EraseFlash.none.upload.erase_cmd=
 odroid_esp32.menu.EraseFlash.all=Enabled
 odroid_esp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -26683,6 +26682,7 @@ heltec_wifi_kit_32.upload.tool.network=esp_ota
 heltec_wifi_kit_32.upload.maximum_size=1310720
 heltec_wifi_kit_32.upload.maximum_data_size=327680
 heltec_wifi_kit_32.upload.flags=
+heltec_wifi_kit_32.upload.erase_cmd=
 heltec_wifi_kit_32.upload.extra_flags=
 
 heltec_wifi_kit_32.serial.disableDTR=true
@@ -26762,7 +26762,6 @@ heltec_wifi_kit_32.menu.DebugLevel.verbose=Verbose
 heltec_wifi_kit_32.menu.DebugLevel.verbose.build.code_debug=5
 
 heltec_wifi_kit_32.menu.EraseFlash.none=Disabled
-heltec_wifi_kit_32.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wifi_kit_32.menu.EraseFlash.all=Enabled
 heltec_wifi_kit_32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -26780,6 +26779,7 @@ heltec_wifi_kit_32_V3.upload.tool.network=esp_ota
 heltec_wifi_kit_32_V3.upload.maximum_size=3342336
 heltec_wifi_kit_32_V3.upload.maximum_data_size=327680
 heltec_wifi_kit_32_V3.upload.flags=
+heltec_wifi_kit_32_V3.upload.erase_cmd=
 heltec_wifi_kit_32_V3.upload.extra_flags=
 heltec_wifi_kit_32_V3.upload.use_1200bps_touch=false
 heltec_wifi_kit_32_V3.upload.wait_for_upload_port=false
@@ -26863,7 +26863,6 @@ heltec_wifi_kit_32_V3.menu.DebugLevel.verbose=Verbose
 heltec_wifi_kit_32_V3.menu.DebugLevel.verbose.build.code_debug=5
 
 heltec_wifi_kit_32_V3.menu.EraseFlash.none=Disabled
-heltec_wifi_kit_32_V3.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wifi_kit_32_V3.menu.EraseFlash.all=Enabled
 heltec_wifi_kit_32_V3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -26881,6 +26880,7 @@ heltec_wifi_lora_32.upload.tool.network=esp_ota
 heltec_wifi_lora_32.upload.maximum_size=1310720
 heltec_wifi_lora_32.upload.maximum_data_size=327680
 heltec_wifi_lora_32.upload.flags=
+heltec_wifi_lora_32.upload.erase_cmd=
 heltec_wifi_lora_32.upload.extra_flags=
 
 heltec_wifi_lora_32.serial.disableDTR=true
@@ -27000,7 +27000,6 @@ heltec_wifi_lora_32.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH
 
 
 heltec_wifi_lora_32.menu.EraseFlash.none=Disabled
-heltec_wifi_lora_32.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wifi_lora_32.menu.EraseFlash.all=Enabled
 heltec_wifi_lora_32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -27018,6 +27017,7 @@ heltec_wifi_lora_32_V2.upload.tool.network=esp_ota
 heltec_wifi_lora_32_V2.upload.maximum_size=3342336
 heltec_wifi_lora_32_V2.upload.maximum_data_size=327680
 heltec_wifi_lora_32_V2.upload.flags=
+heltec_wifi_lora_32_V2.upload.erase_cmd=
 heltec_wifi_lora_32_V2.upload.extra_flags=
 
 heltec_wifi_lora_32_V2.serial.disableDTR=true
@@ -27116,7 +27116,6 @@ heltec_wifi_lora_32_V2.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
 heltec_wifi_lora_32_V2.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
 
 heltec_wifi_lora_32_V2.menu.EraseFlash.none=Disabled
-heltec_wifi_lora_32_V2.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wifi_lora_32_V2.menu.EraseFlash.all=Enabled
 heltec_wifi_lora_32_V2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -27134,6 +27133,7 @@ heltec_wifi_lora_32_V3.upload.tool.network=esp_ota
 heltec_wifi_lora_32_V3.upload.maximum_size=3342336
 heltec_wifi_lora_32_V3.upload.maximum_data_size=327680
 heltec_wifi_lora_32_V3.upload.flags=
+heltec_wifi_lora_32_V3.upload.erase_cmd=
 heltec_wifi_lora_32_V3.upload.extra_flags=
 heltec_wifi_lora_32_V3.upload.use_1200bps_touch=false
 heltec_wifi_lora_32_V3.upload.wait_for_upload_port=false
@@ -27264,7 +27264,6 @@ heltec_wifi_lora_32_V3.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_wifi_lora_32_V3.build.defines=-D{build.band} -DMCU_ESP32_S3 -DHELTEC_BOARD=30 -DWIFI_LORA_32_V3 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_wifi_lora_32_V3.menu.EraseFlash.none=Disabled
-heltec_wifi_lora_32_V3.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wifi_lora_32_V3.menu.EraseFlash.all=Enabled
 heltec_wifi_lora_32_V3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -27282,6 +27281,7 @@ heltec_wifi_lora_32_V4.upload.tool.network=esp_ota
 heltec_wifi_lora_32_V4.upload.maximum_size=1310720
 heltec_wifi_lora_32_V4.upload.maximum_data_size=327680
 heltec_wifi_lora_32_V4.upload.flags=
+heltec_wifi_lora_32_V4.upload.erase_cmd=
 heltec_wifi_lora_32_V4.upload.extra_flags=
 heltec_wifi_lora_32_V4.upload.use_1200bps_touch=false
 heltec_wifi_lora_32_V4.upload.wait_for_upload_port=false
@@ -27543,7 +27543,6 @@ heltec_wifi_lora_32_V4.menu.LORA_RX_LNA.1=Enabled
 heltec_wifi_lora_32_V4.menu.LORA_RX_LNA.1.build.LORA_RX_LNA=0
 
 heltec_wifi_lora_32_V4.menu.EraseFlash.none=Disabled
-heltec_wifi_lora_32_V4.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wifi_lora_32_V4.menu.EraseFlash.all=Enabled
 heltec_wifi_lora_32_V4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -27568,6 +27567,7 @@ heltec_wireless_stick_V3.upload.tool.network=esp_ota
 heltec_wireless_stick_V3.upload.maximum_size=3342336
 heltec_wireless_stick_V3.upload.maximum_data_size=327680
 heltec_wireless_stick_V3.upload.flags=
+heltec_wireless_stick_V3.upload.erase_cmd=
 heltec_wireless_stick_V3.upload.extra_flags=
 heltec_wireless_stick_V3.upload.use_1200bps_touch=false
 heltec_wireless_stick_V3.upload.wait_for_upload_port=false
@@ -27698,7 +27698,6 @@ heltec_wireless_stick_V3.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_wireless_stick_V3.build.defines=-D{build.band} -DMCU_ESP32_S3 -DHELTEC_BOARD=31 -DWIRELESS_STICK_V3 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_wireless_stick_V3.menu.EraseFlash.none=Disabled
-heltec_wireless_stick_V3.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_stick_V3.menu.EraseFlash.all=Enabled
 heltec_wireless_stick_V3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -27716,6 +27715,7 @@ heltec_wireless_stick_lite_V3.upload.tool.network=esp_ota
 heltec_wireless_stick_lite_V3.upload.maximum_size=3342336
 heltec_wireless_stick_lite_V3.upload.maximum_data_size=327680
 heltec_wireless_stick_lite_V3.upload.flags=
+heltec_wireless_stick_lite_V3.upload.erase_cmd=
 heltec_wireless_stick_lite_V3.upload.extra_flags=
 heltec_wireless_stick_lite_V3.upload.use_1200bps_touch=false
 heltec_wireless_stick_lite_V3.upload.wait_for_upload_port=false
@@ -27846,7 +27846,6 @@ heltec_wireless_stick_lite_V3.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_wireless_stick_lite_V3.build.defines=-D{build.band} -DMCU_ESP32_S3 -DHELTEC_BOARD=32 -DWIRELESS_STICK_LITE_V3 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_wireless_stick_lite_V3.menu.EraseFlash.none=Disabled
-heltec_wireless_stick_lite_V3.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_stick_lite_V3.menu.EraseFlash.all=Enabled
 heltec_wireless_stick_lite_V3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -27864,6 +27863,7 @@ heltec_wireless_shell_V3.upload.tool.network=esp_ota
 heltec_wireless_shell_V3.upload.maximum_size=3342336
 heltec_wireless_shell_V3.upload.maximum_data_size=327680
 heltec_wireless_shell_V3.upload.flags=
+heltec_wireless_shell_V3.upload.erase_cmd=
 heltec_wireless_shell_V3.upload.extra_flags=
 heltec_wireless_shell_V3.upload.use_1200bps_touch=false
 heltec_wireless_shell_V3.upload.wait_for_upload_port=false
@@ -27994,7 +27994,6 @@ heltec_wireless_shell_V3.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_wireless_shell_V3.build.defines=-D{build.band} -DMCU_ESP32_S3 -DHELTEC_BOARD=33 -DWIRELESS_SHELL_V3 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_wireless_shell_V3.menu.EraseFlash.none=Disabled
-heltec_wireless_shell_V3.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_shell_V3.menu.EraseFlash.all=Enabled
 heltec_wireless_shell_V3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -28012,6 +28011,7 @@ heltec_capsule_sensor_V3.upload.tool.network=esp_ota
 heltec_capsule_sensor_V3.upload.maximum_size=3342336
 heltec_capsule_sensor_V3.upload.maximum_data_size=327680
 heltec_capsule_sensor_V3.upload.flags=
+heltec_capsule_sensor_V3.upload.erase_cmd=
 heltec_capsule_sensor_V3.upload.extra_flags=
 heltec_capsule_sensor_V3.upload.use_1200bps_touch=false
 heltec_capsule_sensor_V3.upload.wait_for_upload_port=false
@@ -28152,7 +28152,6 @@ heltec_capsule_sensor_V3.menu.NetworkLogLevel.3.build.NetworkLogLevel=3
 heltec_capsule_sensor_V3.build.defines=-D{build.band} -DMCU_ESP32_S3 -DHELTEC_BOARD=50 -DCAPSULE_SENSOR_V3 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board} -DNLOG_LOCAL_LEVEL={build.NetworkLogLevel}
 
 heltec_capsule_sensor_V3.menu.EraseFlash.none=Disabled
-heltec_capsule_sensor_V3.menu.EraseFlash.none.upload.erase_cmd=
 heltec_capsule_sensor_V3.menu.EraseFlash.all=Enabled
 heltec_capsule_sensor_V3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -28170,6 +28169,7 @@ heltec_wireless_paper.upload.tool.network=esp_ota
 heltec_wireless_paper.upload.maximum_size=4026368
 heltec_wireless_paper.upload.maximum_data_size=327680
 heltec_wireless_paper.upload.flags=
+heltec_wireless_paper.upload.erase_cmd=
 heltec_wireless_paper.upload.extra_flags=
 heltec_wireless_paper.upload.use_1200bps_touch=false
 heltec_wireless_paper.upload.wait_for_upload_port=false
@@ -28300,7 +28300,6 @@ heltec_wireless_paper.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_wireless_paper.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=60 -DWIRELESS_PAPER -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_wireless_paper.menu.EraseFlash.none=Disabled
-heltec_wireless_paper.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_paper.menu.EraseFlash.all=Enabled
 heltec_wireless_paper.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -28318,6 +28317,7 @@ heltec_wireless_tracker.upload.tool.network=esp_ota
 heltec_wireless_tracker.upload.maximum_size=3342336
 heltec_wireless_tracker.upload.maximum_data_size=327680
 heltec_wireless_tracker.upload.flags=
+heltec_wireless_tracker.upload.erase_cmd=
 heltec_wireless_tracker.upload.extra_flags=
 heltec_wireless_tracker.upload.use_1200bps_touch=false
 heltec_wireless_tracker.upload.wait_for_upload_port=false
@@ -28475,7 +28475,6 @@ heltec_wireless_tracker.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_wireless_tracker.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=34 -DWIRELESS_TRACKER -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_wireless_tracker.menu.EraseFlash.none=Disabled
-heltec_wireless_tracker.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_tracker.menu.EraseFlash.all=Enabled
 heltec_wireless_tracker.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -28492,6 +28491,7 @@ heltec_wireless_tracker_v2.upload.tool.network=esp_ota
 heltec_wireless_tracker_v2.upload.maximum_size=3342336
 heltec_wireless_tracker_v2.upload.maximum_data_size=327680
 heltec_wireless_tracker_v2.upload.flags=
+heltec_wireless_tracker_v2.upload.erase_cmd=
 heltec_wireless_tracker_v2.upload.extra_flags=
 heltec_wireless_tracker_v2.upload.use_1200bps_touch=false
 heltec_wireless_tracker_v2.upload.wait_for_upload_port=false
@@ -28733,7 +28733,6 @@ heltec_wireless_tracker_v2.menu.SLOW_CLK_TPYE.1=External 32K
 heltec_wireless_tracker_v2.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 
 heltec_wireless_tracker_v2.menu.EraseFlash.none=Disabled
-heltec_wireless_tracker_v2.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_tracker_v2.menu.EraseFlash.all=Enabled
 heltec_wireless_tracker_v2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -28758,6 +28757,7 @@ heltec_wireless_mini_shell.upload.tool.network=esp_ota
 heltec_wireless_mini_shell.upload.maximum_size=1310720
 heltec_wireless_mini_shell.upload.maximum_data_size=327680
 heltec_wireless_mini_shell.upload.flags=
+heltec_wireless_mini_shell.upload.erase_cmd=
 heltec_wireless_mini_shell.upload.extra_flags=
 heltec_wireless_mini_shell.upload.use_1200bps_touch=false
 heltec_wireless_mini_shell.upload.wait_for_upload_port=false
@@ -28863,7 +28863,6 @@ heltec_wireless_mini_shell.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE
 
 heltec_wireless_mini_shell.build.defines=-D{build.band}  -DMCU_ESP32_C3 -DHELTEC_BOARD=70 -DWIRELESS_MINI_SHELL -DSLOW_CLK_TPYE=0 -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 heltec_wireless_mini_shell.menu.EraseFlash.none=Disabled
-heltec_wireless_mini_shell.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_mini_shell.menu.EraseFlash.all=Enabled
 heltec_wireless_mini_shell.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -28881,6 +28880,7 @@ heltec_wireless_stick.upload.tool.network=esp_ota
 heltec_wireless_stick.upload.maximum_size=3342336
 heltec_wireless_stick.upload.maximum_data_size=327680
 heltec_wireless_stick.upload.flags=
+heltec_wireless_stick.upload.erase_cmd=
 heltec_wireless_stick.upload.extra_flags=
 
 heltec_wireless_stick.serial.disableDTR=true
@@ -28979,7 +28979,6 @@ heltec_wireless_stick.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
 heltec_wireless_stick.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
 
 heltec_wireless_stick.menu.EraseFlash.none=Disabled
-heltec_wireless_stick.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_stick.menu.EraseFlash.all=Enabled
 heltec_wireless_stick.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -28997,6 +28996,7 @@ heltec_wireless_stick_lite.upload.tool.network=esp_ota
 heltec_wireless_stick_lite.upload.maximum_size=1310720
 heltec_wireless_stick_lite.upload.maximum_data_size=327680
 heltec_wireless_stick_lite.upload.flags=
+heltec_wireless_stick_lite.upload.erase_cmd=
 heltec_wireless_stick_lite.upload.extra_flags=
 
 heltec_wireless_stick_lite.serial.disableDTR=true
@@ -29095,7 +29095,6 @@ heltec_wireless_stick_lite.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
 heltec_wireless_stick_lite.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
 
 heltec_wireless_stick_lite.menu.EraseFlash.none=Disabled
-heltec_wireless_stick_lite.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_stick_lite.menu.EraseFlash.all=Enabled
 heltec_wireless_stick_lite.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -29114,6 +29113,7 @@ heltec_wireless_bridge.upload.maximum_size=3342336
 heltec_wireless_bridge.upload.maximum_data_size=327680
 heltec_wireless_bridge.upload.wait_for_upload_port=true
 heltec_wireless_bridge.upload.flags=
+heltec_wireless_bridge.upload.erase_cmd=
 heltec_wireless_bridge.upload.extra_flags=
 
 heltec_wireless_bridge.serial.disableDTR=true
@@ -29222,7 +29222,6 @@ heltec_wireless_bridge.menu.LORAWAN_PREAMBLE_LENGTH.1=16(For M00 and M00L)
 heltec_wireless_bridge.menu.LORAWAN_PREAMBLE_LENGTH.1.build.LORAWAN_PREAMBLE_LENGTH=16
 
 heltec_wireless_bridge.menu.EraseFlash.none=Disabled
-heltec_wireless_bridge.menu.EraseFlash.none.upload.erase_cmd=
 heltec_wireless_bridge.menu.EraseFlash.all=Enabled
 heltec_wireless_bridge.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -29240,6 +29239,7 @@ heltec_ht_de01.upload.tool.network=esp_ota
 heltec_ht_de01.upload.maximum_size=4026368
 heltec_ht_de01.upload.maximum_data_size=327680
 heltec_ht_de01.upload.flags=
+heltec_ht_de01.upload.erase_cmd=
 heltec_ht_de01.upload.extra_flags=
 heltec_ht_de01.upload.use_1200bps_touch=false
 heltec_ht_de01.upload.wait_for_upload_port=false
@@ -29334,7 +29334,6 @@ heltec_ht_de01.menu.einksize.3.build.einksize=290;
 heltec_ht_de01.build.defines=   -DEINK={build.einksize}   -D{build.board}
 
 heltec_ht_de01.menu.EraseFlash.none=Disabled
-heltec_ht_de01.menu.EraseFlash.none.upload.erase_cmd=
 heltec_ht_de01.menu.EraseFlash.all=Enabled
 heltec_ht_de01.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -29352,6 +29351,7 @@ heltec_vision_master_e290.upload.tool.network=esp_ota
 heltec_vision_master_e290.upload.maximum_size=3342336
 heltec_vision_master_e290.upload.maximum_data_size=327680
 heltec_vision_master_e290.upload.flags=
+heltec_vision_master_e290.upload.erase_cmd=
 heltec_vision_master_e290.upload.extra_flags=
 heltec_vision_master_e290.upload.use_1200bps_touch=false
 heltec_vision_master_e290.upload.wait_for_upload_port=false
@@ -29509,7 +29509,6 @@ heltec_vision_master_e290.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_vision_master_e290.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=37 -DHELTEC_VISION_MASTER_E290 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_vision_master_e290.menu.EraseFlash.none=Disabled
-heltec_vision_master_e290.menu.EraseFlash.none.upload.erase_cmd=
 heltec_vision_master_e290.menu.EraseFlash.all=Enabled
 heltec_vision_master_e290.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -29527,6 +29526,7 @@ heltec_vision_master_t190.upload.tool.network=esp_ota
 heltec_vision_master_t190.upload.maximum_size=3342336
 heltec_vision_master_t190.upload.maximum_data_size=327680
 heltec_vision_master_t190.upload.flags=
+heltec_vision_master_t190.upload.erase_cmd=
 heltec_vision_master_t190.upload.extra_flags=
 heltec_vision_master_t190.upload.use_1200bps_touch=false
 heltec_vision_master_t190.upload.wait_for_upload_port=false
@@ -29684,7 +29684,6 @@ heltec_vision_master_t190.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_vision_master_t190.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=38 -DHELTEC_VISION_MASTER_T190 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_vision_master_t190.menu.EraseFlash.none=Disabled
-heltec_vision_master_t190.menu.EraseFlash.none.upload.erase_cmd=
 heltec_vision_master_t190.menu.EraseFlash.all=Enabled
 heltec_vision_master_t190.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -29702,6 +29701,7 @@ heltec_vision_master_e_213.upload.tool.network=esp_ota
 heltec_vision_master_e_213.upload.maximum_size=3342336
 heltec_vision_master_e_213.upload.maximum_data_size=327680
 heltec_vision_master_e_213.upload.flags=
+heltec_vision_master_e_213.upload.erase_cmd=
 heltec_vision_master_e_213.upload.extra_flags=
 heltec_vision_master_e_213.upload.use_1200bps_touch=false
 heltec_vision_master_e_213.upload.wait_for_upload_port=false
@@ -29859,7 +29859,6 @@ heltec_vision_master_e_213.menu.SLOW_CLK_TPYE.1.build.SLOW_CLK_TPYE=1
 heltec_vision_master_e_213.build.defines=-D{build.band}  -DMCU_ESP32_S3 -DHELTEC_BOARD=36 -DHELTEC_VISION_MASTER_E_213 -DSLOW_CLK_TPYE={build.SLOW_CLK_TPYE} -DRADIO_CHIP_SX1262  -DLoRaWAN_DEBUG_LEVEL={build.LoRaWanDebugLevel} -DACTIVE_REGION=LORAMAC_{build.band} -DLORAWAN_PREAMBLE_LENGTH={build.LORAWAN_PREAMBLE_LENGTH} -DLORAWAN_DEVEUI_AUTO={build.LORAWAN_DEVEUI_AUTO} -D{build.board}
 
 heltec_vision_master_e_213.menu.EraseFlash.none=Disabled
-heltec_vision_master_e_213.menu.EraseFlash.none.upload.erase_cmd=
 heltec_vision_master_e_213.menu.EraseFlash.all=Enabled
 heltec_vision_master_e_213.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -29877,6 +29876,7 @@ espectro32.upload.tool.network=esp_ota
 espectro32.upload.maximum_size=1310720
 espectro32.upload.maximum_data_size=327680
 espectro32.upload.flags=
+espectro32.upload.erase_cmd=
 espectro32.upload.extra_flags=
 
 espectro32.serial.disableDTR=true
@@ -29943,7 +29943,6 @@ espectro32.menu.DebugLevel.verbose=Verbose
 espectro32.menu.DebugLevel.verbose.build.code_debug=5
 
 espectro32.menu.EraseFlash.none=Disabled
-espectro32.menu.EraseFlash.none.upload.erase_cmd=
 espectro32.menu.EraseFlash.all=Enabled
 espectro32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -29961,6 +29960,7 @@ CoreESP32.upload.tool.network=esp_ota
 CoreESP32.upload.maximum_size=1310720
 CoreESP32.upload.maximum_data_size=327680
 CoreESP32.upload.flags=
+CoreESP32.upload.erase_cmd=
 CoreESP32.upload.extra_flags=
 
 CoreESP32.serial.disableDTR=false
@@ -30035,7 +30035,6 @@ CoreESP32.menu.DebugLevel.verbose=Verbose
 CoreESP32.menu.DebugLevel.verbose.build.code_debug=5
 
 CoreESP32.menu.EraseFlash.none=Disabled
-CoreESP32.menu.EraseFlash.none.upload.erase_cmd=
 CoreESP32.menu.EraseFlash.all=Enabled
 CoreESP32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30053,6 +30052,7 @@ alksesp32.upload.tool.network=esp_ota
 alksesp32.upload.maximum_size=1310720
 alksesp32.upload.maximum_data_size=327680
 alksesp32.upload.flags=
+alksesp32.upload.erase_cmd=
 alksesp32.upload.extra_flags=
 
 alksesp32.serial.disableDTR=true
@@ -30173,7 +30173,6 @@ alksesp32.menu.DebugLevel.verbose=Verbose
 alksesp32.menu.DebugLevel.verbose.build.code_debug=5
 
 alksesp32.menu.EraseFlash.none=Disabled
-alksesp32.menu.EraseFlash.none.upload.erase_cmd=
 alksesp32.menu.EraseFlash.all=Enabled
 alksesp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30191,6 +30190,7 @@ wipy3.upload.tool.network=esp_ota
 wipy3.upload.maximum_size=1310720
 wipy3.upload.maximum_data_size=294912
 wipy3.upload.flags=
+wipy3.upload.erase_cmd=
 wipy3.upload.extra_flags=
 
 wipy3.serial.disableDTR=true
@@ -30245,7 +30245,6 @@ wipy3.menu.DebugLevel.verbose=Verbose
 wipy3.menu.DebugLevel.verbose.build.code_debug=5
 
 wipy3.menu.EraseFlash.none=Disabled
-wipy3.menu.EraseFlash.none.upload.erase_cmd=
 wipy3.menu.EraseFlash.all=Enabled
 wipy3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30263,6 +30262,7 @@ wt32-eth01.upload.tool.network=esp_ota
 wt32-eth01.upload.maximum_size=8388608
 wt32-eth01.upload.maximum_data_size=327680
 wt32-eth01.upload.flags=
+wt32-eth01.upload.erase_cmd=
 wt32-eth01.upload.extra_flags=
 
 wt32-eth01.serial.disableDTR=true
@@ -30351,7 +30351,6 @@ wt32-eth01.menu.DebugLevel.verbose=Verbose
 wt32-eth01.menu.DebugLevel.verbose.build.code_debug=5
 
 wt32-eth01.menu.EraseFlash.none=Disabled
-wt32-eth01.menu.EraseFlash.none.upload.erase_cmd=
 wt32-eth01.menu.EraseFlash.all=Enabled
 wt32-eth01.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30371,6 +30370,7 @@ wt32-sc01-plus.upload.tool.network=esp_ota
 wt32-sc01-plus.upload.maximum_size=1310720
 wt32-sc01-plus.upload.maximum_data_size=327680
 wt32-sc01-plus.upload.flags=
+wt32-sc01-plus.upload.erase_cmd=
 wt32-sc01-plus.upload.extra_flags=
 wt32-sc01-plus.upload.use_1200bps_touch=false
 wt32-sc01-plus.upload.wait_for_upload_port=false
@@ -30503,7 +30503,6 @@ wt32-sc01-plus.menu.DebugLevel.verbose=Verbose
 wt32-sc01-plus.menu.DebugLevel.verbose.build.code_debug=5
 
 wt32-sc01-plus.menu.EraseFlash.none=Disabled
-wt32-sc01-plus.menu.EraseFlash.none.upload.erase_cmd=
 wt32-sc01-plus.menu.EraseFlash.all=Enabled
 wt32-sc01-plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30521,6 +30520,7 @@ bpi-bit.upload.tool.network=esp_ota
 bpi-bit.upload.maximum_size=1310720
 bpi-bit.upload.maximum_data_size=294912
 bpi-bit.upload.flags=
+bpi-bit.upload.erase_cmd=
 bpi-bit.upload.extra_flags=
 
 bpi-bit.serial.disableDTR=true
@@ -30574,7 +30574,6 @@ bpi-bit.menu.DebugLevel.verbose=Verbose
 bpi-bit.menu.DebugLevel.verbose.build.code_debug=5
 
 bpi-bit.menu.EraseFlash.none=Disabled
-bpi-bit.menu.EraseFlash.none.upload.erase_cmd=
 bpi-bit.menu.EraseFlash.all=Enabled
 bpi-bit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30594,6 +30593,7 @@ bpi_leaf_s3.upload.tool.network=esp_ota
 bpi_leaf_s3.upload.maximum_size=1310720
 bpi_leaf_s3.upload.maximum_data_size=327680
 bpi_leaf_s3.upload.flags=
+bpi_leaf_s3.upload.erase_cmd=
 bpi_leaf_s3.upload.extra_flags=
 bpi_leaf_s3.upload.use_1200bps_touch=false
 bpi_leaf_s3.upload.wait_for_upload_port=false
@@ -30788,7 +30788,6 @@ bpi_leaf_s3.menu.DebugLevel.verbose=Verbose
 bpi_leaf_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 bpi_leaf_s3.menu.EraseFlash.none=Disabled
-bpi_leaf_s3.menu.EraseFlash.none.upload.erase_cmd=
 bpi_leaf_s3.menu.EraseFlash.all=Enabled
 bpi_leaf_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30806,6 +30805,7 @@ wesp32.upload.tool.network=esp_ota
 wesp32.upload.maximum_size=1310720
 wesp32.upload.maximum_data_size=327680
 wesp32.upload.flags=
+wesp32.upload.erase_cmd=
 wesp32.upload.extra_flags=
 
 wesp32.serial.disableDTR=true
@@ -30877,7 +30877,6 @@ wesp32.menu.DebugLevel.verbose=Verbose
 wesp32.menu.DebugLevel.verbose.build.code_debug=5
 
 wesp32.menu.EraseFlash.none=Disabled
-wesp32.menu.EraseFlash.none.upload.erase_cmd=
 wesp32.menu.EraseFlash.all=Enabled
 wesp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30895,6 +30894,7 @@ mant1s.upload.tool.network=esp_ota
 mant1s.upload.maximum_size=1310720
 mant1s.upload.maximum_data_size=2424832
 mant1s.upload.flags=
+mant1s.upload.erase_cmd=
 mant1s.upload.extra_flags=
 
 mant1s.serial.disableDTR=true
@@ -30967,7 +30967,6 @@ mant1s.menu.DebugLevel.verbose=Verbose
 mant1s.menu.DebugLevel.verbose.build.code_debug=5
 
 mant1s.menu.EraseFlash.none=Disabled
-mant1s.menu.EraseFlash.none.upload.erase_cmd=
 mant1s.menu.EraseFlash.all=Enabled
 mant1s.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -30985,6 +30984,7 @@ t-beam.upload.tool.network=esp_ota
 t-beam.upload.maximum_size=1310720
 t-beam.upload.maximum_data_size=327680
 t-beam.upload.flags=
+t-beam.upload.erase_cmd=
 t-beam.upload.extra_flags=
 
 t-beam.serial.disableDTR=true
@@ -31056,7 +31056,6 @@ t-beam.menu.DebugLevel.verbose=Verbose
 t-beam.menu.DebugLevel.verbose.build.code_debug=5
 
 t-beam.menu.EraseFlash.none=Disabled
-t-beam.menu.EraseFlash.none.upload.erase_cmd=
 t-beam.menu.EraseFlash.all=Enabled
 t-beam.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31074,6 +31073,7 @@ d-duino-32.upload.tool.network=esp_ota
 d-duino-32.upload.maximum_size=1310720
 d-duino-32.upload.maximum_data_size=327680
 d-duino-32.upload.flags=
+d-duino-32.upload.erase_cmd=
 d-duino-32.upload.extra_flags=
 
 d-duino-32.serial.disableDTR=true
@@ -31142,7 +31142,6 @@ d-duino-32.menu.DebugLevel.verbose=Verbose
 d-duino-32.menu.DebugLevel.verbose.build.code_debug=5
 
 d-duino-32.menu.EraseFlash.none=Disabled
-d-duino-32.menu.EraseFlash.none.upload.erase_cmd=
 d-duino-32.menu.EraseFlash.all=Enabled
 d-duino-32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31160,6 +31159,7 @@ lopy.upload.tool.network=esp_ota
 lopy.upload.maximum_size=1310720
 lopy.upload.maximum_data_size=327680
 lopy.upload.flags=
+lopy.upload.erase_cmd=
 lopy.upload.extra_flags=
 
 lopy.serial.disableDTR=true
@@ -31213,7 +31213,6 @@ lopy.menu.DebugLevel.verbose=Verbose
 lopy.menu.DebugLevel.verbose.build.code_debug=5
 
 lopy.menu.EraseFlash.none=Disabled
-lopy.menu.EraseFlash.none.upload.erase_cmd=
 lopy.menu.EraseFlash.all=Enabled
 lopy.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31231,6 +31230,7 @@ lopy4.upload.tool.network=esp_ota
 lopy4.upload.maximum_size=1310720
 lopy4.upload.maximum_data_size=327680
 lopy4.upload.flags=
+lopy4.upload.erase_cmd=
 lopy4.upload.extra_flags=
 
 lopy4.serial.disableDTR=true
@@ -31291,7 +31291,6 @@ lopy4.menu.DebugLevel.verbose=Verbose
 lopy4.menu.DebugLevel.verbose.build.code_debug=5
 
 lopy4.menu.EraseFlash.none=Disabled
-lopy4.menu.EraseFlash.none.upload.erase_cmd=
 lopy4.menu.EraseFlash.all=Enabled
 lopy4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31309,6 +31308,7 @@ oroca_edubot.upload.tool.network=esp_ota
 oroca_edubot.upload.maximum_size=3145728
 oroca_edubot.upload.maximum_data_size=327680
 oroca_edubot.upload.flags=
+oroca_edubot.upload.erase_cmd=
 oroca_edubot.upload.extra_flags=
 
 oroca_edubot.serial.disableDTR=true
@@ -31370,7 +31370,6 @@ oroca_edubot.menu.DebugLevel.verbose=Verbose
 oroca_edubot.menu.DebugLevel.verbose.build.code_debug=5
 
 oroca_edubot.menu.EraseFlash.none=Disabled
-oroca_edubot.menu.EraseFlash.none.upload.erase_cmd=
 oroca_edubot.menu.EraseFlash.all=Enabled
 oroca_edubot.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31385,6 +31384,7 @@ fm-devkit.upload.tool.network=esp_ota
 fm-devkit.upload.maximum_size=1310720
 fm-devkit.upload.maximum_data_size=327680
 fm-devkit.upload.flags=
+fm-devkit.upload.erase_cmd=
 fm-devkit.upload.extra_flags=
 
 fm-devkit.serial.disableDTR=true
@@ -31435,7 +31435,6 @@ fm-devkit.menu.DebugLevel.verbose=Verbose
 fm-devkit.menu.DebugLevel.verbose.build.code_debug=5
 
 fm-devkit.menu.EraseFlash.none=Disabled
-fm-devkit.menu.EraseFlash.none.upload.erase_cmd=
 fm-devkit.menu.EraseFlash.all=Enabled
 fm-devkit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31454,6 +31453,7 @@ fri3d_2024_esp32s3.upload.tool.network=esp_ota
 fri3d_2024_esp32s3.upload.maximum_size=1310720
 fri3d_2024_esp32s3.upload.maximum_data_size=327680
 fri3d_2024_esp32s3.upload.flags=
+fri3d_2024_esp32s3.upload.erase_cmd=
 fri3d_2024_esp32s3.upload.extra_flags=
 fri3d_2024_esp32s3.upload.use_1200bps_touch=false
 fri3d_2024_esp32s3.upload.wait_for_upload_port=false
@@ -31652,7 +31652,6 @@ fri3d_2024_esp32s3.menu.DebugLevel.verbose=Verbose
 fri3d_2024_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 fri3d_2024_esp32s3.menu.EraseFlash.none=Disabled
-fri3d_2024_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 fri3d_2024_esp32s3.menu.EraseFlash.all=Enabled
 fri3d_2024_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31670,6 +31669,7 @@ frogboard.upload.tool.network=esp_ota
 frogboard.upload.maximum_size=1310720
 frogboard.upload.maximum_data_size=327680
 frogboard.upload.flags=
+frogboard.upload.erase_cmd=
 frogboard.upload.extra_flags=
 
 frogboard.serial.disableDTR=true
@@ -31752,7 +31752,6 @@ frogboard.menu.DebugLevel.verbose=Verbose
 frogboard.menu.DebugLevel.verbose.build.code_debug=5
 
 frogboard.menu.EraseFlash.none=Disabled
-frogboard.menu.EraseFlash.none.upload.erase_cmd=
 frogboard.menu.EraseFlash.all=Enabled
 frogboard.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31770,6 +31769,7 @@ esp32cam.upload.tool.network=esp_ota
 esp32cam.upload.maximum_size=3145728
 esp32cam.upload.maximum_data_size=327680
 esp32cam.upload.flags=
+esp32cam.upload.erase_cmd=
 esp32cam.upload.extra_flags=
 esp32cam.upload.speed=460800
 
@@ -31857,7 +31857,6 @@ esp32cam.menu.DebugLevel.verbose=Verbose
 esp32cam.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32cam.menu.EraseFlash.none=Disabled
-esp32cam.menu.EraseFlash.none.upload.erase_cmd=
 esp32cam.menu.EraseFlash.all=Enabled
 esp32cam.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31876,6 +31875,7 @@ twatch.upload.maximum_size=6553600
 twatch.upload.maximum_data_size=4521984
 twatch.upload.wait_for_upload_port=true
 twatch.upload.flags=
+twatch.upload.erase_cmd=
 twatch.upload.extra_flags=
 
 twatch.serial.disableDTR=true
@@ -31953,7 +31953,6 @@ twatch.menu.DebugLevel.verbose=Verbose
 twatch.menu.DebugLevel.verbose.build.code_debug=5
 
 twatch.menu.EraseFlash.none=Disabled
-twatch.menu.EraseFlash.none.upload.erase_cmd=
 twatch.menu.EraseFlash.all=Enabled
 twatch.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -31971,6 +31970,7 @@ d1_mini32.upload.tool.network=esp_ota
 d1_mini32.upload.maximum_size=1310720
 d1_mini32.upload.maximum_data_size=327680
 d1_mini32.upload.flags=
+d1_mini32.upload.erase_cmd=
 d1_mini32.upload.extra_flags=
 
 d1_mini32.serial.disableDTR=true
@@ -32051,7 +32051,6 @@ d1_mini32.menu.DebugLevel.verbose=Verbose
 d1_mini32.menu.DebugLevel.verbose.build.code_debug=5
 
 d1_mini32.menu.EraseFlash.none=Disabled
-d1_mini32.menu.EraseFlash.none.upload.erase_cmd=
 d1_mini32.menu.EraseFlash.all=Enabled
 d1_mini32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32069,6 +32068,7 @@ d1_uno32.upload.tool.network=esp_ota
 d1_uno32.upload.maximum_size=1310720
 d1_uno32.upload.maximum_data_size=327680
 d1_uno32.upload.flags=
+d1_uno32.upload.erase_cmd=
 d1_uno32.upload.extra_flags=
 
 d1_uno32.serial.disableDTR=true
@@ -32149,7 +32149,6 @@ d1_uno32.menu.DebugLevel.verbose=Verbose
 d1_uno32.menu.DebugLevel.verbose.build.code_debug=5
 
 d1_uno32.menu.EraseFlash.none=Disabled
-d1_uno32.menu.EraseFlash.none.upload.erase_cmd=
 d1_uno32.menu.EraseFlash.all=Enabled
 d1_uno32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32167,6 +32166,7 @@ gpy.upload.tool.network=esp_ota
 gpy.upload.maximum_size=1310720
 gpy.upload.maximum_data_size=327680
 gpy.upload.flags=
+gpy.upload.erase_cmd=
 gpy.upload.extra_flags=
 
 gpy.serial.disableDTR=true
@@ -32220,7 +32220,6 @@ gpy.menu.DebugLevel.verbose=Verbose
 gpy.menu.DebugLevel.verbose.build.code_debug=5
 
 gpy.menu.EraseFlash.none=Disabled
-gpy.menu.EraseFlash.none.upload.erase_cmd=
 gpy.menu.EraseFlash.all=Enabled
 gpy.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32238,6 +32237,7 @@ vintlabs-devkit-v1.upload.tool.network=esp_ota
 vintlabs-devkit-v1.upload.maximum_size=1310720
 vintlabs-devkit-v1.upload.maximum_data_size=327680
 vintlabs-devkit-v1.upload.flags=
+vintlabs-devkit-v1.upload.erase_cmd=
 vintlabs-devkit-v1.upload.extra_flags=
 
 vintlabs-devkit-v1.serial.disableDTR=true
@@ -32337,7 +32337,6 @@ vintlabs-devkit-v1.menu.DebugLevel.verbose=Verbose
 vintlabs-devkit-v1.menu.DebugLevel.verbose.build.code_debug=5
 
 vintlabs-devkit-v1.menu.EraseFlash.none=Disabled
-vintlabs-devkit-v1.menu.EraseFlash.none.upload.erase_cmd=
 vintlabs-devkit-v1.menu.EraseFlash.all=Enabled
 vintlabs-devkit-v1.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32355,6 +32354,7 @@ honeylemon.upload.tool.network=esp_ota
 honeylemon.upload.maximum_size=1310720
 honeylemon.upload.maximum_data_size=327680
 honeylemon.upload.flags=
+honeylemon.upload.erase_cmd=
 honeylemon.upload.extra_flags=
 
 honeylemon.serial.disableDTR=true
@@ -32409,7 +32409,6 @@ honeylemon.menu.DebugLevel.verbose=Verbose
 honeylemon.menu.DebugLevel.verbose.build.code_debug=5
 
 honeylemon.menu.EraseFlash.none=Disabled
-honeylemon.menu.EraseFlash.none.upload.erase_cmd=
 honeylemon.menu.EraseFlash.all=Enabled
 honeylemon.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32427,6 +32426,7 @@ mgbot-iotik32a.upload.tool.network=esp_ota
 mgbot-iotik32a.upload.maximum_size=1310720
 mgbot-iotik32a.upload.maximum_data_size=327680
 mgbot-iotik32a.upload.flags=
+mgbot-iotik32a.upload.erase_cmd=
 mgbot-iotik32a.upload.extra_flags=
 
 mgbot-iotik32a.serial.disableDTR=true
@@ -32556,7 +32556,6 @@ mgbot-iotik32a.menu.DebugLevel.verbose=Verbose
 mgbot-iotik32a.menu.DebugLevel.verbose.build.code_debug=5
 
 mgbot-iotik32a.menu.EraseFlash.none=Disabled
-mgbot-iotik32a.menu.EraseFlash.none.upload.erase_cmd=
 mgbot-iotik32a.menu.EraseFlash.all=Enabled
 mgbot-iotik32a.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32574,6 +32573,7 @@ mgbot-iotik32b.upload.tool.network=esp_ota
 mgbot-iotik32b.upload.maximum_size=1310720
 mgbot-iotik32b.upload.maximum_data_size=327680
 mgbot-iotik32b.upload.flags=
+mgbot-iotik32b.upload.erase_cmd=
 mgbot-iotik32b.upload.extra_flags=
 
 mgbot-iotik32b.serial.disableDTR=true
@@ -32703,7 +32703,6 @@ mgbot-iotik32b.menu.DebugLevel.verbose=Verbose
 mgbot-iotik32b.menu.DebugLevel.verbose.build.code_debug=5
 
 mgbot-iotik32b.menu.EraseFlash.none=Disabled
-mgbot-iotik32b.menu.EraseFlash.none.upload.erase_cmd=
 mgbot-iotik32b.menu.EraseFlash.all=Enabled
 mgbot-iotik32b.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32721,6 +32720,7 @@ piranha_esp-32.upload.tool.network=esp_ota
 piranha_esp-32.upload.maximum_size=1310720
 piranha_esp-32.upload.maximum_data_size=327680
 piranha_esp-32.upload.flags=
+piranha_esp-32.upload.erase_cmd=
 piranha_esp-32.upload.extra_flags=
 
 piranha_esp-32.serial.disableDTR=true
@@ -32784,7 +32784,6 @@ piranha_esp-32.menu.DebugLevel.verbose=Verbose
 piranha_esp-32.menu.DebugLevel.verbose.build.code_debug=5
 
 piranha_esp-32.menu.EraseFlash.none=Disabled
-piranha_esp-32.menu.EraseFlash.none.upload.erase_cmd=
 piranha_esp-32.menu.EraseFlash.all=Enabled
 piranha_esp-32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32802,6 +32801,7 @@ metro_esp-32.upload.tool.network=esp_ota
 metro_esp-32.upload.maximum_size=1310720
 metro_esp-32.upload.maximum_data_size=327680
 metro_esp-32.upload.flags=
+metro_esp-32.upload.erase_cmd=
 metro_esp-32.upload.extra_flags=
 
 metro_esp-32.serial.disableDTR=true
@@ -32865,7 +32865,6 @@ metro_esp-32.menu.DebugLevel.verbose=Verbose
 metro_esp-32.menu.DebugLevel.verbose.build.code_debug=5
 
 metro_esp-32.menu.EraseFlash.none=Disabled
-metro_esp-32.menu.EraseFlash.none.upload.erase_cmd=
 metro_esp-32.menu.EraseFlash.all=Enabled
 metro_esp-32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32883,6 +32882,7 @@ sensesiot_weizen.upload.tool.network=esp_ota
 sensesiot_weizen.upload.maximum_size=1310720
 sensesiot_weizen.upload.maximum_data_size=327680
 sensesiot_weizen.upload.flags=
+sensesiot_weizen.upload.erase_cmd=
 sensesiot_weizen.upload.extra_flags=
 
 sensesiot_weizen.serial.disableDTR=true
@@ -32937,7 +32937,6 @@ sensesiot_weizen.menu.DebugLevel.verbose=Verbose
 sensesiot_weizen.menu.DebugLevel.verbose.build.code_debug=5
 
 sensesiot_weizen.menu.EraseFlash.none=Disabled
-sensesiot_weizen.menu.EraseFlash.none.upload.erase_cmd=
 sensesiot_weizen.menu.EraseFlash.all=Enabled
 sensesiot_weizen.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -32956,6 +32955,7 @@ kits-edu.upload.maximum_size=1310720
 kits-edu.upload.maximum_data_size=327680
 kits-edu.upload.wait_for_upload_port=true
 kits-edu.upload.flags=
+kits-edu.upload.erase_cmd=
 kits-edu.upload.extra_flags=
 
 kits-edu.serial.disableDTR=true
@@ -33015,7 +33015,6 @@ kits-edu.menu.DebugLevel.verbose=Verbose
 kits-edu.menu.DebugLevel.verbose.build.code_debug=5
 
 kits-edu.menu.EraseFlash.none=Disabled
-kits-edu.menu.EraseFlash.none.upload.erase_cmd=
 kits-edu.menu.EraseFlash.all=Enabled
 kits-edu.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33032,6 +33031,7 @@ mPython.upload.tool.network=esp_ota
 mPython.upload.maximum_size=1310720
 mPython.upload.maximum_data_size=327680
 mPython.upload.flags=
+mPython.upload.erase_cmd=
 mPython.upload.extra_flags=
 
 mPython.serial.disableDTR=true
@@ -33132,7 +33132,6 @@ mPython.menu.DebugLevel.verbose=Verbose
 mPython.menu.DebugLevel.verbose.build.code_debug=5
 
 mPython.menu.EraseFlash.none=Disabled
-mPython.menu.EraseFlash.none.upload.erase_cmd=
 mPython.menu.EraseFlash.all=Enabled
 mPython.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33151,6 +33150,7 @@ OpenKB.upload.maximum_size=1310720
 OpenKB.upload.maximum_data_size=327680
 OpenKB.upload.wait_for_upload_port=true
 OpenKB.upload.flags=
+OpenKB.upload.erase_cmd=
 OpenKB.upload.extra_flags=
 
 OpenKB.serial.disableDTR=true
@@ -33205,7 +33205,6 @@ OpenKB.menu.DebugLevel.verbose=Verbose
 OpenKB.menu.DebugLevel.verbose.build.code_debug=5
 
 OpenKB.menu.EraseFlash.none=Disabled
-OpenKB.menu.EraseFlash.none.upload.erase_cmd=
 OpenKB.menu.EraseFlash.all=Enabled
 OpenKB.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33224,6 +33223,7 @@ wifiduino32.upload.maximum_size=1310720
 wifiduino32.upload.maximum_data_size=327680
 wifiduino32.upload.wait_for_upload_port=true
 wifiduino32.upload.flags=
+wifiduino32.upload.erase_cmd=
 wifiduino32.upload.extra_flags=
 
 wifiduino32.serial.disableDTR=true
@@ -33287,7 +33287,6 @@ wifiduino32.menu.DebugLevel.verbose=Verbose
 wifiduino32.menu.DebugLevel.verbose.build.code_debug=5
 
 wifiduino32.menu.EraseFlash.none=Disabled
-wifiduino32.menu.EraseFlash.none.upload.erase_cmd=
 wifiduino32.menu.EraseFlash.all=Enabled
 wifiduino32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33305,6 +33304,7 @@ wifiduino32c3.upload.tool.network=esp_ota
 wifiduino32c3.upload.maximum_size=1310720
 wifiduino32c3.upload.maximum_data_size=327680
 wifiduino32c3.upload.flags=
+wifiduino32c3.upload.erase_cmd=
 wifiduino32c3.upload.extra_flags=
 wifiduino32c3.upload.use_1200bps_touch=false
 wifiduino32c3.upload.wait_for_upload_port=false
@@ -33438,7 +33438,6 @@ wifiduino32c3.menu.DebugLevel.verbose=Verbose
 wifiduino32c3.menu.DebugLevel.verbose.build.code_debug=5
 
 wifiduino32c3.menu.EraseFlash.none=Disabled
-wifiduino32c3.menu.EraseFlash.none.upload.erase_cmd=
 wifiduino32c3.menu.EraseFlash.all=Enabled
 wifiduino32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33456,6 +33455,7 @@ wifiduino32s3.upload.tool.network=esp_ota
 wifiduino32s3.upload.maximum_size=1310720
 wifiduino32s3.upload.maximum_data_size=327680
 wifiduino32s3.upload.flags=
+wifiduino32s3.upload.erase_cmd=
 wifiduino32s3.upload.extra_flags=
 wifiduino32s3.upload.use_1200bps_touch=false
 wifiduino32s3.upload.wait_for_upload_port=false
@@ -33648,7 +33648,6 @@ wifiduino32s3.menu.DebugLevel.verbose=Verbose
 wifiduino32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 wifiduino32s3.menu.EraseFlash.none=Disabled
-wifiduino32s3.menu.EraseFlash.none.upload.erase_cmd=
 wifiduino32s3.menu.EraseFlash.all=Enabled
 wifiduino32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33667,6 +33666,7 @@ imbrios-logsens-v1p1.upload.maximum_size=1310720
 imbrios-logsens-v1p1.upload.maximum_data_size=327680
 imbrios-logsens-v1p1.upload.wait_for_upload_port=true
 imbrios-logsens-v1p1.upload.flags=
+imbrios-logsens-v1p1.upload.erase_cmd=
 imbrios-logsens-v1p1.upload.extra_flags=
 
 imbrios-logsens-v1p1.serial.disableDTR=true
@@ -33747,7 +33747,6 @@ imbrios-logsens-v1p1.menu.DebugLevel.verbose=Verbose
 imbrios-logsens-v1p1.menu.DebugLevel.verbose.build.code_debug=5
 
 imbrios-logsens-v1p1.menu.EraseFlash.none=Disabled
-imbrios-logsens-v1p1.menu.EraseFlash.none.upload.erase_cmd=
 imbrios-logsens-v1p1.menu.EraseFlash.all=Enabled
 imbrios-logsens-v1p1.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33766,6 +33765,7 @@ healthypi4.upload.maximum_size=1310720
 healthypi4.upload.maximum_data_size=327680
 healthypi4.upload.wait_for_upload_port=true
 healthypi4.upload.flags=
+healthypi4.upload.erase_cmd=
 healthypi4.upload.extra_flags=
 
 healthypi4.serial.disableDTR=true
@@ -33829,7 +33829,6 @@ healthypi4.menu.DebugLevel.verbose=Verbose
 healthypi4.menu.DebugLevel.verbose.build.code_debug=5
 
 healthypi4.menu.EraseFlash.none=Disabled
-healthypi4.menu.EraseFlash.none.upload.erase_cmd=
 healthypi4.menu.EraseFlash.all=Enabled
 healthypi4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33848,6 +33847,7 @@ ET-Board.upload.maximum_size=1310720
 ET-Board.upload.maximum_data_size=327680
 ET-Board.upload.wait_for_upload_port=true
 ET-Board.upload.flags=
+ET-Board.upload.erase_cmd=
 ET-Board.upload.extra_flags=
 
 ET-Board.serial.disableDTR=true
@@ -33910,7 +33910,6 @@ ET-Board.menu.DebugLevel.verbose=Verbose
 ET-Board.menu.DebugLevel.verbose.build.code_debug=5
 
 ET-Board.menu.EraseFlash.none=Disabled
-ET-Board.menu.EraseFlash.none.upload.erase_cmd=
 ET-Board.menu.EraseFlash.all=Enabled
 ET-Board.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -33928,6 +33927,7 @@ ch_denky.upload.tool.network=esp_ota
 ch_denky.upload.maximum_size=1310720
 ch_denky.upload.maximum_data_size=327680
 ch_denky.upload.flags=
+ch_denky.upload.erase_cmd=
 ch_denky.upload.extra_flags=
 
 ch_denky.serial.disableDTR=true
@@ -34001,7 +34001,6 @@ ch_denky.menu.DebugLevel.verbose=Verbose
 ch_denky.menu.DebugLevel.verbose.build.code_debug=5
 
 ch_denky.menu.EraseFlash.none=Disabled
-ch_denky.menu.EraseFlash.none.upload.erase_cmd=
 ch_denky.menu.EraseFlash.all=Enabled
 ch_denky.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34019,6 +34018,7 @@ uPesy_wrover.upload.tool.network=esp_ota
 uPesy_wrover.upload.maximum_size=1310720
 uPesy_wrover.upload.maximum_data_size=327680
 uPesy_wrover.upload.flags=
+uPesy_wrover.upload.erase_cmd=
 uPesy_wrover.upload.extra_flags=
 
 uPesy_wrover.serial.disableDTR=true
@@ -34118,7 +34118,6 @@ uPesy_wrover.menu.DebugLevel.verbose=Verbose
 uPesy_wrover.menu.DebugLevel.verbose.build.code_debug=5
 
 uPesy_wrover.menu.EraseFlash.none=Disabled
-uPesy_wrover.menu.EraseFlash.none.upload.erase_cmd=
 uPesy_wrover.menu.EraseFlash.all=Enabled
 uPesy_wrover.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34136,6 +34135,7 @@ uPesy_wroom.upload.tool.network=esp_ota
 uPesy_wroom.upload.maximum_size=1310720
 uPesy_wroom.upload.maximum_data_size=327680
 uPesy_wroom.upload.flags=
+uPesy_wroom.upload.erase_cmd=
 uPesy_wroom.upload.extra_flags=
 
 uPesy_wroom.serial.disableDTR=true
@@ -34228,7 +34228,6 @@ uPesy_wroom.menu.DebugLevel.verbose=Verbose
 uPesy_wroom.menu.DebugLevel.verbose.build.code_debug=5
 
 uPesy_wroom.menu.EraseFlash.none=Disabled
-uPesy_wroom.menu.EraseFlash.none.upload.erase_cmd=
 uPesy_wroom.menu.EraseFlash.all=Enabled
 uPesy_wroom.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34246,6 +34245,7 @@ uPesy_edu_esp32.upload.tool.network=esp_ota
 uPesy_edu_esp32.upload.maximum_size=1310720
 uPesy_edu_esp32.upload.maximum_data_size=327680
 uPesy_edu_esp32.upload.flags=
+uPesy_edu_esp32.upload.erase_cmd=
 uPesy_edu_esp32.upload.extra_flags=
 
 uPesy_edu_esp32.serial.disableDTR=true
@@ -34338,7 +34338,6 @@ uPesy_edu_esp32.menu.DebugLevel.verbose=Verbose
 uPesy_edu_esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 uPesy_edu_esp32.menu.EraseFlash.none=Disabled
-uPesy_edu_esp32.menu.EraseFlash.none.upload.erase_cmd=
 uPesy_edu_esp32.menu.EraseFlash.all=Enabled
 uPesy_edu_esp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34358,6 +34357,7 @@ upesy_esp32c3_basic.upload.tool.network=esp_ota
 upesy_esp32c3_basic.upload.maximum_size=1310720
 upesy_esp32c3_basic.upload.maximum_data_size=327680
 upesy_esp32c3_basic.upload.flags=
+upesy_esp32c3_basic.upload.erase_cmd=
 upesy_esp32c3_basic.upload.extra_flags=
 upesy_esp32c3_basic.upload.use_1200bps_touch=false
 upesy_esp32c3_basic.upload.wait_for_upload_port=false
@@ -34452,7 +34452,6 @@ upesy_esp32c3_basic.menu.DebugLevel.verbose=Verbose
 upesy_esp32c3_basic.menu.DebugLevel.verbose.build.code_debug=5
 
 upesy_esp32c3_basic.menu.EraseFlash.none=Disabled
-upesy_esp32c3_basic.menu.EraseFlash.none.upload.erase_cmd=
 upesy_esp32c3_basic.menu.EraseFlash.all=Enabled
 upesy_esp32c3_basic.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34472,6 +34471,7 @@ upesy_esp32c3_mini.upload.tool.network=esp_ota
 upesy_esp32c3_mini.upload.maximum_size=1310720
 upesy_esp32c3_mini.upload.maximum_data_size=327680
 upesy_esp32c3_mini.upload.flags=
+upesy_esp32c3_mini.upload.erase_cmd=
 upesy_esp32c3_mini.upload.extra_flags=
 upesy_esp32c3_mini.upload.use_1200bps_touch=false
 upesy_esp32c3_mini.upload.wait_for_upload_port=false
@@ -34566,7 +34566,6 @@ upesy_esp32c3_mini.menu.DebugLevel.verbose=Verbose
 upesy_esp32c3_mini.menu.DebugLevel.verbose.build.code_debug=5
 
 upesy_esp32c3_mini.menu.EraseFlash.none=Disabled
-upesy_esp32c3_mini.menu.EraseFlash.none.upload.erase_cmd=
 upesy_esp32c3_mini.menu.EraseFlash.all=Enabled
 upesy_esp32c3_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34586,6 +34585,7 @@ upesy_esp32s3_basic.upload.tool.network=esp_ota
 upesy_esp32s3_basic.upload.maximum_size=1310720
 upesy_esp32s3_basic.upload.maximum_data_size=327680
 upesy_esp32s3_basic.upload.flags=
+upesy_esp32s3_basic.upload.erase_cmd=
 upesy_esp32s3_basic.upload.extra_flags=
 upesy_esp32s3_basic.upload.use_1200bps_touch=false
 upesy_esp32s3_basic.upload.wait_for_upload_port=false
@@ -34728,7 +34728,6 @@ upesy_esp32s3_basic.menu.DebugLevel.verbose=Verbose
 upesy_esp32s3_basic.menu.DebugLevel.verbose.build.code_debug=5
 
 upesy_esp32s3_basic.menu.EraseFlash.none=Disabled
-upesy_esp32s3_basic.menu.EraseFlash.none.upload.erase_cmd=
 upesy_esp32s3_basic.menu.EraseFlash.all=Enabled
 upesy_esp32s3_basic.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34746,6 +34745,7 @@ kb32.upload.tool.network=esp_ota
 kb32.upload.maximum_size=1310720
 kb32.upload.maximum_data_size=327680
 kb32.upload.flags=
+kb32.upload.erase_cmd=
 kb32.upload.extra_flags=
 
 kb32.serial.disableDTR=true
@@ -34896,7 +34896,6 @@ kb32.menu.DebugLevel.verbose=Verbose
 kb32.menu.DebugLevel.verbose.build.code_debug=5
 
 kb32.menu.EraseFlash.none=Disabled
-kb32.menu.EraseFlash.none.upload.erase_cmd=
 kb32.menu.EraseFlash.all=Enabled
 kb32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -34914,6 +34913,7 @@ deneyapkart.upload.tool.network=esp_ota
 deneyapkart.upload.maximum_size=1310720
 deneyapkart.upload.maximum_data_size=327680
 deneyapkart.upload.flags=
+deneyapkart.upload.erase_cmd=
 deneyapkart.upload.extra_flags=
 
 deneyapkart.serial.disableDTR=true
@@ -35074,7 +35074,6 @@ deneyapkart.menu.DebugLevel.verbose=Verbose
 deneyapkart.menu.DebugLevel.verbose.build.code_debug=5
 
 deneyapkart.menu.EraseFlash.none=Disabled
-deneyapkart.menu.EraseFlash.none.upload.erase_cmd=
 deneyapkart.menu.EraseFlash.all=Enabled
 deneyapkart.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -35095,6 +35094,7 @@ deneyapkartv2.upload.tool.network=esp_ota
 deneyapkartv2.upload.maximum_size=1310720
 deneyapkartv2.upload.maximum_data_size=327680
 deneyapkartv2.upload.flags=
+deneyapkartv2.upload.erase_cmd=
 deneyapkartv2.upload.extra_flags=
 deneyapkartv2.upload.use_1200bps_touch=false
 deneyapkartv2.upload.wait_for_upload_port=false
@@ -35301,7 +35301,6 @@ deneyapkartv2.menu.DebugLevel.verbose=Verbose
 deneyapkartv2.menu.DebugLevel.verbose.build.code_debug=5
 
 deneyapkartv2.menu.EraseFlash.none=Disabled
-deneyapkartv2.menu.EraseFlash.none.upload.erase_cmd=
 deneyapkartv2.menu.EraseFlash.all=Enabled
 deneyapkartv2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -35326,6 +35325,7 @@ deneyapkart1A.upload.tool.network=esp_ota
 deneyapkart1A.upload.maximum_size=1310720
 deneyapkart1A.upload.maximum_data_size=327680
 deneyapkart1A.upload.flags=
+deneyapkart1A.upload.erase_cmd=
 deneyapkart1A.upload.extra_flags=
 
 deneyapkart1A.serial.disableDTR=true
@@ -35486,7 +35486,6 @@ deneyapkart1A.menu.DebugLevel.verbose=Verbose
 deneyapkart1A.menu.DebugLevel.verbose.build.code_debug=5
 
 deneyapkart1A.menu.EraseFlash.none=Disabled
-deneyapkart1A.menu.EraseFlash.none.upload.erase_cmd=
 deneyapkart1A.menu.EraseFlash.all=Enabled
 deneyapkart1A.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -35507,6 +35506,7 @@ deneyapkart1Av2.upload.tool.network=esp_ota
 deneyapkart1Av2.upload.maximum_size=1310720
 deneyapkart1Av2.upload.maximum_data_size=327680
 deneyapkart1Av2.upload.flags=
+deneyapkart1Av2.upload.erase_cmd=
 deneyapkart1Av2.upload.extra_flags=
 deneyapkart1Av2.upload.use_1200bps_touch=false
 deneyapkart1Av2.upload.wait_for_upload_port=false
@@ -35714,7 +35714,6 @@ deneyapkart1Av2.menu.DebugLevel.verbose=Verbose
 deneyapkart1Av2.menu.DebugLevel.verbose.build.code_debug=5
 
 deneyapkart1Av2.menu.EraseFlash.none=Disabled
-deneyapkart1Av2.menu.EraseFlash.none.upload.erase_cmd=
 deneyapkart1Av2.menu.EraseFlash.all=Enabled
 deneyapkart1Av2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -35735,6 +35734,7 @@ deneyapmini.upload.tool.network=esp_ota
 deneyapmini.upload.maximum_size=1310720
 deneyapmini.upload.maximum_data_size=327680
 deneyapmini.upload.flags=
+deneyapmini.upload.erase_cmd=
 deneyapmini.upload.extra_flags=
 deneyapmini.upload.use_1200bps_touch=false
 deneyapmini.upload.wait_for_upload_port=false
@@ -35904,7 +35904,6 @@ deneyapmini.menu.DebugLevel.verbose=Verbose
 deneyapmini.menu.DebugLevel.verbose.build.code_debug=5
 
 deneyapmini.menu.EraseFlash.none=Disabled
-deneyapmini.menu.EraseFlash.none.upload.erase_cmd=
 deneyapmini.menu.EraseFlash.all=Enabled
 deneyapmini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -35925,6 +35924,7 @@ deneyapminiv2.upload.tool.network=esp_ota
 deneyapminiv2.upload.maximum_size=1310720
 deneyapminiv2.upload.maximum_data_size=327680
 deneyapminiv2.upload.flags=
+deneyapminiv2.upload.erase_cmd=
 deneyapminiv2.upload.extra_flags=
 deneyapminiv2.upload.use_1200bps_touch=false
 deneyapminiv2.upload.wait_for_upload_port=false
@@ -36094,7 +36094,6 @@ deneyapminiv2.menu.DebugLevel.verbose=Verbose
 deneyapminiv2.menu.DebugLevel.verbose.build.code_debug=5
 
 deneyapminiv2.menu.EraseFlash.none=Disabled
-deneyapminiv2.menu.EraseFlash.none.upload.erase_cmd=
 deneyapminiv2.menu.EraseFlash.all=Enabled
 deneyapminiv2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -36115,6 +36114,7 @@ deneyapkartg.upload.tool.network=esp_ota
 deneyapkartg.upload.maximum_size=1310720
 deneyapkartg.upload.maximum_data_size=327680
 deneyapkartg.upload.flags=
+deneyapkartg.upload.erase_cmd=
 deneyapkartg.upload.extra_flags=
 deneyapkartg.upload.use_1200bps_touch=false
 deneyapkartg.upload.wait_for_upload_port=false
@@ -36261,7 +36261,6 @@ deneyapkartg.menu.DebugLevel.verbose=Verbose
 deneyapkartg.menu.DebugLevel.verbose.build.code_debug=5
 
 deneyapkartg.menu.EraseFlash.none=Disabled
-deneyapkartg.menu.EraseFlash.none.upload.erase_cmd=
 deneyapkartg.menu.EraseFlash.all=Enabled
 deneyapkartg.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -36279,6 +36278,7 @@ esp32-trueverit-iot-driver.upload.tool.network=esp_ota
 esp32-trueverit-iot-driver.upload.maximum_size=1310720
 esp32-trueverit-iot-driver.upload.maximum_data_size=327680
 esp32-trueverit-iot-driver.upload.flags=
+esp32-trueverit-iot-driver.upload.erase_cmd=
 esp32-trueverit-iot-driver.upload.extra_flags=
 
 esp32-trueverit-iot-driver.serial.disableDTR=true
@@ -36329,7 +36329,6 @@ esp32-trueverit-iot-driver.menu.DebugLevel.verbose=Verbose
 esp32-trueverit-iot-driver.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-trueverit-iot-driver.menu.EraseFlash.none=Disabled
-esp32-trueverit-iot-driver.menu.EraseFlash.none.upload.erase_cmd=
 esp32-trueverit-iot-driver.menu.EraseFlash.all=Enabled
 esp32-trueverit-iot-driver.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -36347,6 +36346,7 @@ esp32-trueverit-iot-driver-mkii.upload.tool.network=esp_ota
 esp32-trueverit-iot-driver-mkii.upload.maximum_size=1310720
 esp32-trueverit-iot-driver-mkii.upload.maximum_data_size=327680
 esp32-trueverit-iot-driver-mkii.upload.flags=
+esp32-trueverit-iot-driver-mkii.upload.erase_cmd=
 esp32-trueverit-iot-driver-mkii.upload.extra_flags=
 
 esp32-trueverit-iot-driver-mkii.serial.disableDTR=true
@@ -36397,7 +36397,6 @@ esp32-trueverit-iot-driver-mkii.menu.DebugLevel.verbose=Verbose
 esp32-trueverit-iot-driver-mkii.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32-trueverit-iot-driver-mkii.menu.EraseFlash.none=Disabled
-esp32-trueverit-iot-driver-mkii.menu.EraseFlash.none.upload.erase_cmd=
 esp32-trueverit-iot-driver-mkii.menu.EraseFlash.all=Enabled
 esp32-trueverit-iot-driver-mkii.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -36417,6 +36416,7 @@ atmegazero_esp32s2.upload.tool.network=esp_ota
 atmegazero_esp32s2.upload.maximum_size=1310720
 atmegazero_esp32s2.upload.maximum_data_size=327680
 atmegazero_esp32s2.upload.flags=
+atmegazero_esp32s2.upload.erase_cmd=
 atmegazero_esp32s2.upload.extra_flags=
 atmegazero_esp32s2.upload.use_1200bps_touch=true
 atmegazero_esp32s2.upload.wait_for_upload_port=true
@@ -36566,7 +36566,6 @@ atmegazero_esp32s2.menu.DebugLevel.verbose=Verbose
 atmegazero_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 atmegazero_esp32s2.menu.EraseFlash.none=Disabled
-atmegazero_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 atmegazero_esp32s2.menu.EraseFlash.all=Enabled
 atmegazero_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -36586,6 +36585,7 @@ franzininho_wifi_esp32s2.upload.tool.network=esp_ota
 franzininho_wifi_esp32s2.upload.maximum_size=1310720
 franzininho_wifi_esp32s2.upload.maximum_data_size=327680
 franzininho_wifi_esp32s2.upload.flags=
+franzininho_wifi_esp32s2.upload.erase_cmd=
 franzininho_wifi_esp32s2.upload.extra_flags=
 franzininho_wifi_esp32s2.upload.use_1200bps_touch=true
 franzininho_wifi_esp32s2.upload.wait_for_upload_port=true
@@ -36673,7 +36673,6 @@ franzininho_wifi_esp32s2.menu.DebugLevel.verbose=Verbose
 franzininho_wifi_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 franzininho_wifi_esp32s2.menu.EraseFlash.none=Disabled
-franzininho_wifi_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 franzininho_wifi_esp32s2.menu.EraseFlash.all=Enabled
 franzininho_wifi_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -36693,6 +36692,7 @@ franzininho_wifi_msc_esp32s2.upload.tool.network=esp_ota
 franzininho_wifi_msc_esp32s2.upload.maximum_size=1310720
 franzininho_wifi_msc_esp32s2.upload.maximum_data_size=327680
 franzininho_wifi_msc_esp32s2.upload.flags=
+franzininho_wifi_msc_esp32s2.upload.erase_cmd=
 franzininho_wifi_msc_esp32s2.upload.extra_flags=
 franzininho_wifi_msc_esp32s2.upload.use_1200bps_touch=true
 franzininho_wifi_msc_esp32s2.upload.wait_for_upload_port=true
@@ -36780,7 +36780,6 @@ franzininho_wifi_msc_esp32s2.menu.DebugLevel.verbose=Verbose
 franzininho_wifi_msc_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 franzininho_wifi_msc_esp32s2.menu.EraseFlash.none=Disabled
-franzininho_wifi_msc_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 franzininho_wifi_msc_esp32s2.menu.EraseFlash.all=Enabled
 franzininho_wifi_msc_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -36798,6 +36797,7 @@ tamc_termod_s3.upload.tool.network=esp_ota
 tamc_termod_s3.upload.maximum_size=1310720
 tamc_termod_s3.upload.maximum_data_size=327680
 tamc_termod_s3.upload.flags=
+tamc_termod_s3.upload.erase_cmd=
 tamc_termod_s3.upload.extra_flags=
 tamc_termod_s3.upload.use_1200bps_touch=false
 tamc_termod_s3.upload.wait_for_upload_port=false
@@ -36990,7 +36990,6 @@ tamc_termod_s3.menu.DebugLevel.verbose=Verbose
 tamc_termod_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 tamc_termod_s3.menu.EraseFlash.none=Disabled
-tamc_termod_s3.menu.EraseFlash.none.upload.erase_cmd=
 tamc_termod_s3.menu.EraseFlash.all=Enabled
 tamc_termod_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37008,6 +37007,7 @@ dpu_esp32.upload.tool.network=esp_ota
 dpu_esp32.upload.maximum_size=3342336
 dpu_esp32.upload.maximum_data_size=327680
 dpu_esp32.upload.flags=
+dpu_esp32.upload.erase_cmd=
 dpu_esp32.upload.extra_flags=
 
 dpu_esp32.serial.disableDTR=true
@@ -37102,7 +37102,6 @@ dpu_esp32.menu.DebugLevel.verbose=Verbose
 dpu_esp32.menu.DebugLevel.verbose.build.code_debug=5
 
 dpu_esp32.menu.EraseFlash.none=Disabled
-dpu_esp32.menu.EraseFlash.none.upload.erase_cmd=
 dpu_esp32.menu.EraseFlash.all=Enabled
 dpu_esp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37120,6 +37119,7 @@ sonoff_dualr3.upload.tool.network=esp_ota
 sonoff_dualr3.upload.maximum_size=1310720
 sonoff_dualr3.upload.maximum_data_size=327680
 sonoff_dualr3.upload.flags=
+sonoff_dualr3.upload.erase_cmd=
 sonoff_dualr3.upload.extra_flags=
 
 sonoff_dualr3.serial.disableDTR=true
@@ -37211,7 +37211,6 @@ sonoff_dualr3.menu.DebugLevel.verbose=Verbose
 sonoff_dualr3.menu.DebugLevel.verbose.build.code_debug=5
 
 sonoff_dualr3.menu.EraseFlash.none=Disabled
-sonoff_dualr3.menu.EraseFlash.none.upload.erase_cmd=
 sonoff_dualr3.menu.EraseFlash.all=Enabled
 sonoff_dualr3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37228,6 +37227,7 @@ lionbit.upload.tool.network=esp_ota
 lionbit.upload.maximum_size=1310720
 lionbit.upload.maximum_data_size=327680
 lionbit.upload.flags=
+lionbit.upload.erase_cmd=
 lionbit.upload.extra_flags=
 
 lionbit.serial.disableDTR=true
@@ -37363,7 +37363,6 @@ lionbit.menu.DebugLevel.verbose=Verbose
 lionbit.menu.DebugLevel.verbose.build.code_debug=5
 
 lionbit.menu.EraseFlash.none=Disabled
-lionbit.menu.EraseFlash.none.upload.erase_cmd=
 lionbit.menu.EraseFlash.all=Enabled
 lionbit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37381,6 +37380,7 @@ watchy.upload.tool.network=esp_ota
 watchy.upload.maximum_size=1310720
 watchy.upload.maximum_data_size=327680
 watchy.upload.flags=
+watchy.upload.erase_cmd=
 watchy.upload.extra_flags=
 
 watchy.serial.disableDTR=true
@@ -37445,7 +37445,6 @@ watchy.menu.DebugLevel.verbose=Verbose
 watchy.menu.DebugLevel.verbose.build.code_debug=5
 
 watchy.menu.EraseFlash.none=Disabled
-watchy.menu.EraseFlash.none.upload.erase_cmd=
 watchy.menu.EraseFlash.all=Enabled
 watchy.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37459,6 +37458,7 @@ AirM2M_CORE_ESP32C3.upload.tool.network=esp_ota
 AirM2M_CORE_ESP32C3.upload.maximum_size=1310720
 AirM2M_CORE_ESP32C3.upload.maximum_data_size=327680
 AirM2M_CORE_ESP32C3.upload.flags=
+AirM2M_CORE_ESP32C3.upload.erase_cmd=
 AirM2M_CORE_ESP32C3.upload.extra_flags=
 AirM2M_CORE_ESP32C3.upload.use_1200bps_touch=false
 AirM2M_CORE_ESP32C3.upload.wait_for_upload_port=false
@@ -37551,7 +37551,6 @@ AirM2M_CORE_ESP32C3.menu.DebugLevel.verbose=Verbose
 AirM2M_CORE_ESP32C3.menu.DebugLevel.verbose.build.code_debug=5
 
 AirM2M_CORE_ESP32C3.menu.EraseFlash.none=Disabled
-AirM2M_CORE_ESP32C3.menu.EraseFlash.none.upload.erase_cmd=
 AirM2M_CORE_ESP32C3.menu.EraseFlash.all=Enabled
 AirM2M_CORE_ESP32C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37572,6 +37571,7 @@ XIAO_ESP32C3.upload.tool.network=esp_ota
 XIAO_ESP32C3.upload.maximum_size=1310720
 XIAO_ESP32C3.upload.maximum_data_size=327680
 XIAO_ESP32C3.upload.flags=
+XIAO_ESP32C3.upload.erase_cmd=
 XIAO_ESP32C3.upload.extra_flags=
 XIAO_ESP32C3.upload.use_1200bps_touch=false
 XIAO_ESP32C3.upload.wait_for_upload_port=false
@@ -37705,7 +37705,6 @@ XIAO_ESP32C3.menu.DebugLevel.verbose=Verbose
 XIAO_ESP32C3.menu.DebugLevel.verbose.build.code_debug=5
 
 XIAO_ESP32C3.menu.EraseFlash.none=Disabled
-XIAO_ESP32C3.menu.EraseFlash.none.upload.erase_cmd=
 XIAO_ESP32C3.menu.EraseFlash.all=Enabled
 XIAO_ESP32C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37727,6 +37726,7 @@ XIAO_ESP32C5.upload.tool.network=esp_ota
 XIAO_ESP32C5.upload.maximum_size=1310720
 XIAO_ESP32C5.upload.maximum_data_size=327680
 XIAO_ESP32C5.upload.flags=
+XIAO_ESP32C5.upload.erase_cmd=
 XIAO_ESP32C5.upload.extra_flags=
 XIAO_ESP32C5.upload.use_1200bps_touch=false
 XIAO_ESP32C5.upload.wait_for_upload_port=false
@@ -37880,7 +37880,6 @@ XIAO_ESP32C5.menu.DebugLevel.verbose=Verbose
 XIAO_ESP32C5.menu.DebugLevel.verbose.build.code_debug=5
 
 XIAO_ESP32C5.menu.EraseFlash.none=Disabled
-XIAO_ESP32C5.menu.EraseFlash.none.upload.erase_cmd=
 XIAO_ESP32C5.menu.EraseFlash.all=Enabled
 XIAO_ESP32C5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -37914,6 +37913,7 @@ XIAO_ESP32C6.upload.tool.network=esp_ota
 XIAO_ESP32C6.upload.maximum_size=1310720
 XIAO_ESP32C6.upload.maximum_data_size=327680
 XIAO_ESP32C6.upload.flags=
+XIAO_ESP32C6.upload.erase_cmd=
 XIAO_ESP32C6.upload.extra_flags=
 XIAO_ESP32C6.upload.use_1200bps_touch=false
 XIAO_ESP32C6.upload.wait_for_upload_port=false
@@ -38037,7 +38037,6 @@ XIAO_ESP32C6.menu.DebugLevel.verbose=Verbose
 XIAO_ESP32C6.menu.DebugLevel.verbose.build.code_debug=5
 
 XIAO_ESP32C6.menu.EraseFlash.none=Disabled
-XIAO_ESP32C6.menu.EraseFlash.none.upload.erase_cmd=
 XIAO_ESP32C6.menu.EraseFlash.all=Enabled
 XIAO_ESP32C6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -38069,6 +38068,7 @@ XIAO_ESP32S3.upload.tool.network=esp_ota
 XIAO_ESP32S3.upload.maximum_size=1310720
 XIAO_ESP32S3.upload.maximum_data_size=327680
 XIAO_ESP32S3.upload.flags=
+XIAO_ESP32S3.upload.erase_cmd=
 XIAO_ESP32S3.upload.extra_flags=
 XIAO_ESP32S3.upload.use_1200bps_touch=false
 XIAO_ESP32S3.upload.wait_for_upload_port=false
@@ -38231,7 +38231,6 @@ XIAO_ESP32S3.menu.DebugLevel.verbose=Verbose
 XIAO_ESP32S3.menu.DebugLevel.verbose.build.code_debug=5
 
 XIAO_ESP32S3.menu.EraseFlash.none=Disabled
-XIAO_ESP32S3.menu.EraseFlash.none.upload.erase_cmd=
 XIAO_ESP32S3.menu.EraseFlash.all=Enabled
 XIAO_ESP32S3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -38253,6 +38252,7 @@ XIAO_ESP32S3_Plus.upload.tool.network=esp_ota
 XIAO_ESP32S3_Plus.upload.maximum_size=1310720
 XIAO_ESP32S3_Plus.upload.maximum_data_size=327680
 XIAO_ESP32S3_Plus.upload.flags=
+XIAO_ESP32S3_Plus.upload.erase_cmd=
 XIAO_ESP32S3_Plus.upload.extra_flags=
 XIAO_ESP32S3_Plus.upload.use_1200bps_touch=false
 XIAO_ESP32S3_Plus.upload.wait_for_upload_port=false
@@ -38415,7 +38415,6 @@ XIAO_ESP32S3_Plus.menu.DebugLevel.verbose=Verbose
 XIAO_ESP32S3_Plus.menu.DebugLevel.verbose.build.code_debug=5
 
 XIAO_ESP32S3_Plus.menu.EraseFlash.none=Disabled
-XIAO_ESP32S3_Plus.menu.EraseFlash.none.upload.erase_cmd=
 XIAO_ESP32S3_Plus.menu.EraseFlash.all=Enabled
 XIAO_ESP32S3_Plus.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -38435,6 +38434,7 @@ connaxio_espoir.upload.tool.network=esp_ota
 connaxio_espoir.upload.maximum_size=1310720
 connaxio_espoir.upload.maximum_data_size=327680
 connaxio_espoir.upload.flags=
+connaxio_espoir.upload.erase_cmd=
 connaxio_espoir.upload.extra_flags=
 
 connaxio_espoir.serial.disableDTR=true
@@ -38536,7 +38536,6 @@ connaxio_espoir.menu.DebugLevel.verbose=Verbose
 connaxio_espoir.menu.DebugLevel.verbose.build.code_debug=5
 
 connaxio_espoir.menu.EraseFlash.none=Disabled
-connaxio_espoir.menu.EraseFlash.none.upload.erase_cmd=
 connaxio_espoir.menu.EraseFlash.all=Enabled
 connaxio_espoir.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -38554,6 +38553,7 @@ aw2eth.upload.tool.network=esp_ota
 aw2eth.upload.maximum_size=1310720
 aw2eth.upload.maximum_data_size=327680
 aw2eth.upload.flags=
+aw2eth.upload.erase_cmd=
 aw2eth.upload.extra_flags=
 
 aw2eth.serial.disableDTR=true
@@ -38613,7 +38613,6 @@ aw2eth.menu.DebugLevel.verbose=Verbose
 aw2eth.menu.DebugLevel.verbose.build.code_debug=5
 
 aw2eth.menu.EraseFlash.none=Disabled
-aw2eth.menu.EraseFlash.none.upload.erase_cmd=
 aw2eth.menu.EraseFlash.all=Enabled
 aw2eth.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -38633,6 +38632,7 @@ department_of_alchemy_minimain_esp32s2.upload.tool.network=esp_ota
 department_of_alchemy_minimain_esp32s2.upload.maximum_size=1310720
 department_of_alchemy_minimain_esp32s2.upload.maximum_data_size=327680
 department_of_alchemy_minimain_esp32s2.upload.flags=
+department_of_alchemy_minimain_esp32s2.upload.erase_cmd=
 department_of_alchemy_minimain_esp32s2.upload.extra_flags=
 department_of_alchemy_minimain_esp32s2.upload.use_1200bps_touch=true
 department_of_alchemy_minimain_esp32s2.upload.wait_for_upload_port=true
@@ -38779,7 +38779,6 @@ department_of_alchemy_minimain_esp32s2.menu.DebugLevel.verbose=Verbose
 department_of_alchemy_minimain_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 department_of_alchemy_minimain_esp32s2.menu.EraseFlash.none=Disabled
-department_of_alchemy_minimain_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 department_of_alchemy_minimain_esp32s2.menu.EraseFlash.all=Enabled
 department_of_alchemy_minimain_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -38802,6 +38801,7 @@ Bee_Data_Logger.upload.tool.network=esp_ota
 Bee_Data_Logger.upload.maximum_size=1310720
 Bee_Data_Logger.upload.maximum_data_size=327680
 Bee_Data_Logger.upload.flags=
+Bee_Data_Logger.upload.erase_cmd=
 Bee_Data_Logger.upload.extra_flags=
 Bee_Data_Logger.upload.use_1200bps_touch=true
 Bee_Data_Logger.upload.wait_for_upload_port=true
@@ -38889,7 +38889,6 @@ Bee_Data_Logger.menu.DebugLevel.verbose=Verbose
 Bee_Data_Logger.menu.DebugLevel.verbose.build.code_debug=5
 
 Bee_Data_Logger.menu.EraseFlash.none=Disabled
-Bee_Data_Logger.menu.EraseFlash.none.upload.erase_cmd=
 Bee_Data_Logger.menu.EraseFlash.all=Enabled
 Bee_Data_Logger.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -38911,6 +38910,7 @@ Bee_Motion_S3.upload.tool.network=esp_ota
 Bee_Motion_S3.upload.maximum_size=1310720
 Bee_Motion_S3.upload.maximum_data_size=327680
 Bee_Motion_S3.upload.flags=
+Bee_Motion_S3.upload.erase_cmd=
 Bee_Motion_S3.upload.extra_flags=
 Bee_Motion_S3.upload.use_1200bps_touch=true
 Bee_Motion_S3.upload.wait_for_upload_port=true
@@ -39000,7 +39000,6 @@ Bee_Motion_S3.menu.DebugLevel.verbose=Verbose
 Bee_Motion_S3.menu.DebugLevel.verbose.build.code_debug=5
 
 Bee_Motion_S3.menu.EraseFlash.none=Disabled
-Bee_Motion_S3.menu.EraseFlash.none.upload.erase_cmd=
 Bee_Motion_S3.menu.EraseFlash.all=Enabled
 Bee_Motion_S3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -39022,6 +39021,7 @@ Bee_Motion.upload.tool.network=esp_ota
 Bee_Motion.upload.maximum_size=1310720
 Bee_Motion.upload.maximum_data_size=327680
 Bee_Motion.upload.flags=
+Bee_Motion.upload.erase_cmd=
 Bee_Motion.upload.extra_flags=
 Bee_Motion.upload.use_1200bps_touch=true
 Bee_Motion.upload.wait_for_upload_port=true
@@ -39107,7 +39107,6 @@ Bee_Motion.menu.DebugLevel.verbose=Verbose
 Bee_Motion.menu.DebugLevel.verbose.build.code_debug=5
 
 Bee_Motion.menu.EraseFlash.none=Disabled
-Bee_Motion.menu.EraseFlash.none.upload.erase_cmd=
 Bee_Motion.menu.EraseFlash.all=Enabled
 Bee_Motion.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -39125,6 +39124,7 @@ Bee_Motion_Mini.upload.tool.network=esp_ota
 Bee_Motion_Mini.upload.maximum_size=1310720
 Bee_Motion_Mini.upload.maximum_data_size=327680
 Bee_Motion_Mini.upload.flags=
+Bee_Motion_Mini.upload.erase_cmd=
 Bee_Motion_Mini.upload.extra_flags=
 Bee_Motion_Mini.upload.use_1200bps_touch=false
 Bee_Motion_Mini.upload.wait_for_upload_port=false
@@ -39219,7 +39219,6 @@ Bee_Motion_Mini.menu.DebugLevel.verbose=Verbose
 Bee_Motion_Mini.menu.DebugLevel.verbose.build.code_debug=5
 
 Bee_Motion_Mini.menu.EraseFlash.none=Disabled
-Bee_Motion_Mini.menu.EraseFlash.none.upload.erase_cmd=
 Bee_Motion_Mini.menu.EraseFlash.all=Enabled
 Bee_Motion_Mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -39241,6 +39240,7 @@ Bee_S3.upload.tool.network=esp_ota
 Bee_S3.upload.maximum_size=1310720
 Bee_S3.upload.maximum_data_size=327680
 Bee_S3.upload.flags=
+Bee_S3.upload.erase_cmd=
 Bee_S3.upload.extra_flags=
 Bee_S3.upload.use_1200bps_touch=false
 Bee_S3.upload.wait_for_upload_port=false
@@ -39375,7 +39375,6 @@ Bee_S3.menu.DebugLevel.verbose=Verbose
 Bee_S3.menu.DebugLevel.verbose.build.code_debug=5
 
 Bee_S3.menu.EraseFlash.none=Disabled
-Bee_S3.menu.EraseFlash.none.upload.erase_cmd=
 Bee_S3.menu.EraseFlash.all=Enabled
 Bee_S3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -39393,6 +39392,7 @@ unphone7.upload.tool.network=esp_ota
 unphone7.upload.maximum_size=1310720
 unphone7.upload.maximum_data_size=327680
 unphone7.upload.flags=
+unphone7.upload.erase_cmd=
 unphone7.upload.extra_flags=
 
 unphone7.serial.disableDTR=true
@@ -39456,7 +39456,6 @@ unphone7.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
 unphone7.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
 
 unphone7.menu.EraseFlash.none=Disabled
-unphone7.menu.EraseFlash.none.upload.erase_cmd=
 unphone7.menu.EraseFlash.all=Enabled
 unphone7.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -39476,6 +39475,7 @@ unphone8.upload.tool.network=esp_ota
 unphone8.upload.maximum_size=8323072
 unphone8.upload.maximum_data_size=2424832
 unphone8.upload.flags=
+unphone8.upload.erase_cmd=
 unphone8.upload.extra_flags=
 unphone8.upload.use_1200bps_touch=false
 unphone8.upload.wait_for_upload_port=false
@@ -39632,6 +39632,7 @@ unphone9.upload.tool.network=esp_ota
 unphone9.upload.maximum_size=8323072
 unphone9.upload.maximum_data_size=8716288
 unphone9.upload.flags=
+unphone9.upload.erase_cmd=
 unphone9.upload.extra_flags=
 unphone9.upload.use_1200bps_touch=false
 unphone9.upload.wait_for_upload_port=false
@@ -39773,7 +39774,6 @@ unphone9.menu.DebugLevel.verbose=Verbose
 unphone9.menu.DebugLevel.verbose.build.code_debug=5
 
 unphone9.menu.EraseFlash.none=Disabled
-unphone9.menu.EraseFlash.none.upload.erase_cmd=
 unphone9.menu.EraseFlash.all=Enabled
 unphone9.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -39794,6 +39794,7 @@ cytron_maker_feather_aiot_s3.upload.tool.network=esp_ota
 cytron_maker_feather_aiot_s3.upload.maximum_size=1310720
 cytron_maker_feather_aiot_s3.upload.maximum_data_size=327680
 cytron_maker_feather_aiot_s3.upload.flags=
+cytron_maker_feather_aiot_s3.upload.erase_cmd=
 cytron_maker_feather_aiot_s3.upload.extra_flags=
 cytron_maker_feather_aiot_s3.upload.use_1200bps_touch=true
 cytron_maker_feather_aiot_s3.upload.wait_for_upload_port=true
@@ -39948,7 +39949,6 @@ cytron_maker_feather_aiot_s3.menu.DebugLevel.verbose=Verbose
 cytron_maker_feather_aiot_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 cytron_maker_feather_aiot_s3.menu.EraseFlash.none=Disabled
-cytron_maker_feather_aiot_s3.menu.EraseFlash.none.upload.erase_cmd=
 cytron_maker_feather_aiot_s3.menu.EraseFlash.all=Enabled
 cytron_maker_feather_aiot_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -39967,6 +39967,7 @@ redpill_esp32s3.upload.tool.network=esp_ota
 redpill_esp32s3.upload.maximum_size=1310720
 redpill_esp32s3.upload.maximum_data_size=327680
 redpill_esp32s3.upload.flags=
+redpill_esp32s3.upload.erase_cmd=
 redpill_esp32s3.upload.extra_flags=
 redpill_esp32s3.upload.use_1200bps_touch=true
 redpill_esp32s3.upload.wait_for_upload_port=true
@@ -40121,7 +40122,6 @@ redpill_esp32s3.menu.DebugLevel.verbose=Verbose
 redpill_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 redpill_esp32s3.menu.EraseFlash.none=Disabled
-redpill_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 redpill_esp32s3.menu.EraseFlash.all=Enabled
 redpill_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -40139,6 +40139,7 @@ esp32c3m1IKit.upload.tool.network=esp_ota
 esp32c3m1IKit.upload.maximum_size=1310720
 esp32c3m1IKit.upload.maximum_data_size=327680
 esp32c3m1IKit.upload.flags=
+esp32c3m1IKit.upload.erase_cmd=
 esp32c3m1IKit.upload.extra_flags=
 esp32c3m1IKit.upload.use_1200bps_touch=false
 esp32c3m1IKit.upload.wait_for_upload_port=false
@@ -40239,7 +40240,6 @@ esp32c3m1IKit.menu.DebugLevel.verbose=Verbose
 esp32c3m1IKit.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32c3m1IKit.menu.EraseFlash.none=Disabled
-esp32c3m1IKit.menu.EraseFlash.none.upload.erase_cmd=
 esp32c3m1IKit.menu.EraseFlash.all=Enabled
 esp32c3m1IKit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -40253,6 +40253,7 @@ roboheart_hercules.upload.maximum_size=1310720
 roboheart_hercules.upload.maximum_data_size=327680
 roboheart_hercules.upload.wait_for_upload_port=true
 roboheart_hercules.upload.flags=
+roboheart_hercules.upload.erase_cmd=
 roboheart_hercules.upload.extra_flags=
 
 roboheart_hercules.serial.disableDTR=true
@@ -40369,7 +40370,6 @@ roboheart_hercules.menu.DebugLevel.verbose=Verbose
 roboheart_hercules.menu.DebugLevel.verbose.build.code_debug=5
 
 roboheart_hercules.menu.EraseFlash.none=Disabled
-roboheart_hercules.menu.EraseFlash.none.upload.erase_cmd=
 roboheart_hercules.menu.EraseFlash.all=Enabled
 roboheart_hercules.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -40386,6 +40386,7 @@ VALTRACK_V4_VTS_ESP32_C3.upload.tool.network=esp_ota
 VALTRACK_V4_VTS_ESP32_C3.upload.maximum_size=1310720
 VALTRACK_V4_VTS_ESP32_C3.upload.maximum_data_size=327680
 VALTRACK_V4_VTS_ESP32_C3.upload.flags=
+VALTRACK_V4_VTS_ESP32_C3.upload.erase_cmd=
 VALTRACK_V4_VTS_ESP32_C3.upload.extra_flags=
 VALTRACK_V4_VTS_ESP32_C3.upload.use_1200bps_touch=false
 VALTRACK_V4_VTS_ESP32_C3.upload.wait_for_upload_port=false
@@ -40519,7 +40520,6 @@ VALTRACK_V4_VTS_ESP32_C3.menu.DebugLevel.verbose=Verbose
 VALTRACK_V4_VTS_ESP32_C3.menu.DebugLevel.verbose.build.code_debug=5
 
 VALTRACK_V4_VTS_ESP32_C3.menu.EraseFlash.none=Disabled
-VALTRACK_V4_VTS_ESP32_C3.menu.EraseFlash.none.upload.erase_cmd=
 VALTRACK_V4_VTS_ESP32_C3.menu.EraseFlash.all=Enabled
 VALTRACK_V4_VTS_ESP32_C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -40537,6 +40537,7 @@ VALTRACK_V4_MFW_ESP32_C3.upload.tool.network=esp_ota
 VALTRACK_V4_MFW_ESP32_C3.upload.maximum_size=1310720
 VALTRACK_V4_MFW_ESP32_C3.upload.maximum_data_size=327680
 VALTRACK_V4_MFW_ESP32_C3.upload.flags=
+VALTRACK_V4_MFW_ESP32_C3.upload.erase_cmd=
 VALTRACK_V4_MFW_ESP32_C3.upload.extra_flags=
 VALTRACK_V4_MFW_ESP32_C3.upload.use_1200bps_touch=false
 VALTRACK_V4_MFW_ESP32_C3.upload.wait_for_upload_port=false
@@ -40670,7 +40671,6 @@ VALTRACK_V4_MFW_ESP32_C3.menu.DebugLevel.verbose=Verbose
 VALTRACK_V4_MFW_ESP32_C3.menu.DebugLevel.verbose.build.code_debug=5
 
 VALTRACK_V4_MFW_ESP32_C3.menu.EraseFlash.none=Disabled
-VALTRACK_V4_MFW_ESP32_C3.menu.EraseFlash.none.upload.erase_cmd=
 VALTRACK_V4_MFW_ESP32_C3.menu.EraseFlash.all=Enabled
 VALTRACK_V4_MFW_ESP32_C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -40688,6 +40688,7 @@ Edgebox-ESP-100.upload.tool.network=esp_ota
 Edgebox-ESP-100.upload.maximum_size=1310720
 Edgebox-ESP-100.upload.maximum_data_size=327680
 Edgebox-ESP-100.upload.flags=
+Edgebox-ESP-100.upload.erase_cmd=
 Edgebox-ESP-100.upload.extra_flags=
 Edgebox-ESP-100.upload.use_1200bps_touch=false
 Edgebox-ESP-100.upload.wait_for_upload_port=false
@@ -40882,7 +40883,6 @@ Edgebox-ESP-100.menu.DebugLevel.verbose=Verbose
 Edgebox-ESP-100.menu.DebugLevel.verbose.build.code_debug=5
 
 Edgebox-ESP-100.menu.EraseFlash.none=Disabled
-Edgebox-ESP-100.menu.EraseFlash.none.upload.erase_cmd=
 Edgebox-ESP-100.menu.EraseFlash.all=Enabled
 Edgebox-ESP-100.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -40901,6 +40901,7 @@ crabik_slot_esp32_s3.upload.maximum_size=1310720
 crabik_slot_esp32_s3.upload.maximum_data_size=327680
 crabik_slot_esp32_s3.upload.speed=921600
 crabik_slot_esp32_s3.upload.flags=
+crabik_slot_esp32_s3.upload.erase_cmd=
 crabik_slot_esp32_s3.upload.extra_flags=
 crabik_slot_esp32_s3.upload.use_1200bps_touch=false
 crabik_slot_esp32_s3.upload.wait_for_upload_port=false
@@ -41028,7 +41029,6 @@ crabik_slot_esp32_s3.menu.DebugLevel.verbose=Verbose
 crabik_slot_esp32_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 crabik_slot_esp32_s3.menu.EraseFlash.none=Disabled
-crabik_slot_esp32_s3.menu.EraseFlash.none.upload.erase_cmd=
 crabik_slot_esp32_s3.menu.EraseFlash.all=Enabled
 crabik_slot_esp32_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -41047,6 +41047,7 @@ nebulas3.upload.tool.network=esp_ota
 nebulas3.upload.maximum_size=1310720
 nebulas3.upload.maximum_data_size=327680
 nebulas3.upload.flags=
+nebulas3.upload.erase_cmd=
 nebulas3.upload.extra_flags=
 nebulas3.upload.use_1200bps_touch=false
 nebulas3.upload.wait_for_upload_port=false
@@ -41252,7 +41253,6 @@ nebulas3.menu.DebugLevel.verbose=Verbose
 nebulas3.menu.DebugLevel.verbose.build.code_debug=5
 
 nebulas3.menu.EraseFlash.none=Disabled
-nebulas3.menu.EraseFlash.none.upload.erase_cmd=
 nebulas3.menu.EraseFlash.all=Enabled
 nebulas3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -41270,6 +41270,7 @@ lionbits3.upload.tool.network=esp_ota
 lionbits3.upload.maximum_size=1310720
 lionbits3.upload.maximum_data_size=327680
 lionbits3.upload.flags=
+lionbits3.upload.erase_cmd=
 lionbits3.upload.extra_flags=
 lionbits3.upload.use_1200bps_touch=false
 lionbits3.upload.wait_for_upload_port=false
@@ -41478,7 +41479,6 @@ lionbits3.menu.DebugLevel.verbose=Verbose
 lionbits3.menu.DebugLevel.verbose.build.code_debug=5
 
 lionbits3.menu.EraseFlash.none=Disabled
-lionbits3.menu.EraseFlash.none.upload.erase_cmd=
 lionbits3.menu.EraseFlash.all=Enabled
 lionbits3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -41497,6 +41497,7 @@ gen4-ESP32-S3R8n16.upload.tool.network=esp_ota
 gen4-ESP32-S3R8n16.upload.maximum_size=1310720
 gen4-ESP32-S3R8n16.upload.maximum_data_size=327680
 gen4-ESP32-S3R8n16.upload.flags=
+gen4-ESP32-S3R8n16.upload.erase_cmd=
 gen4-ESP32-S3R8n16.upload.extra_flags=
 gen4-ESP32-S3R8n16.upload.use_1200bps_touch=false
 gen4-ESP32-S3R8n16.upload.wait_for_upload_port=false
@@ -41636,7 +41637,6 @@ gen4-ESP32-S3R8n16.menu.DebugLevel.verbose=Verbose
 gen4-ESP32-S3R8n16.menu.DebugLevel.verbose.build.code_debug=5
 
 gen4-ESP32-S3R8n16.menu.EraseFlash.none=Disabled
-gen4-ESP32-S3R8n16.menu.EraseFlash.none.upload.erase_cmd=
 gen4-ESP32-S3R8n16.menu.EraseFlash.all=Enabled
 gen4-ESP32-S3R8n16.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -41729,6 +41729,7 @@ namino_rosso.upload.tool.network=esp_ota
 namino_rosso.upload.maximum_size=1310720
 namino_rosso.upload.maximum_data_size=327680
 namino_rosso.upload.flags=
+namino_rosso.upload.erase_cmd=
 namino_rosso.upload.extra_flags=
 namino_rosso.upload.use_1200bps_touch=true
 namino_rosso.upload.wait_for_upload_port=true
@@ -41899,7 +41900,6 @@ namino_rosso.menu.DebugLevel.verbose=Verbose
 namino_rosso.menu.DebugLevel.verbose.build.code_debug=5
 
 namino_rosso.menu.EraseFlash.none=Disabled
-namino_rosso.menu.EraseFlash.none.upload.erase_cmd=
 namino_rosso.menu.EraseFlash.all=Enabled
 namino_rosso.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -41918,6 +41918,7 @@ namino_arancio.upload.tool.network=esp_ota
 namino_arancio.upload.maximum_size=1310720
 namino_arancio.upload.maximum_data_size=327680
 namino_arancio.upload.flags=
+namino_arancio.upload.erase_cmd=
 namino_arancio.upload.extra_flags=
 namino_arancio.upload.use_1200bps_touch=true
 namino_arancio.upload.wait_for_upload_port=true
@@ -42088,7 +42089,6 @@ namino_arancio.menu.DebugLevel.verbose=Verbose
 namino_arancio.menu.DebugLevel.verbose.build.code_debug=5
 
 namino_arancio.menu.EraseFlash.none=Disabled
-namino_arancio.menu.EraseFlash.none.upload.erase_cmd=
 namino_arancio.menu.EraseFlash.all=Enabled
 namino_arancio.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -42107,6 +42107,7 @@ namino_bianco.upload.tool.network=esp_ota
 namino_bianco.upload.maximum_size=1310720
 namino_bianco.upload.maximum_data_size=327680
 namino_bianco.upload.flags=
+namino_bianco.upload.erase_cmd=
 namino_bianco.upload.extra_flags=
 namino_bianco.upload.use_1200bps_touch=true
 namino_bianco.upload.wait_for_upload_port=true
@@ -42277,7 +42278,6 @@ namino_bianco.menu.DebugLevel.verbose=Verbose
 namino_bianco.menu.DebugLevel.verbose.build.code_debug=5
 
 namino_bianco.menu.EraseFlash.none=Disabled
-namino_bianco.menu.EraseFlash.none.upload.erase_cmd=
 namino_bianco.menu.EraseFlash.all=Enabled
 namino_bianco.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -42296,6 +42296,7 @@ ioxesp32.upload.tool.network=esp_ota
 ioxesp32.upload.maximum_size=1310720
 ioxesp32.upload.maximum_data_size=327680
 ioxesp32.upload.flags=
+ioxesp32.upload.erase_cmd=
 ioxesp32.upload.extra_flags=
 
 ioxesp32.serial.disableDTR=true
@@ -42383,7 +42384,6 @@ ioxesp32.menu.DebugLevel.verbose=Verbose
 ioxesp32.menu.DebugLevel.verbose.build.code_debug=5
 
 ioxesp32.menu.EraseFlash.none=Disabled
-ioxesp32.menu.EraseFlash.none.upload.erase_cmd=
 ioxesp32.menu.EraseFlash.all=Enabled
 ioxesp32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -42402,6 +42402,7 @@ ioxesp32ps.upload.tool.network=esp_ota
 ioxesp32ps.upload.maximum_size=1310720
 ioxesp32ps.upload.maximum_data_size=327680
 ioxesp32ps.upload.flags=
+ioxesp32ps.upload.erase_cmd=
 ioxesp32ps.upload.extra_flags=
 
 ioxesp32ps.serial.disableDTR=true
@@ -42489,7 +42490,6 @@ ioxesp32ps.menu.DebugLevel.verbose=Verbose
 ioxesp32ps.menu.DebugLevel.verbose.build.code_debug=5
 
 ioxesp32ps.menu.EraseFlash.none=Disabled
-ioxesp32ps.menu.EraseFlash.none.upload.erase_cmd=
 ioxesp32ps.menu.EraseFlash.all=Enabled
 ioxesp32ps.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -42508,6 +42508,7 @@ ioxesp32c6.upload.tool.network=esp_ota
 ioxesp32c6.upload.maximum_size=1310720
 ioxesp32c6.upload.maximum_data_size=327680
 ioxesp32c6.upload.flags=
+ioxesp32c6.upload.erase_cmd=
 ioxesp32c6.upload.extra_flags=
 ioxesp32c6.upload.use_1200bps_touch=false
 ioxesp32c6.upload.wait_for_upload_port=false
@@ -42647,7 +42648,6 @@ ioxesp32c6.menu.DebugLevel.verbose=Verbose
 ioxesp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 ioxesp32c6.menu.EraseFlash.none=Disabled
-ioxesp32c6.menu.EraseFlash.none.upload.erase_cmd=
 ioxesp32c6.menu.EraseFlash.all=Enabled
 ioxesp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -42676,6 +42676,7 @@ atd147_s3.upload.tool.network=esp_ota
 atd147_s3.upload.maximum_size=1310720
 atd147_s3.upload.maximum_data_size=327680
 atd147_s3.upload.flags=
+atd147_s3.upload.erase_cmd=
 atd147_s3.upload.extra_flags=
 atd147_s3.upload.use_1200bps_touch=false
 atd147_s3.upload.wait_for_upload_port=false
@@ -42840,7 +42841,6 @@ atd147_s3.menu.DebugLevel.verbose=Verbose
 atd147_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 atd147_s3.menu.EraseFlash.none=Disabled
-atd147_s3.menu.EraseFlash.none.upload.erase_cmd=
 atd147_s3.menu.EraseFlash.all=Enabled
 atd147_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -42859,6 +42859,7 @@ atd35s3.upload.tool.network=esp_ota
 atd35s3.upload.maximum_size=1310720
 atd35s3.upload.maximum_data_size=327680
 atd35s3.upload.flags=
+atd35s3.upload.erase_cmd=
 atd35s3.upload.extra_flags=
 atd35s3.upload.use_1200bps_touch=false
 atd35s3.upload.wait_for_upload_port=false
@@ -43023,7 +43024,6 @@ atd35s3.menu.DebugLevel.verbose=Verbose
 atd35s3.menu.DebugLevel.verbose.build.code_debug=5
 
 atd35s3.menu.EraseFlash.none=Disabled
-atd35s3.menu.EraseFlash.none.upload.erase_cmd=
 atd35s3.menu.EraseFlash.all=Enabled
 atd35s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -43044,6 +43044,7 @@ esp32s3_powerfeather.upload.tool.network=esp_ota
 esp32s3_powerfeather.upload.maximum_size=1310720
 esp32s3_powerfeather.upload.maximum_data_size=327680
 esp32s3_powerfeather.upload.flags=
+esp32s3_powerfeather.upload.erase_cmd=
 esp32s3_powerfeather.upload.extra_flags=
 esp32s3_powerfeather.upload.use_1200bps_touch=false
 esp32s3_powerfeather.upload.wait_for_upload_port=false
@@ -43203,7 +43204,6 @@ esp32s3_powerfeather.menu.DebugLevel.verbose=Verbose
 esp32s3_powerfeather.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32s3_powerfeather.menu.EraseFlash.none=Disabled
-esp32s3_powerfeather.menu.EraseFlash.none.upload.erase_cmd=
 esp32s3_powerfeather.menu.EraseFlash.all=Enabled
 esp32s3_powerfeather.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -43228,6 +43228,7 @@ sensebox_mcu_esp32s2.upload.tool.network=esp_ota
 sensebox_mcu_esp32s2.upload.maximum_size=1310720
 sensebox_mcu_esp32s2.upload.maximum_data_size=327680
 sensebox_mcu_esp32s2.upload.flags=
+sensebox_mcu_esp32s2.upload.erase_cmd=
 sensebox_mcu_esp32s2.upload.extra_flags=
 sensebox_mcu_esp32s2.upload.use_1200bps_touch=true
 sensebox_mcu_esp32s2.upload.wait_for_upload_port=true
@@ -43374,7 +43375,6 @@ sensebox_mcu_esp32s2.menu.DebugLevel.verbose=Verbose
 sensebox_mcu_esp32s2.menu.DebugLevel.verbose.build.code_debug=5
 
 sensebox_mcu_esp32s2.menu.EraseFlash.none=Disabled
-sensebox_mcu_esp32s2.menu.EraseFlash.none.upload.erase_cmd=
 sensebox_mcu_esp32s2.menu.EraseFlash.all=Enabled
 sensebox_mcu_esp32s2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -43399,6 +43399,7 @@ sensebox_eye.upload.tool.network=esp_ota
 sensebox_eye.upload.maximum_size=1310720
 sensebox_eye.upload.maximum_data_size=327680
 sensebox_eye.upload.flags=
+sensebox_eye.upload.erase_cmd=
 sensebox_eye.upload.extra_flags=
 sensebox_eye.upload.use_1200bps_touch=false
 sensebox_eye.upload.wait_for_upload_port=false
@@ -43564,7 +43565,6 @@ sensebox_eye.menu.DebugLevel.verbose=Verbose
 sensebox_eye.menu.DebugLevel.verbose.build.code_debug=5
 
 sensebox_eye.menu.EraseFlash.none=Disabled
-sensebox_eye.menu.EraseFlash.none.upload.erase_cmd=
 sensebox_eye.menu.EraseFlash.all=Enabled
 sensebox_eye.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -43675,6 +43675,7 @@ makergo_c3_supermini.upload.tool.network=esp_ota
 makergo_c3_supermini.upload.maximum_size=1310720
 makergo_c3_supermini.upload.maximum_data_size=327680
 makergo_c3_supermini.upload.flags=
+makergo_c3_supermini.upload.erase_cmd=
 makergo_c3_supermini.upload.extra_flags=
 makergo_c3_supermini.upload.use_1200bps_touch=false
 makergo_c3_supermini.upload.wait_for_upload_port=false
@@ -43771,7 +43772,6 @@ makergo_c3_supermini.menu.DebugLevel.verbose=Verbose
 makergo_c3_supermini.menu.DebugLevel.verbose.build.code_debug=5
 
 makergo_c3_supermini.menu.EraseFlash.none=Disabled
-makergo_c3_supermini.menu.EraseFlash.none.upload.erase_cmd=
 makergo_c3_supermini.menu.EraseFlash.all=Enabled
 makergo_c3_supermini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -43789,6 +43789,7 @@ makergo_c6_supermini.upload.tool.network=esp_ota
 makergo_c6_supermini.upload.maximum_size=1310720
 makergo_c6_supermini.upload.maximum_data_size=327680
 makergo_c6_supermini.upload.flags=
+makergo_c6_supermini.upload.erase_cmd=
 makergo_c6_supermini.upload.extra_flags=
 makergo_c6_supermini.upload.use_1200bps_touch=false
 makergo_c6_supermini.upload.wait_for_upload_port=false
@@ -43926,7 +43927,6 @@ makergo_c6_supermini.menu.DebugLevel.verbose=Verbose
 makergo_c6_supermini.menu.DebugLevel.verbose.build.code_debug=5
 
 makergo_c6_supermini.menu.EraseFlash.none=Disabled
-makergo_c6_supermini.menu.EraseFlash.none.upload.erase_cmd=
 makergo_c6_supermini.menu.EraseFlash.all=Enabled
 makergo_c6_supermini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -43955,6 +43955,7 @@ epulse_feather.upload.tool.network=esp_ota
 epulse_feather.upload.maximum_size=1310720
 epulse_feather.upload.maximum_data_size=327680
 epulse_feather.upload.flags=
+epulse_feather.upload.erase_cmd=
 epulse_feather.upload.extra_flags=
 
 epulse_feather.serial.disableDTR=true
@@ -44047,7 +44048,6 @@ epulse_feather.menu.DebugLevel.verbose=Verbose
 epulse_feather.menu.DebugLevel.verbose.build.code_debug=5
 
 epulse_feather.menu.EraseFlash.none=Disabled
-epulse_feather.menu.EraseFlash.none.upload.erase_cmd=
 epulse_feather.menu.EraseFlash.all=Enabled
 epulse_feather.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -44066,6 +44066,7 @@ epulse_feather_c6.upload.tool.network=esp_ota
 epulse_feather_c6.upload.maximum_size=1310720
 epulse_feather_c6.upload.maximum_data_size=327680
 epulse_feather_c6.upload.flags=
+epulse_feather_c6.upload.erase_cmd=
 epulse_feather_c6.upload.extra_flags=
 epulse_feather_c6.upload.use_1200bps_touch=false
 epulse_feather_c6.upload.wait_for_upload_port=false
@@ -44206,7 +44207,6 @@ epulse_feather_c6.menu.DebugLevel.verbose=Verbose
 epulse_feather_c6.menu.DebugLevel.verbose.build.code_debug=5
 
 epulse_feather_c6.menu.EraseFlash.none=Disabled
-epulse_feather_c6.menu.EraseFlash.none.upload.erase_cmd=
 epulse_feather_c6.menu.EraseFlash.all=Enabled
 epulse_feather_c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -44234,6 +44234,7 @@ Geekble_ESP32C3.upload.tool.network=esp_ota
 Geekble_ESP32C3.upload.maximum_size=1310720
 Geekble_ESP32C3.upload.maximum_data_size=327680
 Geekble_ESP32C3.upload.flags=
+Geekble_ESP32C3.upload.erase_cmd=
 Geekble_ESP32C3.upload.extra_flags=
 Geekble_ESP32C3.upload.use_1200bps_touch=false
 Geekble_ESP32C3.upload.wait_for_upload_port=false
@@ -44307,7 +44308,6 @@ Geekble_ESP32C3.menu.DebugLevel.verbose=Verbose
 Geekble_ESP32C3.menu.DebugLevel.verbose.build.code_debug=5
 
 Geekble_ESP32C3.menu.EraseFlash.none=Disabled
-Geekble_ESP32C3.menu.EraseFlash.none.upload.erase_cmd=
 Geekble_ESP32C3.menu.EraseFlash.all=Enabled
 Geekble_ESP32C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -44330,6 +44330,7 @@ Geekble_Nano_ESP32S3.upload.maximum_size=1310720
 Geekble_Nano_ESP32S3.upload.maximum_data_size=327680
 Geekble_Nano_ESP32S3.upload.speed=921600
 Geekble_Nano_ESP32S3.upload.flags=
+Geekble_Nano_ESP32S3.upload.erase_cmd=
 Geekble_Nano_ESP32S3.upload.extra_flags=
 Geekble_Nano_ESP32S3.upload.use_1200bps_touch=false
 Geekble_Nano_ESP32S3.upload.wait_for_upload_port=false
@@ -44430,7 +44431,6 @@ Geekble_Nano_ESP32S3.menu.DebugLevel.verbose=Verbose
 Geekble_Nano_ESP32S3.menu.DebugLevel.verbose.build.code_debug=5
 
 Geekble_Nano_ESP32S3.menu.EraseFlash.none=Disabled
-Geekble_Nano_ESP32S3.menu.EraseFlash.none.upload.erase_cmd=
 Geekble_Nano_ESP32S3.menu.EraseFlash.all=Enabled
 Geekble_Nano_ESP32S3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -44448,6 +44448,7 @@ waveshare_p4_poe_eth.upload.tool.network=esp_ota
 waveshare_p4_poe_eth.upload.maximum_size=1310720
 waveshare_p4_poe_eth.upload.maximum_data_size=327680
 waveshare_p4_poe_eth.upload.flags=
+waveshare_p4_poe_eth.upload.erase_cmd=
 waveshare_p4_poe_eth.upload.extra_flags=
 waveshare_p4_poe_eth.upload.use_1200bps_touch=false
 waveshare_p4_poe_eth.upload.wait_for_upload_port=false
@@ -44606,7 +44607,6 @@ waveshare_p4_poe_eth.menu.DebugLevel.verbose=Verbose
 waveshare_p4_poe_eth.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_p4_poe_eth.menu.EraseFlash.none=Disabled
-waveshare_p4_poe_eth.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_p4_poe_eth.menu.EraseFlash.all=Enabled
 waveshare_p4_poe_eth.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -44629,6 +44629,7 @@ waveshare_esp32_s3_zero.upload.maximum_size=1310720
 
 waveshare_esp32_s3_zero.upload.maximum_data_size=327680
 waveshare_esp32_s3_zero.upload.flags=
+waveshare_esp32_s3_zero.upload.erase_cmd=
 waveshare_esp32_s3_zero.upload.extra_flags=
 waveshare_esp32_s3_zero.upload.use_1200bps_touch=false
 waveshare_esp32_s3_zero.upload.wait_for_upload_port=false
@@ -44796,7 +44797,6 @@ waveshare_esp32_s3_zero.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_zero.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_zero.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_zero.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_zero.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_zero.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -44819,6 +44819,7 @@ ws_esp32_s3_matrix.upload.maximum_size=1310720
 
 ws_esp32_s3_matrix.upload.maximum_data_size=327680
 ws_esp32_s3_matrix.upload.flags=
+ws_esp32_s3_matrix.upload.erase_cmd=
 ws_esp32_s3_matrix.upload.extra_flags=
 ws_esp32_s3_matrix.upload.use_1200bps_touch=false
 ws_esp32_s3_matrix.upload.wait_for_upload_port=false
@@ -44989,7 +44990,6 @@ ws_esp32_s3_matrix.menu.DebugLevel.verbose=Verbose
 ws_esp32_s3_matrix.menu.DebugLevel.verbose.build.code_debug=5
 
 ws_esp32_s3_matrix.menu.EraseFlash.none=Disabled
-ws_esp32_s3_matrix.menu.EraseFlash.none.upload.erase_cmd=
 ws_esp32_s3_matrix.menu.EraseFlash.all=Enabled
 ws_esp32_s3_matrix.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -45012,6 +45012,7 @@ waveshare_esp32_s3_touch_lcd_169.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_lcd_169.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_169.upload.flags=
+waveshare_esp32_s3_touch_lcd_169.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_169.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_169.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_169.upload.wait_for_upload_port=false
@@ -45185,7 +45186,6 @@ waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_169.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_169.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -45208,6 +45208,7 @@ waveshare_esp32_s3_touch_amoled_18.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_amoled_18.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_amoled_18.upload.flags=
+waveshare_esp32_s3_touch_amoled_18.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_18.upload.extra_flags=
 waveshare_esp32_s3_touch_amoled_18.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_amoled_18.upload.wait_for_upload_port=false
@@ -45381,7 +45382,6 @@ waveshare_esp32_s3_touch_amoled_18.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_amoled_18.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_amoled_18.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_amoled_18.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_18.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_amoled_18.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -45400,6 +45400,7 @@ waveshare_esp32_s3_touch_amoled_206.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_amoled_206.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_amoled_206.upload.flags=
+waveshare_esp32_s3_touch_amoled_206.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_206.upload.extra_flags=
 waveshare_esp32_s3_touch_amoled_206.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_amoled_206.upload.wait_for_upload_port=false
@@ -45579,7 +45580,6 @@ waveshare_esp32_s3_touch_amoled_206.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_amoled_206.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_amoled_206.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_amoled_206.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_206.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_amoled_206.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -45602,6 +45602,7 @@ waveshare_esp32_s3_lcd_169.upload.maximum_size=1310720
 
 waveshare_esp32_s3_lcd_169.upload.maximum_data_size=327680
 waveshare_esp32_s3_lcd_169.upload.flags=
+waveshare_esp32_s3_lcd_169.upload.erase_cmd=
 waveshare_esp32_s3_lcd_169.upload.extra_flags=
 waveshare_esp32_s3_lcd_169.upload.use_1200bps_touch=false
 waveshare_esp32_s3_lcd_169.upload.wait_for_upload_port=false
@@ -45775,7 +45776,6 @@ waveshare_esp32_s3_lcd_169.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_lcd_169.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_lcd_169.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_lcd_169.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_lcd_169.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_lcd_169.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -45791,6 +45791,7 @@ waveshare_esp32s3_touch_lcd_128.upload.maximum_data_size=327680
 waveshare_esp32s3_touch_lcd_128.upload.wait_for_upload_port=false
 waveshare_esp32s3_touch_lcd_128.upload.speed=460800
 waveshare_esp32s3_touch_lcd_128.upload.flags=
+waveshare_esp32s3_touch_lcd_128.upload.erase_cmd=
 waveshare_esp32s3_touch_lcd_128.upload.extra_flags=
 
 waveshare_esp32s3_touch_lcd_128.bootloader.tool=esptool_py
@@ -45927,7 +45928,6 @@ waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.verbose=Verbose
 waveshare_esp32s3_touch_lcd_128.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.none=Disabled
-waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.all=Enabled
 waveshare_esp32s3_touch_lcd_128.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -45945,6 +45945,7 @@ waveshare_esp32_c3_zero.upload.tool.network=esp_ota
 waveshare_esp32_c3_zero.upload.maximum_size=1310720
 waveshare_esp32_c3_zero.upload.maximum_data_size=327680
 waveshare_esp32_c3_zero.upload.flags=
+waveshare_esp32_c3_zero.upload.erase_cmd=
 waveshare_esp32_c3_zero.upload.extra_flags=
 waveshare_esp32_c3_zero.upload.use_1200bps_touch=false
 waveshare_esp32_c3_zero.upload.wait_for_upload_port=false
@@ -46082,7 +46083,6 @@ waveshare_esp32_c3_zero.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_c3_zero.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_c3_zero.menu.EraseFlash.none=Disabled
-waveshare_esp32_c3_zero.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_c3_zero.menu.EraseFlash.all=Enabled
 waveshare_esp32_c3_zero.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -46107,6 +46107,7 @@ waveshare_esp32_c6_zero.upload.tool.network=esp_ota
 waveshare_esp32_c6_zero.upload.maximum_size=1310720
 waveshare_esp32_c6_zero.upload.maximum_data_size=327680
 waveshare_esp32_c6_zero.upload.flags=
+waveshare_esp32_c6_zero.upload.erase_cmd=
 waveshare_esp32_c6_zero.upload.extra_flags=
 waveshare_esp32_c6_zero.upload.use_1200bps_touch=false
 waveshare_esp32_c6_zero.upload.wait_for_upload_port=false
@@ -46244,7 +46245,6 @@ waveshare_esp32_c6_zero.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_c6_zero.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_c6_zero.menu.EraseFlash.none=Disabled
-waveshare_esp32_c6_zero.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_c6_zero.menu.EraseFlash.all=Enabled
 waveshare_esp32_c6_zero.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -46268,6 +46268,7 @@ weact_studio_esp32c3.upload.tool.network=esp_ota
 weact_studio_esp32c3.upload.maximum_size=1310720
 weact_studio_esp32c3.upload.maximum_data_size=327680
 weact_studio_esp32c3.upload.flags=
+weact_studio_esp32c3.upload.erase_cmd=
 weact_studio_esp32c3.upload.extra_flags=
 weact_studio_esp32c3.upload.use_1200bps_touch=false
 weact_studio_esp32c3.upload.wait_for_upload_port=false
@@ -46389,7 +46390,6 @@ weact_studio_esp32c3.menu.DebugLevel.verbose=Verbose
 weact_studio_esp32c3.menu.DebugLevel.verbose.build.code_debug=5
 
 weact_studio_esp32c3.menu.EraseFlash.none=Disabled
-weact_studio_esp32c3.menu.EraseFlash.none.upload.erase_cmd=
 weact_studio_esp32c3.menu.EraseFlash.all=Enabled
 weact_studio_esp32c3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -46407,6 +46407,7 @@ aslcanx2.upload.tool.network=esp_ota
 aslcanx2.upload.maximum_size=1310720
 aslcanx2.upload.maximum_data_size=327680
 aslcanx2.upload.flags=
+aslcanx2.upload.erase_cmd=
 aslcanx2.upload.extra_flags=
 aslcanx2.upload.use_1200bps_touch=false
 aslcanx2.upload.wait_for_upload_port=false
@@ -46595,7 +46596,6 @@ aslcanx2.menu.DebugLevel.verbose=Verbose
 aslcanx2.menu.DebugLevel.verbose.build.code_debug=5
 
 aslcanx2.menu.EraseFlash.none=Disabled
-aslcanx2.menu.EraseFlash.none.upload.erase_cmd=
 aslcanx2.menu.EraseFlash.all=Enabled
 aslcanx2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -46613,6 +46613,7 @@ walter.upload.tool.network=esp_ota
 walter.upload.maximum_size=1310720
 walter.upload.maximum_data_size=327680
 walter.upload.flags=
+walter.upload.erase_cmd=
 walter.upload.extra_flags=
 walter.upload.use_1200bps_touch=false
 walter.upload.wait_for_upload_port=false
@@ -46768,7 +46769,6 @@ walter.menu.DebugLevel.verbose=Verbose
 walter.menu.DebugLevel.verbose.build.code_debug=5
 
 walter.menu.EraseFlash.none=Disabled
-walter.menu.EraseFlash.none.upload.erase_cmd=
 walter.menu.EraseFlash.all=Enabled
 walter.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -46784,6 +46784,7 @@ elecrow_crowpanel_7.upload.maximum_data_size=327680
 elecrow_crowpanel_7.upload.wait_for_upload_port=false
 elecrow_crowpanel_7.upload.speed=460800
 elecrow_crowpanel_7.upload.flags=
+elecrow_crowpanel_7.upload.erase_cmd=
 elecrow_crowpanel_7.upload.extra_flags=
 
 elecrow_crowpanel_7.bootloader.tool=esptool_py
@@ -46914,7 +46915,6 @@ elecrow_crowpanel_7.menu.DebugLevel.verbose=Verbose
 elecrow_crowpanel_7.menu.DebugLevel.verbose.build.code_debug=5
 
 elecrow_crowpanel_7.menu.EraseFlash.none=Disabled
-elecrow_crowpanel_7.menu.EraseFlash.none.upload.erase_cmd=
 elecrow_crowpanel_7.menu.EraseFlash.all=Enabled
 elecrow_crowpanel_7.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -46934,6 +46934,7 @@ circuitart_zero_s3.upload.tool.network=esp_ota
 circuitart_zero_s3.upload.maximum_size=1310720
 circuitart_zero_s3.upload.maximum_data_size=327680
 circuitart_zero_s3.upload.flags=
+circuitart_zero_s3.upload.erase_cmd=
 circuitart_zero_s3.upload.extra_flags=
 circuitart_zero_s3.upload.use_1200bps_touch=false
 circuitart_zero_s3.upload.wait_for_upload_port=false
@@ -47075,7 +47076,6 @@ circuitart_zero_s3.menu.DebugLevel.verbose=Verbose
 circuitart_zero_s3.menu.DebugLevel.verbose.build.code_debug=5
 
 circuitart_zero_s3.menu.EraseFlash.none=Disabled
-circuitart_zero_s3.menu.EraseFlash.none.upload.erase_cmd=
 circuitart_zero_s3.menu.EraseFlash.all=Enabled
 circuitart_zero_s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -47099,6 +47099,7 @@ alfredo-nou3.upload.tool.network=esp_ota
 alfredo-nou3.upload.maximum_size=3342336
 alfredo-nou3.upload.maximum_data_size=327680
 alfredo-nou3.upload.flags=
+alfredo-nou3.upload.erase_cmd=
 alfredo-nou3.upload.extra_flags=
 alfredo-nou3.upload.use_1200bps_touch=true
 alfredo-nou3.upload.wait_for_upload_port=true
@@ -47241,7 +47242,6 @@ alfredo-nou3.menu.DebugLevel.verbose=Verbose
 alfredo-nou3.menu.DebugLevel.verbose.build.code_debug=5
 
 alfredo-nou3.menu.EraseFlash.none=Disabled
-alfredo-nou3.menu.EraseFlash.none.upload.erase_cmd=
 alfredo-nou3.menu.EraseFlash.all=Enabled
 alfredo-nou3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -47258,6 +47258,7 @@ codecell.upload.tool.network=esp_ota
 codecell.upload.maximum_size=1310720
 codecell.upload.maximum_data_size=327680
 codecell.upload.flags=
+codecell.upload.erase_cmd=
 codecell.upload.extra_flags=
 codecell.upload.use_1200bps_touch=false
 codecell.upload.wait_for_upload_port=false
@@ -47395,7 +47396,6 @@ codecell.menu.DebugLevel.verbose=Verbose
 codecell.menu.DebugLevel.verbose.build.code_debug=5
 
 codecell.menu.EraseFlash.none=Disabled
-codecell.menu.EraseFlash.none.upload.erase_cmd=
 codecell.menu.EraseFlash.all=Enabled
 codecell.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -47419,6 +47419,7 @@ jczn_2432s028r.upload.tool.network=esp_ota
 jczn_2432s028r.upload.maximum_size=1310720
 jczn_2432s028r.upload.maximum_data_size=327680
 jczn_2432s028r.upload.flags=
+jczn_2432s028r.upload.erase_cmd=
 jczn_2432s028r.upload.extra_flags=
 
 jczn_2432s028r.serial.disableDTR=true
@@ -47559,7 +47560,6 @@ jczn_2432s028r.menu.DebugLevel.verbose=Verbose
 jczn_2432s028r.menu.DebugLevel.verbose.build.code_debug=5
 
 jczn_2432s028r.menu.EraseFlash.none=Disabled
-jczn_2432s028r.menu.EraseFlash.none.upload.erase_cmd=
 jczn_2432s028r.menu.EraseFlash.all=Enabled
 jczn_2432s028r.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -47589,6 +47589,7 @@ waveshare_esp32_s3_touch_amoled_241.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_amoled_241.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_amoled_241.upload.flags=
+waveshare_esp32_s3_touch_amoled_241.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_241.upload.extra_flags=
 waveshare_esp32_s3_touch_amoled_241.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_amoled_241.upload.wait_for_upload_port=false
@@ -47763,7 +47764,6 @@ waveshare_esp32_s3_touch_amoled_241.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_amoled_241.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_amoled_241.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_amoled_241.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_241.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_amoled_241.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -47786,6 +47786,7 @@ waveshare_esp32_s3_touch_lcd_43.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_lcd_43.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_43.upload.flags=
+waveshare_esp32_s3_touch_lcd_43.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_43.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_43.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_43.upload.wait_for_upload_port=false
@@ -47964,7 +47965,6 @@ waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_43.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_43.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -47987,6 +47987,7 @@ waveshare_esp32_s3_touch_lcd_43B.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_lcd_43B.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_43B.upload.flags=
+waveshare_esp32_s3_touch_lcd_43B.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_43B.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_43B.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_43B.upload.wait_for_upload_port=false
@@ -48160,7 +48161,6 @@ waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_43B.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -48183,6 +48183,7 @@ waveshare_esp32_s3_touch_lcd_7.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_lcd_7.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_7.upload.flags=
+waveshare_esp32_s3_touch_lcd_7.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_7.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_7.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_7.upload.wait_for_upload_port=false
@@ -48361,7 +48362,6 @@ waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_7.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -48384,6 +48384,7 @@ waveshare_esp32_s3_touch_lcd_5.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_lcd_5.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_5.upload.flags=
+waveshare_esp32_s3_touch_lcd_5.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_5.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_5.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_5.upload.wait_for_upload_port=false
@@ -48557,7 +48558,6 @@ waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_5.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -48580,6 +48580,7 @@ waveshare_esp32_s3_touch_lcd_5B.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_lcd_5B.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_5B.upload.flags=
+waveshare_esp32_s3_touch_lcd_5B.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_5B.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_5B.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_5B.upload.wait_for_upload_port=false
@@ -48753,7 +48754,6 @@ waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_5B.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_5B.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -48776,6 +48776,7 @@ waveshare_esp32_s3_touch_lcd_4.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_lcd_4.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_4.upload.flags=
+waveshare_esp32_s3_touch_lcd_4.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_4.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_4.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_4.upload.wait_for_upload_port=false
@@ -48949,7 +48950,6 @@ waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_4.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -48971,6 +48971,7 @@ waveshare_esp32_s3_touch_lcd_185.upload.tool.network=esp_ota
 waveshare_esp32_s3_touch_lcd_185.upload.maximum_size=1310720
 waveshare_esp32_s3_touch_lcd_185.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_185.upload.flags=
+waveshare_esp32_s3_touch_lcd_185.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_185.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_185.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_185.upload.wait_for_upload_port=false
@@ -49179,7 +49180,6 @@ waveshare_esp32_s3_touch_lcd_185.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_185.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_185.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_185.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_185.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_185.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -49204,6 +49204,7 @@ cezerio_dev_esp32c6.upload.tool.network=esp_ota
 cezerio_dev_esp32c6.upload.maximum_size=1310720
 cezerio_dev_esp32c6.upload.maximum_data_size=327680
 cezerio_dev_esp32c6.upload.flags=
+cezerio_dev_esp32c6.upload.erase_cmd=
 cezerio_dev_esp32c6.upload.extra_flags=
 cezerio_dev_esp32c6.upload.use_1200bps_touch=false
 cezerio_dev_esp32c6.upload.wait_for_upload_port=false
@@ -49346,7 +49347,6 @@ cezerio_dev_esp32c6.menu.DebugLevel.verbose=Verbose
 cezerio_dev_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 cezerio_dev_esp32c6.menu.EraseFlash.none=Disabled
-cezerio_dev_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
 cezerio_dev_esp32c6.menu.EraseFlash.all=Enabled
 cezerio_dev_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -49374,6 +49374,7 @@ cezerio_mini_dev_esp32c6.upload.tool.network=esp_ota
 cezerio_mini_dev_esp32c6.upload.maximum_size=1310720
 cezerio_mini_dev_esp32c6.upload.maximum_data_size=327680
 cezerio_mini_dev_esp32c6.upload.flags=
+cezerio_mini_dev_esp32c6.upload.erase_cmd=
 cezerio_mini_dev_esp32c6.upload.extra_flags=
 cezerio_mini_dev_esp32c6.upload.use_1200bps_touch=false
 cezerio_mini_dev_esp32c6.upload.wait_for_upload_port=false
@@ -49516,7 +49517,6 @@ cezerio_mini_dev_esp32c6.menu.DebugLevel.verbose=Verbose
 cezerio_mini_dev_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 cezerio_mini_dev_esp32c6.menu.EraseFlash.none=Disabled
-cezerio_mini_dev_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
 cezerio_mini_dev_esp32c6.menu.EraseFlash.all=Enabled
 cezerio_mini_dev_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -49548,6 +49548,7 @@ waveshare_esp32_s3_lcd_185.upload.tool.network=esp_ota
 waveshare_esp32_s3_lcd_185.upload.maximum_size=1310720
 waveshare_esp32_s3_lcd_185.upload.maximum_data_size=327680
 waveshare_esp32_s3_lcd_185.upload.flags=
+waveshare_esp32_s3_lcd_185.upload.erase_cmd=
 waveshare_esp32_s3_lcd_185.upload.extra_flags=
 waveshare_esp32_s3_lcd_185.upload.use_1200bps_touch=false
 waveshare_esp32_s3_lcd_185.upload.wait_for_upload_port=false
@@ -49756,7 +49757,6 @@ waveshare_esp32_s3_lcd_185.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_lcd_185.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_lcd_185.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_lcd_185.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_lcd_185.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_lcd_185.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -49785,6 +49785,7 @@ waveshare_esp32_s3_touch_lcd_146.upload.tool.network=esp_ota
 waveshare_esp32_s3_touch_lcd_146.upload.maximum_size=1310720
 waveshare_esp32_s3_touch_lcd_146.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_146.upload.flags=
+waveshare_esp32_s3_touch_lcd_146.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_146.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_146.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_146.upload.wait_for_upload_port=false
@@ -49993,7 +49994,6 @@ waveshare_esp32_s3_touch_lcd_146.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_146.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_146.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_146.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_146.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_146.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -50022,6 +50022,7 @@ waveshare_esp32_s3_lcd_146.upload.tool.network=esp_ota
 waveshare_esp32_s3_lcd_146.upload.maximum_size=1310720
 waveshare_esp32_s3_lcd_146.upload.maximum_data_size=327680
 waveshare_esp32_s3_lcd_146.upload.flags=
+waveshare_esp32_s3_lcd_146.upload.erase_cmd=
 waveshare_esp32_s3_lcd_146.upload.extra_flags=
 waveshare_esp32_s3_lcd_146.upload.use_1200bps_touch=false
 waveshare_esp32_s3_lcd_146.upload.wait_for_upload_port=false
@@ -50230,7 +50231,6 @@ waveshare_esp32_s3_lcd_146.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_lcd_146.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_lcd_146.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_lcd_146.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_lcd_146.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_lcd_146.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -50259,6 +50259,7 @@ waveshare_esp32_s3_touch_lcd_185_box.upload.tool.network=esp_ota
 waveshare_esp32_s3_touch_lcd_185_box.upload.maximum_size=1310720
 waveshare_esp32_s3_touch_lcd_185_box.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_185_box.upload.flags=
+waveshare_esp32_s3_touch_lcd_185_box.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_185_box.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_185_box.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_185_box.upload.wait_for_upload_port=false
@@ -50467,7 +50468,6 @@ waveshare_esp32_s3_touch_lcd_185_box.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_185_box.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_185_box.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_185_box.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_185_box.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_185_box.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -50496,6 +50496,7 @@ waveshare_esp32_s3_lcd_147.upload.tool.network=esp_ota
 waveshare_esp32_s3_lcd_147.upload.maximum_size=1310720
 waveshare_esp32_s3_lcd_147.upload.maximum_data_size=327680
 waveshare_esp32_s3_lcd_147.upload.flags=
+waveshare_esp32_s3_lcd_147.upload.erase_cmd=
 waveshare_esp32_s3_lcd_147.upload.extra_flags=
 waveshare_esp32_s3_lcd_147.upload.use_1200bps_touch=false
 waveshare_esp32_s3_lcd_147.upload.wait_for_upload_port=false
@@ -50704,7 +50705,6 @@ waveshare_esp32_s3_lcd_147.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_lcd_147.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_lcd_147.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_lcd_147.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_lcd_147.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_lcd_147.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -50733,6 +50733,7 @@ waveshare_esp32_s3_touch_lcd_21.upload.tool.network=esp_ota
 waveshare_esp32_s3_touch_lcd_21.upload.maximum_size=1310720
 waveshare_esp32_s3_touch_lcd_21.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_21.upload.flags=
+waveshare_esp32_s3_touch_lcd_21.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_21.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_21.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_21.upload.wait_for_upload_port=false
@@ -50941,7 +50942,6 @@ waveshare_esp32_s3_touch_lcd_21.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_21.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_21.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_21.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_21.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_21.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -50970,6 +50970,7 @@ waveshare_esp32_s3_touch_lcd_28.upload.tool.network=esp_ota
 waveshare_esp32_s3_touch_lcd_28.upload.maximum_size=1310720
 waveshare_esp32_s3_touch_lcd_28.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_lcd_28.upload.flags=
+waveshare_esp32_s3_touch_lcd_28.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_28.upload.extra_flags=
 waveshare_esp32_s3_touch_lcd_28.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_lcd_28.upload.wait_for_upload_port=false
@@ -51178,7 +51179,6 @@ waveshare_esp32_s3_touch_lcd_28.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_lcd_28.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_lcd_28.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_lcd_28.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_lcd_28.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_lcd_28.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -51207,6 +51207,7 @@ waveshare_esp32_s3_relay_6ch.upload.tool.network=esp_ota
 waveshare_esp32_s3_relay_6ch.upload.maximum_size=1310720
 waveshare_esp32_s3_relay_6ch.upload.maximum_data_size=327680
 waveshare_esp32_s3_relay_6ch.upload.flags=
+waveshare_esp32_s3_relay_6ch.upload.erase_cmd=
 waveshare_esp32_s3_relay_6ch.upload.extra_flags=
 waveshare_esp32_s3_relay_6ch.upload.use_1200bps_touch=false
 waveshare_esp32_s3_relay_6ch.upload.wait_for_upload_port=false
@@ -51418,7 +51419,6 @@ waveshare_esp32_s3_relay_6ch.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_relay_6ch.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_relay_6ch.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_relay_6ch.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_relay_6ch.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_relay_6ch.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -51448,6 +51448,7 @@ waveshare_esp32_s3_touch_amoled_164.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_amoled_164.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_amoled_164.upload.flags=
+waveshare_esp32_s3_touch_amoled_164.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_164.upload.extra_flags=
 waveshare_esp32_s3_touch_amoled_164.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_amoled_164.upload.wait_for_upload_port=false
@@ -51622,7 +51623,6 @@ waveshare_esp32_s3_touch_amoled_164.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_amoled_164.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_amoled_164.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_amoled_164.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_164.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_amoled_164.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -51645,6 +51645,7 @@ waveshare_esp32_s3_touch_amoled_143.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_amoled_143.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_amoled_143.upload.flags=
+waveshare_esp32_s3_touch_amoled_143.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_143.upload.extra_flags=
 waveshare_esp32_s3_touch_amoled_143.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_amoled_143.upload.wait_for_upload_port=false
@@ -51819,7 +51820,6 @@ waveshare_esp32_s3_touch_amoled_143.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_amoled_143.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_amoled_143.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_amoled_143.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_143.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_amoled_143.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -51842,6 +51842,7 @@ waveshare_esp32_s3_touch_amoled_191.upload.maximum_size=1310720
 
 waveshare_esp32_s3_touch_amoled_191.upload.maximum_data_size=327680
 waveshare_esp32_s3_touch_amoled_191.upload.flags=
+waveshare_esp32_s3_touch_amoled_191.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_191.upload.extra_flags=
 waveshare_esp32_s3_touch_amoled_191.upload.use_1200bps_touch=false
 waveshare_esp32_s3_touch_amoled_191.upload.wait_for_upload_port=false
@@ -52016,7 +52017,6 @@ waveshare_esp32_s3_touch_amoled_191.menu.DebugLevel.verbose=Verbose
 waveshare_esp32_s3_touch_amoled_191.menu.DebugLevel.verbose.build.code_debug=5
 
 waveshare_esp32_s3_touch_amoled_191.menu.EraseFlash.none=Disabled
-waveshare_esp32_s3_touch_amoled_191.menu.EraseFlash.none.upload.erase_cmd=
 waveshare_esp32_s3_touch_amoled_191.menu.EraseFlash.all=Enabled
 waveshare_esp32_s3_touch_amoled_191.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -52037,6 +52037,7 @@ Pcbcupid_GLYPH_C3.upload.tool.network=esp_ota
 Pcbcupid_GLYPH_C3.upload.maximum_size=1310720
 Pcbcupid_GLYPH_C3.upload.maximum_data_size=327680
 Pcbcupid_GLYPH_C3.upload.flags=
+Pcbcupid_GLYPH_C3.upload.erase_cmd=
 Pcbcupid_GLYPH_C3.upload.extra_flags=
 Pcbcupid_GLYPH_C3.upload.use_1200bps_touch=false
 Pcbcupid_GLYPH_C3.upload.wait_for_upload_port=false
@@ -52152,7 +52153,6 @@ Pcbcupid_GLYPH_C3.menu.DebugLevel.verbose=Verbose
 Pcbcupid_GLYPH_C3.menu.DebugLevel.verbose.build.code_debug=5
 
 Pcbcupid_GLYPH_C3.menu.EraseFlash.none=Disabled
-Pcbcupid_GLYPH_C3.menu.EraseFlash.none.upload.erase_cmd=
 Pcbcupid_GLYPH_C3.menu.EraseFlash.all=Enabled
 Pcbcupid_GLYPH_C3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -52171,6 +52171,7 @@ Pcbcupid_GLYPH_H2.upload.tool.network=esp_ota
 Pcbcupid_GLYPH_H2.upload.maximum_size=1310720
 Pcbcupid_GLYPH_H2.upload.maximum_data_size=327680
 Pcbcupid_GLYPH_H2.upload.flags=
+Pcbcupid_GLYPH_H2.upload.erase_cmd=
 Pcbcupid_GLYPH_H2.upload.extra_flags=
 Pcbcupid_GLYPH_H2.upload.use_1200bps_touch=false
 Pcbcupid_GLYPH_H2.upload.wait_for_upload_port=false
@@ -52302,7 +52303,6 @@ Pcbcupid_GLYPH_H2.menu.DebugLevel.verbose=Verbose
 Pcbcupid_GLYPH_H2.menu.DebugLevel.verbose.build.code_debug=5
 
 Pcbcupid_GLYPH_H2.menu.EraseFlash.none=Disabled
-Pcbcupid_GLYPH_H2.menu.EraseFlash.none.upload.erase_cmd=
 Pcbcupid_GLYPH_H2.menu.EraseFlash.all=Enabled
 Pcbcupid_GLYPH_H2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -52330,6 +52330,7 @@ Pcbcupid_GLYPH_C6.upload.tool.network=esp_ota
 Pcbcupid_GLYPH_C6.upload.maximum_size=1310720
 Pcbcupid_GLYPH_C6.upload.maximum_data_size=327680
 Pcbcupid_GLYPH_C6.upload.flags=
+Pcbcupid_GLYPH_C6.upload.erase_cmd=
 Pcbcupid_GLYPH_C6.upload.extra_flags=
 Pcbcupid_GLYPH_C6.upload.use_1200bps_touch=false
 Pcbcupid_GLYPH_C6.upload.wait_for_upload_port=false
@@ -52453,7 +52454,6 @@ Pcbcupid_GLYPH_C6.menu.DebugLevel.verbose=Verbose
 Pcbcupid_GLYPH_C6.menu.DebugLevel.verbose.build.code_debug=5
 
 Pcbcupid_GLYPH_C6.menu.EraseFlash.none=Disabled
-Pcbcupid_GLYPH_C6.menu.EraseFlash.none.upload.erase_cmd=
 Pcbcupid_GLYPH_C6.menu.EraseFlash.all=Enabled
 Pcbcupid_GLYPH_C6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -52482,6 +52482,7 @@ Pcbcupid_GLYPH_S3.upload.tool.network=esp_ota
 Pcbcupid_GLYPH_S3.upload.maximum_size=3342336
 Pcbcupid_GLYPH_S3.upload.maximum_data_size=327680
 Pcbcupid_GLYPH_S3.upload.flags=
+Pcbcupid_GLYPH_S3.upload.erase_cmd=
 Pcbcupid_GLYPH_S3.upload.extra_flags=
 Pcbcupid_GLYPH_S3.upload.use_1200bps_touch=false
 Pcbcupid_GLYPH_S3.upload.wait_for_upload_port=false
@@ -52588,7 +52589,6 @@ Pcbcupid_GLYPH_S3.menu.DebugLevel.verbose=Verbose
 Pcbcupid_GLYPH_S3.menu.DebugLevel.verbose.build.code_debug=5
 
 Pcbcupid_GLYPH_S3.menu.EraseFlash.none=Disabled
-Pcbcupid_GLYPH_S3.menu.EraseFlash.none.upload.erase_cmd=
 Pcbcupid_GLYPH_S3.menu.EraseFlash.all=Enabled
 Pcbcupid_GLYPH_S3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -52607,6 +52607,7 @@ Pcbcupid_GLYPH_S3_PSRAM.upload.tool.network=esp_ota
 Pcbcupid_GLYPH_S3_PSRAM.upload.maximum_size=1310720
 Pcbcupid_GLYPH_S3_PSRAM.upload.maximum_data_size=327680
 Pcbcupid_GLYPH_S3_PSRAM.upload.flags=
+Pcbcupid_GLYPH_S3_PSRAM.upload.erase_cmd=
 Pcbcupid_GLYPH_S3_PSRAM.upload.extra_flags=
 Pcbcupid_GLYPH_S3_PSRAM.upload.use_1200bps_touch=false
 Pcbcupid_GLYPH_S3_PSRAM.upload.wait_for_upload_port=false
@@ -52712,7 +52713,6 @@ Pcbcupid_GLYPH_S3_PSRAM.menu.DebugLevel.verbose=Verbose
 Pcbcupid_GLYPH_S3_PSRAM.menu.DebugLevel.verbose.build.code_debug=5
 
 Pcbcupid_GLYPH_S3_PSRAM.menu.EraseFlash.none=Disabled
-Pcbcupid_GLYPH_S3_PSRAM.menu.EraseFlash.none.upload.erase_cmd=
 Pcbcupid_GLYPH_S3_PSRAM.menu.EraseFlash.all=Enabled
 Pcbcupid_GLYPH_S3_PSRAM.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -52731,6 +52731,7 @@ pcbcupid_glyph_c5.upload.tool.network=esp_ota
 pcbcupid_glyph_c5.upload.maximum_size=1310720
 pcbcupid_glyph_c5.upload.maximum_data_size=327680
 pcbcupid_glyph_c5.upload.flags=
+Pcbcupid_GLYPH_S3_PSRAM.upload.erase_cmd=
 pcbcupid_glyph_c5.upload.extra_flags=
 pcbcupid_glyph_c5.upload.use_1200bps_touch=false
 pcbcupid_glyph_c5.upload.wait_for_upload_port=false
@@ -52873,7 +52874,6 @@ pcbcupid_glyph_c5.menu.DebugLevel.verbose=Verbose
 pcbcupid_glyph_c5.menu.DebugLevel.verbose.build.code_debug=5
 
 pcbcupid_glyph_c5.menu.EraseFlash.none=Disabled
-pcbcupid_glyph_c5.menu.EraseFlash.none.upload.erase_cmd=
 pcbcupid_glyph_c5.menu.EraseFlash.all=Enabled
 pcbcupid_glyph_c5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -52907,6 +52907,7 @@ yb_esp32s3_amp_v2.upload.tool.network=esp_ota
 yb_esp32s3_amp_v2.upload.maximum_size=1310720
 yb_esp32s3_amp_v2.upload.maximum_data_size=327680
 yb_esp32s3_amp_v2.upload.flags=
+yb_esp32s3_amp_v2.upload.erase_cmd=
 yb_esp32s3_amp_v2.upload.extra_flags=
 yb_esp32s3_amp_v2.upload.use_1200bps_touch=false
 yb_esp32s3_amp_v2.upload.wait_for_upload_port=false
@@ -53103,7 +53104,6 @@ yb_esp32s3_amp_v2.menu.DebugLevel.verbose=Verbose
 yb_esp32s3_amp_v2.menu.DebugLevel.verbose.build.code_debug=5
 
 yb_esp32s3_amp_v2.menu.EraseFlash.none=Disabled
-yb_esp32s3_amp_v2.menu.EraseFlash.none.upload.erase_cmd=
 yb_esp32s3_amp_v2.menu.EraseFlash.all=Enabled
 yb_esp32s3_amp_v2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -53121,6 +53121,7 @@ yb_esp32s3_amp_v3.upload.tool.network=esp_ota
 yb_esp32s3_amp_v3.upload.maximum_size=1310720
 yb_esp32s3_amp_v3.upload.maximum_data_size=327680
 yb_esp32s3_amp_v3.upload.flags=
+yb_esp32s3_amp_v3.upload.erase_cmd=
 yb_esp32s3_amp_v3.upload.extra_flags=
 yb_esp32s3_amp_v3.upload.use_1200bps_touch=false
 yb_esp32s3_amp_v3.upload.wait_for_upload_port=false
@@ -53320,7 +53321,6 @@ yb_esp32s3_amp_v3.menu.DebugLevel.verbose=Verbose
 yb_esp32s3_amp_v3.menu.DebugLevel.verbose.build.code_debug=5
 
 yb_esp32s3_amp_v3.menu.EraseFlash.none=Disabled
-yb_esp32s3_amp_v3.menu.EraseFlash.none.upload.erase_cmd=
 yb_esp32s3_amp_v3.menu.EraseFlash.all=Enabled
 yb_esp32s3_amp_v3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -53338,6 +53338,7 @@ yb_esp32s3_eth.upload.tool.network=esp_ota
 yb_esp32s3_eth.upload.maximum_size=1310720
 yb_esp32s3_eth.upload.maximum_data_size=327680
 yb_esp32s3_eth.upload.flags=
+yb_esp32s3_eth.upload.erase_cmd=
 yb_esp32s3_eth.upload.extra_flags=
 yb_esp32s3_eth.upload.use_1200bps_touch=false
 yb_esp32s3_eth.upload.wait_for_upload_port=false
@@ -53549,7 +53550,6 @@ yb_esp32s3_eth.menu.DebugLevel.verbose=Verbose
 yb_esp32s3_eth.menu.DebugLevel.verbose.build.code_debug=5
 
 yb_esp32s3_eth.menu.EraseFlash.none=Disabled
-yb_esp32s3_eth.menu.EraseFlash.none.upload.erase_cmd=
 yb_esp32s3_eth.menu.EraseFlash.all=Enabled
 yb_esp32s3_eth.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -53567,6 +53567,7 @@ yb_esp32s3_drv.upload.tool.network=esp_ota
 yb_esp32s3_drv.upload.maximum_size=1310720
 yb_esp32s3_drv.upload.maximum_data_size=327680
 yb_esp32s3_drv.upload.flags=
+yb_esp32s3_drv.upload.erase_cmd=
 yb_esp32s3_drv.upload.extra_flags=
 yb_esp32s3_drv.upload.use_1200bps_touch=false
 yb_esp32s3_drv.upload.wait_for_upload_port=false
@@ -53778,7 +53779,6 @@ yb_esp32s3_drv.menu.DebugLevel.verbose=Verbose
 yb_esp32s3_drv.menu.DebugLevel.verbose.build.code_debug=5
 
 yb_esp32s3_drv.menu.EraseFlash.none=Disabled
-yb_esp32s3_drv.menu.EraseFlash.none.upload.erase_cmd=
 yb_esp32s3_drv.menu.EraseFlash.all=Enabled
 yb_esp32s3_drv.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -53796,6 +53796,7 @@ yb_esp32s3_amp.upload.tool.network=esp_ota
 yb_esp32s3_amp.upload.maximum_size=1310720
 yb_esp32s3_amp.upload.maximum_data_size=327680
 yb_esp32s3_amp.upload.flags=
+yb_esp32s3_amp.upload.erase_cmd=
 yb_esp32s3_amp.upload.extra_flags=
 yb_esp32s3_amp.upload.use_1200bps_touch=false
 yb_esp32s3_amp.upload.wait_for_upload_port=false
@@ -54004,7 +54005,6 @@ yb_esp32s3_amp.menu.DebugLevel.verbose=Verbose
 yb_esp32s3_amp.menu.DebugLevel.verbose.build.code_debug=5
 
 yb_esp32s3_amp.menu.EraseFlash.none=Disabled
-yb_esp32s3_amp.menu.EraseFlash.none.upload.erase_cmd=
 yb_esp32s3_amp.menu.EraseFlash.all=Enabled
 yb_esp32s3_amp.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -54022,6 +54022,7 @@ yb_esp32s3_dac.upload.tool.network=esp_ota
 yb_esp32s3_dac.upload.maximum_size=1310720
 yb_esp32s3_dac.upload.maximum_data_size=327680
 yb_esp32s3_dac.upload.flags=
+yb_esp32s3_dac.upload.erase_cmd=
 yb_esp32s3_dac.upload.extra_flags=
 yb_esp32s3_dac.upload.use_1200bps_touch=false
 yb_esp32s3_dac.upload.wait_for_upload_port=false
@@ -54230,7 +54231,6 @@ yb_esp32s3_dac.menu.DebugLevel.verbose=Verbose
 yb_esp32s3_dac.menu.DebugLevel.verbose.build.code_debug=5
 
 yb_esp32s3_dac.menu.EraseFlash.none=Disabled
-yb_esp32s3_dac.menu.EraseFlash.none.upload.erase_cmd=
 yb_esp32s3_dac.menu.EraseFlash.all=Enabled
 yb_esp32s3_dac.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -54250,6 +54250,7 @@ huidu_hd_wf2.upload.tool.network=esp_ota
 huidu_hd_wf2.upload.maximum_size=1310720
 huidu_hd_wf2.upload.maximum_data_size=327680
 huidu_hd_wf2.upload.flags=
+huidu_hd_wf2.upload.erase_cmd=
 huidu_hd_wf2.upload.extra_flags=
 huidu_hd_wf2.upload.use_1200bps_touch=true
 huidu_hd_wf2.upload.wait_for_upload_port=true
@@ -54369,7 +54370,6 @@ huidu_hd_wf2.menu.DebugLevel.verbose=Verbose
 huidu_hd_wf2.menu.DebugLevel.verbose.build.code_debug=5
 
 huidu_hd_wf2.menu.EraseFlash.none=Disabled
-huidu_hd_wf2.menu.EraseFlash.none.upload.erase_cmd=
 huidu_hd_wf2.menu.EraseFlash.all=Enabled
 huidu_hd_wf2.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -54389,6 +54389,7 @@ huidu_hd_wf4.upload.tool.network=esp_ota
 huidu_hd_wf4.upload.maximum_size=1310720
 huidu_hd_wf4.upload.maximum_data_size=327680
 huidu_hd_wf4.upload.flags=
+huidu_hd_wf4.upload.erase_cmd=
 huidu_hd_wf4.upload.extra_flags=
 huidu_hd_wf4.upload.use_1200bps_touch=true
 huidu_hd_wf4.upload.wait_for_upload_port=true
@@ -54508,7 +54509,6 @@ huidu_hd_wf4.menu.DebugLevel.verbose=Verbose
 huidu_hd_wf4.menu.DebugLevel.verbose.build.code_debug=5
 
 huidu_hd_wf4.menu.EraseFlash.none=Disabled
-huidu_hd_wf4.menu.EraseFlash.none.upload.erase_cmd=
 huidu_hd_wf4.menu.EraseFlash.all=Enabled
 huidu_hd_wf4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -54527,6 +54527,7 @@ cyobot_v2_esp32s3.upload.tool.network=esp_ota
 cyobot_v2_esp32s3.upload.maximum_size=1310720
 cyobot_v2_esp32s3.upload.maximum_data_size=327680
 cyobot_v2_esp32s3.upload.flags=
+cyobot_v2_esp32s3.upload.erase_cmd=
 cyobot_v2_esp32s3.upload.extra_flags=
 cyobot_v2_esp32s3.upload.use_1200bps_touch=false
 cyobot_v2_esp32s3.upload.wait_for_upload_port=false
@@ -54753,7 +54754,6 @@ cyobot_v2_esp32s3.menu.DebugLevel.verbose=Verbose
 cyobot_v2_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 cyobot_v2_esp32s3.menu.EraseFlash.none=Disabled
-cyobot_v2_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 cyobot_v2_esp32s3.menu.EraseFlash.all=Enabled
 cyobot_v2_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -54776,6 +54776,7 @@ rakwireless_rak3112.upload.maximum_data_size=327680
 rakwireless_rak3112.upload.wait_for_upload_port=false
 rakwireless_rak3112.upload.speed=460800
 rakwireless_rak3112.upload.flags=
+rakwireless_rak3112.upload.erase_cmd=
 rakwireless_rak3112.upload.extra_flags=
 
 rakwireless_rak3112.bootloader.tool=esptool_py
@@ -54921,7 +54922,6 @@ rakwireless_rak3112.menu.DebugLevel.verbose=Verbose
 rakwireless_rak3112.menu.DebugLevel.verbose.build.code_debug=5
 
 rakwireless_rak3112.menu.EraseFlash.none=Disabled
-rakwireless_rak3112.menu.EraseFlash.none.upload.erase_cmd=
 rakwireless_rak3112.menu.EraseFlash.all=Enabled
 rakwireless_rak3112.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -54943,7 +54943,6 @@ kodedot.upload.use_1200bps_touch=false
 kodedot.upload.wait_for_upload_port=false
 kodedot.upload.speed=921600
 
-kodedot.upload.erase_cmd=
 
 kodedot.serial.disableDTR=false
 kodedot.serial.disableRTS=false
@@ -55012,6 +55011,7 @@ fed4.upload.tool.network=esp_ota
 fed4.upload.maximum_size=1310720
 fed4.upload.maximum_data_size=327680
 fed4.upload.flags=
+fed4.upload.erase_cmd=
 fed4.upload.extra_flags=
 fed4.upload.use_1200bps_touch=false
 fed4.upload.wait_for_upload_port=false
@@ -55168,7 +55168,6 @@ fed4.menu.DebugLevel.verbose=Verbose
 fed4.menu.DebugLevel.verbose.build.code_debug=5
 
 fed4.menu.EraseFlash.none=Disabled
-fed4.menu.EraseFlash.none.upload.erase_cmd=
 fed4.menu.EraseFlash.all=Enabled
 fed4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -55201,6 +55200,7 @@ fobe_quill_esp32s3_mesh.upload.tool.network=esp_ota
 fobe_quill_esp32s3_mesh.upload.maximum_size=1310720
 fobe_quill_esp32s3_mesh.upload.maximum_data_size=327680
 fobe_quill_esp32s3_mesh.upload.flags=
+fobe_quill_esp32s3_mesh.upload.erase_cmd=
 fobe_quill_esp32s3_mesh.upload.extra_flags=
 fobe_quill_esp32s3_mesh.upload.use_1200bps_touch=true
 fobe_quill_esp32s3_mesh.upload.wait_for_upload_port=true
@@ -55383,7 +55383,6 @@ fobe_quill_esp32s3_mesh.menu.DebugLevel.verbose=Verbose
 fobe_quill_esp32s3_mesh.menu.DebugLevel.verbose.build.code_debug=5
 
 fobe_quill_esp32s3_mesh.menu.EraseFlash.none=Disabled
-fobe_quill_esp32s3_mesh.menu.EraseFlash.none.upload.erase_cmd=
 fobe_quill_esp32s3_mesh.menu.EraseFlash.all=Enabled
 fobe_quill_esp32s3_mesh.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -55408,6 +55407,7 @@ twinaiot.upload.tool.network=esp_ota
 twinaiot.upload.maximum_size=1310720
 twinaiot.upload.maximum_data_size=327680
 twinaiot.upload.flags=
+twinaiot.upload.erase_cmd=
 twinaiot.upload.extra_flags=
 twinaiot.upload.use_1200bps_touch=false
 twinaiot.upload.wait_for_upload_port=false
@@ -55596,7 +55596,6 @@ twinaiot.menu.DebugLevel.verbose=Verbose
 twinaiot.menu.DebugLevel.verbose.build.code_debug=5
 
 twinaiot.menu.EraseFlash.none=Disabled
-twinaiot.menu.EraseFlash.none.upload.erase_cmd=
 twinaiot.menu.EraseFlash.all=Enabled
 twinaiot.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -55621,6 +55620,7 @@ esp32p4_4ds_mipi.upload.tool.network=esp_ota
 esp32p4_4ds_mipi.upload.maximum_size=1310720
 esp32p4_4ds_mipi.upload.maximum_data_size=327680
 esp32p4_4ds_mipi.upload.flags=
+esp32p4_4ds_mipi.upload.erase_cmd=
 esp32p4_4ds_mipi.upload.extra_flags=
 esp32p4_4ds_mipi.upload.use_1200bps_touch=false
 esp32p4_4ds_mipi.upload.wait_for_upload_port=false
@@ -55737,7 +55737,6 @@ esp32p4_4ds_mipi.menu.DebugLevel.verbose=Verbose
 esp32p4_4ds_mipi.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32p4_4ds_mipi.menu.EraseFlash.none=Disabled
-esp32p4_4ds_mipi.menu.EraseFlash.none.upload.erase_cmd=
 esp32p4_4ds_mipi.menu.EraseFlash.all=Enabled
 esp32p4_4ds_mipi.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -55782,6 +55781,7 @@ esp32p4_4ds_mipi_round.upload.tool.network=esp_ota
 esp32p4_4ds_mipi_round.upload.maximum_size=1310720
 esp32p4_4ds_mipi_round.upload.maximum_data_size=327680
 esp32p4_4ds_mipi_round.upload.flags=
+esp32p4_4ds_mipi_round.upload.erase_cmd=
 esp32p4_4ds_mipi_round.upload.extra_flags=
 esp32p4_4ds_mipi_round.upload.use_1200bps_touch=false
 esp32p4_4ds_mipi_round.upload.wait_for_upload_port=false
@@ -55895,7 +55895,6 @@ esp32p4_4ds_mipi_round.menu.DebugLevel.verbose=Verbose
 esp32p4_4ds_mipi_round.menu.DebugLevel.verbose.build.code_debug=5
 
 esp32p4_4ds_mipi_round.menu.EraseFlash.none=Disabled
-esp32p4_4ds_mipi_round.menu.EraseFlash.none.upload.erase_cmd=
 esp32p4_4ds_mipi_round.menu.EraseFlash.all=Enabled
 esp32p4_4ds_mipi_round.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -55935,6 +55934,7 @@ axiometa_pixie_m1.upload.tool.network=esp_ota
 axiometa_pixie_m1.upload.maximum_size=1310720
 axiometa_pixie_m1.upload.maximum_data_size=327680
 axiometa_pixie_m1.upload.flags=
+axiometa_pixie_m1.upload.erase_cmd=
 axiometa_pixie_m1.upload.extra_flags=
 axiometa_pixie_m1.upload.use_1200bps_touch=false
 axiometa_pixie_m1.upload.wait_for_upload_port=false
@@ -56136,7 +56136,6 @@ axiometa_pixie_m1.menu.DebugLevel.verbose.build.code_debug=5
 
 ## Erase Flash
 axiometa_pixie_m1.menu.EraseFlash.none=Disabled
-axiometa_pixie_m1.menu.EraseFlash.none.upload.erase_cmd=
 axiometa_pixie_m1.menu.EraseFlash.all=Enabled
 axiometa_pixie_m1.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -56165,6 +56164,7 @@ axiometa_genesis_one.upload.tool.network=esp_ota
 axiometa_genesis_one.upload.maximum_size=1310720
 axiometa_genesis_one.upload.maximum_data_size=327680
 axiometa_genesis_one.upload.flags=
+axiometa_genesis_one.upload.erase_cmd=
 axiometa_genesis_one.upload.extra_flags=
 axiometa_genesis_one.upload.use_1200bps_touch=false
 axiometa_genesis_one.upload.wait_for_upload_port=false
@@ -56369,7 +56369,6 @@ axiometa_genesis_one.menu.DebugLevel.verbose.build.code_debug=5
 
 ## Erase Flash
 axiometa_genesis_one.menu.EraseFlash.none=Disabled
-axiometa_genesis_one.menu.EraseFlash.none.upload.erase_cmd=
 axiometa_genesis_one.menu.EraseFlash.all=Enabled
 axiometa_genesis_one.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -56399,6 +56398,7 @@ axiometa_genesis_mini.upload.tool.network=esp_ota
 axiometa_genesis_mini.upload.maximum_size=1310720
 axiometa_genesis_mini.upload.maximum_data_size=327680
 axiometa_genesis_mini.upload.flags=
+axiometa_genesis_mini.upload.erase_cmd=
 axiometa_genesis_mini.upload.extra_flags=
 axiometa_genesis_mini.upload.use_1200bps_touch=false
 axiometa_genesis_mini.upload.wait_for_upload_port=false
@@ -56597,7 +56597,6 @@ axiometa_genesis_mini.menu.DebugLevel.verbose.build.code_debug=5
 
 ## Erase Flash
 axiometa_genesis_mini.menu.EraseFlash.none=Disabled
-axiometa_genesis_mini.menu.EraseFlash.none.upload.erase_cmd=
 axiometa_genesis_mini.menu.EraseFlash.all=Enabled
 axiometa_genesis_mini.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -56623,6 +56622,7 @@ soldered_nula_deepsleep_esp32s3.upload.tool.network=esp_ota
 soldered_nula_deepsleep_esp32s3.upload.maximum_size=1310720
 soldered_nula_deepsleep_esp32s3.upload.maximum_data_size=327680
 soldered_nula_deepsleep_esp32s3.upload.flags=
+soldered_nula_deepsleep_esp32s3.upload.erase_cmd=
 soldered_nula_deepsleep_esp32s3.upload.extra_flags=
 soldered_nula_deepsleep_esp32s3.upload.use_1200bps_touch=false
 soldered_nula_deepsleep_esp32s3.upload.wait_for_upload_port=false
@@ -56826,7 +56826,6 @@ soldered_nula_deepsleep_esp32s3.menu.DebugLevel.verbose=Verbose
 soldered_nula_deepsleep_esp32s3.menu.DebugLevel.verbose.build.code_debug=5
 
 soldered_nula_deepsleep_esp32s3.menu.EraseFlash.none=Disabled
-soldered_nula_deepsleep_esp32s3.menu.EraseFlash.none.upload.erase_cmd=
 soldered_nula_deepsleep_esp32s3.menu.EraseFlash.all=Enabled
 soldered_nula_deepsleep_esp32s3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -56851,6 +56850,7 @@ soldered_nula_dual_esp32c5.upload.tool.network=esp_ota
 soldered_nula_dual_esp32c5.upload.maximum_size=1310720
 soldered_nula_dual_esp32c5.upload.maximum_data_size=327680
 soldered_nula_dual_esp32c5.upload.flags=
+soldered_nula_dual_esp32c5.upload.erase_cmd=
 soldered_nula_dual_esp32c5.upload.extra_flags=
 soldered_nula_dual_esp32c5.upload.use_1200bps_touch=false
 soldered_nula_dual_esp32c5.upload.wait_for_upload_port=false
@@ -57016,7 +57016,6 @@ soldered_nula_dual_esp32c5.menu.DebugLevel.verbose=Verbose
 soldered_nula_dual_esp32c5.menu.DebugLevel.verbose.build.code_debug=5
 
 soldered_nula_dual_esp32c5.menu.EraseFlash.none=Disabled
-soldered_nula_dual_esp32c5.menu.EraseFlash.none.upload.erase_cmd=
 soldered_nula_dual_esp32c5.menu.EraseFlash.all=Enabled
 soldered_nula_dual_esp32c5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -57050,6 +57049,7 @@ soldered_nula_mini_esp32c6.upload.tool.network=esp_ota
 soldered_nula_mini_esp32c6.upload.maximum_size=1310720
 soldered_nula_mini_esp32c6.upload.maximum_data_size=327680
 soldered_nula_mini_esp32c6.upload.flags=
+soldered_nula_mini_esp32c6.upload.erase_cmd=
 soldered_nula_mini_esp32c6.upload.extra_flags=
 soldered_nula_mini_esp32c6.upload.use_1200bps_touch=false
 soldered_nula_mini_esp32c6.upload.wait_for_upload_port=false
@@ -57186,7 +57186,6 @@ soldered_nula_mini_esp32c6.menu.DebugLevel.verbose=Verbose
 soldered_nula_mini_esp32c6.menu.DebugLevel.verbose.build.code_debug=5
 
 soldered_nula_mini_esp32c6.menu.EraseFlash.none=Disabled
-soldered_nula_mini_esp32c6.menu.EraseFlash.none.upload.erase_cmd=
 soldered_nula_mini_esp32c6.menu.EraseFlash.all=Enabled
 soldered_nula_mini_esp32c6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -57214,6 +57213,7 @@ arduino_nesso_n1.upload.tool.network=esp_ota
 arduino_nesso_n1.upload.maximum_size=1310720
 arduino_nesso_n1.upload.maximum_data_size=327680
 arduino_nesso_n1.upload.flags=
+arduino_nesso_n1.upload.erase_cmd=
 arduino_nesso_n1.upload.extra_flags=
 arduino_nesso_n1.upload.use_1200bps_touch=false
 arduino_nesso_n1.upload.wait_for_upload_port=false
@@ -57332,7 +57332,6 @@ arduino_nesso_n1.menu.DebugLevel.verbose=Verbose
 arduino_nesso_n1.menu.DebugLevel.verbose.build.code_debug=5
 
 arduino_nesso_n1.menu.EraseFlash.none=Disabled
-arduino_nesso_n1.menu.EraseFlash.none.upload.erase_cmd=
 arduino_nesso_n1.menu.EraseFlash.all=Enabled
 arduino_nesso_n1.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -57361,6 +57360,7 @@ pandabyte_x32.upload.tool.network=esp_ota
 pandabyte_x32.upload.maximum_size=1310720
 pandabyte_x32.upload.maximum_data_size=327680
 pandabyte_x32.upload.flags=
+pandabyte_x32.upload.erase_cmd=
 pandabyte_x32.upload.extra_flags=
 
 pandabyte_x32.serial.disableDTR=true
@@ -57523,7 +57523,6 @@ pandabyte_x32.menu.DebugLevel.verbose=Verbose
 pandabyte_x32.menu.DebugLevel.verbose.build.code_debug=5
 
 pandabyte_x32.menu.EraseFlash.none=Disabled
-pandabyte_x32.menu.EraseFlash.none.upload.erase_cmd=
 pandabyte_x32.menu.EraseFlash.all=Enabled
 pandabyte_x32.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -57551,6 +57550,7 @@ pandabyte_xc3m.upload.tool.network=esp_ota
 pandabyte_xc3m.upload.maximum_size=1310720
 pandabyte_xc3m.upload.maximum_data_size=327680
 pandabyte_xc3m.upload.flags=
+pandabyte_xc3m.upload.erase_cmd=
 pandabyte_xc3m.upload.extra_flags=
 pandabyte_xc3m.upload.use_1200bps_touch=false
 pandabyte_xc3m.upload.wait_for_upload_port=false
@@ -57666,7 +57666,6 @@ pandabyte_xc3m.menu.DebugLevel.verbose=Verbose
 pandabyte_xc3m.menu.DebugLevel.verbose.build.code_debug=5
 
 pandabyte_xc3m.menu.EraseFlash.none=Disabled
-pandabyte_xc3m.menu.EraseFlash.none.upload.erase_cmd=
 pandabyte_xc3m.menu.EraseFlash.all=Enabled
 pandabyte_xc3m.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -57684,6 +57683,7 @@ pandabyte_xc5.upload.tool.network=esp_ota
 pandabyte_xc5.upload.maximum_size=1310720
 pandabyte_xc5.upload.maximum_data_size=327680
 pandabyte_xc5.upload.flags=
+pandabyte_xc5.upload.erase_cmd=
 pandabyte_xc5.upload.extra_flags=
 pandabyte_xc5.upload.use_1200bps_touch=false
 pandabyte_xc5.upload.wait_for_upload_port=false
@@ -57861,7 +57861,6 @@ pandabyte_xc5.menu.DebugLevel.verbose=Verbose
 pandabyte_xc5.menu.DebugLevel.verbose.build.code_debug=5
 
 pandabyte_xc5.menu.EraseFlash.none=Disabled
-pandabyte_xc5.menu.EraseFlash.none.upload.erase_cmd=
 pandabyte_xc5.menu.EraseFlash.all=Enabled
 pandabyte_xc5.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -57895,6 +57894,7 @@ pandabyte_xc6.upload.tool.network=esp_ota
 pandabyte_xc6.upload.maximum_size=1310720
 pandabyte_xc6.upload.maximum_data_size=327680
 pandabyte_xc6.upload.flags=
+pandabyte_xc6.upload.erase_cmd=
 pandabyte_xc6.upload.extra_flags=
 pandabyte_xc6.upload.use_1200bps_touch=false
 pandabyte_xc6.upload.wait_for_upload_port=false
@@ -58067,7 +58067,6 @@ pandabyte_xc6.menu.DebugLevel.verbose=Verbose
 pandabyte_xc6.menu.DebugLevel.verbose.build.code_debug=5
 
 pandabyte_xc6.menu.EraseFlash.none=Disabled
-pandabyte_xc6.menu.EraseFlash.none.upload.erase_cmd=
 pandabyte_xc6.menu.EraseFlash.all=Enabled
 pandabyte_xc6.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -58102,6 +58101,7 @@ pandabyte_xs3.upload.tool.network=esp_ota
 pandabyte_xs3.upload.maximum_size=1310720
 pandabyte_xs3.upload.maximum_data_size=327680
 pandabyte_xs3.upload.flags=
+pandabyte_xs3.upload.erase_cmd=
 pandabyte_xs3.upload.extra_flags=
 pandabyte_xs3.upload.use_1200bps_touch=false
 pandabyte_xs3.upload.wait_for_upload_port=false
@@ -58334,7 +58334,6 @@ pandabyte_xs3.menu.DebugLevel.verbose=Verbose
 pandabyte_xs3.menu.DebugLevel.verbose.build.code_debug=5
 
 pandabyte_xs3.menu.EraseFlash.none=Disabled
-pandabyte_xs3.menu.EraseFlash.none.upload.erase_cmd=
 pandabyte_xs3.menu.EraseFlash.all=Enabled
 pandabyte_xs3.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -58359,6 +58358,7 @@ rootmaker.upload.tool.network=esp_ota
 rootmaker.upload.maximum_size=1310720
 rootmaker.upload.maximum_data_size=327680
 rootmaker.upload.flags=
+rootmaker.upload.erase_cmd=
 rootmaker.upload.extra_flags=
 rootmaker.upload.use_1200bps_touch=false
 rootmaker.upload.wait_for_upload_port=false
@@ -58561,7 +58561,6 @@ rootmaker.menu.DebugLevel.verbose=Verbose
 rootmaker.menu.DebugLevel.verbose.build.code_debug=5
 
 rootmaker.menu.EraseFlash.none=Disabled
-rootmaker.menu.EraseFlash.none.upload.erase_cmd=
 rootmaker.menu.EraseFlash.all=Enabled
 rootmaker.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -58586,6 +58585,7 @@ amyboard.upload.tool.network=esp_ota
 amyboard.upload.maximum_size=6553600
 amyboard.upload.maximum_data_size=327680
 amyboard.upload.flags=
+amyboard.upload.erase_cmd=
 amyboard.upload.extra_flags=
 amyboard.upload.use_1200bps_touch=false
 amyboard.upload.wait_for_upload_port=false
@@ -58697,7 +58697,6 @@ amyboard.menu.EventsCore.0=Core 0
 amyboard.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
 
 amyboard.menu.EraseFlash.none=Disabled
-amyboard.menu.EraseFlash.none.upload.erase_cmd=
 amyboard.menu.EraseFlash.all=Enabled
 amyboard.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -58716,6 +58715,7 @@ xteink_x4.upload.maximum_size=1310720
 xteink_x4.upload.maximum_data_size=327680
 xteink_x4.upload.speed=921600
 xteink_x4.upload.flags=
+xteink_x4.upload.erase_cmd=
 xteink_x4.upload.extra_flags=
 xteink_x4.upload.use_1200bps_touch=false
 xteink_x4.upload.wait_for_upload_port=false
@@ -58800,7 +58800,6 @@ xteink_x4.menu.DebugLevel.verbose=Verbose
 xteink_x4.menu.DebugLevel.verbose.build.code_debug=5
 
 xteink_x4.menu.EraseFlash.none=Disabled
-xteink_x4.menu.EraseFlash.none.upload.erase_cmd=
 xteink_x4.menu.EraseFlash.all=Enabled
 xteink_x4.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -58830,6 +58829,7 @@ ozobot_drvkit.upload.tool.network=esp_ota
 ozobot_drvkit.upload.maximum_size=1310720
 ozobot_drvkit.upload.maximum_data_size=327680
 ozobot_drvkit.upload.flags=
+ozobot_drvkit.upload.erase_cmd=
 ozobot_drvkit.upload.extra_flags=
 ozobot_drvkit.upload.use_1200bps_touch=false
 ozobot_drvkit.upload.wait_for_upload_port=false
@@ -58946,7 +58946,6 @@ ozobot_drvkit.menu.DebugLevel.verbose=Verbose
 ozobot_drvkit.menu.DebugLevel.verbose.build.code_debug=5
 
 ozobot_drvkit.menu.EraseFlash.none=Disabled
-ozobot_drvkit.menu.EraseFlash.none.upload.erase_cmd=
 ozobot_drvkit.menu.EraseFlash.all=Enabled
 ozobot_drvkit.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -58971,6 +58970,7 @@ canipulator_v1.upload.tool.network=esp_ota
 canipulator_v1.upload.maximum_size=1310720
 canipulator_v1.upload.maximum_data_size=327680
 canipulator_v1.upload.flags=
+canipulator_v1.upload.erase_cmd=
 canipulator_v1.upload.extra_flags=
 canipulator_v1.upload.use_1200bps_touch=false
 canipulator_v1.upload.wait_for_upload_port=false
@@ -59126,7 +59126,6 @@ canipulator_v1.menu.DebugLevel.verbose=Verbose
 canipulator_v1.menu.DebugLevel.verbose.build.code_debug=5
 
 canipulator_v1.menu.EraseFlash.none=Disabled
-canipulator_v1.menu.EraseFlash.none.upload.erase_cmd=
 canipulator_v1.menu.EraseFlash.all=Enabled
 canipulator_v1.menu.EraseFlash.all.upload.erase_cmd=-e
 
@@ -59154,6 +59153,7 @@ canipulator_v2.upload.tool.network=esp_ota
 canipulator_v2.upload.maximum_size=1310720
 canipulator_v2.upload.maximum_data_size=327680
 canipulator_v2.upload.flags=
+canipulator_v2.upload.erase_cmd=
 canipulator_v2.upload.extra_flags=
 canipulator_v2.upload.use_1200bps_touch=false
 canipulator_v2.upload.wait_for_upload_port=false
@@ -59331,7 +59331,6 @@ canipulator_v2.menu.DebugLevel.verbose=Verbose
 canipulator_v2.menu.DebugLevel.verbose.build.code_debug=5
 
 canipulator_v2.menu.EraseFlash.none=Disabled
-canipulator_v2.menu.EraseFlash.none.upload.erase_cmd=
 canipulator_v2.menu.EraseFlash.all=Enabled
 canipulator_v2.menu.EraseFlash.all.upload.erase_cmd=-e
 

--- a/docs/en/troubleshooting.rst
+++ b/docs/en/troubleshooting.rst
@@ -111,7 +111,7 @@ What works on IDE 1.x (reference patterns)
 
 These patterns are known to expand correctly:
 
-* **Board-scoped** names from ``boards.txt``: ``{upload.speed}``, ``{upload.flags}``, ``{build.mcu}``, ``{upload.erase_cmd}``, etc.
+* **Board-scoped** names from ``boards.txt``: ``{upload.speed}``, ``{upload.flags}``, ``{upload.erase_cmd}``, ``{build.mcu}``, etc. Each ``esptool_py`` board must define ``upload.erase_cmd=`` at board level (empty by default); the EraseFlash menu overrides it with ``-e``.
 * **Runtime** keys set when you select the board/port: ``{runtime.platform.path}``, ``{serial.port}``, ``{build.path}`` (set on upload).
 * **Tool shorthands** for the **selected** ``upload.tool`` only, e.g. ``{path}``, ``{cmd}``, ``{upload.pattern_args}``, ``{network_cmd}`` (from ``tools.esptool_py.network_cmd``).
 

--- a/platform.txt
+++ b/platform.txt
@@ -188,7 +188,9 @@ recipe.hooks.objcopy.postobjcopy.4.pattern=/usr/bin/env bash -c "echo '--flash-m
 recipe.hooks.objcopy.postobjcopy.4.pattern.windows=cmd /c echo --flash-mode {build.flash_mode} --flash-freq {build.img_freq} --flash-size {build.flash_size} > "{build.path}\flash_args" && echo {build.bootloader_addr} {build.project_name}.bootloader.bin >> "{build.path}\flash_args" && echo 0x8000 {build.project_name}.partitions.bin >> "{build.path}\flash_args" && echo 0xe000 boot_app0.bin >> "{build.path}\flash_args" && echo 0x10000 {build.project_name}.bin >> "{build.path}\flash_args"
 
 # Copy boot_app0.bin into the build directory so flash_args is self-contained
-recipe.hooks.objcopy.postobjcopy.5.pattern=/usr/bin/env bash -c "cp -f '{runtime.platform.path}/tools/partitions/boot_app0.bin' '{build.path}/boot_app0.bin'"
+# Do not use bash -c with adjacent single-quoted paths ('...' '...'); IDE 1.x
+# arduino-builder misparses the space between quotes (see postobjcopy.4 note).
+recipe.hooks.objcopy.postobjcopy.5.pattern=/bin/cp -f "{runtime.platform.path}/tools/partitions/boot_app0.bin" "{build.path}/boot_app0.bin"
 recipe.hooks.objcopy.postobjcopy.5.pattern.windows=cmd /c copy /y "{runtime.platform.path}\tools\partitions\boot_app0.bin" "{build.path}\boot_app0.bin"
 
 ## Save bin


### PR DESCRIPTION
## Description of Change

This pull request adds comprehensive support for "Mock Upload Tests" to the CI system, focusing on validating the full Arduino IDE 1.x upload pipeline using a mock bootloader across all supported SoCs and operating systems. It introduces new scripts and documentation, enhances test coverage for upload patterns, and implements robust log filtering to reduce CI noise. The changes are grouped as follows:

**CI/CD Workflow Enhancements:**

* Added detailed documentation for the new "Mock Upload Tests" workflow in `.github/CI_README.md`, describing triggers, job matrix, toolchain, and local validation options. This ensures clarity on how uploads are tested in CI using a mock bootloader and how to run tests locally. [[1]](diffhunk://#diff-b4656400ea337249663ea596b1bc55dcd79f9837df94ca6d5c39e187709cdde6R11) [[2]](diffhunk://#diff-b4656400ea337249663ea596b1bc55dcd79f9837df94ca6d5c39e187709cdde6R176-R235)

**New and Improved Scripts:**

* Introduced `.github/scripts/arduino_headless.sh`, a reusable library for running Arduino IDE 1.x and builder in headless mode with robust log filtering and cross-platform support.
* Added `.github/scripts/arduino-headless-logging.properties` to configure Java logging and suppress excessive mDNS and JVM noise in CI logs.
* Added `.github/scripts/ci_testing/mock_upload_validation.sh` as a local convenience wrapper for running the mock upload validation pipeline outside of CI.

**Test Coverage and Validation Improvements:**

* Significantly expanded `.github/scripts/ci_testing/test_ide1_upload_pattern.py` to:
  - Parse SoC lists and board properties from core config files.
  - Validate upload patterns for all supported boards, ensuring required properties are present and upload commands are properly expanded.
  - Check for correct flash argument pairs and proper handling of erase commands.
  - Provide clear error output for missing or malformed configuration. [[1]](diffhunk://#diff-e75d4f5b3b05e8a0868d70e86a4a0a77a48aace7863c1b08e3860991e17887caR6-R47) [[2]](diffhunk://#diff-e75d4f5b3b05e8a0868d70e86a4a0a77a48aace7863c1b08e3860991e17887caL27) [[3]](diffhunk://#diff-e75d4f5b3b05e8a0868d70e86a4a0a77a48aace7863c1b08e3860991e17887caR86-R110) [[4]](diffhunk://#diff-e75d4f5b3b05e8a0868d70e86a4a0a77a48aace7863c1b08e3860991e17887caR129-R261) [[5]](diffhunk://#diff-e75d4f5b3b05e8a0868d70e86a4a0a77a48aace7863c1b08e3860991e17887caR272)

These changes collectively ensure that Arduino upload support is robustly validated across all platforms and configurations, with improved developer experience both in CI and for local testing.

## Test Scenarios

Tested in my fork and this PR
