### PR TITLE
IDF v5.5.4 with Video. DO NOT MERGE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(ARDUINO_ALL_LIBRARIES
   ESP_NOW
   ESP_SR
   ESP_HostedOTA
+  ESP_Video
   ESPmDNS
   Ethernet
   FFat
@@ -157,6 +158,8 @@ set(ARDUINO_LIBRARY_ESP_SR_SRCS
 
 set(ARDUINO_LIBRARY_ESP_HostedOTA_SRCS
   libraries/ESP_HostedOTA/src/ESP_HostedOTA.cpp)
+
+set(ARDUINO_LIBRARY_ESP_Video_SRCS libraries/ESP_Video/src/ESP_Video.cpp)
 
 set(ARDUINO_LIBRARY_ESPmDNS_SRCS libraries/ESPmDNS/src/ESPmDNS.cpp)
 
@@ -517,4 +520,9 @@ if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_LittleFS
 endif()
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_WiFiProv)
     maybe_add_component(espressif__network_provisioning)
+endif()
+if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_ESP_Video)
+    if(IDF_TARGET STREQUAL "esp32s3" OR IDF_TARGET STREQUAL "esp32p4")
+        maybe_add_component(espressif__esp_video)
+    endif()
 endif()

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -277,6 +277,11 @@ config ARDUINO_SELECTIVE_ESP_SR
     depends on ARDUINO_SELECTIVE_COMPILATION
     default y
 
+config ARDUINO_SELECTIVE_ESP_Video
+    bool "Enable ESP-Video"
+    depends on ARDUINO_SELECTIVE_COMPILATION
+    default y
+
 config ARDUINO_SELECTIVE_EEPROM
     bool "Enable EEPROM"
     depends on ARDUINO_SELECTIVE_COMPILATION

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -121,6 +121,20 @@ const char *perimanGetTypeName(peripheral_bus_type_t type) {
     case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D3:  return "ESP_HOSTED_SDIO_D3";
     case ESP32_BUS_TYPE_ESP_HOSTED_SDIO_RST: return "ESP_HOSTED_SDIO_RST";
 #endif
+#if SOC_LCDCAM_CAM_SUPPORTED
+    case ESP32_BUS_TYPE_LCDCAM_CAM_VSYNC: return "LCDCAM_CAM_VSYNC";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_HSYNC: return "LCDCAM_CAM_HSYNC";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_PCLK:  return "LCDCAM_CAM_PCLK";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_XCLK:  return "LCDCAM_CAM_XCLK";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D0:    return "LCDCAM_CAM_D0";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D1:    return "LCDCAM_CAM_D1";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D2:    return "LCDCAM_CAM_D2";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D3:    return "LCDCAM_CAM_D3";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D4:    return "LCDCAM_CAM_D4";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D5:    return "LCDCAM_CAM_D5";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D6:    return "LCDCAM_CAM_D6";
+    case ESP32_BUS_TYPE_LCDCAM_CAM_D7:    return "LCDCAM_CAM_D7";
+#endif
     default: return "UNKNOWN";
   }
 }

--- a/cores/esp32/esp32-hal-periman.h
+++ b/cores/esp32/esp32-hal-periman.h
@@ -118,6 +118,20 @@ typedef enum {
   ESP32_BUS_TYPE_ESP_HOSTED_SDIO_D3,   // IO is used as ESP-Hosted SDIO D3 pin
   ESP32_BUS_TYPE_ESP_HOSTED_SDIO_RST,  // IO is used as ESP-Hosted slave RESET pin
 #endif
+#if SOC_LCDCAM_CAM_SUPPORTED
+  ESP32_BUS_TYPE_LCDCAM_CAM_VSYNC,  // IO is used as LCDCAM CAM VSYNC pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_HSYNC,  // IO is used as LCDCAM CAM HSYNC/DE pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_PCLK,   // IO is used as LCDCAM CAM PCLK pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_XCLK,   // IO is used as LCDCAM CAM XCLK pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D0,     // IO is used as LCDCAM CAM D0 pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D1,     // IO is used as LCDCAM CAM D1 pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D2,     // IO is used as LCDCAM CAM D2 pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D3,     // IO is used as LCDCAM CAM D3 pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D4,     // IO is used as LCDCAM CAM D4 pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D5,     // IO is used as LCDCAM CAM D5 pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D6,     // IO is used as LCDCAM CAM D6 pin
+  ESP32_BUS_TYPE_LCDCAM_CAM_D7,     // IO is used as LCDCAM CAM D7 pin
+#endif
   ESP32_BUS_TYPE_MAX
 } peripheral_bus_type_t;
 

