### PR TITLE
fix(openthread): fixes CLI UDP example - UDP port + connection track

### DIFF
--- a/libraries/OpenThread/examples/CLI/UDP/README.md
+++ b/libraries/OpenThread/examples/CLI/UDP/README.md
@@ -24,7 +24,7 @@ Demonstrate a many-to-one Thread telemetry topology where:
 - **Control plane**: OpenThread CLI commands via `OThreadCLI`.
 - **Data plane**: OpenThread CLI UDP commands and parsing of CLI async output.
 - **Transport model**:
-  - Sensor sends telemetry to realm-local multicast `ff03::abcd:61631`.
+  - Sensor sends telemetry to realm-local multicast `ff03::abcd:5050`.
   - Collector receives payload, updates in-memory state, sends unicast ACK.
 
 ## Topology
@@ -95,7 +95,7 @@ thread start
 udp close
 udp open
 ipmaddr add ff03::abcd
-udp bind :: 61631
+udp bind :: 5050
 ```
 
 ### Runtime send command (ACK)
@@ -135,13 +135,13 @@ ifconfig up
 thread start
 udp close
 udp open
-udp bind :: 61631
+udp bind :: 5050
 ```
 
 ### Runtime send command (telemetry)
 
 ```text
-udp send ff03::abcd 61631 id=<nodeId>,seq=<u32>,temp_centi=<i32>,batt_mv=<u16>
+udp send ff03::abcd 5050 id=<nodeId>,seq=<u32>,temp_centi=<i32>,batt_mv=<u16>
 ```
 
 ## How RX is handled (CLI output parsing)

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/README.md
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/README.md
@@ -6,7 +6,7 @@ It:
 
 - configures Thread with CLI commands,
 - starts and attaches as a Thread node (Leader in a fresh partition),
-- binds a UDP socket on port `61631`,
+- binds a UDP socket on port `5050`,
 - receives sensor frames from many nodes,
 - prints decoded values and periodic fleet status to Serial,
 - replies with per-frame ACK.
@@ -51,7 +51,7 @@ thread start
 udp close
 udp open
 ipmaddr add ff03::abcd
-udp bind :: 61631
+udp bind :: 5050
 ```
 
 On **subsequent** boots the sketch detects the persisted dataset with the
@@ -77,11 +77,27 @@ Incoming telemetry payload:
 id=<nodeId>,seq=<u32>,temp_centi=<i32>,batt_mv=<u16>
 ```
 
-ACK payload:
+ACK payload (the collector's authoritative last-stored sequence for that node,
+which the node uses to confirm delivery and resync its own counter):
 
 ```text
-OK,<nodeId>,<seq>
+OK,<nodeId>,<collectorLastSeq>
 ```
+
+### Sequence handling
+
+The collector owns each node's sequence and classifies every incoming frame:
+
+| Incoming `seq` vs stored `lastSeq` | Meaning | Action | RX note |
+| --- | --- | --- | --- |
+| first frame / `seq > lastSeq` | new reading | store reading, `lastSeq = seq` | — |
+| `seq == lastSeq` | node missed our ACK | count duplicate, keep reading | `(dup)` |
+| `seq == 1` while `lastSeq > 1` | node restarted | follow it: `lastSeq = 1`, store reading | `(restart)` |
+| other `seq < lastSeq` | old/out-of-order frame | ignore reading | `(stale)` |
+
+In every case the ACK carries the **stored** `lastSeq`, so a node that resent a
+missed frame is confirmed, and a node that sent a stale frame is told the real
+last sequence and resyncs forward.
 
 ## Expected serial output
 
@@ -89,9 +105,9 @@ OK,<nodeId>,<seq>
 === udp_sensor_collector (CLI): Leader + UDP sink ===
 ...
 Attached as Leader
-Collector listening on UDP ff03::abcd:61631
+Collector listening on UDP ff03::abcd:5050
 node 3CAAB123 -> ONLINE
