### PR TITLE
IDF release/v5.5

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-071970e4-v1"
+              "version": "idf-release_v5.5-ac63a927-v1"
             },
             {
               "packager": "esp32",
@@ -79,7 +79,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20260424"
+              "version": "v0.12.0-esp32-20260703"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-071970e4-v1",
+          "version": "idf-release_v5.5-ac63a927-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
-              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
-              "size": "569686766"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
+              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
+              "size": "569741277"
             }
           ]
         },
@@ -417,56 +417,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20260424",
+          "version": "v0.12.0-esp32-20260703",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-linux-amd64-0.12.0-esp32-20260424.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20260424.tar.gz",
-              "checksum": "SHA-256:0c875beb0e8d89cee4335968e8a27c7d151f05b91f636263c81ab01e098d390d",
-              "size": "2630575"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-linux-amd64-0.12.0-esp32-20260703.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20260703.tar.gz",
+              "checksum": "SHA-256:4b71d1b4d8e4025029466e780161262a04137348b68e965c15250dbeebef03ce",
+              "size": "2700256"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-linux-arm64-0.12.0-esp32-20260424.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20260424.tar.gz",
-              "checksum": "SHA-256:f1b87d408adf6f2eb08a2b067ff7de38310829cc952c0f5d1d09920b0200a6e4",
-              "size": "2554716"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-linux-arm64-0.12.0-esp32-20260703.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20260703.tar.gz",
+              "checksum": "SHA-256:3ce059a26a543e96b19bef15a29b850aadaff1d4e2dc291e8c1ab45e331a5f1c",
+              "size": "2641141"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-linux-armel-0.12.0-esp32-20260424.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20260424.tar.gz",
-              "checksum": "SHA-256:6d8d3aa1a4d77610e03cbba48e359c14e7e96f5b3e9d4dfc0b7d1a2846421ca4",
-              "size": "2718565"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-linux-armel-0.12.0-esp32-20260703.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20260703.tar.gz",
+              "checksum": "SHA-256:deb167155c994cd60db93626caf92638614364c16bdc145957eec61950e0ad15",
+              "size": "2818366"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-macos-0.12.0-esp32-20260424.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20260424.tar.gz",
-              "checksum": "SHA-256:f3e3008e6a85e4dfea0177b9ea3fd769447e19a0f132e7754e4a7db164727f8e",
-              "size": "2790443"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-macos-0.12.0-esp32-20260703.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20260703.tar.gz",
+              "checksum": "SHA-256:489daa179ecde646ebf1d2288c96d398f1b8b620ac7487b7c57c3bc45cef0202",
+              "size": "2893284"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-macos-arm64-0.12.0-esp32-20260424.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20260424.tar.gz",
-              "checksum": "SHA-256:c7bffa205ca92a69ae7bc74e6e428824084e404355cbb9df2238fe30f5f435bb",
-              "size": "2613579"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-macos-arm64-0.12.0-esp32-20260703.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20260703.tar.gz",
+              "checksum": "SHA-256:fe366c8b72fc287fbdf5d62a1178dd882c37dc4a5c29205f126a6c3125aa9f41",
+              "size": "2694457"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-win32-0.12.0-esp32-20260424.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20260424.zip",
-              "checksum": "SHA-256:51682616fb443819ba5b3d982d991917576ea24ab4b8b0c4ac7b6427c57d4d67",
-              "size": "3203101"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-win32-0.12.0-esp32-20260703.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20260703.zip",
+              "checksum": "SHA-256:b72e45d6629e9370b59b80998ae47c1aaaf954e6795e7bf515c972ec9fc3f026",
+              "size": "3290643"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-win64-0.12.0-esp32-20260424.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20260424.zip",
-              "checksum": "SHA-256:d0005eea5b916df047afca7b777792050f8c6a6a502407180c8d839e9a841f75",
-              "size": "3203098"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-win64-0.12.0-esp32-20260703.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20260703.zip",
+              "checksum": "SHA-256:a49147705e49be9cab4af473e58b5730d99a0220d10f0976a04bf725cd0aa960",
+              "size": "3290643"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-e7145a10-v1"
+              "version": "idf-release_v5.5-897cf407-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-e7145a10-v1",
+          "version": "idf-release_v5.5-897cf407-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
-              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
-              "size": "569198857"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
+              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
+              "size": "569202100"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-897cf407-v1"
+              "version": "idf-release_v5.5-10ca0dff-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-897cf407-v1",
+          "version": "idf-release_v5.5-10ca0dff-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-897cf407-v1.zip",
-              "checksum": "SHA-256:c1b4c04ae5ad8dca94cbb2fc9f5a17c961b6646d818664e6c0567505ec09e520",
-              "size": "569202100"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
+              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
+              "size": "569346634"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-78d6b634-v1"
+              "version": "idf-release_v5.5-4d47550b-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-78d6b634-v1",
+          "version": "idf-release_v5.5-4d47550b-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
-              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
-              "size": "569416560"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
+              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
+              "size": "569432836"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-bb2188bf-v1"
+              "version": "idf-release_v5.5-e7145a10-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-bb2188bf-v1",
+          "version": "idf-release_v5.5-e7145a10-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
-              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
-              "size": "552910103"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-e7145a10-v1.zip",
+              "checksum": "SHA-256:01ff5ebd88e76d8ce05a98a057593e88c7adb75e401dbf965a665214225447d8",
+              "size": "569198857"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-10ca0dff-v1"
+              "version": "idf-release_v5.5-78d6b634-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-10ca0dff-v1",
+          "version": "idf-release_v5.5-78d6b634-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-10ca0dff-v1.zip",
-              "checksum": "SHA-256:820ba3ed34a0b9125dc8649d81933ccdf67591c0cddfe31685d24482d1b8f888",
-              "size": "569346634"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-78d6b634-v1.zip",
+              "checksum": "SHA-256:f1866ada08cc2bff1a188d067cf112d6c51694552c46ee177d4c2a69b5843d38",
+              "size": "569416560"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-ac63a927-v1"
+              "version": "idf-release_v5.5-dd8d7946-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-ac63a927-v1",
+          "version": "idf-release_v5.5-dd8d7946-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-ac63a927-v1.zip",
-              "checksum": "SHA-256:39036abd2a70e43f5bd92f86802c9e4a3bd0b1797f27a6d1e35e7aba853b1fef",
-              "size": "569741277"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
+              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
+              "size": "570844150"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-4d47550b-v1"
+              "version": "idf-release_v5.5-21f3b71c-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-4d47550b-v1",
+          "version": "idf-release_v5.5-21f3b71c-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-4d47550b-v1.zip",
-              "checksum": "SHA-256:66602fb9d4fb80399ddbf1c39597083356d440d1eed47c577843d6c69608b0e4",
-              "size": "569432836"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
+              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
+              "size": "569672523"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-21f3b71c-v1"
+              "version": "idf-release_v5.5-071970e4-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-21f3b71c-v1",
+          "version": "idf-release_v5.5-071970e4-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-21f3b71c-v1.zip",
-              "checksum": "SHA-256:e758e0ebe125b02de5439ade46797d31035528ceb432762738a1080e9a3de22b",
-              "size": "569672523"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-071970e4-v1.zip",
+              "checksum": "SHA-256:7d0bfdc64414e9b0cea7f121a6e4a3757e1112cdb7fcd2fcde44fce0244eb8c6",
+              "size": "569686766"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-73550728-v8"
+              "version": "idf-release_v5.5-bb2188bf-v1"
             },
             {
               "packager": "esp32",
@@ -64,7 +64,7 @@
             {
               "packager": "esp32",
               "name": "xtensa-esp-elf-gdb",
-              "version": "16.3_20250913"
+              "version": "17.1_20260402"
             },
             {
               "packager": "esp32",
@@ -74,12 +74,12 @@
             {
               "packager": "esp32",
               "name": "riscv32-esp-elf-gdb",
-              "version": "16.3_20250913"
+              "version": "17.1_20260402"
             },
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20251215"
+              "version": "v0.12.0-esp32-20260424"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-73550728-v8",
+          "version": "idf-release_v5.5-bb2188bf-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-bb2188bf-v1.zip",
+              "checksum": "SHA-256:7d05981e51f06672d390b47d995918fc5c37329d5e5c0472c55a63dcb275bea7",
+              "size": "552910103"
             }
           ]
         },