--- a/docs/en/api/esp_video.rst
+++ b/docs/en/api/esp_video.rst
@@ -1,0 +1,965 @@
+#########
+ESP Video
+#########
+
+About
+-----
+
+The ESP Video library wraps the ESP-IDF `esp_video` component and exposes a V4L2-style capture API for camera sensors on supported SoCs.
+It handles low-level initialization for **MIPI-CSI** (with ISP) and **DVP** interfaces, then lets applications open a video device node, allocate buffers, and dequeue frames.
+
+Typical use cases include preview pipelines, frame grabbing for computer vision, JPEG capture, and sensor tuning (gain, exposure, flip, and similar controls).
+
+The library is available when **ESP-IDF 5.4.0 or later** is used and the target is **ESP32-S3** or **ESP32-P4**.
+At least one of ``CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE`` or ``CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE`` must be enabled in the IDF configuration; otherwise ``ESP_Video.h`` exposes no public API.
+Supported interfaces depend on those Kconfig options.
+The library examples target **ESP32-P4** (MIPI-CSI + DVP) and **ESP32-S3** (DVP).
+
+Include the header in your sketch:
+
+.. code-block:: cpp
+
+    #include "ESP_Video.h"
+
+Video device nodes
+******************
+
+After hardware initialization, capture uses standard device paths defined in ``esp_video_device.h``:
+
+* ``ESP_VIDEO_MIPI_CSI_DEVICE_NAME`` — ``/dev/video0`` (MIPI-CSI camera)
+* ``ESP_VIDEO_ISP_DVP_DEVICE_NAME`` — ``/dev/video1`` (ISP + DVP)
+* ``ESP_VIDEO_DVP_DEVICE_NAME`` — ``/dev/video2`` (DVP without ISP path)
+* Additional nodes exist for SPI, USB UVC, JPEG/H264 codec, and ISP devices when enabled in the IDF configuration.
+
+Arduino-ESP32 ESP Video API
+---------------------------
+
+Overview
+********
+
+The API is organized in seven layers:
+
+1. **Pixel Format** — ``esp_video_format_t`` and ``ESPVideoFormatClass``
+2. **Resolution** — ``ESPVideoSolutionClass`` (frame width and height)
+3. **Hardware Configuration** — ``ESPVideoCamConfigClass``, ``ESPVideoCSIConfigClass``, ``ESPVideoDVPPinsConfigClass``, ``ESPVideoDVPConfigClass``
+4. **Hardware Initialization** — ``ESPVideoClass::begin()``
+5. **Capture Device** — ``ESPVideoCaptureDevClass`` (inherits format and resolution bases)
+6. **Buffer** — ``ESPVideoBufferClass`` (inherits format and resolution bases)
+7. **Sensor Controls** — ``ESPVideoCaptureDevClass::setSensor*()`` methods
+
+MIPI-CSI flow (ESP32-P4):
+
+.. code-block:: cpp
+
+    #include "esp_video_device.h"
+
+    ESPVideoClass video;
+    ESPVideoCamConfigClass cam_config;
+    cam_config.begin(port, scl, sda);
+
+    ESPVideoCSIConfigClass csi_config;
+    csi_config.begin(cam_config);
+
+    if (!video.begin(csi_config)) {
+        // handle error
+    }
+
+    ESPVideoCaptureDevClass capture;
+    if (!capture.begin(ESP_VIDEO_MIPI_CSI_DEVICE_NAME, 2)) {
+        // handle error
+    }
+    if (!capture.setFormat(ESP_VIDEO_FORMAT_RGB565)) {
+        // handle error
+    }
+    if (!capture.startCapture()) {
+        // handle error
+    }
+
+    ESPVideoBufferClass frame = capture.captureBuffer();
+    if (frame.valid()) {
+        uint8_t *pixels = frame.data();
+        size_t nbytes = frame.size();
+        const char *format_name = frame.formatName();  // e.g. "JPEG", "RGB565"
+        uint32_t width = frame.getWidth();
+        uint32_t height = frame.getHeight();
+        // use frame; buffer is returned to the driver when `frame` is destroyed
+    }
+
+DVP flow (ESP32-S3 or ESP32-P4):
+
+.. code-block:: cpp
+
+    #include "esp_video_device.h"
+
+    ESPVideoClass video;
+    ESPVideoCamConfigClass cam_config;
+    cam_config.begin(port, scl, sda);
+
+    ESPVideoDVPPinsConfigClass dvp_pins;
+    dvp_pins.begin(vsync, de, pclk, xclk, d0, d1, d2, d3, d4, d5, d6, d7);
+
+    ESPVideoDVPConfigClass dvp_config;
+    dvp_config.begin(cam_config, dvp_pins, xclk_freq_hz);
+
+    if (!video.begin(dvp_config)) {
+        // handle error
+    }
+
+    ESPVideoCaptureDevClass capture;
+    if (!capture.begin(ESP_VIDEO_DVP_DEVICE_NAME, 2)) {
+        // handle error
+    }
+    if (!capture.startCapture()) {
+        // handle error
+    }
+
+    ESPVideoBufferClass frame = capture.captureBuffer();
+    if (frame.valid()) {
+        uint8_t *pixels = frame.data();
+        size_t nbytes = frame.size();
+        const char *format_name = frame.formatName();
+        uint32_t width = frame.getWidth();
+        uint32_t height = frame.getHeight();
+        // use frame; buffer is returned to the driver when `frame` is destroyed
+    }
+
+Design notes
+************
+
+* **Configuration objects are value types.** They store pin and bus settings only and can be copied or assigned. Pin reservation through ``periman`` is performed by ``ESPVideoClass::begin()`` and released in ``ESPVideoClass::end()`` or the destructor.
+* **CSI and DVP can coexist** on SoCs that support both (for example ESP32-P4). Each interface is tracked independently via internal flags and released in ``end()`` or the destructor.
+* **Capture device opening is unified.** ``ESPVideoCaptureDevClass::begin()`` opens the device, reads and re-applies the current V4L2 format (``VIDIOC_G_FMT`` / ``VIDIOC_S_FMT``), stores width and height, and requests capture buffers.
+* **Format and resolution are shared base classes.** ``ESPVideoFormatClass`` and ``ESPVideoSolutionClass`` hold pixel format and frame dimensions. Both ``ESPVideoCaptureDevClass`` and ``ESPVideoBufferClass`` inherit from them so metadata is available on the device and on each dequeued frame.
+* **Pixel format is an Arduino enum.** Use ``setFormat()`` before ``startCapture()`` to select a supported ``esp_video_format_t`` value. If the format changes after buffers were allocated, the driver buffers are re-requested automatically.
+* **Frame metadata travels with the buffer.** ``ESPVideoBufferClass::formatName()`` / ``formatType()`` and ``getWidth()`` / ``getHeight()`` reflect the capture device's active format and resolution when the frame was dequeued.
+* **Resource-owning classes are non-copyable** (``ESPVideoClass``, ``ESPVideoCaptureDevClass``); ``ESPVideoBufferClass`` is move-only.
+
+Pixel format
+************
+
+``esp_video_format_t`` is the Arduino-side pixel format identifier.
+``ESPVideoCaptureDevClass::setFormat()`` maps each value to a V4L2 fourcc before ``VIDIOC_S_FMT`` is issued.
+Format metadata is stored in ``ESPVideoFormatClass``, which is inherited by the capture device and each buffer.
+
+.. code-block:: cpp
+
+    typedef enum {
+      ESP_VIDEO_FORMAT_UNKNOWN = 0,
+      ESP_VIDEO_FORMAT_RAW8,
+      ESP_VIDEO_FORMAT_RAW10,
+      ESP_VIDEO_FORMAT_RAW12,
+      ESP_VIDEO_FORMAT_RGB565,
+      ESP_VIDEO_FORMAT_RGB888,
+      ESP_VIDEO_FORMAT_YUV420,
+      ESP_VIDEO_FORMAT_YUV422_YUYV,
+      ESP_VIDEO_FORMAT_YUV422_UYVY,
+      ESP_VIDEO_FORMAT_GRAY8,
+      ESP_VIDEO_FORMAT_JPEG,
+      ESP_VIDEO_FORMAT_MAX
+    } esp_video_format_t;
+
+Supported formats and their V4L2 mappings:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - ``esp_video_format_t``
+     - Name string
+     - V4L2 fourcc
+   * - ``ESP_VIDEO_FORMAT_RAW8``
+     - ``RAW8``
+     - ``V4L2_PIX_FMT_SRGGB8``
+   * - ``ESP_VIDEO_FORMAT_RAW10``
+     - ``RAW10``
+     - ``V4L2_PIX_FMT_SGRBG10``
+   * - ``ESP_VIDEO_FORMAT_RAW12``
+     - ``RAW12``
+     - ``V4L2_PIX_FMT_SGRBG12``
+   * - ``ESP_VIDEO_FORMAT_RGB565``
+     - ``RGB565``
+     - ``V4L2_PIX_FMT_RGB565``
+   * - ``ESP_VIDEO_FORMAT_RGB888``
+     - ``RGB888``
+     - ``V4L2_PIX_FMT_RGB24``
+   * - ``ESP_VIDEO_FORMAT_YUV420``
+     - ``YUV420``
+     - ``V4L2_PIX_FMT_YUV420``
+   * - ``ESP_VIDEO_FORMAT_YUV422_YUYV``
+     - ``YUV422_YUYV``
+     - ``V4L2_PIX_FMT_YUYV``
+   * - ``ESP_VIDEO_FORMAT_YUV422_UYVY``
+     - ``YUV422_UYVY``
+     - ``V4L2_PIX_FMT_UYVY``
+   * - ``ESP_VIDEO_FORMAT_GRAY8``
+     - ``GRAY8``
+     - ``V4L2_PIX_FMT_GREY``
+   * - ``ESP_VIDEO_FORMAT_JPEG``
+     - ``JPEG``
+     - ``V4L2_PIX_FMT_JPEG``
+
+``ESP_VIDEO_FORMAT_UNKNOWN`` and ``ESP_VIDEO_FORMAT_MAX`` are sentinel values; they cannot be passed to ``setFormat()``.
+Actual availability depends on the sensor driver and the active video device.
+
+Resolution
+**********
+
+``ESPVideoSolutionClass`` stores the active frame width and height.
+It is inherited by ``ESPVideoCaptureDevClass`` (populated during ``begin()`` via ``VIDIOC_G_FMT``) and by ``ESPVideoBufferClass`` (copied from the capture device when a frame is dequeued).
+
+Default constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoSolutionClass();
+
+Creates an empty resolution object (width and height are zero until ``begin()`` is called).
+
+Copy constructor and assignment operator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoSolutionClass(const ESPVideoSolutionClass &config);
+    ESPVideoSolutionClass &operator=(const ESPVideoSolutionClass &config);
+
+Copies width and height values.
+
+begin
+^^^^^
+
+.. code-block:: cpp
+
+    void begin(uint32_t width, uint32_t height);
+
+Stores the frame dimensions. Called internally when the capture device reads the driver format.
+
+getWidth / getHeight
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    uint32_t getWidth() const;
+    uint32_t getHeight() const;
+
+Return the stored frame width and height.
+
+Format metadata
+***************
+
+``ESPVideoFormatClass`` stores the active pixel format type and its human-readable name.
+It is inherited by ``ESPVideoCaptureDevClass`` and ``ESPVideoBufferClass``.
+
+Default constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoFormatClass();
+
+Creates an empty format object (``ESP_VIDEO_FORMAT_UNKNOWN`` until ``begin()`` is called).
+
+Copy constructor and assignment operator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoFormatClass(const ESPVideoFormatClass &config);
+    ESPVideoFormatClass &operator=(const ESPVideoFormatClass &config);
+
+Copies format type and name.
+
+begin
+^^^^^
+
+.. code-block:: cpp
+
+    void begin(esp_video_format_t format_type, const std::string &format_name = "");
+
+Stores the format enum and optional name string.
+When ``format_name`` is empty, ``getFormatName()`` derives the name from ``format_type``.
+
+getFormat
+^^^^^^^^^
+
+.. code-block:: cpp
+
+    esp_video_format_t getFormat() const;
+
+Returns the stored ``esp_video_format_t`` value.
+
+getFormatName
+^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    const char *getFormatName() const;
+
+Returns the human-readable format name (for example ``"RGB565"`` or ``"JPEG"``).
+If no name was provided to ``begin()``, the name is derived from ``getFormat()`` and cached on first access.
+
+Camera configuration (SCCB / I2C)
+*********************************
+
+``ESPVideoCamConfigClass`` holds SCCB (I2C) settings shared by CSI and DVP setups.
+Create an instance, call ``begin()`` to fill in the settings, then pass it to ``ESPVideoCSIConfigClass`` or ``ESPVideoDVPConfigClass``.
+
+Default constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoCamConfigClass();
+
+Creates an empty configuration object. Call one of the ``begin()`` overloads before use.
+
+Copy constructor and assignment operator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoCamConfigClass(const ESPVideoCamConfigClass &config);
+    ESPVideoCamConfigClass &operator=(const ESPVideoCamConfigClass &config);
+
+Copies SCCB port or handle, pin numbers, and I2C frequency.
+Does not reserve GPIOs; pin ownership remains with ``ESPVideoClass::begin()``.
+
+begin (Arduino pin numbers)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool begin(i2c_port_num_t port, int8_t scl_pin, int8_t sda_pin,
+               uint32_t i2c_freq = i2c_freq_hz,
+               int8_t reset_pin = -1, int8_t pwdn_pin = -1);
+
+* ``port`` — I2C port used for SCCB when the library initializes the bus.
+* ``scl_pin`` / ``sda_pin`` — SCCB clock and data pins.
+* ``i2c_freq`` — SCCB frequency in Hz (default 100 kHz).
+* ``reset_pin`` / ``pwdn_pin`` — Optional sensor reset and power-down GPIOs; use ``-1`` if unused.
+
+Returns ``true`` on success.
+
+begin (existing I2C master bus)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool begin(i2c_master_bus_handle_t i2c_handle,
+               uint32_t i2c_freq = i2c_freq_hz,
+               int8_t reset_pin = -1, int8_t pwdn_pin = -1);
+
+Use this when SCCB should reuse an I2C bus already created by your application.
+In that case the library does not initialize a new I2C driver for SCCB.
+
+getSccbConfig
+^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    esp_video_init_sccb_config_t getSccbConfig() const;
+
+Returns the SCCB section used by ESP-IDF ``esp_video`` initialization structures.
+
+getResetPin / getPwdnPin
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    gpio_num_t getResetPin() const;
+    gpio_num_t getPwdnPin() const;
+
+Read-only accessors for optional sensor control GPIOs.
+
+acquirePins / releasePins
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool acquirePins();
+    bool releasePins();
+
+Reserve or release SCCB and optional reset/power-down GPIOs through ``periman``.
+These are called automatically by ``ESPVideoClass::begin()`` and ``end()``; applications normally do not need to call them directly.
+
+MIPI-CSI configuration
+**********************
+
+``ESPVideoCSIConfigClass`` extends ``ESPVideoCamConfigClass`` for MIPI-CSI + ISP initialization.
+Available when ``CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE`` is enabled.
+
+Default constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoCSIConfigClass();
+
+Creates an empty CSI configuration object.
+
+Copy constructor
+^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoCSIConfigClass(const ESPVideoCSIConfigClass &config);
+
+Copies the base camera configuration and the LDO initialization flag.
+
+begin
+^^^^^
+
+.. code-block:: cpp
+
+    bool begin(const ESPVideoCamConfigClass &config, bool dont_init_ldo = false);
+
+* ``config`` — Base camera / SCCB configuration.
+* ``dont_init_ldo`` — When ``true``, skips LDO initialization inside the CSI driver (use if power is supplied externally).
+
+Returns ``true`` on success.
+
+getCsiInitConfig
+^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    esp_video_init_csi_config_t getCsiInitConfig() const;
+
+Builds the ESP-IDF CSI initialization structure from the stored configuration.
+
+getDontInitLdo
+^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool getDontInitLdo() const;
+
+Returns the LDO initialization skip flag.
+
+DVP pin configuration
+*********************
+
+``ESPVideoDVPPinsConfigClass`` describes the parallel DVP data and sync pins.
+Available when ``CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE`` is enabled.
+The ``begin()`` overload always configures 8-bit data width (D0–D7).
+
+Default constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoDVPPinsConfigClass();
+
+Creates an empty DVP pin configuration object.
+
+Copy constructor and assignment operator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoDVPPinsConfigClass(const ESPVideoDVPPinsConfigClass &config);
+    ESPVideoDVPPinsConfigClass &operator=(const ESPVideoDVPPinsConfigClass &config);
+
+Copies the stored ``esp_cam_ctlr_dvp_pin_config_t`` structure.
+
+begin
+^^^^^
+
+.. code-block:: cpp
+
+    bool begin(int8_t vsync_pin, int8_t de_pin, int8_t pclk_pin, int8_t xclk_pin,
+               int8_t data0_pin, int8_t data1_pin, int8_t data2_pin, int8_t data3_pin,
+               int8_t data4_pin, int8_t data5_pin, int8_t data6_pin, int8_t data7_pin);
+
+* ``vsync_pin`` / ``de_pin`` / ``pclk_pin`` / ``xclk_pin`` — Sync and clock pins.
+* ``data0_pin`` … ``data7_pin`` — Eight parallel data lines (D0–D7).
+
+Returns ``true`` on success.
+
+getDvpPin
+^^^^^^^^^
+
+.. code-block:: cpp
+
+    const esp_cam_ctlr_dvp_pin_config_t &getDvpPin() const;
+
+Returns the native ESP-IDF DVP pin structure.
+
+DVP configuration
+*****************
+
+``ESPVideoDVPConfigClass`` combines SCCB settings, DVP pins, and XCLK frequency.
+It inherits from both ``ESPVideoCamConfigClass`` and ``ESPVideoDVPPinsConfigClass``, so a single instance carries the full DVP setup.
+Available when ``CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE`` is enabled.
+
+Default constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoDVPConfigClass();
+
+Creates an empty DVP configuration object.
+
+Copy constructor and assignment operator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoDVPConfigClass(const ESPVideoDVPConfigClass &config);
+    ESPVideoDVPConfigClass &operator=(const ESPVideoDVPConfigClass &config);
+
+Copies SCCB settings, DVP pin mapping, and XCLK frequency.
+
+begin
+^^^^^
+
+.. code-block:: cpp
+
+    bool begin(const ESPVideoCamConfigClass &config,
+               const ESPVideoDVPPinsConfigClass &dvp_pin,
+               uint32_t xclk_freq);
+
+* ``config`` — Base camera / SCCB configuration.
+* ``dvp_pin`` — DVP data, sync, and clock pin mapping (see ESP-IDF camera controller docs).
+* ``xclk_freq`` — Sensor external clock (XCLK) frequency in Hz.
+
+Returns ``true`` on success.
+
+getDvpInitConfig
+^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    esp_video_init_dvp_config_t getDvpInitConfig() const;
+
+Builds the ESP-IDF DVP initialization structure from the stored configuration.
+
+getXclkFreq
+^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    uint32_t getXclkFreq() const;
+
+Returns the configured XCLK frequency in Hz.
+
+acquirePins / releasePins
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool acquirePins();
+    bool releasePins();
+
+Reserve or release SCCB, reset/power-down, and DVP parallel pins through ``periman``.
+Called automatically by ``ESPVideoClass::begin()`` and ``end()`` for DVP setups.
+
+ESPVideoClass
+*************
+
+``ESPVideoClass`` initializes the ``esp_video`` stack for CSI or DVP.
+Create one instance per application (or use a static/global instance).
+
+Destructor
+^^^^^^^^^^
+
+Calls ``end()`` to stop initialized subsystems and release reserved pins.
+
+end
+^^^
+
+.. code-block:: cpp
+
+    void end();
+
+Stops the initialized subsystems via ``esp_video_deinit_with_flags()``, releases pins reserved during ``begin()``, and clears stored configuration.
+
+begin (MIPI-CSI)
+^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool begin(const ESPVideoCSIConfigClass &config);
+
+Available when ``CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE`` is enabled.
+
+Initializes MIPI-CSI and ISP (``ESP_VIDEO_INIT_FLAGS_MIPI_CSI | ESP_VIDEO_INIT_FLAGS_ISP``).
+Reserves pins through ``periman``, calls ``esp_video_init_with_flags()``, and stores the configuration for teardown.
+Returns ``true`` if initialization succeeded or was already done.
+On failure, reserved pins are released before returning ``false``.
+
+isCSIInitialized
+^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool isCSIInitialized() const;
+
+Returns ``true`` if CSI and ISP flags are active.
+
+begin (DVP)
+^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool begin(const ESPVideoDVPConfigClass &config);
+
+Available when ``CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE`` is enabled.
+
+Initializes the DVP video device (``ESP_VIDEO_INIT_FLAGS_DVP``).
+Follows the same pin reservation and rollback rules as the CSI ``begin()`` overload.
+
+isDVPInitialized
+^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool isDVPInitialized() const;
+
+Returns ``true`` if the DVP subsystem is initialized.
+
+ESPVideoCaptureDevClass
+***********************
+
+Opens a V4L2 capture device, manages buffers, and dequeues frames.
+Inherits ``ESPVideoSolutionClass`` and ``ESPVideoFormatClass`` for resolution and format metadata.
+The class is non-copyable and non-movable; use a single long-lived instance or manage lifetime explicitly.
+
+Default constructor
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoCaptureDevClass();
+
+Creates an empty instance. Call ``begin()`` before ``startCapture()``.
+
+Destructor
+^^^^^^^^^^
+
+Calls ``end()`` to stop capture, unmap MMAP buffers, release driver buffers, and close the file descriptor.
+
+begin
+^^^^^
+
+.. code-block:: cpp
+
+    bool begin(const char *path, size_t buf_count = 2);
+
+Opens the device at ``path`` if not already open, reads the driver format (``VIDIOC_G_FMT``), re-applies it (``VIDIOC_S_FMT``), stores width, height, and pixel format, and requests ``buf_count`` MMAP capture buffers.
+The detected format and resolution are exposed through ``getFormat()``, ``getFormatName()``, ``getWidth()``, and ``getHeight()``.
+If the device is already open, returns ``true`` immediately without changing the path.
+On any failure the device is closed and the instance remains unopened.
+
+end
+^^^
+
+.. code-block:: cpp
+
+    void end();
+
+Stops capture, unmaps buffers, releases driver buffers, and closes the file descriptor.
+
+requestBuffer
+^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool requestBuffer(size_t buf_count);
+
+* ``buf_count`` — Number of capture buffers (commonly 2 for double buffering).
+
+Releases any existing buffers, requests new MMAP buffers from the driver, and maps them into userspace.
+On failure, partially allocated buffers are rolled back before returning ``false``.
+Requires the device to be open (via ``begin()``).
+
+startCapture
+^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool startCapture();
+
+Queues all buffers and starts the video stream (``VIDIOC_STREAMON``).
+Requires buffers to be set up first.
+Returns ``true`` on success.
+
+stopCapture
+^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    void stopCapture();
+
+Stops the stream (``VIDIOC_STREAMOFF``) if capture was started.
+
+captureBuffer
+^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoBufferClass captureBuffer();
+
+Dequeues one filled buffer (``VIDIOC_DQBUF``).
+Returns an invalid buffer if capture is not running or dequeue fails.
+
+isOpened
+^^^^^^^^
+
+.. code-block:: cpp
+
+    bool isOpened() const;
+
+Returns ``true`` if the device file descriptor is valid.
+
+isCaptureStarted
+^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool isCaptureStarted() const;
+
+Returns ``true`` if ``startCapture()`` succeeded and the stream has not been stopped.
+
+getFormat
+^^^^^^^^^
+
+.. code-block:: cpp
+
+    esp_video_format_t getFormat() const;
+
+Inherited from ``ESPVideoFormatClass``.
+Returns the active pixel format after ``begin()`` or a successful ``setFormat()`` call.
+If the driver reports an unrecognized V4L2 fourcc during ``begin()``, returns ``ESP_VIDEO_FORMAT_UNKNOWN``.
+
+getFormatName
+^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    const char *getFormatName() const;
+
+Inherited from ``ESPVideoFormatClass``.
+Returns the human-readable format name for ``getFormat()`` (for example ``"RGB565"`` or ``"JPEG"``).
+
+getWidth / getHeight
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    uint32_t getWidth() const;
+    uint32_t getHeight() const;
+
+Inherited from ``ESPVideoSolutionClass``.
+Return the frame width and height, as reported by the driver during ``begin()``.
+
+setFormat
+^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setFormat(esp_video_format_t format);
+
+Selects a pixel format before capture starts, or changes it while the device is open.
+Issues ``VIDIOC_G_FMT`` / ``VIDIOC_S_FMT`` with the V4L2 fourcc that corresponds to ``format``.
+If the format changes and capture buffers were already allocated, existing MMAP buffers are released and re-requested using the buffer count from the last ``begin()`` or ``requestBuffer()`` call.
+Returns ``false`` for unsupported enum values, I/O errors, or buffer re-allocation failures.
+Call this after ``begin()`` and before ``startCapture()`` in typical applications.
+
+Sensor controls
+^^^^^^^^^^^^^^^
+
+These methods map to V4L2 extended controls (``VIDIOC_S_EXT_CTRLS``).
+Availability depends on the sensor driver and current format.
+
+setSensorGain
+^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorGain(int32_t gain);
+
+Sets ``V4L2_CID_GAIN``.
+
+setSensorExposure
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorExposure(int32_t exposure);
+
+Sets ``V4L2_CID_EXPOSURE``.
+
+setSensorExposureTime
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorExposureTime(int32_t exposure_time);
+
+Sets ``V4L2_CID_EXPOSURE_ABSOLUTE``.
+
+setSensorAETargetLevel
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorAETargetLevel(int32_t target_level);
+
+Sets ``V4L2_CID_CAMERA_AE_LEVEL``.
+
+setSensorJPEGQuality
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorJPEGQuality(int32_t quality);
+
+Sets ``V4L2_CID_JPEG_COMPRESSION_QUALITY``.
+
+setSensorVFlip
+^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorVFlip(bool vflip);
+
+Sets ``V4L2_CID_VFLIP``.
+
+setSensorHFlip
+^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorHFlip(bool hflip);
+
+Sets ``V4L2_CID_HFLIP``.
+
+setSensorTestPattern
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    bool setSensorTestPattern(bool test_pattern);
+
+Sets ``V4L2_CID_TEST_PATTERN``.
+
+Each control method returns ``true`` if the driver accepted the value.
+
+ESPVideoBufferClass
+*******************
+
+RAII wrapper for one dequeued frame.
+Inherits ``ESPVideoSolutionClass`` and ``ESPVideoFormatClass`` so each frame carries its own format and resolution metadata.
+When the object is destroyed, moved-from, or ``end()`` is called, the buffer is re-queued (``VIDIOC_QBUF``) so capture can continue.
+
+The class is move-only (copy is deleted).
+
+Move constructor and move assignment operator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    ESPVideoBufferClass(ESPVideoBufferClass &&other) noexcept;
+    ESPVideoBufferClass &operator=(ESPVideoBufferClass &&other) noexcept;
+
+Transfer buffer ownership to another instance.
+The source object is left empty and no longer re-queues the buffer on destruction.
+
+valid
+^^^^^
+
+.. code-block:: cpp
+
+    bool valid() const;
+
+Returns ``true`` if ``data()`` is non-null and ``size()`` is greater than zero.
+
+data
+^^^^
+
+.. code-block:: cpp
+
+    uint8_t *data() const;
+
+Pointer to captured pixel data (MMAP mode).
+Do not store this pointer past the lifetime of the ``ESPVideoBufferClass`` object.
+
+size
+^^^^
+
+.. code-block:: cpp
+
+    size_t size() const;
+
+Number of valid bytes in the buffer (``bytesused`` from V4L2).
+
+index
+^^^^^
+
+.. code-block:: cpp
+
+    int index() const;
+
+Driver buffer index, or ``-1`` after the buffer has been re-queued.
+
+getWidth / getHeight
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: cpp
+
+    uint32_t getWidth() const;
+    uint32_t getHeight() const;
+
+Inherited from ``ESPVideoSolutionClass``.
+Return the frame width and height copied from the capture device when this buffer was dequeued.
+
+formatName
+^^^^^^^^^^
+
+.. code-block:: cpp
+
+    const char *formatName() const;
+
+Convenience alias for ``getFormatName()`` inherited from ``ESPVideoFormatClass``.
+
+formatType
+^^^^^^^^^^
+
+.. code-block:: cpp
+
+    esp_video_format_t formatType() const;
+
+Convenience alias for ``getFormat()`` inherited from ``ESPVideoFormatClass``.
+
+end
+^^^
+
+.. code-block:: cpp
+
+    void end();
+
+Re-queues the buffer to the driver immediately without waiting for destruction.
+
+.. note::
+    Hold ``ESPVideoBufferClass`` only while processing one frame.
+    Destroying, moving, or calling ``end()`` returns the buffer to the driver; failing to release buffers will stall ``captureBuffer()``.
+
+Examples
+--------
+
+MIPI-CSI capture (ESP32-P4):
+
+.. literalinclude:: ../../../libraries/ESP_Video/examples/mipi_csi_camera/mipi_csi_camera.ino
+    :language: cpp
+
+DVP capture (ESP32-S3 or ESP32-P4):
+
+.. literalinclude:: ../../../libraries/ESP_Video/examples/dvp_camera/dvp_camera.ino
+    :language: cpp
+
+See also the `ESP_Video library`_ on GitHub for board-specific pin defines and Kconfig requirements.
+
+.. _`ESP_Video library`: https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP_Video

