### PR TITLE
test(ieee802154): Add Zigbee and OpenThread tests

### DIFF
--- a/tests/validation/openthread/README.md
+++ b/tests/validation/openthread/README.md
@@ -1,0 +1,77 @@
+# OpenThread Validation Test
+
+Validates the OpenThread stack and Arduino `OThread` / `OThreadCLI` APIs on chips with an 802.15.4 radio. This is a **multi-DUT** test: device0 forms a Thread network as leader and device1 joins as child using the leader's active dataset relayed by pytest.
+
+## Architecture
+
+```
+ ┌──────────────┐         802.15.4          ┌──────────────┐
+ │    Leader    │◄─────── wireless ────────►│    Child     │
+ │  (device0)   │                           │  (device1)   │
+ └──────┬───────┘                           └──────┬───────┘
+        │ serial                                   │ serial
+        ▼                                          ▼
+ ┌─────────────────────────────────────────────────────────┐
+ │                 pytest (test_openthread.py)             │
+ └─────────────────────────────────────────────────────────┘
+```
+
+## Test Cases
+
+### Leader (`leader/leader.ino`)
+
+| Test Function | Description |
+|---|---|
+| `test_leader_stack_running` | Verify `OThread` and `OThreadCLI` are started |
+| `test_leader_cli_version` | CLI `version` contains `OPENTHREAD` |
+| `test_leader_cli_detached_state` | CLI `state` is `detached` before joining |
+| `test_leader_cli_util_exec` | `otGetRespCmd("state")` returns detached |
+| `test_leader_form_network` | Init dataset, start Thread, become leader, export dataset hex |
+| `test_leader_ot_role` | `otGetDeviceRole()` and CLI `state` report leader |
+| `test_leader_ot_network_getters` | Network name, channel, PAN ID, ext PAN ID, network key |
+| `test_leader_ot_leader_addresses` | RLOC, mesh-local EID, unicast/multicast address lists |
+| `test_leader_ot_current_dataset` | Active `DataSet` matches formed network |
+| `test_leader_dataset_class` | `DataSet` setters/getters on a local instance |
+| `test_leader_cli_util_network_fields` | CLI `networkname`, `channel`, `panid`, `extpanid` |
+| `test_leader_cli_print_network_info` | `otPrintRespCLI` and `otPrintNetworkInformation` |
+
+### Child (`child/child.ino`)
+
+| Test Function | Description |
+|---|---|
+| `test_child_stack_running` | Verify `OThread` and `OThreadCLI` are started |
+| `test_child_cli_version` | CLI `version` contains `OPENTHREAD` |
+| `test_child_cli_detached_state` | CLI `state` is `detached` before joining |
+| `test_child_cli_util_exec` | `otGetRespCmd("state")` returns detached |
+| `test_child_join_network` | Import dataset from pytest, start Thread, attach to network |
+| `test_child_network_matches_leader` | Network getters match `NETINFO` from pytest |
+| `test_child_ot_role_attached` | Role is child or router after attach |
+| `test_child_ot_network_getters` | Network getters match expected netinfo |
+| `test_child_ot_attached_addresses` | RLOC16, mesh-local EID, address caches |
+| `test_child_ot_current_dataset` | Active `DataSet` matches expected netinfo |
+| `test_child_cli_active_dataset_hex` | CLI `dataset active -x` matches imported dataset |
+| `test_child_cli_util_network_fields` | CLI network fields match `OThread` getters |
+| `test_child_cli_print_network_info` | `otPrintRespCLI` and `otPrintNetworkInformation` |
+
+## Requirements
+
+- **Hardware**: Two ESP32-C6 or ESP32-H2 boards (802.15.4 radio required)
+- **Wokwi/QEMU**: Not supported (multi-device test)
+- **CI Runner**: `two_duts`
+- **SoC Config**: `CONFIG_OPENTHREAD_ENABLED=y`, `CONFIG_SOC_IEEE802154_SUPPORTED=y`
+- **FQBN**: `PartitionScheme=huge_app,OThreadMode=ot_rcp` (both devices)
+
+## Serial Protocol
+
+1. Both devices print `[LEADER] Ready` / `[CHILD] Ready`
+2. pytest sends `GO` to the leader
+3. Leader runs Unity tests, forms the network, then prints `[LEADER] DATASET=<hex>`, `[LEADER] NETINFO name=... channel=... panid=... extpanid=...`, `[LEADER] NETWORK_READY`, and `[LEADER] DONE`
+4. pytest sends `DATASET <hex>` and `NETINFO name=... channel=... panid=... extpanid=...` to the child
+5. Child runs Unity tests and prints `[CHILD] JOINED`, then `[CHILD] DONE`
+
+## Notes
+
+- Shared helpers are in `ot_test_helpers.h`; sketches include it as `#include "../ot_test_helpers.h"`.
+- CLI RX/TX buffer sizes must be set before `OThreadCLI.begin()`; resizing after the CLI task starts breaks command processing.
+- Network attachment timeout is 30 seconds per device.
+- If leader Unity tests fail, the leader prints `[LEADER] EXPORT_FAILED` instead of a dataset.

--- a/tests/validation/openthread/child/child.ino
+++ b/tests/validation/openthread/child/child.ino
@@ -1,0 +1,194 @@
+/*
+ * OpenThread Validation Test -- Child (multi-DUT)
+ *
+ * Receives dataset + network info from pytest (from leader), joins the
+ * network, and verifies the same network parameters on the child.
+ */
+
+#include <Arduino.h>
+
+#if CONFIG_OPENTHREAD_ENABLED
+
+#include <OThread.h>
+#include <OThreadCLI.h>
+#include <OThreadCLI_Util.h>
+#include <unity.h>
+#include "../ot_test_helpers.h"
+
+#define OT_TIMEOUT_MS 30000
+
+static String dataset_hex;
+static ot_test_netinfo_t expected_netinfo;
+
+void setUp(void) {
+  ot_test_drain_cli();
+}
+
+void tearDown(void) {
+  ot_test_drain_cli();
+}
+
+// ==================== Stack / CLI lifecycle ====================
+
+void test_child_stack_running(void) {
+  TEST_ASSERT_TRUE(OThread);
+  TEST_ASSERT_TRUE(OThreadCLI);
+  TEST_ASSERT_NOT_NULL(OThread.getInstance());
+}
+
+void test_child_cli_version(void) {
+  TEST_ASSERT_TRUE(ot_test_cli_contains("version", "OPENTHREAD"));
+}
+
+void test_child_cli_detached_state(void) {
+  TEST_ASSERT_TRUE(ot_test_cli_contains("state", "detached"));
+}
+
+void test_child_cli_util_exec(void) {
+  char buf[OT_TEST_CLI_BUF_SIZE];
+  TEST_ASSERT_TRUE(ot_test_run_cli("state", buf, sizeof(buf)));
+  TEST_ASSERT_TRUE(strstr(buf, "detached") != nullptr);
+}
+
+// ==================== Join network ====================
+
+void test_child_join_network(void) {
+  String cmd = "dataset set active " + dataset_hex;
+  TEST_ASSERT_TRUE(ot_test_run_cli(cmd.c_str(), nullptr, 0));
+  TEST_ASSERT_TRUE(ot_test_run_cli("dataset commit active", nullptr, 0));
+  TEST_ASSERT_TRUE(ot_test_run_cli("ifconfig up", nullptr, 0));
+  TEST_ASSERT_TRUE(ot_test_run_cli("thread start", nullptr, 0));
+  delay(2000);
+
+  bool attached = ot_test_wait_cli_state("child", OT_TIMEOUT_MS) || ot_test_wait_cli_state("router", 5000);
+  TEST_ASSERT_TRUE_MESSAGE(attached, "Child failed to attach to network");
+
+  Serial.println("[CHILD] JOINED");
+}
+
+// ==================== Post-attach API (must match leader) ====================
+
+void test_child_network_matches_leader(void) {
+  ot_test_assert_netinfo_match(expected_netinfo);
+}
+
+void test_child_ot_role_attached(void) {
+  ot_device_role_t role = OThread.otGetDeviceRole();
+  TEST_ASSERT_TRUE(role == OT_ROLE_CHILD || role == OT_ROLE_ROUTER);
+  TEST_ASSERT_TRUE(ot_test_cli_contains("state", OThread.otGetStringDeviceRole()));
+}
+
+void test_child_ot_network_getters(void) {
+  ot_test_assert_network_getters_match_netinfo(expected_netinfo);
+}
+
+void test_child_ot_attached_addresses(void) {
+  ot_test_assert_attached_addresses();
+}
+
+void test_child_ot_current_dataset(void) {
+  ot_test_assert_current_dataset_matches_netinfo(expected_netinfo);
+}
+
+void test_child_cli_active_dataset_hex(void) {
+  String active_hex = ot_test_extract_hex(ot_test_read_cli_response("dataset active -x", 15000));
+  ot_test_assert_dataset_hex(active_hex);
+  TEST_ASSERT_EQUAL_STRING_MESSAGE(dataset_hex.c_str(), active_hex.c_str(), "Active dataset differs from leader export");
+}
+
+void test_child_cli_util_network_fields(void) {
+  ot_test_assert_cli_network_fields();
+}
+
+void test_child_cli_print_network_info(void) {
+  ot_test_assert_cli_print_network_info();
+}
+
+// ==================== Setup ====================
+
+static bool wait_for_serial_config(void) {
+  bool have_dataset = false;
+  bool have_netinfo = false;
+
+  while (!have_dataset || !have_netinfo) {
+    if (Serial.available()) {
+      String line = Serial.readStringUntil('\n');
+      line.trim();
+      if (line.startsWith("DATASET ")) {
+        dataset_hex = line.substring(8);
+        dataset_hex.trim();
+        ot_test_assert_dataset_hex(dataset_hex);
+        have_dataset = true;
+      } else if (ot_test_parse_netinfo_line(line, expected_netinfo)) {
+        have_netinfo = true;
+      }
+    }
+    delay(10);
+  }
+  return true;
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[CHILD] Ready");
+  TEST_ASSERT_TRUE(wait_for_serial_config());
+
+  OThread.begin(false);
+  OThreadCLI.setRxBufferSize(1024);
+  OThreadCLI.setTxBufferSize(256);
+  OThreadCLI.begin();
+  delay(1000);
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_child_stack_running);
+  RUN_TEST(test_child_cli_version);
+  RUN_TEST(test_child_cli_detached_state);
+  RUN_TEST(test_child_cli_util_exec);
+  RUN_TEST(test_child_join_network);
+  RUN_TEST(test_child_network_matches_leader);
+  RUN_TEST(test_child_ot_role_attached);
+  RUN_TEST(test_child_ot_network_getters);
+  RUN_TEST(test_child_ot_attached_addresses);
+  RUN_TEST(test_child_ot_current_dataset);
+  RUN_TEST(test_child_cli_active_dataset_hex);
+  RUN_TEST(test_child_cli_util_network_fields);
+  RUN_TEST(test_child_cli_print_network_info);
+
+  UNITY_END();
+
+  Serial.println("[CHILD] DONE");
+}
+
+void loop() {}
+
+#else  // !CONFIG_OPENTHREAD_ENABLED
+
+#include <unity.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_ot_not_supported(void) {
+  TEST_IGNORE_MESSAGE("OpenThread not enabled in sdkconfig");
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[CHILD] Ready");
+  UNITY_BEGIN();
+  RUN_TEST(test_ot_not_supported);
+  UNITY_END();
+  Serial.println("[CHILD] DONE");
+}
+
+void loop() {}
+#endif

--- a/tests/validation/openthread/ci.yml
+++ b/tests/validation/openthread/ci.yml
@@ -1,0 +1,17 @@
+tags:
+  - two_duts
+
+fqbn_append: PartitionScheme=huge_app,OThreadMode=ot_rcp
+
+multi_device:
+  device0: leader
+  device1: child
+
+platforms:
+  wokwi: false
+  qemu: false
+
+# No two_duts runners using ESP-Hosted
+requires:
+  - CONFIG_OPENTHREAD_ENABLED=y
+  - CONFIG_SOC_IEEE802154_SUPPORTED=y