@@ -231,63 +231,63 @@
         },
         {
           "name": "xtensa-esp-elf-gdb",
-          "version": "16.3_20250913",
+          "version": "17.1_20260402",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:16d05c9104ff84529ac3799abb04d5666c193131ab461f153040721728b48730",
-              "size": "36396804"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:73bc6c4e50b06dceb60e94b53aded61b7769be3cf563572269d9c8d643db8e95",
+              "size": "42655871"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:ecbd53ba28cf24301be8260249bfcfb60567f938f4402797617c8a0fc170dc7d",
-              "size": "35457879"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:00290ffe21b2916ffd343fd28ac34fc8b93e99b992a3656fa09b4f2bdc564bea",
+              "size": "41589296"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:c0895e88797089fd6b16e1cb986c5c85a880e0e8dc03bde1016c7771bc10ddba",
-              "size": "31288407"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:f187a315e0393c2086d47e22f092524e3a1026143daa93c8e2bbdb8eac77d488",
+              "size": "36649511"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-i586-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:64ffefb7625edae77a03a13fd9bd07db088dec9d145eb1124de66f11510f7558",
-              "size": "35094067"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-i586-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:303b06d82d2802f508af603cd7a1e256dca0f232a2fa28ab9fa35539c2c858ac",
+              "size": "41080699"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-x86_64-apple-darwin24.5.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-x86_64-apple-darwin24.5.tar.gz",
-              "checksum": "SHA-256:8341493abc87e6ae468f4eda16c768b2ddb20c98336e1c491a3801ad823680ae",
-              "size": "45646032"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-x86_64-apple-darwin24.5.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-x86_64-apple-darwin24.5.tar.gz",
+              "checksum": "SHA-256:706d58849fd4a83244023051605b3631e835565395fa2783ed5afce1f17413ee",
+              "size": "53815837"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-aarch64-apple-darwin24.5.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-aarch64-apple-darwin24.5.tar.gz",
-              "checksum": "SHA-256:251e3be9c9436d9ab7fee6c05519fd816a05e63bd47495e24ea4e354881a851c",
-              "size": "39809369"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-aarch64-apple-darwin24.5.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-aarch64-apple-darwin24.5.tar.gz",
+              "checksum": "SHA-256:da97440e74a9ff36370bdb598cf421a8183c11ae6fb44431be594ad16dbe77ef",
+              "size": "46924973"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-i686-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:8fc9fa6a934523b6ad6e787cf1664d48496bae456fd85ea7589e3684ce3bbbe5",
-              "size": "32824604"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-i686-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:8125a724e4f25c22b19a0321bce8b6a8675e12e0d12e5757d2ed75bd7262c53c",
+              "size": "43646185"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/xtensa-esp-elf-gdb-16.3_20250913-x86_64-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-gdb-16.3_20250913-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:99a2243b9a75bbac95a672cc3ab4b36013429ab5b4583e7a28339e3015a3fdfa",
-              "size": "33835839"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/xtensa-esp-elf-gdb-17.1_20260402-x86_64-w64-mingw32.zip",
+              "archiveFileName": "xtensa-esp-elf-gdb-17.1_20260402-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:7525ae46b39fc87568717d8f0cc3dfbcdb77b96435dd80acfce6918b0abc2b8a",
+              "size": "44820924"
             }
           ]
         },
