### PR TITLE
feat(board):  Add support for DFRobot Edge101 IOT Controller

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -13032,6 +13032,160 @@ dfrobot_beetle_esp32c6.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr 
 
 ##############################################################
 
+dfrobot_edge101.name=DFRobot Edge101 IOT Controller
+
+dfrobot_edge101.upload.tool=esptool_py
+dfrobot_edge101.upload.tool.default=esptool_py
+dfrobot_edge101.upload.maximum_size=1310720
+dfrobot_edge101.upload.maximum_data_size=327680
+dfrobot_edge101.upload.flags=
+dfrobot_edge101.upload.erase_cmd=
+dfrobot_edge101.upload.extra_flags=
+
+dfrobot_edge101.serial.disableDTR=true
+dfrobot_edge101.serial.disableRTS=true
+
+dfrobot_edge101.build.tarch=xtensa
+dfrobot_edge101.build.bootloader_addr=0x1000
+dfrobot_edge101.build.target=esp32
+dfrobot_edge101.build.mcu=esp32
+dfrobot_edge101.build.core=esp32
+dfrobot_edge101.build.variant=dfrobot_edge101
+dfrobot_edge101.build.board=DFROBOT_EDGE101
+
+dfrobot_edge101.build.f_cpu=240000000L
+dfrobot_edge101.build.flash_size=16MB
+dfrobot_edge101.build.flash_freq=80m
+dfrobot_edge101.build.flash_mode=dio
+dfrobot_edge101.build.boot=dio
+dfrobot_edge101.build.partitions=app3M_fat9M_16MB
+dfrobot_edge101.build.defines=
+dfrobot_edge101.build.loop_core=
+dfrobot_edge101.build.event_core=
+
+dfrobot_edge101.menu.PSRAM.disabled=Disabled
+dfrobot_edge101.menu.PSRAM.disabled.build.defines=
+dfrobot_edge101.menu.PSRAM.disabled.build.extra_libs=
+dfrobot_edge101.menu.PSRAM.enabled=Enabled
+dfrobot_edge101.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw
+dfrobot_edge101.menu.PSRAM.enabled.build.extra_libs=
+
+dfrobot_edge101.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9MB FATFS)
+dfrobot_edge101.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+dfrobot_edge101.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+dfrobot_edge101.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+dfrobot_edge101.menu.PartitionScheme.default.build.partitions=default
+dfrobot_edge101.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+dfrobot_edge101.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+dfrobot_edge101.menu.PartitionScheme.default_8MB=8M Flash (3MB APP/1.5MB FAT)
+dfrobot_edge101.menu.PartitionScheme.default_8MB.build.partitions=default_8MB
+dfrobot_edge101.menu.PartitionScheme.default_8MB.upload.maximum_size=3342336
+dfrobot_edge101.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+dfrobot_edge101.menu.PartitionScheme.minimal.build.partitions=minimal
+dfrobot_edge101.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+dfrobot_edge101.menu.PartitionScheme.no_ota.build.partitions=no_ota
+dfrobot_edge101.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+dfrobot_edge101.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+dfrobot_edge101.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+dfrobot_edge101.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+dfrobot_edge101.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+dfrobot_edge101.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+dfrobot_edge101.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+dfrobot_edge101.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+dfrobot_edge101.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+dfrobot_edge101.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+dfrobot_edge101.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+dfrobot_edge101.menu.PartitionScheme.huge_app.build.partitions=huge_app
+dfrobot_edge101.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+dfrobot_edge101.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
+dfrobot_edge101.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+dfrobot_edge101.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+dfrobot_edge101.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FAT)
+dfrobot_edge101.menu.PartitionScheme.fatflash.build.partitions=ffat
+dfrobot_edge101.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+dfrobot_edge101.menu.PartitionScheme.rainmaker=RainMaker 4MB
+dfrobot_edge101.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+dfrobot_edge101.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+dfrobot_edge101.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+dfrobot_edge101.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+dfrobot_edge101.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+
+dfrobot_edge101.menu.CPUFreq.240=240MHz (WiFi/BT)
+dfrobot_edge101.menu.CPUFreq.240.build.f_cpu=240000000L
+dfrobot_edge101.menu.CPUFreq.160=160MHz (WiFi/BT)
+dfrobot_edge101.menu.CPUFreq.160.build.f_cpu=160000000L
+dfrobot_edge101.menu.CPUFreq.80=80MHz (WiFi/BT)
+dfrobot_edge101.menu.CPUFreq.80.build.f_cpu=80000000L
+dfrobot_edge101.menu.CPUFreq.40=40MHz (40MHz XTAL)
+dfrobot_edge101.menu.CPUFreq.40.build.f_cpu=40000000L
+dfrobot_edge101.menu.CPUFreq.26=26MHz (26MHz XTAL)
+dfrobot_edge101.menu.CPUFreq.26.build.f_cpu=26000000L
+dfrobot_edge101.menu.CPUFreq.20=20MHz (40MHz XTAL)
+dfrobot_edge101.menu.CPUFreq.20.build.f_cpu=20000000L
+dfrobot_edge101.menu.CPUFreq.13=13MHz (26MHz XTAL)
+dfrobot_edge101.menu.CPUFreq.13.build.f_cpu=13000000L
+dfrobot_edge101.menu.CPUFreq.10=10MHz (40MHz XTAL)
+dfrobot_edge101.menu.CPUFreq.10.build.f_cpu=10000000L
+
+dfrobot_edge101.menu.FlashMode.qio=QIO
+dfrobot_edge101.menu.FlashMode.qio.build.flash_mode=dio
+dfrobot_edge101.menu.FlashMode.qio.build.boot=qio
+dfrobot_edge101.menu.FlashMode.dio=DIO
+dfrobot_edge101.menu.FlashMode.dio.build.flash_mode=dio
+dfrobot_edge101.menu.FlashMode.dio.build.boot=dio
+
+dfrobot_edge101.menu.FlashFreq.80=80MHz
+dfrobot_edge101.menu.FlashFreq.80.build.flash_freq=80m
+dfrobot_edge101.menu.FlashFreq.40=40MHz
+dfrobot_edge101.menu.FlashFreq.40.build.flash_freq=40m
+
+dfrobot_edge101.menu.FlashSize.16M=16MB (128Mb)
+dfrobot_edge101.menu.FlashSize.16M.build.flash_size=16MB
+
+dfrobot_edge101.menu.UploadSpeed.921600=921600
+dfrobot_edge101.menu.UploadSpeed.921600.upload.speed=921600
+dfrobot_edge101.menu.UploadSpeed.115200=115200
+dfrobot_edge101.menu.UploadSpeed.115200.upload.speed=115200
+dfrobot_edge101.menu.UploadSpeed.256000.windows=256000
+dfrobot_edge101.menu.UploadSpeed.256000.upload.speed=256000
+dfrobot_edge101.menu.UploadSpeed.230400.windows.upload.speed=256000
+dfrobot_edge101.menu.UploadSpeed.230400=230400
+dfrobot_edge101.menu.UploadSpeed.230400.upload.speed=230400
+dfrobot_edge101.menu.UploadSpeed.460800.linux=460800
+dfrobot_edge101.menu.UploadSpeed.460800.macosx=460800
+dfrobot_edge101.menu.UploadSpeed.460800.upload.speed=460800
+dfrobot_edge101.menu.UploadSpeed.512000.windows=512000
+dfrobot_edge101.menu.UploadSpeed.512000.upload.speed=512000
+
+dfrobot_edge101.menu.LoopCore.1=Core 1
+dfrobot_edge101.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+dfrobot_edge101.menu.LoopCore.0=Core 0
+dfrobot_edge101.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+dfrobot_edge101.menu.EventsCore.1=Core 1
+dfrobot_edge101.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+dfrobot_edge101.menu.EventsCore.0=Core 0
+dfrobot_edge101.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+dfrobot_edge101.menu.DebugLevel.none=None
+dfrobot_edge101.menu.DebugLevel.none.build.code_debug=0
+dfrobot_edge101.menu.DebugLevel.error=Error
+dfrobot_edge101.menu.DebugLevel.error.build.code_debug=1
+dfrobot_edge101.menu.DebugLevel.warn=Warn
+dfrobot_edge101.menu.DebugLevel.warn.build.code_debug=2
+dfrobot_edge101.menu.DebugLevel.info=Info
+dfrobot_edge101.menu.DebugLevel.info.build.code_debug=3
+dfrobot_edge101.menu.DebugLevel.debug=Debug
+dfrobot_edge101.menu.DebugLevel.debug.build.code_debug=4
+dfrobot_edge101.menu.DebugLevel.verbose=Verbose
+dfrobot_edge101.menu.DebugLevel.verbose.build.code_debug=5
+
+dfrobot_edge101.menu.EraseFlash.none=Disabled
+dfrobot_edge101.menu.EraseFlash.all=Enabled
+dfrobot_edge101.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 dfrobot_firebeetle2_esp32e.name=FireBeetle 2 ESP32-E
 
 dfrobot_firebeetle2_esp32e.upload.tool=esptool_py

