### PR TITLE
tests(analog): Add analog and PWM tests

### DIFF
--- a/tests/validation/adc_pwm/README.md
+++ b/tests/validation/adc_pwm/README.md
@@ -1,0 +1,46 @@
+# ADC / PWM Validation Test
+
+Single-device Unity test for ADC, LEDC (PWM), and SigmaDelta peripherals.
+
+## Test Cases
+
+| Test Function | Description |
+|---|---|
+| `test_adc_read_basic` | `analogRead` within 0–4095 |
+| `test_adc_resolution` | `analogReadResolution` at 10-bit and 12-bit |
+| `test_adc_millivolts` | `analogReadMilliVolts` within 0–3300 |
+| `test_adc_attenuation` | `analogSetAttenuation` ADC_0db / ADC_11db |
+| `test_adc_continuous` | `analogContinuous` DMA mode with ISR completion |
+| `test_ledc_attach_detach` | `ledcAttach` / `ledcDetach` |
+| `test_ledc_write_duty` | `ledcWrite` at 0 / 128 / 255 |
+| `test_ledc_read_freq` | `ledcReadFreq` matches set frequency |
+| `test_ledc_change_frequency` | `ledcChangeFrequency` to 10 kHz |
+| `test_ledc_fade` | `ledcFade` 0 to 255 over 500 ms |
+| `test_ledc_tone` | `ledcWriteTone` at 440 Hz |
+| `test_sigmadelta_attach_detach` | SigmaDelta attach / write / detach (`SOC_SDM_SUPPORTED` only) |
+
+## Requirements
+
+- **Hardware**: Single ESP32 devkit
+- **Wokwi**: Disabled — SigmaDelta is not simulated in Wokwi
+- **QEMU**: Disabled
+
+## Pin Configuration
+
+Per-target GPIO numbers are in `pins_config.h`. They follow [CI_README — DevKit GPIO Reference](../../../.github/CI_README.md#devkit-gpio-reference) and [Peripheral API constraints](../../../.github/CI_README.md#peripheral-api-constraints).
+
+| SoC | ADC | LEDC | SigmaDelta |
+|---|---|---|---|
+| ESP32 | `A4` (GPIO32, ADC1) | GPIO16 | GPIO13 |
+| ESP32-S2 | `A0` (GPIO1) | GPIO4 | GPIO5 |
+| ESP32-S3 | `A0` (GPIO1) | GPIO4 | GPIO5 |
+| ESP32-C3 | `A0` (GPIO0) | GPIO3 | GPIO10 |
+| ESP32-C5 | `A0` (GPIO1) | GPIO4 | GPIO9 |
+| ESP32-C6 | `A0` (GPIO0) | GPIO2 | GPIO3 |
+| ESP32-H2 | `A0` (GPIO1) | GPIO4 | GPIO5 |
+| ESP32-P4 | `A4` (GPIO20) | GPIO6 | GPIO7 |
+
+## Notes
+
+- SigmaDelta tests only compile on chips with `SOC_SDM_SUPPORTED`.
+- DAC loopback is covered by the separate `dac` multi-DUT test.

--- a/tests/validation/adc_pwm/adc_pwm.ino
+++ b/tests/validation/adc_pwm/adc_pwm.ino
@@ -12,8 +12,8 @@
 #include "esp_adc/adc_continuous.h"
 #endif
 
-#define LEDC_FREQ   5000
-#define LEDC_RES    8
+#define LEDC_FREQ 5000
+#define LEDC_RES  8
 
 void setUp(void) {}
 

--- a/tests/validation/adc_pwm/adc_pwm.ino
+++ b/tests/validation/adc_pwm/adc_pwm.ino
@@ -1,0 +1,206 @@
+/*
+ * ADC / PWM Validation Test
+ *
+ * Single-device Unity tests for ADC, LEDC (PWM), and SigmaDelta.
+ */
+
+#include <Arduino.h>
+#include <unity.h>
+#include "pins_config.h"
+
+#if SOC_ADC_SUPPORTED
+#include "esp_adc/adc_continuous.h"
+#endif
+
+#define LEDC_FREQ   5000
+#define LEDC_RES    8
+
+void setUp(void) {}
+
+void tearDown(void) {
+#if SOC_LEDC_SUPPORTED
+  ledcDetach(LEDC_PIN);
+#endif
+#if SOC_ADC_SUPPORTED
+  analogContinuousStop();
+  analogContinuousDeinit();
+#endif
+}
+
+// ==================== ADC Tests ====================
+#if SOC_ADC_SUPPORTED
+
+void test_adc_read_basic(void) {
+  uint16_t val = analogRead(ADC_PIN);
+  TEST_ASSERT_LESS_OR_EQUAL(4095, val);
+}
+
+void test_adc_resolution(void) {
+  analogReadResolution(10);
+  uint16_t val10 = analogRead(ADC_PIN);
+  TEST_ASSERT_LESS_OR_EQUAL(1023, val10);
+
+  analogReadResolution(12);
+  uint16_t val12 = analogRead(ADC_PIN);
+  TEST_ASSERT_LESS_OR_EQUAL(4095, val12);
+}
+
+void test_adc_millivolts(void) {
+  analogReadResolution(12);
+  uint32_t mv = analogReadMilliVolts(ADC_PIN);
+  TEST_ASSERT_LESS_OR_EQUAL(3300, mv);
+}
+
+void test_adc_attenuation(void) {
+  analogReadResolution(12);
+
+  analogSetAttenuation(ADC_0db);
+  uint16_t v0 = analogRead(ADC_PIN);
+  TEST_ASSERT_LESS_OR_EQUAL(4095, v0);
+
+  analogSetAttenuation(ADC_11db);
+  uint16_t v11 = analogRead(ADC_PIN);
+  TEST_ASSERT_LESS_OR_EQUAL(4095, v11);
+}
+
+static volatile bool adc_continuous_done = false;
+
+static void IRAM_ATTR adcContinuousISR(void) {
+  adc_continuous_done = true;
+}
+
+void test_adc_continuous(void) {
+  adc_continuous_done = false;
+  const uint8_t pins[] = {(uint8_t)ADC_PIN};
+
+  analogContinuousSetWidth(12);
+  analogContinuousSetAtten(ADC_11db);
+
+  TEST_ASSERT_TRUE(analogContinuous(pins, 1, 6, 20000, adcContinuousISR));
+  TEST_ASSERT_TRUE(analogContinuousStart());
+
+  unsigned long start = millis();
+  while (!adc_continuous_done && millis() - start < 3000) {
+    delay(10);
+  }
+  TEST_ASSERT_TRUE(adc_continuous_done);
+
+  adc_continuous_result_t *results = NULL;
+  TEST_ASSERT_TRUE(analogContinuousRead(&results, 1000));
+  TEST_ASSERT_NOT_NULL(results);
+
+  TEST_ASSERT_TRUE(analogContinuousStop());
+  TEST_ASSERT_TRUE(analogContinuousDeinit());
+}
+
+#endif  // SOC_ADC_SUPPORTED
+
+// ==================== LEDC Tests ====================
+#if SOC_LEDC_SUPPORTED
+
+void test_ledc_attach_detach(void) {
+  TEST_ASSERT_TRUE(ledcAttach(LEDC_PIN, LEDC_FREQ, LEDC_RES));
+  TEST_ASSERT_TRUE(ledcDetach(LEDC_PIN));
+}
+
+void test_ledc_write_duty(void) {
+  TEST_ASSERT_TRUE(ledcAttach(LEDC_PIN, LEDC_FREQ, LEDC_RES));
+
+  TEST_ASSERT_TRUE(ledcWrite(LEDC_PIN, 0));
+  delay(5);
+  TEST_ASSERT_EQUAL(0, ledcRead(LEDC_PIN));
+
+  TEST_ASSERT_TRUE(ledcWrite(LEDC_PIN, 128));
+  delay(5);
+  TEST_ASSERT_EQUAL(128, ledcRead(LEDC_PIN));
+
+  TEST_ASSERT_TRUE(ledcWrite(LEDC_PIN, 255));
+  delay(5);
+  /* 8-bit duty max can read back as 255 or 256 depending on SoC/timer */
+  TEST_ASSERT_UINT32_WITHIN(1, 255, ledcRead(LEDC_PIN));
+
+  ledcDetach(LEDC_PIN);
+}
+
+void test_ledc_read_freq(void) {
+  TEST_ASSERT_TRUE(ledcAttach(LEDC_PIN, LEDC_FREQ, LEDC_RES));
+  TEST_ASSERT_TRUE(ledcWrite(LEDC_PIN, 128));
+
+  uint32_t freq = ledcReadFreq(LEDC_PIN);
+  TEST_ASSERT_UINT32_WITHIN(500, LEDC_FREQ, freq);
+
+  ledcDetach(LEDC_PIN);
+}
+
+void test_ledc_change_frequency(void) {
+  TEST_ASSERT_TRUE(ledcAttach(LEDC_PIN, LEDC_FREQ, LEDC_RES));
+  TEST_ASSERT_TRUE(ledcWrite(LEDC_PIN, 128));
+
+  uint32_t new_freq = ledcChangeFrequency(LEDC_PIN, 10000, LEDC_RES);
+  TEST_ASSERT_UINT32_WITHIN(1000, 10000, new_freq);
+
+  ledcDetach(LEDC_PIN);
+}
+
+void test_ledc_fade(void) {
+  TEST_ASSERT_TRUE(ledcAttach(LEDC_PIN, LEDC_FREQ, LEDC_RES));
+  TEST_ASSERT_TRUE(ledcFade(LEDC_PIN, 0, 255, 500));
+  delay(600);
+  ledcDetach(LEDC_PIN);
+}
+
+void test_ledc_tone(void) {
+  TEST_ASSERT_TRUE(ledcAttach(LEDC_PIN, LEDC_FREQ, LEDC_RES));
+  uint32_t freq = ledcWriteTone(LEDC_PIN, 440);
+  TEST_ASSERT_UINT32_WITHIN(10, 440, freq);
+  ledcDetach(LEDC_PIN);
+}
+
+#endif  // SOC_LEDC_SUPPORTED
+
+// ==================== SigmaDelta Tests ====================
+#if SOC_SDM_SUPPORTED
+
+void test_sigmadelta_attach_detach(void) {
+  TEST_ASSERT_TRUE(sigmaDeltaAttach(SIGMADELTA_PIN, 1000000));
+  TEST_ASSERT_TRUE(sigmaDeltaWrite(SIGMADELTA_PIN, 0));
+  TEST_ASSERT_TRUE(sigmaDeltaWrite(SIGMADELTA_PIN, 127));
+  TEST_ASSERT_TRUE(sigmaDeltaWrite(SIGMADELTA_PIN, -128));
+  TEST_ASSERT_TRUE(sigmaDeltaDetach(SIGMADELTA_PIN));
+}
+
+#endif  // SOC_SDM_SUPPORTED
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  UNITY_BEGIN();
+
+#if SOC_ADC_SUPPORTED
+  RUN_TEST(test_adc_read_basic);
+  RUN_TEST(test_adc_resolution);
+  RUN_TEST(test_adc_millivolts);
+  RUN_TEST(test_adc_attenuation);
+  RUN_TEST(test_adc_continuous);
+#endif
+
+#if SOC_LEDC_SUPPORTED
+  RUN_TEST(test_ledc_attach_detach);
+  RUN_TEST(test_ledc_write_duty);
+  RUN_TEST(test_ledc_read_freq);
+  RUN_TEST(test_ledc_change_frequency);
+  RUN_TEST(test_ledc_fade);
+  RUN_TEST(test_ledc_tone);
+#endif
+
+#if SOC_SDM_SUPPORTED
+  RUN_TEST(test_sigmadelta_attach_detach);
+#endif
+
+  UNITY_END();
+}
+
+void loop() {}

