### PR TITLE
feat(zigbee): Add IAS zone enroll request handler

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -848,6 +848,27 @@ void ZigbeeEP::addPrivilegeCommand(uint16_t cluster_id, uint16_t command_id) {
   }
 }
 
+bool ZigbeeEP::sendIASZoneEnrollResponse(
+  uint16_t dst_short_addr, uint8_t dst_endpoint, uint8_t zone_id, esp_zb_zcl_ias_zone_enroll_response_code_t response_code
+) {
+  esp_zb_zcl_ias_zone_enroll_response_cmd_t cmd_resp;
+  memset(&cmd_resp, 0, sizeof(cmd_resp));
+  cmd_resp.zcl_basic_cmd.dst_addr_u.addr_short = dst_short_addr;
+  cmd_resp.zcl_basic_cmd.dst_endpoint = dst_endpoint;
+  cmd_resp.zcl_basic_cmd.src_endpoint = _endpoint;
+  cmd_resp.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
+  cmd_resp.enroll_rsp_code = (uint8_t)response_code;
+  cmd_resp.zone_id = zone_id;
+
+  if (!acquireCommandLock()) {
+    return false;
+  }
+  esp_zb_zcl_ias_zone_enroll_cmd_resp(&cmd_resp);
+  releaseCommandLock();
+  log_v("IAS Zone Enroll Response sent to 0x%04x endpoint %u (zone id %u, code %u)", dst_short_addr, dst_endpoint, zone_id, (uint8_t)response_code);
+  return true;
+}
+
 void ZigbeeEP::zbPrivilegeCommand(const esp_zb_zcl_privilege_command_message_t *message) {
   if (_on_privilege_command) {
     _on_privilege_command(message);

--- a/libraries/Zigbee/src/ZigbeeEP.h
+++ b/libraries/Zigbee/src/ZigbeeEP.h
@@ -149,6 +149,13 @@ public:
   // Register a privilege command to intercept standard cluster commands before the stack processes them
   void addPrivilegeCommand(uint16_t cluster_id, uint16_t command_id);
 
+  // Send an IAS Zone Enroll Response (CIE/coordinator side) to a device that issued an enroll request.
+  // Typically called from within a zbIASZoneEnrollRequest() override using the request message src address/endpoint.
+  bool sendIASZoneEnrollResponse(
+    uint16_t dst_short_addr, uint8_t dst_endpoint, uint8_t zone_id,
+    esp_zb_zcl_ias_zone_enroll_response_code_t response_code = ESP_ZB_ZCL_IAS_ZONE_ENROLL_RESPONSE_CODE_SUCCESS
+  );
+
   // findEndpoint may be implemented by EPs to find and bind devices
   virtual void findEndpoint(esp_zb_zdo_match_desc_req_param_t *cmd_req) {};
 
@@ -163,6 +170,7 @@ public:
   virtual void zbWindowCoveringMovementCmd(const esp_zb_zcl_window_covering_movement_message_t *message) {};
   virtual void zbReadTimeCluster(const esp_zb_zcl_attribute_t *attribute);  //already implemented
   virtual void zbIASZoneStatusChangeNotification(const esp_zb_zcl_ias_zone_status_change_notification_message_t *message) {};
+  virtual void zbIASZoneEnrollRequest(const esp_zb_zcl_ias_zone_enroll_request_message_t *message) {};
   virtual void zbIASZoneEnrollResponse(const esp_zb_zcl_ias_zone_enroll_response_message_t *message) {};
   virtual void zbDefaultResponse(const esp_zb_zcl_cmd_default_resp_message_t *message);  //already implemented
   virtual void zbPrivilegeCommand(const esp_zb_zcl_privilege_command_message_t *message);

--- a/libraries/Zigbee/src/ZigbeeHandlers.cpp
+++ b/libraries/Zigbee/src/ZigbeeHandlers.cpp
@@ -47,6 +47,7 @@ static esp_err_t zb_cmd_read_attr_resp_handler(const esp_zb_zcl_cmd_read_attr_re
 static esp_err_t zb_cmd_write_attr_resp_handler(const esp_zb_zcl_cmd_write_attr_resp_message_t *message);
 static esp_err_t zb_configure_report_resp_handler(const esp_zb_zcl_cmd_config_report_resp_message_t *message);
 static esp_err_t zb_cmd_ias_zone_status_change_handler(const esp_zb_zcl_ias_zone_status_change_notification_message_t *message);
+static esp_err_t zb_cmd_ias_zone_enroll_request_handler(const esp_zb_zcl_ias_zone_enroll_request_message_t *message);
 static esp_err_t zb_cmd_ias_zone_enroll_response_handler(const esp_zb_zcl_ias_zone_enroll_response_message_t *message);
 static esp_err_t zb_cmd_default_resp_handler(const esp_zb_zcl_cmd_default_resp_message_t *message);
 static esp_err_t zb_window_covering_movement_resp_handler(const esp_zb_zcl_window_covering_movement_message_t *message);
@@ -66,6 +67,9 @@ static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id,
     case ESP_ZB_CORE_CMD_REPORT_CONFIG_RESP_CB_ID: ret = zb_configure_report_resp_handler((esp_zb_zcl_cmd_config_report_resp_message_t *)message); break;
     case ESP_ZB_CORE_CMD_IAS_ZONE_ZONE_STATUS_CHANGE_NOT_ID:
       ret = zb_cmd_ias_zone_status_change_handler((esp_zb_zcl_ias_zone_status_change_notification_message_t *)message);
+      break;
+    case ESP_ZB_CORE_CMD_IAS_ZONE_ZONE_ENROLL_REQUEST_ID:
+      ret = zb_cmd_ias_zone_enroll_request_handler((esp_zb_zcl_ias_zone_enroll_request_message_t *)message);
       break;
     case ESP_ZB_CORE_IAS_ZONE_ENROLL_RESPONSE_VALUE_CB_ID:
       ret = zb_cmd_ias_zone_enroll_response_handler((esp_zb_zcl_ias_zone_enroll_response_message_t *)message);
@@ -245,6 +249,29 @@ static esp_err_t zb_cmd_ias_zone_status_change_handler(const esp_zb_zcl_ias_zone
   for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
     if (message->info.dst_endpoint == (*it)->getEndpoint()) {
       (*it)->zbIASZoneStatusChangeNotification(message);
+    }
+  }
+  return ESP_OK;
+}
+
+static esp_err_t zb_cmd_ias_zone_enroll_request_handler(const esp_zb_zcl_ias_zone_enroll_request_message_t *message) {
+  if (!message) {
+    log_e("Empty message");
+    return ESP_FAIL;
+  }
+  if (message->info.status != ESP_ZB_ZCL_STATUS_SUCCESS) {
+    log_e("Received message: error status(%d)", message->info.status);
+    return ESP_ERR_INVALID_ARG;
+  }
+  log_v(
+    "IAS Zone Enroll Request: from address(0x%x) src endpoint(%u) to dst endpoint(%u) cluster(0x%x) zone type(0x%x) manufacturer code(0x%x)",
+    message->info.src_address.u.short_addr, message->info.src_endpoint, message->info.dst_endpoint, message->info.cluster, message->zone_type,
+    message->manufacturer_code
+  );
+
+  for (std::list<ZigbeeEP *>::iterator it = Zigbee.ep_objects.begin(); it != Zigbee.ep_objects.end(); ++it) {
+    if (message->info.dst_endpoint == (*it)->getEndpoint()) {
+      (*it)->zbIASZoneEnrollRequest(message);
     }
   }
   return ESP_OK;


### PR DESCRIPTION
## Description of Change
This pull request adds support for handling IAS Zone Enroll Requests in the Zigbee endpoint logic. The main changes introduce a new handler for IAS Zone Enroll Requests, a corresponding virtual callback in the `ZigbeeEP` class, and a helper function to send enroll responses. These additions improve the Zigbee stack's ability to interact with IAS Zone devices and handle their enrollment lifecycle.

**IAS Zone Enroll Request Handling:**

* Added a new handler function `zb_cmd_ias_zone_enroll_request_handler` in `ZigbeeHandlers.cpp` to process incoming IAS Zone Enroll Request messages and dispatch them to the appropriate endpoint (`ZigbeeEP`).
* Registered the new handler in the Zigbee action handler switch and declared its prototype. [[1]](diffhunk://#diff-3f85b61e828164904aa3644dd3cdd349185161fe5df9f34959a6e939af4e088fR50) [[2]](diffhunk://#diff-3f85b61e828164904aa3644dd3cdd349185161fe5df9f34959a6e939af4e088fR71-R73)

**Zigbee Endpoint API Enhancements:**

* Added a new virtual method `zbIASZoneEnrollRequest` to the `ZigbeeEP` class for endpoint-specific handling of enroll requests.
* Introduced a helper function `sendIASZoneEnrollResponse` in `ZigbeeEP` to simplify sending enroll responses back to devices, with thread-safety and logging. [[1]](diffhunk://#diff-d6ef64ae3bc8bc786fd05ea9a9a601e2710d012542ef08033c3b2e42285bc750R851-R871) [[2]](diffhunk://#diff-ddc8d9922531a975b3287cea342182baa7d1cac46bcc38727dfe38abd33c288cR152-R158)

## Test Scenarios

## Related links
Closes #12747