-RX node=3CAAB123 seq=1 temp=23.18C batt=3810mV from [fd..]:61631
+RX node=3CAAB123 seq=1 temp=23.18C batt=3810mV from [fd..]:5050
 [collector-cli] role=Leader nodes=1 online=1 packets=1 dropped=0
 node 3CAAB123 -> OFFLINE (silent 96s)
 ```
@@ -111,6 +127,25 @@ node 3CAAB123 -> OFFLINE (silent 96s)
   empty and is rebuilt automatically from the frames sensors keep multicasting -
   no persisted state is needed to recover.
 - A role watchdog re-forms the network if the collector ever detaches.
+
+## Troubleshooting
+
+### `DROP malformed` from RLOC addresses (e.g. `...:0:ff:fe00:f801`)
+
+If the collector logs a stream of `DROP malformed` packets whose source is an
+RLOC address (IID `0000:00ff:fe00:<rloc16>`) and whose payload is binary
+starting with `0x42` ('B'), the application UDP port collides with a Thread
+**reserved port** and the socket is receiving Thread's own management traffic
+(the `0x42` byte is a CoAP `Ver=1, CON, TKL=2` header). Do **not** bind these:
+
+| Port | Used by Thread for |
+| --- | --- |
+| `61631` | Thread Management Framework (TMF) CoAP (address query/notify, network data) |
+| `5683` / `5684` | CoAP / CoAPs |
+| `19788` | MLE |
+
+This example uses `5050`, a free application port. Pick any non-reserved port
+and keep it identical on the collector and the nodes.
 
 ## License
 

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
@@ -255,7 +255,7 @@ static bool setupUdpCli() {
   return true;
 }
 
-// Unicast an "OK,<nodeId>,<seq>" acknowledgement straight back to the sender's
+// Unicast an "OK,<nodeId>,<seq>" acknowledgment straight back to the sender's
 // address/port, where seq is the collector's authoritative last-stored sequence
 // for that node. The node uses this ACK both to confirm delivery and to resync
 // its own counter to ours (rolling back or skipping forward as needed). We push

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
@@ -87,14 +87,18 @@
  // Run a single CLI command and check its result. otExecCommand() sends the
  // command and waits for the terminating "Done"/"Error ..." line; ot_cmd_return_t
  // carries the parsed error code/message so we can log a useful failure.
- static bool otCliCmd(const char *cmd) {
-   ot_cmd_return_t rc;
-   bool ok = otExecCommand(cmd, nullptr, &rc);
-   if (!ok) {
-     Serial.printf("CLI ERROR: '%s' -> %d %s\n", cmd, rc.errorCode, rc.errorMessage.c_str());
-   }
-   return ok;
- }
+static bool otCliCmd(const char *cmd) {
+  ot_cmd_return_t rc;
+  // otExecCommand() uses Stream::readBytesUntil(), which depends on the current
+  // Stream timeout. RX parsing tweaks the timeout frequently, so force a
+  // known-safe value for CLI control commands.
+  OThreadCLI.setTimeout(1000);
+  bool ok = otExecCommand(cmd, nullptr, &rc);
+  if (!ok) {
+    Serial.printf("CLI ERROR: '%s' -> %d %s\n", cmd, rc.errorCode, rc.errorMessage.c_str());
+  }
+  return ok;
+}
  
  // Read one line of asynchronous CLI output. OThreadCLI is an Arduino Stream,
  // so unsolicited output (e.g. incoming UDP datagrams) can be read with the

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
@@ -27,66 +27,66 @@
  * is not available. Pair it with udp_sensor_node.ino.
  */
 
- #include <Arduino.h>
- #include "OThreadCLI.h"       // OThreadCLI object (CLI as an Arduino Stream)
- #include "OThreadCLI_Util.h"  // otExecCommand() / ot_cmd_return_t helpers
- 
- // CLI dataset values. Keep these aligned with udp_sensor_node.
- // Thread network name is limited to 16 bytes (OT_NETWORK_NAME_MAX_SIZE); a
- // longer name makes "dataset networkname" fail with InvalidArgs.
- #define OT_NETWORK_NAME "ESP_OT_SENSORS"
- #define OT_CHANNEL "15"
- #define OT_PANID "0xabcf"
- #define OT_EXTPANID "ce010000deadc0de"
- #define OT_NETWORK_KEY "102030405060708090a0b0c0d0e0f002"
- // Fixed mesh-local prefix so a re-provisioned/rebooted leader forms the exact
- // same network instead of the random prefix "dataset init new" would generate.
- #define OT_MESHLOCAL_PREFIX "fdde:ad00:beef:0::"
- 
- // UDP port we bind/listen on. MUST NOT be one of Thread's reserved UDP ports,
- // or the application socket also receives Thread's own internal traffic:
- //   61631 -> Thread Management Framework (TMF) CoAP  (address query/notify, etc.)
- //   5683/5684 -> CoAP / CoAPs
- //   19788 -> MLE
- // Binding any of those shows up here as "DROP malformed" CoAP datagrams (first
- // byte 0x42 = 'B'). 5050 is a free application port; keep it aligned with the node.
- const uint16_t COLLECTOR_PORT = 5050;         // UDP port we bind/listen on
- const char COLLECTOR_GROUP[] = "ff03::abcd";  // realm-local multicast group sensors send to
- const uint16_t MAX_SENSORS = 256;             // capacity of the in-RAM node table
- const uint32_t REPORT_PERIOD_MS = 30000;      // how often the fleet summary is printed
- 
- // Liveness tracking. A node that goes silent (lost power, crashed, moved out of
- // range) must eventually be recognized as gone, otherwise the collector keeps
- // reporting it forever. NODE_OFFLINE_MS should be a small multiple of the
- // sensor's sample period so a couple of missed reports flips it to OFFLINE;
- // after NODE_EVICT_MS with no contact the table slot is freed entirely.
- const uint32_t NODE_OFFLINE_MS = 95000;               // ~3 missed 30 s samples
- const uint32_t NODE_EVICT_MS = 30UL * 60UL * 1000UL;  // drop dead nodes after 30 min
- 
- // One entry per unique sensor node id seen on the network. The table is a
- // simple fixed array (no dynamic allocation) so memory use is bounded and
- // predictable even with a few hundred nodes.
- struct SensorRecord {
-   bool used;
-   bool online;  // false once the node has been silent past NODE_OFFLINE_MS
-   char nodeId[16];
-   uint32_t lastSeq;
-   int32_t lastTempCenti;
-   uint16_t lastBatteryMv;
-   uint32_t packetCount;
-   uint32_t duplicateCount;
-   uint32_t lastSeenMs;
-   char lastIp[40];
- };
- 
- static SensorRecord s_records[MAX_SENSORS];
- static uint32_t s_totalPackets = 0;
- static uint32_t s_droppedPackets = 0;
- static char s_cliLine[256];
- 
- // Run a single CLI command and check its result. otExecCommand() sends the
- // command and waits for the terminating "Done"/"Error ..." line; ot_cmd_return_t
- // carries the parsed error code/message so we can log a useful failure.
+#include <Arduino.h>
+#include "OThreadCLI.h"       // OThreadCLI object (CLI as an Arduino Stream)
+#include "OThreadCLI_Util.h"  // otExecCommand() / ot_cmd_return_t helpers
+
+// CLI dataset values. Keep these aligned with udp_sensor_node.
+// Thread network name is limited to 16 bytes (OT_NETWORK_NAME_MAX_SIZE); a
+// longer name makes "dataset networkname" fail with InvalidArgs.
+#define OT_NETWORK_NAME "ESP_OT_SENSORS"
+#define OT_CHANNEL      "15"
+#define OT_PANID        "0xabcf"
+#define OT_EXTPANID     "ce010000deadc0de"
+#define OT_NETWORK_KEY  "102030405060708090a0b0c0d0e0f002"
+// Fixed mesh-local prefix so a re-provisioned/rebooted leader forms the exact
+// same network instead of the random prefix "dataset init new" would generate.
+#define OT_MESHLOCAL_PREFIX "fdde:ad00:beef:0::"
+
+// UDP port we bind/listen on. MUST NOT be one of Thread's reserved UDP ports,
+// or the application socket also receives Thread's own internal traffic:
+//   61631 -> Thread Management Framework (TMF) CoAP  (address query/notify, etc.)
+//   5683/5684 -> CoAP / CoAPs
+//   19788 -> MLE
+// Binding any of those shows up here as "DROP malformed" CoAP datagrams (first
+// byte 0x42 = 'B'). 5050 is a free application port; keep it aligned with the node.
+const uint16_t COLLECTOR_PORT = 5050;         // UDP port we bind/listen on
+const char COLLECTOR_GROUP[] = "ff03::abcd";  // realm-local multicast group sensors send to
+const uint16_t MAX_SENSORS = 256;             // capacity of the in-RAM node table
+const uint32_t REPORT_PERIOD_MS = 30000;      // how often the fleet summary is printed
+
+// Liveness tracking. A node that goes silent (lost power, crashed, moved out of
+// range) must eventually be recognized as gone, otherwise the collector keeps
+// reporting it forever. NODE_OFFLINE_MS should be a small multiple of the
+// sensor's sample period so a couple of missed reports flips it to OFFLINE;
+// after NODE_EVICT_MS with no contact the table slot is freed entirely.
+const uint32_t NODE_OFFLINE_MS = 95000;               // ~3 missed 30 s samples
+const uint32_t NODE_EVICT_MS = 30UL * 60UL * 1000UL;  // drop dead nodes after 30 min
+
+// One entry per unique sensor node id seen on the network. The table is a
+// simple fixed array (no dynamic allocation) so memory use is bounded and
+// predictable even with a few hundred nodes.
+struct SensorRecord {
+  bool used;
+  bool online;  // false once the node has been silent past NODE_OFFLINE_MS
+  char nodeId[16];
+  uint32_t lastSeq;
+  int32_t lastTempCenti;
+  uint16_t lastBatteryMv;
+  uint32_t packetCount;
+  uint32_t duplicateCount;
+  uint32_t lastSeenMs;
+  char lastIp[40];
+};
+
+static SensorRecord s_records[MAX_SENSORS];
+static uint32_t s_totalPackets = 0;
+static uint32_t s_droppedPackets = 0;
+static char s_cliLine[256];
+
+// Run a single CLI command and check its result. otExecCommand() sends the
+// command and waits for the terminating "Done"/"Error ..." line; ot_cmd_return_t
+// carries the parsed error code/message so we can log a useful failure.
 static bool otCliCmd(const char *cmd) {
   ot_cmd_return_t rc;
   // otExecCommand() uses Stream::readBytesUntil(), which depends on the current
@@ -99,236 +99,234 @@ static bool otCliCmd(const char *cmd) {
   }
   return ok;
 }
- 
- // Read one line of asynchronous CLI output. OThreadCLI is an Arduino Stream,
- // so unsolicited output (e.g. incoming UDP datagrams) can be read with the
- // usual Stream API. Returns true only when a non-empty line was captured.
- static bool readCliLine(char *line, size_t lineLen, uint32_t timeoutMs) {
-   if (lineLen < 2) {
-     return false;
-   }
-   OThreadCLI.setTimeout(timeoutMs);
-   size_t n = OThreadCLI.readBytesUntil('\n', line, lineLen - 1);
-   if (!n) {
-     line[0] = '\0';
-     return false;
-   }
-   line[n] = '\0';
-   for (size_t i = 0; i < n; i++) {
-     if (line[i] == '\r' || line[i] == '\n') {
-       line[i] = '\0';
-       break;
-     }
-   }
-   return strlen(line) > 0;
- }
- 
- // The CLI prints a received datagram as:
- //   "<N> bytes from <srcIp> <srcPort> <payload>"
- // e.g. "21 bytes from fdde:ad00:beef:0:1234:5678:9abc:def0 49152 id=node-1,seq=5,..."
- // Pull out the source IP, source port, and the payload text. Returns false for
- // any line that is not in this exact UDP-receive shape.
- static bool parseUdpLine(const char *line, char *srcIp, size_t srcIpLen, uint16_t &srcPort, char *payload, size_t payloadLen) {
-   unsigned int bytes = 0;
-   unsigned int port = 0;
-   char ip[40] = { 0 };
-   char msg[160] = { 0 };
-   int m = sscanf(line, "%u bytes from %39s %u %159[^\r\n]", &bytes, ip, &port, msg);
-   if (m != 4) {
-     return false;
-   }
-   strncpy(srcIp, ip, srcIpLen - 1);
-   srcIp[srcIpLen - 1] = '\0';
-   srcPort = (uint16_t)port;
-   strncpy(payload, msg, payloadLen - 1);
-   payload[payloadLen - 1] = '\0';
-   return true;
- }
- 
- // Linear lookup of an existing node record by its string id (-1 if not found).
- static int findRecordById(const char *id) {
-   for (int i = 0; i < MAX_SENSORS; i++) {
-     if (s_records[i].used && !strcmp(s_records[i].nodeId, id)) {
-       return i;
-     }
-   }
-   return -1;
- }
- 
- // Claim the first free slot for a newly seen node id (-1 if the table is full).
- static int allocateRecord(const char *id) {
-   for (int i = 0; i < MAX_SENSORS; i++) {
-     if (!s_records[i].used) {
-       memset(&s_records[i], 0, sizeof(s_records[i]));
-       s_records[i].used = true;
-       strncpy(s_records[i].nodeId, id, sizeof(s_records[i].nodeId) - 1);
-       return i;
-     }
-   }
-   return -1;
- }
- 
- // Bring up Thread purely through the CLI.
- //
- // Reboot recovery (issue: children must rejoin after the leader resets):
- // OpenThread persists the committed dataset in NVS. If one already exists we
- // RESUME it - just bring the interface up and start Thread - which restores the
- // SAME network (same mesh-local prefix and key/frame-counter state). A child
- // that lost its parent then re-attaches to the returning leader within seconds.
- //
- // Only on the very first boot (no stored dataset) do we provision one, and we
- // PIN the mesh-local prefix and active timestamp. Plain "dataset init new"
- // randomizes both, so without pinning every reboot would look like a brand-new
- // network and force a slow, churny re-attach across the whole fleet.
- //
- // NOTE: because the dataset is persisted, changing the OT_* constants above has
- // no effect until the stored dataset is cleared (CLI "factoryreset" or an erase
- // of flash). The dataset MUST match udp_sensor_node.
- static bool setupThreadByCli() {
-   bool datasetPresent = OThread.hasActiveDataset();
-   if (datasetPresent) {
-     Serial.println("Active dataset found in NVS; resuming existing network.");
-     if (!otCliCmd("ifconfig up") || !otCliCmd("thread start")) {
-       return false;
-     }
-   } else {
-     Serial.println("No active dataset; provisioning a new deterministic network.");
-     const char *cmds[] = {
-       "thread stop",
-       "ifconfig down",
-       "dataset clear",
-       "dataset init new",
-       "dataset networkname " OT_NETWORK_NAME,
-       "dataset channel " OT_CHANNEL,
-       "dataset panid " OT_PANID,
-       "dataset extpanid " OT_EXTPANID,
-       "dataset networkkey " OT_NETWORK_KEY,
-       // Pin the fields "dataset init new" would otherwise randomize so the
-       // network is identical every time it is (re)created.
-       "dataset meshlocalprefix " OT_MESHLOCAL_PREFIX,
-       "dataset activetimestamp 1",
-       "dataset commit active",
-       "ifconfig up",
-       "thread start",
-     };
-     for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
-       if (!otCliCmd(cmds[i])) {
-         return false;
-       }
-     }
-   }
- 
-   // Attaching takes a few seconds. Poll the device role until it is at least
-   // a Child (Child/Router/Leader all count as "attached"); give up after ~60s.
-   uint8_t tries = 30;
-   while (tries-- && OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
-     Serial.print(".");
-     delay(2000);
-   }
-   Serial.println();
-   return OThread.otGetDeviceRole() >= OT_ROLE_CHILD;
- }
- 
- // Open the CLI UDP socket and start listening. "ipmaddr add" subscribes the
- // node to the realm-local multicast group the sensors target, and "udp bind ::
- // <port>" binds the socket to our listen port on every address. After this the
- // CLI will asynchronously print each datagram it receives.
- static bool setupUdpCli() {
-   // COLLECTOR_GROUP/COLLECTOR_PORT are runtime variables, so build the CLI
-   // command strings with snprintf (string-literal concatenation only works
-   // with #define macros, not with const char[] variables).
-   char mcastCmd[64];
-   char bindCmd[48];
-   snprintf(mcastCmd, sizeof(mcastCmd), "ipmaddr add %s", COLLECTOR_GROUP);
-   snprintf(bindCmd, sizeof(bindCmd), "udp bind :: %u", COLLECTOR_PORT);
-   const char *cmds[] = {
-     "udp close",  // ensure a clean socket state before (re)opening
-     "udp open",
-     mcastCmd,  // subscribe to the multicast group sensors publish to
-     bindCmd,   // bind to COLLECTOR_PORT so incoming frames are delivered
-   };
-   for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
-     if (!otCliCmd(cmds[i])) {
-       return false;
-     }
-   }
-   return true;
- }
- 
+
+// Read one line of asynchronous CLI output. OThreadCLI is an Arduino Stream,
+// so unsolicited output (e.g. incoming UDP datagrams) can be read with the
+// usual Stream API. Returns true only when a non-empty line was captured.
+static bool readCliLine(char *line, size_t lineLen, uint32_t timeoutMs) {
+  if (lineLen < 2) {
+    return false;
+  }
+  OThreadCLI.setTimeout(timeoutMs);
+  size_t n = OThreadCLI.readBytesUntil('\n', line, lineLen - 1);
+  if (!n) {
+    line[0] = '\0';
+    return false;
+  }
+  line[n] = '\0';
+  for (size_t i = 0; i < n; i++) {
+    if (line[i] == '\r' || line[i] == '\n') {
+      line[i] = '\0';
+      break;
+    }
+  }
+  return strlen(line) > 0;
+}
+
+// The CLI prints a received datagram as:
+//   "<N> bytes from <srcIp> <srcPort> <payload>"
+// e.g. "21 bytes from fdde:ad00:beef:0:1234:5678:9abc:def0 49152 id=node-1,seq=5,..."
+// Pull out the source IP, source port, and the payload text. Returns false for
+// any line that is not in this exact UDP-receive shape.
+static bool parseUdpLine(const char *line, char *srcIp, size_t srcIpLen, uint16_t &srcPort, char *payload, size_t payloadLen) {
+  unsigned int bytes = 0;
+  unsigned int port = 0;
+  char ip[40] = {0};
+  char msg[160] = {0};
+  int m = sscanf(line, "%u bytes from %39s %u %159[^\r\n]", &bytes, ip, &port, msg);
+  if (m != 4) {
+    return false;
+  }
+  strncpy(srcIp, ip, srcIpLen - 1);
+  srcIp[srcIpLen - 1] = '\0';
+  srcPort = (uint16_t)port;
+  strncpy(payload, msg, payloadLen - 1);
+  payload[payloadLen - 1] = '\0';
+  return true;
+}
+
+// Linear lookup of an existing node record by its string id (-1 if not found).
+static int findRecordById(const char *id) {
+  for (int i = 0; i < MAX_SENSORS; i++) {
+    if (s_records[i].used && !strcmp(s_records[i].nodeId, id)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Claim the first free slot for a newly seen node id (-1 if the table is full).
+static int allocateRecord(const char *id) {
+  for (int i = 0; i < MAX_SENSORS; i++) {
+    if (!s_records[i].used) {
+      memset(&s_records[i], 0, sizeof(s_records[i]));
+      s_records[i].used = true;
+      strncpy(s_records[i].nodeId, id, sizeof(s_records[i].nodeId) - 1);
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Bring up Thread purely through the CLI.
+//
+// Reboot recovery (issue: children must rejoin after the leader resets):
+// OpenThread persists the committed dataset in NVS. If one already exists we
+// RESUME it - just bring the interface up and start Thread - which restores the
+// SAME network (same mesh-local prefix and key/frame-counter state). A child
+// that lost its parent then re-attaches to the returning leader within seconds.
+//
+// Only on the very first boot (no stored dataset) do we provision one, and we
+// PIN the mesh-local prefix and active timestamp. Plain "dataset init new"
+// randomizes both, so without pinning every reboot would look like a brand-new
+// network and force a slow, churny re-attach across the whole fleet.
+//
+// NOTE: because the dataset is persisted, changing the OT_* constants above has
+// no effect until the stored dataset is cleared (CLI "factoryreset" or an erase
+// of flash). The dataset MUST match udp_sensor_node.
+static bool setupThreadByCli() {
+  bool datasetPresent = OThread.hasActiveDataset();
+  if (datasetPresent) {
+    Serial.println("Active dataset found in NVS; resuming existing network.");
+    if (!otCliCmd("ifconfig up") || !otCliCmd("thread start")) {
+      return false;
+    }
+  } else {
+    Serial.println("No active dataset; provisioning a new deterministic network.");
+    const char *cmds[] = {
+      "thread stop",
+      "ifconfig down",
+      "dataset clear",
+      "dataset init new",
+      "dataset networkname " OT_NETWORK_NAME,
+      "dataset channel " OT_CHANNEL,
+      "dataset panid " OT_PANID,
+      "dataset extpanid " OT_EXTPANID,
+      "dataset networkkey " OT_NETWORK_KEY,
+      // Pin the fields "dataset init new" would otherwise randomize so the
+      // network is identical every time it is (re)created.
+      "dataset meshlocalprefix " OT_MESHLOCAL_PREFIX,
+      "dataset activetimestamp 1",
+      "dataset commit active",
+      "ifconfig up",
+      "thread start",
+    };
+    for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
+      if (!otCliCmd(cmds[i])) {
+        return false;
+      }
+    }
+  }
+
+  // Attaching takes a few seconds. Poll the device role until it is at least
+  // a Child (Child/Router/Leader all count as "attached"); give up after ~60s.
+  uint8_t tries = 30;
+  while (tries-- && OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
+    Serial.print(".");
+    delay(2000);
+  }
+  Serial.println();
+  return OThread.otGetDeviceRole() >= OT_ROLE_CHILD;
+}
+
+// Open the CLI UDP socket and start listening. "ipmaddr add" subscribes the
+// node to the realm-local multicast group the sensors target, and "udp bind ::
+// <port>" binds the socket to our listen port on every address. After this the
+// CLI will asynchronously print each datagram it receives.
+static bool setupUdpCli() {
+  // COLLECTOR_GROUP/COLLECTOR_PORT are runtime variables, so build the CLI
+  // command strings with snprintf (string-literal concatenation only works
+  // with #define macros, not with const char[] variables).
+  char mcastCmd[64];
+  char bindCmd[48];
+  snprintf(mcastCmd, sizeof(mcastCmd), "ipmaddr add %s", COLLECTOR_GROUP);
+  snprintf(bindCmd, sizeof(bindCmd), "udp bind :: %u", COLLECTOR_PORT);
+  const char *cmds[] = {
+    "udp close",  // ensure a clean socket state before (re)opening
+    "udp open",
+    mcastCmd,  // subscribe to the multicast group sensors publish to
+    bindCmd,   // bind to COLLECTOR_PORT so incoming frames are delivered
+  };
+  for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
+    if (!otCliCmd(cmds[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Unicast an "OK,<nodeId>,<seq>" acknowledgement straight back to the sender's
 // address/port, where seq is the collector's authoritative last-stored sequence
 // for that node. The node uses this ACK both to confirm delivery and to resync
 // its own counter to ours (rolling back or skipping forward as needed). We push
 // the command directly on the CLI stream rather than otExecCommand() because we
 // do not need to block on the "Done" response here.
- static void sendAck(const char *dstIp, uint16_t dstPort, const char *nodeId, uint32_t seq) {
-   char ack[48];
-   char cmd[128];
-   snprintf(ack, sizeof(ack), "OK,%s,%lu", nodeId, (unsigned long)seq);
-   snprintf(cmd, sizeof(cmd), "udp send %s %u %s", dstIp, dstPort, ack);
-   OThreadCLI.println(cmd);
- }
- 
- // Age out nodes we have stopped hearing from. A node still in range but silent
- // past NODE_OFFLINE_MS is flipped to OFFLINE (and reported once), and a node
- // gone longer than NODE_EVICT_MS is removed from the table so its slot can be
- // reused and it stops being counted. This is what lets the collector "sense" a
- // sensor that lost power instead of claiming it is still present.
- static void auditNodes() {
-   uint32_t now = millis();
-   for (int i = 0; i < MAX_SENSORS; i++) {
-     if (!s_records[i].used) {
-       continue;
-     }
-     uint32_t age = now - s_records[i].lastSeenMs;
-     if (s_records[i].online && age > NODE_OFFLINE_MS) {
-       s_records[i].online = false;
-       Serial.printf("node %s -> OFFLINE (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
-     }
-     if (age > NODE_EVICT_MS) {
-       Serial.printf("node %s evicted from table (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
-       s_records[i].used = false;
-     }
-   }
- }
- 
- static void printCompactReport() {
-   uint16_t known = 0;
-   uint16_t online = 0;
-   for (int i = 0; i < MAX_SENSORS; i++) {
-     if (!s_records[i].used) {
-       continue;
-     }
-     known++;
-     if (s_records[i].online) {
-       online++;
-     }
-   }
-   Serial.printf("[collector-cli] role=%s nodes=%u online=%u packets=%lu dropped=%lu\n",
-                 OThread.otGetStringDeviceRole(),
-                 known,
-                 online,
-                 (unsigned long)s_totalPackets,
-                 (unsigned long)s_droppedPackets);
- }
- 
- // Decode one sensor frame, update (or create) its node record, and ACK it.
- // The frame format is the plain-text key/value string the node builds:
- //   "id=<str>,seq=<n>,temp_centi=<int>,batt_mv=<uint>"
- static void processPacket(const char *payload, const char *srcIp, uint16_t srcPort) {
-   char id[16] = { 0 };
-   unsigned long seqTmp = 0;
-   long tempTmp = 0;
-   unsigned int battTmp = 0;
-   if (sscanf(payload, "id=%15[^,],seq=%lu,temp_centi=%ld,batt_mv=%u", id, &seqTmp, &tempTmp, &battTmp) != 4) {
-     s_droppedPackets++;
-     Serial.printf("DROP malformed from [%s]:%u -> '%s'\n", srcIp, srcPort, payload);
-     return;
-   }
-   uint32_t seq = (uint32_t)seqTmp;
-   int32_t tempCenti = (int32_t)tempTmp;
-   uint16_t battMv = (uint16_t)battTmp;
- 
+static void sendAck(const char *dstIp, uint16_t dstPort, const char *nodeId, uint32_t seq) {
+  char ack[48];
+  char cmd[128];
+  snprintf(ack, sizeof(ack), "OK,%s,%lu", nodeId, (unsigned long)seq);
+  snprintf(cmd, sizeof(cmd), "udp send %s %u %s", dstIp, dstPort, ack);
+  OThreadCLI.println(cmd);
+}
+
+// Age out nodes we have stopped hearing from. A node still in range but silent
+// past NODE_OFFLINE_MS is flipped to OFFLINE (and reported once), and a node
+// gone longer than NODE_EVICT_MS is removed from the table so its slot can be
+// reused and it stops being counted. This is what lets the collector "sense" a
+// sensor that lost power instead of claiming it is still present.
+static void auditNodes() {
+  uint32_t now = millis();
+  for (int i = 0; i < MAX_SENSORS; i++) {
+    if (!s_records[i].used) {
+      continue;
+    }
+    uint32_t age = now - s_records[i].lastSeenMs;
+    if (s_records[i].online && age > NODE_OFFLINE_MS) {
+      s_records[i].online = false;
+      Serial.printf("node %s -> OFFLINE (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
+    }
+    if (age > NODE_EVICT_MS) {
+      Serial.printf("node %s evicted from table (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
+      s_records[i].used = false;
+    }
+  }
+}
+
+static void printCompactReport() {
+  uint16_t known = 0;
+  uint16_t online = 0;
+  for (int i = 0; i < MAX_SENSORS; i++) {
+    if (!s_records[i].used) {
+      continue;
+    }
+    known++;
+    if (s_records[i].online) {
+      online++;
+    }
+  }
+  Serial.printf(
+    "[collector-cli] role=%s nodes=%u online=%u packets=%lu dropped=%lu\n", OThread.otGetStringDeviceRole(), known, online, (unsigned long)s_totalPackets,
+    (unsigned long)s_droppedPackets
+  );
+}
+
+// Decode one sensor frame, update (or create) its node record, and ACK it.
+// The frame format is the plain-text key/value string the node builds:
+//   "id=<str>,seq=<n>,temp_centi=<int>,batt_mv=<uint>"
+static void processPacket(const char *payload, const char *srcIp, uint16_t srcPort) {
+  char id[16] = {0};
+  unsigned long seqTmp = 0;
+  long tempTmp = 0;
+  unsigned int battTmp = 0;
+  if (sscanf(payload, "id=%15[^,],seq=%lu,temp_centi=%ld,batt_mv=%u", id, &seqTmp, &tempTmp, &battTmp) != 4) {
+    s_droppedPackets++;
+    Serial.printf("DROP malformed from [%s]:%u -> '%s'\n", srcIp, srcPort, payload);
+    return;
+  }
+  uint32_t seq = (uint32_t)seqTmp;
+  int32_t tempCenti = (int32_t)tempTmp;
+  uint16_t battMv = (uint16_t)battTmp;
+
   int idx = findRecordById(id);
   bool brandNew = (idx < 0);
   if (brandNew) {
@@ -383,99 +381,93 @@ static bool otCliCmd(const char *cmd) {
     Serial.printf("node %s -> ONLINE\n", r.nodeId);
   }
 
-  Serial.printf("RX node=%s seq=%lu temp=%.2fC batt=%umV from [%s]:%u%s\n",
-                r.nodeId,
-                (unsigned long)seq,
-                (float)tempCenti / 100.0f,
-                battMv,
-                srcIp,
-                srcPort,
-                seqNote);
+  Serial.printf(
+    "RX node=%s seq=%lu temp=%.2fC batt=%umV from [%s]:%u%s\n", r.nodeId, (unsigned long)seq, (float)tempCenti / 100.0f, battMv, srcIp, srcPort, seqNote
+  );
 
   // ACK our authoritative last stored sequence (not necessarily the one just
   // received): for a fresh/duplicate/restart frame this equals seq and confirms
   // it; for a stale frame it is higher, telling the node to resync forward.
   sendAck(srcIp, srcPort, r.nodeId, r.lastSeq);
 }
- 
- void setup() {
-   Serial.begin(115200);
- 
-   Serial.println("=== udp_sensor_collector (CLI): Leader + UDP sink ===");
-   // begin(false): start the OpenThread stack but do NOT auto-start a network -
-   // we form the network ourselves through the CLI below. begin() returns only
-   // after stack init has finished (and reloaded any persisted dataset from NVS),
-   // so OThread.hasActiveDataset() is reliable without any extra wait here.
-   OThread.begin(false);
-   OThreadCLI.begin();
-   OThreadCLI.setTimeout(250);
- 
-   if (!setupThreadByCli()) {
-     Serial.println("Thread setup failed. Halting.");
-     while (1) {
-       delay(1000);
-     }
-   }
- 
-   Serial.printf("Attached as %s\n", OThread.otGetStringDeviceRole());
-   // Network we ended up on: this is either the dataset we just provisioned or the
-   // one resumed from NVS on a subsequent boot.
-   Serial.printf("Network:        name=%s panid=0x%04x\n", OThread.getNetworkName().c_str(), OThread.getPanId());
-   Serial.printf("Mesh-Local EID: %s\n", OThread.getMeshLocalEid().toString().c_str());
-   Serial.printf("Leader RLOC:    %s\n", OThread.getLeaderRloc().toString().c_str());
- 
-   if (!setupUdpCli()) {
-     Serial.println("UDP CLI setup failed. Halting.");
-     while (1) {
-       delay(1000);
-     }
-   }
-   Serial.printf("Collector listening on UDP %s:%u\n", COLLECTOR_GROUP, COLLECTOR_PORT);
- }
- 
- void loop() {
-   // Drain whatever the CLI has emitted since last loop. Each readable line is
-   // either CLI bookkeeping ("Done"/"Error", skipped) or an incoming datagram.
-   while (readCliLine(s_cliLine, sizeof(s_cliLine), 20)) {
-     if (!strncmp(s_cliLine, "Done", 4) || !strncmp(s_cliLine, "Error", 5)) {
-       continue;
-     }
-     char srcIp[40] = { 0 };
-     uint16_t srcPort = 0;
-     char payload[160] = { 0 };
-     if (parseUdpLine(s_cliLine, srcIp, sizeof(srcIp), srcPort, payload, sizeof(payload))) {
-       processPacket(payload, srcIp, srcPort);
-     }
-   }
- 
-   // Periodically age the table and print a summary. After a collector reboot
-   // the table starts empty and is rebuilt automatically from the frames sensors
-   // keep multicasting, so no persisted state is needed to recover.
-   static uint32_t lastReport = 0;
-   if (millis() - lastReport >= REPORT_PERIOD_MS) {
-     lastReport = millis();
-     auditNodes();
-     printCompactReport();
-   }
- 
-   // Thread role watchdog: as the network's only infrastructure node the
-   // collector should stay Leader/Router. If it ever drops to detached/child
-   // (e.g. a transient fault), bring Thread back up so sensors have a parent.
-   // setupThreadByCli() resumes the persisted dataset, so this restores the same
-   // network rather than creating a new one.
-   static uint32_t lastRoleCheck = 0;
-   if (millis() - lastRoleCheck >= 5000) {
-     lastRoleCheck = millis();
-     if (OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
-       Serial.println("Collector detached; restarting Thread...");
-       if (!setupThreadByCli()) {
-         Serial.println("Thread restart failed.");
-       } else if (!setupUdpCli()) {
-         Serial.println("UDP CLI setup failed after Thread restart.");
-       }
-     }
-   }
- 
-   delay(20);
- }
- 
+
+void setup() {
+  Serial.begin(115200);
+
+  Serial.println("=== udp_sensor_collector (CLI): Leader + UDP sink ===");
+  // begin(false): start the OpenThread stack but do NOT auto-start a network -
+  // we form the network ourselves through the CLI below. begin() returns only
+  // after stack init has finished (and reloaded any persisted dataset from NVS),
+  // so OThread.hasActiveDataset() is reliable without any extra wait here.
+  OThread.begin(false);
+  OThreadCLI.begin();
+  OThreadCLI.setTimeout(250);
+
+  if (!setupThreadByCli()) {
+    Serial.println("Thread setup failed. Halting.");
+    while (1) {
+      delay(1000);
+    }
+  }
+
+  Serial.printf("Attached as %s\n", OThread.otGetStringDeviceRole());
+  // Network we ended up on: this is either the dataset we just provisioned or the
+  // one resumed from NVS on a subsequent boot.
+  Serial.printf("Network:        name=%s panid=0x%04x\n", OThread.getNetworkName().c_str(), OThread.getPanId());
+  Serial.printf("Mesh-Local EID: %s\n", OThread.getMeshLocalEid().toString().c_str());
+  Serial.printf("Leader RLOC:    %s\n", OThread.getLeaderRloc().toString().c_str());
+
+  if (!setupUdpCli()) {
+    Serial.println("UDP CLI setup failed. Halting.");
+    while (1) {
+      delay(1000);
+    }
+  }
+  Serial.printf("Collector listening on UDP %s:%u\n", COLLECTOR_GROUP, COLLECTOR_PORT);
+}
+
+void loop() {
+  // Drain whatever the CLI has emitted since last loop. Each readable line is
+  // either CLI bookkeeping ("Done"/"Error", skipped) or an incoming datagram.
+  while (readCliLine(s_cliLine, sizeof(s_cliLine), 20)) {
+    if (!strncmp(s_cliLine, "Done", 4) || !strncmp(s_cliLine, "Error", 5)) {
+      continue;
+    }
+    char srcIp[40] = {0};
+    uint16_t srcPort = 0;
+    char payload[160] = {0};
+    if (parseUdpLine(s_cliLine, srcIp, sizeof(srcIp), srcPort, payload, sizeof(payload))) {
+      processPacket(payload, srcIp, srcPort);
+    }
+  }
+
+  // Periodically age the table and print a summary. After a collector reboot
+  // the table starts empty and is rebuilt automatically from the frames sensors
+  // keep multicasting, so no persisted state is needed to recover.
+  static uint32_t lastReport = 0;
+  if (millis() - lastReport >= REPORT_PERIOD_MS) {
+    lastReport = millis();
+    auditNodes();
+    printCompactReport();
+  }
+
+  // Thread role watchdog: as the network's only infrastructure node the
+  // collector should stay Leader/Router. If it ever drops to detached/child
+  // (e.g. a transient fault), bring Thread back up so sensors have a parent.
+  // setupThreadByCli() resumes the persisted dataset, so this restores the same
+  // network rather than creating a new one.
+  static uint32_t lastRoleCheck = 0;
+  if (millis() - lastRoleCheck >= 5000) {
+    lastRoleCheck = millis();
+    if (OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
+      Serial.println("Collector detached; restarting Thread...");
+      if (!setupThreadByCli()) {
+        Serial.println("Thread restart failed.");
+      } else if (!setupUdpCli()) {
+        Serial.println("UDP CLI setup failed after Thread restart.");
+      }
+    }
+  }
+
+  delay(20);
+}

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_collector/udp_sensor_collector.ino
@@ -27,300 +27,307 @@
  * is not available. Pair it with udp_sensor_node.ino.
  */
 
-#include <Arduino.h>
-#include "OThreadCLI.h"       // OThreadCLI object (CLI as an Arduino Stream)
-#include "OThreadCLI_Util.h"  // otExecCommand() / ot_cmd_return_t helpers
-
-// CLI dataset values. Keep these aligned with udp_sensor_node.
-// Thread network name is limited to 16 bytes (OT_NETWORK_NAME_MAX_SIZE); a
-// longer name makes "dataset networkname" fail with InvalidArgs.
-#define OT_NETWORK_NAME "ESP_OT_SENSORS"
-#define OT_CHANNEL      "15"
-#define OT_PANID        "0xabcf"
-#define OT_EXTPANID     "ce010000deadc0de"
-#define OT_NETWORK_KEY  "102030405060708090a0b0c0d0e0f002"
-// Fixed mesh-local prefix so a re-provisioned/rebooted leader forms the exact
-// same network instead of the random prefix "dataset init new" would generate.
-#define OT_MESHLOCAL_PREFIX "fdde:ad00:beef:0::"
-
-const uint16_t COLLECTOR_PORT = 61631;        // UDP port we bind/listen on
-const char COLLECTOR_GROUP[] = "ff03::abcd";  // realm-local multicast group sensors send to
-const int MAX_SENSORS = 256;                  // capacity of the in-RAM node table
-const uint32_t REPORT_PERIOD_MS = 30000;      // how often the fleet summary is printed
-
-// Liveness tracking. A node that goes silent (lost power, crashed, moved out of
-// range) must eventually be recognized as gone, otherwise the collector keeps
-// reporting it forever. NODE_OFFLINE_MS should be a small multiple of the
-// sensor's sample period so a couple of missed reports flips it to OFFLINE;
-// after NODE_EVICT_MS with no contact the table slot is freed entirely.
-const uint32_t NODE_OFFLINE_MS = 95000;               // ~3 missed 30 s samples
-const uint32_t NODE_EVICT_MS = 30UL * 60UL * 1000UL;  // drop dead nodes after 30 min
-
-// One entry per unique sensor node id seen on the network. The table is a
-// simple fixed array (no dynamic allocation) so memory use is bounded and
-// predictable even with a few hundred nodes.
-struct SensorRecord {
-  bool used;
-  bool online;  // false once the node has been silent past NODE_OFFLINE_MS
-  char nodeId[16];
-  uint32_t lastSeq;
-  int32_t lastTempCenti;
-  uint16_t lastBatteryMv;
-  uint32_t packetCount;
-  uint32_t duplicateCount;
-  uint32_t lastSeenMs;
-  char lastIp[40];
-};
-
-static SensorRecord s_records[MAX_SENSORS];
-static uint32_t s_totalPackets = 0;
-static uint32_t s_droppedPackets = 0;
-static char s_cliLine[256];
-
-// Run a single CLI command and check its result. otExecCommand() sends the
-// command and waits for the terminating "Done"/"Error ..." line; ot_cmd_return_t
-// carries the parsed error code/message so we can log a useful failure.
-static bool otCliCmd(const char *cmd) {
-  ot_cmd_return_t rc;
-  // otExecCommand() uses Stream::readBytesUntil(), which depends on the current
-  // Stream timeout. RX parsing tweaks the timeout frequently, so force a
-  // known-safe value for CLI control commands.
-  OThreadCLI.setTimeout(1000);
-  bool ok = otExecCommand(cmd, nullptr, &rc);
-  if (!ok) {
-    Serial.printf("CLI ERROR: '%s' -> %d %s\n", cmd, rc.errorCode, rc.errorMessage.c_str());
-  }
-  return ok;
-}
-
-// Read one line of asynchronous CLI output. OThreadCLI is an Arduino Stream,
-// so unsolicited output (e.g. incoming UDP datagrams) can be read with the
-// usual Stream API. Returns true only when a non-empty line was captured.
-static bool readCliLine(char *line, size_t lineLen, uint32_t timeoutMs) {
-  if (lineLen < 2) {
-    return false;
-  }
-  OThreadCLI.setTimeout(timeoutMs);
-  size_t n = OThreadCLI.readBytesUntil('\n', line, lineLen - 1);
-  if (!n) {
-    line[0] = '\0';
-    return false;
-  }
-  line[n] = '\0';
-  for (size_t i = 0; i < n; i++) {
-    if (line[i] == '\r' || line[i] == '\n') {
-      line[i] = '\0';
-      break;
-    }
-  }
-  return strlen(line) > 0;
-}
-
-// The CLI prints a received datagram as:
-//   "<N> bytes from <srcIp> <srcPort> <payload>"
-// e.g. "21 bytes from fdde:ad00:beef:0:1234:5678:9abc:def0 49152 id=node-1,seq=5,..."
-// Pull out the source IP, source port, and the payload text. Returns false for
-// any line that is not in this exact UDP-receive shape.
-static bool parseUdpLine(const char *line, char *srcIp, size_t srcIpLen, uint16_t &srcPort, char *payload, size_t payloadLen) {
-  unsigned int bytes = 0;
-  unsigned int port = 0;
-  char ip[40] = {0};
-  char msg[160] = {0};
-  int m = sscanf(line, "%u bytes from %39s %u %159[^\r\n]", &bytes, ip, &port, msg);
-  if (m != 4) {
-    return false;
-  }
-  strncpy(srcIp, ip, srcIpLen - 1);
-  srcIp[srcIpLen - 1] = '\0';
-  srcPort = (uint16_t)port;
-  strncpy(payload, msg, payloadLen - 1);
-  payload[payloadLen - 1] = '\0';
-  return true;
-}
-
-// Linear lookup of an existing node record by its string id (-1 if not found).
-static int findRecordById(const char *id) {
-  for (int i = 0; i < MAX_SENSORS; i++) {
-    if (s_records[i].used && !strcmp(s_records[i].nodeId, id)) {
-      return i;
-    }
-  }
-  return -1;
-}
-
-// Claim the first free slot for a newly seen node id (-1 if the table is full).
-static int allocateRecord(const char *id) {
-  for (int i = 0; i < MAX_SENSORS; i++) {
-    if (!s_records[i].used) {
-      memset(&s_records[i], 0, sizeof(s_records[i]));
-      s_records[i].used = true;
-      strncpy(s_records[i].nodeId, id, sizeof(s_records[i].nodeId) - 1);
-      return i;
-    }
-  }
-  return -1;
-}
-
-// Bring up Thread purely through the CLI.
-//
-// Reboot recovery (issue: children must rejoin after the leader resets):
-// OpenThread persists the committed dataset in NVS. If one already exists we
-// RESUME it - just bring the interface up and start Thread - which restores the
-// SAME network (same mesh-local prefix and key/frame-counter state). A child
-// that lost its parent then re-attaches to the returning leader within seconds.
-//
-// Only on the very first boot (no stored dataset) do we provision one, and we
-// PIN the mesh-local prefix and active timestamp. Plain "dataset init new"
-// randomizes both, so without pinning every reboot would look like a brand-new
-// network and force a slow, churny re-attach across the whole fleet.
-//
-// NOTE: because the dataset is persisted, changing the OT_* constants above has
-// no effect until the stored dataset is cleared (CLI "factoryreset" or an erase
-// of flash). The dataset MUST match udp_sensor_node.
-static bool setupThreadByCli() {
-  bool datasetPresent = OThread.hasActiveDataset();
-  if (datasetPresent) {
-    Serial.println("Active dataset found in NVS; resuming existing network.");
-    if (!otCliCmd("ifconfig up") || !otCliCmd("thread start")) {
-      return false;
-    }
-  } else {
-    Serial.println("No active dataset; provisioning a new deterministic network.");
-    const char *cmds[] = {
-      "thread stop",
-      "ifconfig down",
-      "dataset clear",
-      "dataset init new",
-      "dataset networkname " OT_NETWORK_NAME,
-      "dataset channel " OT_CHANNEL,
-      "dataset panid " OT_PANID,
-      "dataset extpanid " OT_EXTPANID,
-      "dataset networkkey " OT_NETWORK_KEY,
-      // Pin the fields "dataset init new" would otherwise randomize so the
-      // network is identical every time it is (re)created.
-      "dataset meshlocalprefix " OT_MESHLOCAL_PREFIX,
-      "dataset activetimestamp 1",
-      "dataset commit active",
-      "ifconfig up",
-      "thread start",
-    };
-    for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
-      if (!otCliCmd(cmds[i])) {
-        return false;
-      }
-    }
-  }
-
-  // Attaching takes a few seconds. Poll the device role until it is at least
-  // a Child (Child/Router/Leader all count as "attached"); give up after ~60s.
-  uint8_t tries = 30;
-  while (tries-- && OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
-    Serial.print(".");
-    delay(2000);
-  }
-  Serial.println();
-  return OThread.otGetDeviceRole() >= OT_ROLE_CHILD;
-}
-
-// Open the CLI UDP socket and start listening. "ipmaddr add" subscribes the
-// node to the realm-local multicast group the sensors target, and "udp bind ::
-// <port>" binds the socket to our listen port on every address. After this the
-// CLI will asynchronously print each datagram it receives.
-static bool setupUdpCli() {
-  // COLLECTOR_GROUP/COLLECTOR_PORT are runtime variables, so build the CLI
-  // command strings with snprintf (string-literal concatenation only works
-  // with #define macros, not with const char[] variables).
-  char mcastCmd[64];
-  char bindCmd[48];
-  snprintf(mcastCmd, sizeof(mcastCmd), "ipmaddr add %s", COLLECTOR_GROUP);
-  snprintf(bindCmd, sizeof(bindCmd), "udp bind :: %u", COLLECTOR_PORT);
-  const char *cmds[] = {
-    "udp close",  // ensure a clean socket state before (re)opening
-    "udp open",
-    mcastCmd,  // subscribe to the multicast group sensors publish to
-    bindCmd,   // bind to COLLECTOR_PORT so incoming frames are delivered
-  };
-  for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
-    if (!otCliCmd(cmds[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Unicast an "OK,<nodeId>,<seq>" acknowledgment straight back to the sender's
-// address/port. The node uses this ACK to confirm delivery (and, for sleepy
-// nodes, as a cue that it can go back to sleep). We push the command directly
-// on the CLI stream rather than otExecCommand() because we do not need to block
-// on the "Done" response here.
-static void sendAck(const char *dstIp, uint16_t dstPort, const char *nodeId, uint32_t seq) {
-  char ack[48];
-  char cmd[128];
-  snprintf(ack, sizeof(ack), "OK,%s,%lu", nodeId, (unsigned long)seq);
-  snprintf(cmd, sizeof(cmd), "udp send %s %u %s", dstIp, dstPort, ack);
-  OThreadCLI.println(cmd);
-}
-
-// Age out nodes we have stopped hearing from. A node still in range but silent
-// past NODE_OFFLINE_MS is flipped to OFFLINE (and reported once), and a node
-// gone longer than NODE_EVICT_MS is removed from the table so its slot can be
-// reused and it stops being counted. This is what lets the collector "sense" a
-// sensor that lost power instead of claiming it is still present.
-static void auditNodes() {
-  uint32_t now = millis();
-  for (int i = 0; i < MAX_SENSORS; i++) {
-    if (!s_records[i].used) {
-      continue;
-    }
-    uint32_t age = now - s_records[i].lastSeenMs;
-    if (s_records[i].online && age > NODE_OFFLINE_MS) {
-      s_records[i].online = false;
-      Serial.printf("node %s -> OFFLINE (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
-    }
-    if (age > NODE_EVICT_MS) {
-      Serial.printf("node %s evicted from table (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
-      s_records[i].used = false;
-    }
-  }
-}
-
-static void printCompactReport() {
-  uint16_t known = 0;
-  uint16_t online = 0;
-  for (int i = 0; i < MAX_SENSORS; i++) {
-    if (!s_records[i].used) {
-      continue;
-    }
-    known++;
-    if (s_records[i].online) {
-      online++;
-    }
-  }
-  Serial.printf(
-    "[collector-cli] role=%s nodes=%u online=%u packets=%lu dropped=%lu\n", OThread.otGetStringDeviceRole(), known, online, (unsigned long)s_totalPackets,
-    (unsigned long)s_droppedPackets
-  );
-}
-
-// Decode one sensor frame, update (or create) its node record, and ACK it.
-// The frame format is the plain-text key/value string the node builds:
-//   "id=<str>,seq=<n>,temp_centi=<int>,batt_mv=<uint>"
-static void processPacket(const char *payload, const char *srcIp, uint16_t srcPort) {
-  char id[16] = {0};
-  unsigned long seqTmp = 0;
-  long tempTmp = 0;
-  unsigned int battTmp = 0;
-  if (sscanf(payload, "id=%15[^,],seq=%lu,temp_centi=%ld,batt_mv=%u", id, &seqTmp, &tempTmp, &battTmp) != 4) {
-    s_droppedPackets++;
-    Serial.printf("DROP malformed from [%s]:%u -> '%s'\n", srcIp, srcPort, payload);
-    return;
-  }
-  uint32_t seq = (uint32_t)seqTmp;
-  int32_t tempCenti = (int32_t)tempTmp;
-  uint16_t battMv = (uint16_t)battTmp;
-
+ #include <Arduino.h>
+ #include "OThreadCLI.h"       // OThreadCLI object (CLI as an Arduino Stream)
+ #include "OThreadCLI_Util.h"  // otExecCommand() / ot_cmd_return_t helpers
+ 
+ // CLI dataset values. Keep these aligned with udp_sensor_node.
+ // Thread network name is limited to 16 bytes (OT_NETWORK_NAME_MAX_SIZE); a
+ // longer name makes "dataset networkname" fail with InvalidArgs.
+ #define OT_NETWORK_NAME "ESP_OT_SENSORS"
+ #define OT_CHANNEL "15"
+ #define OT_PANID "0xabcf"
+ #define OT_EXTPANID "ce010000deadc0de"
+ #define OT_NETWORK_KEY "102030405060708090a0b0c0d0e0f002"
+ // Fixed mesh-local prefix so a re-provisioned/rebooted leader forms the exact
+ // same network instead of the random prefix "dataset init new" would generate.
+ #define OT_MESHLOCAL_PREFIX "fdde:ad00:beef:0::"
+ 
+ // UDP port we bind/listen on. MUST NOT be one of Thread's reserved UDP ports,
+ // or the application socket also receives Thread's own internal traffic:
+ //   61631 -> Thread Management Framework (TMF) CoAP  (address query/notify, etc.)
+ //   5683/5684 -> CoAP / CoAPs
+ //   19788 -> MLE
+ // Binding any of those shows up here as "DROP malformed" CoAP datagrams (first
+ // byte 0x42 = 'B'). 5050 is a free application port; keep it aligned with the node.
+ const uint16_t COLLECTOR_PORT = 5050;         // UDP port we bind/listen on
+ const char COLLECTOR_GROUP[] = "ff03::abcd";  // realm-local multicast group sensors send to
+ const uint16_t MAX_SENSORS = 256;             // capacity of the in-RAM node table
+ const uint32_t REPORT_PERIOD_MS = 30000;      // how often the fleet summary is printed
+ 
+ // Liveness tracking. A node that goes silent (lost power, crashed, moved out of
+ // range) must eventually be recognized as gone, otherwise the collector keeps
+ // reporting it forever. NODE_OFFLINE_MS should be a small multiple of the
+ // sensor's sample period so a couple of missed reports flips it to OFFLINE;
+ // after NODE_EVICT_MS with no contact the table slot is freed entirely.
+ const uint32_t NODE_OFFLINE_MS = 95000;               // ~3 missed 30 s samples
+ const uint32_t NODE_EVICT_MS = 30UL * 60UL * 1000UL;  // drop dead nodes after 30 min
+ 
+ // One entry per unique sensor node id seen on the network. The table is a
+ // simple fixed array (no dynamic allocation) so memory use is bounded and
+ // predictable even with a few hundred nodes.
+ struct SensorRecord {
+   bool used;
+   bool online;  // false once the node has been silent past NODE_OFFLINE_MS
+   char nodeId[16];
+   uint32_t lastSeq;
+   int32_t lastTempCenti;
+   uint16_t lastBatteryMv;
+   uint32_t packetCount;
+   uint32_t duplicateCount;
+   uint32_t lastSeenMs;
+   char lastIp[40];
+ };
+ 
+ static SensorRecord s_records[MAX_SENSORS];
+ static uint32_t s_totalPackets = 0;
+ static uint32_t s_droppedPackets = 0;
+ static char s_cliLine[256];
+ 
+ // Run a single CLI command and check its result. otExecCommand() sends the
+ // command and waits for the terminating "Done"/"Error ..." line; ot_cmd_return_t
+ // carries the parsed error code/message so we can log a useful failure.
+ static bool otCliCmd(const char *cmd) {
+   ot_cmd_return_t rc;
+   bool ok = otExecCommand(cmd, nullptr, &rc);
+   if (!ok) {
+     Serial.printf("CLI ERROR: '%s' -> %d %s\n", cmd, rc.errorCode, rc.errorMessage.c_str());
+   }
+   return ok;
+ }
+ 
+ // Read one line of asynchronous CLI output. OThreadCLI is an Arduino Stream,
+ // so unsolicited output (e.g. incoming UDP datagrams) can be read with the
+ // usual Stream API. Returns true only when a non-empty line was captured.
+ static bool readCliLine(char *line, size_t lineLen, uint32_t timeoutMs) {
+   if (lineLen < 2) {
+     return false;
+   }
+   OThreadCLI.setTimeout(timeoutMs);
+   size_t n = OThreadCLI.readBytesUntil('\n', line, lineLen - 1);
+   if (!n) {
+     line[0] = '\0';
+     return false;
+   }
+   line[n] = '\0';
+   for (size_t i = 0; i < n; i++) {
+     if (line[i] == '\r' || line[i] == '\n') {
+       line[i] = '\0';
+       break;
+     }
+   }
+   return strlen(line) > 0;
+ }
+ 
+ // The CLI prints a received datagram as:
+ //   "<N> bytes from <srcIp> <srcPort> <payload>"
+ // e.g. "21 bytes from fdde:ad00:beef:0:1234:5678:9abc:def0 49152 id=node-1,seq=5,..."
+ // Pull out the source IP, source port, and the payload text. Returns false for
+ // any line that is not in this exact UDP-receive shape.
+ static bool parseUdpLine(const char *line, char *srcIp, size_t srcIpLen, uint16_t &srcPort, char *payload, size_t payloadLen) {
+   unsigned int bytes = 0;
+   unsigned int port = 0;
+   char ip[40] = { 0 };
+   char msg[160] = { 0 };
+   int m = sscanf(line, "%u bytes from %39s %u %159[^\r\n]", &bytes, ip, &port, msg);
+   if (m != 4) {
+     return false;
+   }
+   strncpy(srcIp, ip, srcIpLen - 1);
+   srcIp[srcIpLen - 1] = '\0';
+   srcPort = (uint16_t)port;
+   strncpy(payload, msg, payloadLen - 1);
+   payload[payloadLen - 1] = '\0';
+   return true;
+ }
+ 
+ // Linear lookup of an existing node record by its string id (-1 if not found).
+ static int findRecordById(const char *id) {
+   for (int i = 0; i < MAX_SENSORS; i++) {
+     if (s_records[i].used && !strcmp(s_records[i].nodeId, id)) {
+       return i;
+     }
+   }
+   return -1;
+ }
+ 
+ // Claim the first free slot for a newly seen node id (-1 if the table is full).
+ static int allocateRecord(const char *id) {
+   for (int i = 0; i < MAX_SENSORS; i++) {
+     if (!s_records[i].used) {
+       memset(&s_records[i], 0, sizeof(s_records[i]));
+       s_records[i].used = true;
+       strncpy(s_records[i].nodeId, id, sizeof(s_records[i].nodeId) - 1);
+       return i;
+     }
+   }
+   return -1;
+ }
+ 
+ // Bring up Thread purely through the CLI.
+ //
+ // Reboot recovery (issue: children must rejoin after the leader resets):
+ // OpenThread persists the committed dataset in NVS. If one already exists we
+ // RESUME it - just bring the interface up and start Thread - which restores the
+ // SAME network (same mesh-local prefix and key/frame-counter state). A child
+ // that lost its parent then re-attaches to the returning leader within seconds.
+ //
+ // Only on the very first boot (no stored dataset) do we provision one, and we
+ // PIN the mesh-local prefix and active timestamp. Plain "dataset init new"
+ // randomizes both, so without pinning every reboot would look like a brand-new
+ // network and force a slow, churny re-attach across the whole fleet.
+ //
+ // NOTE: because the dataset is persisted, changing the OT_* constants above has
+ // no effect until the stored dataset is cleared (CLI "factoryreset" or an erase
+ // of flash). The dataset MUST match udp_sensor_node.
+ static bool setupThreadByCli() {
+   bool datasetPresent = OThread.hasActiveDataset();
+   if (datasetPresent) {
+     Serial.println("Active dataset found in NVS; resuming existing network.");
+     if (!otCliCmd("ifconfig up") || !otCliCmd("thread start")) {
+       return false;
+     }
+   } else {
+     Serial.println("No active dataset; provisioning a new deterministic network.");
+     const char *cmds[] = {
+       "thread stop",
+       "ifconfig down",
+       "dataset clear",
+       "dataset init new",
+       "dataset networkname " OT_NETWORK_NAME,
+       "dataset channel " OT_CHANNEL,
+       "dataset panid " OT_PANID,
+       "dataset extpanid " OT_EXTPANID,
+       "dataset networkkey " OT_NETWORK_KEY,
+       // Pin the fields "dataset init new" would otherwise randomize so the
+       // network is identical every time it is (re)created.
+       "dataset meshlocalprefix " OT_MESHLOCAL_PREFIX,
+       "dataset activetimestamp 1",
+       "dataset commit active",
+       "ifconfig up",
+       "thread start",
+     };
+     for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
+       if (!otCliCmd(cmds[i])) {
+         return false;
+       }
+     }
+   }
+ 
+   // Attaching takes a few seconds. Poll the device role until it is at least
+   // a Child (Child/Router/Leader all count as "attached"); give up after ~60s.
+   uint8_t tries = 30;
+   while (tries-- && OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
+     Serial.print(".");
+     delay(2000);
+   }
+   Serial.println();
+   return OThread.otGetDeviceRole() >= OT_ROLE_CHILD;
+ }
+ 
+ // Open the CLI UDP socket and start listening. "ipmaddr add" subscribes the
+ // node to the realm-local multicast group the sensors target, and "udp bind ::
+ // <port>" binds the socket to our listen port on every address. After this the
+ // CLI will asynchronously print each datagram it receives.
+ static bool setupUdpCli() {
+   // COLLECTOR_GROUP/COLLECTOR_PORT are runtime variables, so build the CLI
+   // command strings with snprintf (string-literal concatenation only works
+   // with #define macros, not with const char[] variables).
+   char mcastCmd[64];
+   char bindCmd[48];
+   snprintf(mcastCmd, sizeof(mcastCmd), "ipmaddr add %s", COLLECTOR_GROUP);
+   snprintf(bindCmd, sizeof(bindCmd), "udp bind :: %u", COLLECTOR_PORT);
+   const char *cmds[] = {
+     "udp close",  // ensure a clean socket state before (re)opening
+     "udp open",
+     mcastCmd,  // subscribe to the multicast group sensors publish to
+     bindCmd,   // bind to COLLECTOR_PORT so incoming frames are delivered
+   };
+   for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
+     if (!otCliCmd(cmds[i])) {
+       return false;
+     }
+   }
+   return true;
+ }
+ 
+// Unicast an "OK,<nodeId>,<seq>" acknowledgement straight back to the sender's
+// address/port, where seq is the collector's authoritative last-stored sequence
+// for that node. The node uses this ACK both to confirm delivery and to resync
+// its own counter to ours (rolling back or skipping forward as needed). We push
+// the command directly on the CLI stream rather than otExecCommand() because we
+// do not need to block on the "Done" response here.
+ static void sendAck(const char *dstIp, uint16_t dstPort, const char *nodeId, uint32_t seq) {
+   char ack[48];
+   char cmd[128];
+   snprintf(ack, sizeof(ack), "OK,%s,%lu", nodeId, (unsigned long)seq);
+   snprintf(cmd, sizeof(cmd), "udp send %s %u %s", dstIp, dstPort, ack);
+   OThreadCLI.println(cmd);
+ }
+ 
+ // Age out nodes we have stopped hearing from. A node still in range but silent
+ // past NODE_OFFLINE_MS is flipped to OFFLINE (and reported once), and a node
+ // gone longer than NODE_EVICT_MS is removed from the table so its slot can be
+ // reused and it stops being counted. This is what lets the collector "sense" a
+ // sensor that lost power instead of claiming it is still present.
+ static void auditNodes() {
+   uint32_t now = millis();
+   for (int i = 0; i < MAX_SENSORS; i++) {
+     if (!s_records[i].used) {
+       continue;
+     }
+     uint32_t age = now - s_records[i].lastSeenMs;
+     if (s_records[i].online && age > NODE_OFFLINE_MS) {
+       s_records[i].online = false;
+       Serial.printf("node %s -> OFFLINE (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
+     }
+     if (age > NODE_EVICT_MS) {
+       Serial.printf("node %s evicted from table (silent %lus)\n", s_records[i].nodeId, (unsigned long)(age / 1000));
+       s_records[i].used = false;
+     }
+   }
+ }
+ 
+ static void printCompactReport() {
+   uint16_t known = 0;
+   uint16_t online = 0;
+   for (int i = 0; i < MAX_SENSORS; i++) {
+     if (!s_records[i].used) {
+       continue;
+     }
+     known++;
+     if (s_records[i].online) {
+       online++;
+     }
+   }
+   Serial.printf("[collector-cli] role=%s nodes=%u online=%u packets=%lu dropped=%lu\n",
+                 OThread.otGetStringDeviceRole(),
+                 known,
+                 online,
+                 (unsigned long)s_totalPackets,
+                 (unsigned long)s_droppedPackets);
+ }
+ 
+ // Decode one sensor frame, update (or create) its node record, and ACK it.
+ // The frame format is the plain-text key/value string the node builds:
+ //   "id=<str>,seq=<n>,temp_centi=<int>,batt_mv=<uint>"
+ static void processPacket(const char *payload, const char *srcIp, uint16_t srcPort) {
+   char id[16] = { 0 };
+   unsigned long seqTmp = 0;
+   long tempTmp = 0;
+   unsigned int battTmp = 0;
+   if (sscanf(payload, "id=%15[^,],seq=%lu,temp_centi=%ld,batt_mv=%u", id, &seqTmp, &tempTmp, &battTmp) != 4) {
+     s_droppedPackets++;
+     Serial.printf("DROP malformed from [%s]:%u -> '%s'\n", srcIp, srcPort, payload);
+     return;
+   }
+   uint32_t seq = (uint32_t)seqTmp;
+   int32_t tempCenti = (int32_t)tempTmp;
+   uint16_t battMv = (uint16_t)battTmp;
+ 
   int idx = findRecordById(id);
-  if (idx < 0) {
+  bool brandNew = (idx < 0);
+  if (brandNew) {
     idx = allocateRecord(id);
     if (idx < 0) {
       s_droppedPackets++;
@@ -329,18 +336,35 @@ static void processPacket(const char *payload, const char *srcIp, uint16_t srcPo
     }
   }
 
-  // A retransmitted frame (node resent because it missed our ACK) will carry a
-  // sequence number we have already recorded. Count it but do not overwrite the
-  // stored reading, so duplicates never corrupt the latest values.
+  // Classify the incoming sequence against what we have stored for this node.
+  // The collector is the authoritative owner of each node's sequence: it accepts
+  // forward progress, recognizes exact retransmits as duplicates, treats a reset
+  // to 1 as a node restart, and ignores any other backward (stale/out-of-order)
+  // frame. In every case it ACKs its own stored lastSeq so the node can resync.
   SensorRecord &r = s_records[idx];
-  bool isRebootSeq = (r.packetCount > 0 && seq < r.lastSeq && seq <= 3);
-  bool isDuplicate = (r.packetCount > 0 && !isRebootSeq && seq <= r.lastSeq);
-  if (isDuplicate) {
-    r.duplicateCount++;
-  } else {
+  const char *seqNote = "";
+  if (brandNew || seq > r.lastSeq) {
+    // first contact, or normal forward progress (a gap is tolerated)
     r.lastSeq = seq;
     r.lastTempCenti = tempCenti;
     r.lastBatteryMv = battMv;
+  } else if (seq == r.lastSeq) {
+    // node resent because it missed our ACK: count it, keep the stored reading
+    r.duplicateCount++;
+    seqNote = " (dup)";
+  } else if (seq == 1) {
+    // seq dropped back to 1 while we held a higher value: the node rebooted and
+    // restarted its counter. Follow it back so the ACK logic stays in sync.
+    Serial.printf("node %s restarted: sequence reset to 1\n", r.nodeId);
+    r.lastSeq = 1;
+    r.lastTempCenti = tempCenti;
+    r.lastBatteryMv = battMv;
+    r.duplicateCount = 0;
+    seqNote = " (restart)";
+  } else {
+    // an older/out-of-order frame: ignore the reading but re-ACK our last seq
+    r.duplicateCount++;
+    seqNote = " (stale)";
   }
   r.packetCount++;
   r.lastSeenMs = millis();
@@ -355,91 +379,99 @@ static void processPacket(const char *payload, const char *srcIp, uint16_t srcPo
     Serial.printf("node %s -> ONLINE\n", r.nodeId);
   }
 
-  Serial.printf(
-    "RX node=%s seq=%lu temp=%.2fC batt=%umV from [%s]:%u%s\n", r.nodeId, (unsigned long)seq, (float)tempCenti / 100.0f, battMv, srcIp, srcPort,
-    isDuplicate ? " (dup)" : ""
-  );
+  Serial.printf("RX node=%s seq=%lu temp=%.2fC batt=%umV from [%s]:%u%s\n",
+                r.nodeId,
+                (unsigned long)seq,
+                (float)tempCenti / 100.0f,
+                battMv,
+                srcIp,
+                srcPort,
+                seqNote);
 
-  sendAck(srcIp, srcPort, r.nodeId, seq);
+  // ACK our authoritative last stored sequence (not necessarily the one just
+  // received): for a fresh/duplicate/restart frame this equals seq and confirms
+  // it; for a stale frame it is higher, telling the node to resync forward.
+  sendAck(srcIp, srcPort, r.nodeId, r.lastSeq);
 }
-
-void setup() {
-  Serial.begin(115200);
-
-  Serial.println("=== udp_sensor_collector (CLI): Leader + UDP sink ===");
-  // begin(false): start the OpenThread stack but do NOT auto-start a network -
-  // we form the network ourselves through the CLI below. begin() returns only
-  // after stack init has finished (and reloaded any persisted dataset from NVS),
-  // so OThread.hasActiveDataset() is reliable without any extra wait here.
-  OThread.begin(false);
-  OThreadCLI.begin();
-  OThreadCLI.setTimeout(250);
-
-  if (!setupThreadByCli()) {
-    Serial.println("Thread setup failed. Halting.");
-    while (1) {
-      delay(1000);
-    }
-  }
-
-  Serial.printf("Attached as %s\n", OThread.otGetStringDeviceRole());
-  // Network we ended up on: this is either the dataset we just provisioned or the
-  // one resumed from NVS on a subsequent boot.
-  Serial.printf("Network:        name=%s panid=0x%04x\n", OThread.getNetworkName().c_str(), OThread.getPanId());
-  Serial.printf("Mesh-Local EID: %s\n", OThread.getMeshLocalEid().toString().c_str());
-  Serial.printf("Leader RLOC:    %s\n", OThread.getLeaderRloc().toString().c_str());
-
-  if (!setupUdpCli()) {
-    Serial.println("UDP CLI setup failed. Halting.");
-    while (1) {
-      delay(1000);
-    }
-  }
-  Serial.printf("Collector listening on UDP %s:%u\n", COLLECTOR_GROUP, COLLECTOR_PORT);
-}
-
-void loop() {
-  // Drain whatever the CLI has emitted since last loop. Each readable line is
-  // either CLI bookkeeping ("Done"/"Error", skipped) or an incoming datagram.
-  while (readCliLine(s_cliLine, sizeof(s_cliLine), 20)) {
-    if (!strncmp(s_cliLine, "Done", 4) || !strncmp(s_cliLine, "Error", 5)) {
-      continue;
-    }
-    char srcIp[40] = {0};
-    uint16_t srcPort = 0;
-    char payload[160] = {0};
-    if (parseUdpLine(s_cliLine, srcIp, sizeof(srcIp), srcPort, payload, sizeof(payload))) {
-      processPacket(payload, srcIp, srcPort);
-    }
-  }
-
-  // Periodically age the table and print a summary. After a collector reboot
-  // the table starts empty and is rebuilt automatically from the frames sensors
-  // keep multicasting, so no persisted state is needed to recover.
-  static uint32_t lastReport = 0;
-  if (millis() - lastReport >= REPORT_PERIOD_MS) {
-    lastReport = millis();
-    auditNodes();
-    printCompactReport();
-  }
-
-  // Thread role watchdog: as the network's only infrastructure node the
-  // collector should stay Leader/Router. If it ever drops to detached/child
-  // (e.g. a transient fault), bring Thread back up so sensors have a parent.
-  // setupThreadByCli() resumes the persisted dataset, so this restores the same
-  // network rather than creating a new one.
-  static uint32_t lastRoleCheck = 0;
-  if (millis() - lastRoleCheck >= 5000) {
-    lastRoleCheck = millis();
-    if (OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
-      Serial.println("Collector detached; restarting Thread...");
-      if (!setupThreadByCli()) {
-        Serial.println("Thread restart failed.");
-      } else if (!setupUdpCli()) {
-        Serial.println("UDP CLI setup failed after Thread restart.");
-      }
-    }
-  }
-
-  delay(20);
-}
+ 
+ void setup() {
+   Serial.begin(115200);
+ 
+   Serial.println("=== udp_sensor_collector (CLI): Leader + UDP sink ===");
+   // begin(false): start the OpenThread stack but do NOT auto-start a network -
+   // we form the network ourselves through the CLI below. begin() returns only
+   // after stack init has finished (and reloaded any persisted dataset from NVS),
+   // so OThread.hasActiveDataset() is reliable without any extra wait here.
+   OThread.begin(false);
+   OThreadCLI.begin();
+   OThreadCLI.setTimeout(250);
+ 
+   if (!setupThreadByCli()) {
+     Serial.println("Thread setup failed. Halting.");
+     while (1) {
+       delay(1000);
+     }
+   }
+ 
+   Serial.printf("Attached as %s\n", OThread.otGetStringDeviceRole());
+   // Network we ended up on: this is either the dataset we just provisioned or the
+   // one resumed from NVS on a subsequent boot.
+   Serial.printf("Network:        name=%s panid=0x%04x\n", OThread.getNetworkName().c_str(), OThread.getPanId());
+   Serial.printf("Mesh-Local EID: %s\n", OThread.getMeshLocalEid().toString().c_str());
+   Serial.printf("Leader RLOC:    %s\n", OThread.getLeaderRloc().toString().c_str());
+ 
+   if (!setupUdpCli()) {
+     Serial.println("UDP CLI setup failed. Halting.");
+     while (1) {
+       delay(1000);
+     }
+   }
+   Serial.printf("Collector listening on UDP %s:%u\n", COLLECTOR_GROUP, COLLECTOR_PORT);
+ }
+ 
+ void loop() {
+   // Drain whatever the CLI has emitted since last loop. Each readable line is
+   // either CLI bookkeeping ("Done"/"Error", skipped) or an incoming datagram.
+   while (readCliLine(s_cliLine, sizeof(s_cliLine), 20)) {
+     if (!strncmp(s_cliLine, "Done", 4) || !strncmp(s_cliLine, "Error", 5)) {
+       continue;
+     }
+     char srcIp[40] = { 0 };
+     uint16_t srcPort = 0;
+     char payload[160] = { 0 };
+     if (parseUdpLine(s_cliLine, srcIp, sizeof(srcIp), srcPort, payload, sizeof(payload))) {
+       processPacket(payload, srcIp, srcPort);
+     }
+   }
+ 
+   // Periodically age the table and print a summary. After a collector reboot
+   // the table starts empty and is rebuilt automatically from the frames sensors
+   // keep multicasting, so no persisted state is needed to recover.
+   static uint32_t lastReport = 0;
+   if (millis() - lastReport >= REPORT_PERIOD_MS) {
+     lastReport = millis();
+     auditNodes();
+     printCompactReport();
+   }
+ 
+   // Thread role watchdog: as the network's only infrastructure node the
+   // collector should stay Leader/Router. If it ever drops to detached/child
+   // (e.g. a transient fault), bring Thread back up so sensors have a parent.
+   // setupThreadByCli() resumes the persisted dataset, so this restores the same
+   // network rather than creating a new one.
+   static uint32_t lastRoleCheck = 0;
+   if (millis() - lastRoleCheck >= 5000) {
+     lastRoleCheck = millis();
+     if (OThread.otGetDeviceRole() < OT_ROLE_CHILD) {
+       Serial.println("Collector detached; restarting Thread...");
+       if (!setupThreadByCli()) {
+         Serial.println("Thread restart failed.");
+       } else if (!setupUdpCli()) {
+         Serial.println("UDP CLI setup failed after Thread restart.");
+       }
+     }
+   }
+ 
+   delay(20);
+ }
+ 

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/README.md
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/README.md
@@ -68,7 +68,7 @@ Bring-up:
 ifconfig up
 thread start
 udp open
-udp bind :: 61631
+udp bind :: 5050
 ```
 
 ## Sleep behavior