--- a/tests/validation/adc_pwm/ci.yml
+++ b/tests/validation/adc_pwm/ci.yml
@@ -1,0 +1,3 @@
+platforms:
+  wokwi: false
+  qemu: false

--- a/tests/validation/adc_pwm/pins_config.h
+++ b/tests/validation/adc_pwm/pins_config.h
@@ -13,8 +13,8 @@
 #include <Arduino.h>
 
 #if CONFIG_IDF_TARGET_ESP32
-#define ADC_PIN        A4    /* GPIO32, ADC1 — see CI_README Peripheral API constraints */
-#define LEDC_PIN       16   /* not T0 (GPIO4); see CI_README LEDC + Touch note */
+#define ADC_PIN        A4 /* GPIO32, ADC1 — see CI_README Peripheral API constraints */
+#define LEDC_PIN       16 /* not T0 (GPIO4); see CI_README LEDC + Touch note */
 #define SIGMADELTA_PIN 13
 #elif CONFIG_IDF_TARGET_ESP32S2
 #define ADC_PIN        A0
@@ -41,7 +41,7 @@
 #define LEDC_PIN       4
 #define SIGMADELTA_PIN 5
 #elif CONFIG_IDF_TARGET_ESP32P4
-#define ADC_PIN        A4   /* GPIO20; A0→16 is SDIO */
+#define ADC_PIN        A4 /* GPIO20; A0→16 is SDIO */
 #define LEDC_PIN       6
 #define SIGMADELTA_PIN 7
 #else

