### PR TITLE
IDF release/v6.1

### DIFF
--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -179,6 +179,7 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
             esp32h2_opts=$(echo "$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32p4_opts=$(echo "PSRAM=enabled,USBMode=default,ChipVariant=postv3,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
             esp32c5_opts=$(echo "PSRAM=enabled,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
+            esp32s31_opts=$(echo "USBMode=default,$debug_level,$fqbn_append" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g')
 
             # Select the common part of the FQBN based on the target.  The rest will be
             # appended depending on the passed options.
@@ -217,6 +218,10 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
                 "esp32c5")
                     [ -n "${options:-$esp32c5_opts}" ] && opt=":${options:-$esp32c5_opts}"
                     fqbn="espressif:esp32:esp32c5$opt"
+                ;;
+                "esp32s31")
+                    [ -n "${options:-$esp32s31_opts}" ] && opt=":${options:-$esp32s31_opts}"
+                    fqbn="espressif:esp32:esp32s31$opt"
                 ;;
                 *)
                     echo "ERROR: Invalid chip: $target"

--- a/.github/scripts/socs_config.sh
+++ b/.github/scripts/socs_config.sh
@@ -13,6 +13,7 @@
 
 # All supported SoCs
 ALL_SOCS=(
+    "esp32s31"
     "esp32"
     "esp32c2"
     "esp32c3"
@@ -27,6 +28,7 @@ ALL_SOCS=(
 
 # All supported SoC variants by the ESP32 Arduino core
 CORE_VARIANTS=(
+    "esp32s31"
     "esp32"
     "esp32c3"
     "esp32c5"
@@ -144,6 +146,7 @@ IDF_V6_0_TARGETS=(
 
 # IDF v6.1 supported targets
 IDF_V6_1_TARGETS=(
+    "esp32s31"
     "esp32"
     "esp32c2"
     "esp32c3"

--- a/boards.txt
+++ b/boards.txt
@@ -49,6 +49,209 @@ esp32_family.build.board=ESP32_FAMILY
 
 ##############################################################
 
+esp32s31.name=ESP32S31 Dev Module
+
+esp32s31.bootloader.tool=esptool_py
+esp32s31.bootloader.tool.default=esptool_py
+
+esp32s31.upload.tool=esptool_py
+esp32s31.upload.tool.default=esptool_py
+esp32s31.upload.tool.network=esp_ota
+
+esp32s31.upload.maximum_size=1310720
+esp32s31.upload.maximum_data_size=327680
+esp32s31.upload.flags=
+esp32s31.upload.extra_flags=
+esp32s31.upload.use_1200bps_touch=false
+esp32s31.upload.wait_for_upload_port=false
+
+esp32s31.serial.disableDTR=false
+esp32s31.serial.disableRTS=false
+
+esp32s31.build.tarch=riscv32
+esp32s31.build.bootloader_addr=0x2000
+esp32s31.build.target=esp
+esp32s31.build.mcu=esp32s31
+esp32s31.build.core=esp32
+esp32s31.build.variant=esp32s31
+esp32s31.build.board=ESP32S31_DEV
+
+esp32s31.build.usb_mode=1
+esp32s31.build.cdc_on_boot=0
+esp32s31.build.msc_on_boot=0
+esp32s31.build.dfu_on_boot=0
+esp32s31.build.f_cpu=320000000L
+esp32s31.build.flash_size=4MB
+esp32s31.build.flash_freq=80m
+esp32s31.build.flash_mode=dio
+esp32s31.build.boot=qio
+esp32s31.build.boot_freq=80m
+esp32s31.build.partitions=default
+esp32s31.build.defines=-DBOARD_HAS_PSRAM
+esp32s31.build.loop_core=-DARDUINO_RUNNING_CORE=1
+esp32s31.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+esp32s31.build.psram_type=opi
+esp32s31.build.memory_type={build.boot}_{build.psram_type}
+
+## IDE 2.0 Seems to not update the value
+esp32s31.menu.JTAGAdapter.default=Disabled
+esp32s31.menu.JTAGAdapter.default.build.copy_jtag_files=0
+esp32s31.menu.JTAGAdapter.builtin=Integrated USB JTAG
+esp32s31.menu.JTAGAdapter.builtin.build.openocdscript=esp32s31-builtin.cfg
+esp32s31.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+esp32s31.menu.JTAGAdapter.external=FTDI Adapter
+esp32s31.menu.JTAGAdapter.external.build.openocdscript=esp32s31-ftdi.cfg
+esp32s31.menu.JTAGAdapter.external.build.copy_jtag_files=1
+esp32s31.menu.JTAGAdapter.bridge=ESP USB Bridge
+esp32s31.menu.JTAGAdapter.bridge.build.openocdscript=esp32s31-bridge.cfg
+esp32s31.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+esp32s31.menu.FlashSize.4M=4MB (32Mb)
+esp32s31.menu.FlashSize.4M.build.flash_size=4MB
+esp32s31.menu.FlashSize.8M=8MB (64Mb)
+esp32s31.menu.FlashSize.8M.build.flash_size=8MB
+esp32s31.menu.FlashSize.16M=16MB (128Mb)
+esp32s31.menu.FlashSize.16M.build.flash_size=16MB
+esp32s31.menu.FlashSize.32M=32MB (256Mb)
+esp32s31.menu.FlashSize.32M.build.flash_size=32MB
+
+esp32s31.menu.USBMode.hwcdc=Hardware CDC and JTAG
+esp32s31.menu.USBMode.hwcdc.build.usb_mode=1
+esp32s31.menu.USBMode.default=USB-OTG (TinyUSB)
+esp32s31.menu.USBMode.default.build.usb_mode=0
+
+esp32s31.menu.CDCOnBoot.default=Disabled
+esp32s31.menu.CDCOnBoot.default.build.cdc_on_boot=0
+esp32s31.menu.CDCOnBoot.cdc=Enabled
+esp32s31.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+
+esp32s31.menu.MSCOnBoot.default=Disabled
+esp32s31.menu.MSCOnBoot.default.build.msc_on_boot=0
+esp32s31.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+esp32s31.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+esp32s31.menu.DFUOnBoot.default=Disabled
+esp32s31.menu.DFUOnBoot.default.build.dfu_on_boot=0
+esp32s31.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+esp32s31.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+esp32s31.menu.UploadMode.default=UART0 / Hardware CDC
+esp32s31.menu.UploadMode.default.upload.use_1200bps_touch=false
+esp32s31.menu.UploadMode.default.upload.wait_for_upload_port=false
+esp32s31.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+esp32s31.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+esp32s31.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+esp32s31.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+esp32s31.menu.PartitionScheme.default.build.partitions=default
+esp32s31.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+esp32s31.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+esp32s31.menu.PartitionScheme.default_8MB=8M with spiffs (3MB APP/1.5MB SPIFFS)
+esp32s31.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+esp32s31.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+esp32s31.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+esp32s31.menu.PartitionScheme.minimal.build.partitions=minimal
+esp32s31.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
+esp32s31.menu.PartitionScheme.no_fs.build.partitions=no_fs
+esp32s31.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
+esp32s31.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+esp32s31.menu.PartitionScheme.no_ota.build.partitions=no_ota
+esp32s31.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+esp32s31.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+esp32s31.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+esp32s31.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+esp32s31.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+esp32s31.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+esp32s31.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+esp32s31.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+esp32s31.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+esp32s31.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+esp32s31.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+esp32s31.menu.PartitionScheme.huge_app.build.partitions=huge_app
+esp32s31.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+esp32s31.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
+esp32s31.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+esp32s31.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+esp32s31.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+esp32s31.menu.PartitionScheme.fatflash.build.partitions=ffat
+esp32s31.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+esp32s31.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+esp32s31.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+esp32s31.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+esp32s31.menu.PartitionScheme.rainmaker=RainMaker 4MB
+esp32s31.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+esp32s31.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+esp32s31.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+esp32s31.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+esp32s31.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+esp32s31.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+esp32s31.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+esp32s31.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+esp32s31.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
+esp32s31.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
+esp32s31.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
+esp32s31.menu.PartitionScheme.app5M_little24M_32MB=32M Flash (4.8MB APP/22MB LittleFS)
+esp32s31.menu.PartitionScheme.app5M_little24M_32MB.build.partitions=large_littlefs_32MB
+esp32s31.menu.PartitionScheme.app5M_little24M_32MB.upload.maximum_size=4718592
+esp32s31.menu.PartitionScheme.app13M_data7M_32MB=32M Flash (13MB APP/6.75MB SPIFFS)
+esp32s31.menu.PartitionScheme.app13M_data7M_32MB.build.partitions=default_32MB
+esp32s31.menu.PartitionScheme.app13M_data7M_32MB.upload.maximum_size=13107200
+esp32s31.menu.PartitionScheme.esp_sr_16=ESP SR 16M (3MB APP/6MB SPIFFS/3.9MB MODEL)
+esp32s31.menu.PartitionScheme.esp_sr_16.upload.maximum_size=3145728
+esp32s31.menu.PartitionScheme.esp_sr_16.upload.extra_flags=0xC10000 {build.path}/srmodels.bin
+esp32s31.menu.PartitionScheme.esp_sr_16.build.partitions=esp_sr_16
+esp32s31.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+esp32s31.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+esp32s31.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+esp32s31.menu.PartitionScheme.zigbee_zczr_8MB=Zigbee ZCZR 8MB with spiffs
+esp32s31.menu.PartitionScheme.zigbee_zczr_8MB.build.partitions=zigbee_zczr_8MB
+esp32s31.menu.PartitionScheme.zigbee_zczr_8MB.upload.maximum_size=3407872
+esp32s31.menu.PartitionScheme.custom=Custom
+esp32s31.menu.PartitionScheme.custom.build.partitions=
+esp32s31.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+esp32s31.menu.UploadSpeed.921600=921600
+esp32s31.menu.UploadSpeed.921600.upload.speed=921600
+esp32s31.menu.UploadSpeed.115200=115200
+esp32s31.menu.UploadSpeed.115200.upload.speed=115200
+esp32s31.menu.UploadSpeed.256000.windows=256000
+esp32s31.menu.UploadSpeed.256000.upload.speed=256000
+esp32s31.menu.UploadSpeed.230400.windows.upload.speed=256000
+esp32s31.menu.UploadSpeed.230400=230400
+esp32s31.menu.UploadSpeed.230400.upload.speed=230400
+esp32s31.menu.UploadSpeed.460800.linux=460800
+esp32s31.menu.UploadSpeed.460800.macosx=460800
+esp32s31.menu.UploadSpeed.460800.upload.speed=460800
+esp32s31.menu.UploadSpeed.512000.windows=512000
+esp32s31.menu.UploadSpeed.512000.upload.speed=512000
+
+esp32s31.menu.DebugLevel.none=None
+esp32s31.menu.DebugLevel.none.build.code_debug=0
+esp32s31.menu.DebugLevel.error=Error
+esp32s31.menu.DebugLevel.error.build.code_debug=1
+esp32s31.menu.DebugLevel.warn=Warn
+esp32s31.menu.DebugLevel.warn.build.code_debug=2
+esp32s31.menu.DebugLevel.info=Info
+esp32s31.menu.DebugLevel.info.build.code_debug=3
+esp32s31.menu.DebugLevel.debug=Debug
+esp32s31.menu.DebugLevel.debug.build.code_debug=4
+esp32s31.menu.DebugLevel.verbose=Verbose
+esp32s31.menu.DebugLevel.verbose.build.code_debug=5
+
+esp32s31.menu.EraseFlash.none=Disabled
+esp32s31.menu.EraseFlash.none.upload.erase_cmd=
+esp32s31.menu.EraseFlash.all=Enabled
+esp32s31.menu.EraseFlash.all.upload.erase_cmd=-e
+
+esp32s31.menu.ZigbeeMode.default=Disabled
+esp32s31.menu.ZigbeeMode.default.build.zigbee_mode=
+esp32s31.menu.ZigbeeMode.default.build.zigbee_libs=
+esp32s31.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
+esp32s31.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+esp32s31.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.remote
+
+##############################################################
+
 esp32c2.name=ESP32C2 Dev Module
 esp32c2.hide=true
 

--- a/cores/esp32/esp32-hal-psram.c
+++ b/cores/esp32/esp32-hal-psram.c
@@ -33,6 +33,8 @@
 #include "esp32c5/rom/cache.h"
 #elif CONFIG_IDF_TARGET_ESP32C61
 #include "esp32c61/rom/cache.h"
+#elif CONFIG_IDF_TARGET_ESP32S31
+#include "esp32s31/rom/cache.h"
 #else
 #error Target CONFIG_IDF_TARGET is not supported
 #endif

--- a/idf_component_examples/Arduino_ESP_Matter_over_OpenThread/ci.yml
+++ b/idf_component_examples/Arduino_ESP_Matter_over_OpenThread/ci.yml
@@ -10,6 +10,7 @@ targets:
   esp32c5: false
   esp32c6: false
   esp32h2: false
+  esp32s31: false
 requires:
   - CONFIG_OPENTHREAD_ENABLED=y
   - CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y

--- a/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
+++ b/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ExternalWakeUp.ino
@@ -23,9 +23,14 @@
 
 #include <Arduino.h>
 #include "driver/rtc_io.h"
+#include "esp_sleep.h"
 
 #define BUTTON_PIN_BITMASK(GPIO) (1ULL << GPIO)  // 2 ^ GPIO_NUMBER in hex
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 #define USE_EXT0_WAKEUP          1               // 1 = EXT0 wakeup, 0 = EXT1 wakeup
+#else
+#define USE_EXT0_WAKEUP          0               // 1 = EXT0 wakeup, 0 = EXT1 wakeup
+#endif
 #define WAKEUP_GPIO              GPIO_NUM_33     // Only RTC IO are allowed - ESP32 Pin example
 RTC_DATA_ATTR int bootCount = 0;
 

--- a/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ci.yml
+++ b/libraries/ESP32/examples/DeepSleep/ExternalWakeUp/ci.yml
@@ -4,3 +4,4 @@ targets:
   esp32h2: false
   esp32p4: false
   esp32c5: false
+  esp32s31: false

--- a/libraries/ESP32/examples/DeepSleep/SmoothBlink_ULP_Code/ci.yml
+++ b/libraries/ESP32/examples/DeepSleep/SmoothBlink_ULP_Code/ci.yml
@@ -6,3 +6,4 @@ targets:
   esp32s2: false
   esp32s3: false
   esp32c5: false
+  esp32s31: false

--- a/libraries/ESP32/examples/ResetReason/ResetReason/ResetReason.ino
+++ b/libraries/ESP32/examples/ResetReason/ResetReason/ResetReason.ino
@@ -34,6 +34,8 @@
 #include "esp32c5/rom/rtc.h"
 #elif CONFIG_IDF_TARGET_ESP32C61
 #include "esp32c61/rom/rtc.h"
+#elif CONFIG_IDF_TARGET_ESP32S31
+#include "esp32s31/rom/rtc.h"
 #else
 #error Target CONFIG_IDF_TARGET is not supported
 #endif

--- a/libraries/ESP32/examples/TWAI/TWAIreceive/ci.yml
+++ b/libraries/ESP32/examples/TWAI/TWAIreceive/ci.yml
@@ -1,2 +1,3 @@
 targets:
   esp32c5: false
+  esp32s31: false

--- a/libraries/ESP32/examples/TWAI/TWAItransmit/ci.yml
+++ b/libraries/ESP32/examples/TWAI/TWAItransmit/ci.yml
@@ -1,2 +1,3 @@
 targets:
   esp32c5: false
+  esp32s31: false

--- a/platform.txt
+++ b/platform.txt
@@ -86,6 +86,7 @@ build.extra_flags.esp32h2=-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT={build.
 build.extra_flags.esp32p4=-DARDUINO_USB_MODE={build.usb_mode} -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot} -DARDUINO_USB_MSC_ON_BOOT={build.msc_on_boot} -DARDUINO_USB_DFU_ON_BOOT={build.dfu_on_boot}
 build.extra_flags.esp32c5=-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot}
 build.extra_flags.esp32c61=-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot}
+build.extra_flags.esp32s31=-DARDUINO_USB_MODE={build.usb_mode} -DARDUINO_USB_CDC_ON_BOOT={build.cdc_on_boot} -DARDUINO_USB_MSC_ON_BOOT={build.msc_on_boot} -DARDUINO_USB_DFU_ON_BOOT={build.dfu_on_boot}
 
 # This can be overriden in boards.txt
 build.zigbee_mode=

--- a/variants/esp32s31/pins_arduino.h
+++ b/variants/esp32s31/pins_arduino.h
@@ -59,4 +59,20 @@ static const uint8_t T11 = 17;
 static const uint8_t T12 = 18;
 static const uint8_t T13 = 19;
 
+/* ESP32-S31 EV Function board specific definitions */
+//ETH
+#define ETH_PHY_TYPE    ETH_PHY_TLK110
+#define ETH_PHY_ADDR    1
+#define ETH_PHY_MDC     31
+#define ETH_PHY_MDIO    52
+#define ETH_PHY_POWER   51
+#define ETH_RMII_TX_EN  49
+#define ETH_RMII_TX0    34
+#define ETH_RMII_TX1    35
+#define ETH_RMII_RX0    29
+#define ETH_RMII_RX1_EN 30
+#define ETH_RMII_CRS_DV 28
+#define ETH_RMII_CLK    50
+#define ETH_CLK_MODE    EMAC_CLK_EXT_IN
+
 #endif /* Pins_Arduino_h */


### PR DESCRIPTION
```
lib-builder: release/v6.1 f9cadae
esp-idf: release/v6.1 0d92878008
arduino: release/v4.0.x 4e0d0b270
tinyusb: master 14e20e9f6
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cjson: 1.7.19~2
espressif__dm9051: 1.1.0
espressif__eppp_link: 1.1.5
espressif__esp-dsp: 1.8.2
espressif__esp-modbus: 2.1.2
espressif__esp_hosted: 2.12.9
espressif__esp_modem: 2.0.1
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 1.6.1
espressif__ksz8851snl: 1.0.0
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.0
espressif__mdns: 1.11.1
espressif__network_provisioning: 1.2.4
espressif__w5500: 1.0.1
espressif__wifi_remote_over_eppp: 0.3.2
joltwallet__littlefs: 1.22.1
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
```
