### PR TITLE
fix(fs): Use locks only if FreeRTOS is available

### DIFF
--- a/libraries/FS/src/FS.cpp
+++ b/libraries/FS/src/FS.cpp
@@ -273,8 +273,8 @@ const char *FS::mountpoint() {
 
 void FSImpl::mountpoint(const char *mp) {
   _mountpoint = mp;
-  if (mp && !_mtx) {
-    _mtx = xSemaphoreCreateRecursiveMutex();
+  if (mp && !_mtx && fsMutexEnabled()) {
+    _mtx = fsMutexCreate();
     if (!_mtx) {
       log_w("Failed to create recursive mutex for filesystem in mountpoint %s", mp ? mp : "NULL");
       log_w("Some filesystem operations on this mountpoint will continue without synchronization and will not be serialized.");

--- a/libraries/FS/src/FSImpl.h
+++ b/libraries/FS/src/FSImpl.h
@@ -22,29 +22,65 @@
 
 #include <stddef.h>
 #include <stdint.h>
+
+#if defined(ARDUINO_ARCH_ESP32)
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
+using FSMutexHandle = SemaphoreHandle_t;
+inline void fsLockTake(FSMutexHandle mtx) {
+  if (mtx) {
+    xSemaphoreTakeRecursive(mtx, portMAX_DELAY);
+  }
+}
+inline void fsLockGive(FSMutexHandle mtx) {
+  if (mtx) {
+    xSemaphoreGiveRecursive(mtx);
+  }
+}
+inline void fsLockDelete(FSMutexHandle mtx) {
+  if (mtx) {
+    vSemaphoreDelete(mtx);
+  }
+}
+inline FSMutexHandle fsMutexCreate() {
+  return xSemaphoreCreateRecursiveMutex();
+}
+inline bool fsMutexEnabled() {
+  return true;
+}
+#else
+using FSMutexHandle = void *;
+inline void fsLockTake(FSMutexHandle) {}
+inline void fsLockGive(FSMutexHandle) {}
+inline void fsLockDelete(FSMutexHandle) {}
+inline FSMutexHandle fsMutexCreate() {
+  return nullptr;
+}
+inline bool fsMutexEnabled() {
+  return false;
+}
+#endif
 
 namespace fs {
 
-// RAII lock guard for the per-filesystem recursive mutex.
+// RAII lock guard for the per-filesystem recursive mutex (no-op when _mtx is null).
 class FSLockGuard {
 public:
-  explicit FSLockGuard(SemaphoreHandle_t mtx) : _mtx(mtx) {
-    if (_mtx) {
-      xSemaphoreTakeRecursive(_mtx, portMAX_DELAY);
-    }
+  explicit FSLockGuard(FSMutexHandle mtx = nullptr) : _mtx(mtx) {
+    fsLockTake(_mtx);
   }
   ~FSLockGuard() {
-    if (_mtx) {
-      xSemaphoreGiveRecursive(_mtx);
-    }
+    fsLockGive(_mtx);
   }
   FSLockGuard(const FSLockGuard &) = delete;
   FSLockGuard &operator=(const FSLockGuard &) = delete;
+  FSLockGuard(FSLockGuard &&other) noexcept : _mtx(other._mtx) {
+    other._mtx = nullptr;
+  }
+  FSLockGuard &operator=(FSLockGuard &&) = delete;
 
 private:
-  SemaphoreHandle_t _mtx;
+  FSMutexHandle _mtx;
 };
 
 class FileImpl {
@@ -73,14 +109,15 @@ public:
 class FSImpl {
 protected:
   const char *_mountpoint;
-  SemaphoreHandle_t _mtx;
+  FSMutexHandle _mtx;
+  FSLockGuard fsLock() {
+    return FSLockGuard(_mtx);
+  }
 
 public:
-  FSImpl() : _mountpoint(NULL), _mtx(NULL) {}
+  FSImpl() : _mountpoint(NULL), _mtx(nullptr) {}
   virtual ~FSImpl() {
-    if (_mtx) {
-      vSemaphoreDelete(_mtx);
-    }
+    fsLockDelete(_mtx);
   }
 
   virtual FileImplPtr open(const char *path, const char *mode, const bool create) = 0;

--- a/libraries/FS/src/vfs_api.cpp
+++ b/libraries/FS/src/vfs_api.cpp
@@ -23,7 +23,7 @@ using namespace fs;
 #define DEFAULT_FILE_BUFFER_SIZE 4096
 
 FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create) {
-  FSLockGuard lock(_mtx);
+  auto lock = fsLock();
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return FileImplPtr();
@@ -84,7 +84,7 @@ FileImplPtr VFSImpl::open(const char *fpath, const char *mode, const bool create
 }
 
 bool VFSImpl::exists(const char *fpath) {
-  FSLockGuard lock(_mtx);
+  auto lock = fsLock();
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -99,7 +99,7 @@ bool VFSImpl::exists(const char *fpath) {
 }
 
 bool VFSImpl::rename(const char *pathFrom, const char *pathTo) {
-  FSLockGuard lock(_mtx);
+  auto lock = fsLock();
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -136,7 +136,7 @@ bool VFSImpl::rename(const char *pathFrom, const char *pathTo) {
 }
 
 bool VFSImpl::remove(const char *fpath) {
-  FSLockGuard lock(_mtx);
+  auto lock = fsLock();
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -163,7 +163,7 @@ bool VFSImpl::remove(const char *fpath) {
 }
 
 bool VFSImpl::mkdir(const char *fpath) {
-  FSLockGuard lock(_mtx);
+  auto lock = fsLock();
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;
@@ -216,7 +216,7 @@ bool VFSImpl::mkdir(const char *fpath) {
 }
 
 bool VFSImpl::rmdir(const char *fpath) {
-  FSLockGuard lock(_mtx);
+  auto lock = fsLock();
   if (!_mountpoint) {
     log_e("File system is not mounted");
     return false;

--- a/tests/validation/fs/fs.ino
+++ b/tests/validation/fs/fs.ino
@@ -2,6 +2,10 @@
 #include <unity.h>
 #include <cstring>
 
+#ifndef ARDUINO_ARCH_ESP32
+#error "FS lock validation requires ARDUINO_ARCH_ESP32"
+#endif
+
 #include <FS.h>
 #include <SPIFFS.h>
 #include <FFat.h>
@@ -736,6 +740,87 @@ void test_directory_operations_edge_cases() {
   V.rmdir("/test_dir");
 }
 
+void test_arduino_arch_esp32() {
+  TEST_ASSERT_TRUE(true);
+}
+
+// open(..., create=true) holds the FS lock while calling mkdir() for each path
+// segment. A non-recursive mutex deadlocks here; the call must finish promptly.
+void test_fs_recursive_lock_nested_create() {
+#if !defined(ARDUINO_ARCH_ESP32)
+  TEST_IGNORE_MESSAGE("FS locks require ARDUINO_ARCH_ESP32");
+  return;
+#endif
+
+  auto &V = gFS->vfs();
+  const char *path = "/lock_recursive/a/b/c/d.txt";
+
+  uint32_t start = millis();
+  File f = V.open(path, FILE_WRITE, true);
+  uint32_t elapsed = millis() - start;
+  TEST_ASSERT_TRUE_MESSAGE(f, "nested create open failed");
+  TEST_ASSERT_LESS_THAN(5000, (int)elapsed);
+  f.print("x");
+  f.close();
+
+  File check = V.open(path, FILE_READ);
+  TEST_ASSERT_TRUE(check);
+  TEST_ASSERT_EQUAL_STRING("x", check.readString().c_str());
+  check.close();
+
+  TEST_ASSERT_TRUE(V.remove(path));
+  if (strcmp(gFS->name(), "spiffs") != 0) {
+    TEST_ASSERT_TRUE(V.rmdir("/lock_recursive/a/b/c"));
+    TEST_ASSERT_TRUE(V.rmdir("/lock_recursive/a/b"));
+    TEST_ASSERT_TRUE(V.rmdir("/lock_recursive/a"));
+    TEST_ASSERT_TRUE(V.rmdir("/lock_recursive"));
+  }
+}
+
+static TaskHandle_t g_fs_lock_parent = NULL;
+
+// mkdir() only — exists() opens a VFSFileImpl and can exhaust the 3 FD limit
+// (maxOpenFiles) when the main thread and two workers contend on FFat.
+static void fs_lock_worker_task(void *param) {
+  (void)param;
+  fs::FS &V = gFS->vfs();
+
+  for (int i = 0; i < 30; ++i) {
+    V.mkdir("/__lk_shared__");
+    taskYIELD();
+  }
+
+  xTaskNotifyGive(g_fs_lock_parent);
+  vTaskDelete(NULL);
+}
+
+void test_fs_concurrent_locking() {
+#if !defined(ARDUINO_ARCH_ESP32)
+  TEST_IGNORE_MESSAGE("FS locks require ARDUINO_ARCH_ESP32");
+  return;
+#endif
+
+  auto &V = gFS->vfs();
+  g_fs_lock_parent = xTaskGetCurrentTaskHandle();
+
+  TEST_ASSERT_EQUAL(pdPASS, xTaskCreatePinnedToCore(fs_lock_worker_task, "fs_lk0", 8192, NULL, 1, NULL, 0));
+  TEST_ASSERT_EQUAL(pdPASS, xTaskCreatePinnedToCore(fs_lock_worker_task, "fs_lk1", 8192, NULL, 1, NULL, 0));
+
+  int completed = 0;
+  const uint32_t deadline = millis() + 20000;
+  while (completed < 2 && millis() < deadline) {
+    V.mkdir("/__lk_main__");
+    completed += ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(50));
+  }
+
+  if (strcmp(gFS->name(), "spiffs") != 0) {
+    V.rmdir("/__lk_main__");
+    V.rmdir("/__lk_shared__");
+  }
+
+  TEST_ASSERT_EQUAL(2, completed);
+}
+
 void test_max_open_files_limit() {
   if (strcmp(gFS->name(), "littlefs") == 0) {
     TEST_MESSAGE("Skipping: LittleFS does not have a max open files limit");
@@ -806,6 +891,12 @@ static void run_suite_for(IFileSystem &fs) {
   Serial.print("=== FS: ");
   Serial.println(fs.name());
 
+  static bool arch_esp32_checked = false;
+  if (!arch_esp32_checked) {
+    RUN_TEST(test_arduino_arch_esp32);
+    arch_esp32_checked = true;
+  }
+
   RUN_TEST(test_info_sanity);
   RUN_TEST(test_basic_write_and_read);
   RUN_TEST(test_append_behavior);
@@ -822,6 +913,8 @@ static void run_suite_for(IFileSystem &fs) {
   RUN_TEST(test_large_file_operations);
   RUN_TEST(test_write_read_patterns);
   RUN_TEST(test_directory_operations_edge_cases);
+  RUN_TEST(test_fs_recursive_lock_nested_create);
+  RUN_TEST(test_fs_concurrent_locking);
   RUN_TEST(test_max_open_files_limit);
   RUN_TEST(test_open_read_mode_type_detection);
   gFS = nullptr;


### PR DESCRIPTION
## Description of Change

This pull request refactors the filesystem (FS) locking mechanism to improve portability and robustness, especially for ESP32 platforms. It introduces a platform-agnostic mutex abstraction, ensures recursive locking for nested filesystem operations, and adds comprehensive tests to validate correct locking behavior, including concurrent access scenarios.

### Filesystem Locking Abstraction and Refactoring

* Introduced a platform-agnostic mutex type (`FSMutexHandle`) and related helper functions (`fsLockTake`, `fsLockGive`, `fsLockDelete`, `fsMutexCreate`, `fsMutexEnabled`) to handle recursive mutex creation and usage, with ESP32-specific implementations and no-ops for other platforms. (`libraries/FS/src/FSImpl.h` [libraries/FS/src/FSImpl.hR25-R83](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR25-R83))
* Updated `FSLockGuard` and `FSImpl` classes to use the new mutex abstraction, supporting move semantics and ensuring proper mutex deletion in destructors. (`libraries/FS/src/FSImpl.h` [[1]](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dR25-R83) [[2]](diffhunk://#diff-1b9f0aaa3e67e96778f35ce01d9d438b8ebbfc15b1e3cd8733aa9a7682a5fa5dL76-R120)
* Changed the FS mountpoint logic to only create a mutex if locking is enabled for the platform. (`libraries/FS/src/FS.cpp` [libraries/FS/src/FS.cppL276-R277](diffhunk://#diff-b80c6bdaac6e1221c08312e5a724c4bf6df37ae2321abf960b99c5cff47cff2aL276-R277))
* Updated VFS methods (`open`, `exists`, `rename`, `remove`, `mkdir`, `rmdir`) to use the new `fsLock()` helper for acquiring locks. (`libraries/FS/src/vfs_api.cpp` [[1]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L26-R26) [[2]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L87-R87) [[3]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L102-R102) [[4]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L139-R139) [[5]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L166-R166) [[6]](diffhunk://#diff-d3a7e9ef49c0355382caccc18312df1c317998c3b23e3eaf99cd5efd935bfd47L219-R219)

### Testing and Validation Enhancements

* Added compile-time enforcement to ensure that FS lock validation tests only run on ESP32. (`tests/validation/fs/fs.ino` [tests/validation/fs/fs.inoR5-R8](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR5-R8))
* Introduced new tests to validate recursive locking (nested `open`/`mkdir` calls) and concurrent locking (multiple tasks performing FS operations), checking for deadlocks and correct behavior under contention. (`tests/validation/fs/fs.ino` [tests/validation/fs/fs.inoR743-R823](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR743-R823))
* Integrated the new tests into the test suite and ensured an architecture check is performed once per suite run. (`tests/validation/fs/fs.ino` [[1]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR894-R899) [[2]](diffhunk://#diff-438301d938f0a69564dd8b53b258001992f6ce40666c9315a5abf152d354011fR916-R917)

## Test Scenarios

Tested locally with FS test