--- a/tests/validation/adc_pwm/pins_config.h
+++ b/tests/validation/adc_pwm/pins_config.h
@@ -1,0 +1,51 @@
+/*
+ * Per-target GPIO selection for adc_pwm.
+ *
+ * Pins must be valid for this sketch per .github/CI_README.md (DevKit GPIO
+ * Reference): no strapping / flash / USB-JTAG / input-only pins, and no
+ * conflict with peripherals used here (ADC, LEDC, SigmaDelta only —
+ * Wire, SPI, and Touch are not initialized).
+ */
+
+#ifndef ADC_PWM_PINS_CONFIG_H
+#define ADC_PWM_PINS_CONFIG_H
+
+#include <Arduino.h>
+
+#if CONFIG_IDF_TARGET_ESP32
+#define ADC_PIN        A4    /* GPIO32, ADC1 — see CI_README Peripheral API constraints */
+#define LEDC_PIN       16   /* not T0 (GPIO4); see CI_README LEDC + Touch note */
+#define SIGMADELTA_PIN 13
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define ADC_PIN        A0
+#define LEDC_PIN       4
+#define SIGMADELTA_PIN 5
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define ADC_PIN        A0
+#define LEDC_PIN       4
+#define SIGMADELTA_PIN 5
+#elif CONFIG_IDF_TARGET_ESP32C3
+#define ADC_PIN        A0
+#define LEDC_PIN       3
+#define SIGMADELTA_PIN 10
+#elif CONFIG_IDF_TARGET_ESP32C5
+#define ADC_PIN        A0
+#define LEDC_PIN       4
+#define SIGMADELTA_PIN 9
+#elif CONFIG_IDF_TARGET_ESP32C6
+#define ADC_PIN        A0
+#define LEDC_PIN       2
+#define SIGMADELTA_PIN 3
+#elif CONFIG_IDF_TARGET_ESP32H2
+#define ADC_PIN        A0
+#define LEDC_PIN       4
+#define SIGMADELTA_PIN 5
+#elif CONFIG_IDF_TARGET_ESP32P4
+#define ADC_PIN        A4   /* GPIO20; A0→16 is SDIO */
+#define LEDC_PIN       6
+#define SIGMADELTA_PIN 7
+#else
+#error "adc_pwm: add pins for this target in pins_config.h"
+#endif
+
+#endif /* ADC_PWM_PINS_CONFIG_H */

