### PR TITLE
tests(core): Add tests for core functionalities

### DIFF
--- a/tests/validation/multitasking/README.md
+++ b/tests/validation/multitasking/README.md
@@ -1,0 +1,30 @@
+# Multitasking Validation Test
+
+Validates FreeRTOS primitives via the Arduino framework: task creation, dual-core pinning, portMUX spinlock, binary semaphore, task notification, queue, mutex, event group, stack watermark, and task deletion.
+
+## Test Cases
+
+| Test Function | Description |
+|---|---|
+| `test_task_create` | Create a task, verify it runs |
+| `test_dual_core_pinning` | Pin tasks to core 0 and core 1, verify `xPortGetCoreID()` (multi-core only) |
+| `test_portmux_no_corruption` | Two tasks increment shared counter with portMUX, verify no lost increments |
+| `test_semaphore` | Binary semaphore producer/consumer, verify all values received |
+| `test_task_notification` | Send notification with value, verify receiver gets it |
+| `test_queue_send_receive` | Queue producer sends 1-10, consumer verifies sum = 55 |
+| `test_mutex_no_corruption` | Two tasks increment counter with mutex, verify count = 2000 |
+| `test_event_group` | Set bits from main task, verify waiter receives both bits |
+| `test_stack_watermark` | Verify `uxTaskGetStackHighWaterMark()` returns sensible value |
+| `test_task_delete` | Create then delete a running task |
+
+## Requirements
+
+- **Hardware**: Any ESP32 variant
+- **Wokwi**: Supported
+- **QEMU**: Supported
+
+## Notes
+
+- Dual-core pinning test only runs on multi-core SoCs (ESP32, ESP32-S3).
+- All tests use a 5-second timeout to avoid infinite hangs.
+- portMUX test uses 100,000 iterations per task for reliable corruption detection.