--- a/tests/validation/openthread/leader/leader.ino
+++ b/tests/validation/openthread/leader/leader.ino
@@ -1,0 +1,220 @@
+/*
+ * OpenThread Validation Test -- Leader (multi-DUT)
+ *
+ * Exercises OThread / OThreadCLI / OThreadCLI_Util APIs, forms a network,
+ * exports dataset + network info for the child via pytest.
+ */
+
+#include <Arduino.h>
+
+#if CONFIG_OPENTHREAD_ENABLED
+
+#include <OThread.h>
+#include <OThreadCLI.h>
+#include <OThreadCLI_Util.h>
+#include <unity.h>
+#include "../ot_test_helpers.h"
+
+#define OT_TIMEOUT_MS 30000
+
+static String leader_dataset_hex;
+static ot_test_netinfo_t leader_netinfo;
+
+void setUp(void) {
+  ot_test_drain_cli();
+}
+
+void tearDown(void) {
+  ot_test_drain_cli();
+}
+
+// ==================== Stack / CLI lifecycle ====================
+
+void test_leader_stack_running(void) {
+  TEST_ASSERT_TRUE(OThread);
+  TEST_ASSERT_TRUE(OThreadCLI);
+  TEST_ASSERT_NOT_NULL(OThread.getInstance());
+}
+
+void test_leader_cli_version(void) {
+  TEST_ASSERT_TRUE(ot_test_cli_contains("version", "OPENTHREAD"));
+}
+
+void test_leader_cli_detached_state(void) {
+  TEST_ASSERT_TRUE(ot_test_cli_contains("state", "detached"));
+}
+
+void test_leader_cli_util_exec(void) {
+  char buf[OT_TEST_CLI_BUF_SIZE];
+  TEST_ASSERT_TRUE(ot_test_run_cli("state", buf, sizeof(buf)));
+  TEST_ASSERT_TRUE(strstr(buf, "detached") != nullptr);
+}
+
+// ==================== Network formation ====================
+
+void test_leader_form_network(void) {
+  TEST_ASSERT_TRUE(ot_test_run_cli("dataset init new", nullptr, 0));
+  TEST_ASSERT_TRUE(ot_test_run_cli("dataset commit active", nullptr, 0));
+  TEST_ASSERT_TRUE(ot_test_run_cli("ifconfig up", nullptr, 0));
+  TEST_ASSERT_TRUE(ot_test_run_cli("thread start", nullptr, 0));
+  delay(1000);
+
+  TEST_ASSERT_TRUE_MESSAGE(ot_test_wait_cli_state("leader", OT_TIMEOUT_MS), "Failed to become leader");
+
+  leader_dataset_hex = ot_test_extract_hex(ot_test_read_cli_response("dataset active -x", 15000));
+  ot_test_assert_dataset_hex(leader_dataset_hex);
+
+  leader_netinfo = ot_test_collect_netinfo();
+  TEST_ASSERT_TRUE(leader_netinfo.valid);
+}
+
+// ==================== Post-attach API (leader role) ====================
+
+void test_leader_ot_role(void) {
+  TEST_ASSERT_EQUAL(OT_ROLE_LEADER, OThread.otGetDeviceRole());
+  TEST_ASSERT_EQUAL_STRING("leader", OThread.otGetStringDeviceRole());
+  TEST_ASSERT_TRUE(ot_test_cli_contains("state", "leader"));
+}
+
+void test_leader_ot_network_getters(void) {
+  ot_test_assert_network_getters_match_netinfo(leader_netinfo);
+}
+
+void test_leader_ot_leader_addresses(void) {
+  ot_test_assert_attached_addresses();
+
+  IPAddress leader_rloc = OThread.getLeaderRloc();
+  TEST_ASSERT_FALSE(leader_rloc == IPAddress());
+
+  IPAddress rloc = OThread.getRloc();
+  TEST_ASSERT_FALSE(rloc == IPAddress());
+}
+
+void test_leader_ot_current_dataset(void) {
+  ot_test_assert_current_dataset_matches_netinfo(leader_netinfo);
+}
+
+void test_leader_dataset_class(void) {
+  DataSet ds;
+  ds.initNew();
+  ds.setNetworkName("OT-Validation");
+  ds.setChannel(15);
+  ds.setPanId(0x1234);
+
+  uint8_t key[16];
+  memset(key, 0xAB, sizeof(key));
+  ds.setNetworkKey(key);
+
+  uint8_t ext_pan[8];
+  memset(ext_pan, 0xCD, sizeof(ext_pan));
+  ds.setExtendedPanId(ext_pan);
+
+  TEST_ASSERT_EQUAL_STRING("OT-Validation", ds.getNetworkName());
+  TEST_ASSERT_EQUAL(15, ds.getChannel());
+  TEST_ASSERT_EQUAL(0x1234, ds.getPanId());
+  TEST_ASSERT_NOT_NULL(ds.getNetworkKey());
+  TEST_ASSERT_NOT_NULL(ds.getExtendedPanId());
+}
+
+void test_leader_cli_util_network_fields(void) {
+  ot_test_assert_cli_network_fields();
+}
+
+void test_leader_cli_print_network_info(void) {
+  ot_test_assert_cli_print_network_info();
+}
+
+// ==================== Setup ====================
+
+static void wait_for_go(void) {
+  while (true) {
+    if (Serial.available()) {
+      String cmd = Serial.readStringUntil('\n');
+      cmd.trim();
+      if (cmd == "GO") {
+        return;
+      }
+    }
+    delay(10);
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  OThread.begin(false);
+  // Queue sizes must be set before begin(); resizing later breaks ot_cli_loop.
+  OThreadCLI.setRxBufferSize(1024);
+  OThreadCLI.setTxBufferSize(256);
+  OThreadCLI.begin();
+  delay(1000);
+
+  Serial.println("[LEADER] Ready");
+  wait_for_go();
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_leader_stack_running);
+  RUN_TEST(test_leader_cli_version);
+  RUN_TEST(test_leader_cli_detached_state);
+  RUN_TEST(test_leader_cli_util_exec);
+  RUN_TEST(test_leader_form_network);
+  RUN_TEST(test_leader_ot_role);
+  RUN_TEST(test_leader_ot_network_getters);
+  RUN_TEST(test_leader_ot_leader_addresses);
+  RUN_TEST(test_leader_ot_current_dataset);
+  RUN_TEST(test_leader_dataset_class);
+  RUN_TEST(test_leader_cli_util_network_fields);
+  RUN_TEST(test_leader_cli_print_network_info);
+
+  UNITY_END();
+
+  ot_test_drain_cli();
+
+  if (leader_dataset_hex.length() > 0 && leader_netinfo.valid) {
+    Serial.print("[LEADER] DATASET=");
+    Serial.println(leader_dataset_hex);
+    Serial.flush();
+    ot_test_print_netinfo("[LEADER]");
+    Serial.flush();
+    Serial.println("[LEADER] NETWORK_READY");
+  } else {
+    Serial.println("[LEADER] EXPORT_FAILED");
+  }
+  Serial.flush();
+  Serial.println("[LEADER] DONE");
+}
+
+void loop() {
+  delay(100);
+}
+
+#else  // !CONFIG_OPENTHREAD_ENABLED
+
+#include <unity.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_ot_not_supported(void) {
+  TEST_IGNORE_MESSAGE("OpenThread not enabled in sdkconfig");
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[LEADER] Ready");
+  UNITY_BEGIN();
+  RUN_TEST(test_ot_not_supported);
+  UNITY_END();
+  Serial.println("[LEADER] DONE");
+}
+
+void loop() {}
+#endif

