### PR TITLE
fix(i2s): Fix examples and add void* write

### DIFF
--- a/docs/en/api/i2s.rst
+++ b/docs/en/api/i2s.rst
@@ -541,24 +541,62 @@ This function will return the next available byte or ``-1`` if no data is availa
 or an error occurred.
 
 write
+^^^^^
 
-There are two versions of the write function:
+PCM data must be written in **sample-aligned** chunks. The minimum number of bytes per
+call depends on the data bit width configured in ``begin()`` or ``configureTX()``:
 
-The first version writes a certain amount of data bytes to the I2S interface.
+* ``I2S_DATA_BIT_WIDTH_8BIT`` — 1 byte per sample
+* ``I2S_DATA_BIT_WIDTH_16BIT`` — 2 bytes per sample
+* ``I2S_DATA_BIT_WIDTH_32BIT`` — 4 bytes per sample
+
+For stereo, samples must reach the driver in **interleaved order** (left, then right).
+Each ``write()`` call must contain at least one full sample (2 bytes for 16-bit), but a
+complete stereo frame may be sent in one call or as separate per-channel calls.
+
+Writes smaller than one sample are ignored: the function returns ``0`` and does not set
+``lastError()``. Enable debug logging to see a message when this happens.
+
+Per-channel writes — clear when learning or generating one sample at a time:
 
 .. code-block:: arduino
 
-  size_t write(uint8_t *buffer, size_t size)
+  // 16-bit stereo — left then right
+  int16_t left = ...;
+  int16_t right = ...;
+  i2s.write(&left, sizeof(left));
+  i2s.write(&right, sizeof(right));
+
+Frame buffer — preferred for streaming or bulk PCM:
+
+.. code-block:: arduino
+
+  // 16-bit stereo — one interleaved frame (4 bytes)
+  int16_t frame[2] = {left, right};
+  i2s.write(frame, sizeof(frame));
+
+There are two versions of the write function:
+
+The first version writes a buffer of PCM bytes to the I2S interface.
+
+.. code-block:: arduino
+
+  size_t write(const void *buffer, size_t size)
 
 Parameters:
 
 * [in] ``buffer`` is the buffer containing the data to be written.
 
-* [in] ``size`` is the number of bytes to write from the buffer.
+* [in] ``size`` is the number of bytes to write from the buffer. Must be at least the
+  per-sample minimum above. For streaming, ``size`` should be a multiple of the full
+  frame size (sample size × number of active channels).
 
-This function will return the number of bytes written.
+This function will return the number of bytes written, or ``0`` if the buffer is empty,
+the TX channel is not initialized, or ``size`` is smaller than one sample.
 
-The second version writes a single byte to the I2S interface.
+The second version is inherited from ``Print`` and forwards a single byte to the buffer
+version above. For bit widths greater than 8, a one-byte write is below the sample
+minimum and is therefore ignored (returns ``0`` without setting an error).
 
 .. code-block:: arduino
 
@@ -568,7 +606,8 @@ Parameters:
 
 * [in] ``d`` is the byte to be written.
 
-This function will return ``1`` if the byte was written or ``0`` if an error occurred.
+This function returns ``1`` only when the byte is accepted (8-bit mode). For 16-bit and
+wider formats it returns ``0`` because a single byte is not a complete sample.
 
 available
 ^^^^^^^^^

--- a/libraries/ESP_I2S/examples/Port_selection/Port_selection.ino
+++ b/libraries/ESP_I2S/examples/Port_selection/Port_selection.ino
@@ -20,7 +20,7 @@ const int sampleRate = 8000;
 const unsigned int halfWavelength = sampleRate / frequency / 2;
 
 I2SClass i2s;
-int32_t sample = amplitude;
+int16_t sample = amplitude;
 unsigned int count = 0;
 
 void setup() {
@@ -46,10 +46,10 @@ void loop() {
     sample = -sample;
   }
 
-  i2s.write(sample);
-  i2s.write(sample >> 8);
-  i2s.write(sample);
-  i2s.write(sample >> 8);
+  int16_t left = sample;
+  int16_t right = sample;
+  i2s.write(&left, sizeof(left));
+  i2s.write(&right, sizeof(right));
 
   count++;
 }