--- a/tests/validation/multitasking/multitasking.ino
+++ b/tests/validation/multitasking/multitasking.ino
@@ -1,0 +1,403 @@
+/*
+ * Multitasking Validation Test
+ *
+ * Covers: FreeRTOS task creation, dual-core pinning (ESP32/S3),
+ * portMUX spinlock, binary semaphore give/take between tasks,
+ * task notification, and task deletion.
+ */
+
+#include <Arduino.h>
+#include <unity.h>
+
+#define TASK_STACK_SIZE   4096
+#define INCREMENT_COUNT   100000
+#define TASK_TIMEOUT_MS   5000
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ==================== Task Creation ====================
+
+static volatile bool task_ran = false;
+
+static void simpleTask(void *param) {
+  task_ran = true;
+  vTaskDelete(NULL);
+}
+
+void test_task_create(void) {
+  task_ran = false;
+  BaseType_t ret = xTaskCreate(simpleTask, "simple", TASK_STACK_SIZE, NULL, 1, NULL);
+  TEST_ASSERT_EQUAL(pdPASS, ret);
+  unsigned long start = millis();
+  while (!task_ran && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+  TEST_ASSERT_TRUE(task_ran);
+}
+
+// ==================== Dual-Core Pinning ====================
+
+#if CONFIG_FREERTOS_NUMBER_OF_CORES > 1
+static volatile int task_core_0 = -1;
+static volatile int task_core_1 = -1;
+
+static void coreTask0(void *param) {
+  task_core_0 = xPortGetCoreID();
+  vTaskDelete(NULL);
+}
+
+static void coreTask1(void *param) {
+  task_core_1 = xPortGetCoreID();
+  vTaskDelete(NULL);
+}
+
+void test_dual_core_pinning(void) {
+  task_core_0 = -1;
+  task_core_1 = -1;
+
+  xTaskCreatePinnedToCore(coreTask0, "core0", TASK_STACK_SIZE, NULL, 1, NULL, 0);
+  xTaskCreatePinnedToCore(coreTask1, "core1", TASK_STACK_SIZE, NULL, 1, NULL, 1);
+
+  unsigned long start = millis();
+  while ((task_core_0 < 0 || task_core_1 < 0) && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+
+  TEST_ASSERT_EQUAL(0, task_core_0);
+  TEST_ASSERT_EQUAL(1, task_core_1);
+}
+#endif
+
+// ==================== portMUX Spinlock ====================
+
+static portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
+static int shared_counter = 0;
+static volatile bool mux_task_done_a = false;
+static volatile bool mux_task_done_b = false;
+
+static void muxTaskA(void *param) {
+  for (int i = 0; i < INCREMENT_COUNT; i++) {
+    portENTER_CRITICAL(&mux);
+    shared_counter++;
+    portEXIT_CRITICAL(&mux);
+  }
+  mux_task_done_a = true;
+  vTaskDelete(NULL);
+}
+
+static void muxTaskB(void *param) {
+  for (int i = 0; i < INCREMENT_COUNT; i++) {
+    portENTER_CRITICAL(&mux);
+    shared_counter++;
+    portEXIT_CRITICAL(&mux);
+  }
+  mux_task_done_b = true;
+  vTaskDelete(NULL);
+}
+
+void test_portmux_no_corruption(void) {
+  shared_counter = 0;
+  mux_task_done_a = false;
+  mux_task_done_b = false;
+
+#if CONFIG_FREERTOS_NUMBER_OF_CORES > 1
+  xTaskCreatePinnedToCore(muxTaskA, "muxA", TASK_STACK_SIZE, NULL, 1, NULL, 0);
+  xTaskCreatePinnedToCore(muxTaskB, "muxB", TASK_STACK_SIZE, NULL, 1, NULL, 1);
+#else
+  xTaskCreate(muxTaskA, "muxA", TASK_STACK_SIZE, NULL, 1, NULL);
+  xTaskCreate(muxTaskB, "muxB", TASK_STACK_SIZE, NULL, 1, NULL);
+#endif
+
+  unsigned long start = millis();
+  while ((!mux_task_done_a || !mux_task_done_b) && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(mux_task_done_a);
+  TEST_ASSERT_TRUE(mux_task_done_b);
+  TEST_ASSERT_EQUAL(INCREMENT_COUNT * 2, shared_counter);
+}
+
+// ==================== Binary Semaphore ====================
+
+static SemaphoreHandle_t sem = NULL;
+static volatile int sem_value = 0;
+
+static void semProducer(void *param) {
+  for (int i = 0; i < 5; i++) {
+    sem_value = i + 1;
+    xSemaphoreGive(sem);
+    delay(10);
+  }
+  vTaskDelete(NULL);
+}
+
+static volatile bool sem_consumer_done = false;
+static volatile int sem_last_value = 0;
+
+static void semConsumer(void *param) {
+  for (int i = 0; i < 5; i++) {
+    if (xSemaphoreTake(sem, pdMS_TO_TICKS(TASK_TIMEOUT_MS)) == pdTRUE) {
+      sem_last_value = sem_value;
+    }
+  }
+  sem_consumer_done = true;
+  vTaskDelete(NULL);
+}
+
+void test_semaphore(void) {
+  sem = xSemaphoreCreateBinary();
+  TEST_ASSERT_NOT_NULL(sem);
+  sem_value = 0;
+  sem_last_value = 0;
+  sem_consumer_done = false;
+
+  xTaskCreate(semConsumer, "consumer", TASK_STACK_SIZE, NULL, 1, NULL);
+  xTaskCreate(semProducer, "producer", TASK_STACK_SIZE, NULL, 1, NULL);
+
+  unsigned long start = millis();
+  while (!sem_consumer_done && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(sem_consumer_done);
+  TEST_ASSERT_EQUAL(5, sem_last_value);
+  vSemaphoreDelete(sem);
+  sem = NULL;
+}
+
+// ==================== Task Notification ====================
+
+static volatile bool notify_received = false;
+static volatile uint32_t notify_value = 0;
+
+static void notifyWaiter(void *param) {
+  uint32_t val = 0;
+  if (xTaskNotifyWait(0, ULONG_MAX, &val, pdMS_TO_TICKS(TASK_TIMEOUT_MS)) == pdTRUE) {
+    notify_value = val;
+    notify_received = true;
+  }
+  vTaskDelete(NULL);
+}
+
+void test_task_notification(void) {
+  notify_received = false;
+  notify_value = 0;
+
+  TaskHandle_t waiter = NULL;
+  xTaskCreate(notifyWaiter, "waiter", TASK_STACK_SIZE, NULL, 1, &waiter);
+  TEST_ASSERT_NOT_NULL(waiter);
+
+  delay(50);
+  xTaskNotify(waiter, 0xBEEF, eSetValueWithOverwrite);
+
+  unsigned long start = millis();
+  while (!notify_received && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(notify_received);
+  TEST_ASSERT_EQUAL_HEX32(0xBEEF, notify_value);
+}
+
+// ==================== Queue ====================
+
+static QueueHandle_t test_queue = NULL;
+
+static void queueProducer(void *param) {
+  for (int i = 1; i <= 10; i++) {
+    xQueueSend(test_queue, &i, pdMS_TO_TICKS(1000));
+    delay(5);
+  }
+  vTaskDelete(NULL);
+}
+
+void test_queue_send_receive(void) {
+  test_queue = xQueueCreate(10, sizeof(int));
+  TEST_ASSERT_NOT_NULL(test_queue);
+
+  xTaskCreate(queueProducer, "qProducer", TASK_STACK_SIZE, NULL, 1, NULL);
+
+  int received_sum = 0;
+  int val;
+  for (int i = 0; i < 10; i++) {
+    if (xQueueReceive(test_queue, &val, pdMS_TO_TICKS(TASK_TIMEOUT_MS)) == pdTRUE) {
+      received_sum += val;
+    }
+  }
+  TEST_ASSERT_EQUAL(55, received_sum);
+
+  vQueueDelete(test_queue);
+  test_queue = NULL;
+}
+
+// ==================== Mutex ====================
+
+static SemaphoreHandle_t test_mutex = NULL;
+static int mutex_counter = 0;
+static volatile bool mutex_task_a_done = false;
+static volatile bool mutex_task_b_done = false;
+
+static void mutexTaskA(void *param) {
+  for (int i = 0; i < 1000; i++) {
+    xSemaphoreTake(test_mutex, portMAX_DELAY);
+    mutex_counter++;
+    xSemaphoreGive(test_mutex);
+  }
+  mutex_task_a_done = true;
+  vTaskDelete(NULL);
+}
+
+static void mutexTaskB(void *param) {
+  for (int i = 0; i < 1000; i++) {
+    xSemaphoreTake(test_mutex, portMAX_DELAY);
+    mutex_counter++;
+    xSemaphoreGive(test_mutex);
+  }
+  mutex_task_b_done = true;
+  vTaskDelete(NULL);
+}
+
+void test_mutex_no_corruption(void) {
+  test_mutex = xSemaphoreCreateMutex();
+  TEST_ASSERT_NOT_NULL(test_mutex);
+  mutex_counter = 0;
+  mutex_task_a_done = false;
+  mutex_task_b_done = false;
+
+  xTaskCreate(mutexTaskA, "mutA", TASK_STACK_SIZE, NULL, 1, NULL);
+  xTaskCreate(mutexTaskB, "mutB", TASK_STACK_SIZE, NULL, 1, NULL);
+
+  unsigned long start = millis();
+  while ((!mutex_task_a_done || !mutex_task_b_done) && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(mutex_task_a_done);
+  TEST_ASSERT_TRUE(mutex_task_b_done);
+  TEST_ASSERT_EQUAL(2000, mutex_counter);
+
+  vSemaphoreDelete(test_mutex);
+  test_mutex = NULL;
+}
+
+// ==================== Event Group ====================
+
+#define EVT_BIT_A (1 << 0)
+#define EVT_BIT_B (1 << 1)
+
+static EventGroupHandle_t evt_group = NULL;
+static volatile bool evt_waiter_done = false;
+static volatile EventBits_t evt_result = 0;
+
+static void evtWaiter(void *param) {
+  evt_result = xEventGroupWaitBits(evt_group, EVT_BIT_A | EVT_BIT_B, pdTRUE, pdTRUE, pdMS_TO_TICKS(TASK_TIMEOUT_MS));
+  evt_waiter_done = true;
+  vTaskDelete(NULL);
+}
+
+void test_event_group(void) {
+  evt_group = xEventGroupCreate();
+  TEST_ASSERT_NOT_NULL(evt_group);
+  evt_waiter_done = false;
+  evt_result = 0;
+
+  xTaskCreate(evtWaiter, "evtWait", TASK_STACK_SIZE, NULL, 1, NULL);
+  delay(50);
+
+  xEventGroupSetBits(evt_group, EVT_BIT_A);
+  delay(50);
+  xEventGroupSetBits(evt_group, EVT_BIT_B);
+
+  unsigned long start = millis();
+  while (!evt_waiter_done && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+
+  TEST_ASSERT_TRUE(evt_waiter_done);
+  TEST_ASSERT_BITS(EVT_BIT_A | EVT_BIT_B, EVT_BIT_A | EVT_BIT_B, evt_result);
+
+  vEventGroupDelete(evt_group);
+  evt_group = NULL;
+}
+
+// ==================== Stack Watermark ====================
+
+static volatile UBaseType_t watermark_result = 0;
+
+static void stackWatermarkTask(void *param) {
+  char buf[256];
+  memset(buf, 0xAA, sizeof(buf));
+  watermark_result = uxTaskGetStackHighWaterMark(NULL);
+  vTaskDelete(NULL);
+}
+
+void test_stack_watermark(void) {
+  watermark_result = 0;
+  xTaskCreate(stackWatermarkTask, "watermark", TASK_STACK_SIZE, NULL, 1, NULL);
+
+  unsigned long start = millis();
+  while (watermark_result == 0 && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+
+  // Task used 256 bytes of stack for buf + overhead, watermark should be > 0 and < TASK_STACK_SIZE
+  TEST_ASSERT_GREATER_THAN(0, watermark_result);
+  TEST_ASSERT_LESS_THAN(TASK_STACK_SIZE / sizeof(StackType_t), watermark_result);
+}
+
+// ==================== Task Delete ====================
+
+static volatile bool delete_task_started = false;
+
+static void deletableTask(void *param) {
+  delete_task_started = true;
+  while (true) {
+    delay(100);
+  }
+}
+
+void test_task_delete(void) {
+  delete_task_started = false;
+  TaskHandle_t handle = NULL;
+  xTaskCreate(deletableTask, "deletable", TASK_STACK_SIZE, NULL, 1, &handle);
+  TEST_ASSERT_NOT_NULL(handle);
+
+  unsigned long start = millis();
+  while (!delete_task_started && millis() - start < TASK_TIMEOUT_MS) {
+    delay(10);
+  }
+  TEST_ASSERT_TRUE(delete_task_started);
+
+  vTaskDelete(handle);
+  delay(100);
+}
+
+// ==================== Main ====================
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_task_create);
+#if CONFIG_FREERTOS_NUMBER_OF_CORES > 1
+  RUN_TEST(test_dual_core_pinning);
+#endif
+  RUN_TEST(test_portmux_no_corruption);
+  RUN_TEST(test_semaphore);
+  RUN_TEST(test_task_notification);
+  RUN_TEST(test_queue_send_receive);
+  RUN_TEST(test_mutex_no_corruption);
+  RUN_TEST(test_event_group);
+  RUN_TEST(test_stack_watermark);
+  RUN_TEST(test_task_delete);
+
+  UNITY_END();
+}
+
+void loop() {}

--- a/tests/validation/multitasking/multitasking.ino
+++ b/tests/validation/multitasking/multitasking.ino
@@ -9,9 +9,9 @@
 #include <Arduino.h>
 #include <unity.h>
 
-#define TASK_STACK_SIZE   4096
-#define INCREMENT_COUNT   100000
-#define TASK_TIMEOUT_MS   5000
+#define TASK_STACK_SIZE 4096
+#define INCREMENT_COUNT 100000
+#define TASK_TIMEOUT_MS 5000
 
 void setUp(void) {}
 void tearDown(void) {}

--- a/tests/validation/multitasking/test_multitasking.py
+++ b/tests/validation/multitasking/test_multitasking.py
@@ -1,0 +1,2 @@
+def test_multitasking(dut):
+    dut.expect_unity_test_output(timeout=120)

--- a/tests/validation/power_management/README.md
+++ b/tests/validation/power_management/README.md
@@ -9,8 +9,8 @@ Validates power management features including task watchdog timer (TWDT), light 
 | Test Function | Description |
 |---|---|
 | `test_reset_reason_power_on` | Reset reason is power-on or deep sleep |
-| `test_twdt_feed` | Add task to TWDT, feed it, verify no timeout in 500ms |
-| `test_light_sleep_timer` | Enter light sleep for 500ms, verify wakeup cause and elapsed time |
+| `test_twdt_feed` | Add task to TWDT, feed it, verify no timeout in 500 ms |
+| `test_light_sleep_timer` | Enter light sleep for 500 ms, verify wakeup cause and elapsed time |
 
 ### Phase 1 (After Deep Sleep Wakeup)
 

--- a/tests/validation/power_management/README.md
+++ b/tests/validation/power_management/README.md
@@ -1,0 +1,37 @@
+# Power Management Validation Test
+
+Validates power management features including task watchdog timer (TWDT), light sleep, deep sleep with timer wakeup, and RTC data persistence. Uses a two-phase approach with a deep sleep reboot between phases.
+
+## Test Cases
+
+### Phase 0 (Initial Boot)
+
+| Test Function | Description |
+|---|---|
+| `test_reset_reason_power_on` | Reset reason is power-on or deep sleep |
+| `test_twdt_feed` | Add task to TWDT, feed it, verify no timeout in 500ms |
+| `test_light_sleep_timer` | Enter light sleep for 500ms, verify wakeup cause and elapsed time |
+
+### Phase 1 (After Deep Sleep Wakeup)
+
+| Test Function | Description |
+|---|---|
+| `test_deep_sleep_verify` | Wakeup cause is `ESP_SLEEP_WAKEUP_TIMER` |
+| `test_rtc_data_persisted` | `RTC_DATA_ATTR` magic value (0xDEADBEEF) and boot count survive deep sleep |
+
+## Requirements
+
+- **Hardware**: Any ESP32 variant
+- **Wokwi**: Not supported (RTC only partially simulated)
+- **QEMU**: Not supported
+
+## Serial Protocol
+
+1. Phase 0: Unity test output for initial boot tests
+2. Firmware prints `DEEP_SLEEP_START` then enters deep sleep for 2 seconds
+3. Phase 1: Unity test output for deep sleep verification tests
+
+## Notes
+
+- The pytest script handles the two-phase output by calling `expect_unity_test_output()` twice, with a `DEEP_SLEEP_START` sentinel between them.
+- `RTC_DATA_ATTR` variables (`boot_count`, `rtc_magic`) persist across deep sleep to verify RTC memory retention.

--- a/tests/validation/power_management/ci.yml
+++ b/tests/validation/power_management/ci.yml
@@ -1,0 +1,3 @@
+platforms:
+  wokwi: false
+  qemu: false

--- a/tests/validation/power_management/power_management.ino
+++ b/tests/validation/power_management/power_management.ino
@@ -1,0 +1,122 @@
+/*
+ * Power Management Validation Test (hardware only -- Wokwi disabled)
+ *
+ * RTC is only partially simulated in Wokwi (pull-up/pull-down only),
+ * so deep sleep and RTC_DATA_ATTR persistence do not work reliably.
+ * The entire suite runs on hardware only.
+ *
+ * Covers:
+ *   TWDT: feed/starve, reset reason verification
+ *   Deep sleep: timer wakeup, wakeup cause, RTC_DATA_ATTR persistence
+ *   Light sleep: timer wakeup, no reboot
+ *   Reset reason: power-on vs deep sleep
+ *
+ * The test uses a phased approach:
+ *   Phase 0: Initial boot - run non-reboot tests, then trigger deep sleep
+ *   Phase 1: After deep sleep - verify wakeup cause + RTC data
+ */
+
+#include <Arduino.h>
+#include <unity.h>
+#include <esp_sleep.h>
+#include <esp_task_wdt.h>
+
+#define DEEP_SLEEP_US   2000000  // 2 seconds
+
+RTC_DATA_ATTR int boot_count = 0;
+RTC_DATA_ATTR uint32_t rtc_magic = 0;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ==================== Reset Reason ====================
+
+void test_reset_reason_power_on(void) {
+  esp_reset_reason_t reason = esp_reset_reason();
+  TEST_ASSERT_TRUE_MESSAGE(
+    reason == ESP_RST_POWERON || reason == ESP_RST_DEEPSLEEP,
+    "Unexpected reset reason on initial boot"
+  );
+}
+
+// ==================== TWDT ====================
+
+void test_twdt_feed(void) {
+  esp_task_wdt_config_t config = {
+    .timeout_ms = 3000,
+    .idle_core_mask = 0,
+    .trigger_panic = false,
+  };
+  TEST_ASSERT_EQUAL(ESP_OK, esp_task_wdt_reconfigure(&config));
+  TEST_ASSERT_EQUAL(ESP_OK, esp_task_wdt_add(NULL));
+  TEST_ASSERT_EQUAL(ESP_OK, esp_task_wdt_reset());
+  delay(500);
+  TEST_ASSERT_EQUAL(ESP_OK, esp_task_wdt_reset());
+  TEST_ASSERT_EQUAL(ESP_OK, esp_task_wdt_delete(NULL));
+}
+
+// ==================== Light Sleep ====================
+
+void test_light_sleep_timer(void) {
+  esp_sleep_enable_timer_wakeup(500000);  // 500ms
+  unsigned long before = millis();
+  esp_err_t ret = esp_light_sleep_start();
+  unsigned long elapsed = millis() - before;
+
+  TEST_ASSERT_EQUAL(ESP_OK, ret);
+  TEST_ASSERT_GREATER_OR_EQUAL(400, elapsed);
+  TEST_ASSERT_LESS_OR_EQUAL(2000, elapsed);
+
+  esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+  TEST_ASSERT_EQUAL(ESP_SLEEP_WAKEUP_TIMER, cause);
+}
+
+// ==================== Deep Sleep Phase ====================
+
+void test_deep_sleep_verify(void) {
+  esp_sleep_wakeup_cause_t cause = esp_sleep_get_wakeup_cause();
+  TEST_ASSERT_EQUAL(ESP_SLEEP_WAKEUP_TIMER, cause);
+}
+
+void test_rtc_data_persisted(void) {
+  TEST_ASSERT_EQUAL_HEX32(0xDEADBEEF, rtc_magic);
+  TEST_ASSERT_GREATER_OR_EQUAL(2, boot_count);
+}
+
+// ==================== Main ====================
+
+void setup() {
+  boot_count++;
+
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  UNITY_BEGIN();
+
+  bool woke_from_deep_sleep = (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_TIMER && rtc_magic == 0xDEADBEEF);
+
+  if (woke_from_deep_sleep) {
+    // Phase 1: woke from deep sleep
+    RUN_TEST(test_deep_sleep_verify);
+    RUN_TEST(test_rtc_data_persisted);
+  } else {
+    // Phase 0: initial boot
+    RUN_TEST(test_reset_reason_power_on);
+    RUN_TEST(test_twdt_feed);
+    RUN_TEST(test_light_sleep_timer);
+  }
+
+  UNITY_END();
+
+  if (!woke_from_deep_sleep) {
+    rtc_magic = 0xDEADBEEF;
+    Serial.println("DEEP_SLEEP_START");
+    Serial.flush();
+    esp_sleep_enable_timer_wakeup(DEEP_SLEEP_US);
+    esp_deep_sleep_start();
+  }
+}
+
+void loop() {}

--- a/tests/validation/power_management/power_management.ino
+++ b/tests/validation/power_management/power_management.ino
@@ -21,7 +21,7 @@
 #include <esp_sleep.h>
 #include <esp_task_wdt.h>
 
-#define DEEP_SLEEP_US   2000000  // 2 seconds
+#define DEEP_SLEEP_US 2000000  // 2 seconds
 
 RTC_DATA_ATTR int boot_count = 0;
 RTC_DATA_ATTR uint32_t rtc_magic = 0;
@@ -33,10 +33,7 @@ void tearDown(void) {}
 
 void test_reset_reason_power_on(void) {
   esp_reset_reason_t reason = esp_reset_reason();
-  TEST_ASSERT_TRUE_MESSAGE(
-    reason == ESP_RST_POWERON || reason == ESP_RST_DEEPSLEEP,
-    "Unexpected reset reason on initial boot"
-  );
+  TEST_ASSERT_TRUE_MESSAGE(reason == ESP_RST_POWERON || reason == ESP_RST_DEEPSLEEP, "Unexpected reset reason on initial boot");
 }
 
 // ==================== TWDT ====================

--- a/tests/validation/power_management/test_power_management.py
+++ b/tests/validation/power_management/test_power_management.py
@@ -1,0 +1,14 @@
+import logging
+
+
+def test_power_management(dut):
+    LOGGER = logging.getLogger(__name__)
+
+    LOGGER.info("Phase 0: Running initial boot tests (reset reason, TWDT, light sleep)")
+    dut.expect_unity_test_output(timeout=60)
+
+    LOGGER.info("Waiting for deep sleep entry...")
+    dut.expect_exact("DEEP_SLEEP_START", timeout=30)
+
+    LOGGER.info("Phase 1: Waiting for deep sleep wakeup and RTC verification")
+    dut.expect_unity_test_output(timeout=30)

--- a/tests/validation/ticker/README.md
+++ b/tests/validation/ticker/README.md
@@ -1,0 +1,39 @@
+# Ticker Validation Test
+
+Validates the Ticker library: initial inactive state, periodic callbacks (attach/attach_ms/attach_us), one-shot callbacks (once/once_ms/once_us), active() state transitions, detach behavior, restart with period change, re-attach while running, typed argument callbacks, and large struct arguments.
+
+## Test Cases
+
+| Test Function | Description |
+|---|---|
+| `test_initially_inactive` | New Ticker reports `active() == false` |
+| `test_attach_ms_periodic` | 100ms periodic fires ~5 times in 550ms |
+| `test_attach_us_periodic` | 100000µs periodic fires ~5 times in 550ms |
+| `test_attach_seconds_periodic` | 0.1s periodic fires ~5 times in 550ms |
+| `test_once_ms` | One-shot fires exactly once, becomes inactive |
+| `test_once_us` | One-shot (µs) fires exactly once |
+| `test_once_seconds` | One-shot (float seconds) fires exactly once |
+| `test_active_while_running` | `active()` is true while attached, false after detach |
+| `test_detach_stops_periodic` | No callbacks fire after detach |
+| `test_detach_on_inactive_is_safe` | Double-detach does not crash |
+| `test_restart_ms` | Change period from 5s to 100ms via restart |
+| `test_restart_us` | Restart with µs period |
+| `test_restart_seconds` | Restart with float seconds |
+| `test_reattach_while_running` | Re-attach without manual detach succeeds |
+| `test_reattach_different_callback` | Switch callback while running |
+| `test_attach_ms_with_arg` | Periodic callback receives typed int argument |
+| `test_once_ms_with_arg` | One-shot callback receives typed int argument |
+| `test_once_ms_with_large_arg` | One-shot with struct argument (> sizeof(void*)) |
+| `test_attach_ms_with_large_arg` | Periodic with struct argument |
+
+## Requirements
+
+- **Hardware**: Any ESP32 variant
+- **Wokwi**: Supported
+- **QEMU**: Supported
+
+## Notes
+
+- All timing assertions use `TEST_ASSERT_INT_WITHIN` to tolerate ±1 jitter from simulation.
+- setUp/tearDown detach the ticker between tests for isolation.
+- Large argument tests verify the Ticker template correctly copies structs larger than a pointer.

--- a/tests/validation/ticker/README.md
+++ b/tests/validation/ticker/README.md
@@ -7,16 +7,16 @@ Validates the Ticker library: initial inactive state, periodic callbacks (attach
 | Test Function | Description |
 |---|---|
 | `test_initially_inactive` | New Ticker reports `active() == false` |
-| `test_attach_ms_periodic` | 100ms periodic fires ~5 times in 550ms |
-| `test_attach_us_periodic` | 100000µs periodic fires ~5 times in 550ms |
-| `test_attach_seconds_periodic` | 0.1s periodic fires ~5 times in 550ms |
+| `test_attach_ms_periodic` | 100 ms periodic fires ~5 times in 550 ms |
+| `test_attach_us_periodic` | 100000 µs periodic fires ~5 times in 550 ms |
+| `test_attach_seconds_periodic` | 0.1 s periodic fires ~5 times in 550 ms |
 | `test_once_ms` | One-shot fires exactly once, becomes inactive |
 | `test_once_us` | One-shot (µs) fires exactly once |
 | `test_once_seconds` | One-shot (float seconds) fires exactly once |
 | `test_active_while_running` | `active()` is true while attached, false after detach |
 | `test_detach_stops_periodic` | No callbacks fire after detach |
 | `test_detach_on_inactive_is_safe` | Double-detach does not crash |
-| `test_restart_ms` | Change period from 5s to 100ms via restart |
+| `test_restart_ms` | Change period from 5 s to 100 ms via restart |
 | `test_restart_us` | Restart with µs period |
 | `test_restart_seconds` | Restart with float seconds |
 | `test_reattach_while_running` | Re-attach without manual detach succeeds |

--- a/tests/validation/ticker/test_ticker.py
+++ b/tests/validation/ticker/test_ticker.py
@@ -1,0 +1,2 @@
+def test_ticker(dut):
+    dut.expect_unity_test_output(timeout=120)

--- a/tests/validation/ticker/ticker.ino
+++ b/tests/validation/ticker/ticker.ino
@@ -1,0 +1,275 @@
+/*
+ * Ticker Validation Test
+ *
+ * Covers: initial inactive state, periodic attach (attach/attach_ms/attach_us),
+ * one-shot once (once/once_ms/once_us), active() state transitions,
+ * detach() stops callbacks, restart changes the period, re-attach while
+ * running, callbacks with typed arguments (attach/once with TArg overload),
+ * and large typed arguments (larger than sizeof(void*)).
+ */
+
+#include <Arduino.h>
+#include <Ticker.h>
+#include <unity.h>
+
+static Ticker ticker;
+static volatile int callCount = 0;
+static volatile int argReceived = 0;
+
+static void countCb(void) {
+  callCount = callCount + 1;
+}
+
+static void argCb(int val) {
+  argReceived = val;
+}
+
+void setUp(void) {
+  ticker.detach();
+  callCount = 0;
+  argReceived = 0;
+}
+
+void tearDown(void) {
+  ticker.detach();
+}
+
+// ==================== Initial state ====================
+
+void test_initially_inactive(void) {
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+// ==================== attach (periodic) ====================
+
+void test_attach_ms_periodic(void) {
+  ticker.attach_ms(100, countCb);
+  TEST_ASSERT_TRUE(ticker.active());
+  delay(550);
+  ticker.detach();
+  // Should have fired ~5 times in 550 ms; allow ±1 for simulation jitter
+  TEST_ASSERT_INT_WITHIN(1, 5, callCount);
+}
+
+void test_attach_us_periodic(void) {
+  ticker.attach_us(100000, countCb);  // 100 ms in µs
+  TEST_ASSERT_TRUE(ticker.active());
+  delay(550);
+  ticker.detach();
+  TEST_ASSERT_INT_WITHIN(1, 5, callCount);
+}
+
+void test_attach_seconds_periodic(void) {
+  ticker.attach(0.1f, countCb);  // 100 ms
+  TEST_ASSERT_TRUE(ticker.active());
+  delay(550);
+  ticker.detach();
+  TEST_ASSERT_INT_WITHIN(1, 5, callCount);
+}
+
+// ==================== once (one-shot) ====================
+
+void test_once_ms(void) {
+  ticker.once_ms(100, countCb);
+  TEST_ASSERT_TRUE(ticker.active());
+  delay(300);
+  TEST_ASSERT_EQUAL(1, callCount);
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+void test_once_us(void) {
+  ticker.once_us(100000, countCb);  // 100 ms in µs
+  TEST_ASSERT_TRUE(ticker.active());
+  delay(300);
+  TEST_ASSERT_EQUAL(1, callCount);
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+void test_once_seconds(void) {
+  ticker.once(0.1f, countCb);  // 100 ms
+  TEST_ASSERT_TRUE(ticker.active());
+  delay(300);
+  TEST_ASSERT_EQUAL(1, callCount);
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+// ==================== active() state ====================
+
+void test_active_while_running(void) {
+  ticker.attach_ms(5000, countCb);  // Long period — will not fire during test
+  TEST_ASSERT_TRUE(ticker.active());
+  ticker.detach();
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+// ==================== detach() ====================
+
+void test_detach_stops_periodic(void) {
+  ticker.attach_ms(100, countCb);
+  delay(250);
+  ticker.detach();
+  int count_at_detach = callCount;
+  delay(300);
+  // No additional callbacks after detach
+  TEST_ASSERT_EQUAL(count_at_detach, callCount);
+}
+
+void test_detach_on_inactive_is_safe(void) {
+  // Double-detach must not crash
+  ticker.detach();
+  ticker.detach();
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+// ==================== restart() ====================
+
+void test_restart_ms(void) {
+  // Start with a long period (5 s) so it does not fire during setup
+  ticker.attach_ms(5000, countCb);
+  TEST_ASSERT_EQUAL(0, callCount);
+  // Shorten period to 100 ms
+  ticker.restart_ms(100);
+  delay(400);
+  ticker.detach();
+  // Should have fired at least once after restart
+  TEST_ASSERT_GREATER_THAN(0, callCount);
+}
+
+void test_restart_us(void) {
+  ticker.attach_ms(5000, countCb);
+  ticker.restart_us(100000);  // 100 ms in µs
+  delay(400);
+  ticker.detach();
+  TEST_ASSERT_GREATER_THAN(0, callCount);
+}
+
+void test_restart_seconds(void) {
+  ticker.attach_ms(5000, countCb);
+  ticker.restart(0.1f);  // 100 ms
+  delay(400);
+  ticker.detach();
+  TEST_ASSERT_GREATER_THAN(0, callCount);
+}
+
+// ==================== Re-attach while running ====================
+
+void test_reattach_while_running(void) {
+  ticker.attach_ms(100, countCb);
+  delay(250);
+  TEST_ASSERT_GREATER_THAN(0, callCount);
+  callCount = 0;
+  // Re-attach without manual detach — must not crash or leak the old timer
+  ticker.attach_ms(100, countCb);
+  TEST_ASSERT_TRUE(ticker.active());
+  delay(350);
+  ticker.detach();
+  TEST_ASSERT_INT_WITHIN(1, 3, callCount);
+}
+
+void test_reattach_different_callback(void) {
+  ticker.attach_ms(100, countCb);
+  delay(150);
+  // Switch to a different callback while running
+  ticker.attach_ms(100, argCb, (int)77);
+  delay(200);
+  ticker.detach();
+  TEST_ASSERT_EQUAL(77, argReceived);
+}
+
+// ==================== Callbacks with arguments ====================
+
+void test_attach_ms_with_arg(void) {
+  ticker.attach_ms(100, argCb, (int)99);
+  delay(200);
+  ticker.detach();
+  TEST_ASSERT_EQUAL(99, argReceived);
+}
+
+void test_once_ms_with_arg(void) {
+  ticker.once_ms(100, argCb, (int)42);
+  delay(300);
+  TEST_ASSERT_EQUAL(42, argReceived);
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+// ==================== Large typed arguments ====================
+
+struct BigArg {
+  int a;
+  int b;
+  int c;
+};
+
+static volatile int bigArgSum = 0;
+
+static void bigArgCb(BigArg arg) {
+  bigArgSum = arg.a + arg.b + arg.c;
+}
+
+void test_once_ms_with_large_arg(void) {
+  bigArgSum = 0;
+  BigArg val = {10, 20, 30};
+  ticker.once_ms(100, bigArgCb, val);
+  delay(300);
+  TEST_ASSERT_EQUAL(60, bigArgSum);
+  TEST_ASSERT_FALSE(ticker.active());
+}
+
+void test_attach_ms_with_large_arg(void) {
+  bigArgSum = 0;
+  BigArg val = {100, 200, 300};
+  ticker.attach_ms(100, bigArgCb, val);
+  delay(200);
+  ticker.detach();
+  TEST_ASSERT_EQUAL(600, bigArgSum);
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  UNITY_BEGIN();
+
+  // Initial state
+  RUN_TEST(test_initially_inactive);
+
+  // Periodic attach variants
+  RUN_TEST(test_attach_ms_periodic);
+  RUN_TEST(test_attach_us_periodic);
+  RUN_TEST(test_attach_seconds_periodic);
+
+  // One-shot variants
+  RUN_TEST(test_once_ms);
+  RUN_TEST(test_once_us);
+  RUN_TEST(test_once_seconds);
+
+  // active() state
+  RUN_TEST(test_active_while_running);
+
+  // detach()
+  RUN_TEST(test_detach_stops_periodic);
+  RUN_TEST(test_detach_on_inactive_is_safe);
+
+  // restart() variants
+  RUN_TEST(test_restart_ms);
+  RUN_TEST(test_restart_us);
+  RUN_TEST(test_restart_seconds);
+
+  // Re-attach while running
+  RUN_TEST(test_reattach_while_running);
+  RUN_TEST(test_reattach_different_callback);
+
+  // Argument callbacks
+  RUN_TEST(test_attach_ms_with_arg);
+  RUN_TEST(test_once_ms_with_arg);
+
+  // Large typed arguments (larger than sizeof(void*))
+  RUN_TEST(test_once_ms_with_large_arg);
+  RUN_TEST(test_attach_ms_with_large_arg);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Description of Change

This pull request adds comprehensive validation tests for multitasking, power management, and the Ticker library in the ESP32 Arduino environment. Each test suite includes detailed documentation, test implementation (Arduino and pytest), and platform support notes. The changes ensure robust coverage of FreeRTOS primitives, power management features, and Ticker behaviors, with clear separation of hardware and simulation support.

**Multitasking Validation:**

* Added `README.md` describing coverage of FreeRTOS primitives (task creation, dual-core pinning, synchronization objects, etc.), test cases, and platform support.
* Added `test_multitasking.py` pytest script to run the multitasking test suite and expect Unity test output.

**Power Management Validation:**

* Added `README.md` detailing the two-phase (deep sleep) test approach, test cases for TWDT, sleep modes, RTC data, and platform support.
* Added `power_management.ino` implementing the two-phase test, covering TWDT, light/deep sleep, RTC memory, and reset reasons.
* Added `test_power_management.py` pytest script to handle the two-phase output and deep sleep sentinel.
* Added `ci.yml` to explicitly disable Wokwi and QEMU for power management tests due to incomplete simulation support.

**Ticker Validation:**

* Added `README.md` describing coverage of Ticker features, test cases, and simulation notes.
* Added `ticker.ino` with tests for periodic/one-shot callbacks, state transitions, detach/restart, argument passing, and large struct support.
* Added `test_ticker.py` pytest script to run the Ticker test suite and expect Unity output.

## Test Scenarios

Tested locally