### PR TITLE
IDF v5.5.4 with ESP-Video

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -54,7 +54,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.5-73550728-v8"
+              "version": "idf-release_v5.5-73550728-v9"
             },
             {
               "packager": "esp32",
@@ -107,63 +107,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.5-73550728-v8",
+          "version": "idf-release_v5.5-73550728-v9",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v8.zip",
-              "checksum": "SHA-256:c0a0727e18b9afc8364a5c83bd2cf0050501df0fbda7b6791ce1f4cd71598743",
-              "size": "552378352"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.5/esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.5-73550728-v9.zip",
+              "checksum": "SHA-256:03ecb0ce566dd7f9822a5e081c6b1ccd1fd97c8743347d40a4260970d80e7f38",
+              "size": "568572993"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 0003f90
esp-idf: v5.5.4 735507283d5
arduino: master de93473fd
tinyusb: master 37ea546ab
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.1~4
espressif__esp-dsp: 1.8.2
espressif__esp-modbus: 2.1.3
espressif__esp-nn: 1.2.3
espressif__esp-serial-flasher: 0.0.11
espressif__esp-tflite-micro: 1.3.7
espressif__esp-zboss-lib: 1.6.4
espressif__esp-zigbee-lib: 1.6.8
espressif__esp_daylight: 1.0.1
espressif__esp_delta_ota: 1.1.4
espressif__esp_diag_data_store: 1.1.0
espressif__esp_diagnostics: 1.3.3
espressif__esp_encrypted_img: 2.3.0
espressif__esp_insights: 1.3.3
espressif__esp_matter: 1.5.0
espressif__esp_modem: 2.0.2
espressif__esp_rainmaker: 1.15.0
espressif__esp_rcp_update: 1.3.1
espressif__esp_schedule: 1.3.3
espressif__esp_secure_cert_mgr: 2.9.2
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.22~1
espressif__mdns: 1.11.3
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_cmd_resp: 1.0.0
espressif__rmaker_common: 1.8.5
espressif__rmaker_common_events: 1.0.0
espressif__rmaker_console: 1.0.0
espressif__rmaker_system_ctrl: 1.0.0
espressif__rmaker_time_sync: 1.0.2
espressif__rmaker_work_queue: 1.0.0
joltwallet__littlefs: 1.22.1
espressif__cjson: 1.7.19~2
espressif__cmake_utilities: 0.5.3
espressif__dl_fft: 0.5.0
espressif__eppp_link: 1.1.5
espressif__esp-dsp: 1.8.0
espressif__esp-sr: 2.4.6
espressif__esp_cam_sensor: 2.3.0
espressif__esp_h264: 1.3.0
espressif__esp_hosted: 2.12.9
espressif__esp_ipa: 2.2.0~1
espressif__esp_sccb_intf: 0.0.8
espressif__esp_serial_slave_link: 1.1.2
espressif__esp_video: 2.3.0
espressif__esp_wifi_remote: 1.6.1
espressif__lan867x: 2.0.0
espressif__lan86xx_common: 1.0.1
espressif__usb_host_uvc: 2.5.1
espressif__wifi_remote_over_eppp: 0.3.2
espressif__esp32-camera:
espressif__esp_jpeg: 1.3.1
```