--- a/variants/dfrobot_edge101/pins_arduino.h
+++ b/variants/dfrobot_edge101/pins_arduino.h
@@ -7,8 +7,8 @@
 #define USB_PID 0x55D4
 
 static const uint8_t LED_BUILTIN = 15;
-#define BUILTIN_LED  LED_BUILTIN  // backward compatibility
-#define LED_BUILTIN LED_BUILTIN   // allow testing #ifdef LED_BUILTIN
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 
 // UART0 (USB-serial via CH9102F)
 static const uint8_t TX = 1;
@@ -23,18 +23,18 @@ static const uint8_t SDA = 18;
 static const uint8_t SCL = 23;
 
 // SPI (onboard microSD + Gravity SPI header)
-static const uint8_t SS   = 5;
+static const uint8_t SS = 5;
 static const uint8_t MOSI = 12;
 static const uint8_t MISO = 39;
-static const uint8_t SCK  = 14;
+static const uint8_t SCK = 14;
 
 // Ethernet (IP101GRI PHY, RMII, 50 MHz REF_CLK input on GPIO0)
-#define ETH_PHY_TYPE   ETH_PHY_IP101
-#define ETH_PHY_ADDR   1
-#define ETH_PHY_MDC    4
-#define ETH_PHY_MDIO   13
-#define ETH_PHY_POWER  2
-#define ETH_CLK_MODE   ETH_CLOCK_GPIO0_IN
+#define ETH_PHY_TYPE  ETH_PHY_IP101
+#define ETH_PHY_ADDR  1
+#define ETH_PHY_MDC   4
+#define ETH_PHY_MDIO  13
+#define ETH_PHY_POWER 2
+#define ETH_CLK_MODE  ETH_CLOCK_GPIO0_IN
 
 // CAN (TJA1050, galvanically isolated)
 #define CAN_TX 32

