### PR TITLE
fix(PPP): Use min str size buffer requirements for modem getters

### DIFF
--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -13,7 +13,7 @@
 #include "soc/soc_caps.h"
 #include "esp_private/periph_ctrl.h"
 #if SOC_PERIPH_CLK_CTRL_SHARED
-#define HP_UART_SRC_CLK_ATOMIC()       PERIPH_RCC_ATOMIC()
+#define HP_UART_SRC_CLK_ATOMIC() PERIPH_RCC_ATOMIC()
 #else
 #define HP_UART_SRC_CLK_ATOMIC()
 #endif

--- a/libraries/PPP/src/PPP.cpp
+++ b/libraries/PPP/src/PPP.cpp
@@ -560,7 +560,7 @@ int PPPClass::BER() const {
 String PPPClass::IMSI() const {
   PPP_CMD_MODE_CHECK(String());
 
-  char imsi[32];
+  char imsi[CONFIG_ESP_MODEM_C_API_STR_MAX];
   esp_err_t err = esp_modem_get_imsi(_dce, imsi);
   if (err != ESP_OK) {
     log_e("esp_modem_get_imsi failed with %d %s", err, esp_err_to_name(err));
@@ -573,7 +573,7 @@ String PPPClass::IMSI() const {
 String PPPClass::IMEI() const {
   PPP_CMD_MODE_CHECK(String());
 
-  char imei[32];
+  char imei[CONFIG_ESP_MODEM_C_API_STR_MAX];
   esp_err_t err = esp_modem_get_imei(_dce, imei);
   if (err != ESP_OK) {
     log_e("esp_modem_get_imei failed with %d %s", err, esp_err_to_name(err));
@@ -586,7 +586,7 @@ String PPPClass::IMEI() const {
 String PPPClass::moduleName() const {
   PPP_CMD_MODE_CHECK(String());
 
-  char name[32];
+  char name[CONFIG_ESP_MODEM_C_API_STR_MAX];
   esp_err_t err = esp_modem_get_module_name(_dce, name);
   if (err != ESP_OK) {
     log_e("esp_modem_get_module_name failed with %d %s", err, esp_err_to_name(err));
@@ -599,7 +599,7 @@ String PPPClass::moduleName() const {
 String PPPClass::operatorName() const {
   PPP_CMD_MODE_CHECK(String());
 
-  char oper[32];
+  char oper[CONFIG_ESP_MODEM_C_API_STR_MAX];
   int act = 0;
   esp_err_t err = esp_modem_get_operator_name(_dce, oper, &act);
   if (err != ESP_OK) {


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [ ] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change

Fixes min buffer sizes for esp-modem string getters:
* `esp_modem_get_imsi()`
* `esp_modem_get_imei()`
* `esp_modem_get_module_name()`
* `esp_modem_get_operator_name()`

## Test Scenarios

ESP32 with SIM7600

## Related links

Related to the recent modem fix: https://github.com/espressif/esp-protocols/commit/c6c0b98536b8cc1e98146f1109d8839d8d156894#
