### PR TITLE
fix(i2c): Do not allow reads longer than the size of the rx buffer

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -486,14 +486,6 @@ size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop) {
     return 0;
   }
 #endif /* SOC_I2C_SUPPORT_SLAVE */
-  if (rxBuffer == NULL || txBuffer == NULL) {
-    log_e("NULL buffer pointer");
-    return 0;
-  }
-  if (size > bufferSize) {
-    log_w("Requested size is greater than buffer size: %zu > %zu", size, bufferSize);
-    size = bufferSize;
-  }
   esp_err_t err = ESP_OK;
 #if !CONFIG_DISABLE_HAL_LOCKS
   TaskHandle_t task = xTaskGetCurrentTaskHandle();
@@ -506,6 +498,14 @@ size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop) {
     currentTaskHandle = task;
   }
 #endif
+  if (rxBuffer == NULL || txBuffer == NULL) {
+    log_e("NULL buffer pointer");
+    return 0;
+  }
+  if (size > bufferSize) {
+    log_w("Requested size is greater than buffer size: %zu > %zu", size, bufferSize);
+    size = bufferSize;
+  }
   if (nonStop) {
     if (address != txAddress) {
       log_e("Unfinished Repeated Start transaction! Expected address do not match! %u != %u", address, txAddress);

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -490,6 +490,10 @@ size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop) {
     log_e("NULL buffer pointer");
     return 0;
   }
+  if (size > bufferSize) {
+    log_w("Requested size is greater than buffer size. %lu > %lu", size, bufferSize);
+    size = bufferSize;
+  }
   esp_err_t err = ESP_OK;
 #if !CONFIG_DISABLE_HAL_LOCKS
   TaskHandle_t task = xTaskGetCurrentTaskHandle();

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -491,7 +491,7 @@ size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop) {
     return 0;
   }
   if (size > bufferSize) {
-    log_w("Requested size is greater than buffer size. %lu > %lu", size, bufferSize);
+    log_w("Requested size is greater than buffer size: %zu > %zu", size, bufferSize);
     size = bufferSize;
   }
   esp_err_t err = ESP_OK;

--- a/tests/validation/i2c_master/i2c_master.ino
+++ b/tests/validation/i2c_master/i2c_master.ino
@@ -230,6 +230,24 @@ void change_clock() {
   TEST_ASSERT_EQUAL(start_year, read_year);
 }
 
+void request_from_undersized_buffer() {
+  // The RX/TX buffer cannot be shrunk below 32 bytes (the I2C hardware FIFO
+  // length): setBufferSize() rejects anything smaller and leaves the size as-is.
+  TEST_ASSERT_EQUAL(0, Wire.setBufferSize(31));
+  TEST_ASSERT_EQUAL(32, Wire.setBufferSize(32));
+
+  // Start from a known-empty RX state so available() is deterministic.
+  Wire.flush();
+
+  // Requesting even one byte more than the buffer holds
+  // must be rejected up front.
+  // returns 0 without touching the bus or the buffer.
+  TEST_ASSERT_EQUAL(32, Wire.requestFrom(DS1307_ADDR, (size_t)33));
+  TEST_ASSERT_EQUAL(32, Wire.available());
+
+  // Restore the default buffer size for the remaining tests.
+  TEST_ASSERT_EQUAL(I2C_BUFFER_LENGTH, Wire.setBufferSize(I2C_BUFFER_LENGTH));
+}
 void swap_pins() {
   Wire.setPins(SCL, SDA);
   Wire.begin();
@@ -325,6 +343,7 @@ void setup() {
   RUN_TEST(rtc_set_time);
   RUN_TEST(rtc_run_clock);
   RUN_TEST(change_clock);
+  RUN_TEST(request_from_undersized_buffer);
   RUN_TEST(swap_pins);
   RUN_TEST(test_api);
   UNITY_END();


### PR DESCRIPTION
This pull request adds a safety check to the `TwoWire::requestFrom` method in `Wire.cpp` to prevent buffer overflows when requesting data. Now, if the requested size exceeds the available buffer size, a warning is logged and the size is limited to the buffer capacity.

**Buffer overflow protection:**

* Added a check to ensure `size` does not exceed `bufferSize` in `TwoWire::requestFrom`, logging a warning and adjusting the size if necessary.

Fixes: https://github.com/espressif/arduino-esp32/issues/11180