--- a/tests/validation/adc_pwm/test_adc_pwm.py
+++ b/tests/validation/adc_pwm/test_adc_pwm.py
@@ -1,0 +1,2 @@
+def test_adc_pwm(dut):
+    dut.expect_unity_test_output(timeout=120)

--- a/tests/validation/dac/README.md
+++ b/tests/validation/dac/README.md
@@ -1,0 +1,42 @@
+# DAC Loopback Validation Test
+
+Multi-DUT test validating DAC output via ADC readback on a second device. Uses the `generic_multi_device` runner so that the sender's DAC output is physically wired to the reader's ADC input.
+
+## Architecture
+
+| Device | Sketch | Role |
+|---|---|---|
+| device0 (sender) | `sender/sender.ino` | Writes DAC values on `DAC1` via serial commands |
+| device1 (reader) | `reader/reader.ino` | Reads ADC on the pin connected to sender's DAC output |
+
+## Test Cases
+
+| Step | Description |
+|---|---|
+| DAC_WRITE 0 + ADC_READ | Sender writes DAC=0, reader verifies ADC < 500 mV |
+| DAC_WRITE 255 + ADC_READ | Sender writes DAC=255, reader verifies ADC > 2000 mV |
+| DAC_DISABLE | Sender disables DAC output |
+
+## Requirements
+
+- **Hardware**: Two ESP32 devkits on a `generic_multi_device` runner
+- **Targets**: ESP32 and ESP32-S2 only (`CONFIG_SOC_DAC_SUPPORTED=y`)
+- **Wokwi**: Disabled — DAC is not simulated in Wokwi
+- **QEMU**: Disabled
+- **CI Runner**: `generic_multi_device`
+
+## Harness Wiring
+
+Connect the reader's ADC input to the sender's `DAC1` pin (same GPIO on both boards):
+
+| SoC | Loopback wire |
+|---|---|
+| ESP32 | GPIO25 ↔ GPIO25 |
+| ESP32-S2 | GPIO17 ↔ GPIO17 |
+
+## Serial Protocol
+
+After boot the sender prints `[SENDER] DAC_READY`. The Python orchestrator then sends:
+
+- **Sender**: `DAC_WRITE <value>` / `DAC_DISABLE` / `DONE`
+- **Reader**: `ADC_READ` / `DONE`

