### PR TITLE
ci(tests): Add support for wokwi chips and multiple fqbns for multi-dut

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -566,16 +566,41 @@ Tests are organized in the repository under `tests/` directory:
 - `tests/performance/` - Performance benchmarks (conditional)
 
 Each test directory contains:
-- `{test_name}.ino` - Arduino sketch with test code
+- `{test_name}.ino` - Arduino sketch with test code (or subdirectories for multi-device tests)
 - `test_{test_name}.py` - pytest test file
 - `ci.yml` - Test requirements and configuration
 - `diagram.{chip}.json` - Optional Wokwi hardware diagram
+- `README.md` - Test documentation
+
+#### Pytest Fixtures and Test Authoring
+
+Tests use the [pytest-embedded](https://github.com/espressif/pytest-embedded) framework. Common fixtures are defined in `tests/conftest.py`:
+
+| Fixture | Source | Description |
+|---------|--------|-------------|
+| `dut` | pytest-embedded | Device-Under-Test serial interface. For multi-DUT tests, `dut[0]` and `dut[1]` access individual devices. |
+| `wifi_ssid` | `conftest.py` | WiFi SSID from `--wifi-ssid` CLI arg or `WIFI_SSID` env var |
+| `wifi_pass` | `conftest.py` | WiFi password from `--wifi-pass` CLI arg or `WIFI_PASS` env var |
+| `ci_job_id` | `conftest.py` | CI job identifier for unique naming |
+
+**Common DUT methods:**
+- `dut.expect_exact("string", timeout=N)` - Wait for exact serial output
+- `dut.expect(r"regex_pattern", timeout=N)` - Wait for regex match (returns match object)
+- `dut.write("command\n")` - Send data to device serial
+- `dut.expect_unity_test_output(timeout=N)` - Wait for Unity test framework results
+
+**Writing a new test:**
+1. Create the `.ino` sketch with Unity test framework (`#include <unity.h>`)
+2. Create `test_{name}.py` with a function `def test_{name}(dut):` (or `dut, wifi_ssid, wifi_pass` for WiFi tests)
+3. Create `ci.yml` with platform/tag/requirement configuration
+4. For multi-DUT: create subdirectories with separate sketches and add `multi_device` mapping to `ci.yml`
 
 **Test Configuration (`ci.yml`):**
 Defines test requirements and platform support:
 - `targets: {chip: true/false}` - Which SoCs support this test
 - `platforms: {platform: true/false}` - Which platforms can run it
-- `tags: [tag1, tag2]` - Runner tags or infrastructure constraints (hardware tests)
+- `tags: [tag1, tag2]` - Hardware runner tags applied to all targets (see below)
+- `soc_tags: {chip: [tag1]}` - Per-SoC hardware runner tags (see below)
 - `multi_device: {device0: sketchA, device1: sketchB}` - Multi-DUT test mapping
 - `requires: [CONFIG_X=y]` - Required sdkconfig settings
 - `requires_or: [CONFIG_A=y, CONFIG_B=y]` - Alternative requirements
@@ -598,6 +623,46 @@ platforms:
 requires:
   - CONFIG_SOC_WIFI_SUPPORTED=y
 ```
+
+#### Hardware Runner Tags
+
+The `tags` field in `ci.yml` specifies which GitLab CI hardware runner a test requires. Tags only affect **hardware** tests — Wokwi and QEMU tests ignore them. When no `tags` field is present, the test runs on a default generic runner with a single device and serial access (no special peripherals).
+
+| Tag | Description | Setup |
+|---|---|---|
+| `wifi_router` | Single device with WiFi router/AP access. For tests that need internet or LAN connectivity. | One ESP32 + WiFi network |
+| `two_duts` | Two wirelessly-paired devices. For over-the-air multi-DUT tests (BLE, ESP-NOW, WiFi AP+STA, Zigbee, etc.). Coordinated by pytest via two serial ports. | Two ESP32s on the same runner, no wired connection between them |
+| `generic_multi_device` | Two devices **physically wired together** (GPIO-to-GPIO). For peripheral loopback tests that need a direct electrical connection (I2S, analog DAC→ADC, etc.). | Two ESP32s with jumper wires between specific pins |
+| `ethernet` | Single device with an Ethernet PHY/module (e.g. LAN8720) connected. | One ESP32 + Ethernet hardware |
+| `psram` | Single device with SPI PSRAM. Used for targets where PSRAM is not standard. | One ESP32/S2/C5 board with PSRAM |
+| `octal_psram` | Single device with **octal** SPI PSRAM (higher bandwidth). ESP32-S3 WROOM-1 modules use octal PSRAM. | One ESP32-S3 board with octal PSRAM |
+| *(none)* | Default — generic runner with a single device and serial access. No special peripherals, WiFi, or multi-device setup. | One ESP32 + USB serial |
+
+**`tags` vs `soc_tags`:**
+
+There are two ways to assign runner tags in `ci.yml`:
+
+- **`tags`** (list) — Applied to **every** target uniformly. Use when the runner requirement is the same for all SoCs (e.g., all need WiFi or all need two devices).
+
+```yaml
+tags:
+  - wifi_router
+```
+
+- **`soc_tags`** (dict keyed by SoC) — Applied **per target**. Use when different SoCs need different runner capabilities. SoCs not listed get no extra tags (default runner).
+
+```yaml
+soc_tags:
+  esp32:
+    - psram
+  esp32s3:
+    - octal_psram
+```
+
+Both fields can coexist in the same `ci.yml`. The job generator (`gen_hw_jobs.py`) merges them into a single tag set per target — global `tags` are combined with any matching `soc_tags` entry for that SoC. For example, if a test has `tags: [wifi_router]` and `soc_tags: {esp32s3: [octal_psram]}`, then ESP32-S3 jobs get both `wifi_router` and `octal_psram` tags, while other SoCs get only `wifi_router`.
+
+Notes:
+- Multi-device tests (`two_duts`, `generic_multi_device`) require `ESPPORT1` and `ESPPORT2` environment variables for the two serial ports.
 
 #### Performance test result format
 
@@ -637,6 +702,36 @@ The report generator only accepts this format.
 ### Multi-Device (Multi-DUT) Tests
 
 Some tests require two physical devices (e.g., BLE server/client, WiFi AP/client). These are defined using the `multi_device` field in `ci.yml`, where each entry points to a sketch directory for that device.
+
+> **Important:** Each DUT **must** have its own sketch in a separate subdirectory. The CI does not support multi-DUT tests with a single sketch. The `multi_device` mapping in `ci.yml` is mandatory and each value must correspond to a subdirectory containing `<name>/<name>.ino`. Without this, `build_multi_device_test` in `tests_build.sh` will fail. The `two_duts` or `generic_multi_device` tags alone only select a runner with two devices — they do NOT handle building or flashing firmware.
+
+**Example `ci.yml` for a two-device test:**
+```yaml
+tags:
+  - two_duts
+
+multi_device:
+  device0:
+    sketch: coordinator
+    fqbn_append: PartitionScheme=zigbee,ZigbeeMode=zigbee_zczr
+  device1:
+    sketch: end_device
+    fqbn_append: PartitionScheme=zigbee,ZigbeeMode=zigbee_ed
+
+platforms:
+  wokwi: false
+  qemu: false
+```
+
+This expects `coordinator/coordinator.ino` and `end_device/end_device.ino` to exist as subdirectories of the test.
+
+**`multi_device` value format:**
+
+Each device entry can be either:
+- A **scalar** (just the sketch directory name): `device0: sender`
+- A **map** with `sketch` (required) and `fqbn_append` (optional): useful when devices need different compile-time options (e.g., different Zigbee roles or partition schemes)
+
+When `fqbn_append` is specified per device, it overrides the parent `ci.yml`'s `fqbn_append` for that device's build only.
 
 **How it works:**
 - `tests_build.sh` builds each device sketch separately and stores artifacts under `~/.arduino/tests/<target>/<test>/<sketch>/build.tmp`.
@@ -1531,10 +1626,183 @@ Test the official variant filter script with different scenarios:
 
 Individual scripts can be tested locally:
 - Build scripts can run with Arduino CLI installed
-- Test scripts require appropriate runtime environment (QEMU/hardware/Wokwi)
+- Test scripts require Python **3.13+** and appropriate runtime environment (QEMU/hardware/Wokwi)
 - Matrix generation scripts can be run to verify JSON output
 
 Note: GitHub Actions workflows cannot run locally, but the bash scripts they call can be.
+
+---
+
+## DevKit GPIO Reference
+
+This section documents the GPIO availability for each standard devkit board. Use this when writing tests that need specific pins (e.g., button input, LED output, ADC reads, touch reads, pulldown verification).
+
+Strapping pins have external pull resistors that interfere with internal pull-up/pull-down tests and should be avoided for GPIO input testing.
+
+Pins with aliases are listed in the form `alias`→`GPIO`. This means that, for example, calling `pinMode(A0, INPUT)` will set GPIO36 as an input pin.
+
+### Pin Safety Categories
+
+Not all "safe" pins are equally safe — it depends on which peripherals your test uses. Each board's safe pins are split into two categories:
+
+- **Always safe**: Broken out on the devkit header with no default peripheral bus assignment. Free to use in any test regardless of which peripherals it exercises.
+- **Peripheral-dependent**: Safe for general GPIO use, but serve as default pins for a specific peripheral bus (I2C, SPI, DAC, etc.). If your test initializes that peripheral with default settings, these pins are claimed by it — pick other safe pins for auxiliary GPIO needs.
+
+Pins that are never safe (flash, UART serial monitor, USB-JTAG, strapping, input-only) are already excluded from both categories.
+
+**Example:** On ESP32, GPIO 21 and 22 are the default I2C pins (`SDA` and `SCL`). If you are writing a GPIO test that just toggles pins high and low, you can include 21 and 22 in your pin list without any problem — no I2C driver is running, so the pins behave as regular GPIOs. Now imagine you are writing an I2C test instead. The test will call `Wire.begin()`, which takes over GPIO 21 and 22 for the I2C bus. If that same test also needs a couple of extra GPIOs for something else (say, to wire an interrupt line or a loopback), it must pick those extra pins from elsewhere in the safe list — 21 and 22 are no longer available because I2C is using them.
+
+### ESP32 — `board-esp32-devkit-c-v4`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out** | 0–5, 12–19, 21–23, 25–27, 32–33, 34–36, 39 |
+| **Strapping** | 0, 2, 5, 12, 15 |
+| **SPI flash (do not use)** | 6–11 |
+| **Input-only** | 34, 35, 36, 39 |
+| **UART** | `TX`→1, `RX`→3 |
+| **I2C** | `SDA`→21, `SCL`→22 |
+| **SPI** | `SS`→5, `MOSI`→23, `MISO`→19, `SCK`→18 |
+| **ADC1** [^adc1] | `A0`→36, `A3`→39, `A4`→32, `A5`→33, `A6`→34, `A7`→35 (input-only) |
+| **ADC2** [^adc2] | `A10`→4, `A11`→0, `A12`→2, `A13`→15, `A14`→13, `A15`→12, `A16`→14, `A17`→27, `A18`→25, `A19`→26 |
+| **Touch** [^touch] | `T0`→4, `T1`→0, `T2`→2, `T3`→15, `T4`→13, `T5`→12, `T6`→14, `T7`→27, `T8`→33, `T9`→32 |
+| **DAC** | `DAC1`→25, `DAC2`→26 |
+| **Always safe** | 16, 17 |
+| **Peripheral-dependent** | 4, 13, 14, 27, 32, 33 (Touch) · 18, 19, 23 (SPI) · 21, 22 (I2C) · 25, 26 (DAC) |
+
+[^adc1]: `analogContinuous()` accepts **ADC1 only**. Do not use ADC2 pins for continuous mode even though `analogRead()` works on them. `analogContinuous()` clears requested pins via periman but fails if ADC1 oneshot is still in use on *other* pins. On all other targets (S2, S3, C3, C6, H2, C5, P4) the ADC is a single unit and this split does not apply. Ref: `cores/esp32/esp32-hal-adc.c`.
+
+[^adc2]: `analogRead()` on ADC2 pins can fail or return incorrect values when the Wi-Fi radio is active. ADC2 pins **cannot** be used with `analogContinuous()`.
+
+[^touch]: Prefer pins that are not touch pads (`T0`–`T9`) for `ledcAttach()`. Touch and LEDC on the same GPIO is unreliable — e.g. avoid GPIO4 (`T0` / `A10`); use GPIO 16 or 17 instead.
+
+### ESP32-S2 — `board-esp32-s2-devkitm-1`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out** | 0–21, 33–46 |
+| **Strapping** | 0, 45, 46 |
+| **SPI flash (reserved)** | 26–32 |
+| **Input-only** | 46 |
+| **LED** | `LED_BUILTIN`→18 |
+| **UART** | `TX`→43, `RX`→44 |
+| **I2C** | `SDA`→8, `SCL`→9 |
+| **SPI** | `SS`→34, `MOSI`→35, `MISO`→37, `SCK`→36 |
+| **ADC** | `A0`→1 … `A19`→20 |
+| **Touch** | `T1`→1 … `T14`→14 |
+| **DAC** | `DAC1`→17, `DAC2`→18 |
+| **Always safe** | 15, 16, 19, 20, 21, 33, 38–42 |
+| **Peripheral-dependent** | 1–7, 10–14 (Touch) · 8, 9 (I2C, Touch) · 17 (DAC) · 18 (DAC, LED) · 34–37 (SPI) |
+
+### ESP32-S3 — `board-esp32-s3-devkitc-1`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out** | 0–21, 35–48 |
+| **Strapping** | 0, 3, 45, 46 |
+| **Octal SPI flash (reserved on WROOM-1)** | 35–37 |
+| **USB** | 19, 20 |
+| **LED** | `LED_BUILTIN`→48 |
+| **UART** | `TX`→43, `RX`→44 |
+| **I2C** | `SDA`→8, `SCL`→9 |
+| **SPI** | `SS`→10, `MOSI`→11, `MISO`→13, `SCK`→12 |
+| **ADC** | `A0`→1 … `A19`→20 |
+| **Touch** | `T1`→1 … `T14`→14 |
+| **Always safe** | 15–18, 21, 38–42, 47 |
+| **Peripheral-dependent** | 1, 2, 4–7, 14 (Touch) · 8, 9 (I2C, Touch) · 10–13 (SPI, Touch) |
+
+### ESP32-C3 — `board-esp32-c3-devkitm-1`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out** | 0–10, 18–21 |
+| **Strapping** | 2, 8, 9 |
+| **USB** | 18, 19 |
+| **LED** | `LED_BUILTIN`→8 |
+| **UART** | `TX`→21, `RX`→20 |
+| **I2C** | `SDA`→8, `SCL`→9 |
+| **SPI** | `SS`→7, `MOSI`→6, `MISO`→5, `SCK`→4 |
+| **ADC** | `A0`→0, `A1`→1, `A2`→2, `A3`→3, `A4`→4, `A5`→5 |
+| **Always safe** | 0, 1, 3, 10 |
+| **Peripheral-dependent** | 4–7 (SPI) |
+
+### ESP32-C5 — `board-esp32-c5-devkitc-1`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out** | 0–14, 23–28 (15 only without PSRAM) |
+| **Strapping** | 2, 3, 7, 25, 26, 27, 28 |
+| **USB** | 13, 14 |
+| **LED** | `LED_BUILTIN`→27 |
+| **UART** | `TX`→11, `RX`→12 |
+| **UART (LP)** | `LP_TX`→5, `LP_RX`→4 |
+| **I2C** | `SDA`→0, `SCL`→1 |
+| **I2C (LP)** | `LP_SDA`→2, `LP_SCL`→3 |
+| **SPI** | `SS`→6, `MOSI`→8, `MISO`→9, `SCK`→10 |
+| **ADC** | `A0`→1, `A1`→2, `A2`→3, `A3`→4, `A4`→5, `A5`→6 |
+| **Always safe** | 23, 24 |
+| **Peripheral-dependent** | 0, 1 (I2C) · 4, 5 (LP UART) · 6, 8, 9, 10 (SPI) |
+
+### ESP32-C6 — `board-esp32-c6-devkitc-1`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out** | 0–23 |
+| **Strapping** | 4, 5, 8, 9, 15 |
+| **SPI flash (reserved)** | 24–30 |
+| **LED** | `LED_BUILTIN`→8 |
+| **USB-JTAG** | 12, 13 |
+| **UART** | `TX`→16, `RX`→17 |
+| **I2C** | `SDA`→23, `SCL`→22 |
+| **I2C (Wire1)** | `SDA1`→6, `SCL1`→7 |
+| **SPI** | `SS`→18, `MOSI`→19, `MISO`→20, `SCK`→21 |
+| **ADC** | `A0`→0, `A1`→1, `A2`→2, `A3`→3, `A4`→4, `A5`→5, `A6`→6 |
+| **Always safe** | 0, 1, 2, 3, 10, 11, 14 |
+| **Peripheral-dependent** | 6, 7 (I2C Wire1) · 18–21 (SPI) · 22, 23 (I2C) |
+
+### ESP32-H2 — `board-esp32-h2-devkitm-1`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out** | 0–5, 8–14, 22–27 |
+| **Strapping** | 2, 3, 8, 9, 25 |
+| **32K crystal** | 13, 14 |
+| **USB** | 26, 27 |
+| **LED** | `LED_BUILTIN`→8 |
+| **UART** | `TX`→24, `RX`→23 |
+| **I2C** | `SDA`→12, `SCL`→22 |
+| **SPI** | `SS`→0, `MOSI`→25, `MISO`→11, `SCK`→10 |
+| **ADC** | `A0`→1, `A1`→2, `A2`→3, `A3`→4, `A4`→5 |
+| **Always safe** | 1, 4, 5 |
+| **Peripheral-dependent** | 0, 10, 11 (SPI) · 12, 22 (I2C) |
+
+### ESP32-P4 — `board-esp32-p4-function-ev`
+
+| Property | GPIOs |
+|---|---|
+| **Broken out (J1 header)** | 2–8, 20–23, 32–33, 36–38, 46–48, 53–54 |
+| **ESP-Hosted SDIO** | `CLK`→18, `CMD`→19, `D0`→14, `D1`→15, `D2`→16, `D3`→17, `RESET`→54 |
+| **Ethernet (RMII)** | `MDC`→31, `MDIO`→52, `POWER`→51, `TX_EN`→49, `TX0`→34, `TX1`→35, `RX0`→29, `RX1_EN`→30, `CRS_DV`→28, `CLK`→50 |
+| **SDMMC** | `POWER`→45 |
+| **Strapping** | 34–38 |
+| **Disabled by default** | 0, 1, 45 |
+| **USB-JTAG** | 24, 25 |
+| **UART** | `TX`→37, `RX`→38 |
+| **I2C** | `SDA`→7, `SCL`→8 |
+| **SPI** | `SS`→26, `MOSI`→32, `MISO`→33, `SCK`→36 |
+| **ADC** | `A0`→16, `A1`→17, `A2`→18, `A3`→19, `A4`→20, `A5`→21, `A6`→22, `A7`→23, `A8`→49, `A9`→50, `A10`→51, `A11`→52, `A12`→53, `A13`→54 |
+| **Touch** | `T0`→2, `T1`→3, `T2`→4, `T3`→5, `T4`→6, `T5`→7, `T6`→8, `T7`→9, `T8`→10, `T9`→11, `T10`→12, `T11`→13, `T12`→14, `T13`→15 |
+| **Always safe** | 20–23, 27, 46–48, 53 |
+| **Peripheral-dependent** | 2–6 (Touch) · 7, 8 (I2C, Touch) · 26, 32, 33 (SPI) · 54 (ESP-Hosted RESET) |
+
+### Quick Reference: Choosing Test Pins
+
+When writing tests that need GPIO pins:
+
+1. Start with the **Always safe** row for the target — these pins have no peripheral conflicts.
+2. If you need more pins, use **Peripheral-dependent** pins that don't conflict with the peripherals your test uses.
+3. Check the footnotes on the ESP32 pin table (ADC1/ADC2, LEDC+Touch) when the test calls `analogContinuous()`, DAC, LEDC, or other drivers — alias tables alone are not enough on ESP32.
+4. There is no single GPIO that is safe across all targets — use per-target `#ifdef` in the sketch and per-target `diagram.{chip}.json` wiring.
 
 ---
 

--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -101,6 +101,10 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
             shift
             build_name=$1
             ;;
+        -fa )
+            shift
+            fqbn_append_override=$1
+            ;;
         --arduino-cli )
             use_arduino_cli=1
             ;;
