### PR TITLE
ETH: include driver/spi_master.h in ETH.h (fix spi_host_device_t undeclared in from-source builds)

### DIFF
--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -76,6 +76,7 @@
 #include "esp_system.h"
 #include "esp_eth.h"
 #include "esp_netif.h"
+#include "driver/spi_master.h"  // for spi_host_device_t (used in begin()/beginSPI())
 
 #if CONFIG_ETH_USE_ESP32_EMAC
 #if defined __has_include && __has_include("esp_eth_phy_lan867x.h")


### PR DESCRIPTION
## Description

`libraries/Ethernet/src/ETH.h` uses `spi_host_device_t` in the **public** method signatures `ETHClass::begin(...)` and `ETHClass::beginSPI(...)`, but it does not include the header that declares that type (`driver/spi_master.h`, which provides `hal/spi_types.h`).

`ETH.cpp` includes `ETH.h` (line ~24) **before** `driver/spi_master.h` (line ~32). So when the Ethernet library is **compiled from source**, `ETH.h` is parsed while `spi_host_device_t` is still undeclared. The parameter then mis-parses, yielding:

```
ETH.h:184: error: 'spi_host_device_t' has not been declared
ETH.cpp:578: error: no declaration matches 'bool ETHClass::beginSPI(..., spi_host_device_t, uint8_t)'
ETH.cpp:960: error: no declaration matches 'bool ETHClass::begin(..., spi_host_device_t, int, int, int, uint8_t)'
```

Pre-built-lib builds don't hit this because `ETH.cpp` isn't recompiled, so the header/source pair is never compiled together in a context that lacks the type. It reproduces reliably with a **from-source** Arduino build (e.g. PlatformIO / pioarduino with `custom_sdkconfig`) on ESP-IDF 5.5.x / arduino-esp32 3.3.x.

## Fix

Include `driver/spi_master.h` in `ETH.h` so the type it uses in its own public API is always declared (include-what-you-use). One line, no behavior change.

## Testing

Built `esp32dev` (ESP32) from source via pioarduino with a `custom_sdkconfig` (forces the framework/library to recompile). Before: fails compiling `ETH.cpp`. After: `ETH.cpp` compiles and the full image links/builds successfully.

## Related

- pioarduino/platform-espressif32#504
- espressif/arduino-esp32#11810