@@ -196,11 +196,65 @@ TX payload:
 id=<nodeId>,seq=<u32>,temp_centi=<i32>,batt_mv=<u16>
 ```
 
-ACK expected:
+ACK expected (the value is the collector's authoritative last-stored sequence
+for this node, not necessarily the one just sent):
 
 ```text
-OK,<nodeId>,<seq>
+OK,<nodeId>,<collectorLastSeq>
 ```
+
+## Reliable delivery (application-level ACK + collector-driven sequence)
+
+The Thread link layer (MAC ACKs, mesh forwarding) can look healthy even when the
+collector application is gone, so it is not a reliable signal that data was
+*received and processed*. This sketch therefore treats the collector's
+**application-level ACK as the only ground truth of delivery**, and makes the
+**collector the single source of truth for the sequence number**:
+
+- The frame for a sample uses `seq = lastConfirmedSeq + 1`.
+- `sendFrameAndWaitAck()` only considers an ACK that is a real UDP-receive line,
+  whose source is **not** one of this node's own addresses (so a looped-back
+  frame can never be mistaken for an ACK), and whose `id` field matches ours. It
+  then reads the **sequence number out of the ACK**.
+- After a valid ACK the node **resyncs** its local counter to the collector's
+  reported sequence: it rolls back if it had run ahead, or skips forward if the
+  collector ignored a stale frame. So the node can never drift away from the
+  collector's view.
+- If the ACK sequence equals the frame just sent, the sample is `ACKED`. If it
+  differs, the node logs a `Resync:` line and reports `RESYNC` for that sample.
+- If **no** ACK arrives at all (collector off/unreachable), the sequence is
+  **held** (not advanced), the same reading is retransmitted up to `TX_RETRIES`
+  times, and the sample is reported `NO_ACK (sequence held)` - the count never
+  moves forward without proof of delivery.
+
+### "It still shows ACKED after I turned the collector off"
+
+Every ACK echoes the **exact sequence number** of the frame just sent
+(`OK,<id>,<seq>`). The collector builds that string only when it actually
+receives that specific frame, so if the node keeps printing `status=ACKED` for
+brand-new sequence numbers, a device really is receiving and answering them - a
+powered-off board cannot invent new sequence numbers. Check:
+
+- The collector is **truly unpowered**, not just reset or with its serial monitor
+  closed. Over USB the board stays powered and keeps ACKing; a reset makes it
+  resume the saved network from NVS and keep ACKing. Unplug it (or hold it in
+  reset) to actually stop it.
+- The `ACK ... <-` source address is **not** one of the node's own addresses.
+  The sketch prints `My Mesh-Local EID` and `My own addresses` at startup, and
+  logs `Ignoring datagram from own address ...` if it ever sees a self-sourced
+  frame. If the ACK source matches one of your own addresses, you are seeing
+  loopback, not a remote collector.
+- No second board on the bench is running the collector sketch.
+
+### Node reset
+
+The node id is derived from the factory EUI-64, so it is stable across a reset,
+but `s_seq` restarts at 0 (next frame `seq=1`). The collector still holds the
+old (higher) sequence for that id, so it recognizes `seq=1` as a **restart**,
+follows the node back to 1, logs `node <id> restarted: sequence reset to 1`, and
+ACKs `1`. The node then continues normally from there. (Other backward jumps are
+treated as stale and ignored, and the node is told the collector's real last seq
+so it resyncs forward.)
 
 ## Expected serial output
 
@@ -209,10 +263,19 @@ OK,<nodeId>,<seq>
 ...
 Role: Child
 Node ID: 3CAAB123
-Collector group: ff03::abcd:61631
-TX [ff03::abcd]:61631 -> 'id=3CAAB123,seq=1,temp_centi=2312,batt_mv=3820'
-ACK [fd..]:61631 <- 'OK,3CAAB123,1'
-sample=1 temp=23.12C batt=3820mV status=ACKED
+Collector group: ff03::abcd:5050
+TX [ff03::abcd]:5050 -> 'id=3CAAB123,seq=1,temp_centi=2312,batt_mv=3820'
+ACK [fd..]:5050 <- 'OK,3CAAB123,1'
+sample seq=1 temp=23.12C batt=3820mV status=ACKED
+```
+
+With the collector powered off you instead see the sequence held:
+
+```text
+TX [ff03::abcd]:5050 -> 'id=3CAAB123,seq=2,temp_centi=2298,batt_mv=3810'
+TX [ff03::abcd]:5050 -> 'id=3CAAB123,seq=2,temp_centi=2298,batt_mv=3810' (retransmit)
+ACK timeout (no valid ACK from collector)
+sample seq=2 temp=22.98C batt=3810mV status=NO_ACK (sequence held)
 ```
 
 ## Customization
