### PR TITLE
fix(networking): Remove unused Wire includes

### DIFF
--- a/libraries/HTTPClient/examples/HTTPClientEnterprise/HTTPClientEnterprise.ino
+++ b/libraries/HTTPClient/examples/HTTPClientEnterprise/HTTPClientEnterprise.ino
@@ -17,7 +17,6 @@
 #else
 #include "esp_wpa2.h"
 #endif
-#include <Wire.h>
 #define EAP_IDENTITY "identity"  //if connecting from another corporation, use identity@organization.domain in Eduroam
 #define EAP_PASSWORD "password"  //your Eduroam password
 const char *ssid = "eduroam";    // Eduroam SSID

--- a/libraries/NetworkClientSecure/examples/WiFiClientSecureEnterprise/WiFiClientSecureEnterprise.ino
+++ b/libraries/NetworkClientSecure/examples/WiFiClientSecureEnterprise/WiFiClientSecureEnterprise.ino
@@ -26,7 +26,6 @@
 #else
 #include "esp_wpa2.h"
 #endif
-#include <Wire.h>
 #define EAP_ANONYMOUS_IDENTITY "anonymous@example.com"  //anonymous identity
 #define EAP_IDENTITY           "id@example.com"         //user identity
 #define EAP_PASSWORD           "password"               //eduroam user password


### PR DESCRIPTION
## Description of Change

This pull request removes an unnecessary include statement from two example files related to enterprise WiFi authentication. The change simplifies the code by eliminating the unused `Wire.h` library.

Code cleanup:

* Removed the `#include <Wire.h>` statement from `HTTPClientEnterprise.ino` to avoid including unused dependencies.
* Removed the `#include <Wire.h>` statement from `WiFiClientSecureEnterprise.ino` to avoid including unused dependencies.