@@ -355,118 +355,118 @@
         },
         {
           "name": "riscv32-esp-elf-gdb",
-          "version": "16.3_20250913",
+          "version": "17.1_20260402",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:4e3cf8b7d11c7a2d1b50f40b1c50c0671dfe7eb13782c27c8a8cfdc8548bcdd4",
-              "size": "36557187"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:35f3db841338cb4f9bc60d757bc3e87dfa50ff50607bcbc3867c5b1ac28dd342",
+              "size": "43045928"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:8f1f4f24fa534c76ed9d71efffbf728cc30169e911742d7bd67dd0fdcf5f3ae3",
-              "size": "35664185"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:f185d924497750f254290a32c48163c08e3b2a29eb248d739d90990ebee17f44",
+              "size": "42035040"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:ac4fc85e3daf190b21598ec468933dc2659033580715560f45827da25e15b285",
-              "size": "32183532"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:88c8d492345eb972e5f978defb3395643303a18cf1870ce8cd9b8621d244b36e",
+              "size": "37855622"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-i586-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:905dcd78558d7d559a95dc1eacc4572ea908be4ae6b1c937ea63a98df4482ca9",
-              "size": "35438945"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-i586-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:29efe15235157bee507d97787a03e569f073bfef254c75d9662ec7f6e5162066",
+              "size": "41705144"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-x86_64-apple-darwin24.5.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-x86_64-apple-darwin24.5.tar.gz",
-              "checksum": "SHA-256:2d5e5efead0b189e13cfe2670ca9d6d5965378ef3632d0b163a14f2f0536c274",
-              "size": "45892529"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-x86_64-apple-darwin24.5.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-x86_64-apple-darwin24.5.tar.gz",
+              "checksum": "SHA-256:4845ec4968207e40c9f840f29007d8e0cd7d11eb613bb9e9078a41bb0ceb6d4d",
+              "size": "54514283"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-aarch64-apple-darwin24.5.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-aarch64-apple-darwin24.5.tar.gz",
-              "checksum": "SHA-256:92771492084746fd22521c7c5b52bf1ed6dd86ef3cafe60e771bbdb4f0943f5a",
-              "size": "40145407"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-aarch64-apple-darwin24.5.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-aarch64-apple-darwin24.5.tar.gz",
+              "checksum": "SHA-256:f944bb6a07b03e5d74dd1f878ba05320ee7957d3a06bcc80cd0a9cf355e8ceea",
+              "size": "47663426"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-i686-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:c6a36c469d3b76e2b442be207814f7c3f71f21faf6faab4dd33fdedd56d89c01",
-              "size": "33531234"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-i686-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:77b04d797b699127c7d395c55eef0d09840255e7710a0bd51bcbae83ffec1f0c",
+              "size": "44672431"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v16.3_20250913/riscv32-esp-elf-gdb-16.3_20250913-x86_64-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-gdb-16.3_20250913-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:32e79cb43b40f3b256193139b1fefd2782e3eaf82ee317b757ec8ba18b35159d",
-              "size": "34196400"
+              "url": "https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v17.1_20260402/riscv32-esp-elf-gdb-17.1_20260402-x86_64-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-gdb-17.1_20260402-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:f9e56a0d17414a30f7c457f7804173ecfb078b90d94a7b9f6318dc9652575d3f",
+              "size": "45474783"
             }
           ]
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20251215",
+          "version": "v0.12.0-esp32-20260424",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-linux-amd64-0.12.0-esp32-20251215.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20251215.tar.gz",
-              "checksum": "SHA-256:5e6ff40aeca23bdd203cde04d60bc808c0e6bff110eadcbce3d602618c880531",
-              "size": "2547606"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-linux-amd64-0.12.0-esp32-20260424.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20260424.tar.gz",
+              "checksum": "SHA-256:0c875beb0e8d89cee4335968e8a27c7d151f05b91f636263c81ab01e098d390d",
+              "size": "2630575"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-linux-arm64-0.12.0-esp32-20251215.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20251215.tar.gz",
-              "checksum": "SHA-256:29f98e2f90cd37924b714562b876a471d444a8f2aec428c6760e82bbf3b54cca",
-              "size": "2399117"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-linux-arm64-0.12.0-esp32-20260424.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20260424.tar.gz",
+              "checksum": "SHA-256:f1b87d408adf6f2eb08a2b067ff7de38310829cc952c0f5d1d09920b0200a6e4",
+              "size": "2554716"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-linux-armel-0.12.0-esp32-20251215.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20251215.tar.gz",
-              "checksum": "SHA-256:25de2b2dd0f5b437f5d5540c505eb9d0fbb971256ab13acd19642f8acdbd5cee",
-              "size": "2554256"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-linux-armel-0.12.0-esp32-20260424.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20260424.tar.gz",
+              "checksum": "SHA-256:6d8d3aa1a4d77610e03cbba48e359c14e7e96f5b3e9d4dfc0b7d1a2846421ca4",
+              "size": "2718565"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-macos-0.12.0-esp32-20251215.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20251215.tar.gz",
-              "checksum": "SHA-256:956dd02ccf35116d565be2b148e041bd47c135e551a1f5097eae756d7d4dd079",
-              "size": "2710467"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-macos-0.12.0-esp32-20260424.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20260424.tar.gz",
+              "checksum": "SHA-256:f3e3008e6a85e4dfea0177b9ea3fd769447e19a0f132e7754e4a7db164727f8e",
+              "size": "2790443"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-macos-arm64-0.12.0-esp32-20251215.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20251215.tar.gz",
-              "checksum": "SHA-256:e6414c8db2ab09b687eaf765b1e69a92aecdcfe44e073d6f47ff829777e2e823",
-              "size": "2535504"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-macos-arm64-0.12.0-esp32-20260424.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20260424.tar.gz",
+              "checksum": "SHA-256:c7bffa205ca92a69ae7bc74e6e428824084e404355cbb9df2238fe30f5f435bb",
+              "size": "2613579"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-win32-0.12.0-esp32-20251215.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20251215.zip",
-              "checksum": "SHA-256:032a3791c256c974bceced073dc8cf0e18c07a75f39592110cbe71fc8de914b2",
-              "size": "3109352"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-win32-0.12.0-esp32-20260424.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20260424.zip",
+              "checksum": "SHA-256:51682616fb443819ba5b3d982d991917576ea24ab4b8b0c4ac7b6427c57d4d67",
+              "size": "3203101"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20251215/openocd-esp32-win64-0.12.0-esp32-20251215.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20251215.zip",
-              "checksum": "SHA-256:d406be70d26098ced57eefcf636c4b4c184cd8c151204a459bb6ccbe4aa47eca",
-              "size": "3109355"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260424/openocd-esp32-win64-0.12.0-esp32-20260424.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20260424.zip",
+              "checksum": "SHA-256:d0005eea5b916df047afca7b777792050f8c6a6a502407180c8d839e9a841f75",
+              "size": "3203098"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-c197d718-v1"
+              "version": "idf-release_v5.5-c94f345e-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-c197d718-v1",
+          "version": "idf-release_v5.5-c94f345e-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
-              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
-              "size": "653040509"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
+              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
+              "size": "652920797"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-c94f345e-v1"
+              "version": "idf-release_v5.5-fd0b33df-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-c94f345e-v1",
+          "version": "idf-release_v5.5-fd0b33df-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c94f345e-v1.zip",
-              "checksum": "SHA-256:d6387e848f09ce7be05063e758a823d1bcc456afc5942dab0a6d911327ec1e6f",
-              "size": "652920797"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
+              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
+              "size": "653948487"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-fd0b33df-v1"
+              "version": "idf-release_v5.5-210ac400-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-fd0b33df-v1",
+          "version": "idf-release_v5.5-210ac400-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-fd0b33df-v1.zip",
-              "checksum": "SHA-256:36b172979ae3a01e86ecd678c55cd14dffb7e197ba23f0bc86bc52cd87c40d9a",
-              "size": "653948487"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
+              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
+              "size": "654017415"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-dd8d7946-v1"
+              "version": "idf-release_v5.5-1a1a5aa6-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-dd8d7946-v1",
+          "version": "idf-release_v5.5-1a1a5aa6-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-dd8d7946-v1.zip",
-              "checksum": "SHA-256:b63f7946bc30633a3d16f20aaab713eccff2b8ffe6f48553dc467d05a7eabb11",
-              "size": "570844150"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
+              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
+              "size": "571002016"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-93f18f13-v1"
+              "version": "idf-release_v5.5-c197d718-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-93f18f13-v1",
+          "version": "idf-release_v5.5-c197d718-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
-              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
-              "size": "652836899"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-c197d718-v1.zip",
+              "checksum": "SHA-256:04ccc04663b812ae88ba3abec305f1e3835d078581454fcd759494263d8bf5da",
+              "size": "653040509"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-1a1a5aa6-v1"
+              "version": "idf-release_v5.5-93f18f13-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-1a1a5aa6-v1",
+          "version": "idf-release_v5.5-93f18f13-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-1a1a5aa6-v1.zip",
-              "checksum": "SHA-256:fbef486f12a7efdc22f8782e6ece60f5f6ca56132e6f96c419535aeaa40973d0",
-              "size": "571002016"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-93f18f13-v1.zip",
+              "checksum": "SHA-256:695210b94203df0e5ef0531f25258893a72aa84fcce6a4be556609f16f02cf6c",
+              "size": "652836899"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-210ac400-v1"
+              "version": "idf-release_v5.5-be8aead3-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-210ac400-v1",
+          "version": "idf-release_v5.5-be8aead3-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-210ac400-v1.zip",
-              "checksum": "SHA-256:cc089b47ecf2e842bfbc4604e3e33fd2d91eb631afa15c8adb25c813355b8306",
-              "size": "654017415"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
+              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
+              "size": "653731579"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-be8aead3-v1"
+              "version": "idf-release_v5.5-362a1776-v1"
             },
             {
               "packager": "esp32",
@@ -79,7 +79,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20260703"
+              "version": "v0.12.0-esp32-20260831"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-be8aead3-v1",
+          "version": "idf-release_v5.5-362a1776-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-be8aead3-v1.zip",
-              "checksum": "SHA-256:c4b4e215b1f26144d91f14b1758bb389c8f64132b2614993592a3542902f3597",
-              "size": "653731579"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
+              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
+              "size": "653858871"
             }
           ]
         },