--- a/tests/validation/openthread/ot_test_helpers.h
+++ b/tests/validation/openthread/ot_test_helpers.h
@@ -1,0 +1,273 @@
+/*
+ * Shared helpers for OpenThread validation sketches (leader / child).
+ * Included from leader/ and child/ sketches as ../ot_test_helpers.h.
+ */
+
+#pragma once
+
+#include <unity.h>
+#include <OThread.h>
+#include <OThreadCLI.h>
+#include <OThreadCLI_Util.h>
+#include <StreamString.h>
+
+#define OT_TEST_CLI_BUF_SIZE 512
+#define OT_TEST_EXT_PAN_ID_LEN 8
+
+struct ot_test_netinfo_t {
+  String name;
+  uint8_t channel;
+  uint16_t pan_id;
+  uint8_t ext_pan_id[OT_TEST_EXT_PAN_ID_LEN];
+  bool valid;
+};
+
+inline void ot_test_drain_cli(void) {
+  delay(50);
+  while (OThreadCLI.available() > 0) {
+    OThreadCLI.read();
+  }
+}
+
+inline bool ot_test_run_cli(const char *cmd, char *out, size_t out_len, uint32_t timeout_ms = 5000) {
+  (void)out_len;
+  ot_test_drain_cli();
+  if (out != nullptr && out_len > 0) {
+    out[0] = '\0';
+    return otGetRespCmd(cmd, out, timeout_ms) && out[0] != '\0';
+  }
+  return otGetRespCmd(cmd, nullptr, timeout_ms);
+}
+
+inline bool ot_test_cli_contains(const char *cmd, const char *needle) {
+  char buf[OT_TEST_CLI_BUF_SIZE];
+  if (!ot_test_run_cli(cmd, buf, sizeof(buf))) {
+    return false;
+  }
+  return strstr(buf, needle) != nullptr;
+}
+
+inline bool ot_test_wait_cli_state(const char *role_substr, uint32_t timeout_ms) {
+  unsigned long deadline = millis() + timeout_ms;
+  while (millis() < deadline) {
+    if (ot_test_cli_contains("state", role_substr)) {
+      return true;
+    }
+    delay(500);
+  }
+  return false;
+}
+
+inline String ot_test_hex_from_line(const String &line) {
+  String hex;
+  hex.reserve(line.length());
+  for (size_t i = 0; i < line.length(); i++) {
+    char c = line.charAt(i);
+    if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+      hex += c;
+    }
+  }
+  return hex;
+}
+
+inline String ot_test_extract_hex(const String &input) {
+  String hex;
+  int start = 0;
+  while (start < (int)input.length()) {
+    int end = input.indexOf('\n', start);
+    if (end < 0) {
+      end = input.length();
+    }
+    String line = input.substring(start, end);
+    line.trim();
+    if (line.length() > 0 && !line.startsWith("Done") && !line.startsWith("Error")) {
+      hex += ot_test_hex_from_line(line);
+    }
+    if (end >= (int)input.length()) {
+      break;
+    }
+    start = end + 1;
+  }
+  return hex;
+}
+
+inline String ot_test_read_cli_response(const char *cmd, uint32_t timeout_ms) {
+  ot_test_drain_cli();
+  if (cmd != nullptr) {
+    OThreadCLI.println(cmd);
+  }
+
+  String response;
+  unsigned long deadline = millis() + timeout_ms;
+  while (millis() < deadline) {
+    if (OThreadCLI.available()) {
+      String line = OThreadCLI.readStringUntil('\n');
+      line.trim();
+      if (line.length() == 0) {
+        continue;
+      }
+      if (line.startsWith("Done")) {
+        break;
+      }
+      if (line.startsWith("Error")) {
+        return "";
+      }
+      if (response.length() > 0) {
+        response += '\n';
+      }
+      response += line;
+    }
+    delay(10);
+  }
+  return response;
+}
+
+inline ot_test_netinfo_t ot_test_collect_netinfo(void) {
+  ot_test_netinfo_t info = {};
+  info.name = OThread.getNetworkName();
+  info.channel = OThread.getChannel();
+  info.pan_id = OThread.getPanId();
+  const uint8_t *ext_pan = OThread.getExtendedPanId();
+  if (ext_pan != nullptr) {
+    memcpy(info.ext_pan_id, ext_pan, OT_TEST_EXT_PAN_ID_LEN);
+  }
+  info.valid = info.name.length() > 0 && info.channel > 0 && info.pan_id != 0;
+  return info;
+}
+
+inline void ot_test_print_netinfo(const char *prefix) {
+  ot_test_netinfo_t info = ot_test_collect_netinfo();
+  char ext_hex[(OT_TEST_EXT_PAN_ID_LEN * 2) + 1];
+  for (int i = 0; i < OT_TEST_EXT_PAN_ID_LEN; i++) {
+    sprintf(ext_hex + (i * 2), "%02x", info.ext_pan_id[i]);
+  }
+  Serial.printf("%s NETINFO name=%s channel=%u panid=0x%04x extpanid=%s\n", prefix, info.name.c_str(), info.channel, info.pan_id, ext_hex);
+}
+
+inline bool ot_test_parse_netinfo_line(const String &line, ot_test_netinfo_t &out) {
+  if (!line.startsWith("NETINFO ")) {
+    return false;
+  }
+
+  int name_pos = line.indexOf("name=");
+  int channel_pos = line.indexOf(" channel=");
+  int panid_pos = line.indexOf(" panid=");
+  int extpanid_pos = line.indexOf(" extpanid=");
+  if (name_pos < 0 || channel_pos < 0 || panid_pos < 0 || extpanid_pos < 0) {
+    return false;
+  }
+
+  out.name = line.substring(name_pos + 5, channel_pos);
+  out.channel = (uint8_t)line.substring(channel_pos + 9, panid_pos).toInt();
+  out.pan_id = (uint16_t)strtoul(line.substring(panid_pos + 7, extpanid_pos).c_str(), nullptr, 0);
+
+  String ext_hex = line.substring(extpanid_pos + 10);
+  ext_hex.trim();
+  if (ext_hex.length() != OT_TEST_EXT_PAN_ID_LEN * 2) {
+    return false;
+  }
+  for (int i = 0; i < OT_TEST_EXT_PAN_ID_LEN; i++) {
+    char byte_str[3] = {ext_hex.charAt(i * 2), ext_hex.charAt((i * 2) + 1), '\0'};
+    out.ext_pan_id[i] = (uint8_t)strtoul(byte_str, nullptr, 16);
+  }
+
+  out.valid = out.name.length() > 0 && out.channel > 0 && out.pan_id != 0;
+  return out.valid;
+}
+
+inline bool ot_test_ext_pan_equal(const uint8_t *a, const uint8_t *b) {
+  for (int i = 0; i < OT_TEST_EXT_PAN_ID_LEN; i++) {
+    if (a[i] != b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline void ot_test_assert_netinfo_match(const ot_test_netinfo_t &expected) {
+  ot_test_netinfo_t actual = ot_test_collect_netinfo();
+  TEST_ASSERT_TRUE_MESSAGE(expected.valid, "Expected network info is invalid");
+  TEST_ASSERT_TRUE_MESSAGE(actual.valid, "Actual network info is invalid");
+  TEST_ASSERT_EQUAL_STRING_MESSAGE(expected.name.c_str(), actual.name.c_str(), "Network name mismatch");
+  TEST_ASSERT_EQUAL_MESSAGE(expected.channel, actual.channel, "Channel mismatch");
+  TEST_ASSERT_EQUAL_MESSAGE(expected.pan_id, actual.pan_id, "PAN ID mismatch");
+  TEST_ASSERT_TRUE_MESSAGE(ot_test_ext_pan_equal(expected.ext_pan_id, actual.ext_pan_id), "Extended PAN ID mismatch");
+}
+
+inline void ot_test_assert_network_getters_match_netinfo(const ot_test_netinfo_t &expected) {
+  ot_test_assert_netinfo_match(expected);
+
+  const uint8_t *net_key = OThread.getNetworkKey();
+  TEST_ASSERT_NOT_NULL(net_key);
+
+  TEST_ASSERT_TRUE(OThread.getInstance() != nullptr);
+}
+
+inline void ot_test_assert_network_getters(void) {
+  ot_test_assert_network_getters_match_netinfo(ot_test_collect_netinfo());
+}
+
+inline void ot_test_assert_attached_addresses(void) {
+  uint16_t rloc16 = OThread.getRloc16();
+  TEST_ASSERT_NOT_EQUAL(0, rloc16);
+
+  IPAddress mesh = OThread.getMeshLocalEid();
+  TEST_ASSERT_FALSE(mesh == IPAddress());
+
+  const otMeshLocalPrefix *prefix = OThread.getMeshLocalPrefix();
+  TEST_ASSERT_NOT_NULL(prefix);
+
+  TEST_ASSERT_GREATER_THAN(0, OThread.getUnicastAddressCount());
+  TEST_ASSERT_GREATER_THAN(0, OThread.getMulticastAddressCount());
+
+  std::vector<IPAddress> uni = OThread.getAllUnicastAddresses();
+  TEST_ASSERT_GREATER_THAN(0, uni.size());
+  std::vector<IPAddress> multi = OThread.getAllMulticastAddresses();
+  TEST_ASSERT_GREATER_THAN(0, multi.size());
+
+  OThread.clearAllAddressCache();
+  OThread.clearUnicastAddressCache();
+  OThread.clearMulticastAddressCache();
+}
+
+inline void ot_test_assert_current_dataset_matches_netinfo(const ot_test_netinfo_t &expected) {
+  const DataSet &active = OThread.getCurrentDataSet();
+  TEST_ASSERT_NOT_NULL(active.getNetworkName());
+  TEST_ASSERT_EQUAL_STRING(expected.name.c_str(), active.getNetworkName());
+  TEST_ASSERT_EQUAL(expected.channel, active.getChannel());
+  TEST_ASSERT_EQUAL(expected.pan_id, active.getPanId());
+  TEST_ASSERT_NOT_NULL(active.getExtendedPanId());
+  TEST_ASSERT_TRUE(ot_test_ext_pan_equal(expected.ext_pan_id, active.getExtendedPanId()));
+  TEST_ASSERT_NOT_NULL(active.getNetworkKey());
+}
+
+inline void ot_test_assert_cli_network_fields(void) {
+  char buf[OT_TEST_CLI_BUF_SIZE];
+
+  TEST_ASSERT_TRUE(ot_test_run_cli("networkname", buf, sizeof(buf)));
+  TEST_ASSERT_NOT_NULL(strstr(buf, OThread.getNetworkName().c_str()));
+
+  TEST_ASSERT_TRUE(ot_test_run_cli("channel", buf, sizeof(buf)));
+
+  TEST_ASSERT_TRUE(ot_test_run_cli("panid", buf, sizeof(buf)));
+
+  TEST_ASSERT_TRUE(ot_test_run_cli("extpanid", buf, sizeof(buf)));
+}
+
+inline void ot_test_assert_cli_print_network_info(void) {
+  StreamString out;
+  TEST_ASSERT_TRUE(otPrintRespCLI("state", out, 5000));
+  TEST_ASSERT_TRUE(out.indexOf(OThread.otGetStringDeviceRole()) >= 0);
+
+  out = StreamString();
+  OThread.otPrintNetworkInformation(out);
+  TEST_ASSERT_TRUE(out.indexOf("Network Name:") >= 0);
+  TEST_ASSERT_TRUE(out.indexOf(OThread.getNetworkName()) >= 0);
+  TEST_ASSERT_TRUE(out.indexOf("Channel:") >= 0);
+  TEST_ASSERT_TRUE(out.indexOf("PAN ID:") >= 0);
+}
+
+inline void ot_test_assert_dataset_hex(const String &hex) {
+  TEST_ASSERT_TRUE_MESSAGE(hex.length() >= 100, "Dataset hex too short");
+  TEST_ASSERT_EQUAL_MESSAGE(0, hex.length() % 2, "Dataset hex length must be even");
+}

--- a/tests/validation/openthread/ot_test_helpers.h
+++ b/tests/validation/openthread/ot_test_helpers.h
@@ -11,7 +11,7 @@
 #include <OThreadCLI_Util.h>
 #include <StreamString.h>
 
-#define OT_TEST_CLI_BUF_SIZE 512
+#define OT_TEST_CLI_BUF_SIZE   512
 #define OT_TEST_EXT_PAN_ID_LEN 8
 
 struct ot_test_netinfo_t {

--- a/tests/validation/openthread/test_openthread.py
+++ b/tests/validation/openthread/test_openthread.py
@@ -55,17 +55,11 @@ def test_openthread(dut):
     assert re.fullmatch(r"[0-9a-fA-F]{16}", net_extpanid), f"Invalid extpanid: {net_extpanid}"
 
     LOGGER.info(f"Leader dataset: {dataset_hex[:32]}... ({len(dataset_hex)} chars)")
-    LOGGER.info(
-        f"Leader netinfo: name={net_name} channel={net_channel} "
-        f"panid={net_panid} extpanid={net_extpanid}"
-    )
+    LOGGER.info(f"Leader netinfo: name={net_name} channel={net_channel} " f"panid={net_panid} extpanid={net_extpanid}")
 
     LOGGER.info("Sending dataset and network info to child...")
     child.write(f"DATASET {dataset_hex}\n")
-    child.write(
-        f"NETINFO name={net_name} channel={net_channel} "
-        f"panid={net_panid} extpanid={net_extpanid}\n"
-    )
+    child.write(f"NETINFO name={net_name} channel={net_channel} " f"panid={net_panid} extpanid={net_extpanid}\n")
 
     LOGGER.info("Waiting for child to join network...")
     child.expect_exact("[CHILD] JOINED", timeout=60)

--- a/tests/validation/openthread/test_openthread.py
+++ b/tests/validation/openthread/test_openthread.py
@@ -1,0 +1,76 @@
+import logging
+import re
+
+
+def test_openthread(dut):
+    LOGGER = logging.getLogger(__name__)
+
+    leader = dut[0]
+    child = dut[1]
+
+    LOGGER.info("Waiting for both devices to be ready...")
+    leader.expect_exact("[LEADER] Ready", timeout=120)
+    child.expect_exact("[CHILD] Ready", timeout=120)
+
+    LOGGER.info("Starting leader Unity tests...")
+    leader.write("GO\n")
+
+    LOGGER.info("Waiting for leader to export dataset...")
+    m_export = leader.expect(
+        r"\[LEADER\] (DATASET=([0-9a-fA-F]+)|EXPORT_FAILED)",
+        timeout=180,
+    )
+    export_tag = m_export.group(1)
+    if isinstance(export_tag, bytes):
+        export_tag = export_tag.decode()
+    if export_tag == "EXPORT_FAILED":
+        raise AssertionError("Leader Unity tests failed; no dataset exported")
+    dataset_hex = m_export.group(2)
+    if isinstance(dataset_hex, bytes):
+        dataset_hex = dataset_hex.decode()
+    dataset_hex = dataset_hex.strip()
+
+    LOGGER.info("Waiting for leader network info...")
+    m_net = leader.expect(
+        r"\[LEADER\] NETINFO name=([^ ]+) channel=(\d+) panid=(0x[0-9a-fA-F]+) extpanid=([0-9a-fA-F]{16})",
+        timeout=30,
+    )
+    leader.expect_exact("[LEADER] NETWORK_READY", timeout=30)
+
+    net_name = m_net.group(1)
+    net_channel = m_net.group(2)
+    net_panid = m_net.group(3)
+    net_extpanid = m_net.group(4)
+    if isinstance(net_name, bytes):
+        net_name = net_name.decode()
+    if isinstance(net_channel, bytes):
+        net_channel = net_channel.decode()
+    if isinstance(net_panid, bytes):
+        net_panid = net_panid.decode()
+    if isinstance(net_extpanid, bytes):
+        net_extpanid = net_extpanid.decode()
+
+    assert len(dataset_hex) >= 100, f"Dataset hex too short: {len(dataset_hex)}"
+    assert len(dataset_hex) % 2 == 0, f"Invalid dataset hex length: {len(dataset_hex)}"
+    assert re.fullmatch(r"[0-9a-fA-F]{16}", net_extpanid), f"Invalid extpanid: {net_extpanid}"
+
+    LOGGER.info(f"Leader dataset: {dataset_hex[:32]}... ({len(dataset_hex)} chars)")
+    LOGGER.info(
+        f"Leader netinfo: name={net_name} channel={net_channel} "
+        f"panid={net_panid} extpanid={net_extpanid}"
+    )
+
+    LOGGER.info("Sending dataset and network info to child...")
+    child.write(f"DATASET {dataset_hex}\n")
+    child.write(
+        f"NETINFO name={net_name} channel={net_channel} "
+        f"panid={net_panid} extpanid={net_extpanid}\n"
+    )
+
+    LOGGER.info("Waiting for child to join network...")
+    child.expect_exact("[CHILD] JOINED", timeout=60)
+
+    LOGGER.info("Waiting for child completion...")
+    child.expect_exact("[CHILD] DONE", timeout=120)
+
+    LOGGER.info("OpenThread multi-DUT test passed!")

--- a/tests/validation/zigbee/README.md
+++ b/tests/validation/zigbee/README.md
@@ -1,0 +1,78 @@
+# Zigbee Validation Test
+
+Validates **ZigbeeCore** and all 26 Zigbee endpoint classes from `Zigbee.h`: stack configuration, endpoint registration, deep on-device API tests (getters, callbacks, reporting), network form/join, and coordinator→end-device ZCL interop. This is a **multi-DUT** test on ESP32-C6 / ESP32-H2.
+
+## Architecture
+
+```
+ ┌──────────────────────────────┐         802.15.4          ┌───────────────────────┐
+ │ Coordinator (device0)        │◄─────── wireless ────────►│ End device (device1)  │
+ │ • All 26 endpoint types      │                           │ • Light + temp sensor │
+ │ • Deep API + switch interop  │  epSwitch ──on/off──►     │ • Remote light control│
+ └──────────────┬───────────────┘                           └──────────┬────────────┘
+                │ serial                                               │ serial
+                ▼                                                      ▼
+ ┌─────────────────────────────────────────────────────────────────────────────────┐
+ │                        pytest (test_zigbee.py)                                  │
+ └─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Endpoint registration and pre-`begin()` configuration live in `coordinator/zigbee_endpoint_matrix.h`. Deep endpoint tests are in `coordinator/zigbee_endpoint_deep_tests.h`.
+
+## Test Cases
+
+### Coordinator (`coordinator/coordinator.ino`)
+
+| Test Function | Description |
+|---|---|
+| `test_coordinator_config` | `ZigbeeCore` setters/getters before `begin()` (scan duration, debug, binding, radio/host config) |
+| `test_coordinator_register_all_endpoints` | Register all 26 endpoint types + pre-`begin()` cluster configuration |
+| `test_coordinator_begin` | `begin()`, verify duplicate `begin()` returns `false` |
+| `test_coordinator_stop_start` | `stop()` / `start()` pause and resume |
+| `test_coordinator_role` | `getRole()` returns coordinator |
+| `test_coordinator_form_network` | `openNetwork()`, `connected()`, prints `NETWORK_READY` |
+| `test_coordinator_endpoint_deep_tests` | 14 deep test groups: lights, outlet, fan, covering, IAS zones, temp/humidity, environmental sensors, analog/binary/multistate I/O, electrical measurement |
+
+After Unity, `loop()` runs coordinator→end-device switch/light interop when pytest sends `RUN_INTEROP`.
+
+### End device (`end_device/end_device.ino`)
+
+| Test Function | Description |
+|---|---|
+| `test_end_device_config` | `ZigbeeCore` setters/getters before `begin()` |
+| `test_end_device_add_endpoints` | `ZigbeeLight` and `ZigbeeTempSensor` registration |
+| `test_end_device_begin` | `begin()`, verify duplicate `begin()` returns `false` |
+| `test_end_device_stop_start` | `stop()` / `start()` |
+| `test_end_device_role` | `getRole()` returns end device |
+| `test_end_device_join_network` | Join coordinator network, `connected()`, prints `JOINED` |
+| `test_end_device_temp_sensor` | `setReporting`, `setTemperature`, `reportTemperature` after join |
+| `test_end_device_zcl_interop` | Coordinator switch controls local light via binding (`RUN_INTEROP`) |
+| `test_end_device_light` | Local light callback, on/off, `restoreLight` |
+
+## Requirements
+
+- **Hardware**: Two ESP32-C6 or ESP32-H2 boards (802.15.4 radio required)
+- **Wokwi/QEMU**: Not supported (802.15.4 radio not simulated)
+- **CI Runner**: `two_duts`
+- **SoC Config**: `CONFIG_ZB_ENABLED=y`, `CONFIG_SOC_IEEE802154_SUPPORTED=y`
+- **FQBN**: Coordinator `PartitionScheme=zigbee_zczr,ZigbeeMode=zczr`; end device `PartitionScheme=zigbee,ZigbeeMode=ed`
+
+## Serial Protocol
+
+The coordinator and end device flash at different speeds; pytest drives the end device after the coordinator finishes its suite.
+
+1. Coordinator prints `[COORDINATOR] Ready`, runs Unity tests, then `[COORDINATOR] NETWORK_READY` → `API_TESTS_DONE` → `INTEROP_READY` → `DONE`
+2. End device prints `[ENDDEVICE] Ready`
+3. pytest sends `START` to the end device
+4. End device runs Unity tests, joins network, prints `[ENDDEVICE] JOINED`
+5. pytest sends `RUN_INTEROP` to both devices
+6. Coordinator prints `[COORDINATOR] INTEROP_ARMED`; switch drives end-device light → `[ENDDEVICE] REMOTE_LIGHT_ON` / `REMOTE_LIGHT_OFF` → `SWITCH_INTEROP_DONE` on both
+7. End device completes remaining Unity tests, prints `[ENDDEVICE] DONE`
+
+## Notes
+
+- `Zigbee.begin()` is called once per boot; a second call returns `false`.
+- Unlike Matter validation, Zigbee cannot decommission/reboot mid-suite on a single DUT — depth comes from getter round-trips, callbacks, reporting, pre-begin cluster config, and real ZCL over the air with a second board.
+- Thermostat, gateway, and range-extender endpoints are registered on the coordinator but have no simple local attribute setters in the Arduino API; control paths are covered via registration and ZCL examples.
+- ED→coordinator switch control is not covered (would need bind/discover APIs); coordinator→ED interop uses automatic binding on join.
+- `scanNetworks`, `factoryReset`, and RCP host mode are not covered here (see library examples).

--- a/tests/validation/zigbee/ci.yml
+++ b/tests/validation/zigbee/ci.yml
@@ -1,0 +1,18 @@
+tags:
+  - two_duts
+
+multi_device:
+  device0:
+    sketch: coordinator
+    fqbn_append: PartitionScheme=zigbee_zczr,ZigbeeMode=zczr
+  device1:
+    sketch: end_device
+    fqbn_append: PartitionScheme=zigbee,ZigbeeMode=ed
+
+platforms:
+  wokwi: false
+  qemu: false
+
+requires:
+  - CONFIG_ZB_ENABLED=y
+  - CONFIG_SOC_IEEE802154_SUPPORTED=y

--- a/tests/validation/zigbee/coordinator/coordinator.ino
+++ b/tests/validation/zigbee/coordinator/coordinator.ino
@@ -22,10 +22,16 @@
 #include "zigbee_endpoint_matrix.h"
 #include "zigbee_endpoint_deep_tests.h"
 
-#define ZB_TIMEOUT_MS 30000
+#define ZB_TIMEOUT_MS      30000
 #define ZB_INTEROP_BIND_MS 60000
 
-enum ZbInteropState { ZB_INTEROP_IDLE, ZB_INTEROP_WAIT_BIND, ZB_INTEROP_LIGHT_ON, ZB_INTEROP_LIGHT_OFF, ZB_INTEROP_DONE };
+enum ZbInteropState {
+  ZB_INTEROP_IDLE,
+  ZB_INTEROP_WAIT_BIND,
+  ZB_INTEROP_LIGHT_ON,
+  ZB_INTEROP_LIGHT_OFF,
+  ZB_INTEROP_DONE
+};
 
 static ZbInteropState interop_state = ZB_INTEROP_IDLE;
 static unsigned long interop_phase_ms = 0;
@@ -204,8 +210,7 @@ void loop() {
       }
       break;
 
-    default:
-      break;
+    default: break;
   }
 
   delay(50);

--- a/tests/validation/zigbee/coordinator/coordinator.ino
+++ b/tests/validation/zigbee/coordinator/coordinator.ino
@@ -1,0 +1,239 @@
+/*
+ * Zigbee Validation Test -- Coordinator (multi-DUT)
+ *
+ * Registers all Zigbee library endpoint types, runs ZigbeeCore API tests,
+ * deep endpoint API tests, then forms a network for the end device to join.
+ * ZCL interop (coordinator switch -> end device light) runs in loop() only
+ * after pytest sends RUN_INTEROP (once the end device has joined).
+ *
+ * Zigbee.begin() is called only once per boot.
+ *
+ * Pin-to-pin: wireless (802.15.4 radio)
+ * Runner: two_duts (C6/H2)
+ * Requires: CONFIG_ZB_ENABLED=y, ZigbeeMode=zczr, PartitionScheme=zigbee_zczr
+ */
+
+#include <Arduino.h>
+
+#if CONFIG_ZB_ENABLED
+
+#include <Zigbee.h>
+#include <unity.h>
+#include "zigbee_endpoint_matrix.h"
+#include "zigbee_endpoint_deep_tests.h"
+
+#define ZB_TIMEOUT_MS 30000
+#define ZB_INTEROP_BIND_MS 60000
+
+enum ZbInteropState { ZB_INTEROP_IDLE, ZB_INTEROP_WAIT_BIND, ZB_INTEROP_LIGHT_ON, ZB_INTEROP_LIGHT_OFF, ZB_INTEROP_DONE };
+
+static ZbInteropState interop_state = ZB_INTEROP_IDLE;
+static unsigned long interop_phase_ms = 0;
+static unsigned long interop_bind_start_ms = 0;
+
+static void arm_switch_interop(void) {
+  interop_state = ZB_INTEROP_WAIT_BIND;
+  interop_bind_start_ms = millis();
+  Serial.println("[COORDINATOR] INTEROP_ARMED");
+}
+
+static void poll_serial_commands(void) {
+  while (Serial.available()) {
+    String cmd = Serial.readStringUntil('\n');
+    cmd.trim();
+    if (cmd == "RUN_INTEROP") {
+      arm_switch_interop();
+    }
+  }
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ==================== Configuration (before begin) ====================
+
+void test_coordinator_config(void) {
+  Zigbee.setScanDuration(2);
+  TEST_ASSERT_EQUAL(2, Zigbee.getScanDuration());
+
+  Zigbee.setRxOnWhenIdle(true);
+  TEST_ASSERT_TRUE(Zigbee.getRxOnWhenIdle());
+
+  Zigbee.setDebugMode(true);
+  TEST_ASSERT_TRUE(Zigbee.getDebugMode());
+
+  Zigbee.allowMultiEndpointBinding(true);
+  TEST_ASSERT_TRUE(Zigbee.allowMultiEndpointBinding());
+
+  Zigbee.setTimeout(ZB_TIMEOUT_MS);
+  Zigbee.setPrimaryChannelMask(ESP_ZB_TRANSCEIVER_ALL_CHANNELS_MASK);
+
+  esp_zb_radio_config_t radio = Zigbee.getRadioConfig();
+  TEST_ASSERT_EQUAL(ZB_RADIO_MODE_NATIVE, radio.radio_mode);
+
+  esp_zb_host_config_t host = Zigbee.getHostConfig();
+  TEST_ASSERT_EQUAL(ZB_HOST_CONNECTION_MODE_NONE, host.host_connection_mode);
+}
+
+// ==================== All endpoint types (before begin) ====================
+
+void test_coordinator_register_all_endpoints(void) {
+  TEST_ASSERT_FALSE_MESSAGE(epTemp.setReporting(1, 300, 0.5f), "setReporting must not run before Zigbee.begin()");
+  TEST_ASSERT_TRUE_MESSAGE(register_all_zigbee_endpoints(), "Failed to register one or more Zigbee endpoints");
+}
+
+// ==================== Stack init ====================
+
+void test_coordinator_begin(void) {
+  TEST_ASSERT_TRUE(Zigbee.begin(ZIGBEE_COORDINATOR, true));
+
+  unsigned long start = millis();
+  while (!Zigbee.started() && millis() - start < ZB_TIMEOUT_MS) {
+    delay(100);
+  }
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "Coordinator failed to start stack");
+
+  TEST_ASSERT_FALSE_MESSAGE(Zigbee.begin(ZIGBEE_COORDINATOR, true), "duplicate begin() must return false");
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "stack must keep running after rejected begin()");
+}
+
+// ==================== stop / start ====================
+
+void test_coordinator_stop_start(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "stack must be running");
+
+  Zigbee.stop();
+  TEST_ASSERT_FALSE_MESSAGE(Zigbee.started(), "stop() must clear started()");
+
+  Zigbee.start();
+
+  unsigned long start = millis();
+  while (!Zigbee.started() && millis() - start < 5000) {
+    delay(100);
+  }
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "start() must resume the stack");
+}
+
+// ==================== Role / network ====================
+
+void test_coordinator_role(void) {
+  TEST_ASSERT_EQUAL(ZIGBEE_COORDINATOR, Zigbee.getRole());
+}
+
+void test_coordinator_form_network(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "Zigbee stack must already be running");
+
+  Zigbee.openNetwork(180);
+
+  unsigned long start = millis();
+  while (!Zigbee.connected() && millis() - start < ZB_TIMEOUT_MS) {
+    delay(100);
+  }
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.connected(), "Coordinator failed to form network");
+
+  delay(2000);
+  Serial.println("[COORDINATOR] NETWORK_READY");
+}
+
+// ==================== Deep endpoint APIs (after network up) ====================
+
+void test_coordinator_endpoint_deep_tests(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.connected(), "network required for attribute updates");
+  run_all_zigbee_endpoint_deep_tests();
+  Serial.println("[COORDINATOR] API_TESTS_DONE");
+}
+
+// ==================== Setup ====================
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[COORDINATOR] Ready");
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_coordinator_config);
+  RUN_TEST(test_coordinator_register_all_endpoints);
+  RUN_TEST(test_coordinator_begin);
+  RUN_TEST(test_coordinator_stop_start);
+  RUN_TEST(test_coordinator_role);
+  RUN_TEST(test_coordinator_form_network);
+  RUN_TEST(test_coordinator_endpoint_deep_tests);
+
+  UNITY_END();
+
+  Serial.println("[COORDINATOR] INTEROP_READY");
+  Serial.println("[COORDINATOR] DONE");
+}
+
+void loop() {
+  poll_serial_commands();
+
+  if (interop_state == ZB_INTEROP_IDLE || interop_state == ZB_INTEROP_DONE) {
+    delay(50);
+    return;
+  }
+
+  switch (interop_state) {
+    case ZB_INTEROP_WAIT_BIND:
+      if (epSwitch.bound()) {
+        epSwitch.lightOn();
+        interop_phase_ms = millis();
+        interop_state = ZB_INTEROP_LIGHT_ON;
+      } else if (millis() - interop_bind_start_ms > ZB_INTEROP_BIND_MS) {
+        Serial.println("[COORDINATOR] SWITCH_INTEROP_FAILED");
+        interop_state = ZB_INTEROP_DONE;
+      }
+      break;
+
+    case ZB_INTEROP_LIGHT_ON:
+      if (millis() - interop_phase_ms >= 2000) {
+        epSwitch.lightOff();
+        interop_phase_ms = millis();
+        interop_state = ZB_INTEROP_LIGHT_OFF;
+      }
+      break;
+
+    case ZB_INTEROP_LIGHT_OFF:
+      if (millis() - interop_phase_ms >= 1000) {
+        Serial.println("[COORDINATOR] SWITCH_INTEROP_DONE");
+        interop_state = ZB_INTEROP_DONE;
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  delay(50);
+}
+
+#else  // !CONFIG_ZB_ENABLED
+
+#include <unity.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_zigbee_not_supported(void) {
+  TEST_IGNORE_MESSAGE("Zigbee not enabled in sdkconfig");
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[COORDINATOR] Ready");
+  UNITY_BEGIN();
+  RUN_TEST(test_zigbee_not_supported);
+  UNITY_END();
+  Serial.println("[COORDINATOR] DONE");
+}
+
+void loop() {}
+#endif

--- a/tests/validation/zigbee/coordinator/zigbee_endpoint_deep_tests.h
+++ b/tests/validation/zigbee/coordinator/zigbee_endpoint_deep_tests.h
@@ -1,0 +1,379 @@
+/*
+ * Deep endpoint API tests for the Zigbee coordinator validation suite.
+ * Exercises callbacks, getter round-trips, reporting, and multi-value paths
+ * (similar depth to Matter phase-0 smoke tests, but on-device without a hub).
+ */
+
+#pragma once
+
+#if CONFIG_ZB_ENABLED
+
+#include <unity.h>
+#include "zigbee_endpoint_matrix.h"
+
+// --- callback state shared across tests ---
+
+static volatile bool light_cb_called = false;
+static volatile bool light_cb_state = false;
+
+static volatile bool dimmable_cb_called = false;
+static volatile bool dimmable_cb_state = false;
+static volatile uint8_t dimmable_cb_level = 0;
+
+static volatile bool color_rgb_cb_called = false;
+static volatile uint8_t color_rgb_r = 0;
+static volatile uint8_t color_rgb_g = 0;
+static volatile uint8_t color_rgb_b = 0;
+
+static volatile bool outlet_cb_called = false;
+static volatile bool outlet_cb_state = false;
+
+static volatile bool analog_out_cb_called = false;
+static volatile float analog_out_cb_value = 0.0f;
+
+static volatile bool binary_out_cb_called = false;
+static volatile bool binary_out_cb_state = false;
+
+static volatile bool multistate_out_cb_called = false;
+static volatile uint16_t multistate_out_cb_value = 0;
+
+static void onLightCb(bool state) {
+  light_cb_called = true;
+  light_cb_state = state;
+}
+
+static void onDimmableCb(bool state, uint8_t level) {
+  dimmable_cb_called = true;
+  dimmable_cb_state = state;
+  dimmable_cb_level = level;
+}
+
+static void onColorRgbCb(bool state, uint8_t red, uint8_t green, uint8_t blue, uint8_t level) {
+  (void)state;
+  (void)level;
+  color_rgb_cb_called = true;
+  color_rgb_r = red;
+  color_rgb_g = green;
+  color_rgb_b = blue;
+}
+
+static void onOutletCb(bool state) {
+  outlet_cb_called = true;
+  outlet_cb_state = state;
+}
+
+static void onAnalogOutCb(float value) {
+  analog_out_cb_called = true;
+  analog_out_cb_value = value;
+}
+
+static void onBinaryOutCb(bool value) {
+  binary_out_cb_called = true;
+  binary_out_cb_state = value;
+}
+
+static void onMultistateOutCb(uint16_t value) {
+  multistate_out_cb_called = true;
+  multistate_out_cb_value = value;
+}
+
+// ==================== Lights ====================
+
+static void test_light_onoff_roundtrip(void) {
+  TEST_ASSERT_TRUE(epLight.setLight(false));
+  TEST_ASSERT_FALSE(epLight.getLightState());
+
+  TEST_ASSERT_TRUE(epLight.setLight(true));
+  TEST_ASSERT_TRUE(epLight.getLightState());
+
+  TEST_ASSERT_TRUE(epLight.setLight(false));
+  TEST_ASSERT_FALSE(epLight.getLightState());
+}
+
+static void test_light_callback_and_restore(void) {
+  light_cb_called = false;
+  epLight.onLightChange(onLightCb);
+
+  TEST_ASSERT_TRUE(epLight.setLight(true));
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(light_cb_called, "onLightChange not fired");
+  TEST_ASSERT_TRUE_MESSAGE(light_cb_state, "callback state mismatch");
+
+  light_cb_called = false;
+  TEST_ASSERT_TRUE(epLight.setLight(false));
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(light_cb_called, "onLightChange not fired on off");
+  TEST_ASSERT_FALSE_MESSAGE(light_cb_state, "callback state should be off");
+
+  epLight.restoreLight();
+}
+
+static void test_dimmable_levels(void) {
+  epDimmable.onLightChange(onDimmableCb);
+
+  TEST_ASSERT_TRUE(epDimmable.setLight(false, 0));
+  TEST_ASSERT_FALSE(epDimmable.getLightState());
+  TEST_ASSERT_EQUAL(0, epDimmable.getLightLevel());
+
+  TEST_ASSERT_TRUE(epDimmable.setLight(true, 128));
+  TEST_ASSERT_TRUE(epDimmable.getLightState());
+  TEST_ASSERT_EQUAL(128, epDimmable.getLightLevel());
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(dimmable_cb_called, "dimmable callback not fired");
+  TEST_ASSERT_EQUAL(128, dimmable_cb_level);
+
+  TEST_ASSERT_TRUE(epDimmable.setLightLevel(255));
+  TEST_ASSERT_EQUAL(255, epDimmable.getLightLevel());
+
+  TEST_ASSERT_TRUE(epDimmable.setLightState(false));
+  TEST_ASSERT_FALSE(epDimmable.getLightState());
+  epDimmable.restoreLight();
+}
+
+static void test_color_light_rgb_and_level(void) {
+  epColorDim.onLightChangeRgb(onColorRgbCb);
+
+  TEST_ASSERT_TRUE(epColorDim.setLightState(true));
+  TEST_ASSERT_TRUE(epColorDim.getLightState());
+
+  TEST_ASSERT_TRUE(epColorDim.setLightLevel(200));
+  TEST_ASSERT_EQUAL(200, epColorDim.getLightLevel());
+
+  TEST_ASSERT_TRUE(epColorDim.setLightColor(10, 20, 30));
+  TEST_ASSERT_EQUAL(10, epColorDim.getLightRed());
+  TEST_ASSERT_EQUAL(20, epColorDim.getLightGreen());
+  TEST_ASSERT_EQUAL(30, epColorDim.getLightBlue());
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(color_rgb_cb_called, "RGB callback not fired");
+
+  espRgbColor_t rgb = epColorDim.getLightColor();
+  TEST_ASSERT_EQUAL(10, rgb.r);
+  TEST_ASSERT_EQUAL(20, rgb.g);
+  TEST_ASSERT_EQUAL(30, rgb.b);
+
+  TEST_ASSERT_TRUE(epColorDim.setLightColorTemperature(250));
+  TEST_ASSERT_EQUAL(250, epColorDim.getLightColorTemperature());
+
+  TEST_ASSERT_GREATER_THAN(0, epColorDim.getLightColorCapabilities());
+  epColorDim.restoreLight();
+}
+
+static void test_power_outlet(void) {
+  outlet_cb_called = false;
+  epOutlet.onPowerOutletChange(onOutletCb);
+
+  TEST_ASSERT_TRUE(epOutlet.setState(true));
+  TEST_ASSERT_TRUE(epOutlet.getPowerOutletState());
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(outlet_cb_called, "outlet callback not fired");
+  TEST_ASSERT_TRUE(outlet_cb_state);
+
+  TEST_ASSERT_TRUE(epOutlet.setState(false));
+  TEST_ASSERT_FALSE(epOutlet.getPowerOutletState());
+  epOutlet.restoreState();
+}
+
+// ==================== Actuators ====================
+
+static void test_fan_mode_sequence(void) {
+  TEST_ASSERT_TRUE(epFan.setFanModeSequence(FAN_MODE_SEQUENCE_LOW_MED_HIGH_AUTO));
+  TEST_ASSERT_EQUAL(FAN_MODE_SEQUENCE_LOW_MED_HIGH_AUTO, epFan.getFanModeSequence());
+  TEST_ASSERT_EQUAL(FAN_MODE_OFF, epFan.getFanMode());
+}
+
+static void test_window_covering(void) {
+  TEST_ASSERT_TRUE(epCovering.setCoveringType(BLIND_LIFT_AND_TILT));
+  TEST_ASSERT_TRUE(epCovering.setLimits(0, 100, 0, 90));
+  TEST_ASSERT_TRUE(epCovering.setLiftPercentage(0));
+  TEST_ASSERT_TRUE(epCovering.setLiftPercentage(50));
+  TEST_ASSERT_TRUE(epCovering.setLiftPercentage(100));
+  TEST_ASSERT_TRUE(epCovering.setTiltPercentage(25));
+  TEST_ASSERT_TRUE(epCovering.setTiltPercentage(75));
+}
+
+static void fake_ias_zone_enroll_attrs(uint8_t endpoint) {
+  esp_zb_ieee_addr_t fake_cie = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  uint8_t zone_id = 0;
+  esp_zb_lock_acquire(portMAX_DELAY);
+  esp_zb_zcl_set_attribute_val(
+    endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID, &fake_cie, false
+  );
+  esp_zb_zcl_set_attribute_val(
+    endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &zone_id, false
+  );
+  esp_zb_lock_release();
+}
+
+static void test_ias_zone_devices(void) {
+  // Non-enrolled devices must refuse to set+report
+  TEST_ASSERT_FALSE_MESSAGE(epContact.enrolled(), "contact should start un-enrolled");
+  TEST_ASSERT_FALSE_MESSAGE(epContact.setClosed(), "setClosed must fail when not enrolled");
+
+  TEST_ASSERT_FALSE_MESSAGE(epVibration.enrolled(), "vibration should start un-enrolled");
+  TEST_ASSERT_FALSE_MESSAGE(epVibration.setVibration(true), "setVibration must fail when not enrolled");
+
+  TEST_ASSERT_FALSE_MESSAGE(epDoorHandle.enrolled(), "door handle should start un-enrolled");
+  TEST_ASSERT_FALSE_MESSAGE(epDoorHandle.setClosed(), "setClosed must fail when not enrolled");
+
+  // Simulate enrollment via the production reboot-restore path
+  fake_ias_zone_enroll_attrs(ZB_EP_CONTACT);
+  TEST_ASSERT_TRUE_MESSAGE(epContact.restoreIASZoneEnroll(), "contact restoreIASZoneEnroll failed");
+  TEST_ASSERT_TRUE_MESSAGE(epContact.enrolled(), "contact should be enrolled after restore");
+
+  fake_ias_zone_enroll_attrs(ZB_EP_VIBRATION);
+  TEST_ASSERT_TRUE_MESSAGE(epVibration.restoreIASZoneEnroll(), "vibration restoreIASZoneEnroll failed");
+  TEST_ASSERT_TRUE_MESSAGE(epVibration.enrolled(), "vibration should be enrolled after restore");
+
+  fake_ias_zone_enroll_attrs(ZB_EP_DOOR_HANDLE);
+  TEST_ASSERT_TRUE_MESSAGE(epDoorHandle.restoreIASZoneEnroll(), "door handle restoreIASZoneEnroll failed");
+  TEST_ASSERT_TRUE_MESSAGE(epDoorHandle.enrolled(), "door handle should be enrolled after restore");
+
+  // Enrolled devices: full set + report path
+  TEST_ASSERT_TRUE(epContact.setClosed());
+  TEST_ASSERT_TRUE(epContact.setOpen());
+  TEST_ASSERT_TRUE(epContact.setClosed());
+
+  TEST_ASSERT_TRUE(epVibration.setVibration(true));
+  TEST_ASSERT_TRUE(epVibration.setVibration(false));
+
+  TEST_ASSERT_TRUE(epDoorHandle.setClosed());
+  TEST_ASSERT_TRUE(epDoorHandle.setOpen());
+  TEST_ASSERT_TRUE(epDoorHandle.setTilted());
+  TEST_ASSERT_TRUE(epDoorHandle.setClosed());
+}
+
+// ==================== Sensors ====================
+
+static void test_temp_humidity_sensor(void) {
+  TEST_ASSERT_TRUE(epTemp.setReporting(1, 300, 0.5f));
+  TEST_ASSERT_TRUE(epTemp.setHumidityReporting(1, 300, 1.0f));
+
+  TEST_ASSERT_TRUE(epTemp.setTemperature(20.0f));
+  TEST_ASSERT_TRUE(epTemp.setTemperature(25.5f));
+  TEST_ASSERT_TRUE(epTemp.reportTemperature());
+
+  TEST_ASSERT_TRUE(epTemp.setHumidity(55.0f));
+  TEST_ASSERT_TRUE(epTemp.setHumidity(60.5f));
+  TEST_ASSERT_TRUE(epTemp.reportHumidity());
+  TEST_ASSERT_TRUE(epTemp.report());
+}
+
+static void test_environmental_sensors(void) {
+  TEST_ASSERT_TRUE(epPressure.setReporting(1, 300, 1));
+  TEST_ASSERT_TRUE(epFlow.setReporting(1, 300, 0.5f));
+  TEST_ASSERT_TRUE(epIlluminance.setReporting(1, 300, 10));
+  TEST_ASSERT_TRUE(epCo2.setReporting(1, 300, 10));
+  TEST_ASSERT_TRUE(epPm25.setReporting(1, 300, 1.0f));
+  TEST_ASSERT_TRUE(epWind.setReporting(1, 300, 0.5f));
+
+  TEST_ASSERT_TRUE(epPressure.setPressure(1013));
+  TEST_ASSERT_TRUE(epPressure.report());
+
+  TEST_ASSERT_TRUE(epFlow.setFlow(12.5f));
+  TEST_ASSERT_TRUE(epFlow.report());
+
+  TEST_ASSERT_TRUE(epIlluminance.setIlluminance(500));
+  TEST_ASSERT_TRUE(epIlluminance.setIlluminance(1000));
+  TEST_ASSERT_TRUE(epIlluminance.report());
+
+  TEST_ASSERT_TRUE(epOccupancy.setOccupancy(true));
+  TEST_ASSERT_TRUE(epOccupancy.setOccupancy(false));
+  TEST_ASSERT_TRUE(epOccupancy.report());
+
+  TEST_ASSERT_TRUE(epCo2.setCarbonDioxide(400.0f));
+  TEST_ASSERT_TRUE(epCo2.setCarbonDioxide(800.0f));
+  TEST_ASSERT_TRUE(epCo2.report());
+
+  TEST_ASSERT_TRUE(epPm25.setPM25(12.5f));
+  TEST_ASSERT_TRUE(epPm25.setPM25(25.0f));
+  TEST_ASSERT_TRUE(epPm25.report());
+
+  TEST_ASSERT_TRUE(epWind.setWindSpeed(3.5f));
+  TEST_ASSERT_TRUE(epWind.setWindSpeed(10.0f));
+  TEST_ASSERT_TRUE(epWind.reportWindSpeed());
+}
+
+// ==================== Analog / Binary / Multistate ====================
+
+static void test_analog_io(void) {
+  epAnalog.onAnalogOutputChange(onAnalogOutCb);
+
+  TEST_ASSERT_TRUE(epAnalog.setAnalogInput(1.5f));
+  TEST_ASSERT_TRUE(epAnalog.reportAnalogInput());
+
+  TEST_ASSERT_TRUE(epAnalog.setAnalogOutput(42.5f));
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 42.5f, epAnalog.getAnalogOutput());
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(analog_out_cb_called, "analog output callback not fired");
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 42.5f, analog_out_cb_value);
+
+  TEST_ASSERT_TRUE(epAnalog.setAnalogOutput(0.0f));
+  TEST_ASSERT_TRUE(epAnalog.reportAnalogOutput());
+}
+
+static void test_binary_io(void) {
+  epBinary.onBinaryOutputChange(onBinaryOutCb);
+
+  TEST_ASSERT_TRUE(epBinary.setBinaryInput(true));
+  TEST_ASSERT_TRUE(epBinary.reportBinaryInput());
+
+  TEST_ASSERT_TRUE(epBinary.setBinaryOutput(true));
+  TEST_ASSERT_TRUE(epBinary.getBinaryOutput());
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(binary_out_cb_called, "binary output callback not fired");
+  TEST_ASSERT_TRUE(binary_out_cb_state);
+
+  TEST_ASSERT_TRUE(epBinary.setBinaryOutput(false));
+  TEST_ASSERT_FALSE(epBinary.getBinaryOutput());
+  TEST_ASSERT_TRUE(epBinary.reportBinaryOutput());
+}
+
+static void test_multistate_io(void) {
+  epMultistate.onMultistateOutputChange(onMultistateOutCb);
+
+  TEST_ASSERT_EQUAL(ZB_MULTISTATE_APPLICATION_TYPE_0_NUM_STATES, epMultistate.getMultistateOutputStateNamesLength());
+
+  TEST_ASSERT_TRUE(epMultistate.setMultistateInput(1));
+  TEST_ASSERT_EQUAL(1, epMultistate.getMultistateInput());
+  TEST_ASSERT_TRUE(epMultistate.reportMultistateInput());
+
+  TEST_ASSERT_TRUE(epMultistate.setMultistateOutput(2));
+  TEST_ASSERT_EQUAL(2, epMultistate.getMultistateOutput());
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(multistate_out_cb_called, "multistate output callback not fired");
+  TEST_ASSERT_EQUAL(2, multistate_out_cb_value);
+
+  TEST_ASSERT_TRUE(epMultistate.setMultistateOutput(0));
+  TEST_ASSERT_EQUAL(0, epMultistate.getMultistateOutput());
+  TEST_ASSERT_TRUE(epMultistate.reportMultistateOutput());
+}
+
+static void test_electrical_measurement(void) {
+  TEST_ASSERT_TRUE(epElectrical.setDCReporting(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE, 1, 300, 1));
+
+  TEST_ASSERT_TRUE(epElectrical.setDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE, 120));
+  TEST_ASSERT_TRUE(epElectrical.setDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_CURRENT, 5));
+  TEST_ASSERT_TRUE(epElectrical.reportDC(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE));
+  TEST_ASSERT_TRUE(epElectrical.reportDC(ZIGBEE_DC_MEASUREMENT_TYPE_CURRENT));
+}
+
+// ==================== Runner ====================
+
+static void run_all_zigbee_endpoint_deep_tests(void) {
+  RUN_TEST(test_light_onoff_roundtrip);
+  RUN_TEST(test_light_callback_and_restore);
+  RUN_TEST(test_dimmable_levels);
+  RUN_TEST(test_color_light_rgb_and_level);
+  RUN_TEST(test_power_outlet);
+  RUN_TEST(test_fan_mode_sequence);
+  RUN_TEST(test_window_covering);
+  RUN_TEST(test_ias_zone_devices);
+  RUN_TEST(test_temp_humidity_sensor);
+  RUN_TEST(test_environmental_sensors);
+  RUN_TEST(test_analog_io);
+  RUN_TEST(test_binary_io);
+  RUN_TEST(test_multistate_io);
+  RUN_TEST(test_electrical_measurement);
+}
+
+#endif  // CONFIG_ZB_ENABLED

--- a/tests/validation/zigbee/coordinator/zigbee_endpoint_deep_tests.h
+++ b/tests/validation/zigbee/coordinator/zigbee_endpoint_deep_tests.h
@@ -198,9 +198,7 @@ static void fake_ias_zone_enroll_attrs(uint8_t endpoint) {
   esp_zb_zcl_set_attribute_val(
     endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_IAS_CIE_ADDRESS_ID, &fake_cie, false
   );
-  esp_zb_zcl_set_attribute_val(
-    endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &zone_id, false
-  );
+  esp_zb_zcl_set_attribute_val(endpoint, ESP_ZB_ZCL_CLUSTER_ID_IAS_ZONE, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE, ESP_ZB_ZCL_ATTR_IAS_ZONE_ZONEID_ID, &zone_id, false);
   esp_zb_lock_release();
 }
 

--- a/tests/validation/zigbee/coordinator/zigbee_endpoint_matrix.h
+++ b/tests/validation/zigbee/coordinator/zigbee_endpoint_matrix.h
@@ -1,0 +1,245 @@
+/*
+ * Register all Zigbee endpoint classes from Zigbee.h on the coordinator.
+ * Pre-begin configuration (min/max, clusters) lives in register_all_zigbee_endpoints().
+ * Deep API tests are in zigbee_endpoint_deep_tests.h.
+ */
+
+#pragma once
+
+#if CONFIG_ZB_ENABLED
+
+#include <Zigbee.h>
+
+#define ZB_EP_LIGHT 1
+#define ZB_EP_DIMMABLE 2
+#define ZB_EP_COLOR_DIM 3
+#define ZB_EP_SWITCH 4
+#define ZB_EP_COLOR_DIMMER_SW 5
+#define ZB_EP_OUTLET 6
+#define ZB_EP_FAN 7
+#define ZB_EP_THERMOSTAT 8
+#define ZB_EP_COVERING 9
+#define ZB_EP_ANALOG 10
+#define ZB_EP_BINARY 11
+#define ZB_EP_MULTISTATE 12
+#define ZB_EP_TEMP 13
+#define ZB_EP_PRESSURE 14
+#define ZB_EP_FLOW 15
+#define ZB_EP_ILLUMINANCE 16
+#define ZB_EP_OCCUPANCY 17
+#define ZB_EP_CO2 18
+#define ZB_EP_PM25 19
+#define ZB_EP_WIND 20
+#define ZB_EP_CONTACT 21
+#define ZB_EP_VIBRATION 22
+#define ZB_EP_DOOR_HANDLE 23
+#define ZB_EP_ELECTRICAL 24
+#define ZB_EP_GATEWAY 25
+#define ZB_EP_RANGE_EXT 26
+
+static ZigbeeLight epLight(ZB_EP_LIGHT);
+static ZigbeeDimmableLight epDimmable(ZB_EP_DIMMABLE);
+static ZigbeeColorDimmableLight epColorDim(ZB_EP_COLOR_DIM);
+static ZigbeeSwitch epSwitch(ZB_EP_SWITCH);
+static ZigbeeColorDimmerSwitch epColorDimmerSw(ZB_EP_COLOR_DIMMER_SW);
+static ZigbeePowerOutlet epOutlet(ZB_EP_OUTLET);
+static ZigbeeFanControl epFan(ZB_EP_FAN);
+static ZigbeeThermostat epThermostat(ZB_EP_THERMOSTAT);
+static ZigbeeWindowCovering epCovering(ZB_EP_COVERING);
+static ZigbeeAnalog epAnalog(ZB_EP_ANALOG);
+static ZigbeeBinary epBinary(ZB_EP_BINARY);
+static ZigbeeMultistate epMultistate(ZB_EP_MULTISTATE);
+static ZigbeeTempSensor epTemp(ZB_EP_TEMP);
+static ZigbeePressureSensor epPressure(ZB_EP_PRESSURE);
+static ZigbeeFlowSensor epFlow(ZB_EP_FLOW);
+static ZigbeeIlluminanceSensor epIlluminance(ZB_EP_ILLUMINANCE);
+static ZigbeeOccupancySensor epOccupancy(ZB_EP_OCCUPANCY);
+static ZigbeeCarbonDioxideSensor epCo2(ZB_EP_CO2);
+static ZigbeePM25Sensor epPm25(ZB_EP_PM25);
+static ZigbeeWindSpeedSensor epWind(ZB_EP_WIND);
+static ZigbeeContactSwitch epContact(ZB_EP_CONTACT);
+static ZigbeeVibrationSensor epVibration(ZB_EP_VIBRATION);
+static ZigbeeDoorWindowHandle epDoorHandle(ZB_EP_DOOR_HANDLE);
+static ZigbeeElectricalMeasurement epElectrical(ZB_EP_ELECTRICAL);
+static ZigbeeGateway epGateway(ZB_EP_GATEWAY);
+static ZigbeeRangeExtender epRangeExt(ZB_EP_RANGE_EXT);
+
+static bool register_all_zigbee_endpoints(void) {
+  epLight.setManufacturerAndModel("Espressif", "ZBValLight");
+  if (!Zigbee.addEndpoint(&epLight)) {
+    return false;
+  }
+
+  epDimmable.setManufacturerAndModel("Espressif", "ZBValDim");
+  if (!Zigbee.addEndpoint(&epDimmable)) {
+    return false;
+  }
+
+  epColorDim.setLightColorCapabilities(
+    ZIGBEE_COLOR_CAPABILITY_HUE_SATURATION | ZIGBEE_COLOR_CAPABILITY_X_Y | ZIGBEE_COLOR_CAPABILITY_COLOR_TEMP
+  );
+  epColorDim.setManufacturerAndModel("Espressif", "ZBValColor");
+  if (!Zigbee.addEndpoint(&epColorDim)) {
+    return false;
+  }
+
+  epSwitch.setManufacturerAndModel("Espressif", "ZBValSwitch");
+  if (!Zigbee.addEndpoint(&epSwitch)) {
+    return false;
+  }
+
+  epColorDimmerSw.setManufacturerAndModel("Espressif", "ZBValCDSwitch");
+  if (!Zigbee.addEndpoint(&epColorDimmerSw)) {
+    return false;
+  }
+
+  epOutlet.setManufacturerAndModel("Espressif", "ZBValOutlet");
+  if (!Zigbee.addEndpoint(&epOutlet)) {
+    return false;
+  }
+
+  epFan.setManufacturerAndModel("Espressif", "ZBValFan");
+  if (!Zigbee.addEndpoint(&epFan)) {
+    return false;
+  }
+
+  epThermostat.setManufacturerAndModel("Espressif", "ZBValThermo");
+  if (!Zigbee.addEndpoint(&epThermostat)) {
+    return false;
+  }
+
+  epCovering.setManufacturerAndModel("Espressif", "ZBValCover");
+  if (!Zigbee.addEndpoint(&epCovering)) {
+    return false;
+  }
+
+  if (!epAnalog.addAnalogInput() || !epAnalog.addAnalogOutput()) {
+    return false;
+  }
+  epAnalog.setAnalogInputMinMax(0.0f, 100.0f);
+  epAnalog.setAnalogOutputMinMax(0.0f, 100.0f);
+  epAnalog.setAnalogInputResolution(0.1f);
+  epAnalog.setAnalogOutputResolution(0.1f);
+  epAnalog.setManufacturerAndModel("Espressif", "ZBValAnalog");
+  if (!Zigbee.addEndpoint(&epAnalog)) {
+    return false;
+  }
+
+  if (!epBinary.addBinaryInput() || !epBinary.addBinaryOutput()) {
+    return false;
+  }
+  epBinary.setBinaryInputApplication(BINARY_INPUT_APPLICATION_TYPE_HVAC_OCCUPANCY);
+  epBinary.setBinaryOutputApplication(BINARY_OUTPUT_APPLICATION_TYPE_HVAC_FAN);
+  epBinary.setManufacturerAndModel("Espressif", "ZBValBinary");
+  if (!Zigbee.addEndpoint(&epBinary)) {
+    return false;
+  }
+
+  if (!epMultistate.addMultistateInput() || !epMultistate.addMultistateOutput()) {
+    return false;
+  }
+  epMultistate.setMultistateInputApplication(ZB_MULTISTATE_APPLICATION_TYPE_0_INDEX);
+  epMultistate.setMultistateOutputApplication(ZB_MULTISTATE_APPLICATION_TYPE_0_INDEX);
+  epMultistate.setMultistateInputStates(ZB_MULTISTATE_APPLICATION_TYPE_0_NUM_STATES);
+  epMultistate.setMultistateOutputStates(ZB_MULTISTATE_APPLICATION_TYPE_0_NUM_STATES);
+  epMultistate.setManufacturerAndModel("Espressif", "ZBValMulti");
+  if (!Zigbee.addEndpoint(&epMultistate)) {
+    return false;
+  }
+
+  epTemp.setMinMaxValue(-40.0f, 85.0f);
+  epTemp.setTolerance(0.5f);
+  epTemp.addHumiditySensor(0.0f, 100.0f, 0.5f, 45.0f);
+  epTemp.setManufacturerAndModel("Espressif", "ZBValTemp");
+  if (!Zigbee.addEndpoint(&epTemp)) {
+    return false;
+  }
+
+  epPressure.setMinMaxValue(900, 1100);
+  epPressure.setTolerance(1);
+  epPressure.setManufacturerAndModel("Espressif", "ZBValPress");
+  if (!Zigbee.addEndpoint(&epPressure)) {
+    return false;
+  }
+
+  epFlow.setMinMaxValue(0.0f, 100.0f);
+  epFlow.setTolerance(0.1f);
+  epFlow.setManufacturerAndModel("Espressif", "ZBValFlow");
+  if (!Zigbee.addEndpoint(&epFlow)) {
+    return false;
+  }
+
+  epIlluminance.setMinMaxValue(0, 65535);
+  epIlluminance.setTolerance(1);
+  epIlluminance.setManufacturerAndModel("Espressif", "ZBValIllum");
+  if (!Zigbee.addEndpoint(&epIlluminance)) {
+    return false;
+  }
+
+  epOccupancy.setManufacturerAndModel("Espressif", "ZBValOcc");
+  if (!Zigbee.addEndpoint(&epOccupancy)) {
+    return false;
+  }
+
+  epCo2.setMinMaxValue(0.0f, 5000.0f);
+  epCo2.setTolerance(10.0f);
+  epCo2.setManufacturerAndModel("Espressif", "ZBValCO2");
+  if (!Zigbee.addEndpoint(&epCo2)) {
+    return false;
+  }
+
+  epPm25.setMinMaxValue(0.0f, 500.0f);
+  epPm25.setTolerance(1.0f);
+  epPm25.setManufacturerAndModel("Espressif", "ZBValPM25");
+  if (!Zigbee.addEndpoint(&epPm25)) {
+    return false;
+  }
+
+  epWind.setMinMaxValue(0.0f, 50.0f);
+  epWind.setTolerance(0.5f);
+  epWind.setManufacturerAndModel("Espressif", "ZBValWind");
+  if (!Zigbee.addEndpoint(&epWind)) {
+    return false;
+  }
+
+  epContact.setManufacturerAndModel("Espressif", "ZBValContact");
+  if (!Zigbee.addEndpoint(&epContact)) {
+    return false;
+  }
+
+  epVibration.setManufacturerAndModel("Espressif", "ZBValVibr");
+  if (!Zigbee.addEndpoint(&epVibration)) {
+    return false;
+  }
+
+  epDoorHandle.setManufacturerAndModel("Espressif", "ZBValDoor");
+  if (!Zigbee.addEndpoint(&epDoorHandle)) {
+    return false;
+  }
+
+  if (!epElectrical.addDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE)
+      || !epElectrical.addDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_CURRENT)) {
+    return false;
+  }
+  epElectrical.setDCMinMaxValue(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE, 0, 250);
+  epElectrical.setDCMinMaxValue(ZIGBEE_DC_MEASUREMENT_TYPE_CURRENT, 0, 100);
+  epElectrical.setDCMultiplierDivisor(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE, 1, 10);
+  epElectrical.setManufacturerAndModel("Espressif", "ZBValElec");
+  if (!Zigbee.addEndpoint(&epElectrical)) {
+    return false;
+  }
+
+  epGateway.setManufacturerAndModel("Espressif", "ZBValGW");
+  if (!Zigbee.addEndpoint(&epGateway)) {
+    return false;
+  }
+
+  epRangeExt.setManufacturerAndModel("Espressif", "ZBValRange");
+  if (!Zigbee.addEndpoint(&epRangeExt)) {
+    return false;
+  }
+
+  return true;
+}
+
+#endif  // CONFIG_ZB_ENABLED

--- a/tests/validation/zigbee/coordinator/zigbee_endpoint_matrix.h
+++ b/tests/validation/zigbee/coordinator/zigbee_endpoint_matrix.h
@@ -10,32 +10,32 @@
 
 #include <Zigbee.h>
 
-#define ZB_EP_LIGHT 1
-#define ZB_EP_DIMMABLE 2
-#define ZB_EP_COLOR_DIM 3
-#define ZB_EP_SWITCH 4
+#define ZB_EP_LIGHT           1
+#define ZB_EP_DIMMABLE        2
+#define ZB_EP_COLOR_DIM       3
+#define ZB_EP_SWITCH          4
 #define ZB_EP_COLOR_DIMMER_SW 5
-#define ZB_EP_OUTLET 6
-#define ZB_EP_FAN 7
-#define ZB_EP_THERMOSTAT 8
-#define ZB_EP_COVERING 9
-#define ZB_EP_ANALOG 10
-#define ZB_EP_BINARY 11
-#define ZB_EP_MULTISTATE 12
-#define ZB_EP_TEMP 13
-#define ZB_EP_PRESSURE 14
-#define ZB_EP_FLOW 15
-#define ZB_EP_ILLUMINANCE 16
-#define ZB_EP_OCCUPANCY 17
-#define ZB_EP_CO2 18
-#define ZB_EP_PM25 19
-#define ZB_EP_WIND 20
-#define ZB_EP_CONTACT 21
-#define ZB_EP_VIBRATION 22
-#define ZB_EP_DOOR_HANDLE 23
-#define ZB_EP_ELECTRICAL 24
-#define ZB_EP_GATEWAY 25
-#define ZB_EP_RANGE_EXT 26
+#define ZB_EP_OUTLET          6
+#define ZB_EP_FAN             7
+#define ZB_EP_THERMOSTAT      8
+#define ZB_EP_COVERING        9
+#define ZB_EP_ANALOG          10
+#define ZB_EP_BINARY          11
+#define ZB_EP_MULTISTATE      12
+#define ZB_EP_TEMP            13
+#define ZB_EP_PRESSURE        14
+#define ZB_EP_FLOW            15
+#define ZB_EP_ILLUMINANCE     16
+#define ZB_EP_OCCUPANCY       17
+#define ZB_EP_CO2             18
+#define ZB_EP_PM25            19
+#define ZB_EP_WIND            20
+#define ZB_EP_CONTACT         21
+#define ZB_EP_VIBRATION       22
+#define ZB_EP_DOOR_HANDLE     23
+#define ZB_EP_ELECTRICAL      24
+#define ZB_EP_GATEWAY         25
+#define ZB_EP_RANGE_EXT       26
 
 static ZigbeeLight epLight(ZB_EP_LIGHT);
 static ZigbeeDimmableLight epDimmable(ZB_EP_DIMMABLE);
@@ -75,9 +75,7 @@ static bool register_all_zigbee_endpoints(void) {
     return false;
   }
 
-  epColorDim.setLightColorCapabilities(
-    ZIGBEE_COLOR_CAPABILITY_HUE_SATURATION | ZIGBEE_COLOR_CAPABILITY_X_Y | ZIGBEE_COLOR_CAPABILITY_COLOR_TEMP
-  );
+  epColorDim.setLightColorCapabilities(ZIGBEE_COLOR_CAPABILITY_HUE_SATURATION | ZIGBEE_COLOR_CAPABILITY_X_Y | ZIGBEE_COLOR_CAPABILITY_COLOR_TEMP);
   epColorDim.setManufacturerAndModel("Espressif", "ZBValColor");
   if (!Zigbee.addEndpoint(&epColorDim)) {
     return false;
@@ -217,8 +215,7 @@ static bool register_all_zigbee_endpoints(void) {
     return false;
   }
 
-  if (!epElectrical.addDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE)
-      || !epElectrical.addDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_CURRENT)) {
+  if (!epElectrical.addDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE) || !epElectrical.addDCMeasurement(ZIGBEE_DC_MEASUREMENT_TYPE_CURRENT)) {
     return false;
   }
   epElectrical.setDCMinMaxValue(ZIGBEE_DC_MEASUREMENT_TYPE_VOLTAGE, 0, 250);

--- a/tests/validation/zigbee/end_device/end_device.ino
+++ b/tests/validation/zigbee/end_device/end_device.ino
@@ -1,0 +1,263 @@
+/*
+ * Zigbee Validation Test -- End Device (multi-DUT)
+ *
+ * ZigbeeCore, ZigbeeLight, and ZigbeeTempSensor on an end device. Joins the
+ * coordinator network after pytest sends START. ZCL interop (coordinator switch
+ * -> ED light) runs on RUN_INTEROP.
+ *
+ * Zigbee.begin() is called only once per boot.
+ *
+ * Pin-to-pin: wireless (802.15.4 radio)
+ * Runner: two_duts (C6/H2 devices)
+ * Requires: CONFIG_ZB_ENABLED=y, ZigbeeMode=ed, PartitionScheme=zigbee
+ */
+
+#include <Arduino.h>
+
+#if CONFIG_ZB_ENABLED
+
+#include <Zigbee.h>
+#include <unity.h>
+
+#define ZB_TIMEOUT_MS 30000
+#define ZB_INTEROP_WAIT_MS 60000
+
+#define ZB_EP_LIGHT 1
+#define ZB_EP_TEMP 2
+
+static ZigbeeLight zbLight(ZB_EP_LIGHT);
+static ZigbeeTempSensor zbTemp(ZB_EP_TEMP);
+
+static volatile bool light_cb_called = false;
+static volatile bool light_cb_state = false;
+static volatile bool remote_light_on_seen = false;
+static volatile bool remote_light_off_seen = false;
+
+static void onLightChange(bool state) {
+  light_cb_called = true;
+  light_cb_state = state;
+}
+
+static void onRemoteLightChange(bool state) {
+  if (state) {
+    remote_light_on_seen = true;
+    Serial.println("[ENDDEVICE] REMOTE_LIGHT_ON");
+  } else {
+    remote_light_off_seen = true;
+    Serial.println("[ENDDEVICE] REMOTE_LIGHT_OFF");
+  }
+}
+
+static void wait_for_serial_command(const char *expected) {
+  String cmd;
+  while (cmd != expected) {
+    if (Serial.available()) {
+      cmd = Serial.readStringUntil('\n');
+      cmd.trim();
+    }
+    delay(10);
+  }
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ==================== Configuration (before begin) ====================
+
+void test_end_device_config(void) {
+  Zigbee.setScanDuration(3);
+  TEST_ASSERT_EQUAL(3, Zigbee.getScanDuration());
+
+  Zigbee.setRxOnWhenIdle(true);
+  TEST_ASSERT_TRUE(Zigbee.getRxOnWhenIdle());
+
+  Zigbee.setDebugMode(false);
+  TEST_ASSERT_FALSE(Zigbee.getDebugMode());
+
+  Zigbee.allowMultiEndpointBinding(false);
+  TEST_ASSERT_FALSE(Zigbee.allowMultiEndpointBinding());
+
+  Zigbee.setTimeout(ZB_TIMEOUT_MS);
+
+  esp_zb_radio_config_t radio = Zigbee.getRadioConfig();
+  TEST_ASSERT_EQUAL(ZB_RADIO_MODE_NATIVE, radio.radio_mode);
+}
+
+// ==================== Endpoints (before begin) ====================
+
+void test_end_device_add_endpoints(void) {
+  zbLight.setManufacturerAndModel("Espressif", "ZBValidationED");
+  zbLight.onLightChange(onRemoteLightChange);
+  TEST_ASSERT_TRUE(Zigbee.addEndpoint(&zbLight));
+
+  zbTemp.setMinMaxValue(-10.0f, 50.0f);
+  zbTemp.setTolerance(0.5f);
+  zbTemp.setManufacturerAndModel("Espressif", "ZBValEDTemp");
+  TEST_ASSERT_TRUE(Zigbee.addEndpoint(&zbTemp));
+}
+
+// ==================== Stack init ====================
+
+void test_end_device_begin(void) {
+  TEST_ASSERT_TRUE(Zigbee.begin(ZIGBEE_END_DEVICE, true));
+
+  unsigned long start = millis();
+  while (!Zigbee.started() && millis() - start < ZB_TIMEOUT_MS) {
+    delay(100);
+  }
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "End device failed to start stack");
+
+  TEST_ASSERT_FALSE_MESSAGE(Zigbee.begin(ZIGBEE_END_DEVICE, true), "duplicate begin() must return false");
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "stack must keep running after rejected begin()");
+}
+
+// ==================== stop / start ====================
+
+void test_end_device_stop_start(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "stack must be running");
+
+  Zigbee.stop();
+  TEST_ASSERT_FALSE_MESSAGE(Zigbee.started(), "stop() must clear started()");
+
+  Zigbee.start();
+
+  unsigned long start = millis();
+  while (!Zigbee.started() && millis() - start < 5000) {
+    delay(100);
+  }
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "start() must resume the stack");
+}
+
+// ==================== Role ====================
+
+void test_end_device_role(void) {
+  TEST_ASSERT_EQUAL(ZIGBEE_END_DEVICE, Zigbee.getRole());
+}
+
+// ==================== Join network ====================
+
+void test_end_device_join_network(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.started(), "Zigbee stack must already be running");
+
+  unsigned long join_start = millis();
+  while (!Zigbee.connected() && millis() - join_start < ZB_TIMEOUT_MS) {
+    delay(100);
+  }
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.connected(), "End device failed to join network");
+
+  Serial.println("[ENDDEVICE] JOINED");
+}
+
+// ==================== Temp sensor (after join) ====================
+
+void test_end_device_temp_sensor(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.connected(), "must be joined before sensor tests");
+
+  TEST_ASSERT_TRUE(zbTemp.setReporting(1, 300, 0.5f));
+  TEST_ASSERT_TRUE(zbTemp.setTemperature(22.5f));
+  TEST_ASSERT_TRUE(zbTemp.reportTemperature());
+}
+
+// ==================== ZCL interop (coordinator switch -> ED light) ====================
+
+void test_end_device_zcl_interop(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.connected(), "must be joined before interop");
+
+  remote_light_on_seen = false;
+  remote_light_off_seen = false;
+  zbLight.onLightChange(onRemoteLightChange);
+
+  wait_for_serial_command("RUN_INTEROP");
+
+  unsigned long interop_start = millis();
+  while ((!remote_light_on_seen || !remote_light_off_seen) && millis() - interop_start < ZB_INTEROP_WAIT_MS) {
+    delay(50);
+  }
+
+  TEST_ASSERT_TRUE_MESSAGE(remote_light_on_seen, "coordinator did not turn light on");
+  TEST_ASSERT_TRUE_MESSAGE(remote_light_off_seen, "coordinator did not turn light off");
+
+  Serial.println("[ENDDEVICE] SWITCH_INTEROP_DONE");
+}
+
+// ==================== ZigbeeLight (local API) ====================
+
+void test_end_device_light(void) {
+  TEST_ASSERT_TRUE_MESSAGE(Zigbee.connected(), "must be joined before light tests");
+
+  light_cb_called = false;
+  zbLight.onLightChange(onLightChange);
+
+  TEST_ASSERT_TRUE(zbLight.setLight(true));
+  TEST_ASSERT_TRUE(zbLight.getLightState());
+  delay(50);
+  TEST_ASSERT_TRUE_MESSAGE(light_cb_called, "onLightChange callback not fired");
+  TEST_ASSERT_TRUE_MESSAGE(light_cb_state, "callback state mismatch");
+
+  TEST_ASSERT_TRUE(zbLight.setLight(false));
+  TEST_ASSERT_FALSE(zbLight.getLightState());
+
+  TEST_ASSERT_TRUE(zbLight.setLight(true));
+  TEST_ASSERT_TRUE(zbLight.setLight(false));
+  zbLight.restoreLight();
+
+  zbLight.onLightChange(onRemoteLightChange);
+}
+
+// ==================== Setup ====================
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[ENDDEVICE] Ready");
+
+  wait_for_serial_command("START");
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_end_device_config);
+  RUN_TEST(test_end_device_add_endpoints);
+  RUN_TEST(test_end_device_begin);
+  RUN_TEST(test_end_device_stop_start);
+  RUN_TEST(test_end_device_role);
+  RUN_TEST(test_end_device_join_network);
+  RUN_TEST(test_end_device_temp_sensor);
+  RUN_TEST(test_end_device_zcl_interop);
+  RUN_TEST(test_end_device_light);
+
+  UNITY_END();
+
+  Serial.println("[ENDDEVICE] DONE");
+}
+
+void loop() {}
+
+#else  // !CONFIG_ZB_ENABLED
+
+#include <unity.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_zigbee_not_supported(void) {
+  TEST_IGNORE_MESSAGE("Zigbee not enabled in sdkconfig");
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  Serial.println("[ENDDEVICE] Ready");
+  UNITY_BEGIN();
+  RUN_TEST(test_zigbee_not_supported);
+  UNITY_END();
+  Serial.println("[ENDDEVICE] DONE");
+}
+
+void loop() {}
+#endif

--- a/tests/validation/zigbee/end_device/end_device.ino
+++ b/tests/validation/zigbee/end_device/end_device.ino
@@ -19,11 +19,11 @@
 #include <Zigbee.h>
 #include <unity.h>
 
-#define ZB_TIMEOUT_MS 30000
+#define ZB_TIMEOUT_MS      30000
 #define ZB_INTEROP_WAIT_MS 60000
 
 #define ZB_EP_LIGHT 1
-#define ZB_EP_TEMP 2
+#define ZB_EP_TEMP  2
 
 static ZigbeeLight zbLight(ZB_EP_LIGHT);
 static ZigbeeTempSensor zbTemp(ZB_EP_TEMP);

--- a/tests/validation/zigbee/test_zigbee.py
+++ b/tests/validation/zigbee/test_zigbee.py
@@ -1,0 +1,42 @@
+import logging
+
+
+def test_zigbee(dut):
+    LOGGER = logging.getLogger(__name__)
+
+    coordinator = dut[0]
+    end_device = dut[1]
+
+    # Coordinator boots and runs Unity while the end device may still be flashing.
+    LOGGER.info("Waiting for coordinator to be ready...")
+    coordinator.expect_exact("[COORDINATOR] Ready", timeout=120)
+
+    LOGGER.info("Waiting for coordinator network and deep endpoint tests...")
+    coordinator.expect_exact("[COORDINATOR] NETWORK_READY", timeout=180)
+    coordinator.expect_exact("[COORDINATOR] API_TESTS_DONE", timeout=300)
+    coordinator.expect_exact("[COORDINATOR] INTEROP_READY", timeout=60)
+    coordinator.expect_exact("[COORDINATOR] DONE", timeout=30)
+
+    LOGGER.info("Waiting for end device to be ready...")
+    end_device.expect_exact("[ENDDEVICE] Ready", timeout=180)
+
+    LOGGER.info("Starting end device Unity tests...")
+    end_device.write("START\n")
+
+    LOGGER.info("Waiting for end device to join network...")
+    end_device.expect_exact("[ENDDEVICE] JOINED", timeout=60)
+
+    LOGGER.info("Coordinator switch -> end device light interop...")
+    coordinator.write("RUN_INTEROP\n")
+    end_device.write("RUN_INTEROP\n")
+    coordinator.expect_exact("[COORDINATOR] INTEROP_ARMED", timeout=30)
+
+    end_device.expect_exact("[ENDDEVICE] REMOTE_LIGHT_ON", timeout=90)
+    end_device.expect_exact("[ENDDEVICE] REMOTE_LIGHT_OFF", timeout=90)
+    end_device.expect_exact("[ENDDEVICE] SWITCH_INTEROP_DONE", timeout=30)
+    coordinator.expect_exact("[COORDINATOR] SWITCH_INTEROP_DONE", timeout=90)
+
+    LOGGER.info("Waiting for remaining end device Unity tests...")
+    end_device.expect_exact("[ENDDEVICE] DONE", timeout=120)
+
+    LOGGER.info("Zigbee multi-DUT test passed!")


### PR DESCRIPTION
## Description of Change

This pull request introduces a comprehensive OpenThread and Zigbee validation test suite for Arduino-based devices with 802.15.4 radios, supporting multi-device (multi-DUT) scenarios. It adds leader and child test sketches, shared test helpers, a CI configuration, and detailed documentation. The suite verifies correct OpenThread/Zigbee stack operation, API functionality, and interoperability between devices forming and joining a Thread network.

## Test Scenarios

Tested locally