### PR TITLE
feat(uart): add new API for RX internal pull and onewire UART

### DIFF
--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -14,10 +14,9 @@
 // Array of pointers to active HardwareSerial objects used by HAL to call end() when pins are detached
 static HardwareSerial *uart_instances[SOC_UART_NUM] = {nullptr};
 
-// Register the last HardwareSerial object started with begin
+// Register the HardwareSerial object for HAL termination callbacks
 static void uart_register(uint8_t uart_num, HardwareSerial *serial) {
-  // only register it once
-  if (uart_num < SOC_UART_NUM && uart_instances[uart_num] == nullptr) {
+  if (uart_num < SOC_UART_NUM) {
     uart_instances[uart_num] = serial;
   }
 }
@@ -502,11 +501,17 @@ void HardwareSerial::updateBaudRate(unsigned long baud) {
 void HardwareSerial::end() {
   // default Serial.end() will completely disable HardwareSerial,
   // including any tasks or debug message channel (log_x()) - but not for IDF log messages!
+  if (_uart == NULL) {
+    return;
+  }
   _onReceiveCB = NULL;
   _onReceiveErrorCB = NULL;
   _rxFIFOFull = 0;
+  _destroyEventTask();  // stop task before deleting the UART driver event queue
   uartEnd(_uart_nr);    // fully detach all pins and delete the UART driver
-  _destroyEventTask();  // when IDF uart driver is deleted, _eventTask must finish too
+  if (_uart_nr < SOC_UART_NUM) {
+    uart_instances[_uart_nr] = nullptr;
+  }
   _uart = NULL;
 }
 
@@ -661,6 +666,22 @@ bool HardwareSerial::setClockSource(SerialClkSrc clkSrc) {
     return false;
   }
   return uartSetClockSource(_uart_nr, (uart_sclk_t)clkSrc);
+}
+
+bool HardwareSerial::enableRxInternalPull(bool enable) {
+  if (_uart) {
+    log_e("RX internal pull can't be changed when Serial is already running. Set it before calling begin().");
+    return false;
+  }
+  return uartEnableRxInternalPull(_uart_nr, enable);
+}
+
+bool HardwareSerial::enableOneWireMode(bool enable) {
+  if (_uart) {
+    log_e("One-wire mode can't be changed when Serial is already running. Set it before calling begin().");
+    return false;
+  }
+  return uartEnableOneWireMode(_uart_nr, enable);
 }
 // minimum total RX Buffer size is the UART FIFO space (128 bytes for most SoC) + 1. IDF imposition.
 // LP UART has FIFO of 16 bytes

--- a/cores/esp32/HardwareSerial.cpp
+++ b/cores/esp32/HardwareSerial.cpp
@@ -676,13 +676,6 @@ bool HardwareSerial::enableRxInternalPull(bool enable) {
   return uartEnableRxInternalPull(_uart_nr, enable);
 }
 
-bool HardwareSerial::enableOneWireMode(bool enable) {
-  if (_uart) {
-    log_e("One-wire mode can't be changed when Serial is already running. Set it before calling begin().");
-    return false;
-  }
-  return uartEnableOneWireMode(_uart_nr, enable);
-}
 // minimum total RX Buffer size is the UART FIFO space (128 bytes for most SoC) + 1. IDF imposition.
 // LP UART has FIFO of 16 bytes
 size_t HardwareSerial::setRxBufferSize(size_t new_size) {

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -406,6 +406,8 @@ public:
   // UART_CLK_SRC_REF_TICK     :: ESP32 and ESP32-S2
   // Note: CLK_SRC_PLL Freq depends on the SoC - ESP32-C2 has 40MHz, ESP32-H2 has 48MHz and ESP32-C5, C6, C61 and P4 has 80MHz
   // Note: ESP32-C6, C61, ESP32-P4 and ESP32-C5 have LP UART that will use only RTC_FAST or XTAL/2 as Clock Source
+  bool enableRxInternalPull(bool enable = true);
+  bool enableOneWireMode(bool enable = true);
   bool setClockSource(SerialClkSrc clkSrc);
   size_t setRxBufferSize(size_t new_size);
   size_t setTxBufferSize(size_t new_size);

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -406,9 +406,9 @@ public:
   // UART_CLK_SRC_REF_TICK     :: ESP32 and ESP32-S2
   // Note: CLK_SRC_PLL Freq depends on the SoC - ESP32-C2 has 40MHz, ESP32-H2 has 48MHz and ESP32-C5, C6, C61 and P4 has 80MHz
   // Note: ESP32-C6, C61, ESP32-P4 and ESP32-C5 have LP UART that will use only RTC_FAST or XTAL/2 as Clock Source
-  bool enableRxInternalPull(bool enable = true);
-  bool enableOneWireMode(bool enable = true);
   bool setClockSource(SerialClkSrc clkSrc);
+
+  bool enableRxInternalPull(bool enable = true);
   size_t setRxBufferSize(size_t new_size);
   size_t setTxBufferSize(size_t new_size);
 

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -24,12 +24,12 @@ static peripheral_pin_item_t pins[SOC_GPIO_PIN_COUNT];
 
 const char *perimanGetTypeName(peripheral_bus_type_t type) {
   switch (type) {
-    case ESP32_BUS_TYPE_INIT:     return "INIT";
-    case ESP32_BUS_TYPE_GPIO:     return "GPIO";
-    case ESP32_BUS_TYPE_UART_RX:  return "UART_RX";
-    case ESP32_BUS_TYPE_UART_TX:  return "UART_TX";
-    case ESP32_BUS_TYPE_UART_CTS: return "UART_CTS";
-    case ESP32_BUS_TYPE_UART_RTS: return "UART_RTS";
+    case ESP32_BUS_TYPE_INIT:       return "INIT";
+    case ESP32_BUS_TYPE_GPIO:       return "GPIO";
+    case ESP32_BUS_TYPE_UART_RX:    return "UART_RX";
+    case ESP32_BUS_TYPE_UART_TX:    return "UART_TX";
+    case ESP32_BUS_TYPE_UART_CTS:   return "UART_CTS";
+    case ESP32_BUS_TYPE_UART_RTS:   return "UART_RTS";
     case ESP32_BUS_TYPE_UART_RX_TX: return "UART_RX_TX";
 #if SOC_SDM_SUPPORTED
     case ESP32_BUS_TYPE_SIGMADELTA: return "SIGMADELTA";

--- a/cores/esp32/esp32-hal-periman.c
+++ b/cores/esp32/esp32-hal-periman.c
@@ -30,6 +30,7 @@ const char *perimanGetTypeName(peripheral_bus_type_t type) {
     case ESP32_BUS_TYPE_UART_TX:  return "UART_TX";
     case ESP32_BUS_TYPE_UART_CTS: return "UART_CTS";
     case ESP32_BUS_TYPE_UART_RTS: return "UART_RTS";
+    case ESP32_BUS_TYPE_UART_RX_TX: return "UART_RX_TX";
 #if SOC_SDM_SUPPORTED
     case ESP32_BUS_TYPE_SIGMADELTA: return "SIGMADELTA";
 #endif

--- a/cores/esp32/esp32-hal-periman.h
+++ b/cores/esp32/esp32-hal-periman.h
@@ -18,12 +18,12 @@ extern "C" {
 #define perimanClearPinBus(p) perimanSetPinBus(p, ESP32_BUS_TYPE_INIT, NULL, -1, -1)
 
 typedef enum {
-  ESP32_BUS_TYPE_INIT,      // IO has not been attached to a bus yet
-  ESP32_BUS_TYPE_GPIO,      // IO is used as GPIO
-  ESP32_BUS_TYPE_UART_RX,   // IO is used as UART RX pin
-  ESP32_BUS_TYPE_UART_TX,   // IO is used as UART TX pin
-  ESP32_BUS_TYPE_UART_CTS,  // IO is used as UART CTS pin
-  ESP32_BUS_TYPE_UART_RTS,   // IO is used as UART RTS pin
+  ESP32_BUS_TYPE_INIT,        // IO has not been attached to a bus yet
+  ESP32_BUS_TYPE_GPIO,        // IO is used as GPIO
+  ESP32_BUS_TYPE_UART_RX,     // IO is used as UART RX pin
+  ESP32_BUS_TYPE_UART_TX,     // IO is used as UART TX pin
+  ESP32_BUS_TYPE_UART_CTS,    // IO is used as UART CTS pin
+  ESP32_BUS_TYPE_UART_RTS,    // IO is used as UART RTS pin
   ESP32_BUS_TYPE_UART_RX_TX,  // IO is used as open-drain UART RX and TX pin (one-wire mode)
 #if SOC_SDM_SUPPORTED
   ESP32_BUS_TYPE_SIGMADELTA,  // IO is used as SigmeDelta output

--- a/cores/esp32/esp32-hal-periman.h
+++ b/cores/esp32/esp32-hal-periman.h
@@ -24,7 +24,7 @@ typedef enum {
   ESP32_BUS_TYPE_UART_TX,   // IO is used as UART TX pin
   ESP32_BUS_TYPE_UART_CTS,  // IO is used as UART CTS pin
   ESP32_BUS_TYPE_UART_RTS,   // IO is used as UART RTS pin
-  ESP32_BUS_TYPE_UART_RX_TX,  // IO is used as UART RX and TX pin (one-wire mode)
+  ESP32_BUS_TYPE_UART_RX_TX,  // IO is used as open-drain UART RX and TX pin (one-wire mode)
 #if SOC_SDM_SUPPORTED
   ESP32_BUS_TYPE_SIGMADELTA,  // IO is used as SigmeDelta output
 #endif

--- a/cores/esp32/esp32-hal-periman.h
+++ b/cores/esp32/esp32-hal-periman.h
@@ -23,7 +23,8 @@ typedef enum {
   ESP32_BUS_TYPE_UART_RX,   // IO is used as UART RX pin
   ESP32_BUS_TYPE_UART_TX,   // IO is used as UART TX pin
   ESP32_BUS_TYPE_UART_CTS,  // IO is used as UART CTS pin
-  ESP32_BUS_TYPE_UART_RTS,  // IO is used as UART RTS pin
+  ESP32_BUS_TYPE_UART_RTS,   // IO is used as UART RTS pin
+  ESP32_BUS_TYPE_UART_RX_TX,  // IO is used as UART RX and TX pin (one-wire mode)
 #if SOC_SDM_SUPPORTED
   ESP32_BUS_TYPE_SIGMADELTA,  // IO is used as SigmeDelta output
 #endif

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -41,7 +41,7 @@
 #else
 #include "esp_private/periph_ctrl.h"
 #if SOC_PERIPH_CLK_CTRL_SHARED
-#define HP_UART_SRC_CLK_ATOMIC()       PERIPH_RCC_ATOMIC()
+#define HP_UART_SRC_CLK_ATOMIC() PERIPH_RCC_ATOMIC()
 #else
 #define HP_UART_SRC_CLK_ATOMIC()
 #endif
@@ -777,8 +777,7 @@ static bool _uartAttachSharedPin(uint8_t uart_num, int8_t pin) {
       attachSuccess = false;
     }
   }
-  if (attachSuccess && _uartInternalSetPin(uart->num, pin, pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE)
-      && _uartApplyOneWireOpenDrain(pin, true)) {
+  if (attachSuccess && _uartInternalSetPin(uart->num, pin, pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE) && _uartApplyOneWireOpenDrain(pin, true)) {
     if (perimanSetPinBus(pin, ESP32_BUS_TYPE_UART_RX_TX, (void *)uart, uart_num, -1)) {
       if (perimanGetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX) == NULL) {
         perimanSetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX, _uartDetachBus_RX_TX);

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -266,11 +266,20 @@ static bool _uartApplyOneWireOpenDrain(int8_t pin, bool enable) {
   if (pin < 0) {
     return true;
   }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
   esp_err_t err = enable ? gpio_od_enable((gpio_num_t)pin) : gpio_od_disable((gpio_num_t)pin);
   if (err != ESP_OK) {
     log_e("Failed to %s open-drain on UART one-wire pin %d: %s", enable ? "enable" : "disable", pin, esp_err_to_name(err));
     return false;
   }
+#else
+  // IDF < 5.4 has no gpio_od_*; match the gpio_ll_* fallback used elsewhere in this file.
+  if (enable) {
+    gpio_ll_od_enable(&GPIO, (uint32_t)pin);
+  } else {
+    gpio_ll_od_disable(&GPIO, (uint32_t)pin);
+  }
+#endif
   return true;
 }
 

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -366,7 +366,27 @@ static bool _uartValidatePins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8
   }
 
   uart_t *uart = &_uart_bus_array[uart_num];
-  if (rxPin >= 0 && txPin >= 0 && rxPin == txPin) {
+
+  // Same-pin RX/TX is only valid when the caller explicitly passes (p, p).
+  // -1 means "keep the current pin" and is not rejected by itself. Reject only when
+  // that kept pin plus the newly set pin would form an implicit one-wire config, e.g.
+  // RX=2 TX=3 then setPins(-1, 2) => effective RX=TX=2 without going through UART_RX_TX.
+  const bool changingRx = (rxPin >= 0);
+  const bool changingTx = (txPin >= 0);
+  const bool explicitSamePin = (changingRx && changingTx && rxPin == txPin);
+  if ((changingRx || changingTx) && !explicitSamePin) {
+    const int8_t effectiveRx = changingRx ? rxPin : uart->_rxPin;
+    const int8_t effectiveTx = changingTx ? txPin : uart->_txPin;
+    if (effectiveRx >= 0 && effectiveTx >= 0 && effectiveRx == effectiveTx) {
+      log_e(
+        "UART%u rejecting implicit same-pin RX/TX (%d): pass both pins as (%d, %d) with enableOneWireMode(true)", uart_num, effectiveRx, effectiveRx,
+        effectiveRx
+      );
+      allPinsAreGood = false;
+    }
+  }
+
+  if (explicitSamePin) {
     if (!uart->_oneWireModeEnabled) {
       log_e("UART%u RX and TX on same pin (%d) requires enableOneWireMode(true) before begin()", uart_num, rxPin);
       allPinsAreGood = false;
@@ -421,8 +441,17 @@ static bool _uartDetachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
     } else {
       esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_HIGH, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
     }
-    gpio_pullup_dis((gpio_num_t)rxPin);
-    gpio_pulldown_dis((gpio_num_t)rxPin);
+    // Mirror _uartApplyRxPull(): LP UART RX pulls use RTC GPIO APIs; clear those on detach.
+#if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
+    if (uart_num >= SOC_UART_HP_NUM) {
+      rtc_gpio_pullup_dis((gpio_num_t)rxPin);
+      rtc_gpio_pulldown_dis((gpio_num_t)rxPin);
+    } else
+#endif
+    {
+      gpio_pullup_dis((gpio_num_t)rxPin);
+      gpio_pulldown_dis((gpio_num_t)rxPin);
+    }
     uart->_rxPin = -1;  // -1 means unassigned/detached
     if (!perimanClearPinBus(rxPin)) {
       retCode = false;
@@ -1072,6 +1101,8 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   // Track which other UARTs had their pins taken (for termination check after attach)
   int8_t rxPinPrevUART = -1, txPinPrevUART = -1, ctsPinPrevUART = -1, rtsPinPrevUART = -1;
 
+  // Explicit one-wire only: both RX and TX arguments must be the same valid pin.
+  // Implicit same-pin (e.g. setPins(currentTx, -1)) is rejected in _uartValidatePins().
   bool oneWireRequest = (rxPin >= 0 && txPin >= 0 && rxPin == txPin);
   bool sharedAttach = false;
   if (oneWireRequest) {

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -257,9 +257,22 @@ static bool _uartIsOneWireActive(const uart_t *uart) {
 }
 
 static bool _uartApplyRxPull(uart_t *uart, int8_t rxPin);
+static bool _uartApplyOneWireOpenDrain(int8_t pin, bool enable);
 static bool _uartDetachSharedPin(uint8_t uart_num, int8_t pin);
 static bool _uartAttachSharedPin(uint8_t uart_num, int8_t pin);
 static bool _uartDetachBus_RX_TX(void *busptr);
+
+static bool _uartApplyOneWireOpenDrain(int8_t pin, bool enable) {
+  if (pin < 0) {
+    return true;
+  }
+  esp_err_t err = enable ? gpio_od_enable((gpio_num_t)pin) : gpio_od_disable((gpio_num_t)pin);
+  if (err != ESP_OK) {
+    log_e("Failed to %s open-drain on UART one-wire pin %d: %s", enable ? "enable" : "disable", pin, esp_err_to_name(err));
+    return false;
+  }
+  return true;
+}
 
 static bool _uartApplyRxPull(uart_t *uart, int8_t rxPin) {
   if (rxPin < 0) {
@@ -495,6 +508,7 @@ static bool _uartDetachBus_RX_TX(void *busptr) {
   }
   int8_t pin = bus->_rxPin;
   log_d("_uartDetachBus_RX_TX: detaching shared pin %d from UART%u, terminating driver", pin, bus->num);
+  bool retCode = _uartApplyOneWireOpenDrain(pin, false);
   esp_rom_gpio_pad_select_gpio(pin);
   if (_uartRxPadInverted(bus)) {
     esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(bus->num, SOC_UART_RX_PIN_IDX), false);
@@ -505,7 +519,7 @@ static bool _uartDetachBus_RX_TX(void *busptr) {
   bus->_rxPin = -1;
   bus->_txPin = -1;
   hardware_serial_end(bus->num);
-  return true;
+  return retCode;
 }
 
 static bool _uartDetachSharedPin(uint8_t uart_num, int8_t pin) {
@@ -516,6 +530,7 @@ static bool _uartDetachSharedPin(uint8_t uart_num, int8_t pin) {
   if (!_uartIsOneWireActive(uart) || uart->_rxPin != pin) {
     return true;
   }
+  bool retCode = _uartApplyOneWireOpenDrain(pin, false);
   esp_rom_gpio_pad_select_gpio(pin);
   if (_uartRxPadInverted(uart)) {
     esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
@@ -525,7 +540,7 @@ static bool _uartDetachSharedPin(uint8_t uart_num, int8_t pin) {
   esp_rom_gpio_connect_out_signal(pin, SIG_GPIO_OUT_IDX, false, false);
   uart->_rxPin = -1;
   uart->_txPin = -1;
-  return perimanClearPinBus(pin);
+  return perimanClearPinBus(pin) && retCode;
 }
 
 static bool _uartDetachBus_RX(void *busptr) {
@@ -753,7 +768,8 @@ static bool _uartAttachSharedPin(uint8_t uart_num, int8_t pin) {
       attachSuccess = false;
     }
   }
-  if (attachSuccess && _uartInternalSetPin(uart->num, pin, pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE)) {
+  if (attachSuccess && _uartInternalSetPin(uart->num, pin, pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE)
+      && _uartApplyOneWireOpenDrain(pin, true)) {
     if (perimanSetPinBus(pin, ESP32_BUS_TYPE_UART_RX_TX, (void *)uart, uart_num, -1)) {
       if (perimanGetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX) == NULL) {
         perimanSetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX, _uartDetachBus_RX_TX);
@@ -763,6 +779,7 @@ static bool _uartAttachSharedPin(uint8_t uart_num, int8_t pin) {
       _uartApplyRxPull(uart, pin);
     } else {
       log_e("UART%u failed to register shared RX/TX pin %d", uart_num, pin);
+      _uartApplyOneWireOpenDrain(pin, false);
       attachSuccess = false;
     }
   } else {
@@ -1179,6 +1196,12 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   if (rtsAttach) {
     log_d("Attaching pin %d to UART%d as RTS", rtsPin, uart_num);
     retCode &= _uartAttachPins(uart_num, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, rtsPin);
+  }
+
+  // Keep-current setPins calls do not reattach the shared pin, so reassert the
+  // electrical one-wire policy in case another low-level operation changed it.
+  if (oneWireRequest && _uartIsOneWireActive(uart)) {
+    retCode &= _uartApplyOneWireOpenDrain(uart->_rxPin, true);
   }
 
   // Collect unique UARTs that lost both RX and TX (need termination after mutex release)

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -86,6 +86,9 @@ struct uart_struct_t {
   uint8_t _rxfifo_full_thrhd;                 // UART RX FIFO full threshold
   int8_t _uart_clock_source;                  // UART Clock Source that should be used if user defines an specific one with setClockSource()
   uint32_t inv_mask;                          // UART inverse mask used to maintain related pin state
+  bool _rxPullEnabled;                        // internal pull on RX pad (default true)
+  bool _oneWireModeEnabled;                   // allow RX and TX on the same GPIO
+  uart_mode_t _uart_mode;                     // current UART mode for pin validation
 };
 
 #if CONFIG_DISABLE_HAL_LOCKS
@@ -94,21 +97,21 @@ struct uart_struct_t {
 #define UART_MUTEX_UNLOCK()
 
 static uart_t _uart_bus_array[] = {
-  {0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #if SOC_UART_NUM > 1
-  {1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 2
-  {2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 3
-  {3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 4
-  {4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 5
-  {5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 };
 
@@ -123,21 +126,21 @@ static uart_t _uart_bus_array[] = {
   xSemaphoreGive(uart->lock)
 
 static uart_t _uart_bus_array[] = {
-  {NULL, 0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {NULL, 0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #if SOC_UART_NUM > 1
-  {NULL, 1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {NULL, 1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 2
-  {NULL, 2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {NULL, 2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 3
-  {NULL, 3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {NULL, 3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 4
-  {NULL, 4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {NULL, 4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 5
-  {NULL, 5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0},
+  {NULL, 5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
 #endif
 };
 
@@ -243,6 +246,76 @@ static bool lpuartCheckPins(int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rt
 #define GPIO_FUNC_IN_HIGH GPIO_MATRIX_CONST_ONE_INPUT
 #endif
 
+#define _UART_PERIMAN_TYPE_MIN ESP32_BUS_TYPE_UART_RX
+#define _UART_PERIMAN_TYPE_MAX ESP32_BUS_TYPE_UART_RX_TX
+
+static bool _uartRxPadInverted(const uart_t *u) {
+  return (u->inv_mask & UART_SIGNAL_RXD_INV) != 0;
+}
+
+static bool _uartIsOneWireActive(const uart_t *uart) {
+  return uart->_rxPin >= 0 && uart->_rxPin == uart->_txPin;
+}
+
+static bool _uartApplyRxPull(uart_t *uart, int8_t rxPin);
+static bool _uartDetachSharedPin(uint8_t uart_num, int8_t pin);
+static bool _uartAttachSharedPin(uint8_t uart_num, int8_t pin);
+static bool _uartDetachBus_RX_TX(void *busptr);
+
+static bool _uartApplyRxPull(uart_t *uart, int8_t rxPin) {
+  if (rxPin < 0) {
+    return true;
+  }
+
+  if (_uartIsOneWireActive(uart)) {
+#if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
+    if (uart->num >= SOC_UART_HP_NUM) {
+      rtc_gpio_pullup_dis((gpio_num_t)rxPin);
+      rtc_gpio_pulldown_dis((gpio_num_t)rxPin);
+      return true;
+    }
+#endif
+    gpio_pullup_dis((gpio_num_t)rxPin);
+    gpio_pulldown_dis((gpio_num_t)rxPin);
+    return true;
+  }
+
+  if (!uart->_rxPullEnabled) {
+#if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
+    if (uart->num >= SOC_UART_HP_NUM) {
+      rtc_gpio_pullup_dis((gpio_num_t)rxPin);
+      rtc_gpio_pulldown_dis((gpio_num_t)rxPin);
+      return true;
+    }
+#endif
+    gpio_pullup_dis((gpio_num_t)rxPin);
+    gpio_pulldown_dis((gpio_num_t)rxPin);
+    return true;
+  }
+
+  bool inv = _uartRxPadInverted(uart);
+#if (SOC_UART_LP_NUM >= 1) && (SOC_RTCIO_PIN_COUNT >= 1)
+  if (uart->num >= SOC_UART_HP_NUM) {
+    if (inv) {
+      rtc_gpio_pullup_dis((gpio_num_t)rxPin);
+      rtc_gpio_pulldown_en((gpio_num_t)rxPin);
+    } else {
+      rtc_gpio_pulldown_dis((gpio_num_t)rxPin);
+      rtc_gpio_pullup_en((gpio_num_t)rxPin);
+    }
+    return true;
+  }
+#endif
+  if (inv) {
+    gpio_pullup_dis((gpio_num_t)rxPin);
+    gpio_pulldown_en((gpio_num_t)rxPin);
+  } else {
+    gpio_pulldown_dis((gpio_num_t)rxPin);
+    gpio_pullup_en((gpio_num_t)rxPin);
+  }
+  return true;
+}
+
 // Validate all pins together before attempting attachment
 // Issues all error messages for any invalid pins, then returns true or false
 static bool _uartValidatePins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin) {
@@ -292,6 +365,22 @@ static bool _uartValidatePins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8
     }
   }
 
+  uart_t *uart = &_uart_bus_array[uart_num];
+  if (rxPin >= 0 && txPin >= 0 && rxPin == txPin) {
+    if (!uart->_oneWireModeEnabled) {
+      log_e("UART%u RX and TX on same pin (%d) requires enableOneWireMode(true) before begin()", uart_num, rxPin);
+      allPinsAreGood = false;
+    } else if (uart->_uart_mode != UART_MODE_UART) {
+      log_e("UART%u one-wire mode is not compatible with the current UART mode", uart_num);
+      allPinsAreGood = false;
+#if (SOC_UART_LP_NUM >= 1) && !SOC_LP_GPIO_MATRIX_SUPPORTED
+    } else if (uart_num >= SOC_UART_HP_NUM) {
+      log_e("UART%u LP UART does not support one-wire mode on this SoC", uart_num);
+      allPinsAreGood = false;
+#endif
+    }
+  }
+
   return allPinsAreGood;
 }
 
@@ -309,22 +398,38 @@ static bool _uartDetachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
   //        uart->_rxPin, rxPin, uart->_txPin, txPin, uart->_ctsPin, ctsPin, uart->_rtsPin, rtsPin); vTaskDelay(10);
 
   // detaches HP and LP pins and sets Peripheral Manager and UART information
-  if (rxPin >= 0 && uart->_rxPin == rxPin && perimanGetPinBusType(rxPin) == ESP32_BUS_TYPE_UART_RX) {
-    //gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[rxPin], PIN_FUNC_GPIO);
+  if (rxPin >= 0 && uart->_rxPin == rxPin && _uartIsOneWireActive(uart) && perimanGetPinBusType(rxPin) == ESP32_BUS_TYPE_UART_RX_TX) {
     esp_rom_gpio_pad_select_gpio(rxPin);
-    // avoids causing BREAK in the UART line
-    if (uart->_inverted) {
+    if (_uartRxPadInverted(uart)) {
       esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
     } else {
       esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_HIGH, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
     }
+    esp_rom_gpio_connect_out_signal(rxPin, SIG_GPIO_OUT_IDX, false, false);
+    uart->_rxPin = -1;
+    uart->_txPin = -1;
+    if (!perimanClearPinBus(rxPin)) {
+      retCode = false;
+      log_e("UART%u failed to detach shared RX/TX pin %d", uart_num, rxPin);
+    }
+  } else if (rxPin >= 0 && uart->_rxPin == rxPin && perimanGetPinBusType(rxPin) == ESP32_BUS_TYPE_UART_RX) {
+    //gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[rxPin], PIN_FUNC_GPIO);
+    esp_rom_gpio_pad_select_gpio(rxPin);
+    // avoids causing BREAK in the UART line
+    if (_uartRxPadInverted(uart)) {
+      esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
+    } else {
+      esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_HIGH, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
+    }
+    gpio_pullup_dis((gpio_num_t)rxPin);
+    gpio_pulldown_dis((gpio_num_t)rxPin);
     uart->_rxPin = -1;  // -1 means unassigned/detached
     if (!perimanClearPinBus(rxPin)) {
       retCode = false;
       log_e("UART%u failed to detach RX pin %d", uart_num, rxPin);
     }
   }
-  if (txPin >= 0 && uart->_txPin == txPin && perimanGetPinBusType(txPin) == ESP32_BUS_TYPE_UART_TX) {
+  if (txPin >= 0 && uart->_txPin == txPin && !_uartIsOneWireActive(uart) && perimanGetPinBusType(txPin) == ESP32_BUS_TYPE_UART_TX) {
     //gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[txPin], PIN_FUNC_GPIO);
     esp_rom_gpio_pad_select_gpio(txPin);
     esp_rom_gpio_connect_out_signal(txPin, SIG_GPIO_OUT_IDX, false, false);
@@ -358,6 +463,51 @@ static bool _uartDetachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
 }
 
 // Peripheral Manager detach callback for each specific UART PIN
+static bool _uartDetachBus_RX_TX(void *busptr) {
+  if (busptr == NULL) {
+    log_e("_uartDetachBus_RX_TX: busptr is NULL");
+    return false;
+  }
+  uart_t *bus = (uart_t *)busptr;
+  if (bus->_rxPin < 0 || bus->_rxPin != bus->_txPin) {
+    log_d("_uartDetachBus_RX_TX: shared pin already detached for UART%u", bus->num);
+    return true;
+  }
+  int8_t pin = bus->_rxPin;
+  log_d("_uartDetachBus_RX_TX: detaching shared pin %d from UART%u, terminating driver", pin, bus->num);
+  esp_rom_gpio_pad_select_gpio(pin);
+  if (_uartRxPadInverted(bus)) {
+    esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(bus->num, SOC_UART_RX_PIN_IDX), false);
+  } else {
+    esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_HIGH, UART_PERIPH_SIGNAL(bus->num, SOC_UART_RX_PIN_IDX), false);
+  }
+  esp_rom_gpio_connect_out_signal(pin, SIG_GPIO_OUT_IDX, false, false);
+  bus->_rxPin = -1;
+  bus->_txPin = -1;
+  hardware_serial_end(bus->num);
+  return true;
+}
+
+static bool _uartDetachSharedPin(uint8_t uart_num, int8_t pin) {
+  if (pin < 0) {
+    return true;
+  }
+  uart_t *uart = &_uart_bus_array[uart_num];
+  if (!_uartIsOneWireActive(uart) || uart->_rxPin != pin) {
+    return true;
+  }
+  esp_rom_gpio_pad_select_gpio(pin);
+  if (_uartRxPadInverted(uart)) {
+    esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_LOW, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
+  } else {
+    esp_rom_gpio_connect_in_signal(GPIO_FUNC_IN_HIGH, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), false);
+  }
+  esp_rom_gpio_connect_out_signal(pin, SIG_GPIO_OUT_IDX, false, false);
+  uart->_rxPin = -1;
+  uart->_txPin = -1;
+  return perimanClearPinBus(pin);
+}
+
 static bool _uartDetachBus_RX(void *busptr) {
   // sanity check - it should never happen
   if (busptr == NULL) {
@@ -365,6 +515,9 @@ static bool _uartDetachBus_RX(void *busptr) {
     return false;
   }
   uart_t *bus = (uart_t *)busptr;
+  if (_uartIsOneWireActive(bus)) {
+    return _uartDetachBus_RX_TX(busptr);
+  }
   if (bus->_rxPin < 0) {
     log_d("_uartDetachBus_RX: RX pin already detached for UART%u", bus->num);
     return true;
@@ -384,6 +537,9 @@ static bool _uartDetachBus_TX(void *busptr) {
     return false;
   }
   uart_t *bus = (uart_t *)busptr;
+  if (_uartIsOneWireActive(bus)) {
+    return _uartDetachBus_RX_TX(busptr);
+  }
   if (bus->_txPin < 0) {
     log_d("_uartDetachBus_TX: TX pin already detached for UART%u", bus->num);
     return true;
@@ -422,6 +578,15 @@ static bool _uartDetachBus_RTS(void *busptr) {
     return true;
   }
   return _uartDetachPins(bus->num, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, bus->_rtsPin);
+}
+
+// Returns true when io_num is the native IOMUX pin for the given UART signal.
+static bool _uartIsNativeIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) {
+  if (uart_num >= SOC_UART_HP_NUM || io_num < 0) {
+    return false;
+  }
+  const uart_periph_sig_t *upin = &uart_periph_signal[uart_num].pins[idx];
+  return (upin->default_gpio != -1 && upin->default_gpio == io_num && upin->iomux_func != -1);
 }
 
 // This function will try setting HP UART IOMUX attaching for the requested pin.
@@ -470,6 +635,7 @@ static bool _uartTrySetIomuxPin(uart_port_t uart_num, int io_num, uint32_t idx) 
 
 static bool _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx_io_num, int rts_io_num, int cts_io_num) {
   bool retCode = true;
+  bool tx_rx_same_io = (tx_io_num >= 0 && rx_io_num >= 0 && tx_io_num == rx_io_num);
   // In the following statements, if the io_num is negative, no need to configure anything.
   // _uartTrySetIomuxPin() will solve LP UART pin configuration using IOMUX and GPIO Matrix.
   // Only HP UART pins are configured in case _uartTrySetIomuxPin() returns false
@@ -480,11 +646,18 @@ static bool _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx_io_n
     // Therefore, we should disable the switch of the TX pin to sleep configuration
     retCode &= ESP_OK == gpio_sleep_sel_dis(tx_io_num);
 #endif
-    if (!_uartTrySetIomuxPin(uart_num, tx_io_num, SOC_UART_TX_PIN_IDX)) {
+    if (tx_rx_same_io || !_uartTrySetIomuxPin(uart_num, tx_io_num, SOC_UART_TX_PIN_IDX)) {
       if (uart_num < SOC_UART_HP_NUM) {
         retCode &= ESP_OK == gpio_func_sel(tx_io_num, PIN_FUNC_GPIO);
         esp_rom_gpio_connect_out_signal(tx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_TX_PIN_IDX), 0, 0);
-      } else {
+      }
+#if (SOC_UART_LP_NUM >= 1) && SOC_LP_GPIO_MATRIX_SUPPORTED
+      else if (tx_rx_same_io) {
+        retCode &= ESP_OK == rtc_gpio_init((gpio_num_t)tx_io_num);
+        lp_gpio_connect_out_signal(tx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_TX_PIN_IDX), 0, 0);
+      }
+#endif
+      else if (!tx_rx_same_io) {
         // LP UART couldn't attach pin, therefore it has failed
         retCode = false;
       }
@@ -498,7 +671,7 @@ static bool _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx_io_n
     // Therefore, we should disable the switch of the RX pin to sleep configuration
     retCode &= ESP_OK == gpio_sleep_sel_dis(rx_io_num);
 #endif
-    if (!_uartTrySetIomuxPin(uart_num, rx_io_num, SOC_UART_RX_PIN_IDX)) {
+    if (tx_rx_same_io || !_uartTrySetIomuxPin(uart_num, rx_io_num, SOC_UART_RX_PIN_IDX)) {
       if (uart_num < SOC_UART_HP_NUM) {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
         retCode &= ESP_OK == gpio_input_enable(rx_io_num);
@@ -507,7 +680,15 @@ static bool _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx_io_n
         gpio_ll_input_enable(&GPIO, rx_io_num);
 #endif
         esp_rom_gpio_connect_in_signal(rx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), 0);
-      } else {
+      }
+#if (SOC_UART_LP_NUM >= 1) && SOC_LP_GPIO_MATRIX_SUPPORTED
+      else if (tx_rx_same_io) {
+        rtc_gpio_mode_t mode = RTC_GPIO_MODE_INPUT_OUTPUT;
+        retCode &= ESP_OK == rtc_gpio_set_direction((gpio_num_t)rx_io_num, mode);
+        lp_gpio_connect_in_signal(rx_io_num, UART_PERIPH_SIGNAL(uart_num, SOC_UART_RX_PIN_IDX), 0);
+      }
+#endif
+      else if (!tx_rx_same_io) {
         // LP UART couldn't attach pin, therefore it has failed
         retCode = false;
       }
@@ -543,6 +724,36 @@ static bool _uartInternalSetPin(uart_port_t uart_num, int tx_io_num, int rx_io_n
   return retCode;
 }
 
+static bool _uartAttachSharedPin(uint8_t uart_num, int8_t pin) {
+  uart_t *uart = &_uart_bus_array[uart_num];
+  bool attachSuccess = true;
+
+  if (perimanGetPinBusType(pin) != ESP32_BUS_TYPE_INIT) {
+    if (!perimanClearPinBus(pin)) {
+      attachSuccess = false;
+    }
+  }
+  if (attachSuccess && _uartInternalSetPin(uart->num, pin, pin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE)) {
+    if (perimanSetPinBus(pin, ESP32_BUS_TYPE_UART_RX_TX, (void *)uart, uart_num, -1)) {
+      if (perimanGetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX) == NULL) {
+        perimanSetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX, _uartDetachBus_RX_TX);
+      }
+      uart->_rxPin = pin;
+      uart->_txPin = pin;
+      _uartApplyRxPull(uart, pin);
+    } else {
+      log_e("UART%u failed to register shared RX/TX pin %d", uart_num, pin);
+      attachSuccess = false;
+    }
+  } else {
+    attachSuccess = false;
+  }
+  if (!attachSuccess) {
+    log_e("UART%u failed to attach shared RX/TX pin %d", uart_num, pin);
+  }
+  return attachSuccess;
+}
+
 // Attach function for UART
 // connects the IO Pad, set Paripheral Manager and internal UART structure data
 static bool _uartAttachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, int8_t rtsPin) {
@@ -569,6 +780,7 @@ static bool _uartAttachPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t
           perimanSetBusDeinit(ESP32_BUS_TYPE_UART_RX, _uartDetachBus_RX);
         }
         uart->_rxPin = rxPin;
+        _uartApplyRxPull(uart, rxPin);
       } else {
         log_e("UART%u failed to clear previous bus assignment on RX pin %d", uart_num, rxPin);
         attachSuccess = false;
@@ -727,7 +939,7 @@ static void _uartDetectPin(int8_t pin, const char *funcName, peripheral_bus_type
   }
 
   peripheral_bus_type_t t = perimanGetPinBusType(pin);
-  bool isUART = (t >= ESP32_BUS_TYPE_UART_RX && t <= ESP32_BUS_TYPE_UART_RTS);
+  bool isUART = (t >= _UART_PERIMAN_TYPE_MIN && t <= _UART_PERIMAN_TYPE_MAX);
   int8_t prevU = isUART ? perimanGetPinBusNum(pin) : -1;
 
   *needsAttach = (t != expectedType || target_uart != prevU);
@@ -756,7 +968,7 @@ static bool _uartDetachConflictingPin(int8_t pin, uint8_t target_uart_num, const
   }
 
   peripheral_bus_type_t currentType = perimanGetPinBusType(pin);
-  bool isPeriTypeUART = (currentType >= ESP32_BUS_TYPE_UART_RX && currentType <= ESP32_BUS_TYPE_UART_RTS);
+  bool isPeriTypeUART = (currentType >= _UART_PERIMAN_TYPE_MIN && currentType <= _UART_PERIMAN_TYPE_MAX);
   if (!isPeriTypeUART) {
     return true;  // Pin not assigned to any UART; nothing to detach
   }
@@ -774,6 +986,9 @@ static bool _uartDetachConflictingPin(int8_t pin, uint8_t target_uart_num, const
   } else if (currentType == ESP32_BUS_TYPE_UART_TX) {
     d_tx = pin;
     currentFuncName = "TX";
+  } else if (currentType == ESP32_BUS_TYPE_UART_RX_TX) {
+    d_rx = pin;
+    currentFuncName = "RX_TX";
   } else if (currentType == ESP32_BUS_TYPE_UART_CTS) {
     d_cts = pin;
     currentFuncName = "CTS";
@@ -833,10 +1048,12 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   // mute bus detaching callbacks to avoid terminating the UART driver when both RX and TX pins are detached
   peripheral_bus_deinit_cb_t rxDeinit = perimanGetBusDeinit(ESP32_BUS_TYPE_UART_RX);
   peripheral_bus_deinit_cb_t txDeinit = perimanGetBusDeinit(ESP32_BUS_TYPE_UART_TX);
+  peripheral_bus_deinit_cb_t rxTxDeinit = perimanGetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX);
   peripheral_bus_deinit_cb_t ctsDeinit = perimanGetBusDeinit(ESP32_BUS_TYPE_UART_CTS);
   peripheral_bus_deinit_cb_t rtsDeinit = perimanGetBusDeinit(ESP32_BUS_TYPE_UART_RTS);
   perimanClearBusDeinit(ESP32_BUS_TYPE_UART_RX);
   perimanClearBusDeinit(ESP32_BUS_TYPE_UART_TX);
+  perimanClearBusDeinit(ESP32_BUS_TYPE_UART_RX_TX);
   perimanClearBusDeinit(ESP32_BUS_TYPE_UART_CTS);
   perimanClearBusDeinit(ESP32_BUS_TYPE_UART_RTS);
 
@@ -855,16 +1072,33 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   // Track which other UARTs had their pins taken (for termination check after attach)
   int8_t rxPinPrevUART = -1, txPinPrevUART = -1, ctsPinPrevUART = -1, rtsPinPrevUART = -1;
 
+  bool oneWireRequest = (rxPin >= 0 && txPin >= 0 && rxPin == txPin);
+  bool sharedAttach = false;
+  if (oneWireRequest) {
+    peripheral_bus_type_t pinType = perimanGetPinBusType(rxPin);
+    sharedAttach = (pinType != ESP32_BUS_TYPE_UART_RX_TX || perimanGetPinBusNum(rxPin) != (int8_t)uart_num);
+  }
+
+  // First step: detach old one-wire pin when switching away from shared RX/TX
+  if (_uartIsOneWireActive(uart)) {
+    int8_t sharedPin = uart->_rxPin;
+    bool keepShared = oneWireRequest && rxPin == sharedPin && txPin == sharedPin;
+    if (!keepShared) {
+      log_d("Detaching old shared RX/TX pin %d from UART%d", sharedPin, uart_num);
+      retCode &= _uartDetachSharedPin(uart_num, sharedPin);
+    }
+  }
+
   // First step: for each pin, detach any conflict (pin already assigned elsewhere),
   // then detach the old pin of this UART that is being replaced.
-  if (rxPin >= 0) {
+  if (!_uartIsOneWireActive(uart) && rxPin >= 0) {
     retCode &= _uartDetachConflictingPin(rxPin, uart_num, "RX", rxAttach, &rxPinPrevUART);
     if (rxPin != uart->_rxPin && uart->_rxPin >= 0) {
       log_d("Detaching old RX pin %d from UART%d", uart->_rxPin, uart_num);
       retCode &= _uartDetachPins(uart_num, uart->_rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
     }
   }
-  if (txPin >= 0) {
+  if (!_uartIsOneWireActive(uart) && txPin >= 0) {
     retCode &= _uartDetachConflictingPin(txPin, uart_num, "TX", txAttach, &txPinPrevUART);
     if (txPin != uart->_txPin && uart->_txPin >= 0) {
       log_d("Detaching old TX pin %d from UART%d", uart->_txPin, uart_num);
@@ -887,13 +1121,19 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   }
 
   // Second step: attach all UART new pins
-  if (rxAttach) {
-    log_d("Attaching pin %d to UART%d as RX", rxPin, uart_num);
-    retCode &= _uartAttachPins(uart_num, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-  }
-  if (txAttach) {
-    log_d("Attaching pin %d to UART%d as TX", txPin, uart_num);
-    retCode &= _uartAttachPins(uart_num, UART_PIN_NO_CHANGE, txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+  if (sharedAttach) {
+    retCode &= _uartDetachConflictingPin(rxPin, uart_num, "RX_TX", true, &rxPinPrevUART);
+    log_d("Attaching pin %d to UART%d as shared RX/TX (one-wire)", rxPin, uart_num);
+    retCode &= _uartAttachSharedPin(uart_num, rxPin);
+  } else {
+    if (rxAttach) {
+      log_d("Attaching pin %d to UART%d as RX", rxPin, uart_num);
+      retCode &= _uartAttachPins(uart_num, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    }
+    if (txAttach) {
+      log_d("Attaching pin %d to UART%d as TX", txPin, uart_num);
+      retCode &= _uartAttachPins(uart_num, UART_PIN_NO_CHANGE, txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    }
   }
   if (ctsAttach) {
     log_d("Attaching pin %d to UART%d as CTS", ctsPin, uart_num);
@@ -946,6 +1186,9 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   }
   if (txDeinit != NULL) {
     perimanSetBusDeinit(ESP32_BUS_TYPE_UART_TX, txDeinit);
+  }
+  if (rxTxDeinit != NULL) {
+    perimanSetBusDeinit(ESP32_BUS_TYPE_UART_RX_TX, rxTxDeinit);
   }
   if (ctsDeinit != NULL) {
     perimanSetBusDeinit(ESP32_BUS_TYPE_UART_CTS, ctsDeinit);
@@ -1088,25 +1331,13 @@ uart_t *uartBegin(
       if (retCode) {
         uart->_config = config;
       }
-      if (retCode && rxPin > 0 && uart->_rxPin != rxPin) {
-        retCode &= _uartDetachPins(uart_nr, uart->_rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-        retCode &= _uartAttachPins(uart_nr, rxPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-        if (!retCode) {
-          log_e("UART%u changing RX pin failed.", uart_nr);
-        } else {
-          log_v("UART%u changed RX pin to %d", uart_nr, rxPin);
-        }
-      }
-      if (retCode && txPin > 0 && uart->_txPin != txPin) {
-        retCode &= _uartDetachPins(uart_nr, UART_PIN_NO_CHANGE, uart->_txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-        retCode &= _uartAttachPins(uart_nr, UART_PIN_NO_CHANGE, txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-        if (!retCode) {
-          log_e("UART%u changing TX pin failed.", uart_nr);
-        } else {
-          log_v("UART%u changed TX pin to %d", uart_nr, txPin);
-        }
-      }
       UART_MUTEX_UNLOCK();
+      if (retCode && (rxPin >= 0 || txPin >= 0)) {
+        retCode &= uartSetPins(uart_nr, rxPin, txPin, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+        if (!retCode) {
+          log_e("UART%u changing pins failed.", uart_nr);
+        }
+      }
       if (retCode) {
         // UART driver was already working, just return the uart_t structure, saying that no new driver was installed
         return uart;
@@ -1322,6 +1553,9 @@ bool uartPinSignalInversion(uart_t *uart, uint32_t invMask, bool inverted) {
 
 bool uartSetRxInvert(uart_t *uart, bool invert) {
   if (uartPinSignalInversion(uart, UART_SIGNAL_RXD_INV, invert)) {
+    if (uart->_rxPin >= 0 && !_uartIsOneWireActive(uart)) {
+      _uartApplyRxPull(uart, uart->_rxPin);
+    }
     log_v("UART%u: RX signal inversion %s", uart->num, invert ? "enabled" : "disabled");
     return true;
   }
@@ -1650,6 +1884,9 @@ bool uartSetMode(uart_t *uart, uart_mode_t mode) {
 
   UART_MUTEX_LOCK();
   bool retCode = (ESP_OK == uart_set_mode(uart->num, mode));
+  if (retCode) {
+    uart->_uart_mode = mode;
+  }
   UART_MUTEX_UNLOCK();
   return retCode;
 }
@@ -1719,6 +1956,34 @@ bool uartSetClockSource(uint8_t uartNum, uart_sclk_t clkSrc) {
     uart->_uart_clock_source = clkSrc;
   }
   log_v("UART%u set clock source to %d", uart->num, uart->_uart_clock_source);
+  return true;
+}
+
+bool uartEnableRxInternalPull(uint8_t uartNum, bool enable) {
+  if (uartNum >= SOC_UART_NUM) {
+    log_e("UART%u is invalid. This device has %u UARTs, from 0 to %u.", uartNum, SOC_UART_NUM, SOC_UART_NUM - 1);
+    return false;
+  }
+  if (uart_is_driver_installed(uartNum)) {
+    log_e("UART%u RX internal pull can't be changed when Serial is already running. Set it before calling begin().", uartNum);
+    return false;
+  }
+  _uart_bus_array[uartNum]._rxPullEnabled = enable;
+  log_v("UART%u RX internal pull %s", uartNum, enable ? "enabled" : "disabled");
+  return true;
+}
+
+bool uartEnableOneWireMode(uint8_t uartNum, bool enable) {
+  if (uartNum >= SOC_UART_NUM) {
+    log_e("UART%u is invalid. This device has %u UARTs, from 0 to %u.", uartNum, SOC_UART_NUM, SOC_UART_NUM - 1);
+    return false;
+  }
+  if (uart_is_driver_installed(uartNum)) {
+    log_e("UART%u one-wire mode can't be changed when Serial is already running. Set it before calling begin().", uartNum);
+    return false;
+  }
+  _uart_bus_array[uartNum]._oneWireModeEnabled = enable;
+  log_v("UART%u one-wire mode %s", uartNum, enable ? "enabled" : "disabled");
   return true;
 }
 
@@ -1961,13 +2226,23 @@ void uart_internal_loopback(uint8_t uartNum, int8_t rxPin) {
     log_e("UART%u is not supported for loopback or RX pin %d is invalid.", uartNum, rxPin);
     return;
   }
-#if 0  // leave this code here for future reference and need
-  // forces rxPin to use GPIO Matrix and setup the pin to receive UART TX Signal - IDF 5.4.1 Change with uart_release_pin()
-  gpio_func_sel((gpio_num_t)rxPin, PIN_FUNC_GPIO);
-  gpio_pullup_en((gpio_num_t)rxPin);
-  gpio_input_enable((gpio_num_t)rxPin);
-  esp_rom_gpio_connect_in_signal(rxPin, uart_periph_signal[uartNum].pins[SOC_UART_RX_PIN_IDX].signal, false);
-#endif
+
+  uart_t *uart = &_uart_bus_array[uartNum];
+  const bool same_uart_rx = (rxPin == uart->_rxPin);
+  const bool iomux_rx = _uartIsNativeIomuxPin((uart_port_t)uartNum, rxPin, SOC_UART_RX_PIN_IDX);
+
+  // Native IOMUX RX pins bypass the GPIO matrix; route loopback inside the UART peripheral instead.
+  if (same_uart_rx && iomux_rx) {
+    if (uart_set_loop_back((uart_port_t)uartNum, true) != ESP_OK) {
+      log_e("UART%u failed to enable internal loopback mode.", uartNum);
+    } else {
+      log_d("UART%u internal loopback enabled (peripheral).", uartNum);
+    }
+    return;
+  }
+
+  // GPIO matrix loopback (cross-UART or non-native RX pins): disable peripheral loopback first.
+  uart_set_loop_back((uart_port_t)uartNum, false);
   esp_rom_gpio_connect_out_signal(rxPin, uart_periph_signal[uartNum].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
 }
 

--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -87,7 +87,6 @@ struct uart_struct_t {
   int8_t _uart_clock_source;                  // UART Clock Source that should be used if user defines an specific one with setClockSource()
   uint32_t inv_mask;                          // UART inverse mask used to maintain related pin state
   bool _rxPullEnabled;                        // internal pull on RX pad (default true)
-  bool _oneWireModeEnabled;                   // allow RX and TX on the same GPIO
   uart_mode_t _uart_mode;                     // current UART mode for pin validation
 };
 
@@ -97,21 +96,21 @@ struct uart_struct_t {
 #define UART_MUTEX_UNLOCK()
 
 static uart_t _uart_bus_array[] = {
-  {0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #if SOC_UART_NUM > 1
-  {1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 2
-  {2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 3
-  {3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 4
-  {4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 5
-  {5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 };
 
@@ -126,21 +125,21 @@ static uart_t _uart_bus_array[] = {
   xSemaphoreGive(uart->lock)
 
 static uart_t _uart_bus_array[] = {
-  {NULL, 0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {NULL, 0, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #if SOC_UART_NUM > 1
-  {NULL, 1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {NULL, 1, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 2
-  {NULL, 2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {NULL, 2, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 3
-  {NULL, 3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {NULL, 3, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 4
-  {NULL, 4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {NULL, 4, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 #if SOC_UART_NUM > 5
-  {NULL, 5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, false, UART_MODE_UART},
+  {NULL, 5, false, 0, NULL, -1, -1, -1, -1, 0, 0, 0, 0, false, 0, -1, 0, true, UART_MODE_UART},
 #endif
 };
 
@@ -367,30 +366,14 @@ static bool _uartValidatePins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8
 
   uart_t *uart = &_uart_bus_array[uart_num];
 
-  // Same-pin RX/TX is only valid when the caller explicitly passes (p, p).
-  // -1 means "keep the current pin" and is not rejected by itself. Reject only when
-  // that kept pin plus the newly set pin would form an implicit one-wire config, e.g.
-  // RX=2 TX=3 then setPins(-1, 2) => effective RX=TX=2 without going through UART_RX_TX.
-  const bool changingRx = (rxPin >= 0);
-  const bool changingTx = (txPin >= 0);
-  const bool explicitSamePin = (changingRx && changingTx && rxPin == txPin);
-  if ((changingRx || changingTx) && !explicitSamePin) {
-    const int8_t effectiveRx = changingRx ? rxPin : uart->_rxPin;
-    const int8_t effectiveTx = changingTx ? txPin : uart->_txPin;
-    if (effectiveRx >= 0 && effectiveTx >= 0 && effectiveRx == effectiveTx) {
-      log_e(
-        "UART%u rejecting implicit same-pin RX/TX (%d): pass both pins as (%d, %d) with enableOneWireMode(true)", uart_num, effectiveRx, effectiveRx,
-        effectiveRx
-      );
-      allPinsAreGood = false;
-    }
-  }
-
-  if (explicitSamePin) {
-    if (!uart->_oneWireModeEnabled) {
-      log_e("UART%u RX and TX on same pin (%d) requires enableOneWireMode(true) before begin()", uart_num, rxPin);
-      allPinsAreGood = false;
-    } else if (uart->_uart_mode != UART_MODE_UART) {
+  // One-wire is automatic when effective RX and TX resolve to the same GPIO.
+  // -1 means "keep the current pin" (e.g. RX=2 TX=3 then setPins(-1, 2) => RX=TX=2).
+  const int8_t effectiveRx = (rxPin >= 0) ? rxPin : uart->_rxPin;
+  const int8_t effectiveTx = (txPin >= 0) ? txPin : uart->_txPin;
+  const int8_t effectiveCts = (ctsPin >= 0) ? ctsPin : uart->_ctsPin;
+  const int8_t effectiveRts = (rtsPin >= 0) ? rtsPin : uart->_rtsPin;
+  if (effectiveRx >= 0 && effectiveTx >= 0 && effectiveRx == effectiveTx) {
+    if (uart->_uart_mode != UART_MODE_UART) {
       log_e("UART%u one-wire mode is not compatible with the current UART mode", uart_num);
       allPinsAreGood = false;
 #if (SOC_UART_LP_NUM >= 1) && !SOC_LP_GPIO_MATRIX_SUPPORTED
@@ -398,6 +381,14 @@ static bool _uartValidatePins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8
       log_e("UART%u LP UART does not support one-wire mode on this SoC", uart_num);
       allPinsAreGood = false;
 #endif
+    }
+    if (effectiveCts == effectiveRx) {
+      log_e("UART%u one-wire RX/TX pin %d cannot also be used for CTS", uart_num, effectiveRx);
+      allPinsAreGood = false;
+    }
+    if (effectiveRts == effectiveRx) {
+      log_e("UART%u one-wire RX/TX pin %d cannot also be used for RTS", uart_num, effectiveRx);
+      allPinsAreGood = false;
     }
   }
 
@@ -1054,6 +1045,15 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   bool retCode = true;
   UART_MUTEX_LOCK();
 
+  // Resolve -1 (keep current). Same-pin effective RX/TX becomes an explicit (p, p) one-wire request.
+  int8_t setRx = (rxPin >= 0) ? rxPin : uart->_rxPin;
+  int8_t setTx = (txPin >= 0) ? txPin : uart->_txPin;
+  bool oneWireRequest = (setRx >= 0 && setTx >= 0 && setRx == setTx);
+  if (oneWireRequest) {
+    rxPin = setRx;
+    txPin = setTx;
+  }
+
   // If driver is not yet installed, just store the pin configuration
   // The pins will be properly attached when the driver is installed in uartBegin()
   if (!uartIsDriverInstalled(uart)) {
@@ -1101,9 +1101,7 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   // Track which other UARTs had their pins taken (for termination check after attach)
   int8_t rxPinPrevUART = -1, txPinPrevUART = -1, ctsPinPrevUART = -1, rtsPinPrevUART = -1;
 
-  // Explicit one-wire only: both RX and TX arguments must be the same valid pin.
-  // Implicit same-pin (e.g. setPins(currentTx, -1)) is rejected in _uartValidatePins().
-  bool oneWireRequest = (rxPin >= 0 && txPin >= 0 && rxPin == txPin);
+  // oneWireRequest was resolved above from effective RX/TX (including -1 keep-current).
   bool sharedAttach = false;
   if (oneWireRequest) {
     peripheral_bus_type_t pinType = perimanGetPinBusType(rxPin);
@@ -1113,10 +1111,16 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   // First step: detach old one-wire pin when switching away from shared RX/TX
   if (_uartIsOneWireActive(uart)) {
     int8_t sharedPin = uart->_rxPin;
-    bool keepShared = oneWireRequest && rxPin == sharedPin && txPin == sharedPin;
+    bool keepShared = setRx == sharedPin && setTx == sharedPin;
     if (!keepShared) {
       log_d("Detaching old shared RX/TX pin %d from UART%d", sharedPin, uart_num);
       retCode &= _uartDetachSharedPin(uart_num, sharedPin);
+      // Detaching shared ownership clears both stored pins. Reattach both effective
+      // targets, including a side supplied as -1 ("keep current").
+      rxPin = setRx;
+      txPin = setTx;
+      rxAttach = rxPin >= 0;
+      txAttach = txPin >= 0;
     }
   }
 
@@ -1152,10 +1156,12 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
   }
 
   // Second step: attach all UART new pins
-  if (sharedAttach) {
-    retCode &= _uartDetachConflictingPin(rxPin, uart_num, "RX_TX", true, &rxPinPrevUART);
-    log_d("Attaching pin %d to UART%d as shared RX/TX (one-wire)", rxPin, uart_num);
-    retCode &= _uartAttachSharedPin(uart_num, rxPin);
+  if (oneWireRequest) {
+    if (sharedAttach) {
+      retCode &= _uartDetachConflictingPin(rxPin, uart_num, "RX_TX", true, &rxPinPrevUART);
+      log_d("Attaching pin %d to UART%d as shared RX/TX (one-wire)", rxPin, uart_num);
+      retCode &= _uartAttachSharedPin(uart_num, rxPin);
+    }
   } else {
     if (rxAttach) {
       log_d("Attaching pin %d to UART%d as RX", rxPin, uart_num);
@@ -1913,6 +1919,11 @@ bool uartSetMode(uart_t *uart, uart_mode_t mode) {
     return false;
   }
 
+  if (mode != UART_MODE_UART && _uartIsOneWireActive(uart)) {
+    log_e("UART%u one-wire mode is not compatible with the requested UART mode", uart->num);
+    return false;
+  }
+
   UART_MUTEX_LOCK();
   bool retCode = (ESP_OK == uart_set_mode(uart->num, mode));
   if (retCode) {
@@ -2001,20 +2012,6 @@ bool uartEnableRxInternalPull(uint8_t uartNum, bool enable) {
   }
   _uart_bus_array[uartNum]._rxPullEnabled = enable;
   log_v("UART%u RX internal pull %s", uartNum, enable ? "enabled" : "disabled");
-  return true;
-}
-
-bool uartEnableOneWireMode(uint8_t uartNum, bool enable) {
-  if (uartNum >= SOC_UART_NUM) {
-    log_e("UART%u is invalid. This device has %u UARTs, from 0 to %u.", uartNum, SOC_UART_NUM, SOC_UART_NUM - 1);
-    return false;
-  }
-  if (uart_is_driver_installed(uartNum)) {
-    log_e("UART%u one-wire mode can't be changed when Serial is already running. Set it before calling begin().", uartNum);
-    return false;
-  }
-  _uart_bus_array[uartNum]._oneWireModeEnabled = enable;
-  log_v("UART%u one-wire mode %s", uartNum, enable ? "enabled" : "disabled");
   return true;
 }
 

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -136,7 +136,6 @@ bool uartSetClockSource(uint8_t uartNum, uart_sclk_t clkSrc);
 
 // Must be set before uartBegin(); no effect after the driver is running
 bool uartEnableRxInternalPull(uint8_t uartNum, bool enable);
-bool uartEnableOneWireMode(uint8_t uartNum, bool enable);
 
 void uartStartDetectBaudrate(uart_t *uart);
 unsigned long uartDetectBaudrate(uart_t *uart);

--- a/cores/esp32/esp32-hal-uart.h
+++ b/cores/esp32/esp32-hal-uart.h
@@ -134,6 +134,10 @@ bool uartSetIrdaDirection(uart_t *uart, esp32_uart_irda_direction_t irdaDirectio
 // Note: ESP32-C6, C61, ESP32-P4 and ESP32-C5 have LP UART that will use only LP_UART_SCLK_LP_FAST (RTC_FAST) or LP_UART_SCLK_XTAL_D2 (XTAL/2) as Clock Source
 bool uartSetClockSource(uint8_t uartNum, uart_sclk_t clkSrc);
 
+// Must be set before uartBegin(); no effect after the driver is running
+bool uartEnableRxInternalPull(uint8_t uartNum, bool enable);
+bool uartEnableOneWireMode(uint8_t uartNum, bool enable);
+
 void uartStartDetectBaudrate(uart_t *uart);
 unsigned long uartDetectBaudrate(uart_t *uart);
 

--- a/docs/en/api/serial.rst
+++ b/docs/en/api/serial.rst
@@ -362,6 +362,30 @@ Examples:
 
    One-wire mode routes both TX output and RX input through the same GPIO. ESP-IDF warns that this can cause electrical conflicts on the pad; use open-drain with an external pull-up, or a half-duplex protocol. One-wire mode is **not** a substitute for RS485 half-duplex (which requires separate TX, RX, and RTS pins to an external transceiver).
 
+Why one-wire UART can receive ghost data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In one-wire mode, the pad is deliberately left **floating** (no internal pull), and RX is always listening on the same pin that TX drives. Any brief LOW or noise on that pad looks like a UART start bit, so the receiver produces framing errors, BREAK events, or "ghost" bytes even with no intentional traffic.
+
+Main causes:
+
+1. **No idle bias** — split-pin UART uses RX pull-up so idle stays HIGH. One-wire disables that pull so TX is not fighting an internal resistor. When TX is not firmly driving (startup, pin mux change, tri-state between turns, weak/open bus), the line floats and RX samples garbage.
+2. **TX/RX pad conflict** — both output and input are on one GPIO. During attach or mux changes the line can glitch LOW, causing a start bit or BREAK.
+3. **Self-echo** — TX is also seen on RX. That is expected for intentional transmission; noise on TX looks the same.
+4. **External bus without pull-up** — two one-wire peers with listening TX tri-stated leave the wire floating between turns.
+
+How to prevent it
+^^^^^^^^^^^^^^^^^
+
+* Add an **external pull-up** (approximately 4.7–10 kΩ to 3.3 V) on the one-wire pad or shared bus. This holds idle HIGH when nothing drives the line and is the strongest fix.
+* Drain RX after ``begin()`` or ``setPins()`` using ``while (Serial1.available()) { Serial1.read(); }`` to clear glitches generated during pin attachment.
+* Ignore data until the first valid frame, or require a known preamble, to filter noise before real protocol traffic.
+* Use half-duplex only: never leave both TX drivers enabled, and tri-state the listener to avoid push-pull conflicts that corrupt the idle level.
+* Use shorter wires and reduce nearby electrical noise to reduce false start bits on a floating pad.
+* Do not re-enable the internal pull in one-wire mode because it can fight TX.
+
+The internal pull is intentionally disabled in one-wire mode. Rely on **TX idle HIGH** while transmitting and use an **external pull-up** whenever the line can float.
+
 **Related Example:**
 
 * `OneWire_UART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo>`_ — Self loopback on one GPIO, optional UART1→UART2 peer loopback (internal matrix or external bus wire), and half-duplex USB bridge.

--- a/docs/en/api/serial.rst
+++ b/docs/en/api/serial.rst
@@ -360,7 +360,7 @@ Examples:
 
 .. warning::
 
-   One-wire mode routes both TX output and RX input through the same GPIO. ESP-IDF warns that this can cause electrical conflicts on the pad; use open-drain with an external pull-up, or a half-duplex protocol. One-wire mode is **not** a substitute for RS485 half-duplex (which requires separate TX, RX, and RTS pins to an external transceiver).
+   One-wire mode routes both TX output and RX input through the same GPIO. ESP-IDF warns that this can cause electrical conflicts on the pad. Use a half-duplex protocol and ensure that no more than one push-pull TX output drives a shared wire. A multi-node electrical design may instead use separately configured open-drain outputs with an external pull-up or an external transceiver. One-wire mode is **not** a substitute for RS485 half-duplex (which requires separate TX, RX, and RTS pins to an external transceiver).
 
 Why one-wire UART can receive ghost data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -372,7 +372,7 @@ Main causes:
 1. **No idle bias** — split-pin UART uses RX pull-up so idle stays HIGH. One-wire disables that pull so TX is not fighting an internal resistor. When TX is not firmly driving (startup, pin mux change, tri-state between turns, weak/open bus), the line floats and RX samples garbage.
 2. **TX/RX pad conflict** — both output and input are on one GPIO. During attach or mux changes the line can glitch LOW, causing a start bit or BREAK.
 3. **Self-echo** — TX is also seen on RX. That is expected for intentional transmission; noise on TX looks the same.
-4. **External bus without pull-up** — two one-wire peers with listening TX tri-stated leave the wire floating between turns.
+4. **External bus without idle bias** — a shared wire can float while UART pins are detached or TX outputs are disconnected between half-duplex turns.
 
 How to prevent it
 ^^^^^^^^^^^^^^^^^
@@ -380,7 +380,7 @@ How to prevent it
 * Add an **external pull-up** (approximately 4.7–10 kΩ to 3.3 V) on the one-wire pad or shared bus. This holds idle HIGH when nothing drives the line and is the strongest fix.
 * Drain RX after ``begin()`` or ``setPins()`` using ``while (Serial1.available()) { Serial1.read(); }`` to clear glitches generated during pin attachment.
 * Ignore data until the first valid frame, or require a known preamble, to filter noise before real protocol traffic.
-* Use half-duplex only: never leave both TX drivers enabled, and tri-state the listener to avoid push-pull conflicts that corrupt the idle level.
+* Use half-duplex only: never connect two active push-pull TX outputs to the shared wire. Disconnect, reroute, or otherwise disable the listener's TX before the other endpoint transmits.
 * Use shorter wires and reduce nearby electrical noise to reduce false start bits on a floating pad.
 * Do not re-enable the internal pull in one-wire mode because it can fight TX.
 
@@ -388,7 +388,7 @@ The internal pull is intentionally disabled in one-wire mode. Rely on **TX idle 
 
 **Related Example:**
 
-* `OneWire_UART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo>`_ — Self loopback on one GPIO, optional UART1→UART2 peer loopback (internal matrix or external bus wire), and half-duplex USB bridge.
+* `OneWire_UART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo>`_ — Same-pad one-wire self-echo, optional bidirectional UART1↔UART2 cross-test (internal matrix or external signal wire), printed wiring instructions, and a half-duplex USB bridge.
 
 .. _signal-inversion-rx-pull:
 
@@ -917,7 +917,7 @@ Demonstrates floating RX idle (pull on vs off), pull direction vs ``begin(invert
 
 One-Wire UART Example:
 
-Demonstrates same-pin (one-wire) UART with a startup self-test on one GPIO, optional **UART1 → UART2** peer loopback (``USE_INTERNAL_LOOPBACK`` or external bus wire), board-specific GPIO wiring printed on USB Serial, and interactive half-duplex forwarding from USB Serial.
+Demonstrates same-pin (one-wire) UART with a startup self-echo test on one GPIO and an optional bidirectional **UART1 ↔ UART2** cross-test. The cross-test can use internal GPIO-matrix routing or one external signal wire; external mode parks inactive RX/TX signals on unconnected GPIOs so only one push-pull TX drives the wire. The example prints board-specific wiring and supports interactive half-duplex forwarding from USB Serial.
 
 `OneWire_UART_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino>`_
 

--- a/docs/en/api/serial.rst
+++ b/docs/en/api/serial.rst
@@ -13,19 +13,23 @@ with additional features for advanced use cases.
 
 **Key Features:**
 
-* **Full-duplex communication**: Simultaneous transmission and reception
-* **Configurable baud rates**: From 300 to 5,000,000+ baud
-* **Multiple data formats**: Configurable data bits, parity, and stop bits
-* **Hardware flow control**: Support for RTS/CTS signals
-* **RS485 support**: Half-duplex RS485 communication mode
-* **Low-power UART**: Some SoCs support LP (Low-Power) UART for ultra-low power applications
-* **Baud rate detection**: Automatic baud rate detection (ESP32, ESP32-S2 only)
-* **Event callbacks**: Receive and error event callbacks
-* **Configurable buffers**: Adjustable RX and TX buffer sizes
+* **Full-duplex communication**: Simultaneous transmission and reception.
+* **Configurable baud rates**: From 300 to 5,000,000+ baud.
+* **Multiple data formats**: Configurable data bits, parity, and stop bits.
+* **Hardware flow control**: Support for RTS/CTS signals.
+* **RS485 support**: Half-duplex RS485 communication mode.
+* **Low-power UART**: Some SoCs support LP (Low-Power) UART for ultra-low power applications.
+* **Baud rate detection**: Automatic baud rate detection (ESP32, ESP32-S2 only).
+* **Event callbacks**: Receive and error event callbacks.
+* **Configurable buffers**: Adjustable RX and TX buffer sizes.
+* **RX internal pull**: Automatic pull-up or pull-down on the RX pad (see :ref:`rx-internal-pull`).
+* **One-wire UART**: Optional single-GPIO RX+TX mode (see :ref:`one-wire-uart`).
 
 .. note::
    In case that both pins, RX and TX are detached from UART, the driver will be stopped.
    Detaching may occur when, for instance, starting another peripheral using RX and TX pins, such as Wire.begin(RX0, TX0).
+   In one-wire mode, RX and TX share a single GPIO registered as ``UART_RX_TX`` in the Peripheral Manager;
+   an external deinit of that pin (for example ``pinMode()`` or another peripheral claiming the GPIO) terminates the UART driver.
 
 UART Availability
 -----------------
@@ -57,7 +61,7 @@ ESP32-P4  5        1
 
   **Example:** The ESP32-C6 has 2 HP UARTs and 1 LP UART. The Arduino Core creates ``Serial0`` and ``Serial1`` (HP UARTs) plus ``Serial2`` (LP UART) HardwareSerial objects.
 
-  **Important:** LP UARTs can be used as regular UART ports, but they have fixed GPIO pins for RX, TX, CTS, and RTS. It is not possible to change the pins for LP UARTs using ``setPins()``.
+  **Important:** On ESP32-C5, ESP32-C6, and ESP32-C61, LP UARTs use fixed GPIO pins for RX, TX, CTS, and RTS; ``setPins()`` cannot change them. On ESP32-P4, the LP UART supports the GPIO matrix and follows the same pin rules as HP UARTs (including one-wire mode when enabled).
 
 Arduino-ESP32 Serial API
 ------------------------
@@ -90,7 +94,7 @@ Initializes the Serial port with the specified baud rate and configuration.
 
 * ``txPin`` - TX pin number. Use ``-1`` to keep the default pin or current pin assignment.
 
-* ``invert`` - If ``true``, inverts the RX and TX signal polarity.
+* ``invert`` - If ``true``, inverts the RX and TX signal polarity. Also sets the RX internal pull to pull-down when :ref:`enableRxInternalPull` is enabled (see :ref:`signal-inversion-rx-pull`).
 
 * ``timeout_ms`` - Timeout in milliseconds for baud rate detection (when ``baud = 0``). Default: 20000 ms (20 seconds).
 
@@ -313,6 +317,105 @@ Sets or changes the RX, TX, CTS, and RTS pins for the Serial port.
 
 **Note:** This function can be called before or after ``begin()``. When pins are changed, the previous pins are automatically detached.
 
+When RX and TX are set to the same GPIO, ``enableOneWireMode(true)`` must be called **before** ``begin()``, and the UART must be in ``UART_MODE_UART``. RS485 and IrDA modes reject same-pin configuration. See :ref:`one-wire-uart` and :ref:`mode-pin-compatibility`.
+
+enableRxInternalPull
+********************
+
+.. _enableRxInternalPull:
+
+.. _rx-internal-pull:
+
+Enables or disables the internal pull resistor on the RX GPIO. Must be called **before** ``begin()`` to take effect.
+
+.. code-block:: arduino
+
+    bool enableRxInternalPull(bool enable = true);
+
+* ``enable`` - If ``true`` (default), the core applies an internal pull on the RX pad after attach. If ``false``, the RX pad is left floating (no internal pull).
+
+**Returns:** ``true`` if the setting was applied, ``false`` if the UART is already running.
+
+When enabled, pull direction follows RX signal inversion (see :ref:`signal-inversion-rx-pull`):
+
+* Normal RX (not inverted): pull-up (idle HIGH)
+* RX inverted: pull-down (idle LOW)
+
+Internal pull is **not** applied in one-wire mode (same GPIO for RX and TX).
+
+**Related Example:**
+
+* `RxPull_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/RxPull_Demo>`_ — Floating RX, inverted-RX pull direction, and optional wired loopback on split pins.
+
+enableOneWireMode
+*****************
+
+.. _enableOneWireMode:
+
+.. _one-wire-uart:
+
+Enables single-GPIO (one-wire) UART mode where RX and TX share one pin. Must be called **before** ``begin()``.
+
+.. code-block:: arduino
+
+    bool enableOneWireMode(bool enable = true);
+
+* ``enable`` - If ``true``, allows ``setPins(p, p)`` or ``begin(..., p, p)`` with the same GPIO for RX and TX. Default is ``false``.
+
+**Returns:** ``true`` if the setting was applied, ``false`` if the UART is already running.
+
+.. warning::
+
+   One-wire mode routes both TX output and RX input through the same GPIO. ESP-IDF warns that this can cause electrical conflicts on the pad; use open-drain with an external pull-up, or a half-duplex protocol. One-wire mode is **not** a substitute for RS485 half-duplex (which requires separate TX, RX, and RTS pins to an external transceiver).
+
+**Related Example:**
+
+* `OneWire_UART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo>`_ — Self loopback on one GPIO, optional UART1→UART2 peer loopback (internal matrix or external bus wire), and half-duplex USB bridge.
+
+Signal Inversion and RX Internal Pull
+-------------------------------------
+
+.. _signal-inversion-rx-pull:
+
+RX internal pull (when :ref:`enableRxInternalPull` is enabled) tracks **RX signal inversion** only:
+
++---------------------------+----------------------------------+
+| Event                     | RX internal pull (when enabled)  |
++===========================+==================================+
+| ``begin(..., invert=false)`` | Pull-up                       |
+| ``begin(..., invert=true)``  | Pull-down                     |
+| ``setRxInvert(true/false)``  | Pull-down / pull-up           |
+| ``setTxInvert()`` only       | Unchanged                     |
+| One-wire mode                | Disabled (floating)           |
+| ``enableRxInternalPull(false)`` | Disabled (floating)        |
++---------------------------+----------------------------------+
+
+Pin Configuration Order
+-----------------------
+
+Call these **before** ``begin()`` (same pattern as ``setClockSource()`` and ``setRxBufferSize()``):
+
+1. ``enableOneWireMode()`` (optional, default off)
+2. ``enableRxInternalPull()`` (optional, default on)
+3. ``setClockSource()``, ``setRxBufferSize()``, ``setTxBufferSize()`` (optional)
+4. ``setPins()`` (optional; can also be called after ``begin()``)
+5. ``begin()``
+
+Mode and Pin Compatibility
+--------------------------
+
+.. _mode-pin-compatibility:
+
++----------------------+-------------+------------------------+
+| Mode                 | One-wire    | RX internal pull       |
++======================+=============+========================+
+| ``UART_MODE_UART``   | If enabled  | Yes (unless one-wire)  |
+| RS485 modes          | No          | Yes (split pins)       |
+| ``UART_MODE_IRDA``   | No          | Yes (split pins)       |
+| LP UART (C5/C6/C61)   | No          | Fixed RX pad only      |
+| LP UART (P4 matrix)  | If enabled  | Yes (unless one-wire)  |
++----------------------+-------------+------------------------+
+
 setRxBufferSize
 ***************
 
@@ -517,7 +620,7 @@ Sets the UART operating mode.
 
 **Returns:** ``true`` if mode is set successfully, ``false`` otherwise.
 
-**Note:** For RS485 half-duplex mode, the RTS pin must be configured using ``setPins()`` to control the transceiver.
+**Note:** For RS485 half-duplex mode, the RTS pin must be configured using ``setPins()`` to control the transceiver. RS485 does **not** support one-wire (same GPIO for RX and TX). See :ref:`mode-pin-compatibility`.
 
 setIrdaDirection
 ****************
@@ -538,6 +641,7 @@ Sets the IrDA transmission direction (TX or RX mode). Can only be used after ``s
 .. note::
 
    * IrDA mode works in exclusive directions: the UART can either transmit or receive, but not both simultaneously.
+   * IrDA requires **separate** TX and RX GPIO pins; one-wire mode is not supported.
    * The ``setMode(UART_MODE_IRDA)`` function must be called before using ``setIrdaDirection()``.
    * Switching between TX and RX modes can be done by calling ``setIrdaDirection()`` with different parameters.
    * The ESP32 UART hardware automatically handles IrDA pulse timing and encoding/decoding.
@@ -563,9 +667,9 @@ Sets the IrDA transmission direction (TX or RX mode). Can only be used after ``s
 
 **Related Examples:**
 
-* **IrdaMode_DualUART_Demo** - Single-board demonstration using two UARTs with internal loopback. Requires ESP32 with 3+ UARTs (ESP32, ESP32-S3, ESP32-P4). No external hardware needed. Ideal for testing IrDA mode functionality.
+* `IrdaMode_DualUART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/IrdaMode_DualUART_Demo>`_ - Single-board demonstration using two UARTs with internal loopback. Requires ESP32 with 3+ UARTs (ESP32, ESP32-S3, ESP32-P4). No external hardware needed. Ideal for testing IrDA mode functionality.
 
-* **IrdaMode_TwoBoard_Demo** - Two-board peer-to-peer IrDA communication with user-selectable TX/RX modes via Serial Monitor. Works on any ESP32 variant. Requires IR LED (TX side) and IR receiver (RX side) connected between two boards. Demonstrates real infrared communication.
+* `IrdaMode_TwoBoard_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/IrdaMode_TwoBoard_Demo>`_ - Two-board peer-to-peer IrDA communication with user-selectable TX/RX modes via Serial Monitor. Works on any ESP32 variant. Requires IR LED (TX side) and IR receiver (RX side) connected between two boards. Demonstrates real infrared communication.
 
 setClockSource
 **************
@@ -605,6 +709,8 @@ Enables or disables RX signal inversion.
 * ``invert`` - If ``true``, inverts the RX signal polarity
 
 **Returns:** ``true`` if inversion is set successfully, ``false`` otherwise.
+
+When :ref:`enableRxInternalPull` is enabled, changing RX inversion also updates the RX pad pull direction (pull-down when inverted, pull-up when normal).
 
 setTxInvert
 ***********
@@ -681,7 +787,7 @@ Returns whether the Serial port is initialized and ready.
 Testing and Helper Functions
 ----------------------------
 
-The following HAL-level functions are available for testing UART functionality without external hardware connections. These functions use the ESP32 GPIO matrix to create internal loopback connections.
+The following HAL-level functions are available for testing UART functionality without external hardware connections.
 
 uart_internal_loopback
 **********************
@@ -696,9 +802,10 @@ Creates an internal loopback connection from a UART's TX signal to a specified R
 * ``rxPin`` - GPIO pin number to receive the TX signal
 
 **Note:**
-* This function uses the ESP32 GPIO matrix to internally connect the UART's TX output to the specified RX pin.
+* When ``rxPin`` is the UART's current RX pad and that pad uses **native IOMUX** routing (the SoC default pin for that UART's RX signal), loopback is enabled inside the UART peripheral via ``uart_set_loop_back()``.
+* Otherwise (GPIO-matrix RX pins, cross-UART routing, or alternate RX GPIOs), the function uses the **GPIO matrix** to connect the UART TX signal to ``rxPin``.
 * LP (Low-Power) UARTs are not supported for loopback.
-* This is useful for testing UART communication without physical connections.
+* This is useful for testing UART communication without physical connections. The CI validation suite ``tests/validation/uart/uart.ino`` exercises both paths.
 
 **Example:**
 
@@ -761,34 +868,40 @@ Example Applications
 
 Baud Rate Detection Example:
 
-.. literalinclude:: ../../../libraries/ESP32/examples/Serial/BaudRateDetect_Demo/BaudRateDetect_Demo.ino
-    :language: arduino
+`BaudRateDetect_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/BaudRateDetect_Demo/BaudRateDetect_Demo.ino>`_
 
 OnReceive Callback Example:
 
-.. literalinclude:: ../../../libraries/ESP32/examples/Serial/OnReceive_Demo/OnReceive_Demo.ino
-    :language: arduino
+`OnReceive_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/OnReceive_Demo/OnReceive_Demo.ino>`_
 
 RS485 Communication Example:
 
-.. literalinclude:: ../../../libraries/ESP32/examples/Serial/RS485_Echo_Demo/RS485_Echo_Demo.ino
-    :language: arduino
+`RS485_Echo_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/RS485_Echo_Demo/RS485_Echo_Demo.ino>`_
 
 IrDA Mode Examples:
 
 Dual-UART Example (Single Board with 3+ UARTs):
 
-.. literalinclude:: ../../../libraries/ESP32/examples/Serial/IrdaMode_DualUART_Demo/IrdaMode_DualUART_Demo.ino
-    :language: arduino
+`IrdaMode_DualUART_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/IrdaMode_DualUART_Demo/IrdaMode_DualUART_Demo.ino>`_
 
 Two-Board Example (Peer-to-Peer Communication):
 
-.. literalinclude:: ../../../libraries/ESP32/examples/Serial/IrdaMode_TwoBoard_Demo/IrdaMode_TwoBoard_Demo.ino
-    :language: arduino
+`IrdaMode_TwoBoard_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/IrdaMode_TwoBoard_Demo/IrdaMode_TwoBoard_Demo.ino>`_
 
 Hardware Flow Control Example:
 
-.. literalinclude:: ../../../libraries/ESP32/examples/Serial/HardwareFlowControl_Demo/HardwareFlowControl_Demo.ino
-    :language: arduino
+`HardwareFlowControl_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/HardwareFlowControl_Demo/HardwareFlowControl_Demo.ino>`_
+
+RX Internal Pull Example:
+
+Demonstrates floating RX idle (pull on vs off), pull direction vs ``begin(invert)`` / ``setRxInvert()``, and optional **TX1 → RX2** wired loopback on boards with 3+ UARTs. Prints board-specific GPIO wiring for Part C and pull state from ``gpio_get_io_config()`` on USB Serial at **115200** baud.
+
+`RxPull_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino>`_
+
+One-Wire UART Example:
+
+Demonstrates ``enableOneWireMode(true)`` with a startup self-test on one GPIO, optional **UART1 → UART2** peer loopback (``USE_INTERNAL_LOOPBACK`` or external bus wire), board-specific GPIO wiring printed on USB Serial, and interactive half-duplex forwarding from USB Serial.
+
+`OneWire_UART_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino>`_
 
 Complete list of `Serial examples <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial>`_.

--- a/docs/en/api/serial.rst
+++ b/docs/en/api/serial.rst
@@ -22,8 +22,8 @@ with additional features for advanced use cases.
 * **Baud rate detection**: Automatic baud rate detection (ESP32, ESP32-S2 only).
 * **Event callbacks**: Receive and error event callbacks.
 * **Configurable buffers**: Adjustable RX and TX buffer sizes.
-* **RX internal pull**: Automatic pull-up or pull-down on the RX pad (see :ref:`rx-internal-pull`).
-* **One-wire UART**: Optional single-GPIO RX+TX mode (see :ref:`one-wire-uart`).
+* **RX internal pull**: Automatic pull-up or pull-down on the RX pad (see `RX internal pull <rx-internal-pull_>`_).
+* **One-wire UART**: Optional single-GPIO RX+TX mode (see `one-wire UART <one-wire-uart_>`_).
 
 .. note::
    In case that both pins, RX and TX are detached from UART, the driver will be stopped.
@@ -77,7 +77,7 @@ Initializes the Serial port with the specified baud rate and configuration.
 
 * ``baud`` - Baud rate (bits per second). Common values: 9600, 115200, 230400, etc.
 
-  **Special value:** ``0`` enables baud rate detection (ESP32, ESP32-S2 only). The function will attempt to detect the baud rate for up to ``timeout_ms`` milliseconds. See the :ref:`Baud Rate Detection Example <baud-rate-detection-example>` for usage details.
+  **Special value:** ``0`` enables baud rate detection (ESP32, ESP32-S2 only). The function will attempt to detect the baud rate for up to ``timeout_ms`` milliseconds. See the `Baud Rate Detection Example <baud-rate-detection-example_>`_ for usage details.
 * ``config`` - Serial configuration (data bits, parity, stop bits):
 
   * ``SERIAL_8N1`` - 8 data bits, no parity, 1 stop bit (default)
@@ -94,7 +94,7 @@ Initializes the Serial port with the specified baud rate and configuration.
 
 * ``txPin`` - TX pin number. Use ``-1`` to keep the default pin or current pin assignment.
 
-* ``invert`` - If ``true``, inverts the RX and TX signal polarity. Also sets the RX internal pull to pull-down when :ref:`enableRxInternalPull` is enabled (see :ref:`signal-inversion-rx-pull`).
+* ``invert`` - If ``true``, inverts the RX and TX signal polarity. Also sets the RX internal pull to pull-down when `enableRxInternalPull() <enable-rx-internal-pull_>`_ is enabled (see `Signal Inversion and RX Internal Pull <signal-inversion-rx-pull_>`_).
 
 * ``timeout_ms`` - Timeout in milliseconds for baud rate detection (when ``baud = 0``). Default: 20000 ms (20 seconds).
 
@@ -317,14 +317,13 @@ Sets or changes the RX, TX, CTS, and RTS pins for the Serial port.
 
 **Note:** This function can be called before or after ``begin()``. When pins are changed, the previous pins are automatically detached.
 
-When RX and TX are set to the same GPIO, ``enableOneWireMode(true)`` must be called **before** ``begin()``, and the UART must be in ``UART_MODE_UART``. RS485 and IrDA modes reject same-pin configuration. See :ref:`one-wire-uart` and :ref:`mode-pin-compatibility`.
+When RX and TX are set to the same GPIO, ``enableOneWireMode(true)`` must be called **before** ``begin()``, and the UART must be in ``UART_MODE_UART``. RS485 and IrDA modes reject same-pin configuration. See `one-wire UART <one-wire-uart_>`_ and `Mode and Pin Compatibility <mode-pin-compatibility_>`_.
+
+.. _enable-rx-internal-pull:
+.. _rx-internal-pull:
 
 enableRxInternalPull
 ********************
-
-.. _enableRxInternalPull:
-
-.. _rx-internal-pull:
 
 Enables or disables the internal pull resistor on the RX GPIO. Must be called **before** ``begin()`` to take effect.
 
@@ -336,7 +335,7 @@ Enables or disables the internal pull resistor on the RX GPIO. Must be called **
 
 **Returns:** ``true`` if the setting was applied, ``false`` if the UART is already running.
 
-When enabled, pull direction follows RX signal inversion (see :ref:`signal-inversion-rx-pull`):
+When enabled, pull direction follows RX signal inversion (see `Signal Inversion and RX Internal Pull <signal-inversion-rx-pull_>`_):
 
 * Normal RX (not inverted): pull-up (idle HIGH)
 * RX inverted: pull-down (idle LOW)
@@ -347,12 +346,11 @@ Internal pull is **not** applied in one-wire mode (same GPIO for RX and TX).
 
 * `RxPull_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/RxPull_Demo>`_ — Floating RX, inverted-RX pull direction, and optional wired loopback on split pins.
 
+.. _enable-one-wire-mode:
+.. _one-wire-uart:
+
 enableOneWireMode
 *****************
-
-.. _enableOneWireMode:
-
-.. _one-wire-uart:
 
 Enables single-GPIO (one-wire) UART mode where RX and TX share one pin. Must be called **before** ``begin()``.
 
@@ -372,12 +370,12 @@ Enables single-GPIO (one-wire) UART mode where RX and TX share one pin. Must be 
 
 * `OneWire_UART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo>`_ — Self loopback on one GPIO, optional UART1→UART2 peer loopback (internal matrix or external bus wire), and half-duplex USB bridge.
 
+.. _signal-inversion-rx-pull:
+
 Signal Inversion and RX Internal Pull
 -------------------------------------
 
-.. _signal-inversion-rx-pull:
-
-RX internal pull (when :ref:`enableRxInternalPull` is enabled) tracks **RX signal inversion** only:
+RX internal pull (when `enableRxInternalPull() <enable-rx-internal-pull_>`_ is enabled) tracks **RX signal inversion** only:
 
 +---------------------------+----------------------------------+
 | Event                     | RX internal pull (when enabled)  |
@@ -401,10 +399,10 @@ Call these **before** ``begin()`` (same pattern as ``setClockSource()`` and ``se
 4. ``setPins()`` (optional; can also be called after ``begin()``)
 5. ``begin()``
 
+.. _mode-pin-compatibility:
+
 Mode and Pin Compatibility
 --------------------------
-
-.. _mode-pin-compatibility:
 
 +----------------------+-------------+------------------------+
 | Mode                 | One-wire    | RX internal pull       |
@@ -620,7 +618,7 @@ Sets the UART operating mode.
 
 **Returns:** ``true`` if mode is set successfully, ``false`` otherwise.
 
-**Note:** For RS485 half-duplex mode, the RTS pin must be configured using ``setPins()`` to control the transceiver. RS485 does **not** support one-wire (same GPIO for RX and TX). See :ref:`mode-pin-compatibility`.
+**Note:** For RS485 half-duplex mode, the RTS pin must be configured using ``setPins()`` to control the transceiver. RS485 does **not** support one-wire (same GPIO for RX and TX). See `Mode and Pin Compatibility <mode-pin-compatibility_>`_.
 
 setIrdaDirection
 ****************
@@ -710,7 +708,7 @@ Enables or disables RX signal inversion.
 
 **Returns:** ``true`` if inversion is set successfully, ``false`` otherwise.
 
-When :ref:`enableRxInternalPull` is enabled, changing RX inversion also updates the RX pad pull direction (pull-down when inverted, pull-up when normal).
+When `enableRxInternalPull() <enable-rx-internal-pull_>`_ is enabled, changing RX inversion also updates the RX pad pull direction (pull-down when inverted, pull-up when normal).
 
 setTxInvert
 ***********

--- a/docs/en/api/serial.rst
+++ b/docs/en/api/serial.rst
@@ -412,7 +412,7 @@ Mode and Pin Compatibility
 | ``UART_MODE_UART``   | If enabled  | Yes (unless one-wire)  |
 | RS485 modes          | No          | Yes (split pins)       |
 | ``UART_MODE_IRDA``   | No          | Yes (split pins)       |
-| LP UART (C5/C6/C61)   | No          | Fixed RX pad only      |
+| LP UART (C5/C6/C61)  | No          | Fixed RX pad only      |
 | LP UART (P4 matrix)  | If enabled  | Yes (unless one-wire)  |
 +----------------------+-------------+------------------------+
 

--- a/docs/en/api/serial.rst
+++ b/docs/en/api/serial.rst
@@ -23,7 +23,7 @@ with additional features for advanced use cases.
 * **Event callbacks**: Receive and error event callbacks.
 * **Configurable buffers**: Adjustable RX and TX buffer sizes.
 * **RX internal pull**: Automatic pull-up or pull-down on the RX pad (see `RX internal pull <rx-internal-pull_>`_).
-* **One-wire UART**: Optional single-GPIO RX+TX mode (see `one-wire UART <one-wire-uart_>`_).
+* **One-wire UART**: Automatic single-GPIO RX+TX when RX and TX resolve to the same pin (see `one-wire UART <one-wire-uart_>`_).
 
 .. note::
    In case that both pins, RX and TX are detached from UART, the driver will be stopped.
@@ -61,7 +61,7 @@ ESP32-P4  5        1
 
   **Example:** The ESP32-C6 has 2 HP UARTs and 1 LP UART. The Arduino Core creates ``Serial0`` and ``Serial1`` (HP UARTs) plus ``Serial2`` (LP UART) HardwareSerial objects.
 
-  **Important:** On ESP32-C5, ESP32-C6, and ESP32-C61, LP UARTs use fixed GPIO pins for RX, TX, CTS, and RTS; ``setPins()`` cannot change them. On ESP32-P4, the LP UART supports the GPIO matrix and follows the same pin rules as HP UARTs (including one-wire mode when enabled).
+  **Important:** On ESP32-C5, ESP32-C6, and ESP32-C61, LP UARTs use fixed GPIO pins for RX, TX, CTS, and RTS; ``setPins()`` cannot change them. On ESP32-P4, the LP UART supports the GPIO matrix and follows the same pin rules as HP UARTs (including automatic one-wire when RX equals TX).
 
 Arduino-ESP32 Serial API
 ------------------------
@@ -317,7 +317,7 @@ Sets or changes the RX, TX, CTS, and RTS pins for the Serial port.
 
 **Note:** This function can be called before or after ``begin()``. When pins are changed, the previous pins are automatically detached.
 
-When RX and TX are set to the same GPIO, ``enableOneWireMode(true)`` must be called **before** ``begin()``, and the UART must be in ``UART_MODE_UART``. RS485 and IrDA modes reject same-pin configuration. See `one-wire UART <one-wire-uart_>`_ and `Mode and Pin Compatibility <mode-pin-compatibility_>`_.
+When the effective RX and TX pins resolve to the same GPIO (explicit ``setPins(p, p)`` / ``begin(..., p, p)``, or ``-1`` keep-current that makes them equal), the driver automatically enters **one-wire** mode and registers a shared ``UART_RX_TX`` pin. The UART must be in ``UART_MODE_UART``. RS485 and IrDA reject same-pin configuration, and ``setMode()`` rejects switching away from ``UART_MODE_UART`` while one-wire is active. See `one-wire UART <one-wire-uart_>`_ and `Mode and Pin Compatibility <mode-pin-compatibility_>`_.
 
 .. _enable-rx-internal-pull:
 .. _rx-internal-pull:
@@ -346,21 +346,17 @@ Internal pull is **not** applied in one-wire mode (same GPIO for RX and TX).
 
 * `RxPull_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/RxPull_Demo>`_ — Floating RX, inverted-RX pull direction, and optional wired loopback on split pins.
 
-.. _enable-one-wire-mode:
 .. _one-wire-uart:
 
-enableOneWireMode
-*****************
+One-wire UART
+*************
 
-Enables single-GPIO (one-wire) UART mode where RX and TX share one pin. Must be called **before** ``begin()``.
+One-wire (single-GPIO RX+TX) is enabled automatically when the effective RX and TX pins are the same GPIO. No separate opt-in API is required.
 
-.. code-block:: arduino
+Examples:
 
-    bool enableOneWireMode(bool enable = true);
-
-* ``enable`` - If ``true``, allows ``setPins(p, p)`` or ``begin(..., p, p)`` with the same GPIO for RX and TX. Default is ``false``.
-
-**Returns:** ``true`` if the setting was applied, ``false`` if the UART is already running.
+* ``Serial1.setPins(8, 8);`` or ``Serial1.begin(115200, SERIAL_8N1, 8, 8);``
+* With RX already ``8`` and TX ``9``, ``Serial1.setPins(-1, 8);`` resolves to RX=TX=``8`` and enters one-wire
 
 .. warning::
 
@@ -393,26 +389,25 @@ Pin Configuration Order
 
 Call these **before** ``begin()`` (same pattern as ``setClockSource()`` and ``setRxBufferSize()``):
 
-1. ``enableOneWireMode()`` (optional, default off)
-2. ``enableRxInternalPull()`` (optional, default on)
-3. ``setClockSource()``, ``setRxBufferSize()``, ``setTxBufferSize()`` (optional)
-4. ``setPins()`` (optional; can also be called after ``begin()``)
-5. ``begin()``
+1. ``enableRxInternalPull()`` (optional, default on)
+2. ``setClockSource()``, ``setRxBufferSize()``, ``setTxBufferSize()`` (optional)
+3. ``setPins()`` (optional; can also be called after ``begin()``; same-pin auto-enables one-wire)
+4. ``begin()``
 
 .. _mode-pin-compatibility:
 
 Mode and Pin Compatibility
 --------------------------
 
-+----------------------+-------------+------------------------+
-| Mode                 | One-wire    | RX internal pull       |
-+======================+=============+========================+
-| ``UART_MODE_UART``   | If enabled  | Yes (unless one-wire)  |
-| RS485 modes          | No          | Yes (split pins)       |
-| ``UART_MODE_IRDA``   | No          | Yes (split pins)       |
-| LP UART (C5/C6/C61)  | No          | Fixed RX pad only      |
-| LP UART (P4 matrix)  | If enabled  | Yes (unless one-wire)  |
-+----------------------+-------------+------------------------+
++----------------------+---------------------------+------------------------+
+| Mode                 | One-wire                  | RX internal pull       |
++======================+===========================+========================+
+| ``UART_MODE_UART``   | Auto when RX == TX        | Yes (unless one-wire)  |
+| RS485 modes          | No                        | Yes (split pins)       |
+| ``UART_MODE_IRDA``   | No                        | Yes (split pins)       |
+| LP UART (C5/C6/C61)  | No                        | Fixed RX pad only      |
+| LP UART (P4 matrix)  | Auto when RX == TX        | Yes (unless one-wire)  |
++----------------------+---------------------------+------------------------+
 
 setRxBufferSize
 ***************
@@ -898,7 +893,7 @@ Demonstrates floating RX idle (pull on vs off), pull direction vs ``begin(invert
 
 One-Wire UART Example:
 
-Demonstrates ``enableOneWireMode(true)`` with a startup self-test on one GPIO, optional **UART1 → UART2** peer loopback (``USE_INTERNAL_LOOPBACK`` or external bus wire), board-specific GPIO wiring printed on USB Serial, and interactive half-duplex forwarding from USB Serial.
+Demonstrates same-pin (one-wire) UART with a startup self-test on one GPIO, optional **UART1 → UART2** peer loopback (``USE_INTERNAL_LOOPBACK`` or external bus wire), board-specific GPIO wiring printed on USB Serial, and interactive half-duplex forwarding from USB Serial.
 
 `OneWire_UART_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino>`_
 

--- a/docs/en/api/serial.rst
+++ b/docs/en/api/serial.rst
@@ -23,7 +23,7 @@ with additional features for advanced use cases.
 * **Event callbacks**: Receive and error event callbacks.
 * **Configurable buffers**: Adjustable RX and TX buffer sizes.
 * **RX internal pull**: Automatic pull-up or pull-down on the RX pad (see `RX internal pull <rx-internal-pull_>`_).
-* **One-wire UART**: Automatic single-GPIO RX+TX when RX and TX resolve to the same pin (see `one-wire UART <one-wire-uart_>`_).
+* **One-wire UART**: Automatic open-drain single-GPIO RX+TX when RX and TX resolve to the same pin (see `one-wire UART <one-wire-uart_>`_).
 
 .. note::
    In case that both pins, RX and TX are detached from UART, the driver will be stopped.
@@ -317,7 +317,7 @@ Sets or changes the RX, TX, CTS, and RTS pins for the Serial port.
 
 **Note:** This function can be called before or after ``begin()``. When pins are changed, the previous pins are automatically detached.
 
-When the effective RX and TX pins resolve to the same GPIO (explicit ``setPins(p, p)`` / ``begin(..., p, p)``, or ``-1`` keep-current that makes them equal), the driver automatically enters **one-wire** mode and registers a shared ``UART_RX_TX`` pin. The UART must be in ``UART_MODE_UART``. RS485 and IrDA reject same-pin configuration, and ``setMode()`` rejects switching away from ``UART_MODE_UART`` while one-wire is active. See `one-wire UART <one-wire-uart_>`_ and `Mode and Pin Compatibility <mode-pin-compatibility_>`_.
+When the effective RX and TX pins resolve to the same GPIO (explicit ``setPins(p, p)`` / ``begin(..., p, p)``, or ``-1`` keep-current that makes them equal), the driver automatically enters **open-drain one-wire** mode and registers a shared ``UART_RX_TX`` pin. An external pull-up is required. The UART must be in ``UART_MODE_UART``. RS485 and IrDA reject same-pin configuration, and ``setMode()`` rejects switching away from ``UART_MODE_UART`` while one-wire is active. See `one-wire UART <one-wire-uart_>`_ and `Mode and Pin Compatibility <mode-pin-compatibility_>`_.
 
 .. _enable-rx-internal-pull:
 .. _rx-internal-pull:
@@ -344,14 +344,14 @@ Internal pull is **not** applied in one-wire mode (same GPIO for RX and TX).
 
 **Related Example:**
 
-* `RxPull_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/RxPull_Demo>`_ — Floating RX, inverted-RX pull direction, and optional wired loopback on split pins.
+* `RxPull_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/RxPull_Demo>`_ — Floating RX vs default internal pull, and inverted-RX pull direction on split pins.
 
 .. _one-wire-uart:
 
 One-wire UART
 *************
 
-One-wire (single-GPIO RX+TX) is enabled automatically when the effective RX and TX pins are the same GPIO. No separate opt-in API is required.
+One-wire (single-GPIO RX+TX) is enabled automatically when the effective RX and TX pins are the same GPIO. The HAL configures that shared pad as open-drain. No separate opt-in API is required.
 
 Examples:
 
@@ -360,35 +360,36 @@ Examples:
 
 .. warning::
 
-   One-wire mode routes both TX output and RX input through the same GPIO. ESP-IDF warns that this can cause electrical conflicts on the pad. Use a half-duplex protocol and ensure that no more than one push-pull TX output drives a shared wire. A multi-node electrical design may instead use separately configured open-drain outputs with an external pull-up or an external transceiver. One-wire mode is **not** a substitute for RS485 half-duplex (which requires separate TX, RX, and RTS pins to an external transceiver).
+   Open-drain one-wire requires an **external pull-up to 3.3 V** using a suitable conventional pull-up resistor. TX actively drives LOW and releases HIGH, so without the resistor the line has no valid idle HIGH. Use a half-duplex protocol and never let multiple peers transmit simultaneously. One-wire mode is **not** a substitute for RS485 half-duplex (which requires separate TX, RX, and RTS pins to an external transceiver).
 
 Why one-wire UART can receive ghost data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In one-wire mode, the pad is deliberately left **floating** (no internal pull), and RX is always listening on the same pin that TX drives. Any brief LOW or noise on that pad looks like a UART start bit, so the receiver produces framing errors, BREAK events, or "ghost" bytes even with no intentional traffic.
+In one-wire mode, RX is always listening on the same open-drain pin that TX uses. The external pull-up establishes idle HIGH whenever all transmitters release the bus. Any brief LOW or noise looks like a UART start bit, so the receiver can produce framing errors, BREAK events, or "ghost" bytes.
 
 Main causes:
 
-1. **No idle bias** — split-pin UART uses RX pull-up so idle stays HIGH. One-wire disables that pull so TX is not fighting an internal resistor. When TX is not firmly driving (startup, pin mux change, tri-state between turns, weak/open bus), the line floats and RX samples garbage.
-2. **TX/RX pad conflict** — both output and input are on one GPIO. During attach or mux changes the line can glitch LOW, causing a start bit or BREAK.
+1. **Missing external pull-up** — open-drain TX releases HIGH and cannot establish idle HIGH by itself.
+2. **Startup or mux transients** — attaching the shared pin can briefly look like a LOW start bit.
 3. **Self-echo** — TX is also seen on RX. That is expected for intentional transmission; noise on TX looks the same.
-4. **External bus without idle bias** — a shared wire can float while UART pins are detached or TX outputs are disconnected between half-duplex turns.
+4. **Bus noise or collisions** — wiring noise or simultaneous transmitters corrupt frames.
 
 How to prevent it
 ^^^^^^^^^^^^^^^^^
 
-* Add an **external pull-up** (approximately 4.7–10 kΩ to 3.3 V) on the one-wire pad or shared bus. This holds idle HIGH when nothing drives the line and is the strongest fix.
+* Add an **external pull-up** to 3.3 V on the one-wire pad or shared bus. This holds idle HIGH whenever all open-drain outputs release the line.
 * Drain RX after ``begin()`` or ``setPins()`` using ``while (Serial1.available()) { Serial1.read(); }`` to clear glitches generated during pin attachment.
-* Ignore data until the first valid frame, or require a known preamble, to filter noise before real protocol traffic.
-* Use half-duplex only: never connect two active push-pull TX outputs to the shared wire. Disconnect, reroute, or otherwise disable the listener's TX before the other endpoint transmits.
-* Use shorter wires and reduce nearby electrical noise to reduce false start bits on a floating pad.
-* Do not re-enable the internal pull in one-wire mode because it can fight TX.
+* Match and discard the expected local self-echo after each write before processing peer data.
+* Ignore data until the first valid frame, or require a known preamble, to filter startup noise before real protocol traffic.
+* Use half-duplex only: never let multiple peers transmit simultaneously.
+* Use suitable wiring and pull-up value to maintain clean signal edges.
 
-The internal pull is intentionally disabled in one-wire mode. Rely on **TX idle HIGH** while transmitting and use an **external pull-up** whenever the line can float.
+The weak internal pull is intentionally disabled in normal one-wire operation. A real one-wire bus requires an external pull-up. Open-drain does not impose a special UART baud-rate restriction.
 
 **Related Example:**
 
-* `OneWire_UART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo>`_ — Same-pad one-wire self-echo, optional bidirectional UART1↔UART2 cross-test (internal matrix or external signal wire), printed wiring instructions, and a half-duplex USB bridge.
+* `OneWire_UART_Demo <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo>`_ — Single-board one-wire self-echo on one GPIO (RX == TX), using the UART internal loopback so it runs with no external wiring, plus a half-duplex USB bridge.
+* `OneWire_UART_Two_Boards <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards>`_ — Open-drain PING/PONG communication between two ESP32-family boards over one signal wire plus common GND. Both peers remain in same-pin RX/TX mode, use an external pull-up, and discard local TX self-echo.
 
 .. _signal-inversion-rx-pull:
 
@@ -397,16 +398,16 @@ Signal Inversion and RX Internal Pull
 
 RX internal pull (when `enableRxInternalPull() <enable-rx-internal-pull_>`_ is enabled) tracks **RX signal inversion** only:
 
-+---------------------------+----------------------------------+
-| Event                     | RX internal pull (when enabled)  |
-+===========================+==================================+
-| ``begin(..., invert=false)`` | Pull-up                       |
-| ``begin(..., invert=true)``  | Pull-down                     |
-| ``setRxInvert(true/false)``  | Pull-down / pull-up           |
-| ``setTxInvert()`` only       | Unchanged                     |
-| One-wire mode                | Disabled (floating)           |
-| ``enableRxInternalPull(false)`` | Disabled (floating)        |
-+---------------------------+----------------------------------+
++---------------------------------+----------------------------------+
+| Event                           | RX internal pull (when enabled)  |
++=================================+==================================+
+| ``begin(..., invert=false)``    | Pull-up                          |
+| ``begin(..., invert=true)``     | Pull-down                        |
+| ``setRxInvert(true/false)``     | Pull-down / pull-up              |
+| ``setTxInvert()`` only          | Unchanged                        |
+| One-wire mode                   | Disabled (external pull-up)      |
+| ``enableRxInternalPull(false)`` | Disabled (floating)              |
++---------------------------------+----------------------------------+
 
 Pin Configuration Order
 -----------------------
@@ -911,14 +912,20 @@ Hardware Flow Control Example:
 
 RX Internal Pull Example:
 
-Demonstrates floating RX idle (pull on vs off), pull direction vs ``begin(invert)`` / ``setRxInvert()``, and optional **TX1 → RX2** wired loopback on boards with 3+ UARTs. Prints board-specific GPIO wiring for Part C and pull state from ``gpio_get_io_config()`` on USB Serial at **115200** baud.
+Demonstrates floating RX idle (pull on vs off) and pull direction vs ``begin(invert)`` / ``setRxInvert()`` on split pins. Leave UART1 RX unconnected; the sketch prints pull state from ``gpio_get_io_config()`` on USB Serial at **115200** baud.
 
 `RxPull_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino>`_
 
 One-Wire UART Example:
 
-Demonstrates same-pin (one-wire) UART with a startup self-echo test on one GPIO and an optional bidirectional **UART1 ↔ UART2** cross-test. The cross-test can use internal GPIO-matrix routing or one external signal wire; external mode parks inactive RX/TX signals on unconnected GPIOs so only one push-pull TX drives the wire. The example prints board-specific wiring and supports interactive half-duplex forwarding from USB Serial.
+Demonstrates same-pin open-drain UART on a single board: UART1 transmits and receives on one GPIO (**RX == TX**) and receives its own transmission back through the UART internal loopback, so the example runs with no external wiring. After the startup self-echo test, typed characters are forwarded onto the one-wire GPIO and echoed back on USB Serial. On a real bus, an external pull-up to 3.3 V replaces the internal loopback.
 
 `OneWire_UART_Demo.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino>`_
+
+One-Wire UART Two-Board Example:
+
+Demonstrates same-pin open-drain, half-duplex PING/PONG communication between two ESP32-family boards using one signal wire, common GND, and an external pull-up. The HAL configures open-drain automatically; the example keeps RX and TX on the same pad for every turn and discards expected local TX self-echo. Roles and GPIOs are configured independently on each board, allowing different SoCs.
+
+`OneWire_UART_Two_Boards.ino <https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards/OneWire_UART_Two_Boards.ino>`_
 
 Complete list of `Serial examples <https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Serial>`_.

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
@@ -4,11 +4,13 @@
   Same-pin RX/TX automatically enables one-wire UART (no opt-in API).
   Use setPins(p, p) or begin(..., p, p); -1 keep-current that makes RX==TX also enables it.
 
-  Part A (all boards): UART1 self loopback on one GPIO — verifies one-wire TX/RX on the same pad.
-  Part B (3+ UART boards): UART1 <-> UART2 half-duplex cross test over one external wire.
+  Part A (all boards): UART1 self-echo on one GPIO — verifies one-wire TX/RX on the same pad.
+  Part B (3+ UART boards): UART1 <-> UART2 half-duplex cross test over one signal wire.
 
   Set USE_INTERNAL_LOOPBACK to 1 for GPIO-matrix routing (no jumper), or 0 and wire ONEWIRE_PIN1
-  to ONEWIRE_PIN2 with an external pull-up on the shared line for bus-style use.
+  to ONEWIRE_PIN2 with a recommended external pull-up (4.7–10 kΩ to 3.3 V). External Part B
+  uses split RX/TX assignments and keeps only one UART TX on the shared wire. It is a
+  single-wire half-duplex link; Part A is the direct one-wire (RX == TX) demonstration.
   Default ONEWIRE_PIN1 is board SDA (pins_arduino.h); ONEWIRE_PIN2 defaults to RX2.
 
   WARNING: Never drive TX on both UARTs at the same time. Use half-duplex turn-taking.
@@ -17,7 +19,6 @@
 */
 
 #include <Arduino.h>
-#include "driver/gpio.h"
 #include "esp_rom_gpio.h"
 #include "soc/uart_periph.h"
 
@@ -26,15 +27,21 @@
 #define USE_INTERNAL_LOOPBACK 1
 
 #ifndef ONEWIRE_PIN1
-#define ONEWIRE_PIN1 SDA
+#define ONEWIRE_PIN1 SDA // using a valid pin for the board
 #endif
 
 #ifdef SOC_UART_HP_NUM
 #if SOC_UART_HP_NUM >= 3
-#ifdef RX2
+#if defined(RX2) && defined(TX1) && defined(TX2)
 #define HAS_UART2 1
 #ifndef ONEWIRE_PIN2
 #define ONEWIRE_PIN2 RX2
+#endif
+#ifndef ONEWIRE_PARK_PIN1
+#define ONEWIRE_PARK_PIN1 TX1
+#endif
+#ifndef ONEWIRE_PARK_PIN2
+#define ONEWIRE_PARK_PIN2 TX2
 #endif
 #else
 #define HAS_UART2 0
@@ -53,6 +60,8 @@ static const char *TEST_MSG = "ONEWIRE";
 static const char *PEER_REQUEST = "UART1_TO_UART2";
 static const char *PEER_REPLY = "UART2_TO_UART1";
 static bool g_dualPeerReady = false;
+// External interactive mode keeps the UART2 -> UART1 roles verified by Turn 2.
+static bool g_interactiveUart2Drives = false;
 #endif
 
 static void beginOneWire(HardwareSerial &uart, int8_t pin) {
@@ -95,13 +104,34 @@ static void restoreUartTxToOwnPin(uint8_t uartNum, int8_t pin) {
 #endif
 
 #if HAS_UART2 && !USE_INTERNAL_LOOPBACK
-static bool setOneWireDrive(int8_t pin, bool enabled) {
-  // Do not use pinMode(): it would release the UART_RX_TX peripheral-manager ownership.
-  gpio_mode_t mode = enabled ? GPIO_MODE_INPUT_OUTPUT : GPIO_MODE_INPUT;
-  if (gpio_set_direction((gpio_num_t)pin, mode) != ESP_OK) {
-    Serial.printf("  Failed to %s TX drive on GPIO %d.\n", enabled ? "enable" : "disable", pin);
+// External Part B uses split RX/TX assignments so only the active endpoint's TX is
+// connected to the bus. The inactive RX or TX is parked on an otherwise unused GPIO.
+static bool beginSplitUart(HardwareSerial &uart, int8_t rxPin, int8_t txPin) {
+  uart.setPins(rxPin, txPin);
+  uart.begin(BAUD, SERIAL_8N1, rxPin, txPin);
+  if (!uart) {
+    Serial.printf("  Failed to start UART with RX GPIO %d and TX GPIO %d.\n", rxPin, txPin);
     return false;
   }
+  return true;
+}
+
+static bool setExternalBusRoles(
+  HardwareSerial &driver, int8_t driverBusTxPin, int8_t driverOffBusRxPin, HardwareSerial &listener, int8_t listenerBusRxPin,
+  int8_t listenerOffBusTxPin
+) {
+  driver.end();
+  listener.end();
+  delay(20);
+  if (!beginSplitUart(driver, driverOffBusRxPin, driverBusTxPin)) {
+    return false;
+  }
+  if (!beginSplitUart(listener, listenerBusRxPin, listenerOffBusTxPin)) {
+    return false;
+  }
+  delay(20);
+  drain(driver);
+  drain(listener);
   return true;
 }
 #endif
@@ -111,7 +141,7 @@ static void printLoopbackModeBanner() {
   if (USE_INTERNAL_LOOPBACK) {
     Serial.println(" — no external jumpers required (GPIO-matrix loopback).");
   } else {
-    Serial.println(" — external jumper wiring required (see instructions below).");
+    Serial.println(" — external signal-wire connection required for Part B.");
   }
 }
 
@@ -119,7 +149,7 @@ static void printPartAWiringInstructions() {
   if (USE_INTERNAL_LOOPBACK) {
     Serial.printf("  Part A: no wire — internal loopback on UART1 one-wire GPIO %d.\n", ONEWIRE_PIN1);
   } else {
-    Serial.printf("  Part A: optional self-jumper on UART1 one-wire GPIO %d (same pad for TX and RX).\n", ONEWIRE_PIN1);
+    Serial.printf("  Part A: no jumper — UART1 TX and RX share GPIO %d; an external pull-up is optional.\n", ONEWIRE_PIN1);
   }
 }
 
@@ -132,24 +162,25 @@ static void printPartBWiringInstructions() {
     Serial.println("  Both GPIOs carry the same active UART TX signal during each turn.");
     Serial.printf("    UART1 GPIO %d  <~~internal~~>  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
   } else {
-    Serial.println("  Part B wiring — one wire between both UART one-wire pads:");
+    Serial.println("  Part B wiring — one signal wire between both UART bus pads:");
     Serial.printf("    UART1 GPIO %d  <----bus---->  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-    Serial.println("  External pull-up on the shared line recommended.");
-    Serial.println("  The sketch tri-states the listening UART TX; never enable both TX drivers together.");
+    Serial.printf("  Leave parking GPIOs %d and %d unconnected.\n", ONEWIRE_PARK_PIN1, ONEWIRE_PARK_PIN2);
+    Serial.println("  External 4.7–10 kΩ pull-up to 3.3 V is recommended.");
+    Serial.println("  Never transmit from both UARTs at the same time.");
   }
   Serial.println();
 }
 #endif
 
 static bool runSelfLoopbackTest() {
-  Serial.printf("\n=== Part A: UART1 one-wire self loopback (GPIO %d) ===\n", ONEWIRE_PIN1);
+  Serial.printf("\n=== Part A: UART1 one-wire self-echo (GPIO %d) ===\n", ONEWIRE_PIN1);
   beginOneWire(Serial1, ONEWIRE_PIN1);
 
 #if USE_INTERNAL_LOOPBACK
   uart_internal_loopback(1, ONEWIRE_PIN1);
   Serial.printf("  Internal loopback: UART1 TX -> same GPIO %d (RX input)\n", ONEWIRE_PIN1);
 #else
-  Serial.printf("  External loopback: optional jumper on UART1 one-wire GPIO %d\n", ONEWIRE_PIN1);
+  Serial.printf("  Same-pad self-echo on UART1 one-wire GPIO %d (no jumper needed)\n", ONEWIRE_PIN1);
 #endif
 
   drain(Serial1);
@@ -158,23 +189,23 @@ static bool runSelfLoopbackTest() {
   delay(100);
 
   if (!waitForBytes(Serial1, 300)) {
-    Serial.printf("  Self loopback failed on GPIO %d.", ONEWIRE_PIN1);
+    Serial.printf("  Self-echo failed on GPIO %d.", ONEWIRE_PIN1);
     if (USE_INTERNAL_LOOPBACK) {
       Serial.println(" Internal loopback enabled — verify one-wire on this GPIO.");
     } else {
-      Serial.println(" Set USE_INTERNAL_LOOPBACK=1 or add optional self-jumper on this GPIO.");
+      Serial.println(" Verify that this GPIO supports UART matrix routing; try the recommended external pull-up.");
     }
     return false;
   }
 
   String line = readLine(Serial1);
-  Serial.printf("Self loopback received: \"%s\"\n", line.c_str());
+  Serial.printf("Self-echo received: \"%s\"\n", line.c_str());
   return line == TEST_MSG;
 }
 
 #if HAS_UART2
 static bool runDualPeerCrossTest() {
-  Serial.printf("\n=== Part B: UART1 <-> UART2 one-wire cross test (GPIO %d <-> GPIO %d) ===\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+  Serial.printf("\n=== Part B: UART1 <-> UART2 single-wire cross test (GPIO %d <-> GPIO %d) ===\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
   printPartBWiringInstructions();
 
   if (ONEWIRE_PIN1 == ONEWIRE_PIN2) {
@@ -182,34 +213,41 @@ static bool runDualPeerCrossTest() {
     g_dualPeerReady = false;
     return false;
   }
-
-  beginOneWire(Serial1, ONEWIRE_PIN1);
-  beginOneWire(Serial2, ONEWIRE_PIN2);
+#if !USE_INTERNAL_LOOPBACK
+  if (ONEWIRE_PARK_PIN1 == ONEWIRE_PIN1 || ONEWIRE_PARK_PIN1 == ONEWIRE_PIN2 || ONEWIRE_PARK_PIN2 == ONEWIRE_PIN1
+      || ONEWIRE_PARK_PIN2 == ONEWIRE_PIN2 || ONEWIRE_PARK_PIN1 == ONEWIRE_PARK_PIN2) {
+    Serial.println("  Cross test requires four distinct bus/parking GPIOs; override ONEWIRE_PIN1, ONEWIRE_PIN2,");
+    Serial.println("  ONEWIRE_PARK_PIN1, or ONEWIRE_PARK_PIN2 for this board.");
+    g_dualPeerReady = false;
+    return false;
+  }
+#endif
 
 #if USE_INTERNAL_LOOPBACK
+  beginOneWire(Serial1, ONEWIRE_PIN1);
+  beginOneWire(Serial2, ONEWIRE_PIN2);
   // GPIO ONEWIRE_PIN1 already carries UART1 TX; route that same signal onto
   // ONEWIRE_PIN2. With an optional jumper, both ends therefore have identical levels.
   uart_internal_loopback(1, ONEWIRE_PIN2);
   Serial.printf("  Internal loopback: UART1 TX -> UART2 one-wire GPIO %d\n", ONEWIRE_PIN2);
 #else
   Serial.printf("  External bus: jumper GPIO %d <-> GPIO %d (+ pull-up recommended)\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-  if (!setOneWireDrive(ONEWIRE_PIN1, false) || !setOneWireDrive(ONEWIRE_PIN2, false) || !setOneWireDrive(ONEWIRE_PIN1, true)) {
+  Serial.printf(
+    "  Turn 1 roles: UART1 TX on GPIO %d (RX parked on GPIO %d); UART2 RX on GPIO %d (TX parked on GPIO %d).\n", ONEWIRE_PIN1,
+    ONEWIRE_PARK_PIN1, ONEWIRE_PIN2, ONEWIRE_PARK_PIN2
+  );
+  if (!setExternalBusRoles(Serial1, ONEWIRE_PIN1, ONEWIRE_PARK_PIN1, Serial2, ONEWIRE_PIN2, ONEWIRE_PARK_PIN2)) {
     g_dualPeerReady = false;
     return false;
   }
 #endif
 
+  delay(20);
   drain(Serial1);
   drain(Serial2);
   Serial.printf("  Turn 1: UART1 sends \"%s\" to UART2\n", PEER_REQUEST);
   Serial1.println(PEER_REQUEST);
   Serial1.flush();
-#if !USE_INTERNAL_LOOPBACK
-  if (!setOneWireDrive(ONEWIRE_PIN1, false)) {
-    g_dualPeerReady = false;
-    return false;
-  }
-#endif
   delay(150);
 
   if (!waitForBytes(Serial2, 300)) {
@@ -217,7 +255,7 @@ static bool runDualPeerCrossTest() {
     if (USE_INTERNAL_LOOPBACK) {
       Serial.println(" Internal loopback enabled — verify board has 3+ UARTs and valid ONEWIRE_PIN2.");
     } else {
-      Serial.printf(" Connect GPIO %d to GPIO %d, add bus pull-up, reset, or set USE_INTERNAL_LOOPBACK=1.\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+      Serial.printf(" Check wire GPIO %d <-> %d and pull-up to 3.3 V.\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
     }
     g_dualPeerReady = false;
     return false;
@@ -231,8 +269,7 @@ static bool runDualPeerCrossTest() {
     return false;
   }
 
-  // The sender also sees its own transmission in one-wire mode; clear both receivers
-  // before reversing direction on the half-duplex bus.
+  // Clear both receivers before reversing direction on the half-duplex bus.
   drain(Serial1);
   drain(Serial2);
 
@@ -245,8 +282,11 @@ static bool runDualPeerCrossTest() {
   uart_internal_loopback(2, ONEWIRE_PIN1);
   Serial.printf("  Internal loopback reversed: UART2 TX -> UART1 one-wire GPIO %d\n", ONEWIRE_PIN1);
 #else
-  Serial.println("  Turn 2: same external wire, UART2 now transmits while UART1 listens.");
-  if (!setOneWireDrive(ONEWIRE_PIN2, true)) {
+  Serial.printf(
+    "  Turn 2 roles: UART2 TX on GPIO %d (RX parked on GPIO %d); UART1 RX on GPIO %d (TX parked on GPIO %d).\n", ONEWIRE_PIN2,
+    ONEWIRE_PARK_PIN2, ONEWIRE_PIN1, ONEWIRE_PARK_PIN1
+  );
+  if (!setExternalBusRoles(Serial2, ONEWIRE_PIN2, ONEWIRE_PARK_PIN2, Serial1, ONEWIRE_PIN1, ONEWIRE_PARK_PIN1)) {
     g_dualPeerReady = false;
     return false;
   }
@@ -255,12 +295,6 @@ static bool runDualPeerCrossTest() {
   Serial.printf("  Turn 2: UART2 sends \"%s\" to UART1\n", PEER_REPLY);
   Serial2.println(PEER_REPLY);
   Serial2.flush();
-#if !USE_INTERNAL_LOOPBACK
-  if (!setOneWireDrive(ONEWIRE_PIN2, false)) {
-    g_dualPeerReady = false;
-    return false;
-  }
-#endif
   delay(150);
 
   if (!waitForBytes(Serial1, 300)) {
@@ -280,15 +314,17 @@ static bool runDualPeerCrossTest() {
   // Restore UART1 TX on both pads for interactive UART1 -> UART2 forwarding.
   restoreUartTxToOwnPin(1, ONEWIRE_PIN1);
   uart_internal_loopback(1, ONEWIRE_PIN2);
+  g_interactiveUart2Drives = false;
 #else
-  // Interactive mode sends UART1 -> UART2, so only UART1 may drive the wire.
-  if (!setOneWireDrive(ONEWIRE_PIN1, true)) {
-    g_dualPeerReady = false;
-    return false;
-  }
+  // Keep Turn 2 roles for interactive mode. A second swap back to UART1-TX/UART2-RX
+  // is unnecessary because Turn 2 already proved UART2 -> UART1.
+  g_interactiveUart2Drives = true;
+  Serial.printf(
+    "  Interactive roles (unchanged from Turn 2): UART2 TX on GPIO %d; UART1 RX on GPIO %d.\n", ONEWIRE_PIN2, ONEWIRE_PIN1
+  );
 #endif
 
-  // Remove any sender self-echo before entering interactive mode.
+  // Remove any leftover RX data before entering interactive mode.
   drain(Serial1);
   drain(Serial2);
 
@@ -304,9 +340,9 @@ void setup() {
   Serial.begin(BAUD);
   delay(500);
   Serial.println("\n=== One-Wire UART Demo ===");
-  Serial.printf("UART1 one-wire pin (ONEWIRE_PIN1): GPIO %d\n", ONEWIRE_PIN1);
+  Serial.printf("UART1 one-wire/bus pin (ONEWIRE_PIN1): GPIO %d\n", ONEWIRE_PIN1);
 #if HAS_UART2
-  Serial.printf("UART2 one-wire pin (ONEWIRE_PIN2): GPIO %d\n", ONEWIRE_PIN2);
+  Serial.printf("UART2 peer bus pin (ONEWIRE_PIN2): GPIO %d\n", ONEWIRE_PIN2);
 #else
   Serial.println("Part B skipped on this board (fewer than 3 HP UARTs or no RX2 define).");
 #endif
@@ -326,13 +362,19 @@ void setup() {
 
   if (runSelfLoopbackTest()) {
     Serial.println("Part A OK");
+  } else {
+    Serial.println("Part A failed");
   }
 
 #if HAS_UART2
   if (runDualPeerCrossTest()) {
     Serial.println("Part B OK");
     Serial.println("\nBidirectional single-wire cross test passed.");
-    Serial.println("Type in Serial Monitor — bytes go from UART1 to UART2 and print here.");
+    if (g_interactiveUart2Drives) {
+      Serial.println("Type in Serial Monitor and press Send — bytes go UART2 -> bus -> UART1 and print here.");
+    } else {
+      Serial.println("Type in Serial Monitor and press Send — bytes go UART1 -> bus -> UART2 and print here.");
+    }
   } else {
     Serial.println("Part B failed — interactive peer mode disabled.");
   }
@@ -345,11 +387,24 @@ void setup() {
 void loop() {
 #if HAS_UART2
   if (g_dualPeerReady) {
-    if (Serial.available()) {
-      Serial1.write(Serial.read());
+    HardwareSerial &driveUart = g_interactiveUart2Drives ? Serial2 : Serial1;
+    HardwareSerial &listenUart = g_interactiveUart2Drives ? Serial1 : Serial2;
+    bool sent = false;
+    while (Serial.available()) {
+      driveUart.write((uint8_t)Serial.read());
+      sent = true;
     }
-    while (Serial2.available()) {
-      Serial.write(Serial2.read());
+    if (sent) {
+      driveUart.flush();
+    }
+#if USE_INTERNAL_LOOPBACK
+    // One-wire / matrix path also receives its own TX; discard so the RX buffer cannot fill.
+    while (driveUart.available()) {
+      driveUart.read();
+    }
+#endif
+    while (listenUart.available()) {
+      Serial.write(listenUart.read());
     }
     return;
   }

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
@@ -18,6 +18,8 @@
 
 #include <Arduino.h>
 #include "driver/gpio.h"
+#include "esp_rom_gpio.h"
+#include "soc/uart_periph.h"
 
 // 1 = GPIO matrix connects UART1 TX to the peer RX pad (no external wire)
 // 0 = jumper ONEWIRE_PIN1 <-> ONEWIRE_PIN2 (+ external pull-up recommended on the bus)
@@ -82,6 +84,16 @@ static void drain(HardwareSerial &uart) {
   }
 }
 
+#if HAS_UART2 && USE_INTERNAL_LOOPBACK
+// uart_internal_loopback() routes src UART TX onto dstPad but does not clear a previous
+// TX drive left on that pad. Restore the pad owner's TX before reversing direction so
+// both pads carry the same UART TX signal during each turn. An optional jumper then
+// connects identical signals instead of shorting UART1 TX against UART2 TX.
+static void restoreUartTxToOwnPin(uint8_t uartNum, int8_t pin) {
+  esp_rom_gpio_connect_out_signal(pin, uart_periph_signal[uartNum].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+}
+#endif
+
 #if HAS_UART2 && !USE_INTERNAL_LOOPBACK
 static bool setOneWireDrive(int8_t pin, bool enabled) {
   // Do not use pinMode(): it would release the UART_RX_TX peripheral-manager ownership.
@@ -115,7 +127,9 @@ static void printPartAWiringInstructions() {
 static void printPartBWiringInstructions() {
   Serial.println();
   if (USE_INTERNAL_LOOPBACK) {
-    Serial.println("  Part B: no wire — GPIO-matrix routing switches direction between each half-duplex turn.");
+    Serial.println("  Part B: no external wire required; an existing jumper is optional and redundant.");
+    Serial.println("  GPIO-matrix routing switches direction between each half-duplex turn.");
+    Serial.println("  Both GPIOs carry the same active UART TX signal during each turn.");
     Serial.printf("    UART1 GPIO %d  <~~internal~~>  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
   } else {
     Serial.println("  Part B wiring — one wire between both UART one-wire pads:");
@@ -173,6 +187,8 @@ static bool runDualPeerCrossTest() {
   beginOneWire(Serial2, ONEWIRE_PIN2);
 
 #if USE_INTERNAL_LOOPBACK
+  // GPIO ONEWIRE_PIN1 already carries UART1 TX; route that same signal onto
+  // ONEWIRE_PIN2. With an optional jumper, both ends therefore have identical levels.
   uart_internal_loopback(1, ONEWIRE_PIN2);
   Serial.printf("  Internal loopback: UART1 TX -> UART2 one-wire GPIO %d\n", ONEWIRE_PIN2);
 #else
@@ -221,6 +237,11 @@ static bool runDualPeerCrossTest() {
   drain(Serial2);
 
 #if USE_INTERNAL_LOOPBACK
+  // Turn 1 left UART1 TX driving ONEWIRE_PIN2. Put UART2 TX back on its own pad first;
+  // then route UART2 TX onto ONEWIRE_PIN1. Both changes happen after UART1.flush(),
+  // while the line is idle HIGH. During Turn 2 both pads carry UART2 TX, so an
+  // optional jumper connects identical signals instead of causing output contention.
+  restoreUartTxToOwnPin(2, ONEWIRE_PIN2);
   uart_internal_loopback(2, ONEWIRE_PIN1);
   Serial.printf("  Internal loopback reversed: UART2 TX -> UART1 one-wire GPIO %d\n", ONEWIRE_PIN1);
 #else
@@ -245,6 +266,7 @@ static bool runDualPeerCrossTest() {
   if (!waitForBytes(Serial1, 300)) {
     Serial.printf("  Cross test failed — UART1 GPIO %d received no reply.\n", ONEWIRE_PIN1);
 #if USE_INTERNAL_LOOPBACK
+    restoreUartTxToOwnPin(1, ONEWIRE_PIN1);
     uart_internal_loopback(1, ONEWIRE_PIN2);
 #endif
     g_dualPeerReady = false;
@@ -255,7 +277,8 @@ static bool runDualPeerCrossTest() {
   Serial.printf("UART1 received reply: \"%s\"\n", line.c_str());
 
 #if USE_INTERNAL_LOOPBACK
-  // Restore UART1 -> UART2 for the interactive mode in loop().
+  // Restore UART1 TX on both pads for interactive UART1 -> UART2 forwarding.
+  restoreUartTxToOwnPin(1, ONEWIRE_PIN1);
   uart_internal_loopback(1, ONEWIRE_PIN2);
 #else
   // Interactive mode sends UART1 -> UART2, so only UART1 may drive the wire.
@@ -290,7 +313,14 @@ void setup() {
   printLoopbackModeBanner();
   printPartAWiringInstructions();
 #if HAS_UART2
+#if USE_INTERNAL_LOOPBACK
+  Serial.printf(
+    "Part B preview: no jumper required (optional/redundant); internal matrix routes UART1 GPIO %d <-> UART2 GPIO %d.\n", ONEWIRE_PIN1,
+    ONEWIRE_PIN2
+  );
+#else
   Serial.printf("Part B preview: connect one wire between UART1 GPIO %d and UART2 GPIO %d.\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+#endif
 #endif
   Serial.println();
 

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
@@ -1,0 +1,240 @@
+/*
+  One-Wire UART Demo
+
+  Uses enableOneWireMode(true) so RX and TX share one GPIO (ESP-IDF one-wire / single-wire UART).
+
+  Part A (all boards): UART1 self loopback on one GPIO — verifies one-wire TX/RX on the same pad.
+  Part B (3+ UART boards): UART1 one-wire peer -> UART2 one-wire peer (half-duplex bus).
+
+  Set USE_INTERNAL_LOOPBACK to 1 for GPIO-matrix routing (no jumper), or 0 and wire ONEWIRE_PIN1
+  to ONEWIRE_PIN2 with an external pull-up on the shared line for bus-style use.
+  Default ONEWIRE_PIN1 is board SDA (pins_arduino.h); ONEWIRE_PIN2 defaults to RX2.
+
+  WARNING: Never drive TX on both UARTs at the same time. Use half-duplex turn-taking.
+
+  Open Serial Monitor at 115200 baud on USB Serial.
+*/
+
+#include <Arduino.h>
+
+// 1 = GPIO matrix connects UART1 TX to the peer RX pad (no external wire)
+// 0 = jumper ONEWIRE_PIN1 <-> ONEWIRE_PIN2 (+ external pull-up recommended on the bus)
+#define USE_INTERNAL_LOOPBACK 1
+
+#ifndef ONEWIRE_PIN1
+#define ONEWIRE_PIN1 SDA
+#endif
+
+#ifdef SOC_UART_HP_NUM
+#if SOC_UART_HP_NUM >= 3
+#ifdef RX2
+#define HAS_UART2 1
+#ifndef ONEWIRE_PIN2
+#define ONEWIRE_PIN2 RX2
+#endif
+#else
+#define HAS_UART2 0
+#endif
+#else
+#define HAS_UART2 0
+#endif
+#else
+#define HAS_UART2 0
+#endif
+
+static const uint32_t BAUD = 115200;
+static const char *TEST_MSG = "ONEWIRE";
+
+static bool g_dualPeerReady = false;
+
+static void beginOneWire(HardwareSerial &uart, int8_t pin) {
+  uart.end();
+  uart.enableOneWireMode(true);
+  uart.setPins(pin, pin);
+  uart.begin(BAUD, SERIAL_8N1, pin, pin);
+  while (!uart) {
+    delay(10);
+  }
+}
+
+static bool waitForBytes(HardwareSerial &uart, uint32_t timeoutMs) {
+  uint32_t start = millis();
+  while (millis() - start < timeoutMs) {
+    if (uart.available() > 0) {
+      return true;
+    }
+    delay(1);
+  }
+  return false;
+}
+
+static String readLine(HardwareSerial &uart) {
+  String line = uart.readStringUntil('\n');
+  line.trim();
+  return line;
+}
+
+static void drain(HardwareSerial &uart) {
+  while (uart.available()) {
+    uart.read();
+  }
+}
+
+static void printLoopbackModeBanner() {
+  Serial.printf("USE_INTERNAL_LOOPBACK=%d", USE_INTERNAL_LOOPBACK);
+  if (USE_INTERNAL_LOOPBACK) {
+    Serial.println(" — no external jumpers required (GPIO-matrix loopback).");
+  } else {
+    Serial.println(" — external jumper wiring required (see instructions below).");
+  }
+}
+
+static void printPartAWiringInstructions() {
+  if (USE_INTERNAL_LOOPBACK) {
+    Serial.printf("  Part A: no wire — internal loopback on UART1 one-wire GPIO %d.\n", ONEWIRE_PIN1);
+  } else {
+    Serial.printf("  Part A: optional self-jumper on UART1 one-wire GPIO %d (same pad for TX and RX).\n", ONEWIRE_PIN1);
+  }
+}
+
+#if HAS_UART2
+static void printPartBWiringInstructions() {
+  Serial.println();
+  if (USE_INTERNAL_LOOPBACK) {
+    Serial.println("  Part B: no wire — UART1 TX routed internally to UART2 one-wire pad.");
+    Serial.printf("    UART1 one-wire GPIO %d  ~~internal~~>  UART2 one-wire GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+  } else {
+    Serial.println("  Part B wiring — half-duplex bus between UART one-wire pads:");
+    Serial.printf("    UART1 GPIO %d  <----bus---->  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+    Serial.println("  External pull-up on the shared line recommended.");
+    Serial.println("  Never transmit from both UARTs at the same time.");
+  }
+  Serial.println();
+}
+#endif
+
+static bool runSelfLoopbackTest() {
+  Serial.printf("\n=== Part A: UART1 one-wire self loopback (GPIO %d) ===\n", ONEWIRE_PIN1);
+  beginOneWire(Serial1, ONEWIRE_PIN1);
+
+#if USE_INTERNAL_LOOPBACK
+  uart_internal_loopback(1, ONEWIRE_PIN1);
+  Serial.printf("  Internal loopback: UART1 TX -> same GPIO %d (RX input)\n", ONEWIRE_PIN1);
+#else
+  Serial.printf("  External loopback: optional jumper on UART1 one-wire GPIO %d\n", ONEWIRE_PIN1);
+#endif
+
+  drain(Serial1);
+  Serial1.println(TEST_MSG);
+  Serial1.flush();
+  delay(100);
+
+  if (!waitForBytes(Serial1, 300)) {
+    Serial.printf("  Self loopback failed on GPIO %d.", ONEWIRE_PIN1);
+    if (USE_INTERNAL_LOOPBACK) {
+      Serial.println(" Internal loopback enabled — verify one-wire on this GPIO.");
+    } else {
+      Serial.println(" Set USE_INTERNAL_LOOPBACK=1 or add optional self-jumper on this GPIO.");
+    }
+    return false;
+  }
+
+  String line = readLine(Serial1);
+  Serial.printf("Self loopback received: \"%s\"\n", line.c_str());
+  return line == TEST_MSG;
+}
+
+#if HAS_UART2
+static bool runDualPeerLoopbackTest() {
+  Serial.printf("\n=== Part B: UART1 -> UART2 one-wire peer (GPIO %d -> GPIO %d) ===\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+  printPartBWiringInstructions();
+
+  beginOneWire(Serial1, ONEWIRE_PIN1);
+  beginOneWire(Serial2, ONEWIRE_PIN2);
+
+#if USE_INTERNAL_LOOPBACK
+  uart_internal_loopback(1, ONEWIRE_PIN2);
+  Serial.printf("  Internal loopback: UART1 TX -> UART2 one-wire GPIO %d\n", ONEWIRE_PIN2);
+#else
+  Serial.printf("  External bus: jumper GPIO %d <-> GPIO %d (+ pull-up recommended)\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+#endif
+
+  drain(Serial2);
+  Serial1.println(TEST_MSG);
+  Serial1.flush();
+  delay(150);
+
+  if (!waitForBytes(Serial2, 300)) {
+    Serial.printf("  Peer loopback failed — UART2 GPIO %d received nothing.", ONEWIRE_PIN2);
+    if (USE_INTERNAL_LOOPBACK) {
+      Serial.println(" Internal loopback enabled — verify board has 3+ UARTs and valid ONEWIRE_PIN2.");
+    } else {
+      Serial.printf(" Connect GPIO %d to GPIO %d, add bus pull-up, reset, or set USE_INTERNAL_LOOPBACK=1.\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+    }
+    g_dualPeerReady = false;
+    return false;
+  }
+
+  String line = readLine(Serial2);
+  Serial.printf("UART2 received: \"%s\"\n", line.c_str());
+  g_dualPeerReady = (line == TEST_MSG);
+  return g_dualPeerReady;
+}
+#endif
+
+void setup() {
+  Serial.begin(BAUD);
+  delay(500);
+  Serial.println("\n=== One-Wire UART Demo ===");
+  Serial.printf("UART1 one-wire pin (ONEWIRE_PIN1): GPIO %d\n", ONEWIRE_PIN1);
+#if HAS_UART2
+  Serial.printf("UART2 one-wire pin (ONEWIRE_PIN2): GPIO %d\n", ONEWIRE_PIN2);
+#else
+  Serial.println("Part B skipped on this board (fewer than 3 HP UARTs or no RX2 define).");
+#endif
+  printLoopbackModeBanner();
+  printPartAWiringInstructions();
+#if HAS_UART2
+  Serial.printf("Part B preview: UART1 GPIO %d -> UART2 GPIO %d (details before Part B runs).\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+#endif
+  Serial.println();
+
+  if (runSelfLoopbackTest()) {
+    Serial.println("Part A OK");
+  }
+
+#if HAS_UART2
+  if (runDualPeerLoopbackTest()) {
+    Serial.println("Part B OK");
+    Serial.println("\nType in Serial Monitor — bytes go to UART1; replies print from UART2 (half-duplex peer).");
+  } else {
+    Serial.println("Part B failed — interactive peer mode disabled.");
+  }
+#else
+  Serial.println("\nPart B skipped (board has fewer than 3 UARTs or no RX2 define).");
+  Serial.println("Type in Serial Monitor — UART1 echoes on the same one-wire GPIO (Part A only).");
+#endif
+}
+
+void loop() {
+#if HAS_UART2
+  if (g_dualPeerReady) {
+    if (Serial.available()) {
+      Serial1.write(Serial.read());
+    }
+    while (Serial2.available()) {
+      Serial.write(Serial2.read());
+    }
+    return;
+  }
+#endif
+
+  if (Serial.available()) {
+    int c = Serial.read();
+    Serial1.write(c);
+    Serial1.flush();
+  }
+  if (Serial1.available()) {
+    Serial.write(Serial1.read());
+  }
+}

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
@@ -46,10 +46,12 @@
 
 static const uint32_t BAUD = 115200;
 static const char *TEST_MSG = "ONEWIRE";
+
+#if HAS_UART2
 static const char *PEER_REQUEST = "UART1_TO_UART2";
 static const char *PEER_REPLY = "UART2_TO_UART1";
-
 static bool g_dualPeerReady = false;
+#endif
 
 static void beginOneWire(HardwareSerial &uart, int8_t pin) {
   uart.end();

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
@@ -57,9 +57,6 @@ static void beginOneWire(HardwareSerial &uart, int8_t pin) {
   uart.end();
   uart.setPins(pin, pin);  // same-pin auto-enables one-wire
   uart.begin(BAUD, SERIAL_8N1, pin, pin);
-  while (!uart) {
-    delay(10);
-  }
 }
 
 static bool waitForBytes(HardwareSerial &uart, uint32_t timeoutMs) {

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
@@ -1,90 +1,33 @@
 /*
-  One-Wire UART Demo
+  One-Wire UART Demo (single board)
 
-  Same-pin RX/TX automatically enables one-wire UART (no opt-in API).
-  Use setPins(p, p) or begin(..., p, p); -1 keep-current that makes RX==TX also enables it.
+  Shows how one UART can transmit and receive on a single GPIO (half-duplex,
+  one-wire mode). Same-pin RX/TX automatically enables one-wire UART:
+  begin(baud, config, pin, pin) makes RX == TX and turns the pad into an
+  open-drain one-wire bus.
 
-  Part A (all boards): UART1 self-echo on one GPIO — verifies one-wire TX/RX on the same pad.
-  Part B (3+ UART boards): UART1 <-> UART2 half-duplex cross test over one signal wire.
+  This example runs on a single board with no external wiring: it uses the
+  UART internal loopback so UART1 receives its own transmission on the same
+  GPIO. On a real one-wire bus, an external pull-up resistor to 3.3 V is
+  required instead of the internal loopback.
 
-  Set USE_INTERNAL_LOOPBACK to 1 for GPIO-matrix routing (no jumper), or 0 and wire ONEWIRE_PIN1
-  to ONEWIRE_PIN2 with a recommended external pull-up (4.7–10 kΩ to 3.3 V). External Part B
-  uses split RX/TX assignments and keeps only one UART TX on the shared wire. It is a
-  single-wire half-duplex link; Part A is the direct one-wire (RX == TX) demonstration.
-  Default ONEWIRE_PIN1 is board SDA (pins_arduino.h); ONEWIRE_PIN2 defaults to RX2.
-
-  WARNING: Never drive TX on both UARTs at the same time. Use half-duplex turn-taking.
-
-  Open Serial Monitor at 115200 baud on USB Serial.
+  Open the Serial Monitor at 115200 baud. After the self-test, anything you
+  type is sent on the one-wire GPIO and echoed back.
 */
 
 #include <Arduino.h>
-#include "esp_rom_gpio.h"
-#include "soc/uart_periph.h"
+#include "driver/gpio.h"
 
-// 1 = GPIO matrix connects UART1 TX to the peer RX pad (no external wire)
-// 0 = jumper ONEWIRE_PIN1 <-> ONEWIRE_PIN2 (+ external pull-up recommended on the bus)
-#define USE_INTERNAL_LOOPBACK 1
-
-#ifndef ONEWIRE_PIN1
-#define ONEWIRE_PIN1 SDA // using a valid pin for the board
-#endif
-
-#ifdef SOC_UART_HP_NUM
-#if SOC_UART_HP_NUM >= 3
-#if defined(RX2) && defined(TX1) && defined(TX2)
-#define HAS_UART2 1
-#ifndef ONEWIRE_PIN2
-#define ONEWIRE_PIN2 RX2
-#endif
-#ifndef ONEWIRE_PARK_PIN1
-#define ONEWIRE_PARK_PIN1 TX1
-#endif
-#ifndef ONEWIRE_PARK_PIN2
-#define ONEWIRE_PARK_PIN2 TX2
-#endif
-#else
-#define HAS_UART2 0
-#endif
-#else
-#define HAS_UART2 0
-#endif
-#else
-#define HAS_UART2 0
+#ifndef ONEWIRE_PIN
+#define ONEWIRE_PIN SDA  // any valid GPIO for the board
 #endif
 
 static const uint32_t BAUD = 115200;
 static const char *TEST_MSG = "ONEWIRE";
 
-#if HAS_UART2
-static const char *PEER_REQUEST = "UART1_TO_UART2";
-static const char *PEER_REPLY = "UART2_TO_UART1";
-static bool g_dualPeerReady = false;
-// External interactive mode keeps the UART2 -> UART1 roles verified by Turn 2.
-static bool g_interactiveUart2Drives = false;
-#endif
-
 static void beginOneWire(HardwareSerial &uart, int8_t pin) {
   uart.end();
-  uart.setPins(pin, pin);  // same-pin auto-enables one-wire
-  uart.begin(BAUD, SERIAL_8N1, pin, pin);
-}
-
-static bool waitForBytes(HardwareSerial &uart, uint32_t timeoutMs) {
-  uint32_t start = millis();
-  while (millis() - start < timeoutMs) {
-    if (uart.available() > 0) {
-      return true;
-    }
-    delay(1);
-  }
-  return false;
-}
-
-static String readLine(HardwareSerial &uart) {
-  String line = uart.readStringUntil('\n');
-  line.trim();
-  return line;
+  uart.begin(BAUD, SERIAL_8N1, pin, pin);  // same pin for RX and TX -> one-wire
 }
 
 static void drain(HardwareSerial &uart) {
@@ -93,328 +36,57 @@ static void drain(HardwareSerial &uart) {
   }
 }
 
-#if HAS_UART2 && USE_INTERNAL_LOOPBACK
-// uart_internal_loopback() routes src UART TX onto dstPad but does not clear a previous
-// TX drive left on that pad. Restore the pad owner's TX before reversing direction so
-// both pads carry the same UART TX signal during each turn. An optional jumper then
-// connects identical signals instead of shorting UART1 TX against UART2 TX.
-static void restoreUartTxToOwnPin(uint8_t uartNum, int8_t pin) {
-  esp_rom_gpio_connect_out_signal(pin, uart_periph_signal[uartNum].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
-}
-#endif
+static bool runSelfEchoTest() {
+  Serial.printf("\n=== One-wire self-echo on GPIO %d ===\n", ONEWIRE_PIN);
 
-#if HAS_UART2 && !USE_INTERNAL_LOOPBACK
-// External Part B uses split RX/TX assignments so only the active endpoint's TX is
-// connected to the bus. The inactive RX or TX is parked on an otherwise unused GPIO.
-static bool beginSplitUart(HardwareSerial &uart, int8_t rxPin, int8_t txPin) {
-  uart.setPins(rxPin, txPin);
-  uart.begin(BAUD, SERIAL_8N1, rxPin, txPin);
-  if (!uart) {
-    Serial.printf("  Failed to start UART with RX GPIO %d and TX GPIO %d.\n", rxPin, txPin);
-    return false;
-  }
-  return true;
-}
+  beginOneWire(Serial1, ONEWIRE_PIN);
 
-static bool setExternalBusRoles(
-  HardwareSerial &driver, int8_t driverBusTxPin, int8_t driverOffBusRxPin, HardwareSerial &listener, int8_t listenerBusRxPin,
-  int8_t listenerOffBusTxPin
-) {
-  driver.end();
-  listener.end();
-  delay(20);
-  if (!beginSplitUart(driver, driverOffBusRxPin, driverBusTxPin)) {
-    return false;
-  }
-  if (!beginSplitUart(listener, listenerBusRxPin, listenerOffBusTxPin)) {
-    return false;
-  }
-  delay(20);
-  drain(driver);
-  drain(listener);
-  return true;
-}
-#endif
+  // No external wire needed: route UART1 TX back to its own RX input on the
+  // same GPIO. On real hardware, use an external pull-up on the bus instead.
+  uart_internal_loopback(1, ONEWIRE_PIN);
 
-static void printLoopbackModeBanner() {
-  Serial.printf("USE_INTERNAL_LOOPBACK=%d", USE_INTERNAL_LOOPBACK);
-  if (USE_INTERNAL_LOOPBACK) {
-    Serial.println(" — no external jumpers required (GPIO-matrix loopback).");
-  } else {
-    Serial.println(" — external signal-wire connection required for Part B.");
-  }
-}
-
-static void printPartAWiringInstructions() {
-  if (USE_INTERNAL_LOOPBACK) {
-    Serial.printf("  Part A: no wire — internal loopback on UART1 one-wire GPIO %d.\n", ONEWIRE_PIN1);
-  } else {
-    Serial.printf("  Part A: no jumper — UART1 TX and RX share GPIO %d; an external pull-up is optional.\n", ONEWIRE_PIN1);
-  }
-}
-
-#if HAS_UART2
-static void printPartBWiringInstructions() {
-  Serial.println();
-  if (USE_INTERNAL_LOOPBACK) {
-    Serial.println("  Part B: no external wire required; an existing jumper is optional and redundant.");
-    Serial.println("  GPIO-matrix routing switches direction between each half-duplex turn.");
-    Serial.println("  Both GPIOs carry the same active UART TX signal during each turn.");
-    Serial.printf("    UART1 GPIO %d  <~~internal~~>  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-  } else {
-    Serial.println("  Part B wiring — one signal wire between both UART bus pads:");
-    Serial.printf("    UART1 GPIO %d  <----bus---->  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-    Serial.printf("  Leave parking GPIOs %d and %d unconnected.\n", ONEWIRE_PARK_PIN1, ONEWIRE_PARK_PIN2);
-    Serial.println("  External 4.7–10 kΩ pull-up to 3.3 V is recommended.");
-    Serial.println("  Never transmit from both UARTs at the same time.");
-  }
-  Serial.println();
-}
-#endif
-
-static bool runSelfLoopbackTest() {
-  Serial.printf("\n=== Part A: UART1 one-wire self-echo (GPIO %d) ===\n", ONEWIRE_PIN1);
-  beginOneWire(Serial1, ONEWIRE_PIN1);
-
-#if USE_INTERNAL_LOOPBACK
-  uart_internal_loopback(1, ONEWIRE_PIN1);
-  Serial.printf("  Internal loopback: UART1 TX -> same GPIO %d (RX input)\n", ONEWIRE_PIN1);
-#else
-  Serial.printf("  Same-pad self-echo on UART1 one-wire GPIO %d (no jumper needed)\n", ONEWIRE_PIN1);
-#endif
+  // The one-wire pad is open-drain, so released HIGH bits float. This weak
+  // internal pull-up lets the no-wire loopback observe them; it is only a test
+  // fixture and does not replace the external pull-up needed on a real bus.
+  gpio_pullup_en((gpio_num_t)ONEWIRE_PIN);
 
   drain(Serial1);
   Serial1.println(TEST_MSG);
   Serial1.flush();
-  delay(100);
+  delay(50);
 
-  if (!waitForBytes(Serial1, 300)) {
-    Serial.printf("  Self-echo failed on GPIO %d.", ONEWIRE_PIN1);
-    if (USE_INTERNAL_LOOPBACK) {
-      Serial.println(" Internal loopback enabled — verify one-wire on this GPIO.");
-    } else {
-      Serial.println(" Verify that this GPIO supports UART matrix routing; try the recommended external pull-up.");
-    }
-    return false;
+  String line = Serial1.readStringUntil('\n');
+  line.trim();
+
+  if (line == TEST_MSG) {
+    Serial.printf("Received back: \"%s\" -> one-wire OK\n", line.c_str());
+    return true;
   }
 
-  String line = readLine(Serial1);
-  Serial.printf("Self-echo received: \"%s\"\n", line.c_str());
-  return line == TEST_MSG;
+  Serial.printf("Self-echo failed (got \"%s\").\n", line.c_str());
+  return false;
 }
-
-#if HAS_UART2
-static bool runDualPeerCrossTest() {
-  Serial.printf("\n=== Part B: UART1 <-> UART2 single-wire cross test (GPIO %d <-> GPIO %d) ===\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-  printPartBWiringInstructions();
-
-  if (ONEWIRE_PIN1 == ONEWIRE_PIN2) {
-    Serial.println("  Cross test requires two different GPIOs connected by one wire; change ONEWIRE_PIN1 or ONEWIRE_PIN2.");
-    g_dualPeerReady = false;
-    return false;
-  }
-#if !USE_INTERNAL_LOOPBACK
-  if (ONEWIRE_PARK_PIN1 == ONEWIRE_PIN1 || ONEWIRE_PARK_PIN1 == ONEWIRE_PIN2 || ONEWIRE_PARK_PIN2 == ONEWIRE_PIN1
-      || ONEWIRE_PARK_PIN2 == ONEWIRE_PIN2 || ONEWIRE_PARK_PIN1 == ONEWIRE_PARK_PIN2) {
-    Serial.println("  Cross test requires four distinct bus/parking GPIOs; override ONEWIRE_PIN1, ONEWIRE_PIN2,");
-    Serial.println("  ONEWIRE_PARK_PIN1, or ONEWIRE_PARK_PIN2 for this board.");
-    g_dualPeerReady = false;
-    return false;
-  }
-#endif
-
-#if USE_INTERNAL_LOOPBACK
-  beginOneWire(Serial1, ONEWIRE_PIN1);
-  beginOneWire(Serial2, ONEWIRE_PIN2);
-  // GPIO ONEWIRE_PIN1 already carries UART1 TX; route that same signal onto
-  // ONEWIRE_PIN2. With an optional jumper, both ends therefore have identical levels.
-  uart_internal_loopback(1, ONEWIRE_PIN2);
-  Serial.printf("  Internal loopback: UART1 TX -> UART2 one-wire GPIO %d\n", ONEWIRE_PIN2);
-#else
-  Serial.printf("  External bus: jumper GPIO %d <-> GPIO %d (+ pull-up recommended)\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-  Serial.printf(
-    "  Turn 1 roles: UART1 TX on GPIO %d (RX parked on GPIO %d); UART2 RX on GPIO %d (TX parked on GPIO %d).\n", ONEWIRE_PIN1,
-    ONEWIRE_PARK_PIN1, ONEWIRE_PIN2, ONEWIRE_PARK_PIN2
-  );
-  if (!setExternalBusRoles(Serial1, ONEWIRE_PIN1, ONEWIRE_PARK_PIN1, Serial2, ONEWIRE_PIN2, ONEWIRE_PARK_PIN2)) {
-    g_dualPeerReady = false;
-    return false;
-  }
-#endif
-
-  delay(20);
-  drain(Serial1);
-  drain(Serial2);
-  Serial.printf("  Turn 1: UART1 sends \"%s\" to UART2\n", PEER_REQUEST);
-  Serial1.println(PEER_REQUEST);
-  Serial1.flush();
-  delay(150);
-
-  if (!waitForBytes(Serial2, 300)) {
-    Serial.printf("  Cross test failed — UART2 GPIO %d received nothing.", ONEWIRE_PIN2);
-    if (USE_INTERNAL_LOOPBACK) {
-      Serial.println(" Internal loopback enabled — verify board has 3+ UARTs and valid ONEWIRE_PIN2.");
-    } else {
-      Serial.printf(" Check wire GPIO %d <-> %d and pull-up to 3.3 V.\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-    }
-    g_dualPeerReady = false;
-    return false;
-  }
-
-  String line = readLine(Serial2);
-  Serial.printf("UART2 received: \"%s\"\n", line.c_str());
-  if (line != PEER_REQUEST) {
-    Serial.println("  Cross test failed — UART2 request did not match.");
-    g_dualPeerReady = false;
-    return false;
-  }
-
-  // Clear both receivers before reversing direction on the half-duplex bus.
-  drain(Serial1);
-  drain(Serial2);
-
-#if USE_INTERNAL_LOOPBACK
-  // Turn 1 left UART1 TX driving ONEWIRE_PIN2. Put UART2 TX back on its own pad first;
-  // then route UART2 TX onto ONEWIRE_PIN1. Both changes happen after UART1.flush(),
-  // while the line is idle HIGH. During Turn 2 both pads carry UART2 TX, so an
-  // optional jumper connects identical signals instead of causing output contention.
-  restoreUartTxToOwnPin(2, ONEWIRE_PIN2);
-  uart_internal_loopback(2, ONEWIRE_PIN1);
-  Serial.printf("  Internal loopback reversed: UART2 TX -> UART1 one-wire GPIO %d\n", ONEWIRE_PIN1);
-#else
-  Serial.printf(
-    "  Turn 2 roles: UART2 TX on GPIO %d (RX parked on GPIO %d); UART1 RX on GPIO %d (TX parked on GPIO %d).\n", ONEWIRE_PIN2,
-    ONEWIRE_PARK_PIN2, ONEWIRE_PIN1, ONEWIRE_PARK_PIN1
-  );
-  if (!setExternalBusRoles(Serial2, ONEWIRE_PIN2, ONEWIRE_PARK_PIN2, Serial1, ONEWIRE_PIN1, ONEWIRE_PARK_PIN1)) {
-    g_dualPeerReady = false;
-    return false;
-  }
-#endif
-
-  Serial.printf("  Turn 2: UART2 sends \"%s\" to UART1\n", PEER_REPLY);
-  Serial2.println(PEER_REPLY);
-  Serial2.flush();
-  delay(150);
-
-  if (!waitForBytes(Serial1, 300)) {
-    Serial.printf("  Cross test failed — UART1 GPIO %d received no reply.\n", ONEWIRE_PIN1);
-#if USE_INTERNAL_LOOPBACK
-    restoreUartTxToOwnPin(1, ONEWIRE_PIN1);
-    uart_internal_loopback(1, ONEWIRE_PIN2);
-#endif
-    g_dualPeerReady = false;
-    return false;
-  }
-
-  line = readLine(Serial1);
-  Serial.printf("UART1 received reply: \"%s\"\n", line.c_str());
-
-#if USE_INTERNAL_LOOPBACK
-  // Restore UART1 TX on both pads for interactive UART1 -> UART2 forwarding.
-  restoreUartTxToOwnPin(1, ONEWIRE_PIN1);
-  uart_internal_loopback(1, ONEWIRE_PIN2);
-  g_interactiveUart2Drives = false;
-#else
-  // Keep Turn 2 roles for interactive mode. A second swap back to UART1-TX/UART2-RX
-  // is unnecessary because Turn 2 already proved UART2 -> UART1.
-  g_interactiveUart2Drives = true;
-  Serial.printf(
-    "  Interactive roles (unchanged from Turn 2): UART2 TX on GPIO %d; UART1 RX on GPIO %d.\n", ONEWIRE_PIN2, ONEWIRE_PIN1
-  );
-#endif
-
-  // Remove any leftover RX data before entering interactive mode.
-  drain(Serial1);
-  drain(Serial2);
-
-  g_dualPeerReady = (line == PEER_REPLY);
-  if (!g_dualPeerReady) {
-    Serial.println("  Cross test failed — UART1 reply did not match.");
-  }
-  return g_dualPeerReady;
-}
-#endif
 
 void setup() {
-  Serial.begin(BAUD);
+  Serial.begin(115200);
   delay(500);
   Serial.println("\n=== One-Wire UART Demo ===");
-  Serial.printf("UART1 one-wire/bus pin (ONEWIRE_PIN1): GPIO %d\n", ONEWIRE_PIN1);
-#if HAS_UART2
-  Serial.printf("UART2 peer bus pin (ONEWIRE_PIN2): GPIO %d\n", ONEWIRE_PIN2);
-#else
-  Serial.println("Part B skipped on this board (fewer than 3 HP UARTs or no RX2 define).");
-#endif
-  printLoopbackModeBanner();
-  printPartAWiringInstructions();
-#if HAS_UART2
-#if USE_INTERNAL_LOOPBACK
-  Serial.printf(
-    "Part B preview: no jumper required (optional/redundant); internal matrix routes UART1 GPIO %d <-> UART2 GPIO %d.\n", ONEWIRE_PIN1,
-    ONEWIRE_PIN2
-  );
-#else
-  Serial.printf("Part B preview: connect one wire between UART1 GPIO %d and UART2 GPIO %d.\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
-#endif
-#endif
-  Serial.println();
+  Serial.printf("One-wire GPIO: %d\n", ONEWIRE_PIN);
 
-  if (runSelfLoopbackTest()) {
-    Serial.println("Part A OK");
+  if (runSelfEchoTest()) {
+    Serial.println("\nType in the Serial Monitor: bytes are sent on the one-wire GPIO and echoed back.");
   } else {
-    Serial.println("Part A failed");
+    Serial.println("\nSelf-echo failed. Check that ONEWIRE_PIN is a valid GPIO.");
   }
-
-#if HAS_UART2
-  if (runDualPeerCrossTest()) {
-    Serial.println("Part B OK");
-    Serial.println("\nBidirectional single-wire cross test passed.");
-    if (g_interactiveUart2Drives) {
-      Serial.println("Type in Serial Monitor and press Send — bytes go UART2 -> bus -> UART1 and print here.");
-    } else {
-      Serial.println("Type in Serial Monitor and press Send — bytes go UART1 -> bus -> UART2 and print here.");
-    }
-  } else {
-    Serial.println("Part B failed — interactive peer mode disabled.");
-  }
-#else
-  Serial.println("\nPart B skipped (board has fewer than 3 UARTs or no RX2 define).");
-  Serial.println("Type in Serial Monitor — UART1 echoes on the same one-wire GPIO (Part A only).");
-#endif
 }
 
 void loop() {
-#if HAS_UART2
-  if (g_dualPeerReady) {
-    HardwareSerial &driveUart = g_interactiveUart2Drives ? Serial2 : Serial1;
-    HardwareSerial &listenUart = g_interactiveUart2Drives ? Serial1 : Serial2;
-    bool sent = false;
-    while (Serial.available()) {
-      driveUart.write((uint8_t)Serial.read());
-      sent = true;
-    }
-    if (sent) {
-      driveUart.flush();
-    }
-#if USE_INTERNAL_LOOPBACK
-    // One-wire / matrix path also receives its own TX; discard so the RX buffer cannot fill.
-    while (driveUart.available()) {
-      driveUart.read();
-    }
-#endif
-    while (listenUart.available()) {
-      Serial.write(listenUart.read());
-    }
-    return;
-  }
-#endif
-
+  // Forward Serial Monitor input onto the one-wire UART.
   if (Serial.available()) {
-    int c = Serial.read();
-    Serial1.write(c);
+    Serial1.write((uint8_t)Serial.read());
     Serial1.flush();
   }
+  // Print whatever comes back on the one-wire GPIO (its own echo).
   if (Serial1.available()) {
     Serial.write(Serial1.read());
   }

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/OneWire_UART_Demo.ino
@@ -1,10 +1,11 @@
 /*
   One-Wire UART Demo
 
-  Uses enableOneWireMode(true) so RX and TX share one GPIO (ESP-IDF one-wire / single-wire UART).
+  Same-pin RX/TX automatically enables one-wire UART (no opt-in API).
+  Use setPins(p, p) or begin(..., p, p); -1 keep-current that makes RX==TX also enables it.
 
   Part A (all boards): UART1 self loopback on one GPIO — verifies one-wire TX/RX on the same pad.
-  Part B (3+ UART boards): UART1 one-wire peer -> UART2 one-wire peer (half-duplex bus).
+  Part B (3+ UART boards): UART1 <-> UART2 half-duplex cross test over one external wire.
 
   Set USE_INTERNAL_LOOPBACK to 1 for GPIO-matrix routing (no jumper), or 0 and wire ONEWIRE_PIN1
   to ONEWIRE_PIN2 with an external pull-up on the shared line for bus-style use.
@@ -16,6 +17,7 @@
 */
 
 #include <Arduino.h>
+#include "driver/gpio.h"
 
 // 1 = GPIO matrix connects UART1 TX to the peer RX pad (no external wire)
 // 0 = jumper ONEWIRE_PIN1 <-> ONEWIRE_PIN2 (+ external pull-up recommended on the bus)
@@ -44,13 +46,14 @@
 
 static const uint32_t BAUD = 115200;
 static const char *TEST_MSG = "ONEWIRE";
+static const char *PEER_REQUEST = "UART1_TO_UART2";
+static const char *PEER_REPLY = "UART2_TO_UART1";
 
 static bool g_dualPeerReady = false;
 
 static void beginOneWire(HardwareSerial &uart, int8_t pin) {
   uart.end();
-  uart.enableOneWireMode(true);
-  uart.setPins(pin, pin);
+  uart.setPins(pin, pin);  // same-pin auto-enables one-wire
   uart.begin(BAUD, SERIAL_8N1, pin, pin);
   while (!uart) {
     delay(10);
@@ -80,6 +83,18 @@ static void drain(HardwareSerial &uart) {
   }
 }
 
+#if HAS_UART2 && !USE_INTERNAL_LOOPBACK
+static bool setOneWireDrive(int8_t pin, bool enabled) {
+  // Do not use pinMode(): it would release the UART_RX_TX peripheral-manager ownership.
+  gpio_mode_t mode = enabled ? GPIO_MODE_INPUT_OUTPUT : GPIO_MODE_INPUT;
+  if (gpio_set_direction((gpio_num_t)pin, mode) != ESP_OK) {
+    Serial.printf("  Failed to %s TX drive on GPIO %d.\n", enabled ? "enable" : "disable", pin);
+    return false;
+  }
+  return true;
+}
+#endif
+
 static void printLoopbackModeBanner() {
   Serial.printf("USE_INTERNAL_LOOPBACK=%d", USE_INTERNAL_LOOPBACK);
   if (USE_INTERNAL_LOOPBACK) {
@@ -101,13 +116,13 @@ static void printPartAWiringInstructions() {
 static void printPartBWiringInstructions() {
   Serial.println();
   if (USE_INTERNAL_LOOPBACK) {
-    Serial.println("  Part B: no wire — UART1 TX routed internally to UART2 one-wire pad.");
-    Serial.printf("    UART1 one-wire GPIO %d  ~~internal~~>  UART2 one-wire GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+    Serial.println("  Part B: no wire — GPIO-matrix routing switches direction between each half-duplex turn.");
+    Serial.printf("    UART1 GPIO %d  <~~internal~~>  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
   } else {
-    Serial.println("  Part B wiring — half-duplex bus between UART one-wire pads:");
+    Serial.println("  Part B wiring — one wire between both UART one-wire pads:");
     Serial.printf("    UART1 GPIO %d  <----bus---->  UART2 GPIO %d\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
     Serial.println("  External pull-up on the shared line recommended.");
-    Serial.println("  Never transmit from both UARTs at the same time.");
+    Serial.println("  The sketch tri-states the listening UART TX; never enable both TX drivers together.");
   }
   Serial.println();
 }
@@ -145,9 +160,15 @@ static bool runSelfLoopbackTest() {
 }
 
 #if HAS_UART2
-static bool runDualPeerLoopbackTest() {
-  Serial.printf("\n=== Part B: UART1 -> UART2 one-wire peer (GPIO %d -> GPIO %d) ===\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+static bool runDualPeerCrossTest() {
+  Serial.printf("\n=== Part B: UART1 <-> UART2 one-wire cross test (GPIO %d <-> GPIO %d) ===\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
   printPartBWiringInstructions();
+
+  if (ONEWIRE_PIN1 == ONEWIRE_PIN2) {
+    Serial.println("  Cross test requires two different GPIOs connected by one wire; change ONEWIRE_PIN1 or ONEWIRE_PIN2.");
+    g_dualPeerReady = false;
+    return false;
+  }
 
   beginOneWire(Serial1, ONEWIRE_PIN1);
   beginOneWire(Serial2, ONEWIRE_PIN2);
@@ -157,15 +178,27 @@ static bool runDualPeerLoopbackTest() {
   Serial.printf("  Internal loopback: UART1 TX -> UART2 one-wire GPIO %d\n", ONEWIRE_PIN2);
 #else
   Serial.printf("  External bus: jumper GPIO %d <-> GPIO %d (+ pull-up recommended)\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+  if (!setOneWireDrive(ONEWIRE_PIN1, false) || !setOneWireDrive(ONEWIRE_PIN2, false) || !setOneWireDrive(ONEWIRE_PIN1, true)) {
+    g_dualPeerReady = false;
+    return false;
+  }
 #endif
 
+  drain(Serial1);
   drain(Serial2);
-  Serial1.println(TEST_MSG);
+  Serial.printf("  Turn 1: UART1 sends \"%s\" to UART2\n", PEER_REQUEST);
+  Serial1.println(PEER_REQUEST);
   Serial1.flush();
+#if !USE_INTERNAL_LOOPBACK
+  if (!setOneWireDrive(ONEWIRE_PIN1, false)) {
+    g_dualPeerReady = false;
+    return false;
+  }
+#endif
   delay(150);
 
   if (!waitForBytes(Serial2, 300)) {
-    Serial.printf("  Peer loopback failed — UART2 GPIO %d received nothing.", ONEWIRE_PIN2);
+    Serial.printf("  Cross test failed — UART2 GPIO %d received nothing.", ONEWIRE_PIN2);
     if (USE_INTERNAL_LOOPBACK) {
       Serial.println(" Internal loopback enabled — verify board has 3+ UARTs and valid ONEWIRE_PIN2.");
     } else {
@@ -177,7 +210,70 @@ static bool runDualPeerLoopbackTest() {
 
   String line = readLine(Serial2);
   Serial.printf("UART2 received: \"%s\"\n", line.c_str());
-  g_dualPeerReady = (line == TEST_MSG);
+  if (line != PEER_REQUEST) {
+    Serial.println("  Cross test failed — UART2 request did not match.");
+    g_dualPeerReady = false;
+    return false;
+  }
+
+  // The sender also sees its own transmission in one-wire mode; clear both receivers
+  // before reversing direction on the half-duplex bus.
+  drain(Serial1);
+  drain(Serial2);
+
+#if USE_INTERNAL_LOOPBACK
+  uart_internal_loopback(2, ONEWIRE_PIN1);
+  Serial.printf("  Internal loopback reversed: UART2 TX -> UART1 one-wire GPIO %d\n", ONEWIRE_PIN1);
+#else
+  Serial.println("  Turn 2: same external wire, UART2 now transmits while UART1 listens.");
+  if (!setOneWireDrive(ONEWIRE_PIN2, true)) {
+    g_dualPeerReady = false;
+    return false;
+  }
+#endif
+
+  Serial.printf("  Turn 2: UART2 sends \"%s\" to UART1\n", PEER_REPLY);
+  Serial2.println(PEER_REPLY);
+  Serial2.flush();
+#if !USE_INTERNAL_LOOPBACK
+  if (!setOneWireDrive(ONEWIRE_PIN2, false)) {
+    g_dualPeerReady = false;
+    return false;
+  }
+#endif
+  delay(150);
+
+  if (!waitForBytes(Serial1, 300)) {
+    Serial.printf("  Cross test failed — UART1 GPIO %d received no reply.\n", ONEWIRE_PIN1);
+#if USE_INTERNAL_LOOPBACK
+    uart_internal_loopback(1, ONEWIRE_PIN2);
+#endif
+    g_dualPeerReady = false;
+    return false;
+  }
+
+  line = readLine(Serial1);
+  Serial.printf("UART1 received reply: \"%s\"\n", line.c_str());
+
+#if USE_INTERNAL_LOOPBACK
+  // Restore UART1 -> UART2 for the interactive mode in loop().
+  uart_internal_loopback(1, ONEWIRE_PIN2);
+#else
+  // Interactive mode sends UART1 -> UART2, so only UART1 may drive the wire.
+  if (!setOneWireDrive(ONEWIRE_PIN1, true)) {
+    g_dualPeerReady = false;
+    return false;
+  }
+#endif
+
+  // Remove any sender self-echo before entering interactive mode.
+  drain(Serial1);
+  drain(Serial2);
+
+  g_dualPeerReady = (line == PEER_REPLY);
+  if (!g_dualPeerReady) {
+    Serial.println("  Cross test failed — UART1 reply did not match.");
+  }
   return g_dualPeerReady;
 }
 #endif
@@ -195,7 +291,7 @@ void setup() {
   printLoopbackModeBanner();
   printPartAWiringInstructions();
 #if HAS_UART2
-  Serial.printf("Part B preview: UART1 GPIO %d -> UART2 GPIO %d (details before Part B runs).\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
+  Serial.printf("Part B preview: connect one wire between UART1 GPIO %d and UART2 GPIO %d.\n", ONEWIRE_PIN1, ONEWIRE_PIN2);
 #endif
   Serial.println();
 
@@ -204,9 +300,10 @@ void setup() {
   }
 
 #if HAS_UART2
-  if (runDualPeerLoopbackTest()) {
+  if (runDualPeerCrossTest()) {
     Serial.println("Part B OK");
-    Serial.println("\nType in Serial Monitor — bytes go to UART1; replies print from UART2 (half-duplex peer).");
+    Serial.println("\nBidirectional single-wire cross test passed.");
+    Serial.println("Type in Serial Monitor — bytes go from UART1 to UART2 and print here.");
   } else {
     Serial.println("Part B failed — interactive peer mode disabled.");
   }

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
@@ -68,6 +68,30 @@ ESP-IDF documents that routing TX output and RX input to one GPIO can cause **pa
 
 Internal pull on RX is **disabled** in one-wire mode.
 
+## Why one-wire UART can receive ghost data
+
+In one-wire mode, the pad is deliberately left **floating** (no internal pull), and RX is always listening on the same pin that TX drives. Any brief LOW or noise on that pad looks like a UART start bit, so the receiver produces framing errors, BREAK events, or “ghost” bytes even with no intentional traffic.
+
+Main causes:
+
+1. **No idle bias** — split-pin UART uses RX pull-up so idle stays HIGH. One-wire disables that pull so TX isn’t fighting an internal resistor. When TX is not firmly driving (startup, pin mux change, tri-state between turns, weak/open bus), the line floats and RX samples garbage.
+2. **TX/RX pad conflict** — both output and input are on one GPIO. During attach/mux changes the line can glitch LOW, causing a start bit or BREAK.
+3. **Self-echo** — TX is also seen on RX. That is expected for intentional transmission; noise on TX looks the same.
+4. **External bus without pull-up** — two one-wire peers with listening TX tri-stated leave the wire floating between turns.
+
+## How to prevent it
+
+| Approach | Effect |
+|---|---|
+| **External pull-up** (approximately 4.7–10 kΩ to 3.3 V) on the one-wire pad or shared bus | Holds idle HIGH when nothing drives—the strongest fix |
+| **Drain RX after `begin()` or `setPins()`** using `while (available()) read()` | Clears glitches generated during pin attachment |
+| **Ignore data until the first valid frame** or require a known preamble | Filters noise before real protocol traffic |
+| **Use half-duplex only**—never leave both TX drivers enabled; tri-state the listener | Avoids push-pull conflicts that corrupt the idle level |
+| **Use shorter wires and reduce nearby electrical noise** | Reduces false start bits on a floating pad |
+| **Do not re-enable the internal pull in one-wire mode** | Prevents the pull resistor from fighting TX |
+
+The internal pull is intentionally disabled in one-wire mode. Rely on **TX idle HIGH** while transmitting and use an **external pull-up** whenever the line can float.
+
 ## Usage
 
 1. Upload `OneWire_UART_Demo.ino`.

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
@@ -1,6 +1,6 @@
 # One-Wire UART Demo
 
-Demonstrates **one-wire mode**: RX and TX on the **same GPIO** using `enableOneWireMode(true)`.
+Demonstrates **one-wire mode**: RX and TX on the **same GPIO**. Same-pin configuration auto-enables one-wire (no separate opt-in API).
 
 ## Supported SoCs
 
@@ -24,16 +24,16 @@ LP UART on **ESP32-C5/C6/C61** uses fixed RX/TX pins — one-wire is **not** sup
 | Part | UARTs | Connection | Purpose |
 |------|-------|------------|---------|
 | **A — Self loopback** | UART1 only | Same GPIO for RX+TX | Proves one-wire TX/RX on one pad |
-| **B — Peer loopback** | UART1 → UART2 | Two one-wire GPIOs | Half-duplex bus between two UART instances |
+| **B — Cross connection** | UART1 ↔ UART2 | One signal wire between two one-wire GPIOs | Bidirectional half-duplex request/reply between two UART instances |
 
-Part B runs only when the board has **3+ HP UARTs** and defines `RX2` (same guard as `IrdaMode_DualUART_Demo` / `RxPull_Demo`).
+Part B runs only when the board has **3+ HP UARTs** and defines `RX2` (UART0 remains available for Serial Monitor output). UART1 first sends a request to UART2; UART2 then sends a reply to UART1 over the same wire.
 
 ## Requirements
 
-- `enableOneWireMode(true)` **before** `begin()`
 - `UART_MODE_UART` only (not RS485, not IrDA)
-- Same GPIO for RX and TX in `setPins(p, p)` or `begin(..., p, p)`
-- **Half-duplex traffic** — do not transmit from both UARTs at once
+- Same GPIO for RX and TX in `setPins(p, p)` or `begin(..., p, p)` — one-wire is automatic
+- `-1` keep-current that makes effective RX equal TX also enables one-wire (e.g. RX=8 TX=9 then `setPins(-1, 8)`)
+- **Half-duplex traffic** — only one UART TX output may be enabled at a time
 
 ## Loopback options
 
@@ -41,10 +41,10 @@ Set `USE_INTERNAL_LOOPBACK` at the top of the sketch:
 
 | Value | Part A | Part B |
 |-------|--------|--------|
-| `1` (default) | `uart_internal_loopback(1, ONEWIRE_PIN1)` | `uart_internal_loopback(1, ONEWIRE_PIN2)` routes UART1 TX to UART2’s GPIO |
-| `0` | Optional jumper on ONEWIRE_PIN1 | Jumper **ONEWIRE_PIN1 ↔ ONEWIRE_PIN2** |
+| `1` (default) | `uart_internal_loopback(1, ONEWIRE_PIN1)` | GPIO-matrix routing switches UART1→UART2, then UART2→UART1 |
+| `0` | Optional jumper on ONEWIRE_PIN1 | One signal wire: **ONEWIRE_PIN1 ↔ ONEWIRE_PIN2**; both directions use it in turn |
 
-For external bus wiring, add a **pull-up** on the shared line (open-drain / multi-drop style). Push-pull one-wire on two GPIOs wired together can work for this demo if only one side drives at a time.
+For external wiring, the sketch changes the listening GPIO to input-only while preserving its UART RX routing, then enables input/output mode only for the current transmitter. This prevents the listening push-pull TX from holding the line HIGH against the sender. Add an external **pull-up** to hold the line at UART idle HIGH during direction changes.
 
 On USB Serial, the sketch prints **`USE_INTERNAL_LOOPBACK`**, the **GPIO numbers** for `ONEWIRE_PIN1` / `ONEWIRE_PIN2`, and wiring instructions (no jumper vs external bus) before each part runs.
 
@@ -55,14 +55,15 @@ On USB Serial, the sketch prints **`USE_INTERNAL_LOOPBACK`**, the **GPIO numbers
 | `ONEWIRE_PIN1` | `SDA` (board `pins_arduino.h`) | UART1 one-wire GPIO |
 | `ONEWIRE_PIN2` | `RX2` | UART2 one-wire GPIO (Part B) |
 
-Change the `#ifndef` defaults for your board if those pads are unavailable.
+Change the `#ifndef` defaults for your board if those pads are unavailable. Part B requires two different GPIOs; the sketch rejects equal `ONEWIRE_PIN1` and `ONEWIRE_PIN2` values.
 
 ## Electrical warning
 
 ESP-IDF documents that routing TX output and RX input to one GPIO can cause **pad conflicts**. Recommended practices:
 
-- Half-duplex protocol (never drive TX while listening on the same peer)
-- Open-drain TX with external pull-up on shared bus lines
+- Half-duplex protocol with the listening TX output tri-stated
+- External pull-up so the line remains idle HIGH while neither UART drives
+- Never enable both push-pull TX outputs on the connected wire simultaneously
 - **Not** a replacement for RS485 (which needs separate TX, RX, and RTS to a transceiver)
 
 Internal pull on RX is **disabled** in one-wire mode.
@@ -74,21 +75,22 @@ Internal pull on RX is **disabled** in one-wire mode.
 3. Read the startup lines: one-wire **GPIO numbers**, `USE_INTERNAL_LOOPBACK` mode, and Part A/B wiring summary.
 4. If `USE_INTERNAL_LOOPBACK=0`, connect the jumper(s) shown on Serial Monitor, then reset or re-upload.
 5. Read Part A/B self-test results on startup.
-6. **Part B interactive:** type characters — they are sent on UART1; bytes received on UART2 are printed to USB Serial.
-7. **Part A only (2-UART boards without Part B):** typed characters echo on UART1’s one-wire GPIO.
+6. **Part B startup test:** confirm UART2 receives `UART1_TO_UART2`, then UART1 receives `UART2_TO_UART1` over the same connection.
+7. **Part B interactive:** type characters — they are sent on UART1; bytes received on UART2 are printed to USB Serial.
+8. **Part A only (2-UART boards without Part B):** typed characters echo on UART1’s one-wire GPIO.
 
 ## Expected serial output
 
 1. **Startup** — `ONEWIRE_PIN1` / `ONEWIRE_PIN2` GPIO numbers, loopback mode banner, Part A wiring line, Part B preview (when compiled).
 2. **Part A** — `"ONEWIRE"` received on UART1 self loopback, or failure text with GPIO and loopback hint.
-3. **Part B** — wiring block (internal or external), then `"ONEWIRE"` on UART2, or failure text with GPIO pair to connect when external loopback is used.
+3. **Part B** — wiring block (internal or one external wire), `"UART1_TO_UART2"` received on UART2, then `"UART2_TO_UART1"` received on UART1.
 
 ## Wiring (external loopback, `USE_INTERNAL_LOOPBACK = 0`)
 
 The sketch prints the exact GPIO numbers for your board. Conceptually:
 
 ```
-UART1 GPIO (ONEWIRE_PIN1) ---- bus ---- UART2 GPIO (ONEWIRE_PIN2)
+UART1 GPIO (ONEWIRE_PIN1) ---- one wire ---- UART2 GPIO (ONEWIRE_PIN2)
                                 |
                            pull-up (recommended)
 ```

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
@@ -23,10 +23,12 @@ LP UART on **ESP32-C5/C6/C61** uses fixed RX/TX pins — one-wire is **not** sup
 
 | Part | UARTs | Connection | Purpose |
 |------|-------|------------|---------|
-| **A — Self loopback** | UART1 only | Same GPIO for RX+TX | Proves one-wire TX/RX on one pad |
-| **B — Cross connection** | UART1 ↔ UART2 | One signal wire between two one-wire GPIOs | Bidirectional half-duplex request/reply between two UART instances |
+| **A — Self-echo** | UART1 only | Same GPIO for RX+TX; no jumper | Proves automatic one-wire RX/TX on one pad |
+| **B — Cross connection** | UART1 ↔ UART2 | One signal wire between two bus GPIOs | Bidirectional half-duplex request/reply between two UART instances |
 
-Part B runs only when the board has **3+ HP UARTs** and defines `RX2` (UART0 remains available for Serial Monitor output). UART1 first sends a request to UART2; UART2 then sends a reply to UART1 over the same wire.
+Part B runs only when the board has **3+ HP UARTs** and defines `RX2`, `TX1`, and `TX2` (UART0 remains available for Serial Monitor output). UART1 first sends a request to UART2; UART2 then sends a reply to UART1 over the same wire.
+
+Part A is the direct one-wire API demonstration (`RX == TX`). External Part B uses split RX/TX assignments to ensure that only one push-pull TX output is connected to the shared wire. It demonstrates a practical single-wire half-duplex link, but it does not put both UART endpoints in one-wire mode simultaneously.
 
 ## Requirements
 
@@ -42,7 +44,7 @@ Set `USE_INTERNAL_LOOPBACK` at the top of the sketch:
 | Value | Part A | Part B |
 |-------|--------|--------|
 | `1` (default) | `uart_internal_loopback(1, ONEWIRE_PIN1)` | No jumper required; an existing jumper is optional and redundant |
-| `0` | Optional jumper on ONEWIRE_PIN1 | One signal wire: **ONEWIRE_PIN1 ↔ ONEWIRE_PIN2**; both directions use it in turn |
+| `0` | No jumper; same-pad self-echo | One signal wire: **ONEWIRE_PIN1 ↔ ONEWIRE_PIN2**; **4.7–10 kΩ pull-up to 3.3 V recommended** |
 
 With `USE_INTERNAL_LOOPBACK=1`, the sketch synchronizes GPIO-matrix output routing before each turn:
 
@@ -52,7 +54,16 @@ With `USE_INTERNAL_LOOPBACK=1`, the sketch synchronizes GPIO-matrix output routi
 
 Consequently, an installed jumper connects two pads carrying the same signal rather than shorting UART1 TX against UART2 TX. The jumper is harmless in this test but electrically redundant because the GPIO matrix already provides the connection.
 
-For external wiring, the sketch changes the listening GPIO to input-only while preserving its UART RX routing, then enables input/output mode only for the current transmitter. This prevents the listening push-pull TX from holding the line HIGH against the sender. Add an external **pull-up** to hold the line at UART idle HIGH during direction changes.
+With `USE_INTERNAL_LOOPBACK=0`, connecting two push-pull TX outputs to one wire would cause contention. The sketch therefore keeps **only one UART TX on the bus** each turn:
+
+- **Driver:** TX on its bus pad; RX is parked on its off-bus parking GPIO.
+- **Listener:** RX on its bus pad; TX is parked on its off-bus parking GPIO.
+
+The default parking GPIOs are `TX1` and `TX2`; leave them physically unconnected. You may override them with `ONEWIRE_PARK_PIN1` and `ONEWIRE_PARK_PIN2`. The sketch rejects any duplicate bus/parking GPIO assignment.
+
+Roles swap between Turn 1 and Turn 2. For interactive mode after an external Part B, the sketch **keeps Turn 2 roles** (UART2 drives, UART1 listens). This avoids another pin-role change and uses the direction that the startup test just verified.
+
+The external pull-up is recommended because both UARTs are briefly detached while roles change; the test may work without it because the active TX drives idle HIGH. Never transmit from both UARTs at once.
 
 On USB Serial, the sketch prints **`USE_INTERNAL_LOOPBACK`**, the **GPIO numbers** for `ONEWIRE_PIN1` / `ONEWIRE_PIN2`, and wiring instructions (no jumper vs external bus) before each part runs.
 
@@ -60,18 +71,20 @@ On USB Serial, the sketch prints **`USE_INTERNAL_LOOPBACK`**, the **GPIO numbers
 
 | Define | Default | Role |
 |--------|---------|------|
-| `ONEWIRE_PIN1` | `SDA` (board `pins_arduino.h`) | UART1 one-wire GPIO |
-| `ONEWIRE_PIN2` | `RX2` | UART2 one-wire GPIO (Part B) |
+| `ONEWIRE_PIN1` | `SDA` (board `pins_arduino.h`) | UART1 one-wire pad in Part A; UART1 bus pad in Part B |
+| `ONEWIRE_PIN2` | `RX2` | UART2 bus pad in Part B |
+| `ONEWIRE_PARK_PIN1` | `TX1` | UART1 off-bus RX/TX parking GPIO in external Part B |
+| `ONEWIRE_PARK_PIN2` | `TX2` | UART2 off-bus RX/TX parking GPIO in external Part B |
 
-Change the `#ifndef` defaults for your board if those pads are unavailable. Part B requires two different GPIOs; the sketch rejects equal `ONEWIRE_PIN1` and `ONEWIRE_PIN2` values.
+Override these defines before their `#ifndef` defaults if the selected pads are unavailable. External Part B requires all four bus/parking GPIOs to be distinct.
 
 ## Electrical warning
 
 ESP-IDF documents that routing TX output and RX input to one GPIO can cause **pad conflicts**. Recommended practices:
 
-- Half-duplex protocol with the listening TX output tri-stated
-- External pull-up so the line remains idle HIGH while neither UART drives
-- Never enable both push-pull TX outputs on the connected wire simultaneously
+- On a two-UART external bus: only one TX on the wire; park unused RX/TX off-bus (this demo’s external Part B)
+- External pull-up (4.7–10 kΩ to 3.3 V) so idle stays HIGH
+- Half-duplex protocol — never transmit from both UARTs at once
 - **Not** a replacement for RS485 (which needs separate TX, RX, and RTS to a transceiver)
 
 Internal pull on RX is **disabled** in one-wire mode.
@@ -85,7 +98,7 @@ Main causes:
 1. **No idle bias** — split-pin UART uses RX pull-up so idle stays HIGH. One-wire disables that pull so TX isn’t fighting an internal resistor. When TX is not firmly driving (startup, pin mux change, tri-state between turns, weak/open bus), the line floats and RX samples garbage.
 2. **TX/RX pad conflict** — both output and input are on one GPIO. During attach/mux changes the line can glitch LOW, causing a start bit or BREAK.
 3. **Self-echo** — TX is also seen on RX. That is expected for intentional transmission; noise on TX looks the same.
-4. **External bus without pull-up** — two one-wire peers with listening TX tri-stated leave the wire floating between turns.
+4. **External bus without idle bias** — a shared wire can float while UART pins are detached or TX outputs are disconnected between turns.
 
 ## How to prevent it
 
@@ -94,7 +107,7 @@ Main causes:
 | **External pull-up** (approximately 4.7–10 kΩ to 3.3 V) on the one-wire pad or shared bus | Holds idle HIGH when nothing drives—the strongest fix |
 | **Drain RX after `begin()` or `setPins()`** using `while (available()) read()` | Clears glitches generated during pin attachment |
 | **Ignore data until the first valid frame** or require a known preamble | Filters noise before real protocol traffic |
-| **Use half-duplex only**—never leave both TX drivers enabled; tri-state the listener | Avoids push-pull conflicts that corrupt the idle level |
+| **Use half-duplex only**—disconnect, reroute, or disable the listener's TX | Prevents two push-pull TX outputs from driving the shared wire |
 | **Use shorter wires and reduce nearby electrical noise** | Reduces false start bits on a floating pad |
 | **Do not re-enable the internal pull in one-wire mode** | Prevents the pull resistor from fighting TX |
 
@@ -105,29 +118,45 @@ The internal pull is intentionally disabled in one-wire mode. Rely on **TX idle 
 1. Upload `OneWire_UART_Demo.ino`.
 2. Open Serial Monitor at **115200** baud.
 3. Read the startup lines: one-wire **GPIO numbers**, `USE_INTERNAL_LOOPBACK` mode, and Part A/B wiring summary.
-4. If `USE_INTERNAL_LOOPBACK=0`, connect the jumper(s) shown on Serial Monitor, then reset or re-upload.
-5. Read Part A/B self-test results on startup.
-6. **Part B startup test:** confirm UART2 receives `UART1_TO_UART2`, then UART1 receives `UART2_TO_UART1` over the same connection.
-7. **Part B interactive:** type characters — they are sent on UART1; bytes received on UART2 are printed to USB Serial.
-8. **Part A only (2-UART boards without Part B):** typed characters echo on UART1’s one-wire GPIO.
+4. To reproduce the external test, set `USE_INTERNAL_LOOPBACK` to `0`, connect `ONEWIRE_PIN1` directly to `ONEWIRE_PIN2`, and leave both parking GPIOs unconnected.
+5. Connect a 4.7–10 kΩ resistor from the signal wire to 3.3 V (recommended), then reset or re-upload.
+6. Read Part A/B self-test results on startup.
+7. **Part B startup test:** confirm UART2 receives `UART1_TO_UART2`, then UART1 receives `UART2_TO_UART1` over the same connection.
+8. **Part B interactive:** type text and press Send — external mode keeps Turn 2 roles, so bytes travel UART2 → wire → UART1 and print in Serial Monitor.
+9. **Part A only (boards without Part B):** typed characters self-echo through UART1’s one-wire GPIO.
 
 ## Expected serial output
 
 1. **Startup** — `ONEWIRE_PIN1` / `ONEWIRE_PIN2` GPIO numbers, loopback mode banner, Part A wiring line, Part B preview (when compiled).
-2. **Part A** — `"ONEWIRE"` received on UART1 self loopback, or failure text with GPIO and loopback hint.
-3. **Part B** — wiring block (internal or one external wire), `"UART1_TO_UART2"` received on UART2, then `"UART2_TO_UART1"` received on UART1.
+2. **Part A** — `"ONEWIRE"` received through UART1 same-pad self-echo, or failure text with a GPIO hint.
+3. **Part B** — wiring block (internal or one external signal wire), `"UART1_TO_UART2"` received on UART2, then `"UART2_TO_UART1"` received on UART1.
+4. **Interactive** — a direction line followed by the text entered in Serial Monitor.
 
-## Wiring (external loopback, `USE_INTERNAL_LOOPBACK = 0`)
+## Wiring (external cross-test, `USE_INTERNAL_LOOPBACK = 0`)
 
 The sketch prints the exact GPIO numbers for your board. Conceptually:
 
 ```
-UART1 GPIO (ONEWIRE_PIN1) ---- one wire ---- UART2 GPIO (ONEWIRE_PIN2)
+UART1 GPIO (ONEWIRE_PIN1) ---- bus ---- UART2 GPIO (ONEWIRE_PIN2)
                                 |
-                           pull-up (recommended)
+                     4.7–10 kΩ pull-up to 3.3 V
+
+UART1 parking GPIO (ONEWIRE_PARK_PIN1) ---- not connected
+UART2 parking GPIO (ONEWIRE_PARK_PIN2) ---- not connected
 ```
 
-For Part A self-test only, you can optionally short `ONEWIRE_PIN1` to itself; Part B needs the inter-UART jumper above.
+Part A needs no jumper because UART1 RX and TX are already routed to the same physical pad. Part B needs the inter-UART signal wire above; the pull-up is recommended but not required while an active TX holds the line HIGH.
+
+### Tested ESP32-S3 wiring
+
+With the generic ESP32-S3 variant defaults, Serial Monitor should print these assignments:
+
+- `ONEWIRE_PIN1`: GPIO 8
+- `ONEWIRE_PIN2`: GPIO 19
+- `ONEWIRE_PARK_PIN1`: GPIO 16 — leave unconnected
+- `ONEWIRE_PARK_PIN2`: GPIO 20 — leave unconnected
+
+Connect GPIO 8 directly to GPIO 19. A tested idle-bias value is **5.6 kΩ from that signal wire to 3.3 V**; the startup and interactive tests can also pass without it while the active TX holds the line HIGH. Set `USE_INTERNAL_LOOPBACK` to `0`, upload, open Serial Monitor at 115200 baud, type text, and press Send.
 
 ## Real-world note
 

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
@@ -1,0 +1,102 @@
+# One-Wire UART Demo
+
+Demonstrates **one-wire mode**: RX and TX on the **same GPIO** using `enableOneWireMode(true)`.
+
+## Supported SoCs
+
+| SoC | One-wire on HP UART | Notes |
+|-----|---------------------|-------|
+| ESP32 | ✓ | GPIO matrix |
+| ESP32-S2 | ✓ | GPIO matrix |
+| ESP32-S3 | ✓ | GPIO matrix |
+| ESP32-C2 | ✓ | GPIO matrix |
+| ESP32-C3 | ✓ | GPIO matrix |
+| ESP32-C5 | ✓ | HP UART only |
+| ESP32-C6 | ✓ | HP UART only |
+| ESP32-C61 | ✓ | HP UART only |
+| ESP32-H2 | ✓ | GPIO matrix |
+| ESP32-P4 | ✓ | HP UART and LP UART (GPIO matrix) |
+
+LP UART on **ESP32-C5/C6/C61** uses fixed RX/TX pins — one-wire is **not** supported there.
+
+## What the demo shows
+
+| Part | UARTs | Connection | Purpose |
+|------|-------|------------|---------|
+| **A — Self loopback** | UART1 only | Same GPIO for RX+TX | Proves one-wire TX/RX on one pad |
+| **B — Peer loopback** | UART1 → UART2 | Two one-wire GPIOs | Half-duplex bus between two UART instances |
+
+Part B runs only when the board has **3+ HP UARTs** and defines `RX2` (same guard as `IrdaMode_DualUART_Demo` / `RxPull_Demo`).
+
+## Requirements
+
+- `enableOneWireMode(true)` **before** `begin()`
+- `UART_MODE_UART` only (not RS485, not IrDA)
+- Same GPIO for RX and TX in `setPins(p, p)` or `begin(..., p, p)`
+- **Half-duplex traffic** — do not transmit from both UARTs at once
+
+## Loopback options
+
+Set `USE_INTERNAL_LOOPBACK` at the top of the sketch:
+
+| Value | Part A | Part B |
+|-------|--------|--------|
+| `1` (default) | `uart_internal_loopback(1, ONEWIRE_PIN1)` | `uart_internal_loopback(1, ONEWIRE_PIN2)` routes UART1 TX to UART2’s GPIO |
+| `0` | Optional jumper on ONEWIRE_PIN1 | Jumper **ONEWIRE_PIN1 ↔ ONEWIRE_PIN2** |
+
+For external bus wiring, add a **pull-up** on the shared line (open-drain / multi-drop style). Push-pull one-wire on two GPIOs wired together can work for this demo if only one side drives at a time.
+
+On USB Serial, the sketch prints **`USE_INTERNAL_LOOPBACK`**, the **GPIO numbers** for `ONEWIRE_PIN1` / `ONEWIRE_PIN2`, and wiring instructions (no jumper vs external bus) before each part runs.
+
+## Pins
+
+| Define | Default | Role |
+|--------|---------|------|
+| `ONEWIRE_PIN1` | `SDA` (board `pins_arduino.h`) | UART1 one-wire GPIO |
+| `ONEWIRE_PIN2` | `RX2` | UART2 one-wire GPIO (Part B) |
+
+Change the `#ifndef` defaults for your board if those pads are unavailable.
+
+## Electrical warning
+
+ESP-IDF documents that routing TX output and RX input to one GPIO can cause **pad conflicts**. Recommended practices:
+
+- Half-duplex protocol (never drive TX while listening on the same peer)
+- Open-drain TX with external pull-up on shared bus lines
+- **Not** a replacement for RS485 (which needs separate TX, RX, and RTS to a transceiver)
+
+Internal pull on RX is **disabled** in one-wire mode.
+
+## Usage
+
+1. Upload `OneWire_UART_Demo.ino`.
+2. Open Serial Monitor at **115200** baud.
+3. Read the startup lines: one-wire **GPIO numbers**, `USE_INTERNAL_LOOPBACK` mode, and Part A/B wiring summary.
+4. If `USE_INTERNAL_LOOPBACK=0`, connect the jumper(s) shown on Serial Monitor, then reset or re-upload.
+5. Read Part A/B self-test results on startup.
+6. **Part B interactive:** type characters — they are sent on UART1; bytes received on UART2 are printed to USB Serial.
+7. **Part A only (2-UART boards without Part B):** typed characters echo on UART1’s one-wire GPIO.
+
+## Expected serial output
+
+1. **Startup** — `ONEWIRE_PIN1` / `ONEWIRE_PIN2` GPIO numbers, loopback mode banner, Part A wiring line, Part B preview (when compiled).
+2. **Part A** — `"ONEWIRE"` received on UART1 self loopback, or failure text with GPIO and loopback hint.
+3. **Part B** — wiring block (internal or external), then `"ONEWIRE"` on UART2, or failure text with GPIO pair to connect when external loopback is used.
+
+## Wiring (external loopback, `USE_INTERNAL_LOOPBACK = 0`)
+
+The sketch prints the exact GPIO numbers for your board. Conceptually:
+
+```
+UART1 GPIO (ONEWIRE_PIN1) ---- bus ---- UART2 GPIO (ONEWIRE_PIN2)
+                                |
+                           pull-up (recommended)
+```
+
+For Part A self-test only, you can optionally short `ONEWIRE_PIN1` to itself; Part B needs the inter-UART jumper above.
+
+## Real-world note
+
+For same-pin half-duplex on a **single** UART pad, Part A is the relevant model. For a **bus** between two UART instances, see Part B and keep half-duplex discipline.
+
+For split-pin RX pull behavior, see `RxPull_Demo`.

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
@@ -2,6 +2,8 @@
 
 Demonstrates **one-wire mode**: RX and TX on the **same GPIO**. Same-pin configuration auto-enables one-wire (no separate opt-in API).
 
+This is a single-board example that runs with **no external wiring**. UART1 transmits and receives on one GPIO; the sketch uses the UART internal loopback so UART1 receives its own transmission on that same pad.
+
 ## Supported SoCs
 
 | SoC | One-wire on HP UART | Notes |
@@ -21,145 +23,54 @@ LP UART on **ESP32-C5/C6/C61** uses fixed RX/TX pins — one-wire is **not** sup
 
 ## What the demo shows
 
-| Part | UARTs | Connection | Purpose |
-|------|-------|------------|---------|
-| **A — Self-echo** | UART1 only | Same GPIO for RX+TX; no jumper | Proves automatic one-wire RX/TX on one pad |
-| **B — Cross connection** | UART1 ↔ UART2 | One signal wire between two bus GPIOs | Bidirectional half-duplex request/reply between two UART instances |
+UART1 sends a test string on a single GPIO and receives it back on the same pad, proving that same-pin RX/TX automatically enables one-wire mode. After the self-test, anything typed in the Serial Monitor is sent on the one-wire GPIO and echoed back.
 
-Part B runs only when the board has **3+ HP UARTs** and defines `RX2`, `TX1`, and `TX2` (UART0 remains available for Serial Monitor output). UART1 first sends a request to UART2; UART2 then sends a reply to UART1 over the same wire.
+## How one-wire is enabled
 
-Part A is the direct one-wire API demonstration (`RX == TX`). External Part B uses split RX/TX assignments to ensure that only one push-pull TX output is connected to the shared wire. It demonstrates a practical single-wire half-duplex link, but it does not put both UART endpoints in one-wire mode simultaneously.
+Use the same GPIO for RX and TX — one-wire is automatic:
 
-## Requirements
+```cpp
+Serial1.begin(115200, SERIAL_8N1, pin, pin);  // RX == TX -> one-wire
+```
 
-- `UART_MODE_UART` only (not RS485, not IrDA)
-- Same GPIO for RX and TX in `setPins(p, p)` or `begin(..., p, p)` — one-wire is automatic
-- `-1` keep-current that makes effective RX equal TX also enables one-wire (e.g. RX=8 TX=9 then `setPins(-1, 8)`)
-- **Half-duplex traffic** — only one UART TX output may be enabled at a time
-
-## Loopback options
-
-Set `USE_INTERNAL_LOOPBACK` at the top of the sketch:
-
-| Value | Part A | Part B |
-|-------|--------|--------|
-| `1` (default) | `uart_internal_loopback(1, ONEWIRE_PIN1)` | No jumper required; an existing jumper is optional and redundant |
-| `0` | No jumper; same-pad self-echo | One signal wire: **ONEWIRE_PIN1 ↔ ONEWIRE_PIN2**; **4.7–10 kΩ pull-up to 3.3 V recommended** |
-
-With `USE_INTERNAL_LOOPBACK=1`, the sketch synchronizes GPIO-matrix output routing before each turn:
-
-- **Turn 1:** both `ONEWIRE_PIN1` and `ONEWIRE_PIN2` carry UART1 TX.
-- **Turn 2:** both pins carry UART2 TX.
-- Direction changes happen after `flush()`, while UART is idle HIGH.
-
-Consequently, an installed jumper connects two pads carrying the same signal rather than shorting UART1 TX against UART2 TX. The jumper is harmless in this test but electrically redundant because the GPIO matrix already provides the connection.
-
-With `USE_INTERNAL_LOOPBACK=0`, connecting two push-pull TX outputs to one wire would cause contention. The sketch therefore keeps **only one UART TX on the bus** each turn:
-
-- **Driver:** TX on its bus pad; RX is parked on its off-bus parking GPIO.
-- **Listener:** RX on its bus pad; TX is parked on its off-bus parking GPIO.
-
-The default parking GPIOs are `TX1` and `TX2`; leave them physically unconnected. You may override them with `ONEWIRE_PARK_PIN1` and `ONEWIRE_PARK_PIN2`. The sketch rejects any duplicate bus/parking GPIO assignment.
-
-Roles swap between Turn 1 and Turn 2. For interactive mode after an external Part B, the sketch **keeps Turn 2 roles** (UART2 drives, UART1 listens). This avoids another pin-role change and uses the direction that the startup test just verified.
-
-The external pull-up is recommended because both UARTs are briefly detached while roles change; the test may work without it because the active TX drives idle HIGH. Never transmit from both UARTs at once.
-
-On USB Serial, the sketch prints **`USE_INTERNAL_LOOPBACK`**, the **GPIO numbers** for `ONEWIRE_PIN1` / `ONEWIRE_PIN2`, and wiring instructions (no jumper vs external bus) before each part runs.
+The pad is configured **open-drain**: TX pulls the line LOW and releases HIGH. On a real one-wire bus, an **external pull-up resistor to 3.3 V** (a suitable conventional value) holds the line idle HIGH. This example needs no external wiring: it routes TX back to RX internally with `uart_internal_loopback()` and enables a weak internal pull-up so released HIGH bits are observable. That internal pull-up is only a test fixture and does not replace the external resistor on a real bus.
 
 ## Pins
 
 | Define | Default | Role |
 |--------|---------|------|
-| `ONEWIRE_PIN1` | `SDA` (board `pins_arduino.h`) | UART1 one-wire pad in Part A; UART1 bus pad in Part B |
-| `ONEWIRE_PIN2` | `RX2` | UART2 bus pad in Part B |
-| `ONEWIRE_PARK_PIN1` | `TX1` | UART1 off-bus RX/TX parking GPIO in external Part B |
-| `ONEWIRE_PARK_PIN2` | `TX2` | UART2 off-bus RX/TX parking GPIO in external Part B |
+| `ONEWIRE_PIN` | `SDA` (board `pins_arduino.h`) | UART1 one-wire pad (RX and TX) |
 
-Override these defines before their `#ifndef` defaults if the selected pads are unavailable. External Part B requires all four bus/parking GPIOs to be distinct.
+Override `ONEWIRE_PIN` before its `#ifndef` default if the selected pad is unavailable.
 
-## Electrical warning
+## Requirements
 
-ESP-IDF documents that routing TX output and RX input to one GPIO can cause **pad conflicts**. Recommended practices:
-
-- On a two-UART external bus: only one TX on the wire; park unused RX/TX off-bus (this demo’s external Part B)
-- External pull-up (4.7–10 kΩ to 3.3 V) so idle stays HIGH
-- Half-duplex protocol — never transmit from both UARTs at once
-- **Not** a replacement for RS485 (which needs separate TX, RX, and RTS to a transceiver)
-
-Internal pull on RX is **disabled** in one-wire mode.
+- `UART_MODE_UART` only (not RS485, not IrDA)
+- Same GPIO for RX and TX in `begin(..., p, p)` — one-wire is automatic
+- **Half-duplex traffic** — only one direction transmits at a time
+- On a real bus: an **external pull-up to 3.3 V** (internal RX pull is disabled in one-wire mode)
 
 ## Why one-wire UART can receive ghost data
 
-In one-wire mode, the pad is deliberately left **floating** (no internal pull), and RX is always listening on the same pin that TX drives. Any brief LOW or noise on that pad looks like a UART start bit, so the receiver produces framing errors, BREAK events, or “ghost” bytes even with no intentional traffic.
+In one-wire mode, RX always listens on the same open-drain pin that TX uses. The pad releases HIGH bits, so a pull-up must hold the bus idle HIGH. Any brief LOW or noise looks like a UART start bit and can produce framing errors, BREAK events, or "ghost" bytes.
 
 Main causes:
 
-1. **No idle bias** — split-pin UART uses RX pull-up so idle stays HIGH. One-wire disables that pull so TX isn’t fighting an internal resistor. When TX is not firmly driving (startup, pin mux change, tri-state between turns, weak/open bus), the line floats and RX samples garbage.
-2. **TX/RX pad conflict** — both output and input are on one GPIO. During attach/mux changes the line can glitch LOW, causing a start bit or BREAK.
-3. **Self-echo** — TX is also seen on RX. That is expected for intentional transmission; noise on TX looks the same.
-4. **External bus without idle bias** — a shared wire can float while UART pins are detached or TX outputs are disconnected between turns.
+1. **Missing external pull-up** — open-drain TX releases HIGH and cannot establish idle HIGH by itself.
+2. **Startup/mux transients** — attaching the shared pin can briefly look like a LOW start bit.
+3. **Self-echo** — TX is also seen on RX. That is expected for intentional transmission.
 
-## How to prevent it
-
-| Approach | Effect |
-|---|---|
-| **External pull-up** (approximately 4.7–10 kΩ to 3.3 V) on the one-wire pad or shared bus | Holds idle HIGH when nothing drives—the strongest fix |
-| **Drain RX after `begin()` or `setPins()`** using `while (available()) read()` | Clears glitches generated during pin attachment |
-| **Ignore data until the first valid frame** or require a known preamble | Filters noise before real protocol traffic |
-| **Use half-duplex only**—disconnect, reroute, or disable the listener's TX | Prevents two push-pull TX outputs from driving the shared wire |
-| **Use shorter wires and reduce nearby electrical noise** | Reduces false start bits on a floating pad |
-| **Do not re-enable the internal pull in one-wire mode** | Prevents the pull resistor from fighting TX |
-
-The internal pull is intentionally disabled in one-wire mode. Rely on **TX idle HIGH** while transmitting and use an **external pull-up** whenever the line can float.
+Mitigations: add the external pull-up, drain RX after `begin()` (`while (available()) read()`), keep traffic half-duplex, and discard the expected self-echo after each write.
 
 ## Usage
 
 1. Upload `OneWire_UART_Demo.ino`.
 2. Open Serial Monitor at **115200** baud.
-3. Read the startup lines: one-wire **GPIO numbers**, `USE_INTERNAL_LOOPBACK` mode, and Part A/B wiring summary.
-4. To reproduce the external test, set `USE_INTERNAL_LOOPBACK` to `0`, connect `ONEWIRE_PIN1` directly to `ONEWIRE_PIN2`, and leave both parking GPIOs unconnected.
-5. Connect a 4.7–10 kΩ resistor from the signal wire to 3.3 V (recommended), then reset or re-upload.
-6. Read Part A/B self-test results on startup.
-7. **Part B startup test:** confirm UART2 receives `UART1_TO_UART2`, then UART1 receives `UART2_TO_UART1` over the same connection.
-8. **Part B interactive:** type text and press Send — external mode keeps Turn 2 roles, so bytes travel UART2 → wire → UART1 and print in Serial Monitor.
-9. **Part A only (boards without Part B):** typed characters self-echo through UART1’s one-wire GPIO.
-
-## Expected serial output
-
-1. **Startup** — `ONEWIRE_PIN1` / `ONEWIRE_PIN2` GPIO numbers, loopback mode banner, Part A wiring line, Part B preview (when compiled).
-2. **Part A** — `"ONEWIRE"` received through UART1 same-pad self-echo, or failure text with a GPIO hint.
-3. **Part B** — wiring block (internal or one external signal wire), `"UART1_TO_UART2"` received on UART2, then `"UART2_TO_UART1"` received on UART1.
-4. **Interactive** — a direction line followed by the text entered in Serial Monitor.
-
-## Wiring (external cross-test, `USE_INTERNAL_LOOPBACK = 0`)
-
-The sketch prints the exact GPIO numbers for your board. Conceptually:
-
-```
-UART1 GPIO (ONEWIRE_PIN1) ---- bus ---- UART2 GPIO (ONEWIRE_PIN2)
-                                |
-                     4.7–10 kΩ pull-up to 3.3 V
-
-UART1 parking GPIO (ONEWIRE_PARK_PIN1) ---- not connected
-UART2 parking GPIO (ONEWIRE_PARK_PIN2) ---- not connected
-```
-
-Part A needs no jumper because UART1 RX and TX are already routed to the same physical pad. Part B needs the inter-UART signal wire above; the pull-up is recommended but not required while an active TX holds the line HIGH.
-
-### Tested ESP32-S3 wiring
-
-With the generic ESP32-S3 variant defaults, Serial Monitor should print these assignments:
-
-- `ONEWIRE_PIN1`: GPIO 8
-- `ONEWIRE_PIN2`: GPIO 19
-- `ONEWIRE_PARK_PIN1`: GPIO 16 — leave unconnected
-- `ONEWIRE_PARK_PIN2`: GPIO 20 — leave unconnected
-
-Connect GPIO 8 directly to GPIO 19. A tested idle-bias value is **5.6 kΩ from that signal wire to 3.3 V**; the startup and interactive tests can also pass without it while the active TX holds the line HIGH. Set `USE_INTERNAL_LOOPBACK` to `0`, upload, open Serial Monitor at 115200 baud, type text, and press Send.
+3. Read the startup lines and the self-echo result.
+4. Type text and press Send — bytes are transmitted on the one-wire GPIO and echoed back.
 
 ## Real-world note
 
-For same-pin half-duplex on a **single** UART pad, Part A is the relevant model. For a **bus** between two UART instances, see Part B and keep half-duplex discipline.
+For a one-wire **bus** between two separate ESP32-family boards using one signal wire plus common GND and an external pull-up, see [`OneWire_UART_Two_Boards`](../OneWire_UART_Two_Boards/).
 
 For split-pin RX pull behavior, see `RxPull_Demo`.

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Demo/README.md
@@ -41,8 +41,16 @@ Set `USE_INTERNAL_LOOPBACK` at the top of the sketch:
 
 | Value | Part A | Part B |
 |-------|--------|--------|
-| `1` (default) | `uart_internal_loopback(1, ONEWIRE_PIN1)` | GPIO-matrix routing switches UART1→UART2, then UART2→UART1 |
+| `1` (default) | `uart_internal_loopback(1, ONEWIRE_PIN1)` | No jumper required; an existing jumper is optional and redundant |
 | `0` | Optional jumper on ONEWIRE_PIN1 | One signal wire: **ONEWIRE_PIN1 ↔ ONEWIRE_PIN2**; both directions use it in turn |
+
+With `USE_INTERNAL_LOOPBACK=1`, the sketch synchronizes GPIO-matrix output routing before each turn:
+
+- **Turn 1:** both `ONEWIRE_PIN1` and `ONEWIRE_PIN2` carry UART1 TX.
+- **Turn 2:** both pins carry UART2 TX.
+- Direction changes happen after `flush()`, while UART is idle HIGH.
+
+Consequently, an installed jumper connects two pads carrying the same signal rather than shorting UART1 TX against UART2 TX. The jumper is harmless in this test but electrically redundant because the GPIO matrix already provides the connection.
 
 For external wiring, the sketch changes the listening GPIO to input-only while preserving its UART RX routing, then enables input/output mode only for the current transmitter. This prevents the listening push-pull TX from holding the line HIGH against the sender. Add an external **pull-up** to hold the line at UART idle HIGH during direction changes.
 

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards/OneWire_UART_Two_Boards.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards/OneWire_UART_Two_Boards.ino
@@ -1,0 +1,168 @@
+/*
+  Open-Drain One-Wire UART Between Two Boards
+
+  Flash the same sketch on both boards. Set NODE_ROLE differently on each board.
+  Same-pin UART (RX == TX) automatically enables open-drain.
+
+  Wiring (external pull-up REQUIRED):
+                        3.3 V
+                          |
+                   pull-up resistor
+                          |
+    Board A BUS_PIN  -----+-----  Board B BUS_PIN
+    Board A GND      -----------  Board B GND
+
+  Local TX is also received on RX. sendLine() discards that self-echo before
+  waiting for the peer.
+
+  --- Single board (UART1 + UART2) ---
+  On SoCs with Serial1 and Serial2 (typically ESP32, ESP32-S3, ESP32-P4),
+  you can run initiator and responder on one board:
+
+  1. Remove NODE_ROLE (and ROLE_INITIATOR / ROLE_RESPONDER). That define
+     picks only one role per flash; a single board must run both.
+  2. Remove the #if NODE_ROLE branches in setup()/loop() that call either
+     runInitiator() or runResponder().
+  3. Use two same-pin UARTs (Serial1 and Serial2), two BUS pins, and wire
+     them together with an external pull-up to 3.3 V.
+
+  Full steps, capable boards, wiring diagram, and code outline: README.md
+*/
+
+#include <Arduino.h>
+
+#define ROLE_INITIATOR 1
+#define ROLE_RESPONDER 2
+
+// Change this per board: one INITIATOR, one RESPONDER.
+// For a single-board UART1+UART2 setup, remove NODE_ROLE entirely (see header / README.md).
+#define NODE_ROLE ROLE_INITIATOR
+
+#ifndef BUS_PIN
+#ifdef RX1
+#define BUS_PIN RX1
+#else
+#error "Define BUS_PIN to a GPIO supported by Serial1 on this board"
+#endif
+#endif
+
+#ifndef LINK_BAUD
+#define LINK_BAUD 115200
+#endif
+
+static HardwareSerial &Link = Serial1;
+
+static void drainLink() {
+  while (Link.available()) {
+    Link.read();
+  }
+}
+
+// Write one line, then discard the local self-echo of that same line.
+static void sendLine(const String &line) {
+  drainLink();
+
+  String wire = line + "\n";
+  Link.print(wire);
+  Link.flush();
+  delay(2);  // let the last stop bit reach RX
+
+  // Same-pin RX sees our own TX — read it back and drop it.
+  uint32_t start = millis();
+  size_t got = 0;
+  while (got < wire.length() && millis() - start < 300) {
+    if (Link.available()) {
+      Link.read();
+      got++;
+    } else {
+      delay(1);
+    }
+  }
+
+  // Drop any post-TX glitch bytes before listening for the peer.
+  delay(10);
+  drainLink();
+}
+
+static bool readLine(String &line, uint32_t timeoutMs) {
+  line = "";
+  uint32_t start = millis();
+  while (millis() - start < timeoutMs) {
+    while (Link.available()) {
+      char c = (char)Link.read();
+      if (c == '\n') {
+        line.trim();
+        return true;
+      }
+      if (c != '\r' && line.length() < 64) {
+        line += c;
+      }
+    }
+    delay(1);
+  }
+  return false;
+}
+
+static void runInitiator() {
+  static uint32_t n = 0;
+  String request = "PING " + String(n);
+  String expected = "PONG " + String(n);
+
+  Serial.printf("TX: %s\n", request.c_str());
+  sendLine(request);
+
+  String reply;
+  if (readLine(reply, 1500) && reply == expected) {
+    Serial.printf("RX: %s (OK)\n", reply.c_str());
+  } else if (reply.length()) {
+    Serial.printf("RX: \"%s\" (unexpected)\n", reply.c_str());
+  } else {
+    Serial.println("RX timeout — check wiring, GND, pull-up, roles, and baud.");
+  }
+
+  drainLink();
+  n++;
+  delay(1000);
+}
+
+static void runResponder() {
+  String request;
+  if (!readLine(request, 200) || !request.startsWith("PING ")) {
+    return;
+  }
+
+  Serial.printf("RX: %s\n", request.c_str());
+  delay(50);  // let the initiator finish discarding its own echo
+
+  String reply = "PONG " + request.substring(5);
+  Serial.printf("TX: %s\n", reply.c_str());
+  sendLine(reply);
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(500);
+
+  Serial.println("\n=== One-Wire UART Two-Board Demo ===");
+  Serial.printf("Role: %s\n", NODE_ROLE == ROLE_INITIATOR ? "INITIATOR" : "RESPONDER");
+  Serial.printf("BUS_PIN: %d  baud: %lu\n", BUS_PIN, (unsigned long)LINK_BAUD);
+  Serial.println("Wire: BUS_PIN<->BUS_PIN, GND<->GND, pull-up to 3.3 V.");
+
+  Link.begin(LINK_BAUD, SERIAL_8N1, BUS_PIN, BUS_PIN);
+  drainLink();
+
+#if NODE_ROLE == ROLE_INITIATOR
+  // Give the responder time to boot and sit idle on the bus.
+  delay(1500);
+#else
+  Serial.println("Waiting for PING...");
+#endif
+}
+
+void loop() {
+#if NODE_ROLE == ROLE_INITIATOR
+  runInitiator();
+#else
+  runResponder();
+#endif
+}

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards/OneWire_UART_Two_Boards.ino
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards/OneWire_UART_Two_Boards.ino
@@ -103,6 +103,7 @@ static bool readLine(String &line, uint32_t timeoutMs) {
   return false;
 }
 
+#if NODE_ROLE == ROLE_INITIATOR
 static void runInitiator() {
   static uint32_t n = 0;
   String request = "PING " + String(n);
@@ -124,7 +125,7 @@ static void runInitiator() {
   n++;
   delay(1000);
 }
-
+#else
 static void runResponder() {
   String request;
   if (!readLine(request, 200) || !request.startsWith("PING ")) {
@@ -138,6 +139,7 @@ static void runResponder() {
   Serial.printf("TX: %s\n", reply.c_str());
   sendLine(reply);
 }
+#endif
 
 void setup() {
   Serial.begin(115200);

--- a/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards/README.md
+++ b/libraries/ESP32/examples/Serial/OneWire_UART_Two_Boards/README.md
@@ -1,0 +1,134 @@
+# One-Wire UART Between Two Boards
+
+Simple half-duplex PING/PONG over one signal wire between two ESP32-family boards.
+
+- Each board uses `Serial1` with `RX == TX` on one `BUS_PIN` (open-drain is automatic).
+- Connect `BUS_PIN` to `BUS_PIN`, `GND` to `GND`, and a pull-up resistor from the bus to 3.3 V.
+- Flash the same sketch on both boards with different `NODE_ROLE` values.
+- After every write, discard the local self-echo before reading the peer.
+- Optional: run both roles on one board with UART1 and UART2 (see [Single board with UART1 and UART2](#single-board-with-uart1-and-uart2)).
+
+## Wiring
+
+```text
+                            3.3 V
+                              |
+                         pull-up resistor
+                              |
+ESP32-S3 BUS_PIN  ------------+-------  ESP32 BUS_PIN
+ESP32-S3 GND      --------------------  ESP32 GND
+```
+
+Do not tie the boards' 3.3 V supplies together. Power both boards and connect the pull-up to one board's 3.3 V.
+
+## Configure
+
+```cpp
+// Board A
+#define NODE_ROLE ROLE_INITIATOR
+#define BUS_PIN   15   // example ESP32-S3 UART1 RX
+
+// Board B
+#define NODE_ROLE ROLE_RESPONDER
+#define BUS_PIN   26   // example classic ESP32 UART1 RX
+```
+
+If `BUS_PIN` is omitted, the sketch uses `RX1`. Override `LINK_BAUD` if needed (default 115200).
+
+## Single board with UART1 and UART2
+
+You can run both roles on **one** board instead of two devices. Wire two open-drain one-wire pads together with the same **external pull-up to 3.3 V** (required — the bus has no valid idle HIGH without it).
+
+```text
+                         3.3 V
+                           |
+                    pull-up resistor
+                           |
+UART1 BUS_PIN1  -----------+-----------  UART2 BUS_PIN2
+```
+
+### Capable boards
+
+Needs **Serial1** and **Serial2** as high-performance (HP) UARTs while USB `Serial` stays free for the monitor — typically **3+ HP UARTs**:
+
+| SoC | Single-board UART1↔UART2 |
+|-----|--------------------------|
+| ESP32 | Yes |
+| ESP32-S3 | Yes |
+| ESP32-P4 | Yes |
+| ESP32-S2, C2, C3, C5, C6, C61, H2 | Usually no (fewer than three HP UARTs) |
+
+Confirm the board defines usable pins for `Serial1` / `Serial2` (for example `RX1` / `RX2`).
+
+### How to adapt the sketch
+
+This sketch is written for **two flashes**: `NODE_ROLE` selects initiator *or* responder. On one board you must run **both**, so that compile-time role switch has to go.
+
+**Steps:**
+
+1. **Remove the role switch**
+   - Delete `ROLE_INITIATOR`, `ROLE_RESPONDER`, and `#define NODE_ROLE ...`
+   - Delete every `#if NODE_ROLE == ...` / `#else` / `#endif` in `setup()` and `loop()` (those call only one of `runInitiator()` / `runResponder()`)
+
+2. **Use two one-wire UARTs**
+   - `Serial1` = initiator, `Serial2` = responder (USB `Serial` stays the monitor)
+   - Two pins, each with `RX == TX` (open-drain is automatic)
+   - Wire `BUS_PIN1` to `BUS_PIN2` and add an **external pull-up to 3.3 V** (required)
+
+3. **Call both roles from one `loop()`**
+   - Make `sendLine` / `readLine` take `HardwareSerial &` (or keep two thin wrappers)
+   - In `loop()`, run the initiator turn on `Serial1`, then service the responder on `Serial2` (half-duplex: only one transmits at a time)
+   - Keep discarding local TX self-echo after every write
+
+**Outline:**
+
+```cpp
+// Do NOT define NODE_ROLE — both roles run in this firmware.
+
+#ifndef BUS_PIN1
+#define BUS_PIN1 RX1
+#endif
+#ifndef BUS_PIN2
+#define BUS_PIN2 RX2
+#endif
+
+static HardwareSerial &Initiator = Serial1;
+static HardwareSerial &Responder = Serial2;
+
+void setup() {
+  Serial.begin(115200);
+  Initiator.begin(LINK_BAUD, SERIAL_8N1, BUS_PIN1, BUS_PIN1);  // RX == TX
+  Responder.begin(LINK_BAUD, SERIAL_8N1, BUS_PIN2, BUS_PIN2);
+  // drain both UARTs
+}
+
+void loop() {
+  // Same PING/PONG logic as runInitiator() / runResponder(), but:
+  // send/read on Initiator for the PING side, on Responder for the PONG side.
+}
+```
+
+See the capable-boards table above. Without removing `NODE_ROLE`, the sketch still builds only one role and cannot talk UART1 ↔ UART2 by itself.
+
+## What to expect
+
+Initiator:
+
+```text
+TX: PING 0
+RX: PONG 0 (OK)
+```
+
+Responder:
+
+```text
+Waiting for PING...
+RX: PING 0
+TX: PONG 0
+```
+
+## Notes
+
+- Half-duplex only: never transmit from both boards at once.
+- Same-pin RX always hears local TX; `sendLine()` discards that echo.
+- This is a two-node demo, not a multi-drop arbitration protocol.

--- a/libraries/ESP32/examples/Serial/RxPull_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/RxPull_Demo/README.md
@@ -22,7 +22,7 @@ Demonstrates **why** internal pull on the UART **RX** pad matters on split RX/TX
 - Applies to **split** RX and TX pins only (not one-wire mode).
 - Pull direction follows **RX inversion**: pull-up when normal, pull-down when RX is inverted.
 - `setTxInvert()` alone does not change RX pull.
-- Call `enableRxInternalPull()` **before** `begin()`.
+- Call `enableRxInternalPull()` **before** `begin()`. Default is **on** (internal pull applied).
 
 ## What the demo shows
 
@@ -30,57 +30,29 @@ Demonstrates **why** internal pull on the UART **RX** pad matters on split RX/TX
 |------|--------|-------|
 | **A — Floating RX** | **No wire** on UART1 `RX1` | Pull defines idle when nothing drives RX; floating pad may show UART errors or noise |
 | **B — Inverted RX** | No wire required | Pull-down tracks `begin(invert)` / `setRxInvert()`; matches RS-232 style idle |
-| **C — Wired loopback** | Jumper **TX1 → RX2** (3+ UART boards); exact GPIOs printed on Serial | Partner TX holds idle — pull on UART2 RX is often **redundant** but reception still works with pull on or off |
-
-Part C is compiled only when the board defines `RX2` and has three or more HP UARTs (same guard as `IrdaMode_DualUART_Demo`).
 
 ## Wiring
 
-### Parts A and B (required)
-
 - Leave **UART1 RX1** unconnected (no jumper, no partner device on RX).
 - Default pins come from board definitions (`RX1`, `TX1`). Override the `#ifndef` defaults in the sketch if needed.
-- On USB Serial, Part A prints the **RX1 GPIO number** to keep unconnected (for example `No jumper on UART1 RX1 (GPIO 15).`).
-
-### Part C (optional)
-
-Single-board loopback on ESP32-class boards with UART2:
-
-```
-UART1 TX1 (GPIO from board) -----> UART2 RX2 (GPIO from board)
-```
-
-The sketch prints the **exact GPIO numbers** for your board:
-
-- At startup (after UART1 pin summary): `Part C (after A & B): jumper UART1 TX1 GPIO … -> UART2 RX2 GPIO …`
-- Again before Part C runs: a wiring block with `UART1 TX1 (GPIO …) ------> UART2 RX2 (GPIO …)`
-- If no data is received: the same GPIO pair is repeated in the failure line
-
-Parts A and B run **without** the Part C jumper. Connect the wire when the wiring block appears (or after reading the startup preview), then **reset or re-upload** before expecting Part C to pass.
-
-Do **not** tie UART1 RX1 for Part A while the Part C jumper is on UART2 RX — run A and B first, add the jumper, then reset for Part C.
+- On USB Serial, Part A prints the **RX1 GPIO number** to keep unconnected.
 
 ## Expected serial output
 
-1. **Startup** — `UART1 pins: RX=… TX=…`; on 3+ UART boards, a one-line Part C jumper preview with GPIO numbers.
+1. **Startup** — `UART1 pins: RX=… TX=…`
 2. **Floating RX (Part A)** — unconnected RX GPIO called out; IO pull state reports `floating` vs `pull-up`; error count during idle may be higher with pull disabled (environment-dependent).
 3. **Inverted RX (Part B)** — pull-up for normal RX, pull-down after `begin(invert=true)` or `setRxInvert(true)`.
-4. **Wired loopback (Part C)** — wiring block with GPIO numbers, then `"RxPull loopback"` received on UART2 with `enableRxInternalPull(true)` and `false` on UART2 RX.
 
 ## Usage
 
 1. Open `RxPull_Demo.ino` in the Arduino IDE.
 2. Select your ESP32 board and upload.
 3. Open Serial Monitor at **115200** baud.
-4. Read the printed **GPIO numbers** for your board (startup line and Part C wiring block).
-5. For Part C, connect the jumper shown on Serial Monitor (`UART1 TX1` GPIO → `UART2 RX2` GPIO), then reset or re-upload so loopback runs with the wire in place.
-
-Verify pull direction with the printed IO pull state from `gpio_get_io_config()` or a scope on the RX GPIO.
+4. Leave RX1 unconnected and read the Part A / Part B results.
 
 ## Real-world use cases
 
 - **Unconnected or tri-stated RX** — GPS/radio/modem RX before attach, or transceiver high-Z: pull prevents false BREAK/framing from undefined idle.
 - **Inverted RX** — RS-232 or inverted PHY: pull-down matches electrical idle LOW.
-- **Direct TX→RX wire** — partner output drives idle; internal pull is secondary (Part C illustrates this).
 
 For same-pin half-duplex buses, see `OneWire_UART_Demo` (same-pin auto-enables one-wire; internal pull is disabled there by design).

--- a/libraries/ESP32/examples/Serial/RxPull_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/RxPull_Demo/README.md
@@ -83,4 +83,4 @@ Verify pull direction with the printed IO pull state from `gpio_get_io_config()`
 - **Inverted RX** — RS-232 or inverted PHY: pull-down matches electrical idle LOW.
 - **Direct TX→RX wire** — partner output drives idle; internal pull is secondary (Part C illustrates this).
 
-For same-pin half-duplex buses, see `OneWire_UART_Demo` (internal pull is disabled there by design).
+For same-pin half-duplex buses, see `OneWire_UART_Demo` (same-pin auto-enables one-wire; internal pull is disabled there by design).

--- a/libraries/ESP32/examples/Serial/RxPull_Demo/README.md
+++ b/libraries/ESP32/examples/Serial/RxPull_Demo/README.md
@@ -1,0 +1,86 @@
+# RX Internal Pull Demo
+
+Demonstrates **why** internal pull on the UART **RX** pad matters on split RX/TX pins, using `enableRxInternalPull()`, `begin(invert)`, and `setRxInvert()`.
+
+## Supported SoCs
+
+| SoC | Support | Notes |
+|-----|---------|-------|
+| ESP32 | ✓ | HP UART GPIO pull |
+| ESP32-S2 | ✓ | HP UART GPIO pull |
+| ESP32-S3 | ✓ | HP UART GPIO pull |
+| ESP32-C2 | ✓ | HP UART GPIO pull |
+| ESP32-C3 | ✓ | HP UART GPIO pull |
+| ESP32-C5 | ✓ | HP UART; LP UART uses fixed pins |
+| ESP32-C6 | ✓ | HP UART; LP UART uses fixed pins |
+| ESP32-C61 | ✓ | HP UART; LP UART uses fixed pins |
+| ESP32-H2 | ✓ | HP UART GPIO pull |
+| ESP32-P4 | ✓ | HP and LP (matrix) RTC pull APIs |
+
+## Scope
+
+- Applies to **split** RX and TX pins only (not one-wire mode).
+- Pull direction follows **RX inversion**: pull-up when normal, pull-down when RX is inverted.
+- `setTxInvert()` alone does not change RX pull.
+- Call `enableRxInternalPull()` **before** `begin()`.
+
+## What the demo shows
+
+| Part | Wiring | Point |
+|------|--------|-------|
+| **A — Floating RX** | **No wire** on UART1 `RX1` | Pull defines idle when nothing drives RX; floating pad may show UART errors or noise |
+| **B — Inverted RX** | No wire required | Pull-down tracks `begin(invert)` / `setRxInvert()`; matches RS-232 style idle |
+| **C — Wired loopback** | Jumper **TX1 → RX2** (3+ UART boards); exact GPIOs printed on Serial | Partner TX holds idle — pull on UART2 RX is often **redundant** but reception still works with pull on or off |
+
+Part C is compiled only when the board defines `RX2` and has three or more HP UARTs (same guard as `IrdaMode_DualUART_Demo`).
+
+## Wiring
+
+### Parts A and B (required)
+
+- Leave **UART1 RX1** unconnected (no jumper, no partner device on RX).
+- Default pins come from board definitions (`RX1`, `TX1`). Override the `#ifndef` defaults in the sketch if needed.
+- On USB Serial, Part A prints the **RX1 GPIO number** to keep unconnected (for example `No jumper on UART1 RX1 (GPIO 15).`).
+
+### Part C (optional)
+
+Single-board loopback on ESP32-class boards with UART2:
+
+```
+UART1 TX1 (GPIO from board) -----> UART2 RX2 (GPIO from board)
+```
+
+The sketch prints the **exact GPIO numbers** for your board:
+
+- At startup (after UART1 pin summary): `Part C (after A & B): jumper UART1 TX1 GPIO … -> UART2 RX2 GPIO …`
+- Again before Part C runs: a wiring block with `UART1 TX1 (GPIO …) ------> UART2 RX2 (GPIO …)`
+- If no data is received: the same GPIO pair is repeated in the failure line
+
+Parts A and B run **without** the Part C jumper. Connect the wire when the wiring block appears (or after reading the startup preview), then **reset or re-upload** before expecting Part C to pass.
+
+Do **not** tie UART1 RX1 for Part A while the Part C jumper is on UART2 RX — run A and B first, add the jumper, then reset for Part C.
+
+## Expected serial output
+
+1. **Startup** — `UART1 pins: RX=… TX=…`; on 3+ UART boards, a one-line Part C jumper preview with GPIO numbers.
+2. **Floating RX (Part A)** — unconnected RX GPIO called out; IO pull state reports `floating` vs `pull-up`; error count during idle may be higher with pull disabled (environment-dependent).
+3. **Inverted RX (Part B)** — pull-up for normal RX, pull-down after `begin(invert=true)` or `setRxInvert(true)`.
+4. **Wired loopback (Part C)** — wiring block with GPIO numbers, then `"RxPull loopback"` received on UART2 with `enableRxInternalPull(true)` and `false` on UART2 RX.
+
+## Usage
+
+1. Open `RxPull_Demo.ino` in the Arduino IDE.
+2. Select your ESP32 board and upload.
+3. Open Serial Monitor at **115200** baud.
+4. Read the printed **GPIO numbers** for your board (startup line and Part C wiring block).
+5. For Part C, connect the jumper shown on Serial Monitor (`UART1 TX1` GPIO → `UART2 RX2` GPIO), then reset or re-upload so loopback runs with the wire in place.
+
+Verify pull direction with the printed IO pull state from `gpio_get_io_config()` or a scope on the RX GPIO.
+
+## Real-world use cases
+
+- **Unconnected or tri-stated RX** — GPS/radio/modem RX before attach, or transceiver high-Z: pull prevents false BREAK/framing from undefined idle.
+- **Inverted RX** — RS-232 or inverted PHY: pull-down matches electrical idle LOW.
+- **Direct TX→RX wire** — partner output drives idle; internal pull is secondary (Part C illustrates this).
+
+For same-pin half-duplex buses, see `OneWire_UART_Demo` (internal pull is disabled there by design).

--- a/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
+++ b/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
@@ -4,19 +4,14 @@
   Demonstrates why enableRxInternalPull() matters on split RX/TX pins:
     A) Floating RX — pull defines idle when nothing drives the line
     B) Inverted RX — pull direction tracks begin(invert) / setRxInvert()
-    C) Wired loopback (optional, 3+ UART boards) — partner TX usually holds idle;
-       internal pull is often redundant but still verified here
 
-  Wiring:
-    Part A & B: leave UART1 RX1 unconnected (no wire on RX pin)
-    Part C (optional): jumper UART1 TX1 -> UART2 RX2
+  Wiring: leave UART1 RX1 unconnected (no wire on the RX pin).
 
   Open Serial Monitor at 115200 baud.
 */
 
 #include <Arduino.h>
 #include "driver/gpio.h"
-#include "hal/gpio_types.h"
 
 #ifndef RX1
 #define RX1 4
@@ -25,111 +20,62 @@
 #define TX1 5
 #endif
 
-#ifdef SOC_UART_HP_NUM
-#if SOC_UART_HP_NUM >= 3
-#ifdef RX2
-#define HAS_UART2 1
-#else
-#define HAS_UART2 0
-#endif
-#else
-#define HAS_UART2 0
-#endif
-#else
-#define HAS_UART2 0
-#endif
-
 static const uint32_t BAUD = 115200;
 static const uint32_t FLOAT_SAMPLE_MS = 500;
-#if HAS_UART2
-static const char *TEST_MSG = "RxPull loopback";
-#endif
 
 static volatile uint32_t g_rxErrors = 0;
 
-static const char *pullModeName(gpio_pull_mode_t mode) {
-  switch (mode) {
-    case GPIO_PULLUP_ONLY:   return "pull-up";
-    case GPIO_PULLDOWN_ONLY: return "pull-down";
-    case GPIO_FLOATING:      return "floating";
-    default:                 return "other";
-  }
-}
-
 static void onRxError(hardwareSerial_error_t err) {
   if (err != UART_NO_ERROR) {
-    uint32_t errors = g_rxErrors;
-    g_rxErrors = errors + 1;
+    g_rxErrors++;
   }
-}
-
-static gpio_pull_mode_t readRxPullMode(int8_t rxPin) {
-  gpio_io_config_t cfg = {};
-  if (gpio_get_io_config((gpio_num_t)rxPin, &cfg) != ESP_OK) {
-    return GPIO_FLOATING;
-  }
-  if (cfg.pu && cfg.pd) {
-    return GPIO_PULLUP_PULLDOWN;
-  }
-  if (cfg.pu) {
-    return GPIO_PULLUP_ONLY;
-  }
-  if (cfg.pd) {
-    return GPIO_PULLDOWN_ONLY;
-  }
-  return GPIO_FLOATING;
 }
 
 static void printPullState(int8_t rxPin, const char *expect) {
-  gpio_pull_mode_t mode = readRxPullMode(rxPin);
-  Serial.printf("  RX GPIO %d pull: %s", rxPin, pullModeName(mode));
-  if (expect != nullptr) {
-    Serial.printf(" (expect %s)", expect);
+  gpio_io_config_t cfg = {};
+  const char *mode = "floating";
+  if (gpio_get_io_config((gpio_num_t)rxPin, &cfg) == ESP_OK) {
+    if (cfg.pu && !cfg.pd) {
+      mode = "pull-up";
+    } else if (cfg.pd && !cfg.pu) {
+      mode = "pull-down";
+    } else if (cfg.pu && cfg.pd) {
+      mode = "pull-up+down";
+    }
   }
-  Serial.println();
+  Serial.printf("  RX GPIO %d pull: %s (expect %s)\n", rxPin, mode, expect);
 }
 
-#if HAS_UART2
-static void printPartCWiringInstructions() {
-  Serial.println();
-  Serial.println("  Part C wiring — connect with a jumper wire:");
-  Serial.printf("    UART1 TX1  (GPIO %d)  ------>  UART2 RX2  (GPIO %d)\n", TX1, RX2);
-  Serial.printf("  Leave UART1 RX1 (GPIO %d) unconnected for Parts A and B.\n", RX1);
-  Serial.println("  Reset or re-upload after connecting the wire, then read Part C output below.");
-  Serial.println();
-}
-#endif
-
-static void sampleFloatingIdle(HardwareSerial &uart, int8_t rxPin, int8_t txPin, bool pullEnabled, const char *label) {
-  uart.end();
-  uart.enableRxInternalPull(pullEnabled);
-  uart.setPins(rxPin, txPin);
-  uart.begin(BAUD, SERIAL_8N1, rxPin, txPin);
+static void sampleFloatingIdle(bool pullEnabled, const char *label) {
+  Serial1.end();
+  Serial1.enableRxInternalPull(pullEnabled);
+  Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1);
 
   Serial.printf("\n--- %s ---\n", label);
   Serial.printf("  enableRxInternalPull(%s)\n", pullEnabled ? "true" : "false");
-  printPullState(rxPin, pullEnabled ? "pull-up" : "floating");
+  printPullState(RX1, pullEnabled ? "pull-up" : "floating");
 
   g_rxErrors = 0;
-  uart.onReceiveError(onRxError);
+  Serial1.onReceiveError(onRxError);
   delay(FLOAT_SAMPLE_MS);
-  uart.onReceiveError(nullptr);
+  Serial1.onReceiveError(nullptr);
 
-  Serial.printf("  %lu ms idle on unconnected RX: UART errors=%lu, available=%u\n", FLOAT_SAMPLE_MS, g_rxErrors, uart.available());
+  Serial.printf("  %lu ms idle on unconnected RX: UART errors=%lu, available=%u\n", FLOAT_SAMPLE_MS, g_rxErrors,
+                Serial1.available());
   if (!pullEnabled) {
-    Serial.println("  Tip: floating RX may pick up noise; scope or onReceiveError helps show undefined idle.");
+    Serial.println("  Tip: floating RX may pick up noise; pull-up holds idle HIGH.");
   } else {
     Serial.println("  Pull-up holds logical idle HIGH so the receiver sees a defined line level.");
   }
 
-  uart.end();
+  Serial1.end();
 }
 
 static void runFloatingRxDemo() {
   Serial.println("\n=== Part A: Floating RX (leave RX1 unconnected) ===");
   Serial.printf("  No jumper on UART1 RX1 (GPIO %d).\n", RX1);
-  sampleFloatingIdle(Serial1, RX1, TX1, false, "Pull disabled — RX pad floats");
-  sampleFloatingIdle(Serial1, RX1, TX1, true, "Default pull enabled — RX idle defined");
+  sampleFloatingIdle(false, "Pull disabled — RX pad floats");
+  sampleFloatingIdle(true, "Default pull enabled — RX idle defined");
 }
 
 static void runInversionPullDemo() {
@@ -137,7 +83,6 @@ static void runInversionPullDemo() {
 
   Serial1.end();
   Serial1.enableRxInternalPull(true);
-  Serial1.setPins(RX1, TX1);
   Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1);
   Serial.println("\n--- Default begin() ---");
   printPullState(RX1, "pull-up");
@@ -166,84 +111,17 @@ static void runInversionPullDemo() {
   Serial.println("\nInverted UART (RS-232 style PHY) needs pull-down on RX to match electrical idle LOW.");
 }
 
-#if HAS_UART2
-static bool waitForBytes(HardwareSerial &uart, uint32_t timeoutMs) {
-  uint32_t start = millis();
-  while (millis() - start < timeoutMs) {
-    if (uart.available() > 0) {
-      return true;
-    }
-    delay(1);
-  }
-  return false;
-}
-
-static void runWiredLoopbackDemo(bool pullEnabled) {
-  Serial1.end();
-  Serial2.end();
-
-  Serial1.setPins(RX1, TX1);
-  Serial2.enableRxInternalPull(pullEnabled);
-  Serial2.setPins(RX2, TX2);
-  Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1);
-  Serial2.begin(BAUD, SERIAL_8N1, RX2, TX2);
-
-  Serial.printf("\n--- Loopback with enableRxInternalPull(%s) on UART2 RX ---\n", pullEnabled ? "true" : "false");
-  printPullState(RX2, pullEnabled ? "pull-up" : "floating");
-
-  while (Serial2.available()) {
-    Serial2.read();
-  }
-
-  Serial1.println(TEST_MSG);
-  Serial1.flush();
-
-  if (waitForBytes(Serial2, 300)) {
-    String line = Serial2.readStringUntil('\n');
-    line.trim();
-    Serial.printf("  Received on UART2: \"%s\"\n", line.c_str());
-    Serial.println("  OK — partner TX drives the line during idle and while sending.");
-  } else {
-    Serial.printf("  No data received — connect GPIO %d (UART1 TX1) to GPIO %d (UART2 RX2) and reset.\n", TX1, RX2);
-  }
-
-  Serial1.end();
-  Serial2.end();
-}
-
-static void runWiredLoopbackSection() {
-  Serial.println("\n=== Part C: Wired loopback ===");
-  printPartCWiringInstructions();
-  Serial.println("When UART1 TX is wired to UART2 RX, the transmitter output usually holds idle HIGH.");
-  Serial.println("Internal pull on UART2 RX is often redundant here; both cases below should receive data.");
-
-  runWiredLoopbackDemo(true);
-  runWiredLoopbackDemo(false);
-}
-#endif
-
 void setup() {
-  Serial.begin(BAUD);
+  Serial.begin(115200);
   delay(500);
   Serial.println("\n=== RX Internal Pull Demo ===");
   Serial.printf("UART1 pins: RX=%d TX=%d\n", RX1, TX1);
-#if HAS_UART2
-  Serial.printf("Part C (after A & B): jumper UART1 TX1 GPIO %d -> UART2 RX2 GPIO %d\n", TX1, RX2);
-#endif
+  Serial.println("Leave RX1 unconnected for the whole demo.");
 
   runFloatingRxDemo();
   runInversionPullDemo();
 
-#if HAS_UART2
-  Serial.printf("Board has UART2 — RX2=%d TX2=%d\n", RX2, TX2);
-  runWiredLoopbackSection();
-#else
-  Serial.println("\n=== Part C: skipped (board has fewer than 3 UARTs) ===");
-  Serial.println("Wired loopback needs a second UART: jumper peer TX (GPIO) -> peer RX (GPIO), split pins.");
-#endif
-
   Serial.println("\nDemo complete.");
 }
 
-void loop() {
-}
+void loop() {}

--- a/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
+++ b/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
@@ -60,8 +60,7 @@ static void sampleFloatingIdle(bool pullEnabled, const char *label) {
   delay(FLOAT_SAMPLE_MS);
   Serial1.onReceiveError(nullptr);
 
-  Serial.printf("  %lu ms idle on unconnected RX: UART errors=%lu, available=%u\n", FLOAT_SAMPLE_MS, g_rxErrors,
-                Serial1.available());
+  Serial.printf("  %lu ms idle on unconnected RX: UART errors=%lu, available=%u\n", FLOAT_SAMPLE_MS, g_rxErrors, Serial1.available());
   if (!pullEnabled) {
     Serial.println("  Tip: floating RX may pick up noise; pull-up holds idle HIGH.");
   } else {

--- a/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
+++ b/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
@@ -41,7 +41,9 @@
 
 static const uint32_t BAUD = 115200;
 static const uint32_t FLOAT_SAMPLE_MS = 500;
+#if HAS_UART2
 static const char *TEST_MSG = "RxPull loopback";
+#endif
 
 static volatile uint32_t g_rxErrors = 0;
 
@@ -56,7 +58,8 @@ static const char *pullModeName(gpio_pull_mode_t mode) {
 
 static void onRxError(hardwareSerial_error_t err) {
   if (err != UART_NO_ERROR) {
-    g_rxErrors++;
+    uint32_t errors = g_rxErrors;
+    g_rxErrors = errors + 1;
   }
 }
 

--- a/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
+++ b/libraries/ESP32/examples/Serial/RxPull_Demo/RxPull_Demo.ino
@@ -1,0 +1,246 @@
+/*
+  RX Internal Pull Demo
+
+  Demonstrates why enableRxInternalPull() matters on split RX/TX pins:
+    A) Floating RX — pull defines idle when nothing drives the line
+    B) Inverted RX — pull direction tracks begin(invert) / setRxInvert()
+    C) Wired loopback (optional, 3+ UART boards) — partner TX usually holds idle;
+       internal pull is often redundant but still verified here
+
+  Wiring:
+    Part A & B: leave UART1 RX1 unconnected (no wire on RX pin)
+    Part C (optional): jumper UART1 TX1 -> UART2 RX2
+
+  Open Serial Monitor at 115200 baud.
+*/
+
+#include <Arduino.h>
+#include "driver/gpio.h"
+#include "hal/gpio_types.h"
+
+#ifndef RX1
+#define RX1 4
+#endif
+#ifndef TX1
+#define TX1 5
+#endif
+
+#ifdef SOC_UART_HP_NUM
+#if SOC_UART_HP_NUM >= 3
+#ifdef RX2
+#define HAS_UART2 1
+#else
+#define HAS_UART2 0
+#endif
+#else
+#define HAS_UART2 0
+#endif
+#else
+#define HAS_UART2 0
+#endif
+
+static const uint32_t BAUD = 115200;
+static const uint32_t FLOAT_SAMPLE_MS = 500;
+static const char *TEST_MSG = "RxPull loopback";
+
+static volatile uint32_t g_rxErrors = 0;
+
+static const char *pullModeName(gpio_pull_mode_t mode) {
+  switch (mode) {
+    case GPIO_PULLUP_ONLY:   return "pull-up";
+    case GPIO_PULLDOWN_ONLY: return "pull-down";
+    case GPIO_FLOATING:      return "floating";
+    default:                 return "other";
+  }
+}
+
+static void onRxError(hardwareSerial_error_t err) {
+  if (err != UART_NO_ERROR) {
+    g_rxErrors++;
+  }
+}
+
+static gpio_pull_mode_t readRxPullMode(int8_t rxPin) {
+  gpio_io_config_t cfg = {};
+  if (gpio_get_io_config((gpio_num_t)rxPin, &cfg) != ESP_OK) {
+    return GPIO_FLOATING;
+  }
+  if (cfg.pu && cfg.pd) {
+    return GPIO_PULLUP_PULLDOWN;
+  }
+  if (cfg.pu) {
+    return GPIO_PULLUP_ONLY;
+  }
+  if (cfg.pd) {
+    return GPIO_PULLDOWN_ONLY;
+  }
+  return GPIO_FLOATING;
+}
+
+static void printPullState(int8_t rxPin, const char *expect) {
+  gpio_pull_mode_t mode = readRxPullMode(rxPin);
+  Serial.printf("  RX GPIO %d pull: %s", rxPin, pullModeName(mode));
+  if (expect != nullptr) {
+    Serial.printf(" (expect %s)", expect);
+  }
+  Serial.println();
+}
+
+#if HAS_UART2
+static void printPartCWiringInstructions() {
+  Serial.println();
+  Serial.println("  Part C wiring — connect with a jumper wire:");
+  Serial.printf("    UART1 TX1  (GPIO %d)  ------>  UART2 RX2  (GPIO %d)\n", TX1, RX2);
+  Serial.printf("  Leave UART1 RX1 (GPIO %d) unconnected for Parts A and B.\n", RX1);
+  Serial.println("  Reset or re-upload after connecting the wire, then read Part C output below.");
+  Serial.println();
+}
+#endif
+
+static void sampleFloatingIdle(HardwareSerial &uart, int8_t rxPin, int8_t txPin, bool pullEnabled, const char *label) {
+  uart.end();
+  uart.enableRxInternalPull(pullEnabled);
+  uart.setPins(rxPin, txPin);
+  uart.begin(BAUD, SERIAL_8N1, rxPin, txPin);
+
+  Serial.printf("\n--- %s ---\n", label);
+  Serial.printf("  enableRxInternalPull(%s)\n", pullEnabled ? "true" : "false");
+  printPullState(rxPin, pullEnabled ? "pull-up" : "floating");
+
+  g_rxErrors = 0;
+  uart.onReceiveError(onRxError);
+  delay(FLOAT_SAMPLE_MS);
+  uart.onReceiveError(nullptr);
+
+  Serial.printf("  %lu ms idle on unconnected RX: UART errors=%lu, available=%u\n", FLOAT_SAMPLE_MS, g_rxErrors, uart.available());
+  if (!pullEnabled) {
+    Serial.println("  Tip: floating RX may pick up noise; scope or onReceiveError helps show undefined idle.");
+  } else {
+    Serial.println("  Pull-up holds logical idle HIGH so the receiver sees a defined line level.");
+  }
+
+  uart.end();
+}
+
+static void runFloatingRxDemo() {
+  Serial.println("\n=== Part A: Floating RX (leave RX1 unconnected) ===");
+  Serial.printf("  No jumper on UART1 RX1 (GPIO %d).\n", RX1);
+  sampleFloatingIdle(Serial1, RX1, TX1, false, "Pull disabled — RX pad floats");
+  sampleFloatingIdle(Serial1, RX1, TX1, true, "Default pull enabled — RX idle defined");
+}
+
+static void runInversionPullDemo() {
+  Serial.println("\n=== Part B: Pull follows RX inversion ===");
+
+  Serial1.end();
+  Serial1.enableRxInternalPull(true);
+  Serial1.setPins(RX1, TX1);
+  Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1);
+  Serial.println("\n--- Default begin() ---");
+  printPullState(RX1, "pull-up");
+  Serial1.end();
+
+  Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1, true);
+  Serial.println("\n--- begin(..., invert=true) ---");
+  printPullState(RX1, "pull-down");
+  Serial1.end();
+
+  Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1);
+  Serial1.setRxInvert(true);
+  Serial.println("\n--- setRxInvert(true) after begin() ---");
+  printPullState(RX1, "pull-down");
+  Serial1.setRxInvert(false);
+  Serial.println("\n--- setRxInvert(false) ---");
+  printPullState(RX1, "pull-up");
+  Serial1.end();
+
+  Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1);
+  Serial1.setTxInvert(true);
+  Serial.println("\n--- setTxInvert(true) only (RX pull unchanged) ---");
+  printPullState(RX1, "pull-up");
+  Serial1.end();
+
+  Serial.println("\nInverted UART (RS-232 style PHY) needs pull-down on RX to match electrical idle LOW.");
+}
+
+#if HAS_UART2
+static bool waitForBytes(HardwareSerial &uart, uint32_t timeoutMs) {
+  uint32_t start = millis();
+  while (millis() - start < timeoutMs) {
+    if (uart.available() > 0) {
+      return true;
+    }
+    delay(1);
+  }
+  return false;
+}
+
+static void runWiredLoopbackDemo(bool pullEnabled) {
+  Serial1.end();
+  Serial2.end();
+
+  Serial1.setPins(RX1, TX1);
+  Serial2.enableRxInternalPull(pullEnabled);
+  Serial2.setPins(RX2, TX2);
+  Serial1.begin(BAUD, SERIAL_8N1, RX1, TX1);
+  Serial2.begin(BAUD, SERIAL_8N1, RX2, TX2);
+
+  Serial.printf("\n--- Loopback with enableRxInternalPull(%s) on UART2 RX ---\n", pullEnabled ? "true" : "false");
+  printPullState(RX2, pullEnabled ? "pull-up" : "floating");
+
+  while (Serial2.available()) {
+    Serial2.read();
+  }
+
+  Serial1.println(TEST_MSG);
+  Serial1.flush();
+
+  if (waitForBytes(Serial2, 300)) {
+    String line = Serial2.readStringUntil('\n');
+    line.trim();
+    Serial.printf("  Received on UART2: \"%s\"\n", line.c_str());
+    Serial.println("  OK — partner TX drives the line during idle and while sending.");
+  } else {
+    Serial.printf("  No data received — connect GPIO %d (UART1 TX1) to GPIO %d (UART2 RX2) and reset.\n", TX1, RX2);
+  }
+
+  Serial1.end();
+  Serial2.end();
+}
+
+static void runWiredLoopbackSection() {
+  Serial.println("\n=== Part C: Wired loopback ===");
+  printPartCWiringInstructions();
+  Serial.println("When UART1 TX is wired to UART2 RX, the transmitter output usually holds idle HIGH.");
+  Serial.println("Internal pull on UART2 RX is often redundant here; both cases below should receive data.");
+
+  runWiredLoopbackDemo(true);
+  runWiredLoopbackDemo(false);
+}
+#endif
+
+void setup() {
+  Serial.begin(BAUD);
+  delay(500);
+  Serial.println("\n=== RX Internal Pull Demo ===");
+  Serial.printf("UART1 pins: RX=%d TX=%d\n", RX1, TX1);
+#if HAS_UART2
+  Serial.printf("Part C (after A & B): jumper UART1 TX1 GPIO %d -> UART2 RX2 GPIO %d\n", TX1, RX2);
+#endif
+
+  runFloatingRxDemo();
+  runInversionPullDemo();
+
+#if HAS_UART2
+  Serial.printf("Board has UART2 — RX2=%d TX2=%d\n", RX2, TX2);
+  runWiredLoopbackSection();
+#else
+  Serial.println("\n=== Part C: skipped (board has fewer than 3 UARTs) ===");
+  Serial.println("Wired loopback needs a second UART: jumper peer TX (GPIO) -> peer RX (GPIO), split pins.");
+#endif
+
+  Serial.println("\nDemo complete.");
+}
+
+void loop() {
+}

--- a/tests/validation/uart/README.md
+++ b/tests/validation/uart/README.md
@@ -1,37 +1,74 @@
 # UART Validation Test
 
-Comprehensive test suite for the `HardwareSerial` (UART) driver covering transmission, baudrate changes, pin management, peripheral manager integration, CPU frequency changes, hardware flow control, and IrDA mode.
+Comprehensive Unity test suite for the `HardwareSerial` (UART) driver covering transmission, baudrate changes, pin management, peripheral manager integration, CPU frequency changes, hardware flow control, IrDA mode, RX internal pull, and one-wire UART.
 
 ## Test Cases
 
+Tests run in the order listed in `setup()` (`RUN_TEST` sequence).
+
 | Test Function | Description |
 |---|---|
-| `begin_when_running_test` | Call `begin()` twice without crash |
-| `basic_transmission_test` | Transmit and receive a message via internal loopback |
-| `resize_buffers_test` | Verify RX/TX buffer resize behavior (while running and stopped) |
-| `change_baudrate_test` | Change baudrate to 9600 and back, verify transmission at each rate |
-| `change_cpu_frequency_test` | Change CPU frequency, verify UART still works at new and original frequency |
-| `disabled_uart_calls_test` | Call all UART methods on a stopped UART, verify safe return values |
-| `enabled_uart_calls_test` | Call all UART methods on a running UART, verify correct return values |
-| `auto_baudrate_test` | Auto baudrate detection (ESP32 and ESP32-S2 only) |
-| `periman_test` | Peripheral manager: attach I2C to UART pins, verify UART stops, then re-enable |
-| `change_pins_test` | Change UART RX/TX pins and verify transmission on new pins |
-| `irda_mode_test` | Set IrDA mode, switch TX/RX directions, verify directional behavior with 2 UARTs |
-| `inter_uart_pin_move_test` | Move UART1 pins to UART2's pins, verify UART2 is terminated (requires 2+ UARTs) |
-| `same_uart_pin_swap_test` | Swap RX and TX on the same UART, verify it stays running |
-| `move_rx_tx_to_cts_rts_test` | Move RX/TX pins to CTS/RTS slots, verify UART is terminated |
-| `cross_uart_cts_rts_test` | Assign another UART's pins as CTS/RTS, verify source UART terminates (requires 2+ UARTs) |
+| `begin_when_running_test` | Call `begin()` twice on a running UART without crash |
+| `basic_transmission_test` | Transmit and receive via `onReceive` + internal loopback on default pins |
+| `resize_buffers_test` | RX/TX buffer resize while running (expect error) and while stopped (expect success) |
+| `change_baudrate_test` | Change baudrate to 9600 and back; verify transmission at each rate |
+| `change_cpu_frequency_test` | Change CPU frequency; verify UART at new and restored frequency |
+| `disabled_uart_calls_test` | Call UART APIs on a stopped UART; verify safe return values / no crash |
+| `enabled_uart_calls_test` | Echo a message, then exercise running-UART APIs (`peek`, `setRxTimeout`, inverts, etc.); verify pre-begin APIs fail while running |
+| `auto_baudrate_test` | Auto baudrate detection (**ESP32 and ESP32-S2 only**) |
+| `periman_test` | Attach I2C to UART RX pin; verify UART cannot receive; reattach UART and verify reception |
+| `change_pins_test` | Move RX to alternate GPIO (keep TX on default when only one test UART); verify transmission |
+| `irda_mode_test` | IrDA mode/direction API checks; with 2+ UARTs, cross-UART IrDA RX/TX behavior at 9600 baud |
+| `inter_uart_pin_move_test` | Move UART1 to UART2's pins; UART2 terminates (**requires 2+ test UARTs**) |
+| `same_uart_pin_swap_test` | Swap RX/TX on the same UART; driver stays up; echo works |
+| `move_rx_tx_to_cts_rts_test` | Move RX/TX into CTS/RTS slots; UART terminates (no valid RX/TX) |
+| `cross_uart_cts_rts_test` | Assign another UART's pins as CTS/RTS; source UART terminates (**requires 2+ test UARTs**) |
+| `rx_pull_pre_begin_api_test` | `enableRxInternalPull` / `enableOneWireMode` succeed only before `begin()` |
+| `rx_pull_inversion_test` | RX pull-up/down vs `begin(invert)`, `setRxInvert`, not `setTxInvert`; disabled pull → float |
+| `same_pin_validation_test` | `setPins(p,p)` fails without `enableOneWireMode(true)` |
+| `same_pin_pull_disabled_test` | One-wire same pin → RX pad floating even with invert |
+| `same_pin_transmission_test` | One-wire echo on `TEST_AUX_PIN` (`SCL`) with internal loopback |
+| `same_pin_periman_test` | Shared pin registers as `UART_RX_TX`; `pinMode()` terminates UART |
+| `same_pin_mode_rejection_test` | RS485 and IrDA reject same-pin `setPins` |
+| `same_pin_split_transition_test` | Split pins → one-wire (`end`/`begin`) → back to split via `setPins`; driver stays up; echo at each stage |
+| `rx_pull_setpins_reattach_test` | Pull follows RX pin after `setPins` swap; updates after `setRxInvert` |
 | `end_when_stopped_test` | Call `end()` twice without crash |
-| `hardware_flow_control_test` | Enable RTS/CTS flow control with internal loopback, verify transmission |
+| `hardware_flow_control_test` | RTS/CTS on spare GPIOs with internal TX→RX and RTS→CTS loopback; ON/OFF flow control |
 
 ## Requirements
 
-- **Hardware**: Any ESP32 variant with at least 2 UART peripherals (UART0 for reporting, UART1+ for testing)
+- **Hardware**: Any ESP32 variant with at least **one HP UART besides UART0** (UART0/`Serial` is used only for status output)
+- **Multi-UART tests**: `inter_uart_pin_move_test`, `cross_uart_cts_rts_test`, and the functional section of `irda_mode_test` require **2+ HP UARTs** beyond UART0 (e.g. ESP32-S3 with Serial1 + Serial2)
 - **Wokwi/QEMU**: QEMU not supported
+
+## Pin assignments (sketch constants)
+
+Default test UART pins come from board macros (`RX1`/`TX1`, `RX2`/`TX2`, …). See the pin table at the top of `uart.ino`.
+
+Additional constants come from the board `pins_arduino.h` I2C pin variables (`SDA`, `SCL`):
+
+| Constant | Source | Use |
+|---|---|---|
+| `NEW_RX1` | `SDA` | Alternate RX for pin-change, pull, and flow-control (CTS) tests |
+| `NEW_TX1` | `SCL` | Alternate TX for split-pin tests; RTS in flow-control test |
+| `TEST_AUX_PIN` | `SCL` | One-wire tests (same pad as `NEW_TX1`, but never active as split TX in the same step) |
+
+Compile-time checks reject boards where `SDA`/`SCL` overlap `Serial1`/`Serial2` default UART pins. One-wire stages use `SCL` so split-pin steps can use `SDA` (RX) and `SCL` (TX) without two roles on one GPIO at once.
+
+On ESP32-P4, UART1 defaults are hardcoded to RX=2, TX=3 for EV-board compatibility.
+
+Hardware flow control assigns CTS/RTS to `SDA`/`SCL` while data RX/TX remain on the UART default pins.
+
+## Test harness behavior
+
+- **`setUp()`** (before each test): `end()` → `begin()` → register stable `onReceive` callback → establish internal loopback on the current RX pin.
+- **`tearDown()`** (after each test): `end()` on all configured test UARTs.
+- **Loopback**: `transmit_and_check_msg()` re-applies loopback, drains RX, sends a string, polls `available()` (and invokes `onReceive` synchronously when data is pending).
+- **Internal loopback mechanism**: On native IOMUX RX pins (e.g. ESP32-S3 UART1 RX=15), the core uses peripheral loopback (`uart_set_loop_back`). On GPIO-matrix RX pins or cross-UART routing, it uses GPIO-matrix TX→RX wiring. See `uart_internal_loopback()` in `esp32-hal-uart.c`.
 
 ## Notes
 
-- UART0 (`Serial`) is reserved for test status reporting; UART1+ are configured with internal loopback (TX routed back to RX) for self-test.
-- The `auto_baudrate_test` is only compiled on ESP32 and ESP32-S2 targets.
-- Pin assignments vary by target; the sketch uses default `RX1`/`TX1`/`RX2`/`TX2` macros except on ESP32-P4 which uses hardcoded pins 2/3.
-- Tests involving pin reassignment between UARTs require at least 2 UART peripherals beyond UART0.
+- UART0 (`Serial`) is reserved for Unity status and diagnostics only.
+- `auto_baudrate_test` is compiled only on ESP32 and ESP32-S2.
+- One-wire and pull tests operate on `Serial1` directly (outside the shared `UARTTestConfig` vector) and call `Serial1.end()` at the start of each test.
+- `change_pins_test` with a single test UART moves **RX only** (`setPins(NEW_RX1, -1)`); TX stays on the default pin.

--- a/tests/validation/uart/README.md
+++ b/tests/validation/uart/README.md
@@ -23,13 +23,13 @@ Tests run in the order listed in `setup()` (`RUN_TEST` sequence).
 | `same_uart_pin_swap_test` | Swap RX/TX on the same UART; driver stays up; echo works |
 | `move_rx_tx_to_cts_rts_test` | Move RX/TX into CTS/RTS slots; UART terminates (no valid RX/TX) |
 | `cross_uart_cts_rts_test` | Assign another UART's pins as CTS/RTS; source UART terminates (**requires 2+ test UARTs**) |
-| `rx_pull_pre_begin_api_test` | `enableRxInternalPull` / `enableOneWireMode` succeed only before `begin()` |
+| `rx_pull_pre_begin_api_test` | `enableRxInternalPull` succeeds only before `begin()` |
 | `rx_pull_inversion_test` | RX pull-up/down vs `begin(invert)`, `setRxInvert`, not `setTxInvert`; disabled pull → float |
-| `same_pin_validation_test` | `setPins(p,p)` fails without `enableOneWireMode(true)` |
+| `same_pin_validation_test` | Same-pin auto-detects one-wire; shared-pin CTS/RTS overlap is rejected; `-1` preserves shared pins and non-conflicting CTS updates; implicit split↔one-wire transitions preserve the kept pin, bus ownership, driver, and RX pull |
 | `same_pin_pull_disabled_test` | One-wire same pin → RX pad floating even with invert |
 | `same_pin_transmission_test` | One-wire echo on `TEST_AUX_PIN` (`SCL`) with internal loopback |
 | `same_pin_periman_test` | Shared pin registers as `UART_RX_TX`; `pinMode()` terminates UART |
-| `same_pin_mode_rejection_test` | RS485 and IrDA reject same-pin `setPins` |
+| `same_pin_mode_rejection_test` | RS485/IrDA reject same-pin `setPins`; `setMode` rejects active one-wire |
 | `same_pin_split_transition_test` | Split pins → one-wire (`end`/`begin`) → back to split via `setPins`; driver stays up; echo at each stage |
 | `rx_pull_setpins_reattach_test` | Pull follows RX pin after `setPins` swap; updates after `setRxInvert` |
 | `end_when_stopped_test` | Call `end()` twice without crash |

--- a/tests/validation/uart/README.md
+++ b/tests/validation/uart/README.md
@@ -25,9 +25,9 @@ Tests run in the order listed in `setup()` (`RUN_TEST` sequence).
 | `cross_uart_cts_rts_test` | Assign another UART's pins as CTS/RTS; source UART terminates (**requires 2+ test UARTs**) |
 | `rx_pull_pre_begin_api_test` | `enableRxInternalPull` succeeds only before `begin()` |
 | `rx_pull_inversion_test` | RX pull-up/down vs `begin(invert)`, `setRxInvert`, not `setTxInvert`; disabled pull → float |
-| `same_pin_validation_test` | Same-pin auto-detects one-wire; shared-pin CTS/RTS overlap is rejected; `-1` preserves shared pins and non-conflicting CTS updates; implicit split↔one-wire transitions preserve the kept pin, bus ownership, driver, and RX pull |
-| `same_pin_pull_disabled_test` | One-wire same pin → RX pad floating even with invert |
-| `same_pin_transmission_test` | One-wire echo on `TEST_AUX_PIN` (`SCL`) with internal loopback |
+| `same_pin_validation_test` | Same-pin auto-detects open-drain one-wire; shared-pin CTS/RTS overlap is rejected; `-1` preserves shared pins and non-conflicting CTS updates; split↔one-wire transitions verify OD lifecycle, bus ownership, driver, and RX pull |
+| `same_pin_pull_disabled_test` | One-wire same pin → OD enabled and internal RX pulls disabled even with invert |
+| `same_pin_transmission_test` | One-wire echo on `TEST_AUX_PIN` (`SCL`) via internal loopback; OD is temporarily disabled so the loopback is deterministic with no external pull-up |
 | `same_pin_periman_test` | Shared pin registers as `UART_RX_TX`; `pinMode()` terminates UART |
 | `same_pin_mode_rejection_test` | RS485/IrDA reject same-pin `setPins`; `setMode` rejects active one-wire |
 | `same_pin_split_transition_test` | Split pins → one-wire (`end`/`begin`) → back to split via `setPins`; driver stays up; echo at each stage |

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -33,6 +33,9 @@
 #include <unity.h>
 #include "HardwareSerial.h"
 #include "esp_rom_gpio.h"
+#include "esp32-hal-periman.h"
+#include "driver/gpio.h"
+#include "hal/gpio_types.h"
 #include "Wire.h"
 
 /* Utility defines */
@@ -54,8 +57,11 @@ public:
     : uart_num(num), serial(serial_ref), peeked_char(-1), default_rx_pin(rx_pin), default_tx_pin(tx_pin), recv_msg("") {}
 
   void begin(unsigned long baudrate) {
-    // pinMode will force enabling the internal pullup resistor (IDF 5.3.2 Change)
-    pinMode(default_rx_pin, INPUT_PULLUP);
+    // pinMode clears the peripheral bus and detaches UART RX when Serial is already running.
+    // Internal RX pull is applied by the driver on begin(); only pre-configure GPIO when stopped.
+    if (!serial) {
+      pinMode(default_rx_pin, INPUT_PULLUP);
+    }
     serial.begin(baudrate, SERIAL_8N1, default_rx_pin, default_tx_pin);
     while (!serial) {
       delay(10);
@@ -79,13 +85,32 @@ public:
   }
 
   void transmit_and_check_msg(const String &msg_append, bool perform_assert = true) {
+    const String expected = "Hello from Serial" + String(uart_num) + " " + msg_append;
+    const int8_t rx_pin = uart_get_RxPin(uart_num);
+    uart_internal_loopback(uart_num, rx_pin);
     reset_buffers();
-    delay(50);
-    serial.print("Hello from Serial" + String(uart_num) + " " + msg_append);
+    clear_rx_buffer();
+    delay(10);
+    serial.print(expected);
     serial.flush();
-    delay(50);
+    uint32_t start = millis();
+    while (millis() - start < 500) {
+      while (serial.available()) {
+        onReceive();
+      }
+      if (recv_msg.length() >= expected.length()) {
+        break;
+      }
+      delay(5);
+    }
+    if (perform_assert && recv_msg != expected) {
+      Serial.printf(
+        "UART%d diag: rx=%d tx=%d avail=%u got='%s'\n", uart_num, rx_pin, uart_get_TxPin(uart_num), serial.available(), recv_msg.c_str()
+      );
+      Serial.flush();
+    }
     if (perform_assert) {
-      TEST_ASSERT_EQUAL_STRING(("Hello from Serial" + String(uart_num) + " " + msg_append).c_str(), recv_msg.c_str());
+      TEST_ASSERT_EQUAL_STRING(expected.c_str(), recv_msg.c_str());
       log_d("UART%d received message: %s\n", uart_num, recv_msg.c_str());
     }
   }
@@ -112,13 +137,68 @@ public:
 
 /* Utility global variables */
 
-[[maybe_unused]]
-static const int NEW_RX1 = 9;
-[[maybe_unused]]
-static const int NEW_TX1 = 10;
+// Alternate Serial1 split-pin pads from the board I2C bus (pins_arduino.h: SDA/SCL).
+static const int8_t NEW_RX1 = SDA;
+static const int8_t NEW_TX1 = SCL;
+
+// One-wire tests use SCL so they never share a GPIO with split-pin RX (SDA) in the same
+// test step. Sequential stages may reuse pads after end()/begin() (see same_pin_split_transition_test).
+static const int8_t TEST_AUX_PIN = SCL;
+
+static_assert(NEW_RX1 != NEW_TX1, "UART test alternate RX/TX pins (SDA/SCL) must differ");
+static_assert(NEW_RX1 != RX1 && NEW_RX1 != TX1, "SDA must not overlap Serial1 default pins on this board");
+static_assert(NEW_TX1 != RX1 && NEW_TX1 != TX1, "SCL must not overlap Serial1 default pins on this board");
+#if defined(RX2) && defined(TX2)
+static_assert(NEW_RX1 != RX2 && NEW_RX1 != TX2, "SDA must not overlap Serial2 default pins on this board");
+static_assert(NEW_TX1 != RX2 && NEW_TX1 != TX2, "SCL must not overlap Serial2 default pins on this board");
+#endif
+
 std::vector<UARTTestConfig *> uart_test_configs;
 
-/* Utility functions */
+static gpio_pull_mode_t read_rx_pull_mode(int8_t gpio) {
+  gpio_io_config_t cfg = {};
+  if (gpio_get_io_config((gpio_num_t)gpio, &cfg) != ESP_OK) {
+    return GPIO_FLOATING;
+  }
+  if (cfg.pu && cfg.pd) {
+    return GPIO_PULLUP_PULLDOWN;
+  }
+  if (cfg.pu) {
+    return GPIO_PULLUP_ONLY;
+  }
+  if (cfg.pd) {
+    return GPIO_PULLDOWN_ONLY;
+  }
+  return GPIO_FLOATING;
+}
+
+static void reset_serial_pin_options(HardwareSerial &s) {
+  s.enableOneWireMode(false);
+  s.enableRxInternalPull(true);
+}
+
+static void test_serial_begin(HardwareSerial &s, int8_t rx, int8_t tx, unsigned long baud = 115200, bool invert = false) {
+  s.end();
+  s.setPins(rx, tx);
+  s.begin(baud, SERIAL_8N1, rx, tx, invert);
+  while (!s) {
+    delay(10);
+  }
+}
+
+static void uart_test_register_on_receive(UARTTestConfig &config) {
+  UARTTestConfig *cfg = &config;
+  config.serial.onReceive([cfg]() {
+    cfg->onReceive();
+  });
+}
+
+static void uart_test_init_config(UARTTestConfig &config, unsigned long baudrate = 115200) {
+  config.end();
+  config.begin(baudrate);
+  uart_test_register_on_receive(config);
+  uart_internal_loopback(config.uart_num, uart_get_RxPin(config.uart_num));
+}
 
 extern "C" int8_t uart_get_RxPin(uint8_t uart_num);
 extern "C" int8_t uart_get_TxPin(uint8_t uart_num);
@@ -139,13 +219,7 @@ void task_delayed_msg(void *pvParameters) {
 // This function is automatically called by unity before each test is run
 void setUp(void) {
   for (auto *ref : uart_test_configs) {
-    UARTTestConfig &config = *ref;
-    //log_d("Setup internal loop-back from and back to UART%d TX >> UART%d RX", config.uart_num, config.uart_num);
-    config.begin(115200);
-    config.serial.onReceive([&config]() {
-      config.onReceive();
-    });
-    uart_internal_loopback(config.uart_num, uart_get_RxPin(config.uart_num));
+    uart_test_init_config(*ref);
   }
 }
 
@@ -251,6 +325,10 @@ void enabled_uart_calls_test(void) {
   long int integer_ret;
   uint8_t test_buf[1];
 
+  UARTTestConfig &config = *uart_test_configs[0];
+  config.transmit_and_check_msg("", false);
+  TEST_ASSERT_GREATER_OR_EQUAL(0, config.peeked_char);
+
   log_d("Checking if Serial 1 can set the RX timeout while running");
   boolean_ret = Serial1.setRxTimeout(1);
   TEST_ASSERT_EQUAL(true, boolean_ret);
@@ -262,9 +340,6 @@ void enabled_uart_calls_test(void) {
   log_d("Checking if Serial 1 is writable while running");
   boolean_ret = Serial1.availableForWrite();
   TEST_ASSERT_EQUAL(true, boolean_ret);
-
-  log_d("Checking if Serial 1 is peekable while running");
-  TEST_ASSERT_GREATER_OR_EQUAL(0, uart_test_configs[0]->peeked_char);
 
   log_d("Checking if Serial 1 can read bytes while running");
   integer_ret = Serial1.readBytes(test_buf, 1);
@@ -295,6 +370,10 @@ void enabled_uart_calls_test(void) {
   log_d("Checking if Serial 1 TX can be inverted while running");
   Serial1.setTxInvert(true);
   Serial1.setTxInvert(false);
+
+  log_d("Checking if Serial 1 RX internal pull can't be changed while running");
+  TEST_ASSERT_FALSE(Serial1.enableRxInternalPull(true));
+  TEST_ASSERT_FALSE(Serial1.enableOneWireMode(true));
 
   Serial.println("Enabled UART calls test successful");
 }
@@ -376,6 +455,11 @@ void disabled_uart_calls_test(void) {
   Serial1.setTxInvert(true);
   Serial1.setTxInvert(false);
 
+  log_d("Checking if Serial 1 pin options can be set when stopped");
+  TEST_ASSERT_TRUE(Serial1.enableRxInternalPull(true));
+  TEST_ASSERT_TRUE(Serial1.enableOneWireMode(true));
+  reset_serial_pin_options(Serial1);
+
   Serial.println("Disabled UART calls test successful");
 }
 
@@ -401,6 +485,7 @@ void change_pins_test(void) {
     //TEST_ASSERT_EQUAL(NEW_TX1, uart_get_TxPin(config.uart_num));
 
     uart_internal_loopback(config.uart_num, NEW_RX1);
+    uart_test_register_on_receive(config);
     config.transmit_and_check_msg("using new pins");
   } else {
     for (int i = 0; i < TEST_UART_NUM; i++) {
@@ -413,6 +498,7 @@ void change_pins_test(void) {
       //TEST_ASSERT_EQUAL(uart_get_TxPin(config.uart_num), next_uart.default_tx_pin);
 
       uart_internal_loopback(config.uart_num, next_uart.default_rx_pin);
+      uart_test_register_on_receive(config);
       config.transmit_and_check_msg("using new pins");
     }
   }
@@ -467,6 +553,8 @@ void auto_baudrate_test(void) {
 void periman_test(void) {
   log_d("Checking if peripheral manager can properly manage UART pins");
 
+  Wire.end();
+
   log_d("Setting up I2C on the same pins as UART");
 
   for (auto *ref : uart_test_configs) {
@@ -482,12 +570,16 @@ void periman_test(void) {
 
     log_d("Disabling I2C and re-enabling UART%d", config.uart_num);
 
+    Wire.end();
     config.serial.setPins(config.default_rx_pin, config.default_tx_pin);
+    uart_test_register_on_receive(config);
     uart_internal_loopback(config.uart_num, config.default_rx_pin);
 
     log_d("Trying to send message using UART%d with I2C disabled", config.uart_num);
     config.transmit_and_check_msg("while I2C is disabled");
   }
+
+  Wire.end();
 
   Serial.println("Peripheral manager test successful");
 }
@@ -528,10 +620,9 @@ void change_cpu_frequency_test(void) {
 void hardware_flow_control_test(void) {
   log_d("Starting hardware flow control test");
 
-  // Define CTS and RTS pins for testing
-  // I2C are always valid pins
-  const int8_t TEST_RTS_PIN = SDA;
-  const int8_t TEST_CTS_PIN = SCL;
+  // Use board I2C pads (SDA/SCL) for CTS/RTS; default RX/TX stay on UART1 pins.
+  const int8_t TEST_RTS_PIN = NEW_TX1;
+  const int8_t TEST_CTS_PIN = NEW_RX1;
 
   for (auto *ref : uart_test_configs) {
     UARTTestConfig &config = *ref;
@@ -550,8 +641,9 @@ void hardware_flow_control_test(void) {
     log_d("Setting up internal loopbacks: TX->RX and RTS->CTS");
     uart_internal_loopback(config.uart_num, config.default_rx_pin);
     uart_internal_hw_flow_ctrl_loopback(config.uart_num, TEST_CTS_PIN);
+    uart_test_register_on_receive(config);
 
-    delay(50);
+    delay(100);
     config.transmit_and_check_msg("Hardware Flow Control ON");
 
     // Test that flow control can be disabled
@@ -789,6 +881,231 @@ void cross_uart_cts_rts_test(void) {
   Serial.println("Cross-UART CTS/RTS terminates source UART test successful");
 }
 
+void rx_pull_pre_begin_api_test(void) {
+  log_d("RX pull / one-wire APIs must be pre-begin only");
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+  TEST_ASSERT_TRUE(Serial1.enableRxInternalPull(true));
+  TEST_ASSERT_TRUE(Serial1.enableOneWireMode(true));
+
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  TEST_ASSERT_FALSE(Serial1.enableRxInternalPull(true));
+  TEST_ASSERT_FALSE(Serial1.enableOneWireMode(true));
+  Serial1.end();
+
+  Serial.println("RX pull pre-begin API test successful");
+}
+
+void rx_pull_inversion_test(void) {
+  log_d("RX internal pull vs inversion");
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+  Serial1.end();
+
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1, 115200, true);
+  TEST_ASSERT_EQUAL(GPIO_PULLDOWN_ONLY, read_rx_pull_mode(NEW_RX1));
+  Serial1.end();
+
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  Serial1.setRxInvert(true);
+  TEST_ASSERT_EQUAL(GPIO_PULLDOWN_ONLY, read_rx_pull_mode(NEW_RX1));
+  Serial1.end();
+
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1, 115200, true);
+  Serial1.setRxInvert(false);
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+  Serial1.end();
+
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  Serial1.setTxInvert(true);
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+  Serial1.end();
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+  Serial1.enableRxInternalPull(false);
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(NEW_RX1));
+  Serial1.end();
+
+  Serial.println("RX pull inversion test successful");
+}
+
+void same_pin_validation_test(void) {
+  log_d("Same-pin requires enableOneWireMode(true)");
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+  TEST_ASSERT_FALSE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
+
+  Serial1.enableOneWireMode(true);
+  TEST_ASSERT_TRUE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
+  Serial1.end();
+
+  Serial.println("Same-pin validation test successful");
+}
+
+void same_pin_pull_disabled_test(void) {
+  log_d("One-wire mode disables RX internal pull");
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+  Serial1.enableOneWireMode(true);
+  test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN, 115200, true);
+  TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(TEST_AUX_PIN));
+  Serial1.end();
+
+  Serial.println("Same-pin pull disabled test successful");
+}
+
+void same_pin_transmission_test(void) {
+  log_d("One-wire UART echo on shared pin");
+
+  Serial1.end();
+  String recv;
+  reset_serial_pin_options(Serial1);
+  Serial1.enableOneWireMode(true);
+  test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN);
+  Serial1.onReceive([&recv]() {
+    while (Serial1.available()) {
+      char c = Serial1.read();
+      if (c > 31 && c < 128) {
+        recv += c;
+      }
+    }
+  });
+  uart_internal_loopback(1, TEST_AUX_PIN);
+  delay(50);
+  recv = "";
+  Serial1.print("ONEWIRE");
+  Serial1.flush();
+  delay(150);
+  TEST_ASSERT_EQUAL_STRING("ONEWIRE", recv.c_str());
+  Serial1.end();
+
+  Serial.println("Same-pin transmission test successful");
+}
+
+void same_pin_periman_test(void) {
+  log_d("One-wire pin uses UART_RX_TX periman type; external deinit terminates UART");
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+  Serial1.enableOneWireMode(true);
+  test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN);
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(TEST_AUX_PIN));
+  TEST_ASSERT_TRUE(Serial1);
+
+  pinMode(TEST_AUX_PIN, INPUT);
+  delay(50);
+  TEST_ASSERT_FALSE(Serial1);
+  Serial1.end();
+
+  Serial.println("Same-pin periman test successful");
+}
+
+void same_pin_mode_rejection_test(void) {
+  log_d("RS485 and IrDA reject same-pin configuration");
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+  Serial1.enableOneWireMode(true);
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+
+  TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_RS485_HALF_DUPLEX));
+  TEST_ASSERT_FALSE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
+
+  TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_UART));
+  TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_IRDA));
+  TEST_ASSERT_FALSE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
+
+  TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_UART));
+  Serial1.end();
+
+  Serial.println("Same-pin mode rejection test successful");
+}
+
+void same_pin_split_transition_test(void) {
+  log_d("Split <-> one-wire transitions keep driver alive");
+
+  Serial1.end();
+  String recv;
+  reset_serial_pin_options(Serial1);
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  Serial1.onReceive([&recv]() {
+    while (Serial1.available()) {
+      char c = Serial1.read();
+      if (c > 31 && c < 128) {
+        recv += c;
+      }
+    }
+  });
+  uart_internal_loopback(1, NEW_RX1);
+  delay(50);
+  recv = "";
+  Serial1.print("SPLIT");
+  Serial1.flush();
+  delay(150);
+  TEST_ASSERT_EQUAL_STRING("SPLIT", recv.c_str());
+  TEST_ASSERT_TRUE(Serial1);
+
+  Serial1.end();
+  Serial1.enableOneWireMode(true);
+  test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN);
+  Serial1.onReceive([&recv]() {
+    while (Serial1.available()) {
+      char c = Serial1.read();
+      if (c > 31 && c < 128) {
+        recv += c;
+      }
+    }
+  });
+  TEST_ASSERT_TRUE(Serial1);
+  uart_internal_loopback(1, TEST_AUX_PIN);
+  recv = "";
+  Serial1.print("SHARED");
+  Serial1.flush();
+  delay(150);
+  TEST_ASSERT_EQUAL_STRING("SHARED", recv.c_str());
+
+  TEST_ASSERT_TRUE(Serial1.setPins(NEW_RX1, NEW_TX1));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_TX1, uart_get_TxPin(1));
+  uart_internal_loopback(1, NEW_RX1);
+  recv = "";
+  Serial1.print("SPLIT2");
+  Serial1.flush();
+  delay(150);
+  TEST_ASSERT_EQUAL_STRING("SPLIT2", recv.c_str());
+  Serial1.end();
+
+  Serial.println("Same-pin split transition test successful");
+}
+
+void rx_pull_setpins_reattach_test(void) {
+  log_d("RX pull follows pin changes and setRxInvert()");
+
+  Serial1.end();
+  reset_serial_pin_options(Serial1);
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+
+  TEST_ASSERT_TRUE(Serial1.setPins(NEW_TX1, NEW_RX1));
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_TX1));
+
+  Serial1.setRxInvert(true);
+  TEST_ASSERT_EQUAL(GPIO_PULLDOWN_ONLY, read_rx_pull_mode(NEW_TX1));
+  Serial1.end();
+
+  Serial.println("RX pull setPins reattach test successful");
+}
+
 /* Main functions */
 
 void setup() {
@@ -825,16 +1142,13 @@ void setup() {
   }
 
   log_d("TEST_UART_NUM = %d", TEST_UART_NUM);
-
+  Serial.printf("UART validation: TEST_UART_NUM=%d\r\n", TEST_UART_NUM);
   for (auto *ref : uart_test_configs) {
     UARTTestConfig &config = *ref;
-    config.begin(115200);
-    log_d("Setup internal loop-back from and back to UART%d TX >> UART%d RX", config.uart_num, config.uart_num);
-    config.serial.onReceive([&config]() {
-      config.onReceive();
-    });
-    uart_internal_loopback(config.uart_num, uart_get_RxPin(config.uart_num));
+    Serial.printf("  UART%d default RX=%d TX=%d\r\n", config.uart_num, config.default_rx_pin, config.default_tx_pin);
   }
+  Serial.printf("  Serial1 alt split RX=%d TX=%d one-wire=%d\r\n", NEW_RX1, NEW_TX1, TEST_AUX_PIN);
+  Serial.flush();
 
   log_d("Setup done. Starting tests");
 
@@ -856,6 +1170,15 @@ void setup() {
   RUN_TEST(same_uart_pin_swap_test);
   RUN_TEST(move_rx_tx_to_cts_rts_test);
   RUN_TEST(cross_uart_cts_rts_test);
+  RUN_TEST(rx_pull_pre_begin_api_test);
+  RUN_TEST(rx_pull_inversion_test);
+  RUN_TEST(same_pin_validation_test);
+  RUN_TEST(same_pin_pull_disabled_test);
+  RUN_TEST(same_pin_transmission_test);
+  RUN_TEST(same_pin_periman_test);
+  RUN_TEST(same_pin_mode_rejection_test);
+  RUN_TEST(same_pin_split_transition_test);
+  RUN_TEST(rx_pull_setpins_reattach_test);
   RUN_TEST(end_when_stopped_test);
   RUN_TEST(hardware_flow_control_test);
   UNITY_END();

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -180,9 +180,6 @@ static void test_serial_begin(HardwareSerial &s, int8_t rx, int8_t tx, unsigned 
   s.end();
   s.setPins(rx, tx);
   s.begin(baud, SERIAL_8N1, rx, tx, invert);
-  while (!s) {
-    delay(10);
-  }
 }
 
 static void uart_test_register_on_receive(UARTTestConfig &config) {

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -109,9 +109,7 @@ public:
       delay(5);
     }
     if (perform_assert && recv_msg != expected) {
-      Serial.printf(
-        "UART%d diag: rx=%d tx=%d avail=%u got='%s'\n", uart_num, rx_pin, uart_get_TxPin(uart_num), serial.available(), recv_msg.c_str()
-      );
+      Serial.printf("UART%d diag: rx=%d tx=%d avail=%u got='%s'\n", uart_num, rx_pin, uart_get_TxPin(uart_num), serial.available(), recv_msg.c_str());
       Serial.flush();
     }
     if (perform_assert) {

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -35,7 +35,11 @@
 #include "esp_rom_gpio.h"
 #include "esp32-hal-periman.h"
 #include "driver/gpio.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
 #include "esp_private/gpio.h"
+#else
+#include "hal/gpio_ll.h"
+#endif
 #include "hal/gpio_types.h"
 #include "Wire.h"
 
@@ -176,6 +180,15 @@ static gpio_pull_mode_t read_rx_pull_mode(int8_t gpio) {
 static bool read_open_drain_enabled(int8_t gpio) {
   gpio_io_config_t cfg = {};
   return gpio_get_io_config((gpio_num_t)gpio, &cfg) == ESP_OK && cfg.od;
+}
+
+// Temporarily force push-pull for internal loopback CI (no external pull-up).
+static void force_push_pull_for_loopback(int8_t gpio) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+  gpio_od_disable((gpio_num_t)gpio);
+#else
+  gpio_ll_od_disable(&GPIO, (uint32_t)gpio);
+#endif
 }
 
 static void reset_serial_pin_options(HardwareSerial &s) {
@@ -1065,7 +1078,7 @@ void same_pin_transmission_test(void) {
   // defined by an external pull-up. This CI sketch must run with no external parts
   // (including in simulators), so drive the loopback push-pull for a deterministic
   // pad level here. OD configuration itself is asserted in the validation/pull tests.
-  gpio_od_disable((gpio_num_t)TEST_AUX_PIN);
+  force_push_pull_for_loopback(TEST_AUX_PIN);
   delay(50);
   recv = "";
   Serial1.print("ONEWIRE");
@@ -1156,7 +1169,7 @@ void same_pin_split_transition_test(void) {
   uart_internal_loopback(1, TEST_AUX_PIN);
   // Same-pin loopback is driven push-pull for a deterministic pad level with no
   // external pull-up (see same_pin_transmission_test).
-  gpio_od_disable((gpio_num_t)TEST_AUX_PIN);
+  force_push_pull_for_loopback(TEST_AUX_PIN);
   recv = "";
   Serial1.print("SHARED");
   Serial1.flush();

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -173,7 +173,6 @@ static gpio_pull_mode_t read_rx_pull_mode(int8_t gpio) {
 }
 
 static void reset_serial_pin_options(HardwareSerial &s) {
-  s.enableOneWireMode(false);
   s.enableRxInternalPull(true);
 }
 
@@ -373,7 +372,6 @@ void enabled_uart_calls_test(void) {
 
   log_d("Checking if Serial 1 RX internal pull can't be changed while running");
   TEST_ASSERT_FALSE(Serial1.enableRxInternalPull(true));
-  TEST_ASSERT_FALSE(Serial1.enableOneWireMode(true));
 
   Serial.println("Enabled UART calls test successful");
 }
@@ -457,7 +455,6 @@ void disabled_uart_calls_test(void) {
 
   log_d("Checking if Serial 1 pin options can be set when stopped");
   TEST_ASSERT_TRUE(Serial1.enableRxInternalPull(true));
-  TEST_ASSERT_TRUE(Serial1.enableOneWireMode(true));
   reset_serial_pin_options(Serial1);
 
   Serial.println("Disabled UART calls test successful");
@@ -882,16 +879,14 @@ void cross_uart_cts_rts_test(void) {
 }
 
 void rx_pull_pre_begin_api_test(void) {
-  log_d("RX pull / one-wire APIs must be pre-begin only");
+  log_d("RX pull API must be pre-begin only");
 
   Serial1.end();
   reset_serial_pin_options(Serial1);
   TEST_ASSERT_TRUE(Serial1.enableRxInternalPull(true));
-  TEST_ASSERT_TRUE(Serial1.enableOneWireMode(true));
 
   test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
   TEST_ASSERT_FALSE(Serial1.enableRxInternalPull(true));
-  TEST_ASSERT_FALSE(Serial1.enableOneWireMode(true));
   Serial1.end();
 
   Serial.println("RX pull pre-begin API test successful");
@@ -937,14 +932,91 @@ void rx_pull_inversion_test(void) {
 }
 
 void same_pin_validation_test(void) {
-  log_d("Same-pin requires enableOneWireMode(true)");
+  log_d("Same-pin auto-detects one-wire; -1 keep-current also enables it");
 
   Serial1.end();
   reset_serial_pin_options(Serial1);
-  TEST_ASSERT_FALSE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
-
-  Serial1.enableOneWireMode(true);
   TEST_ASSERT_TRUE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
+  TEST_ASSERT_EQUAL(TEST_AUX_PIN, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(TEST_AUX_PIN, uart_get_TxPin(1));
+  Serial1.end();
+
+  // Explicit (p, p) then begin: shared periman type
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  TEST_ASSERT_FALSE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN, TEST_AUX_PIN, -1));
+  TEST_ASSERT_FALSE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN, -1, TEST_AUX_PIN));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_TX1, uart_get_TxPin(1));
+  TEST_ASSERT_TRUE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(TEST_AUX_PIN));
+  TEST_ASSERT_EQUAL(TEST_AUX_PIN, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(TEST_AUX_PIN, uart_get_TxPin(1));
+  TEST_ASSERT_FALSE(Serial1.setPins(-1, -1, TEST_AUX_PIN, -1));
+  TEST_ASSERT_FALSE(Serial1.setPins(-1, -1, -1, TEST_AUX_PIN));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(TEST_AUX_PIN));
+
+  // Keeping both data pins while adding CTS must preserve one-wire ownership and the driver.
+  TEST_ASSERT_TRUE(Serial1.setPins(-1, -1));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(TEST_AUX_PIN));
+  TEST_ASSERT_TRUE(Serial1.setPins(-1, -1, NEW_RX1, -1));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(TEST_AUX_PIN, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(TEST_AUX_PIN, uart_get_TxPin(1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(TEST_AUX_PIN));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_CTS, perimanGetPinBusType(NEW_RX1));
+  Serial1.end();
+
+  // Back to split, then implicit one-wire via setPins(-1, currentRx)
+  test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
+  TEST_ASSERT_TRUE(Serial1.setPins(-1, NEW_RX1));
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_TxPin(1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(NEW_RX1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_INIT, perimanGetPinBusType(NEW_TX1));
+  TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(NEW_RX1));
+
+  // Leave one-wire while keeping RX via -1; the kept RX must regain its pull.
+  TEST_ASSERT_TRUE(Serial1.setPins(-1, NEW_TX1));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_TX1, uart_get_TxPin(1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX, perimanGetPinBusType(NEW_RX1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_TX, perimanGetPinBusType(NEW_TX1));
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+
+  // Enter through the other implicit form, then leave while keeping TX via -1.
+  TEST_ASSERT_TRUE(Serial1.setPins(NEW_TX1, -1));
+  TEST_ASSERT_EQUAL(NEW_TX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_TX1, uart_get_TxPin(1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(NEW_TX1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_INIT, perimanGetPinBusType(NEW_RX1));
+  TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(NEW_TX1));
+  TEST_ASSERT_TRUE(Serial1.setPins(NEW_RX1, -1));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_TX1, uart_get_TxPin(1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX, perimanGetPinBusType(NEW_RX1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_TX, perimanGetPinBusType(NEW_TX1));
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+
+  // Explicit split -> one-wire collapsing onto the former RX pad, then re-expand to split.
+  TEST_ASSERT_TRUE(Serial1.setPins(NEW_RX1, NEW_RX1));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_TxPin(1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(NEW_RX1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_INIT, perimanGetPinBusType(NEW_TX1));
+  TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(NEW_RX1));
+  TEST_ASSERT_TRUE(Serial1.setPins(NEW_RX1, NEW_TX1));
+  TEST_ASSERT_TRUE(Serial1);
+  TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
+  TEST_ASSERT_EQUAL(NEW_TX1, uart_get_TxPin(1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX, perimanGetPinBusType(NEW_RX1));
+  TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_TX, perimanGetPinBusType(NEW_TX1));
+  TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
   Serial1.end();
 
   Serial.println("Same-pin validation test successful");
@@ -955,7 +1027,6 @@ void same_pin_pull_disabled_test(void) {
 
   Serial1.end();
   reset_serial_pin_options(Serial1);
-  Serial1.enableOneWireMode(true);
   test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN, 115200, true);
   TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(TEST_AUX_PIN));
   Serial1.end();
@@ -969,7 +1040,6 @@ void same_pin_transmission_test(void) {
   Serial1.end();
   String recv;
   reset_serial_pin_options(Serial1);
-  Serial1.enableOneWireMode(true);
   test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN);
   Serial1.onReceive([&recv]() {
     while (Serial1.available()) {
@@ -996,7 +1066,6 @@ void same_pin_periman_test(void) {
 
   Serial1.end();
   reset_serial_pin_options(Serial1);
-  Serial1.enableOneWireMode(true);
   test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN);
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(TEST_AUX_PIN));
   TEST_ASSERT_TRUE(Serial1);
@@ -1010,11 +1079,10 @@ void same_pin_periman_test(void) {
 }
 
 void same_pin_mode_rejection_test(void) {
-  log_d("RS485 and IrDA reject same-pin configuration");
+  log_d("RS485 and IrDA reject same-pin configuration; setMode rejects active one-wire");
 
   Serial1.end();
   reset_serial_pin_options(Serial1);
-  Serial1.enableOneWireMode(true);
   test_serial_begin(Serial1, NEW_RX1, NEW_TX1);
 
   TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_RS485_HALF_DUPLEX));
@@ -1024,6 +1092,10 @@ void same_pin_mode_rejection_test(void) {
   TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_IRDA));
   TEST_ASSERT_FALSE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
 
+  TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_UART));
+  TEST_ASSERT_TRUE(Serial1.setPins(TEST_AUX_PIN, TEST_AUX_PIN));
+  TEST_ASSERT_FALSE(Serial1.setMode(UART_MODE_RS485_HALF_DUPLEX));
+  TEST_ASSERT_FALSE(Serial1.setMode(UART_MODE_IRDA));
   TEST_ASSERT_TRUE(Serial1.setMode(UART_MODE_UART));
   Serial1.end();
 
@@ -1055,7 +1127,6 @@ void same_pin_split_transition_test(void) {
   TEST_ASSERT_TRUE(Serial1);
 
   Serial1.end();
-  Serial1.enableOneWireMode(true);
   test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN);
   Serial1.onReceive([&recv]() {
     while (Serial1.available()) {

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -35,6 +35,7 @@
 #include "esp_rom_gpio.h"
 #include "esp32-hal-periman.h"
 #include "driver/gpio.h"
+#include "esp_private/gpio.h"
 #include "hal/gpio_types.h"
 #include "Wire.h"
 
@@ -170,6 +171,11 @@ static gpio_pull_mode_t read_rx_pull_mode(int8_t gpio) {
     return GPIO_PULLDOWN_ONLY;
   }
   return GPIO_FLOATING;
+}
+
+static bool read_open_drain_enabled(int8_t gpio) {
+  gpio_io_config_t cfg = {};
+  return gpio_get_io_config((gpio_num_t)gpio, &cfg) == ESP_OK && cfg.od;
 }
 
 static void reset_serial_pin_options(HardwareSerial &s) {
@@ -953,6 +959,7 @@ void same_pin_validation_test(void) {
   TEST_ASSERT_FALSE(Serial1.setPins(-1, -1, -1, TEST_AUX_PIN));
   TEST_ASSERT_TRUE(Serial1);
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(TEST_AUX_PIN));
+  TEST_ASSERT_TRUE(read_open_drain_enabled(TEST_AUX_PIN));
 
   // Keeping both data pins while adding CTS must preserve one-wire ownership and the driver.
   TEST_ASSERT_TRUE(Serial1.setPins(-1, -1));
@@ -974,6 +981,7 @@ void same_pin_validation_test(void) {
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(NEW_RX1));
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_INIT, perimanGetPinBusType(NEW_TX1));
   TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(NEW_RX1));
+  TEST_ASSERT_TRUE(read_open_drain_enabled(NEW_RX1));
 
   // Leave one-wire while keeping RX via -1; the kept RX must regain its pull.
   TEST_ASSERT_TRUE(Serial1.setPins(-1, NEW_TX1));
@@ -983,6 +991,7 @@ void same_pin_validation_test(void) {
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX, perimanGetPinBusType(NEW_RX1));
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_TX, perimanGetPinBusType(NEW_TX1));
   TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+  TEST_ASSERT_FALSE(read_open_drain_enabled(NEW_RX1));
 
   // Enter through the other implicit form, then leave while keeping TX via -1.
   TEST_ASSERT_TRUE(Serial1.setPins(NEW_TX1, -1));
@@ -991,6 +1000,7 @@ void same_pin_validation_test(void) {
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(NEW_TX1));
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_INIT, perimanGetPinBusType(NEW_RX1));
   TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(NEW_TX1));
+  TEST_ASSERT_TRUE(read_open_drain_enabled(NEW_TX1));
   TEST_ASSERT_TRUE(Serial1.setPins(NEW_RX1, -1));
   TEST_ASSERT_TRUE(Serial1);
   TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
@@ -998,6 +1008,7 @@ void same_pin_validation_test(void) {
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX, perimanGetPinBusType(NEW_RX1));
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_TX, perimanGetPinBusType(NEW_TX1));
   TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+  TEST_ASSERT_FALSE(read_open_drain_enabled(NEW_TX1));
 
   // Explicit split -> one-wire collapsing onto the former RX pad, then re-expand to split.
   TEST_ASSERT_TRUE(Serial1.setPins(NEW_RX1, NEW_RX1));
@@ -1007,6 +1018,7 @@ void same_pin_validation_test(void) {
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX_TX, perimanGetPinBusType(NEW_RX1));
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_INIT, perimanGetPinBusType(NEW_TX1));
   TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(NEW_RX1));
+  TEST_ASSERT_TRUE(read_open_drain_enabled(NEW_RX1));
   TEST_ASSERT_TRUE(Serial1.setPins(NEW_RX1, NEW_TX1));
   TEST_ASSERT_TRUE(Serial1);
   TEST_ASSERT_EQUAL(NEW_RX1, uart_get_RxPin(1));
@@ -1014,6 +1026,7 @@ void same_pin_validation_test(void) {
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_RX, perimanGetPinBusType(NEW_RX1));
   TEST_ASSERT_EQUAL(ESP32_BUS_TYPE_UART_TX, perimanGetPinBusType(NEW_TX1));
   TEST_ASSERT_EQUAL(GPIO_PULLUP_ONLY, read_rx_pull_mode(NEW_RX1));
+  TEST_ASSERT_FALSE(read_open_drain_enabled(NEW_RX1));
   Serial1.end();
 
   Serial.println("Same-pin validation test successful");
@@ -1026,6 +1039,7 @@ void same_pin_pull_disabled_test(void) {
   reset_serial_pin_options(Serial1);
   test_serial_begin(Serial1, TEST_AUX_PIN, TEST_AUX_PIN, 115200, true);
   TEST_ASSERT_EQUAL(GPIO_FLOATING, read_rx_pull_mode(TEST_AUX_PIN));
+  TEST_ASSERT_TRUE(read_open_drain_enabled(TEST_AUX_PIN));
   Serial1.end();
 
   Serial.println("Same-pin pull disabled test successful");
@@ -1047,6 +1061,11 @@ void same_pin_transmission_test(void) {
     }
   });
   uart_internal_loopback(1, TEST_AUX_PIN);
+  // The HAL configures the shared pad open-drain, whose released-HIGH level is only
+  // defined by an external pull-up. This CI sketch must run with no external parts
+  // (including in simulators), so drive the loopback push-pull for a deterministic
+  // pad level here. OD configuration itself is asserted in the validation/pull tests.
+  gpio_od_disable((gpio_num_t)TEST_AUX_PIN);
   delay(50);
   recv = "";
   Serial1.print("ONEWIRE");
@@ -1135,6 +1154,9 @@ void same_pin_split_transition_test(void) {
   });
   TEST_ASSERT_TRUE(Serial1);
   uart_internal_loopback(1, TEST_AUX_PIN);
+  // Same-pin loopback is driven push-pull for a deterministic pad level with no
+  // external pull-up (see same_pin_transmission_test).
+  gpio_od_disable((gpio_num_t)TEST_AUX_PIN);
   recv = "";
   Serial1.print("SHARED");
   Serial1.flush();


### PR DESCRIPTION
## Description of Change

This pull request introduces advanced UART features to the ESP32 Arduino core, focusing on two main areas: (1) support for open-drain one-wire UART (single GPIO for RX and TX), and (2) configurable internal pull resistors on the RX pin. It also updates the documentation to explain these features, their usage, and compatibility constraints. Several minor improvements and clarifications to the documentation are included.

**New UART Features:**

* Added support for automatic open-drain one-wire UART mode when RX and TX are assigned to the same GPIO. This is reflected in the HAL, Peripheral Manager, and user documentation. [[1]](diffhunk://#diff-c000debbd8a1f78bce815451cf47df688b77276d783a9a2f415a4381d18078bbR27) [[2]](diffhunk://#diff-b13165e864af00ee872517324ae4929b78d0411fff6f4fb2b98114f241c00f22R33) [[3]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cR320-R436)
* Introduced `enableRxInternalPull(bool enable)` method to `HardwareSerial`, allowing users to enable or disable the internal pull resistor on the RX pin before calling `begin()`. The pull direction follows RX signal inversion, and is disabled in one-wire mode. [[1]](diffhunk://#diff-ba8df4ae3e43ea0d34307f26d6def560d7c458d88bf6fb2ddd315a94a60dbdaeR410-R411) [[2]](diffhunk://#diff-ba8326df1da045f1f613db50d92fefb7bd8ed28256aff9af66685f091f64557aR670-R678) [[3]](diffhunk://#diff-49a988ec8cbc8364d7aa2bb277c54dddb72d30293e4e97e26132c8d188ba1947R137-R139) [[4]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cR320-R436)

**Documentation Updates:**

* Thoroughly documented the new one-wire UART mode and RX internal pull feature, including usage patterns, caveats, and examples. Added sections on mode and pin compatibility, signal inversion effects, and guidance for preventing ghost data in one-wire mode. [[1]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cL16-R32) [[2]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cR320-R436)
* Clarified LP UART pin rules for different ESP32 variants, and updated notes on RS485 and IrDA mode compatibility with one-wire and RX pull features. [[1]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cL60-R64) [[2]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cL520-R641) [[3]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cR662)
* Improved documentation for internal loopback testing, explaining when native peripheral loopback is used versus GPIO matrix routing. [[1]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cL684-R808) [[2]](diffhunk://#diff-214fce74d1857c5d6851b2a4deb0c5a780acd52478b823926a560b97178b5b2cL699-R826)

**Internal/Codebase Improvements:**

* Refined the UART instance registration and cleanup logic to ensure proper de-registration of `HardwareSerial` objects when UART is stopped. [[1]](diffhunk://#diff-ba8326df1da045f1f613db50d92fefb7bd8ed28256aff9af66685f091f64557aL17-R19) [[2]](diffhunk://#diff-ba8326df1da045f1f613db50d92fefb7bd8ed28256aff9af66685f091f64557aR504-R514)

These changes add significant flexibility for advanced UART use cases, especially for half-duplex and bus-style protocols, while making configuration and compatibility more transparent to users.

## Test Scenarios
Tested with the examples and also with uart.ino (validation test) using ESP32, S2, S3, C3 and C6 


## Related links
Closes #12729 
Closes #12734 