--- a/variants/dfrobot_edge101/pins_arduino.h
+++ b/variants/dfrobot_edge101/pins_arduino.h
@@ -1,0 +1,48 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x1A86
+#define USB_PID 0x55D4
+
+static const uint8_t LED_BUILTIN = 15;
+#define BUILTIN_LED  LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN   // allow testing #ifdef LED_BUILTIN
+
+// UART0 (USB-serial via CH9102F)
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+// UART1 (optional 4G modem mini-PCIe slot)
+static const uint8_t TX1 = 33;
+static const uint8_t RX1 = 34;
+
+// I2C (onboard PCF8563 RTC + Gravity connectors)
+static const uint8_t SDA = 18;
+static const uint8_t SCL = 23;
+
+// SPI (onboard microSD + Gravity SPI header)
+static const uint8_t SS   = 5;
+static const uint8_t MOSI = 12;
+static const uint8_t MISO = 39;
+static const uint8_t SCK  = 14;
+
+// Ethernet (IP101GRI PHY, RMII, 50 MHz REF_CLK input on GPIO0)
+#define ETH_PHY_TYPE   ETH_PHY_IP101
+#define ETH_PHY_ADDR   1
+#define ETH_PHY_MDC    4
+#define ETH_PHY_MDIO   13
+#define ETH_PHY_POWER  2
+#define ETH_CLK_MODE   ETH_CLOCK_GPIO0_IN
+
+// CAN (TJA1050, galvanically isolated)
+#define CAN_TX 32
+#define CAN_RX 35
+
+// RS485 (TPT75176H, galvanically isolated)
+#define RS485_TX 17
+#define RS485_RX 36
+#define RS485_DE 16
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Add board support for the DFRobot Edge101 IoT Controller by extending `boards.txt` and adding `pins_arduino.h`.
Wiki: https://wiki.dfrobot.com/dfr0886/docs/23040
Product: https://www.dfrobot.com/product-2739.html