--- a/libraries/ESP_Video/examples/dvp_camera/ci.yml
+++ b/libraries/ESP_Video/examples/dvp_camera/ci.yml
@@ -1,0 +1,4 @@
+fqbn_append: PartitionScheme=esp_sr_16,FlashSize=16M
+
+requires:
+  - CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE=y

--- a/libraries/ESP_Video/examples/dvp_camera/dvp_camera.ino
+++ b/libraries/ESP_Video/examples/dvp_camera/dvp_camera.ino
@@ -1,0 +1,151 @@
+/**
+ * DVP ESP_Video capture example.
+ *
+ * This sketch demonstrates the minimal flow for capturing camera frames over a
+ * DVP (parallel) interface with the ESP_Video library: initialize the camera
+ * sensor via SCCB, configure parallel data pins, open a V4L2-style capture
+ * device, start streaming, and dequeue frames in a loop.
+ *
+ * Requirements:
+ * - ESP-IDF >= 5.4.0
+ * - CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE=y
+ *
+ * Supported targets and default board wiring:
+ * - ESP32-S3: DVP camera on ESP32-S3-EYE (SCCB + parallel data pins, 10 MHz
+ *   XCLK).
+ * - ESP32-P4: DVP camera on ESP32-P4-Function-EV-Board V1.5 (SCCB + parallel
+ *   data pins, 20 MHz XCLK).
+ *
+ * How it works:
+ * 1. setup() configures SCCB (I2C) with ESPVideoCamConfigClass, parallel pins
+ *    with ESPVideoDVPPinsConfigClass, and wraps both in ESPVideoDVPConfigClass
+ *    before calling ESPVideoClass::begin().
+ * 2. capture_dev.begin() opens ESP_VIDEO_DVP_DEVICE_NAME, requests two mmap
+ *    capture buffers, and startCapture() starts streaming.
+ * 3. loop() calls ESPVideoCaptureDevClass::captureBuffer() to dequeue the next
+ *    frame. On success it prints the buffer pointer and size to Serial; the
+ *    buffer is returned to the driver when the ESPVideoBufferClass object is
+ *    destroyed at the end of each iteration.
+ *
+ * Open Serial Monitor at 115200 baud to see capture status and frame metadata.
+ * Adapt the EXAMPLE_DVP_* pin defines if your camera is wired to a different board.
+ */
+#include "Arduino.h"
+#include <array>
+#include <memory>
+#include <ESP_Video.h>
+#include "esp_video_device.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#if CONFIG_IDF_TARGET_ESP32P4
+/**
+ * @brief This configuration is for the ESP32-P4-Function-EV-Board V1.5
+ */
+#define EXAMPLE_DVP_SCCB_I2C_PORT    0
+#define EXAMPLE_DVP_SCCB_I2C_SCL_PIN 8
+#define EXAMPLE_DVP_SCCB_I2C_SDA_PIN 7
+#define EXAMPLE_DVP_XCLK_PIN         20
+#define EXAMPLE_DVP_PCLK_PIN         4
+#define EXAMPLE_DVP_VSYNC_PIN        37
+#define EXAMPLE_DVP_DE_PIN           22
+#define EXAMPLE_DVP_D0_PIN           2
+#define EXAMPLE_DVP_D1_PIN           32
+#define EXAMPLE_DVP_D2_PIN           33
+#define EXAMPLE_DVP_D3_PIN           23
+#define EXAMPLE_DVP_D4_PIN           3
+#define EXAMPLE_DVP_D5_PIN           6
+#define EXAMPLE_DVP_D6_PIN           5
+#define EXAMPLE_DVP_D7_PIN           21
+#define EXAMPLE_DVP_XCLK_FREQ        20000000
+#elif CONFIG_IDF_TARGET_ESP32S3
+/**
+ * @brief This configuration is for the ESP32-S3-EYE board
+ */
+#define EXAMPLE_DVP_SCCB_I2C_PORT    0
+#define EXAMPLE_DVP_SCCB_I2C_SCL_PIN 5
+#define EXAMPLE_DVP_SCCB_I2C_SDA_PIN 4
+#define EXAMPLE_DVP_XCLK_PIN         15
+#define EXAMPLE_DVP_PCLK_PIN         13
+#define EXAMPLE_DVP_VSYNC_PIN        6
+#define EXAMPLE_DVP_DE_PIN           7
+#define EXAMPLE_DVP_D0_PIN           11
+#define EXAMPLE_DVP_D1_PIN           9
+#define EXAMPLE_DVP_D2_PIN           8
+#define EXAMPLE_DVP_D3_PIN           10
+#define EXAMPLE_DVP_D4_PIN           12
+#define EXAMPLE_DVP_D5_PIN           18
+#define EXAMPLE_DVP_D6_PIN           17
+#define EXAMPLE_DVP_D7_PIN           16
+#define EXAMPLE_DVP_XCLK_FREQ        10000000
+#else
+#error "The selected target SoC is not supported"
+#endif
+
+ESPVideoClass video;
+ESPVideoCaptureDevClass capture_dev;
+/**
+ * @brief Number of capture buffers, buffer > 2 for double buffering, this can avoid frame dropping
+ */
+const size_t kCaptureBufferCount = 2;
+
+void setup() {
+  Serial.begin(115200);
+
+  ESPVideoCamConfigClass cam_config;
+  cam_config.begin(EXAMPLE_DVP_SCCB_I2C_PORT, EXAMPLE_DVP_SCCB_I2C_SCL_PIN, EXAMPLE_DVP_SCCB_I2C_SDA_PIN);
+
+  ESPVideoDVPPinsConfigClass dvp_pins;
+  dvp_pins.begin(
+    EXAMPLE_DVP_VSYNC_PIN, EXAMPLE_DVP_DE_PIN, EXAMPLE_DVP_PCLK_PIN, EXAMPLE_DVP_XCLK_PIN, EXAMPLE_DVP_D0_PIN, EXAMPLE_DVP_D1_PIN, EXAMPLE_DVP_D2_PIN,
+    EXAMPLE_DVP_D3_PIN, EXAMPLE_DVP_D4_PIN, EXAMPLE_DVP_D5_PIN, EXAMPLE_DVP_D6_PIN, EXAMPLE_DVP_D7_PIN
+  );
+
+  ESPVideoDVPConfigClass dvp_config;
+  dvp_config.begin(cam_config, dvp_pins, EXAMPLE_DVP_XCLK_FREQ);
+
+  if (!video.begin(dvp_config)) {
+    Serial.println("failed to init DVP camera");
+    return;
+  }
+
+  if (!capture_dev.begin(ESP_VIDEO_DVP_DEVICE_NAME, kCaptureBufferCount)) {
+    Serial.println("failed to open capture device");
+    return;
+  }
+
+  if (!capture_dev.startCapture()) {
+    Serial.println("failed to start capture");
+    return;
+  }
+
+  Serial.println("Arduino camera example started");
+}
+
+void loop() {
+  if (!capture_dev.isOpened() || !capture_dev.isCaptureStarted()) {
+    delay(1000);
+    return;
+  }
+
+  ESPVideoBufferClass buffer = capture_dev.captureBuffer();
+  if (!buffer.valid()) {
+    Serial.println("failed to capture buffer");
+    delay(10);
+    return;
+  }
+
+  Serial.printf(
+    "captured buffer: %p size: %lu format: %s width: %u height: %u\n", buffer.data(), (unsigned long)buffer.size(), buffer.formatName(), buffer.getWidth(),
+    buffer.getHeight()
+  );
+}
+#else
+void setup() {
+  Serial.begin(115200);
+  Serial.println("ESP_IDF_VERSION < 5.4.0, this example is not supported");
+}
+
+void loop() {
+  delay(1000);
+}
+#endif  // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)