--- a/libraries/ESP_I2S/examples/Simple_tone/Simple_tone.ino
+++ b/libraries/ESP_I2S/examples/Simple_tone/Simple_tone.ino
@@ -46,7 +46,7 @@ i2s_slot_mode_t slot = I2S_SLOT_MODE_STEREO;
 
 const unsigned int halfWavelength = sampleRate / frequency / 2;  // half wavelength of square wave
 
-int32_t sample = amplitude;  // current sample value
+int16_t sample = amplitude;  // current sample value
 unsigned int count = 0;
 
 I2SClass i2s;
@@ -70,13 +70,10 @@ void loop() {
     sample = -1 * sample;
   }
 
-  // Left channel, the low 8 bits then high 8 bits
-  i2s.write(sample);
-  i2s.write(sample >> 8);
-
-  // Right channel, the low 8 bits then high 8 bits
-  i2s.write(sample);
-  i2s.write(sample >> 8);
+  int16_t left = sample;
+  int16_t right = sample;
+  i2s.write(&left, sizeof(left));
+  i2s.write(&right, sizeof(right));
 
   // increment the counter for the next sample
   count++;

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -1217,6 +1217,11 @@ size_t I2SClass::readBytes(char *buffer, size_t size) {
 }
 
 size_t I2SClass::write(const uint8_t *buffer, size_t size) {
+  return write((const void *)buffer, size);
+}
+
+size_t I2SClass::write(const void *buffer, size_t size) {
+  const uint8_t *data = (const uint8_t *)buffer;
   size_t written = 0;
   size_t bytes_sent = 0;
   size_t bytes_to_send = 0;
@@ -1226,6 +1231,8 @@ size_t I2SClass::write(const uint8_t *buffer, size_t size) {
   }
   size_t min_size = (tx_data_bit_width == I2S_DATA_BIT_WIDTH_8BIT) ? 1 : (tx_data_bit_width / 8);
   if (size < min_size) {
+    log_w("I2S write ignored: %u byte(s) is less than the %u-byte minimum for %u-bit PCM", (unsigned)size, (unsigned)min_size,
+          (unsigned)tx_data_bit_width);
     last_error = ESP_OK;
     return 0;
   }
@@ -1233,7 +1240,7 @@ size_t I2SClass::write(const uint8_t *buffer, size_t size) {
   if (_8bit_hw_packing && _mono_hw_workaround) {
     // 8-bit mono on HW v1: pack each int8_t sample into the high byte of
     // a uint16_t, then duplicate into L+R stereo for DMA.
-    const int8_t *src = (const int8_t *)buffer;
+    const int8_t *src = (const int8_t *)data;
     size_t mono_samples = size;
     size_t mono_written = 0;
     while (mono_written < mono_samples) {
@@ -1265,7 +1272,7 @@ size_t I2SClass::write(const uint8_t *buffer, size_t size) {
   }
   if (_8bit_hw_packing && !_mono_hw_workaround) {
     // 8-bit stereo on HW v1: pack each int8_t into the high byte of a uint16_t.
-    const int8_t *src = (const int8_t *)buffer;
+    const int8_t *src = (const int8_t *)data;
     size_t n_samples = size;
     size_t samples_written = 0;
     while (samples_written < n_samples) {
@@ -1294,7 +1301,7 @@ size_t I2SClass::write(const uint8_t *buffer, size_t size) {
     return samples_written;
   }
   if (_mono_hw_workaround) {
-    const int16_t *src = (const int16_t *)buffer;
+    const int16_t *src = (const int16_t *)data;
     size_t mono_samples = size / sizeof(int16_t);
     size_t mono_written = 0;
     while (mono_written < mono_samples) {
@@ -1327,7 +1334,7 @@ size_t I2SClass::write(const uint8_t *buffer, size_t size) {
   while (written < size) {
     bytes_sent = 0;
     bytes_to_send = size - written;
-    esp_err_t err = i2s_channel_write(tx_chan, (char *)(buffer + written), bytes_to_send, &bytes_sent, _timeout);
+    esp_err_t err = i2s_channel_write(tx_chan, (char *)(data + written), bytes_to_send, &bytes_sent, _timeout);
     setWriteError(err);
     I2S_ERROR_CHECK_RETURN(err, written);
     written += bytes_sent;

--- a/libraries/ESP_I2S/src/ESP_I2S.cpp
+++ b/libraries/ESP_I2S/src/ESP_I2S.cpp
@@ -1231,8 +1231,7 @@ size_t I2SClass::write(const void *buffer, size_t size) {
   }
   size_t min_size = (tx_data_bit_width == I2S_DATA_BIT_WIDTH_8BIT) ? 1 : (tx_data_bit_width / 8);
   if (size < min_size) {
-    log_w("I2S write ignored: %u byte(s) is less than the %u-byte minimum for %u-bit PCM", (unsigned)size, (unsigned)min_size,
-          (unsigned)tx_data_bit_width);
+    log_w("I2S write ignored: %u byte(s) is less than the %u-byte minimum for %u-bit PCM", (unsigned)size, (unsigned)min_size, (unsigned)tx_data_bit_width);
     last_error = ESP_OK;
     return 0;
   }

--- a/libraries/ESP_I2S/src/ESP_I2S.h
+++ b/libraries/ESP_I2S/src/ESP_I2S.h
@@ -75,7 +75,8 @@ public:
   bool end();
 
   size_t readBytes(char *buffer, size_t size);
-  size_t write(const uint8_t *buffer, size_t size);
+  size_t write(const void *buffer, size_t size);
+  size_t write(const uint8_t *buffer, size_t size) override;
 
   i2s_chan_handle_t txChan();
   uint32_t txSampleRate();


### PR DESCRIPTION
## Description of Change

This pull request improves the documentation, usage examples, and implementation of the I2S `write()` method to clarify and enforce correct sample alignment and buffer handling. The changes ensure that data is written in sample-aligned chunks, update example code for clarity and correctness, and refactor the implementation for better type safety and error handling.

**Documentation and Usage Clarifications:**

* Expanded the `write` section in `docs/en/api/i2s.rst` to clearly explain sample alignment requirements, buffer sizes, and behavior when writing less than a full sample. Added detailed examples for both per-channel and frame buffer writes. Also clarified the return values for single-byte writes in different bit-width modes. [[1]](diffhunk://#diff-cb43a8cb9c95322e8e25769cebc06bd9eb5b09d22c05140b85626d9dac9e1c67R544-R600) [[2]](diffhunk://#diff-cb43a8cb9c95322e8e25769cebc06bd9eb5b09d22c05140b85626d9dac9e1c67L571-R611)

**Example Code Updates:**

* Updated `Port_selection.ino` and `Simple_tone.ino` examples to use `int16_t` for samples and to write full samples using buffer pointers, ensuring correct stereo output and alignment with the new documentation. [[1]](diffhunk://#diff-83106048f857f9dfe09ab261914a41a1b7db81e72fe7c8edee71a88cf4d381a2L23-R23) [[2]](diffhunk://#diff-83106048f857f9dfe09ab261914a41a1b7db81e72fe7c8edee71a88cf4d381a2L49-R52) [[3]](diffhunk://#diff-05d56898ed9f96744c21d3dc76306fe9db2664f80b62155ed39d17774be3cfe1L49-R49) [[4]](diffhunk://#diff-05d56898ed9f96744c21d3dc76306fe9db2664f80b62155ed39d17774be3cfe1L73-R76)

**Implementation Improvements:**

* Refactored the `I2SClass::write` method to accept a `const void*` buffer, improving type safety and flexibility. Internally, the function now checks for minimum sample size and logs a warning if the buffer is too small, returning `0` without error. Updated internal buffer handling to use the new pointer type throughout. [[1]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8R1220-R1224) [[2]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8R1234-R1243) [[3]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1268-R1275) [[4]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1297-R1304) [[5]](diffhunk://#diff-352d206076976bb3ae1104525f4eea6949fb6c46fa436e5957a7b3ac3280fad8L1330-R1337) [[6]](diffhunk://#diff-e4065872b7a7ae36efad2c93fa0a6b8cd14d5be6ea526159583f3d94a26bc503L78-R79)

## Test Scenarios

Tested with WIP I2S test
