### PR TITLE
fix(sta): Only disconnect if actually started

### DIFF
--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -535,6 +535,10 @@ bool STAClass::connect(
 #endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
 
 bool STAClass::disconnect(bool eraseap, unsigned long timeout) {
+  if (!started()) {
+    return true;
+  }
+
   esp_err_t err = esp_wifi_disconnect();
   if (err != ESP_OK) {
     log_e("STA disconnect failed! 0x%x: %s", err, esp_err_to_name(err));


### PR DESCRIPTION
## Description of Change

This pull request introduces a small but important change to the `STAClass::disconnect` method in `STA.cpp`. Now, the method will immediately return `true` if the WiFi station has not been started, preventing crashes. 

* Added a check in `STAClass::disconnect` to return early if the WiFi station is not started, improving method robustness.

## Test Scenarios

Tested locally