--- a/libraries/ESP_Video/examples/dvp_camera/dvp_camera.ino
+++ b/libraries/ESP_Video/examples/dvp_camera/dvp_camera.ino
@@ -31,10 +31,7 @@
  * Adapt the EXAMPLE_DVP_* pin defines if your camera is wired to a different board.
  */
 #include "Arduino.h"
-#include <array>
-#include <memory>
 #include <ESP_Video.h>
-#include "esp_video_device.h"
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
 #if CONFIG_IDF_TARGET_ESP32P4
@@ -135,7 +132,7 @@ void loop() {
   }
 
   Serial.printf(
-    "captured buffer: %p size: %lu format: %s width: %u height: %u\n", buffer.data(), (unsigned long)buffer.size(), buffer.formatName(), buffer.getWidth(),
+    "captured buffer: %p size: %lu format: %s width: %lu height: %lu\n", buffer.data(), (unsigned long)buffer.size(), buffer.formatName(), buffer.getWidth(),
     buffer.getHeight()
   );
 }

--- a/libraries/ESP_Video/examples/mipi_csi_camera/ci.yml
+++ b/libraries/ESP_Video/examples/mipi_csi_camera/ci.yml
@@ -1,0 +1,4 @@
+fqbn_append: PartitionScheme=esp_sr_16,FlashSize=16M
+
+requires:
+  - CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE=y

--- a/libraries/ESP_Video/examples/mipi_csi_camera/mipi_csi_camera.ino
+++ b/libraries/ESP_Video/examples/mipi_csi_camera/mipi_csi_camera.ino
@@ -1,0 +1,114 @@
+/**
+ * MIPI-CSI ESP_Video capture example.
+ *
+ * This sketch demonstrates the minimal flow for capturing camera frames over a
+ * MIPI-CSI interface with the ESP_Video library: initialize the camera sensor
+ * via SCCB, open a V4L2-style capture device, start streaming, and dequeue
+ * frames in a loop.
+ *
+ * Requirements:
+ * - ESP-IDF >= 5.4.0
+ * - CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE=y
+ *
+ * Supported target and default board wiring:
+ * - ESP32-P4: MIPI-CSI camera on ESP32-P4-Function-EV-Board V1.5
+ *   (SCCB I2C port 0, SCL GPIO 8, SDA GPIO 7).
+ *
+ * How it works:
+ * 1. setup() configures SCCB (I2C) with ESPVideoCamConfigClass, wraps it in
+ *    ESPVideoCSIConfigClass, and calls ESPVideoClass::begin().
+ * 2. capture_dev.begin() opens ESP_VIDEO_MIPI_CSI_DEVICE_NAME, requests two
+ *    mmap capture buffers, and startCapture() starts streaming.
+ * 3. loop() calls ESPVideoCaptureDevClass::captureBuffer() to dequeue the next
+ *    frame. On success it prints the buffer pointer and size to Serial; the
+ *    buffer is returned to the driver when the ESPVideoBufferClass object is
+ *    destroyed at the end of each iteration.
+ *
+ * Open Serial Monitor at 115200 baud to see capture status and frame metadata.
+ * Adapt the EXAMPLE_MIPI_CSI_* pin defines if your camera is wired differently.
+ */
+#include "Arduino.h"
+#include <array>
+#include <memory>
+#include <ESP_Video.h>
+#include "esp_video_device.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#if CONFIG_IDF_TARGET_ESP32P4
+/**
+ * @brief This configuration is for the ESP32-P4-Function-EV-Board V1.5
+ */
+#define EXAMPLE_MIPI_CSI_SCCB_I2C_PORT    0
+#define EXAMPLE_MIPI_CSI_SCCB_I2C_SCL_PIN 8
+#define EXAMPLE_MIPI_CSI_SCCB_I2C_SDA_PIN 7
+#else
+#error "The selected target SoC is not supported"
+#endif
+
+ESPVideoClass video;
+ESPVideoCaptureDevClass capture_dev;
+/**
+ * @brief Number of capture buffers, buffer > 2 for double buffering, this can avoid frame dropping
+ */
+const size_t kCaptureBufferCount = 2;
+
+void setup() {
+  Serial.begin(115200);
+
+  ESPVideoCamConfigClass cam_config;
+  cam_config.begin(EXAMPLE_MIPI_CSI_SCCB_I2C_PORT, EXAMPLE_MIPI_CSI_SCCB_I2C_SCL_PIN, EXAMPLE_MIPI_CSI_SCCB_I2C_SDA_PIN);
+
+  ESPVideoCSIConfigClass csi_config;
+  csi_config.begin(cam_config);
+
+  if (!video.begin(csi_config)) {
+    Serial.println("failed to init CSI camera");
+    return;
+  }
+
+  if (!capture_dev.begin(ESP_VIDEO_MIPI_CSI_DEVICE_NAME, kCaptureBufferCount)) {
+    Serial.println("failed to open capture device");
+    return;
+  }
+
+  if (!capture_dev.setFormat(ESP_VIDEO_FORMAT_RGB565)) {
+    Serial.println("failed to set format");
+    return;
+  }
+
+  if (!capture_dev.startCapture()) {
+    Serial.println("failed to start capture");
+    return;
+  }
+
+  Serial.println("Arduino camera example started");
+}
+
+void loop() {
+  if (!capture_dev.isOpened() || !capture_dev.isCaptureStarted()) {
+    delay(1000);
+    return;
+  }
+
+  ESPVideoBufferClass buffer = capture_dev.captureBuffer();
+  if (!buffer.valid()) {
+    Serial.println("failed to capture buffer");
+    delay(10);
+    return;
+  }
+
+  Serial.printf(
+    "captured buffer: %p size: %lu format: %s width: %u height: %u\n", buffer.data(), (unsigned long)buffer.size(), buffer.formatName(), buffer.getWidth(),
+    buffer.getHeight()
+  );
+}
+#else
+void setup() {
+  Serial.begin(115200);
+  Serial.println("ESP_IDF_VERSION < 5.4.0, this example is not supported");
+}
+
+void loop() {
+  delay(1000);
+}
+#endif  // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)

--- a/libraries/ESP_Video/examples/mipi_csi_camera/mipi_csi_camera.ino
+++ b/libraries/ESP_Video/examples/mipi_csi_camera/mipi_csi_camera.ino
@@ -28,10 +28,7 @@
  * Adapt the EXAMPLE_MIPI_CSI_* pin defines if your camera is wired differently.
  */
 #include "Arduino.h"
-#include <array>
-#include <memory>
 #include <ESP_Video.h>
-#include "esp_video_device.h"
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
 #if CONFIG_IDF_TARGET_ESP32P4
@@ -98,7 +95,7 @@ void loop() {
   }
 
   Serial.printf(
-    "captured buffer: %p size: %lu format: %s width: %u height: %u\n", buffer.data(), (unsigned long)buffer.size(), buffer.formatName(), buffer.getWidth(),
+    "captured buffer: %p size: %lu format: %s width: %lu height: %lu\n", buffer.data(), (unsigned long)buffer.size(), buffer.formatName(), buffer.getWidth(),
     buffer.getHeight()
   );
 }

--- a/libraries/ESP_Video/keywords.txt
+++ b/libraries/ESP_Video/keywords.txt
@@ -1,0 +1,71 @@
+#######################################
+# Syntax Coloring Map For ESP_Video
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+ESP_Video	KEYWORD1
+ESPVideoClass	KEYWORD1
+ESPVideoCamConfigClass	KEYWORD1
+ESPVideoCSIConfigClass	KEYWORD1
+ESPVideoDVPPinsConfigClass	KEYWORD1
+ESPVideoDVPConfigClass	KEYWORD1
+ESPVideoBufferClass	KEYWORD1
+ESPVideoCaptureDevClass	KEYWORD1
+esp_video_init_sccb_config_t	KEYWORD1
+esp_cam_ctlr_dvp_pin_config_t	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+getSccbConfig	KEYWORD2
+getCsiInitConfig	KEYWORD2
+getDvpInitConfig	KEYWORD2
+getResetPin	KEYWORD2
+getPwdnPin	KEYWORD2
+getDontInitLdo	KEYWORD2
+getDvpPin	KEYWORD2
+getXclkFreq	KEYWORD2
+acquirePins	KEYWORD2
+releasePins	KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+isCSIInitialized	KEYWORD2
+isDVPInitialized	KEYWORD2
+valid	KEYWORD2
+data	KEYWORD2
+size	KEYWORD2
+index	KEYWORD2
+requestBuffer	KEYWORD2
+startCapture	KEYWORD2
+stopCapture	KEYWORD2
+captureBuffer	KEYWORD2
+isOpened	KEYWORD2
+isCaptureStarted	KEYWORD2
+setSensorGain	KEYWORD2
+setSensorExposure	KEYWORD2
+setSensorExposureTime	KEYWORD2
+setSensorAETargetLevel	KEYWORD2
+setSensorJPEGQuality	KEYWORD2
+setSensorVFlip	KEYWORD2
+setSensorHFlip	KEYWORD2
+setSensorTestPattern	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+V4L2_BUF_TYPE_VIDEO_CAPTURE	LITERAL1
+V4L2_MEMORY_MMAP	LITERAL1
+V4L2_MEMORY_USERPTR	LITERAL1
+V4L2_CID_GAIN	LITERAL1
+V4L2_CID_EXPOSURE	LITERAL1
+V4L2_CID_EXPOSURE_ABSOLUTE	LITERAL1
+V4L2_CID_CAMERA_AE_LEVEL	LITERAL1
+V4L2_CID_JPEG_COMPRESSION_QUALITY	LITERAL1
+V4L2_CID_VFLIP	LITERAL1
+V4L2_CID_HFLIP	LITERAL1
+V4L2_CID_TEST_PATTERN	LITERAL1