@@ -417,56 +417,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20260703",
+          "version": "v0.12.0-esp32-20260831",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-linux-amd64-0.12.0-esp32-20260703.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20260703.tar.gz",
-              "checksum": "SHA-256:4b71d1b4d8e4025029466e780161262a04137348b68e965c15250dbeebef03ce",
-              "size": "2700256"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260831/openocd-esp32-linux-amd64-0.12.0-esp32-20260831.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20260831.tar.gz",
+              "checksum": "SHA-256:89dcf8efc32296fa5c1f1cfb0268b82a2f14ce9b9cdcf76e817c51365aee6e5a",
+              "size": "2677335"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-linux-arm64-0.12.0-esp32-20260703.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20260703.tar.gz",
-              "checksum": "SHA-256:3ce059a26a543e96b19bef15a29b850aadaff1d4e2dc291e8c1ab45e331a5f1c",
-              "size": "2641141"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260831/openocd-esp32-linux-arm64-0.12.0-esp32-20260831.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20260831.tar.gz",
+              "checksum": "SHA-256:59236b2160dfcef1db3dbb0b7718e0ed9e127630dd65c5ccb6f13ef56c1e84ba",
+              "size": "2608313"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-linux-armel-0.12.0-esp32-20260703.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20260703.tar.gz",
-              "checksum": "SHA-256:deb167155c994cd60db93626caf92638614364c16bdc145957eec61950e0ad15",
-              "size": "2818366"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260831/openocd-esp32-linux-armel-0.12.0-esp32-20260831.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20260831.tar.gz",
+              "checksum": "SHA-256:3d1f6f9738ed9ad7851cc474d60e81c1c77f0e04dfe1142c1bee72561b07b9e6",
+              "size": "2774449"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-macos-0.12.0-esp32-20260703.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20260703.tar.gz",
-              "checksum": "SHA-256:489daa179ecde646ebf1d2288c96d398f1b8b620ac7487b7c57c3bc45cef0202",
-              "size": "2893284"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260831/openocd-esp32-macos-0.12.0-esp32-20260831.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20260831.tar.gz",
+              "checksum": "SHA-256:0db9db27da168e1c280f223767251d54cd5ccbf794460a2bf4284d15517a61dc",
+              "size": "2836639"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-macos-arm64-0.12.0-esp32-20260703.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20260703.tar.gz",
-              "checksum": "SHA-256:fe366c8b72fc287fbdf5d62a1178dd882c37dc4a5c29205f126a6c3125aa9f41",
-              "size": "2694457"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260831/openocd-esp32-macos-arm64-0.12.0-esp32-20260831.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20260831.tar.gz",
+              "checksum": "SHA-256:75dc62bf15d5a20a92b1c809048896c9af0ca5024fd89d4219b3b5b92f3a9f88",
+              "size": "2638802"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-win32-0.12.0-esp32-20260703.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20260703.zip",
-              "checksum": "SHA-256:b72e45d6629e9370b59b80998ae47c1aaaf954e6795e7bf515c972ec9fc3f026",
-              "size": "3290643"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260831/openocd-esp32-win32-0.12.0-esp32-20260831.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20260831.zip",
+              "checksum": "SHA-256:b3a7cce1f16d63c5023f97c3408bda1c10371bcb76e88e3ddb1111918cdc77a2",
+              "size": "3291881"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260703/openocd-esp32-win64-0.12.0-esp32-20260703.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20260703.zip",
-              "checksum": "SHA-256:a49147705e49be9cab4af473e58b5730d99a0220d10f0976a04bf725cd0aa960",
-              "size": "3290643"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20260831/openocd-esp32-win64-0.12.0-esp32-20260831.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20260831.zip",
+              "checksum": "SHA-256:d508bbe1d166e38415d57b495dd0409f46883251087433cfb3eabf513be93ff7",
+              "size": "3291878"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-362a1776-v1"
+              "version": "idf-release_v5.5-02c6ca33-v1"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-362a1776-v1",
+          "version": "idf-release_v5.5-02c6ca33-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-362a1776-v1.zip",
-              "checksum": "SHA-256:0a19d8099400246664b9324a15a90e2b32281fd3585fc76d43f65bb9185ad4bb",
-              "size": "653858871"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-02c6ca33-v1.zip",
+              "checksum": "SHA-256:89cd1642ae02a56cd5d82684302154a7fa6d87ac5ec5ff4abee7b87a50defd99",
+              "size": "654142805"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master a2413b1
esp-idf: release/v5.5 bb2188bfb80
arduino: master 7c5ec7f41
tinyusb: master 7a4111b96
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cjson: 1.7.19~2
espressif__dl_fft: 0.5.0
espressif__eppp_link: 1.1.5
espressif__esp-dsp: 1.8.0
espressif__esp-modbus: 2.1.3
espressif__esp-nn: 1.2.3
espressif__esp-sr: 2.4.6
espressif__esp-tflite-micro: 1.3.7
espressif__esp_hosted: 2.12.9
espressif__esp_modem: 2.0.2
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_wifi_remote: 1.6.1
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.1
espressif__libsodium: 1.0.22~1
espressif__mdns: 1.11.3
espressif__network_provisioning: 1.0.2
espressif__wifi_remote_over_eppp: 0.3.2
joltwallet__littlefs: 1.22.1
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.8.2
espressif__esp-serial-flasher: 0.0.11
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_daylight: 1.0.1
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.1.0
espressif__esp_diagnostics: 1.3.3
espressif__esp_encrypted_img: 2.3.0
espressif__esp_insights: 1.3.3
espressif__esp_matter: 1.5.0
espressif__esp_rainmaker: 1.15.0
espressif__esp_rcp_update: 1.3.1
espressif__esp_schedule: 1.3.3
espressif__esp_secure_cert_mgr: 2.9.2
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_cmd_resp: 1.0.0
espressif__rmaker_common: 1.8.5
espressif__rmaker_common_events: 1.0.0
espressif__rmaker_console: 1.0.0
espressif__rmaker_system_ctrl: 1.0.0
espressif__rmaker_time_sync: 1.0.2
espressif__rmaker_work_queue: 1.0.0
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
```