@@ -220,6 +283,8 @@ sample=1 temp=23.12C batt=3820mV status=ACKED
 Tune these constants in `udp_sensor_node.ino`:
 
 - `SAMPLE_PERIOD_MS`
+- `ACK_TIMEOUT_MS` (how long to wait for the collector's ACK per attempt)
+- `TX_RETRIES` (immediate resends of the same sequence before reporting NO_ACK)
 - `USE_SLEEPY_MODE`
 - `SED_POLL_MS`
 - `CHILD_TIMEOUT_S`

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/README.md
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/README.md
@@ -229,11 +229,7 @@ collector application is gone, so it is not a reliable signal that data was
 
 ### "It still shows ACKED after I turned the collector off"
 
-Every ACK echoes the **exact sequence number** of the frame just sent
-(`OK,<id>,<seq>`). The collector builds that string only when it actually
-receives that specific frame, so if the node keeps printing `status=ACKED` for
-brand-new sequence numbers, a device really is receiving and answering them - a
-powered-off board cannot invent new sequence numbers. Check:
+When the node prints `status=ACKED`, the collector’s ACK carried the same sequence number as the frame just sent (`OK,<id>,<collectorLastSeq>` where `collectorLastSeq == seq`). The collector can only generate such an ACK after actually receiving that datagram, so if the node keeps printing `status=ACKED` for brand-new sequence numbers, a device really is receiving and answering them — a powered-off board cannot invent new sequence numbers. Check:
 
 - The collector is **truly unpowered**, not just reset or with its serial monitor
   closed. Over USB the board stays powered and keeps ACKing; a reset makes it

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/udp_sensor_node.ino
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/udp_sensor_node.ino
@@ -43,10 +43,15 @@
 #define OT_EXTPANID     "ce010000deadc0de"
 #define OT_NETWORK_KEY  "102030405060708090a0b0c0d0e0f002"
 
-const uint16_t COLLECTOR_PORT = 61631;        // destination/listen UDP port
-const char COLLECTOR_GROUP[] = "ff03::abcd";  // multicast group the collector subscribes to
-const uint32_t SAMPLE_PERIOD_MS = 30000;      // time between sensor samples
-const uint32_t ACK_TIMEOUT_MS = 1200;         // how long to wait for the collector's ACK
+// Destination/listen UDP port. MUST match the collector and MUST NOT be one of
+// Thread's reserved UDP ports (61631 = TMF CoAP, 5683/5684 = CoAP/CoAPs,
+// 19788 = MLE); binding those makes the app socket receive Thread's internal
+// management traffic, which shows up at the collector as "DROP malformed".
+const uint16_t COLLECTOR_PORT   = 5050;           // destination/listen UDP port
+const char     COLLECTOR_GROUP[] = "ff03::abcd";  // multicast group the collector subscribes to
+const uint32_t SAMPLE_PERIOD_MS = 30000;          // time between sensor samples
+const uint32_t ACK_TIMEOUT_MS   = 1200;           // how long to wait for the collector's ACK
+const uint8_t  TX_RETRIES       = 2;              // immediate resends of the SAME seq before giving up on this sample
 
 // Recovery: if this many samples in a row get no ACK, assume the collector (our
 // parent/leader) rebooted or vanished and force a clean Thread re-attach instead
@@ -55,15 +60,16 @@ const uint32_t ACK_TIMEOUT_MS = 1200;         // how long to wait for the collec
 const uint8_t REATTACH_AFTER_MISSED = 3;
 
 // Sleepy End Device setup via CLI.
-const bool USE_SLEEPY_MODE = true;     // set false to stay a normal (always-on) child
-const uint32_t SED_POLL_MS = 1000;     // data poll interval while sleeping (lower = lower latency, higher power)
-const uint32_t CHILD_TIMEOUT_S = 300;  // parent keeps us as a child if we poll within this window
+const bool USE_SLEEPY_MODE      = true;   // set false to stay a normal (always-on) child
+const uint32_t SED_POLL_MS      = 1000;   // data poll interval while sleeping (lower = lower latency, higher power)
+const uint32_t CHILD_TIMEOUT_S  = 300;    // parent keeps us as a child if we poll within this window
 
 // Sleepy behavior in this sketch (mode n / pollperiod / childtimeout) is only
 // meaningful when the build enables the required OT/802.15.4 low-power stack
 // options. This is typically configured in Arduino-as-IDF-component projects.
 #if defined(CONFIG_OPENTHREAD_MTD) && defined(CONFIG_IEEE802154_SLEEP_ENABLE) && defined(CONFIG_PM_ENABLE)
-static constexpr bool kBuildHasSleepySupport = (CONFIG_OPENTHREAD_MTD && CONFIG_IEEE802154_SLEEP_ENABLE && CONFIG_PM_ENABLE);
+static constexpr bool kBuildHasSleepySupport =
+  (CONFIG_OPENTHREAD_MTD && CONFIG_IEEE802154_SLEEP_ENABLE && CONFIG_PM_ENABLE);
 #else
 static constexpr bool kBuildHasSleepySupport = false;
 #endif
@@ -262,51 +268,113 @@ static void readFakeSensor(int32_t &tempCenti, uint16_t &battMv) {
   battMv = 3600 + (uint16_t)random(0, 400);
 }
 
-// Multicast one sensor frame and block until the collector's matching ACK
-// arrives (or ACK_TIMEOUT_MS elapses). The ACK is "OK,<nodeId>,<seq>"; we only
-// accept the one whose sequence matches this frame, so a late ACK for an older
-// frame does not falsely confirm this one. Returns true only on a matching ACK.
-static bool sendFrameAndWaitAck(uint32_t seq, int32_t tempCenti, uint16_t battMv) {
+// True if "ip" is one of this node's own Thread addresses. Used to reject a
+// datagram that looped back to us (a node is never its own collector), so the
+// node can never mistake its own traffic for a real ACK from the collector.
+static bool isOwnAddress(const char *ip) {
+  IPAddress addr;
+  if (!addr.fromString(ip)) {
+    return false;
+  }
+  for (const IPAddress &own : OThread.getAllUnicastAddresses()) {
+    if (own == addr) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Parse a collector ACK payload "OK,<nodeId>,<seq>" addressed to THIS node.
+// Returns the acknowledged sequence number, or -1 if the line is not an ACK for
+// us. The collector reports its own authoritative last-stored sequence here, so
+// the caller can resync to it.
+static long parseAckSeq(const char *payload) {
+  char id[16] = {0};
+  unsigned long ackSeq = 0;
+  if (sscanf(payload, "OK,%15[^,],%lu", id, &ackSeq) != 2) {
+    return -1;
+  }
+  if (strcmp(id, s_nodeId) != 0) {
+    return -1;  // an ACK for a different node
+  }
+  return (long)ackSeq;
+}
+
+// Send one sensor frame for sequence "seq" and wait for the collector's ACK.
+//
+// The ACK payload is "OK,<nodeId>,<collectorLastSeq>", where collectorLastSeq is
+// the last sequence the collector has stored for THIS node (its authoritative
+// value). An ACK is considered only when it parses as a genuine UDP-receive line
+// whose source is NOT one of our own addresses (no loopback) and whose id field
+// matches ours.
+//
+// Returns the acknowledged sequence number (>= 0) so the caller can resync its
+// own counter to the collector, or -1 if no valid ACK was seen after every
+// retransmission (collector off/unreachable). On a miss we retransmit the SAME
+// seq up to TX_RETRIES times so a single lost frame/ACK does not waste a whole
+// sample period. An exact match (ack == seq) is returned immediately; otherwise
+// the highest sequence the collector reported is returned for resyncing.
+static long sendFrameAndWaitAck(uint32_t seq, int32_t tempCenti, uint16_t battMv) {
   char frame[120];
   char cmd[192];
-  char expectedAck[48];
-  snprintf(frame, sizeof(frame), "id=%s,seq=%lu,temp_centi=%ld,batt_mv=%u", s_nodeId, (unsigned long)seq, (long)tempCenti, battMv);
+  snprintf(frame, sizeof(frame), "id=%s,seq=%lu,temp_centi=%ld,batt_mv=%u",
+           s_nodeId, (unsigned long)seq, (long)tempCenti, battMv);
   snprintf(cmd, sizeof(cmd), "udp send %s %u %s", COLLECTOR_GROUP, COLLECTOR_PORT, frame);
-  snprintf(expectedAck, sizeof(expectedAck), "OK,%s,%lu", s_nodeId, (unsigned long)seq);
 
-  // Drain stale CLI lines before issuing the next tx command.
-  while (readCliLine(s_cliLine, sizeof(s_cliLine), 10)) {}
+  long bestAcked = -1;  // highest sequence the collector reported, for resync
+  for (uint8_t attempt = 0; attempt <= TX_RETRIES; attempt++) {
+    // Drain any stale CLI output (e.g. a duplicate ACK for an older seq) so it
+    // cannot be confused with the response to the frame we are about to send.
+    while (readCliLine(s_cliLine, sizeof(s_cliLine), 10)) {
+    }
 
-  OThreadCLI.println(cmd);
-  Serial.printf("TX [%s]:%u -> '%s'\n", COLLECTOR_GROUP, COLLECTOR_PORT, frame);
+    OThreadCLI.println(cmd);
+    Serial.printf("TX [%s]:%u -> '%s'%s\n", COLLECTOR_GROUP, COLLECTOR_PORT, frame,
+                  attempt ? " (retransmit)" : "");
 
-  // Watch the CLI stream for the ACK until the timeout. "Done" is just the echo
-  // of our send command; "Error" means the send itself failed; anything else is
-  // tested for a UDP receive line.
-  uint32_t started = millis();
-  while (millis() - started < ACK_TIMEOUT_MS) {
-    if (!readCliLine(s_cliLine, sizeof(s_cliLine), 30)) {
-      continue;
-    }
-    if (!strncmp(s_cliLine, "Done", 4)) {
-      continue;
-    }
-    if (!strncmp(s_cliLine, "Error", 5)) {
-      Serial.printf("UDP send command failed: %s\n", s_cliLine);
-      return false;
-    }
-    char srcIp[40] = {0};
-    uint16_t srcPort = 0;
-    char payload[160] = {0};
-    if (parseUdpLine(s_cliLine, srcIp, sizeof(srcIp), srcPort, payload, sizeof(payload))) {
-      Serial.printf("ACK [%s]:%u <- '%s'\n", srcIp, srcPort, payload);
-      if (!strcmp(payload, expectedAck)) {
-        return true;
+    // Watch the CLI stream for the ACK until the timeout. "Done" is just the
+    // result of our send command; "Error" means the send itself failed (no
+    // route to the collector) so we retry; anything else is tested as a UDP
+    // receive line.
+    uint32_t started = millis();
+    while (millis() - started < ACK_TIMEOUT_MS) {
+      if (!readCliLine(s_cliLine, sizeof(s_cliLine), 30)) {
+        continue;
+      }
+      if (!strncmp(s_cliLine, "Done", 4)) {
+        continue;
+      }
+      if (!strncmp(s_cliLine, "Error", 5)) {
+        Serial.printf("UDP send command failed: %s\n", s_cliLine);
+        break;  // give up on this attempt; the retry loop will resend
+      }
+      char srcIp[40] = {0};
+      uint16_t srcPort = 0;
+      char payload[160] = {0};
+      if (parseUdpLine(s_cliLine, srcIp, sizeof(srcIp), srcPort, payload, sizeof(payload))) {
+        if (isOwnAddress(srcIp)) {
+          // Our own looped-back traffic is never a valid ACK. Log it so a
+          // loopback situation is visible instead of silently masquerading.
+          Serial.printf("Ignoring datagram from own address [%s]: '%s'\n", srcIp, payload);
+          continue;
+        }
+        long ackSeq = parseAckSeq(payload);
+        if (ackSeq >= 0) {
+          Serial.printf("ACK [%s]:%u <- '%s'\n", srcIp, srcPort, payload);
+          if ((uint32_t)ackSeq == seq) {
+            return ackSeq;  // exact confirmation of the frame we just sent
+          }
+          if (ackSeq > bestAcked) {
+            bestAcked = ackSeq;  // remember the collector's reported seq for resync
+          }
+        }
       }
     }
   }
-  Serial.println("ACK timeout");
-  return false;
+  if (bestAcked < 0) {
+    Serial.println("ACK timeout (no valid ACK from collector)");
+  }
+  return bestAcked;
 }
 
 // Force a clean re-attach to the Thread network. A Sleepy End Device only talks
@@ -382,18 +450,38 @@ void loop() {
   uint16_t battMv;
   readFakeSensor(tempCenti, battMv);
 
-  // Monotonic sequence number lets the collector detect duplicates/retransmits.
-  s_seq++;
-  bool ok = sendFrameAndWaitAck(s_seq, tempCenti, battMv);
-  Serial.printf("sample=%lu temp=%.2fC batt=%umV status=%s\n", (unsigned long)s_seq, (float)tempCenti / 100.0f, battMv, ok ? "ACKED" : "NO_ACK");
+  // Candidate sequence number: s_seq is the last value the collector has
+  // confirmed, so the frame we send is always s_seq + 1.
+  uint32_t seqToSend = s_seq + 1;
+  long acked = sendFrameAndWaitAck(seqToSend, tempCenti, battMv);
 
-  // Track consecutive misses. A run of them is the signature of a collector
-  // that rebooted/disappeared, so trigger a re-attach to recover quickly.
-  if (ok) {
+  if (acked < 0) {
+    // No ACK at all: the collector is off/unreachable. HOLD the sequence (do
+    // not advance s_seq) and resend the same reading next time, so the count
+    // never moves forward without proof of delivery.
+    Serial.printf("sample seq=%lu temp=%.2fC batt=%umV status=NO_ACK (sequence held)\n",
+                  (unsigned long)seqToSend, (float)tempCenti / 100.0f, battMv);
+    // A run of misses is the signature of a collector that rebooted/vanished,
+    // so trigger a clean re-attach to recover the network quickly.
+    if (++s_consecutiveNoAck >= REATTACH_AFTER_MISSED) {
+      forceReattach();
+      s_consecutiveNoAck = 0;
+    }
+  } else {
+    // The collector responded, so the network is healthy. Resync our counter to
+    // the collector's authoritative last sequence: this rolls back if we ran
+    // ahead, or skips forward if the collector ignored a stale/old frame.
     s_consecutiveNoAck = 0;
-  } else if (++s_consecutiveNoAck >= REATTACH_AFTER_MISSED) {
-    forceReattach();
-    s_consecutiveNoAck = 0;
+    uint32_t ackedSeq = (uint32_t)acked;
+    bool delivered = (ackedSeq == seqToSend);
+    if (!delivered) {
+      Serial.printf("Resync: collector last seq=%lu (we sent %lu); aligning local sequence.\n",
+                    (unsigned long)ackedSeq, (unsigned long)seqToSend);
+    }
+    s_seq = ackedSeq;  // collector is the source of truth for the sequence
+    Serial.printf("sample seq=%lu temp=%.2fC batt=%umV status=%s\n",
+                  (unsigned long)seqToSend, (float)tempCenti / 100.0f, battMv,
+                  delivered ? "ACKED" : "RESYNC");
   }
 
   delay(SAMPLE_PERIOD_MS);

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/udp_sensor_node.ino
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/udp_sensor_node.ino
@@ -47,11 +47,11 @@
 // Thread's reserved UDP ports (61631 = TMF CoAP, 5683/5684 = CoAP/CoAPs,
 // 19788 = MLE); binding those makes the app socket receive Thread's internal
 // management traffic, which shows up at the collector as "DROP malformed".
-const uint16_t COLLECTOR_PORT   = 5050;           // destination/listen UDP port
-const char     COLLECTOR_GROUP[] = "ff03::abcd";  // multicast group the collector subscribes to
-const uint32_t SAMPLE_PERIOD_MS = 30000;          // time between sensor samples
-const uint32_t ACK_TIMEOUT_MS   = 1200;           // how long to wait for the collector's ACK
-const uint8_t  TX_RETRIES       = 2;              // immediate resends of the SAME seq before giving up on this sample
+const uint16_t COLLECTOR_PORT = 5050;         // destination/listen UDP port
+const char COLLECTOR_GROUP[] = "ff03::abcd";  // multicast group the collector subscribes to
+const uint32_t SAMPLE_PERIOD_MS = 30000;      // time between sensor samples
+const uint32_t ACK_TIMEOUT_MS = 1200;         // how long to wait for the collector's ACK
+const uint8_t TX_RETRIES = 2;                 // immediate resends of the SAME seq before giving up on this sample
 
 // Recovery: if this many samples in a row get no ACK, assume the collector (our
 // parent/leader) rebooted or vanished and force a clean Thread re-attach instead
@@ -60,16 +60,15 @@ const uint8_t  TX_RETRIES       = 2;              // immediate resends of the SA
 const uint8_t REATTACH_AFTER_MISSED = 3;
 
 // Sleepy End Device setup via CLI.
-const bool USE_SLEEPY_MODE      = true;   // set false to stay a normal (always-on) child
-const uint32_t SED_POLL_MS      = 1000;   // data poll interval while sleeping (lower = lower latency, higher power)
-const uint32_t CHILD_TIMEOUT_S  = 300;    // parent keeps us as a child if we poll within this window
+const bool USE_SLEEPY_MODE = true;     // set false to stay a normal (always-on) child
+const uint32_t SED_POLL_MS = 1000;     // data poll interval while sleeping (lower = lower latency, higher power)
+const uint32_t CHILD_TIMEOUT_S = 300;  // parent keeps us as a child if we poll within this window
 
 // Sleepy behavior in this sketch (mode n / pollperiod / childtimeout) is only
 // meaningful when the build enables the required OT/802.15.4 low-power stack
 // options. This is typically configured in Arduino-as-IDF-component projects.
 #if defined(CONFIG_OPENTHREAD_MTD) && defined(CONFIG_IEEE802154_SLEEP_ENABLE) && defined(CONFIG_PM_ENABLE)
-static constexpr bool kBuildHasSleepySupport =
-  (CONFIG_OPENTHREAD_MTD && CONFIG_IEEE802154_SLEEP_ENABLE && CONFIG_PM_ENABLE);
+static constexpr bool kBuildHasSleepySupport = (CONFIG_OPENTHREAD_MTD && CONFIG_IEEE802154_SLEEP_ENABLE && CONFIG_PM_ENABLE);
 #else
 static constexpr bool kBuildHasSleepySupport = false;
 #endif
@@ -317,20 +316,17 @@ static long parseAckSeq(const char *payload) {
 static long sendFrameAndWaitAck(uint32_t seq, int32_t tempCenti, uint16_t battMv) {
   char frame[120];
   char cmd[192];
-  snprintf(frame, sizeof(frame), "id=%s,seq=%lu,temp_centi=%ld,batt_mv=%u",
-           s_nodeId, (unsigned long)seq, (long)tempCenti, battMv);
+  snprintf(frame, sizeof(frame), "id=%s,seq=%lu,temp_centi=%ld,batt_mv=%u", s_nodeId, (unsigned long)seq, (long)tempCenti, battMv);
   snprintf(cmd, sizeof(cmd), "udp send %s %u %s", COLLECTOR_GROUP, COLLECTOR_PORT, frame);
 
   long bestAcked = -1;  // highest sequence the collector reported, for resync
   for (uint8_t attempt = 0; attempt <= TX_RETRIES; attempt++) {
     // Drain any stale CLI output (e.g. a duplicate ACK for an older seq) so it
     // cannot be confused with the response to the frame we are about to send.
-    while (readCliLine(s_cliLine, sizeof(s_cliLine), 10)) {
-    }
+    while (readCliLine(s_cliLine, sizeof(s_cliLine), 10)) {}
 
     OThreadCLI.println(cmd);
-    Serial.printf("TX [%s]:%u -> '%s'%s\n", COLLECTOR_GROUP, COLLECTOR_PORT, frame,
-                  attempt ? " (retransmit)" : "");
+    Serial.printf("TX [%s]:%u -> '%s'%s\n", COLLECTOR_GROUP, COLLECTOR_PORT, frame, attempt ? " (retransmit)" : "");
 
     // Watch the CLI stream for the ACK until the timeout. "Done" is just the
     // result of our send command; "Error" means the send itself failed (no
@@ -459,8 +455,7 @@ void loop() {
     // No ACK at all: the collector is off/unreachable. HOLD the sequence (do
     // not advance s_seq) and resend the same reading next time, so the count
     // never moves forward without proof of delivery.
-    Serial.printf("sample seq=%lu temp=%.2fC batt=%umV status=NO_ACK (sequence held)\n",
-                  (unsigned long)seqToSend, (float)tempCenti / 100.0f, battMv);
+    Serial.printf("sample seq=%lu temp=%.2fC batt=%umV status=NO_ACK (sequence held)\n", (unsigned long)seqToSend, (float)tempCenti / 100.0f, battMv);
     // A run of misses is the signature of a collector that rebooted/vanished,
     // so trigger a clean re-attach to recover the network quickly.
     if (++s_consecutiveNoAck >= REATTACH_AFTER_MISSED) {
@@ -475,13 +470,12 @@ void loop() {
     uint32_t ackedSeq = (uint32_t)acked;
     bool delivered = (ackedSeq == seqToSend);
     if (!delivered) {
-      Serial.printf("Resync: collector last seq=%lu (we sent %lu); aligning local sequence.\n",
-                    (unsigned long)ackedSeq, (unsigned long)seqToSend);
+      Serial.printf("Resync: collector last seq=%lu (we sent %lu); aligning local sequence.\n", (unsigned long)ackedSeq, (unsigned long)seqToSend);
     }
     s_seq = ackedSeq;  // collector is the source of truth for the sequence
-    Serial.printf("sample seq=%lu temp=%.2fC batt=%umV status=%s\n",
-                  (unsigned long)seqToSend, (float)tempCenti / 100.0f, battMv,
-                  delivered ? "ACKED" : "RESYNC");
+    Serial.printf(
+      "sample seq=%lu temp=%.2fC batt=%umV status=%s\n", (unsigned long)seqToSend, (float)tempCenti / 100.0f, battMv, delivered ? "ACKED" : "RESYNC"
+    );
   }
 
   delay(SAMPLE_PERIOD_MS);

--- a/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/udp_sensor_node.ino
+++ b/libraries/OpenThread/examples/CLI/UDP/udp_sensor_node/udp_sensor_node.ino
@@ -276,8 +276,8 @@ static bool isOwnAddress(const char *ip) {
   if (!addr.fromString(ip)) {
     return false;
   }
-  for (const IPAddress &own : OThread.getAllUnicastAddresses()) {
-    if (own == addr) {
+  for (size_t i = 0, n = OThread.getUnicastAddressCount(); i < n; i++) {
+    if (OThread.getUnicastAddress(i) == addr) {
       return true;
     }
   }


### PR DESCRIPTION
## Description of Change
This pull request updates the OpenThread UDP sensor/collector example to avoid using Thread-reserved UDP ports and improves reliability and documentation around sequence handling and acknowledgments. The main focus is to switch from the reserved port `61631` (used by Thread Management Framework) to the application-safe port `5050`, and to clarify and enforce robust application-level delivery semantics.

**Key changes:**

#### Port Change & Reserved Port Handling

* Changed all UDP port references from `61631` (a Thread-reserved port) to `5050` in both documentation and code for both the sensor node and collector. This avoids conflicts with Thread's internal management traffic and prevents "DROP malformed" errors. 
* Added documentation and code comments explaining the importance of not using reserved ports, with a troubleshooting section that details symptoms and lists reserved ports. 

#### Application-level ACK and Sequence Handling

* Improved documentation and code comments to clarify that the collector is the single source of truth for the sequence number, and that the node resynchronizes its local counter based on the collector's authoritative ACK. 
* Added detailed explanations and a table in the collector's README for how sequence numbers are classified (new, duplicate, restart, stale) and how the collector responds in each case.
* Updated code in the collector (`udp_sensor_collector.ino`) to implement robust sequence classification, including handling node restarts, duplicates, and stale frames, and always ACKing the collector's last stored sequence.

#### Code Quality and Minor Improvements

* Improved formatting and variable types for clarity and consistency in both `.ino` files. 
* Added or clarified configuration options (e.g., `TX_RETRIES`, `ACK_TIMEOUT_MS`) and their documentation in the sensor node. 

These changes make the example more robust and production-ready by avoiding protocol conflicts, ensuring reliable delivery semantics, and providing clear documentation for users and developers.


## Test Scenarios
Tested the example running with C5, C6 and H2. 
1 Collector node + 2 Sensor nodes.

Tested failures:
- Reseting Sensor Node;
- Reseting Collector Node;
- Keeping the Sendor Node unpowered for 5 minutes while other 2 nodes were active, then powering this node to check if it enters the Thread network and reports correctly to the Collector Node;
- Keeping the Collector Node unpowered for 10 minutes while the Sensor nodes were active, then powering it back to check if the Thread network is correctly formed and the data is collected. 

## Related links
Related to #12616