--- a/tests/validation/dac/ci.yml
+++ b/tests/validation/dac/ci.yml
@@ -1,0 +1,13 @@
+tags:
+  - generic_multi_device
+
+multi_device:
+  device0: sender
+  device1: reader
+
+platforms:
+  wokwi: false
+  qemu: false
+
+requires:
+  - CONFIG_SOC_DAC_SUPPORTED=y

--- a/tests/validation/dac/reader/reader.ino
+++ b/tests/validation/dac/reader/reader.ino
@@ -1,0 +1,40 @@
+/*
+ * DAC loopback validation -- Reader (multi-DUT, generic_multi_device)
+ *
+ * Reads ADC on the pin connected to the sender's DAC output.
+ * Pin-to-pin mapping: sender DAC1 <-> reader DAC1
+ * (GPIO25 on ESP32, GPIO17 on ESP32-S2).
+ */
+
+#include <Arduino.h>
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  analogReadResolution(12);
+  analogSetAttenuation(ADC_11db);
+  pinMode(DAC1, INPUT);
+
+  Serial.println("[READER] Ready");
+}
+
+void loop() {
+  if (Serial.available()) {
+    String cmd = Serial.readStringUntil('\n');
+    cmd.trim();
+
+    if (cmd == "ADC_READ") {
+      uint32_t mv = analogReadMilliVolts(DAC1);
+      Serial.printf("[READER] ADC_MV=%lu\n", (unsigned long)mv);
+    } else if (cmd == "DONE") {
+      Serial.println("[READER] DONE");
+      while (true) {
+        delay(1000);
+      }
+    }
+  }
+  delay(10);
+}