@@ -160,7 +164,9 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
 
             len=1
 
-            if [ -n "$ci_yml_for_build" ]; then
+            if [ -n "${fqbn_append_override:-}" ]; then
+                fqbn_append="$fqbn_append_override"
+            elif [ -n "$ci_yml_for_build" ]; then
                 fqbn_append=$(yq eval '.fqbn_append' "$ci_yml_for_build" 2>/dev/null)
                 if [ "$fqbn_append" == "null" ]; then
                     fqbn_append=""

--- a/.github/scripts/socs_config.sh
+++ b/.github/scripts/socs_config.sh
@@ -220,6 +220,19 @@ is_qemu_supported() {
     return 1
 }
 
+# Check if SoC is supported by Wokwi
+# Usage: is_wokwi_supported "esp32c3"
+# Returns: 0 if supported, 1 otherwise
+is_wokwi_supported() {
+    local soc="$1"
+    for target in "${WOKWI_TEST_TARGETS[@]}"; do
+        if [ "$target" = "$soc" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # ==============================================================================
 # IDF Specific Configuration
 # ==============================================================================

--- a/.github/scripts/tests_build.sh
+++ b/.github/scripts/tests_build.sh
@@ -109,8 +109,21 @@ function build_multi_device_test {
     local sketch_name
     local sketch_path
     local sketch_dir
+    local device_fqbn_append
     for device in $devices; do
-        sketch_name=$(yq eval ".multi_device.$device" "$test_dir/ci.yml" 2>/dev/null)
+        # multi_device values can be either a scalar (sketch name) or a map
+        # with "sketch" and optional "fqbn_append" keys.
+        local device_type
+        device_type=$(yq eval ".multi_device.$device | type" "$test_dir/ci.yml" 2>/dev/null)
+
+        if [ "$device_type" == "!!map" ]; then
+            sketch_name=$(yq eval ".multi_device.$device.sketch" "$test_dir/ci.yml" 2>/dev/null)
+            device_fqbn_append=$(yq eval ".multi_device.$device.fqbn_append // \"\"" "$test_dir/ci.yml" 2>/dev/null)
+        else
+            sketch_name=$(yq eval ".multi_device.$device" "$test_dir/ci.yml" 2>/dev/null)
+            device_fqbn_append=""
+        fi
+
         sketch_path="$test_dir/$sketch_name/$sketch_name.ino"
         sketch_dir="$test_dir/$sketch_name"
 
@@ -123,8 +136,13 @@ function build_multi_device_test {
 
         # -td: ci.yml lives in the parent test directory
         # -bn: sets the parent build dir to the test name (nested: $test_name/$sketch_name/build.tmp)
+        local fa_args=()
+        if [ -n "$device_fqbn_append" ]; then
+            fa_args=(-fa "$device_fqbn_append")
+        fi
+
         ${SKETCH_UTILS} build "${build_args[@]}" -s "$sketch_dir" \
-            -td "$test_dir" -bn "$test_name"
+            -td "$test_dir" -bn "$test_name" "${fa_args[@]}"
         result=$?
         if [ $result -ne 0 ]; then
             echo "ERROR: Failed to build sketch $sketch_name for test $test_name"

--- a/.github/scripts/tests_run.sh
+++ b/.github/scripts/tests_run.sh
@@ -38,8 +38,9 @@ function run_multi_device_test {
     if [ -f "$test_dir/ci.yml" ]; then
         is_target=$(yq eval ".targets.${target}" "$test_dir/ci.yml" 2>/dev/null)
         selected_platform=$(yq eval ".platforms.${platform}" "$test_dir/ci.yml" 2>/dev/null)
+        platform_target=$(yq eval ".platforms.${platform}.${target}" "$test_dir/ci.yml" 2>/dev/null)
 
-        if [[ $is_target == "false" ]] || [[ $selected_platform == "false" ]]; then
+        if [[ $is_target == "false" ]] || [[ $selected_platform == "false" ]] || [[ $platform_target == "false" ]]; then
             printf "\033[93mSkipping %s test for %s, platform: %s\033[0m\n" "$test_name" "$target" "$platform"
             printf "\n\n\n"
             return 0
@@ -122,7 +123,14 @@ function run_multi_device_test {
         local sdkconfig_path
         local compiled_target
         for device in $devices; do
-            sketch_name=$(yq eval ".multi_device.$device" "$test_dir/ci.yml" 2>/dev/null)
+            # multi_device values can be a scalar (sketch name) or a map with a "sketch" key
+            local device_type
+            device_type=$(yq eval ".multi_device.$device | type" "$test_dir/ci.yml" 2>/dev/null)
+            if [ "$device_type" == "!!map" ]; then
+                sketch_name=$(yq eval ".multi_device.$device.sketch" "$test_dir/ci.yml" 2>/dev/null)
+            else
+                sketch_name=$(yq eval ".multi_device.$device" "$test_dir/ci.yml" 2>/dev/null)
+            fi
             if [ "$fqbn_len" -eq 1 ]; then
                 build_dir="$HOME/.arduino/tests/$target/${test_name}/${sketch_name}/build.tmp"
             else
@@ -213,6 +221,36 @@ function run_multi_device_test {
     return $error
 }
 
+function generate_wokwi_toml {
+    local sketchdir=$1
+    local build_dir=$2
+    local sketchname=$3
+    local toml_file="$sketchdir/wokwi.toml"
+
+    local rel_build_dir
+    rel_build_dir=$(python3 -c "import os.path; print(os.path.relpath('$build_dir', '$sketchdir'))")
+
+    {
+        echo "[wokwi]"
+        echo "version = 1"
+        echo "elf = '$rel_build_dir/$sketchname.ino.elf'"
+        echo "firmware = '$rel_build_dir/$sketchname.ino.merged.bin'"
+    } > "$toml_file"
+
+    if [ -d "$sketchdir/chips" ]; then
+        for chip_json in "$sketchdir/chips/"*.chip.json; do
+            [ -f "$chip_json" ] || continue
+            chip_name=$(basename "$chip_json" .chip.json)
+            {
+                echo ""
+                echo "[[chip]]"
+                echo "name = '$chip_name'"
+                echo "binary = 'chips/$chip_name.chip.wasm'"
+            } >> "$toml_file"
+        done
+    fi
+}
+
 function run_test {
     local target=$1
     local sketch=$2
@@ -249,8 +287,9 @@ function run_test {
         # If the target or platform is listed as false, skip the sketch. Otherwise, include it.
         is_target=$(yq eval ".targets.${target}" "$sketchdir"/ci.yml 2>/dev/null)
         selected_platform=$(yq eval ".platforms.${platform}" "$sketchdir"/ci.yml 2>/dev/null)
+        platform_target=$(yq eval ".platforms.${platform}.${target}" "$sketchdir"/ci.yml 2>/dev/null)
 
-        if [[ $is_target == "false" ]] || [[ $selected_platform == "false" ]]; then
+        if [[ $is_target == "false" ]] || [[ $selected_platform == "false" ]] || [[ $platform_target == "false" ]]; then
             printf "\033[93mSkipping %s test for %s, platform: %s\033[0m\n" "$sketchname" "$target" "$platform"
             printf "\n\n\n"
             return 0
@@ -301,10 +340,18 @@ function run_test {
         fi
 
         if [ $platform == "wokwi" ]; then
+            # Check if target is supported by Wokwi
+            if ! is_wokwi_supported "$target"; then
+                printf "\033[93mSkipping %s: unsupported Wokwi target %s\033[0m\n" "$sketchname" "$target"
+                printf "\n\n\n"
+                return 0
+            fi
+
             extra_args=("--target" "$target" "--embedded-services" "arduino,wokwi")
             if [[ -f "$sketchdir/diagram.$target.json" ]]; then
                 extra_args+=("--wokwi-diagram" "$sketchdir/diagram.$target.json")
             fi
+            generate_wokwi_toml "$sketchdir" "$build_dir" "$sketchname"
         elif [ $platform == "qemu" ]; then
             PATH=$HOME/qemu/bin:$PATH
             extra_args=("--embedded-services" "qemu" "--qemu-image-path" "$build_dir/$sketchname.ino.merged.bin")
@@ -483,6 +530,13 @@ if [ -n "$sketch" ]; then
     IFS=',' read -ra sketches_to_run <<< "$sketch"
 fi
 
+# Select the appropriate default target list based on platform
+case "$platform" in
+    wokwi)   default_targets=("${WOKWI_TEST_TARGETS[@]}") ;;
+    qemu)    default_targets=("${QEMU_TEST_TARGETS[@]}") ;;
+    *)       default_targets=("${BUILD_TEST_TARGETS[@]}") ;;
+esac
+
 # Handle default target and sketch logic
 if [ -z "$target" ] && [ -z "$sketch" ]; then
     # No target or sketch specified - run all sketches for all targets
@@ -495,12 +549,12 @@ if [ -z "$target" ] && [ -z "$sketch" ]; then
     if [ -z "$chunk_max" ]; then
         chunk_max=1
     fi
-    targets_to_run=("${BUILD_TEST_TARGETS[@]}")
+    targets_to_run=("${default_targets[@]}")
     sketches_to_run=()
 elif [ -z "$target" ]; then
     # No target specified, but sketch(es) specified - run sketches for all targets
     echo "No target specified, running sketch(es) '${sketches_to_run[*]}' for all targets"
-    targets_to_run=("${BUILD_TEST_TARGETS[@]}")
+    targets_to_run=("${default_targets[@]}")
 elif [ -z "$sketch" ]; then
     # No sketch specified, but target(s) specified - run all sketches for targets
     echo "No sketch specified, running all sketches for target(s) '${targets_to_run[*]}'"

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,12 @@ tools/openocd-esp32
 .*.swo
 *~
 
-# Ignore build and temporary files
+# Ignore build, environment, and temporary files
 /build
 *.tmp
+.env
+.venv/
+venv/
 
 # Ignore files built by Visual Studio/Visual Micro and other IDEs
 [Dd]ebug/
@@ -50,6 +53,7 @@ debug.svd
 debug_custom.json
 libraries/Insights/examples/*/*.ino.zip
 test_results.json
+debug.xml
 
 # Vale Style
 .vale/styles/*

--- a/.gitlab/scripts/gen_hw_jobs.py
+++ b/.gitlab/scripts/gen_hw_jobs.py
@@ -125,11 +125,13 @@ def test_enabled_for_target(ci_json: dict, chip: str) -> bool:
     return True
 
 
-def platform_allowed(ci_json: dict, platform: str = "hardware") -> bool:
+def platform_allowed(ci_json: dict, platform: str = "hardware", chip: str = "") -> bool:
     platforms = ci_json.get("platforms")
     if isinstance(platforms, dict):
         v = platforms.get(platform)
         if v is False:
+            return False
+        if chip and isinstance(v, dict) and v.get(chip) is False:
             return False
     return True
 
@@ -154,7 +156,12 @@ def sdkconfig_path_for(chip: str, sketch: str, ci_json: dict) -> Path:
     # {test_name}/{first_device}/build[0].tmp/ (see tests_build.sh build_multi_device_test).
     multi_device = ci_json.get("multi_device") if isinstance(ci_json, dict) else None
     if isinstance(multi_device, dict) and multi_device:
-        first_device = str(next(iter(multi_device.values())))
+        first_val = next(iter(multi_device.values()))
+        # multi_device values can be a scalar (sketch name) or a map with a "sketch" key
+        if isinstance(first_val, dict):
+            first_device = str(first_val.get("sketch", ""))
+        else:
+            first_device = str(first_val)
         return Path.home() / f".arduino/tests/{chip}/{sketch}/{first_device}/{build_suffix}/sdkconfig"
 
     return Path.home() / f".arduino/tests/{chip}/{sketch}/{build_suffix}/sdkconfig"
@@ -414,7 +421,7 @@ def main():
             if not test_enabled_for_target(ci, chip):
                 continue
             # Skip tests that explicitly disable the hardware platform
-            if not platform_allowed(ci, "hardware"):
+            if not platform_allowed(ci, "hardware", chip):
                 continue
             sdk = sdkconfig_path_for(chip, sketch, ci)
             if not args.dry_run and not sdk_meets_requirements(sdk, ci):

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 result_*.json
 diagram.json
 wokwi.toml
+wokwi-api.h


### PR DESCRIPTION
## Description of Change

This pull request enhances the CI documentation and scripts for multi-device and hardware-specific testing, making the test infrastructure more flexible and easier to use. Major improvements include support for device-specific build options in multi-device tests, expanded documentation on hardware runner tags and GPIO safety, and utility functions for platform checks and Wokwi simulation.

**Multi-device test enhancements:**
- Added support for specifying `fqbn_append` per device in the `multi_device` map within `ci.yml`, allowing different compile-time options for each device in a multi-device test. The build and run scripts (`tests_build.sh`, `sketch_utils.sh`, `tests_run.sh`) were updated to parse and apply these device-specific options. [[1]](diffhunk://#diff-d950f68457d32f433b4b052cc4a3c92ef2b41c1301e72492cccb5d0c3894e24eR112-R126) [[2]](diffhunk://#diff-d950f68457d32f433b4b052cc4a3c92ef2b41c1301e72492cccb5d0c3894e24eR139-R145) [[3]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5R104-R107) [[4]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L163-R169) [[5]](diffhunk://#diff-a79d5ef8d7e3ab662a0d9905060081ad57b8a9f3364c515b80a085558ac19492R126-R133)
- Improved documentation and examples in `.github/CI_README.md` for authoring multi-device tests, clarifying the required directory structure and configuration. [[1]](diffhunk://#diff-b4656400ea337249663ea596b1bc55dcd79f9837df94ca6d5c39e187709cdde6L569-R603) [[2]](diffhunk://#diff-b4656400ea337249663ea596b1bc55dcd79f9837df94ca6d5c39e187709cdde6R706-R735)

**Hardware runner and platform support:**
- Expanded the documentation of hardware runner tags (`tags`, `soc_tags`) and their usage in `ci.yml`, including a detailed table of supported tags and how they interact for different SoCs and test requirements.
- Added a new Bash utility function `is_wokwi_supported` to check if a SoC is supported by Wokwi, improving platform-specific logic in CI scripts.

**Test authoring and GPIO reference:**
- Introduced a comprehensive GPIO reference section in `.github/CI_README.md` for all supported devkit boards, categorizing pins by safety and peripheral conflicts to guide test authors in choosing appropriate pins.

**Wokwi simulation support:**
- Added a `generate_wokwi_toml` function to `tests_run.sh` to automate creation of `wokwi.toml` files for Wokwi simulation, including support for additional chip binaries.

**Other improvements:**
- Improved the handling of platform exclusion in multi-device tests by checking for per-target platform disables in `ci.yml`.

These changes make the CI test infrastructure more robust, flexible, and easier to use for both single- and multi-device scenarios.

## Test Scenarios

Tested locally