--- a/libraries/ESP_Video/library.properties
+++ b/libraries/ESP_Video/library.properties
@@ -1,0 +1,10 @@
+name=ESP_Video
+version=3.3.10
+author=Dong Heng
+maintainer=Dong Heng <dongheng@espressif.com>
+sentence=Library for ESP camera video capture
+paragraph=Wraps esp_video for MIPI-CSI, DVP and V4L2 capture on supported SoCs.
+category=Signal Input/Output
+url=https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP_Video
+architectures=esp32
+includes=ESP_Video.h

--- a/libraries/ESP_Video/src/ESP_Video.cpp
+++ b/libraries/ESP_Video/src/ESP_Video.cpp
@@ -1,0 +1,984 @@
+/*
+* SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+*
+* SPDX-License-Identifier: ESPRESSIF MIT
+*/
+
+#include "sdkconfig.h"
+#if (CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE || CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE)
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#include "ESP_Video.h"
+#include "esp32-hal-periman.h"
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <cstring>
+
+#include "esp_video_ioctl.h"
+
+const uint32_t ESPVideoCamConfigClass::i2c_freq_hz = 100 * 1000;
+
+static bool video_format_to_v4l2_format(esp_video_format_t format, uint32_t &v4l2_format, std::string &format_name) {
+  switch (format) {
+    case ESP_VIDEO_FORMAT_RAW8:
+      v4l2_format = V4L2_PIX_FMT_SRGGB8;
+      format_name = "RAW8";
+      break;
+    case ESP_VIDEO_FORMAT_RAW10:
+      v4l2_format = V4L2_PIX_FMT_SGRBG10;
+      format_name = "RAW10";
+      break;
+    case ESP_VIDEO_FORMAT_RAW12:
+      v4l2_format = V4L2_PIX_FMT_SGRBG12;
+      format_name = "RAW12";
+      break;
+    case ESP_VIDEO_FORMAT_RGB565:
+      v4l2_format = V4L2_PIX_FMT_RGB565;
+      format_name = "RGB565";
+      break;
+    case ESP_VIDEO_FORMAT_RGB888:
+      v4l2_format = V4L2_PIX_FMT_RGB24;
+      format_name = "RGB888";
+      break;
+    case ESP_VIDEO_FORMAT_YUV420:
+      v4l2_format = V4L2_PIX_FMT_YUV420;
+      format_name = "YUV420";
+      break;
+    case ESP_VIDEO_FORMAT_YUV422_YUYV:
+      v4l2_format = V4L2_PIX_FMT_YUYV;
+      format_name = "YUV422_YUYV";
+      break;
+    case ESP_VIDEO_FORMAT_YUV422_UYVY:
+      v4l2_format = V4L2_PIX_FMT_UYVY;
+      format_name = "YUV422_UYVY";
+      break;
+    case ESP_VIDEO_FORMAT_GRAY8:
+      v4l2_format = V4L2_PIX_FMT_GREY;
+      format_name = "GRAY8";
+      break;
+    case ESP_VIDEO_FORMAT_JPEG:
+      v4l2_format = V4L2_PIX_FMT_JPEG;
+      format_name = "JPEG";
+      break;
+    default: return false;
+  }
+
+  return true;
+}
+
+static bool v4l2_format_to_video_format(uint32_t v4l2_format, esp_video_format_t &format_type, std::string &format_name) {
+  switch (v4l2_format) {
+    case V4L2_PIX_FMT_SRGGB8:
+      format_type = ESP_VIDEO_FORMAT_RAW8;
+      format_name = "RAW8";
+      break;
+    case V4L2_PIX_FMT_SGRBG10:
+      format_type = ESP_VIDEO_FORMAT_RAW10;
+      format_name = "RAW10";
+      break;
+    case V4L2_PIX_FMT_SGRBG12:
+      format_type = ESP_VIDEO_FORMAT_RAW12;
+      format_name = "RAW12";
+      break;
+    case V4L2_PIX_FMT_RGB565:
+      format_type = ESP_VIDEO_FORMAT_RGB565;
+      format_name = "RGB565";
+      break;
+    case V4L2_PIX_FMT_RGB24:
+      format_type = ESP_VIDEO_FORMAT_RGB888;
+      format_name = "RGB888";
+      break;
+    case V4L2_PIX_FMT_YUV420:
+      format_type = ESP_VIDEO_FORMAT_YUV420;
+      format_name = "YUV420";
+      break;
+    case V4L2_PIX_FMT_YUYV:
+      format_type = ESP_VIDEO_FORMAT_YUV422_YUYV;
+      format_name = "YUV422_YUYV";
+      break;
+    case V4L2_PIX_FMT_UYVY:
+      format_type = ESP_VIDEO_FORMAT_YUV422_UYVY;
+      format_name = "YUV422_UYVY";
+      break;
+    case V4L2_PIX_FMT_GREY:
+      format_type = ESP_VIDEO_FORMAT_GRAY8;
+      format_name = "GRAY8";
+      break;
+    case V4L2_PIX_FMT_JPEG:
+      format_type = ESP_VIDEO_FORMAT_JPEG;
+      format_name = "JPEG";
+      break;
+    default: return false;
+  }
+
+  return true;
+}
+
+ESPVideoSolutionClass &ESPVideoSolutionClass::operator=(const ESPVideoSolutionClass &config) {
+  if (this != &config) {
+    width_ = config.width_;
+    height_ = config.height_;
+  }
+  return *this;
+}
+
+void ESPVideoSolutionClass::begin(uint32_t width, uint32_t height) {
+  width_ = width;
+  height_ = height;
+}
+
+uint32_t ESPVideoSolutionClass::getWidth() const {
+  return width_;
+}
+
+uint32_t ESPVideoSolutionClass::getHeight() const {
+  return height_;
+}
+
+ESPVideoFormatClass &ESPVideoFormatClass::operator=(const ESPVideoFormatClass &config) {
+  if (this != &config) {
+    format_type_ = config.format_type_;
+    format_name_ = config.format_name_;
+  }
+  return *this;
+}
+
+void ESPVideoFormatClass::begin(esp_video_format_t format_type, const std::string &format_name) {
+  format_type_ = format_type;
+  format_name_ = format_name;
+}
+
+esp_video_format_t ESPVideoFormatClass::getFormat() const {
+  return format_type_;
+}
+
+const char *ESPVideoFormatClass::getFormatName() const {
+  if (format_name_.empty()) {
+    uint32_t buf_format = 0;
+
+    if (!video_format_to_v4l2_format(format_type_, buf_format, format_name_)) {
+      format_name_ = "UNKNOWN";
+    }
+  }
+
+  return format_name_.c_str();
+}
+
+ESPVideoCamConfigClass::ESPVideoCamConfigClass(const ESPVideoCamConfigClass &config)
+  : port(config.port), scl_pin(config.scl_pin), sda_pin(config.sda_pin), i2c_freq(config.i2c_freq), reset_pin(config.reset_pin), pwdn_pin(config.pwdn_pin),
+    i2c_handle(config.i2c_handle) {}
+
+ESPVideoCamConfigClass &ESPVideoCamConfigClass::operator=(const ESPVideoCamConfigClass &config) {
+  if (this != &config) {
+    port = config.port;
+    scl_pin = config.scl_pin;
+    sda_pin = config.sda_pin;
+    i2c_freq = config.i2c_freq;
+    reset_pin = config.reset_pin;
+    pwdn_pin = config.pwdn_pin;
+    i2c_handle = config.i2c_handle;
+  }
+  return *this;
+}
+
+bool ESPVideoCamConfigClass::begin(i2c_port_num_t port, int8_t scl_pin, int8_t sda_pin, uint32_t i2c_freq, int8_t reset_pin, int8_t pwdn_pin) {
+  this->port = port;
+  this->scl_pin = static_cast<gpio_num_t>(scl_pin);
+  this->sda_pin = static_cast<gpio_num_t>(sda_pin);
+  this->i2c_freq = i2c_freq;
+  this->reset_pin = static_cast<gpio_num_t>(reset_pin);
+  this->pwdn_pin = static_cast<gpio_num_t>(pwdn_pin);
+  this->i2c_handle = nullptr;
+  return true;
+}
+
+bool ESPVideoCamConfigClass::begin(i2c_master_bus_handle_t i2c_handle, uint32_t i2c_freq, int8_t reset_pin, int8_t pwdn_pin) {
+  this->port = static_cast<i2c_port_num_t>(-1);
+  this->scl_pin = GPIO_NUM_NC;
+  this->sda_pin = GPIO_NUM_NC;
+  this->i2c_freq = i2c_freq;
+  this->reset_pin = static_cast<gpio_num_t>(reset_pin);
+  this->pwdn_pin = static_cast<gpio_num_t>(pwdn_pin);
+  this->i2c_handle = i2c_handle;
+  return true;
+}
+
+bool ESPVideoCamConfigClass::needInitI2C() const {
+  return i2c_handle == nullptr;
+}
+
+bool ESPVideoCamConfigClass::acquirePins() {
+  return setPinsBus();
+}
+
+bool ESPVideoCamConfigClass::releasePins() {
+  return clearPinsBus();
+}
+
+bool ESPVideoCamConfigClass::setPinsBus() {
+  if (!clearPinsBus()) {
+    log_e("failed to clear pins bus");
+    return false;
+  }
+
+  if (reset_pin != GPIO_NUM_NC) {
+    if (!perimanSetPinBus(reset_pin, ESP32_BUS_TYPE_GPIO, (void *)this, -1, -1)) {
+      log_e("failed to set reset pin");
+      goto cleanup;
+    }
+  }
+
+  if (pwdn_pin != GPIO_NUM_NC) {
+    if (!perimanSetPinBus(pwdn_pin, ESP32_BUS_TYPE_GPIO, (void *)this, -1, -1)) {
+      log_e("failed to set pwdn pin");
+      goto cleanup;
+    }
+  }
+
+  if (needInitI2C()) {
+    if (!perimanSetPinBus(scl_pin, ESP32_BUS_TYPE_I2C_MASTER_SCL, (void *)(port + 1), port, -1)) {
+      log_e("failed to set scl pin");
+      goto cleanup;
+    }
+    if (!perimanSetPinBus(sda_pin, ESP32_BUS_TYPE_I2C_MASTER_SDA, (void *)(port + 1), port, -1)) {
+      log_e("failed to set sda pin");
+      goto cleanup;
+    }
+  }
+
+  return true;
+
+cleanup:
+  clearPinsBus();
+  return false;
+}
+
+bool ESPVideoCamConfigClass::clearPinsBus() {
+  if (reset_pin != GPIO_NUM_NC) {
+    if (!perimanClearPinBus(reset_pin)) {
+      log_e("failed to clear reset pin");
+      return false;
+    }
+  }
+
+  if (pwdn_pin != GPIO_NUM_NC) {
+    if (!perimanClearPinBus(pwdn_pin)) {
+      log_e("failed to clear pwdn pin");
+      return false;
+    }
+  }
+
+  if (needInitI2C()) {
+    if (!perimanClearPinBus(scl_pin)) {
+      log_e("failed to clear scl pin");
+      return false;
+    }
+    if (!perimanClearPinBus(sda_pin)) {
+      log_e("failed to clear sda pin");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+esp_video_init_sccb_config_t ESPVideoCamConfigClass::getSccbConfig() const {
+  esp_video_init_sccb_config_t config = {};
+
+  if (needInitI2C()) {
+    config.init_sccb = true;
+    config.i2c_config.port = static_cast<uint8_t>(port);
+    config.i2c_config.scl_pin = scl_pin;
+    config.i2c_config.sda_pin = sda_pin;
+  } else {
+    config.init_sccb = false;
+    config.i2c_handle = i2c_handle;
+  }
+  config.freq = i2c_freq;
+
+  return config;
+}
+
+#if CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+ESPVideoCSIConfigClass::ESPVideoCSIConfigClass(const ESPVideoCSIConfigClass &config) : ESPVideoCamConfigClass(config), dont_init_ldo(config.dont_init_ldo) {}
+
+bool ESPVideoCSIConfigClass::begin(const ESPVideoCamConfigClass &config, bool dont_init_ldo) {
+  ESPVideoCamConfigClass::operator=(config);
+  this->dont_init_ldo = dont_init_ldo;
+  return true;
+}
+
+esp_video_init_csi_config_t ESPVideoCSIConfigClass::getCsiInitConfig() const {
+  esp_video_init_csi_config_t config = {
+    .sccb_config = getSccbConfig(),
+    .reset_pin = getResetPin(),
+    .pwdn_pin = getPwdnPin(),
+    .dont_init_ldo = dont_init_ldo,
+  };
+
+  return config;
+}
+#endif  // CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+ESPVideoDVPPinsConfigClass::ESPVideoDVPPinsConfigClass(const ESPVideoDVPPinsConfigClass &config) : dvp_pin(config.dvp_pin) {}
+
+bool ESPVideoDVPPinsConfigClass::begin(
+  int8_t vsync_pin, int8_t de_pin, int8_t pclk_pin, int8_t xclk_pin, int8_t data0_pin, int8_t data1_pin, int8_t data2_pin, int8_t data3_pin, int8_t data4_pin,
+  int8_t data5_pin, int8_t data6_pin, int8_t data7_pin
+) {
+  dvp_pin.data_width = CAM_CTLR_DATA_WIDTH_8;
+
+  dvp_pin.vsync_io = static_cast<gpio_num_t>(vsync_pin);
+  dvp_pin.de_io = static_cast<gpio_num_t>(de_pin);
+  dvp_pin.pclk_io = static_cast<gpio_num_t>(pclk_pin);
+  dvp_pin.xclk_io = static_cast<gpio_num_t>(xclk_pin);
+
+  dvp_pin.data_io[0] = static_cast<gpio_num_t>(data0_pin);
+  dvp_pin.data_io[1] = static_cast<gpio_num_t>(data1_pin);
+  dvp_pin.data_io[2] = static_cast<gpio_num_t>(data2_pin);
+  dvp_pin.data_io[3] = static_cast<gpio_num_t>(data3_pin);
+  dvp_pin.data_io[4] = static_cast<gpio_num_t>(data4_pin);
+  dvp_pin.data_io[5] = static_cast<gpio_num_t>(data5_pin);
+  dvp_pin.data_io[6] = static_cast<gpio_num_t>(data6_pin);
+  dvp_pin.data_io[7] = static_cast<gpio_num_t>(data7_pin);
+
+  return true;
+}
+
+ESPVideoDVPPinsConfigClass &ESPVideoDVPPinsConfigClass::operator=(const ESPVideoDVPPinsConfigClass &config) {
+  if (this != &config) {
+    dvp_pin = config.dvp_pin;
+  }
+  return *this;
+}
+
+bool ESPVideoDVPPinsConfigClass::setPinsBus() {
+  if (!clearPinsBus()) {
+    log_e("failed to clear pins bus");
+    return false;
+  }
+
+  if (!perimanSetPinBus(dvp_pin.xclk_io, ESP32_BUS_TYPE_LCDCAM_CAM_XCLK, (void *)(dvp_pin.xclk_io + 1), -1, -1)) {
+    log_e("failed to set xclk pin");
+    goto cleanup;
+  }
+
+  if (!perimanSetPinBus(dvp_pin.vsync_io, ESP32_BUS_TYPE_LCDCAM_CAM_VSYNC, (void *)(dvp_pin.vsync_io + 1), -1, -1)) {
+    log_e("failed to set vsync pin");
+    goto cleanup;
+  }
+
+  if (!perimanSetPinBus(dvp_pin.de_io, ESP32_BUS_TYPE_LCDCAM_CAM_HSYNC, (void *)(dvp_pin.de_io + 1), -1, -1)) {
+    log_e("failed to set de pin");
+    goto cleanup;
+  }
+
+  if (!perimanSetPinBus(dvp_pin.pclk_io, ESP32_BUS_TYPE_LCDCAM_CAM_PCLK, (void *)(dvp_pin.pclk_io + 1), -1, -1)) {
+    log_e("failed to set pclk pin");
+    goto cleanup;
+  }
+
+  for (int i = 0; i < 8; ++i) {
+    if (!perimanSetPinBus(dvp_pin.data_io[i], (peripheral_bus_type_t)(ESP32_BUS_TYPE_LCDCAM_CAM_D0 + i), (void *)(dvp_pin.data_io[i] + 1), -1, -1)) {
+      log_e("failed to set data pin");
+      goto cleanup;
+    }
+  }
+
+  return true;
+
+cleanup:
+  clearPinsBus();
+  return false;
+}
+
+bool ESPVideoDVPPinsConfigClass::clearPinsBus() {
+  if (!perimanClearPinBus(dvp_pin.xclk_io)) {
+    log_e("failed to clear xclk pin");
+    return false;
+  }
+  if (!perimanClearPinBus(dvp_pin.vsync_io)) {
+    log_e("failed to clear vsync pin");
+    return false;
+  }
+  if (!perimanClearPinBus(dvp_pin.de_io)) {
+    log_e("failed to clear de pin");
+    return false;
+  }
+  if (!perimanClearPinBus(dvp_pin.pclk_io)) {
+    log_e("failed to clear pclk pin");
+    return false;
+  }
+  for (int i = 0; i < 8; ++i) {
+    if (!perimanClearPinBus(dvp_pin.data_io[i])) {
+      log_e("failed to clear data pin %d", i);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+ESPVideoDVPConfigClass::ESPVideoDVPConfigClass(const ESPVideoDVPConfigClass &config)
+  : ESPVideoCamConfigClass(config), ESPVideoDVPPinsConfigClass(config), xclk_freq(config.xclk_freq) {}
+
+bool ESPVideoDVPConfigClass::begin(const ESPVideoCamConfigClass &config, const ESPVideoDVPPinsConfigClass &dvp_pin, uint32_t xclk_freq) {
+  ESPVideoCamConfigClass::operator=(config);
+  ESPVideoDVPPinsConfigClass::operator=(dvp_pin);
+  this->xclk_freq = xclk_freq;
+  return true;
+}
+
+ESPVideoDVPConfigClass &ESPVideoDVPConfigClass::operator=(const ESPVideoDVPConfigClass &config) {
+  if (this != &config) {
+    ESPVideoCamConfigClass::operator=(config);
+    ESPVideoDVPPinsConfigClass::operator=(config);
+    xclk_freq = config.xclk_freq;
+  }
+  return *this;
+}
+
+esp_video_init_dvp_config_t ESPVideoDVPConfigClass::getDvpInitConfig() const {
+  esp_video_init_dvp_config_t config = {
+    .sccb_config = getSccbConfig(),
+    .reset_pin = getResetPin(),
+    .pwdn_pin = getPwdnPin(),
+    .dvp_pin = getDvpPin(),
+    .xclk_freq = xclk_freq,
+  };
+
+  return config;
+}
+
+bool ESPVideoDVPConfigClass::acquirePins() {
+  return setPinsBus();
+}
+
+bool ESPVideoDVPConfigClass::releasePins() {
+  return clearPinsBus();
+}
+
+bool ESPVideoDVPConfigClass::setPinsBus() {
+  if (!ESPVideoCamConfigClass::setPinsBus()) {
+    log_e("failed to set camera pins bus");
+    return false;
+  }
+
+  if (!ESPVideoDVPPinsConfigClass::setPinsBus()) {
+    log_e("failed to set pins bus");
+    ESPVideoCamConfigClass::clearPinsBus();
+    return false;
+  }
+
+  return true;
+}
+
+bool ESPVideoDVPConfigClass::clearPinsBus() {
+  bool ok = ESPVideoDVPPinsConfigClass::clearPinsBus();
+  if (!ESPVideoCamConfigClass::clearPinsBus()) {
+    log_e("failed to clear camera pins bus");
+    ok = false;
+  }
+
+  return ok;
+}
+#endif  // CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+
+ESPVideoBufferClass::ESPVideoBufferClass(
+  int fd, uint8_t *ptr, size_t n, int index, uint32_t type, uint32_t memory, const ESPVideoSolutionClass &solution, const ESPVideoFormatClass &format
+)
+  : ESPVideoSolutionClass(solution), ESPVideoFormatClass(format), buf_fd(fd), buf_ptr(ptr), buf_size(n), buf_index(index), buf_type(type), memory_type(memory) {
+}
+
+ESPVideoBufferClass::ESPVideoBufferClass(ESPVideoBufferClass &&other) noexcept
+  : ESPVideoSolutionClass(other), ESPVideoFormatClass(other), buf_fd(other.buf_fd), buf_ptr(other.buf_ptr), buf_size(other.buf_size),
+    buf_index(other.buf_index), buf_type(other.buf_type), memory_type(other.memory_type) {
+  other.buf_fd = -1;
+  other.buf_ptr = nullptr;
+  other.buf_size = 0;
+  other.buf_index = -1;
+}
+
+ESPVideoBufferClass &ESPVideoBufferClass::operator=(ESPVideoBufferClass &&other) noexcept {
+  if (this != &other) {
+    end();
+
+    ESPVideoSolutionClass::operator=(other);
+    ESPVideoFormatClass::operator=(other);
+
+    buf_fd = other.buf_fd;
+    buf_ptr = other.buf_ptr;
+    buf_size = other.buf_size;
+    buf_index = other.buf_index;
+    buf_type = other.buf_type;
+    memory_type = other.memory_type;
+
+    other.buf_fd = -1;
+    other.buf_ptr = nullptr;
+    other.buf_size = 0;
+    other.buf_index = -1;
+  }
+  return *this;
+}
+
+ESPVideoBufferClass::~ESPVideoBufferClass() {
+  end();
+}
+
+void ESPVideoBufferClass::end() {
+  reclaim();
+}
+
+bool ESPVideoBufferClass::valid() const {
+  return buf_ptr != nullptr && buf_size > 0;
+}
+
+uint8_t *ESPVideoBufferClass::data() const {
+  return buf_ptr;
+}
+
+size_t ESPVideoBufferClass::size() const {
+  return buf_size;
+}
+
+int ESPVideoBufferClass::index() const {
+  return buf_index;
+}
+
+const char *ESPVideoBufferClass::formatName() const {
+  return getFormatName();
+}
+
+esp_video_format_t ESPVideoBufferClass::formatType() const {
+  return getFormat();
+}
+
+void ESPVideoBufferClass::reclaim() {
+  if (buf_fd >= 0 && buf_index >= 0) {
+    struct v4l2_buffer buf = {};
+
+    buf.type = buf_type;
+    buf.memory = memory_type;
+    buf.index = buf_index;
+    if (ioctl(buf_fd, VIDIOC_QBUF, &buf) != 0) {
+      log_e("failed to queue video frame");
+    }
+
+    buf_fd = -1;
+    buf_index = -1;
+  }
+}
+
+ESPVideoCaptureDevClass::~ESPVideoCaptureDevClass() {
+  end();
+}
+
+bool ESPVideoCaptureDevClass::begin(const char *path, size_t buf_count) {
+  if (isOpened()) {
+    return true;
+  }
+
+  if (!open(path)) {
+    return false;
+  }
+
+  if (!requestBuffer(buf_count)) {
+    end();
+    return false;
+  }
+
+  buf_count_ = buf_count;
+
+  return true;
+}
+
+void ESPVideoCaptureDevClass::end() {
+  stopCapture();
+  releaseBuffers();
+
+  if (fd >= 0) {
+    close(fd);
+    fd = -1;
+  }
+}
+
+bool ESPVideoCaptureDevClass::open(const char *path) {
+  if (fd >= 0) {
+    return true;
+  }
+
+  fd = ::open(path, O_RDWR);
+  if (fd < 0) {
+    log_e("failed to open %s", path);
+    return false;
+  }
+
+  if (!applyFormat()) {
+    close(fd);
+    fd = -1;
+    return false;
+  }
+
+  return true;
+}
+
+bool ESPVideoCaptureDevClass::applyFormat() {
+  if (fd < 0) {
+    return false;
+  }
+
+  struct v4l2_format format = {};
+  format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  if (ioctl(fd, VIDIOC_G_FMT, &format) != 0) {
+    log_e("failed to get format");
+    return false;
+  }
+
+  esp_video_format_t format_type = ESP_VIDEO_FORMAT_UNKNOWN;
+  std::string format_name;
+
+  if (!v4l2_format_to_video_format(format.fmt.pix.pixelformat, format_type, format_name)) {
+    ESPVideoFormatClass::begin(ESP_VIDEO_FORMAT_UNKNOWN, "UNKNOWN");
+  } else {
+    ESPVideoFormatClass::begin(format_type, format_name);
+  }
+
+  if (ioctl(fd, VIDIOC_S_FMT, &format) != 0) {
+    log_e("failed to set format");
+    return false;
+  }
+
+  ESPVideoSolutionClass::begin(format.fmt.pix.width, format.fmt.pix.height);
+
+  return true;
+}
+
+void ESPVideoCaptureDevClass::releaseBuffers() {
+  for (size_t i = 0; i < buf_ptr_.size(); ++i) {
+    if (buf_ptr_[i] != nullptr && buf_ptr_[i] != MAP_FAILED) {
+      munmap(buf_ptr_[i], buf_len_[i]);
+    }
+  }
+  buf_ptr_.clear();
+  buf_len_.clear();
+
+  if (fd >= 0) {
+    struct v4l2_requestbuffers req = {};
+    req.count = 0;
+    req.type = buffer_type_;
+    req.memory = memory_type_;
+    ioctl(fd, VIDIOC_REQBUFS, &req);
+  }
+}
+
+bool ESPVideoCaptureDevClass::requestBuffer(size_t buf_count) {
+  if (fd < 0) {
+    return false;
+  }
+
+  releaseBuffers();
+
+  struct v4l2_requestbuffers req = {};
+  memory_type_ = V4L2_MEMORY_MMAP;
+  req.count = buf_count;
+  req.type = buffer_type_;
+  req.memory = memory_type_;
+  if (ioctl(fd, VIDIOC_REQBUFS, &req) != 0) {
+    log_e("failed to require buffer");
+    return false;
+  }
+
+  buf_ptr_.reserve(buf_count);
+  buf_len_.reserve(buf_count);
+
+  for (size_t i = 0; i < buf_count; ++i) {
+    struct v4l2_buffer buf = {};
+    buf.type = buffer_type_;
+    buf.memory = memory_type_;
+    buf.index = static_cast<uint32_t>(i);
+    if (ioctl(fd, VIDIOC_QUERYBUF, &buf) != 0) {
+      log_e("failed to query buffer");
+      releaseBuffers();
+      return false;
+    }
+
+    uint8_t *ptr = static_cast<uint8_t *>(mmap(nullptr, buf.length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, buf.m.offset));
+    if (ptr == MAP_FAILED) {
+      log_e("failed to map buffer");
+      releaseBuffers();
+      return false;
+    }
+
+    buf_ptr_.push_back(ptr);
+    buf_len_.push_back(buf.length);
+  }
+
+  return true;
+}
+
+bool ESPVideoCaptureDevClass::startCapture() {
+  if (!isOpened()) {
+    return false;
+  }
+
+  if (buf_ptr_.empty()) {
+    log_e("no buffer is setup");
+    return false;
+  }
+
+  for (size_t i = 0; i < buf_ptr_.size(); ++i) {
+    struct v4l2_buffer buf = {};
+    buf.type = buffer_type_;
+    buf.memory = memory_type_;
+    buf.index = static_cast<uint32_t>(i);
+    if (ioctl(fd, VIDIOC_QBUF, &buf) != 0) {
+      log_e("failed to queue video frame");
+      return false;
+    }
+  }
+
+  int type = buffer_type_;
+  if (ioctl(fd, VIDIOC_STREAMON, &type) != 0) {
+    log_e("failed to start stream");
+    return false;
+  }
+
+  capture_started_ = true;
+  return true;
+}
+
+void ESPVideoCaptureDevClass::stopCapture() {
+  if (!capture_started_ || fd < 0) {
+    return;
+  }
+
+  int type = buffer_type_;
+  if (ioctl(fd, VIDIOC_STREAMOFF, &type) != 0) {
+    log_e("failed to stop stream");
+  }
+  capture_started_ = false;
+}
+
+ESPVideoBufferClass ESPVideoCaptureDevClass::captureBuffer() {
+  if (!capture_started_ || fd < 0) {
+    return ESPVideoBufferClass();
+  }
+
+  struct v4l2_buffer buf = {};
+  buf.type = buffer_type_;
+  buf.memory = memory_type_;
+  if (ioctl(fd, VIDIOC_DQBUF, &buf) != 0) {
+    log_e("failed to receive video frame");
+    return ESPVideoBufferClass();
+  }
+
+  if (buf.index >= buf_ptr_.size()) {
+    log_e("invalid buffer index %u", buf.index);
+    return ESPVideoBufferClass();
+  }
+
+  return ESPVideoBufferClass(fd, buf_ptr_[buf.index], buf.bytesused, static_cast<int>(buf.index), buffer_type_, memory_type_, *this, *this);
+}
+
+bool ESPVideoCaptureDevClass::isOpened() const {
+  return fd >= 0;
+}
+
+bool ESPVideoCaptureDevClass::isCaptureStarted() const {
+  return capture_started_;
+}
+
+bool ESPVideoCaptureDevClass::setFormat(esp_video_format_t format) {
+  if (fd < 0) {
+    return false;
+  }
+
+  uint32_t video_format = 0;
+  std::string format_name;
+
+  if (!video_format_to_v4l2_format(format, video_format, format_name)) {
+    return false;
+  }
+
+  struct v4l2_format v4l2_format = {};
+  v4l2_format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  if (ioctl(fd, VIDIOC_G_FMT, &v4l2_format) != 0) {
+    log_e("failed to get format");
+    return false;
+  }
+
+  if (v4l2_format.fmt.pix.pixelformat != video_format) {
+    v4l2_format.fmt.pix.pixelformat = video_format;
+    if (ioctl(fd, VIDIOC_S_FMT, &v4l2_format) != 0) {
+      log_e("failed to set format");
+      return false;
+    }
+
+    if (buf_count_ > 0) {
+      if (!requestBuffer(buf_count_)) {
+        log_e("failed to request buffer");
+        releaseBuffers();
+        return false;
+      }
+    }
+  }
+
+  ESPVideoFormatClass::begin(format, format_name);
+
+  return true;
+}
+
+bool ESPVideoCaptureDevClass::setSensorGain(int32_t gain) {
+  return setExtCtrlValue(V4L2_CID_GAIN, gain);
+}
+
+bool ESPVideoCaptureDevClass::setSensorExposure(int32_t exposure) {
+  return setExtCtrlValue(V4L2_CID_EXPOSURE, exposure);
+}
+
+bool ESPVideoCaptureDevClass::setSensorExposureTime(int32_t exposure_time) {
+  return setExtCtrlValue(V4L2_CID_EXPOSURE_ABSOLUTE, exposure_time);
+}
+
+bool ESPVideoCaptureDevClass::setSensorAETargetLevel(int32_t target_level) {
+  return setExtCtrlValue(V4L2_CID_CAMERA_AE_LEVEL, target_level);
+}
+
+bool ESPVideoCaptureDevClass::setSensorJPEGQuality(int32_t quality) {
+  return setExtCtrlValue(V4L2_CID_JPEG_COMPRESSION_QUALITY, quality);
+}
+
+bool ESPVideoCaptureDevClass::setSensorVFlip(bool vflip) {
+  return setExtCtrlValue(V4L2_CID_VFLIP, vflip);
+}
+
+bool ESPVideoCaptureDevClass::setSensorHFlip(bool hflip) {
+  return setExtCtrlValue(V4L2_CID_HFLIP, hflip);
+}
+
+bool ESPVideoCaptureDevClass::setSensorTestPattern(bool test_pattern) {
+  return setExtCtrlValue(V4L2_CID_TEST_PATTERN, test_pattern);
+}
+
+bool ESPVideoCaptureDevClass::setExtCtrlValue(uint32_t id, int32_t value) {
+  if (fd < 0) {
+    return false;
+  }
+
+  struct v4l2_ext_control control = {};
+  struct v4l2_ext_controls controls = {};
+
+  controls.count = 1;
+  controls.controls = &control;
+  control.id = id;
+  control.value = value;
+
+  return ioctl(fd, VIDIOC_S_EXT_CTRLS, &controls) == 0;
+}
+
+ESPVideoClass::~ESPVideoClass() {
+  end();
+}
+
+void ESPVideoClass::end() {
+  if (flags_ != 0) {
+#if CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+    if (flags_ & ESP_VIDEO_INIT_FLAGS_MIPI_CSI && csi_config_) {
+      csi_config_->releasePins();
+    }
+#endif
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+    if (flags_ & ESP_VIDEO_INIT_FLAGS_DVP && dvp_config_) {
+      dvp_config_->releasePins();
+    }
+#endif
+
+    esp_video_deinit_with_flags(flags_);
+    flags_ = 0;
+  }
+
+#if CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+  csi_config_.reset();
+#endif
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+  dvp_config_.reset();
+#endif
+}
+
+#if CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+bool ESPVideoClass::begin(const ESPVideoCSIConfigClass &config) {
+  constexpr uint32_t target_flags = ESP_VIDEO_INIT_FLAGS_MIPI_CSI | ESP_VIDEO_INIT_FLAGS_ISP;
+  if ((flags_ & target_flags) == target_flags) {
+    return true;
+  }
+
+  esp_video_init_csi_config_t csi_config = config.getCsiInitConfig();
+  esp_video_init_config_t cam_config = {};
+  cam_config.csi = &csi_config;
+
+  csi_config_ = std::make_unique<ESPVideoCSIConfigClass>(config);
+  if (!csi_config_->acquirePins()) {
+    log_e("failed to acquire pins");
+    csi_config_->releasePins();
+    csi_config_.reset();
+    return false;
+  }
+
+  if (esp_video_init_with_flags(&cam_config, target_flags) != ESP_OK) {
+    log_e("failed to init CSI");
+    csi_config_->releasePins();
+    csi_config_.reset();
+    return false;
+  }
+
+  flags_ |= target_flags;
+  return true;
+}
+
+bool ESPVideoClass::isCSIInitialized() const {
+  constexpr uint32_t target_flags = ESP_VIDEO_INIT_FLAGS_MIPI_CSI | ESP_VIDEO_INIT_FLAGS_ISP;
+  return (flags_ & target_flags) == target_flags;
+}
+#endif  // CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+bool ESPVideoClass::begin(const ESPVideoDVPConfigClass &config) {
+  constexpr uint32_t target_flags = ESP_VIDEO_INIT_FLAGS_DVP;
+  if ((flags_ & target_flags) == target_flags) {
+    return true;
+  }
+
+  esp_video_init_dvp_config_t dvp_config = config.getDvpInitConfig();
+  esp_video_init_config_t cam_config = {};
+  cam_config.dvp = &dvp_config;
+
+  dvp_config_ = std::make_unique<ESPVideoDVPConfigClass>(config);
+  if (!dvp_config_->acquirePins()) {
+    log_e("failed to acquire pins");
+    dvp_config_->releasePins();
+    dvp_config_.reset();
+    return false;
+  }
+
+  if (esp_video_init_with_flags(&cam_config, target_flags) != ESP_OK) {
+    log_e("failed to init DVP");
+    dvp_config_->releasePins();
+    dvp_config_.reset();
+    return false;
+  }
+
+  flags_ |= target_flags;
+  return true;
+}
+
+bool ESPVideoClass::isDVPInitialized() const {
+  constexpr uint32_t target_flags = ESP_VIDEO_INIT_FLAGS_DVP;
+  return (flags_ & target_flags) == target_flags;
+}
+#endif  // CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+
+#endif  // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#endif  // CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE || CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE

--- a/libraries/ESP_Video/src/ESP_Video.h
+++ b/libraries/ESP_Video/src/ESP_Video.h
@@ -11,14 +11,11 @@
 #include "esp_idf_version.h"
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
 #include "Arduino.h"
-#include <array>
-#include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <string>
-#include <vector>
 #include "linux/videodev2.h"
 #include "esp_video_init.h"
+#include "esp_video_device.h"
 
 typedef enum {
   ESP_VIDEO_FORMAT_UNKNOWN = 0,

--- a/libraries/ESP_Video/src/ESP_Video.h
+++ b/libraries/ESP_Video/src/ESP_Video.h
@@ -1,0 +1,307 @@
+/*
+* SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+*
+* SPDX-License-Identifier: ESPRESSIF MIT
+*/
+
+#pragma once
+
+#include "sdkconfig.h"
+#if (CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE || CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE)
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#include "Arduino.h"
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include "linux/videodev2.h"
+#include "esp_video_init.h"
+
+typedef enum {
+  ESP_VIDEO_FORMAT_UNKNOWN = 0,
+  ESP_VIDEO_FORMAT_RAW8,
+  ESP_VIDEO_FORMAT_RAW10,
+  ESP_VIDEO_FORMAT_RAW12,
+  ESP_VIDEO_FORMAT_RGB565,
+  ESP_VIDEO_FORMAT_RGB888,
+  ESP_VIDEO_FORMAT_YUV420,
+  ESP_VIDEO_FORMAT_YUV422_YUYV,
+  ESP_VIDEO_FORMAT_YUV422_UYVY,
+  ESP_VIDEO_FORMAT_GRAY8,
+  ESP_VIDEO_FORMAT_JPEG,
+  ESP_VIDEO_FORMAT_MAX
+} esp_video_format_t;
+
+class ESPVideoSolutionClass {
+public:
+  ESPVideoSolutionClass() = default;
+  ESPVideoSolutionClass(const ESPVideoSolutionClass &config) = default;
+  ~ESPVideoSolutionClass() = default;
+  ESPVideoSolutionClass &operator=(const ESPVideoSolutionClass &config);
+
+  void begin(uint32_t width, uint32_t height);
+
+  uint32_t getWidth() const;
+  uint32_t getHeight() const;
+
+private:
+  uint32_t width_ = 0;
+  uint32_t height_ = 0;
+};
+
+class ESPVideoFormatClass {
+public:
+  ESPVideoFormatClass() = default;
+  ESPVideoFormatClass(const ESPVideoFormatClass &config) = default;
+  ~ESPVideoFormatClass() = default;
+  ESPVideoFormatClass &operator=(const ESPVideoFormatClass &config);
+
+  void begin(esp_video_format_t format_type, const std::string &format_name = "");
+
+  esp_video_format_t getFormat() const;
+  const char *getFormatName() const;
+
+private:
+  esp_video_format_t format_type_ = ESP_VIDEO_FORMAT_UNKNOWN;
+  mutable std::string format_name_;
+};
+
+class ESPVideoCamConfigClass {
+public:
+  ESPVideoCamConfigClass() = default;
+  ESPVideoCamConfigClass(const ESPVideoCamConfigClass &config);
+
+  ESPVideoCamConfigClass &operator=(const ESPVideoCamConfigClass &config);
+
+  virtual ~ESPVideoCamConfigClass() = default;
+
+  bool begin(i2c_port_num_t port, int8_t scl_pin, int8_t sda_pin, uint32_t i2c_freq = i2c_freq_hz, int8_t reset_pin = -1, int8_t pwdn_pin = -1);
+  bool begin(i2c_master_bus_handle_t i2c_handle, uint32_t i2c_freq = i2c_freq_hz, int8_t reset_pin = -1, int8_t pwdn_pin = -1);
+
+  esp_video_init_sccb_config_t getSccbConfig() const;
+
+  gpio_num_t getResetPin() const {
+    return reset_pin;
+  }
+  gpio_num_t getPwdnPin() const {
+    return pwdn_pin;
+  }
+
+  bool acquirePins();
+  bool releasePins();
+
+protected:
+  virtual bool setPinsBus();
+  virtual bool clearPinsBus();
+
+private:
+  bool needInitI2C() const;
+
+  i2c_port_num_t port = static_cast<i2c_port_num_t>(-1);
+  gpio_num_t scl_pin = GPIO_NUM_NC;
+  gpio_num_t sda_pin = GPIO_NUM_NC;
+
+  uint32_t i2c_freq = i2c_freq_hz;
+
+  gpio_num_t reset_pin = GPIO_NUM_NC;
+  gpio_num_t pwdn_pin = GPIO_NUM_NC;
+
+  i2c_master_bus_handle_t i2c_handle = nullptr;
+  static const uint32_t i2c_freq_hz;
+};
+
+#if CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+class ESPVideoCSIConfigClass : public ESPVideoCamConfigClass {
+public:
+  ESPVideoCSIConfigClass() = default;
+  ESPVideoCSIConfigClass(const ESPVideoCSIConfigClass &config);
+
+  bool begin(const ESPVideoCamConfigClass &config, bool dont_init_ldo = false);
+
+  bool getDontInitLdo() const {
+    return dont_init_ldo;
+  }
+
+  esp_video_init_csi_config_t getCsiInitConfig() const;
+
+private:
+  bool dont_init_ldo = false;
+};
+#endif  // CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+class ESPVideoDVPPinsConfigClass {
+public:
+  ESPVideoDVPPinsConfigClass() = default;
+  ESPVideoDVPPinsConfigClass(const ESPVideoDVPPinsConfigClass &config);
+
+  ESPVideoDVPPinsConfigClass &operator=(const ESPVideoDVPPinsConfigClass &config);
+
+  bool begin(
+    int8_t vsync_pin, int8_t de_pin, int8_t pclk_pin, int8_t xclk_pin, int8_t data0_pin, int8_t data1_pin, int8_t data2_pin, int8_t data3_pin, int8_t data4_pin,
+    int8_t data5_pin, int8_t data6_pin, int8_t data7_pin
+  );
+
+  const esp_cam_ctlr_dvp_pin_config_t &getDvpPin() const {
+    return dvp_pin;
+  }
+
+protected:
+  bool setPinsBus();
+  bool clearPinsBus();
+
+private:
+  esp_cam_ctlr_dvp_pin_config_t dvp_pin = {};
+};
+#endif  // CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+class ESPVideoDVPConfigClass : public ESPVideoCamConfigClass, public ESPVideoDVPPinsConfigClass {
+public:
+  ESPVideoDVPConfigClass() = default;
+  ESPVideoDVPConfigClass(const ESPVideoDVPConfigClass &config);
+
+  ESPVideoDVPConfigClass &operator=(const ESPVideoDVPConfigClass &config);
+
+  bool begin(const ESPVideoCamConfigClass &config, const ESPVideoDVPPinsConfigClass &dvp_pin, uint32_t xclk_freq);
+
+  uint32_t getXclkFreq() const {
+    return xclk_freq;
+  }
+
+  esp_video_init_dvp_config_t getDvpInitConfig() const;
+
+  bool acquirePins();
+  bool releasePins();
+
+private:
+  bool setPinsBus() override;
+  bool clearPinsBus() override;
+
+  uint32_t xclk_freq = 0;
+};
+#endif  // CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+
+class ESPVideoBufferClass : public ESPVideoSolutionClass, public ESPVideoFormatClass {
+public:
+  ESPVideoBufferClass() = default;
+
+  ESPVideoBufferClass(ESPVideoBufferClass &&other) noexcept;
+
+  ESPVideoBufferClass(const ESPVideoBufferClass &) = delete;
+  ESPVideoBufferClass &operator=(const ESPVideoBufferClass &) = delete;
+
+  ESPVideoBufferClass &operator=(ESPVideoBufferClass &&other) noexcept;
+
+  ~ESPVideoBufferClass();
+
+  void end();
+
+  bool valid() const;
+  uint8_t *data() const;
+  size_t size() const;
+  int index() const;
+  const char *formatName() const;
+  esp_video_format_t formatType() const;
+
+private:
+  friend class ESPVideoCaptureDevClass;
+
+  ESPVideoBufferClass(
+    int fd, uint8_t *ptr, size_t n, int index, uint32_t type, uint32_t memory, const ESPVideoSolutionClass &solution, const ESPVideoFormatClass &format
+  );
+
+  void reclaim();
+
+  int buf_fd = -1;
+  uint8_t *buf_ptr = nullptr;
+  size_t buf_size = 0;
+  int buf_index = -1;
+  uint32_t buf_type = 0;
+  uint32_t memory_type = 0;
+};
+
+class ESPVideoCaptureDevClass : public ESPVideoSolutionClass, public ESPVideoFormatClass {
+public:
+  ESPVideoCaptureDevClass() = default;
+
+  ESPVideoCaptureDevClass(const ESPVideoCaptureDevClass &) = delete;
+  ESPVideoCaptureDevClass &operator=(const ESPVideoCaptureDevClass &) = delete;
+  ESPVideoCaptureDevClass(ESPVideoCaptureDevClass &&) = delete;
+  ESPVideoCaptureDevClass &operator=(ESPVideoCaptureDevClass &&) = delete;
+
+  ~ESPVideoCaptureDevClass();
+
+  bool begin(const char *path, size_t buf_count = 2);
+  void end();
+
+  bool requestBuffer(size_t buf_count);
+  bool startCapture();
+  void stopCapture();
+  ESPVideoBufferClass captureBuffer();
+
+  bool isOpened() const;
+  bool isCaptureStarted() const;
+
+  bool setFormat(esp_video_format_t format);
+
+  bool setSensorGain(int32_t gain);
+  bool setSensorExposure(int32_t exposure);
+  bool setSensorExposureTime(int32_t exposure_time);
+  bool setSensorAETargetLevel(int32_t target_level);
+  bool setSensorJPEGQuality(int32_t quality);
+  bool setSensorVFlip(bool vflip);
+  bool setSensorHFlip(bool hflip);
+  bool setSensorTestPattern(bool test_pattern);
+
+private:
+  bool open(const char *path);
+  bool applyFormat();
+  void releaseBuffers();
+  bool setExtCtrlValue(uint32_t id, int32_t value);
+
+  int fd = -1;
+  bool capture_started_ = false;
+  std::vector<uint8_t *> buf_ptr_;
+  std::vector<size_t> buf_len_;
+  const int buffer_type_ = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  int memory_type_ = V4L2_MEMORY_MMAP;
+  uint32_t buf_count_ = 0;
+};
+
+class ESPVideoClass {
+public:
+  ESPVideoClass() = default;
+
+  ~ESPVideoClass();
+
+  ESPVideoClass(const ESPVideoClass &) = delete;
+  ESPVideoClass &operator=(const ESPVideoClass &) = delete;
+
+  void end();
+
+#if CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+  bool begin(const ESPVideoCSIConfigClass &config);
+  bool isCSIInitialized() const;
+#endif  // CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+  bool begin(const ESPVideoDVPConfigClass &config);
+  bool isDVPInitialized() const;
+#endif  // CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+
+private:
+  uint32_t flags_ = 0;
+#if CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+  std::unique_ptr<ESPVideoCSIConfigClass> csi_config_;
+#endif  // CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE
+#if CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+  std::unique_ptr<ESPVideoDVPConfigClass> dvp_config_;
+#endif  // CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE
+};
+
+#endif  // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+#endif  // CONFIG_ESP_VIDEO_ENABLE_MIPI_CSI_VIDEO_DEVICE || CONFIG_ESP_VIDEO_ENABLE_DVP_VIDEO_DEVICE

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-73550728-v6"
+              "version": "idf-release_v5.5-73550728-v7"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-73550728-v6",
+          "version": "idf-release_v5.5-73550728-v7",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v6.zip",
-              "checksum": "SHA-256:6d923bbf17f16d094adc6b503697bf90cce306856350ee815e087d5582f7d37a",
-              "size": "525997017"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v7.zip",
+              "checksum": "SHA-256:8def3e946b474ed052e602437b59e8c0437200e56940bef8fbd09d04425aa9fa",
+              "size": "542247975"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 8fde0eb
esp-idf: v5.5.4 735507283d
arduino: master 4aedf819a
tinyusb: master dffc57135
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cjson: 1.7.19~2
espressif__cmake_utilities: 0.5.3
espressif__dl_fft: 0.4.0
espressif__eppp_link: 1.1.5
espressif__esp-dsp: 1.8.0
espressif__esp-modbus: 2.1.2
espressif__esp-nn: 1.2.3
espressif__esp-sr: 2.4.6
espressif__esp-tflite-micro: 1.3.7
espressif__esp_cam_sensor: 2.2.0
espressif__esp_h264: 1.3.0
espressif__esp_hosted: 2.12.9
espressif__esp_ipa: 2.1.0
espressif__esp_modem: 2.0.1
espressif__esp_sccb_intf: 0.0.8
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_video: 2.2.0
espressif__esp_wifi_remote: 1.6.1
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__libsodium: 1.0.22
espressif__mdns: 1.11.1
espressif__network_provisioning: 1.0.2
espressif__usb_host_uvc: 2.5.1
espressif__wifi_remote_over_eppp: 0.3.2
joltwallet__littlefs: 1.22.1
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.8.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.2.2
espressif__esp_matter: 1.4.1
espressif__esp_rainmaker: 1.5.2
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.9.2
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
```