--- a/tests/validation/dac/sender/sender.ino
+++ b/tests/validation/dac/sender/sender.ino
@@ -1,0 +1,40 @@
+/*
+ * DAC loopback validation -- Sender (multi-DUT, generic_multi_device)
+ *
+ * Writes DAC values on DAC1; the reader verifies the output via ADC.
+ */
+
+#include <Arduino.h>
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[SENDER] Ready");
+  Serial.println("[SENDER] DAC_READY");
+}
+
+void loop() {
+  if (Serial.available()) {
+    String cmd = Serial.readStringUntil('\n');
+    cmd.trim();
+
+    if (cmd.startsWith("DAC_WRITE ")) {
+      int value = cmd.substring(10).toInt();
+      dacWrite(DAC1, value);
+      delay(50);
+      Serial.printf("[SENDER] DAC_WRITTEN %d\n", value);
+    } else if (cmd == "DAC_DISABLE") {
+      dacDisable(DAC1);
+      Serial.println("[SENDER] DAC_DISABLED");
+    } else if (cmd == "DONE") {
+      Serial.println("[SENDER] DONE");
+      while (true) {
+        delay(1000);
+      }
+    }
+  }
+  delay(10);
+}

--- a/tests/validation/dac/test_dac.py
+++ b/tests/validation/dac/test_dac.py
@@ -1,0 +1,44 @@
+import logging
+
+
+def test_dac(dut):
+    LOGGER = logging.getLogger(__name__)
+
+    sender = dut[0]
+    reader = dut[1]
+
+    LOGGER.info("Waiting for devices to be ready...")
+    sender.expect_exact("[SENDER] Ready", timeout=120)
+    reader.expect_exact("[READER] Ready", timeout=120)
+    sender.expect_exact("[SENDER] DAC_READY", timeout=10)
+
+    LOGGER.info("DAC loopback: writing 0...")
+    sender.write("DAC_WRITE 0")
+    sender.expect_exact("[SENDER] DAC_WRITTEN 0", timeout=10)
+
+    reader.write("ADC_READ")
+    m = reader.expect(r"\[READER\] ADC_MV=(\d+)", timeout=10)
+    mv_low = int(m.group(1))
+    LOGGER.info(f"DAC=0 -> reader ADC: {mv_low} mV")
+    assert mv_low < 500, f"Expected < 500 mV for DAC=0, got {mv_low}"
+
+    LOGGER.info("DAC loopback: writing 255...")
+    sender.write("DAC_WRITE 255")
+    sender.expect_exact("[SENDER] DAC_WRITTEN 255", timeout=10)
+
+    reader.write("ADC_READ")
+    m = reader.expect(r"\[READER\] ADC_MV=(\d+)", timeout=10)
+    mv_high = int(m.group(1))
+    LOGGER.info(f"DAC=255 -> reader ADC: {mv_high} mV")
+    assert mv_high > 2000, f"Expected > 2000 mV for DAC=255, got {mv_high}"
+
+    LOGGER.info("DAC loopback: disabling DAC...")
+    sender.write("DAC_DISABLE")
+    sender.expect_exact("[SENDER] DAC_DISABLED", timeout=10)
+
+    sender.write("DONE")
+    sender.expect_exact("[SENDER] DONE", timeout=10)
+    reader.write("DONE")
+    reader.expect_exact("[READER] DONE", timeout=10)
+
+    LOGGER.info("DAC loopback test passed!")


### PR DESCRIPTION
## Description of Change

This pull request introduces two new validation test suites for ESP32 platforms: a single-device ADC/PWM validation and a multi-device DAC loopback test. These additions provide comprehensive automated hardware validation for analog and PWM peripherals, with clear per-target pin assignments, test orchestration, and CI integration.

**ADC/PWM Validation Test (Single Device):**

- Adds a new test suite (`adc_pwm.ino`) covering ADC, LEDC (PWM), and SigmaDelta features, with Unity-based test cases for analog read, resolution, millivolts, attenuation, continuous DMA, PWM attach/detach, duty cycle, frequency, fade, tone, and SigmaDelta operations.
- Introduces per-target pin configuration in `pins_config.h`, ensuring correct and conflict-free GPIO assignment for all supported ESP32 variants.
- Documents test coverage, requirements, and pin mapping in a detailed `README.md`.
- Disables Wokwi and QEMU for this test in CI (`ci.yml`), and adds a Python harness for automated test output validation. [[1]](diffhunk://#diff-9617144bcf48410ad1f4defd797bc9e7bb37f66e9a89785f345d0c987036cd2cR1-R3) [[2]](diffhunk://#diff-eb9868a0b2ab1e0e67965e3fe1352cf7c47c3709ba0a8cba3baee9f7ebf39f0bR1-R2)

**DAC Loopback Validation Test (Multi-Device):**

- Implements a multi-device test where one device (sender) outputs DAC values and another (reader) measures them via ADC, with explicit serial protocol for orchestration. [[1]](diffhunk://#diff-45fc8b12bafd34f10e1382a9daa050f9fae9b4298ea5f342b8623a3108e5e2ffR1-R40) [[2]](diffhunk://#diff-cb153c9be3de93c2a06673ddd897da058807d413f269d1030c9f96d95bb0b142R1-R40)
- Provides a Python orchestrator (`test_dac.py`) to coordinate the sender and reader, validate analog voltage levels, and ensure correct DAC/ADC interaction.
- Documents wiring, requirements, and serial protocol in a new `README.md`, and configures CI to use the `generic_multi_device` runner with appropriate tags and requirements. [[1]](diffhunk://#diff-97579f431abcf6a081240ae9bcddc722e89b22e562cbf2dd5b87f174473f81d0R1-R42) [[2]](diffhunk://#diff-8bacb07e78479144acd0b1135d5205470d7cbfa8ece9b7f55e4e2e269a21c326R1-R13)

**Summary of Most Important Changes:**

**1. New ADC/PWM Validation Suite**
- Adds `adc_pwm.ino` with comprehensive Unity tests for ADC, PWM (LEDC), and SigmaDelta peripherals, including continuous DMA mode and parameterized tests for resolution, attenuation, and frequency.
- Defines per-target GPIO assignments in `pins_config.h` for all supported ESP32 SoCs, ensuring hardware compatibility and avoiding pin conflicts.
- Documents test cases, hardware requirements, and pin mapping in `README.md`.
- Integrates test into CI with Wokwi and QEMU disabled; adds Python test harness for automated Unity output validation. [[1]](diffhunk://#diff-9617144bcf48410ad1f4defd797bc9e7bb37f66e9a89785f345d0c987036cd2cR1-R3) [[2]](diffhunk://#diff-eb9868a0b2ab1e0e67965e3fe1352cf7c47c3709ba0a8cba3baee9f7ebf39f0bR1-R2)

**2. New DAC Loopback Validation Suite**
- Adds sender (`sender.ino`) and reader (`reader.ino`) sketches for multi-device DAC-to-ADC loopback testing, with a defined serial protocol for control and measurement. [[1]](diffhunk://#diff-45fc8b12bafd34f10e1382a9daa050f9fae9b4298ea5f342b8623a3108e5e2ffR1-R40) [[2]](diffhunk://#diff-cb153c9be3de93c2a06673ddd897da058807d413f269d1030c9f96d95bb0b142R1-R40)
- Provides a Python orchestrator (`test_dac.py`) to automate the test sequence, perform assertions on measured voltages, and coordinate test completion.
- Documents test architecture, wiring, and protocol in `README.md`, and configures CI runner and requirements in `ci.yml`. [[1]](diffhunk://#diff-97579f431abcf6a081240ae9bcddc722e89b22e562cbf2dd5b87f174473f81d0R1-R42) [[2]](diffhunk://#diff-8bacb07e78479144acd0b1135d5205470d7cbfa8ece9b7f55e4e2e269a21c326R1-R13)

## Test Scenarios

Tested locally