### PR TITLE
fix(esp32p4): Allow selecting the USB device port

### DIFF
--- a/cores/esp32/USBCDC.cpp
+++ b/cores/esp32/USBCDC.cpp
@@ -30,7 +30,7 @@ USBCDC *devices[CFG_TUD_CDC];
 static uint16_t load_cdc_descriptor(uint8_t *dst, uint8_t *itf) {
   uint8_t str_index = tinyusb_add_string_descriptor("TinyUSB CDC");
   uint8_t descriptor[TUD_CDC_DESC_LEN] = {// Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-                                          TUD_CDC_DESCRIPTOR(*itf, str_index, 0x85, CFG_TUD_ENDPOINT_SIZE, 0x03, 0x84, CFG_TUD_ENDPOINT_SIZE)
+                                          TUD_CDC_DESCRIPTOR(*itf, str_index, 0x85, ARDUINO_USB_ENDPOINT_SIZE, 0x03, 0x84, ARDUINO_USB_ENDPOINT_SIZE)
   };
   *itf += 2;
   memcpy(dst, descriptor, TUD_CDC_DESC_LEN);
@@ -47,7 +47,9 @@ static uint16_t load_cdc_descriptor2(uint8_t *dst, uint8_t *itf) {
   TU_VERIFY(ep_out != 0);
   uint8_t descriptor[TUD_CDC_DESC_LEN] = {
     // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-    TUD_CDC_DESCRIPTOR(*itf, str_index, (uint8_t)(0x80 | ep_ntfy), CFG_TUD_ENDPOINT_SIZE, ep_out, (uint8_t)(0x80 | ep_in), CFG_TUD_ENDPOINT_SIZE)
+    TUD_CDC_DESCRIPTOR(
+      *itf, str_index, (uint8_t)(0x80 | ep_ntfy), ARDUINO_USB_ENDPOINT_SIZE, ep_out, (uint8_t)(0x80 | ep_in), ARDUINO_USB_ENDPOINT_SIZE
+    )
   };
   *itf += 2;
   memcpy(dst, descriptor, TUD_CDC_DESC_LEN);

--- a/cores/esp32/USBMSC.cpp
+++ b/cores/esp32/USBMSC.cpp
@@ -24,7 +24,7 @@ extern "C" uint16_t tusb_msc_load_descriptor(uint8_t *dst, uint8_t *itf) {
   uint8_t ep_num = tinyusb_get_free_duplex_endpoint();
   TU_VERIFY(ep_num != 0);
   uint8_t descriptor[TUD_MSC_DESC_LEN] = {// Interface number, string index, EP Out & EP In address, EP size
-                                          TUD_MSC_DESCRIPTOR(*itf, str_index, ep_num, (uint8_t)(0x80 | ep_num), CFG_TUD_ENDPOINT_SIZE)
+                                          TUD_MSC_DESCRIPTOR(*itf, str_index, ep_num, (uint8_t)(0x80 | ep_num), ARDUINO_USB_ENDPOINT_SIZE)
   };
   *itf += 1;
   memcpy(dst, descriptor, TUD_MSC_DESC_LEN);

--- a/cores/esp32/esp32-hal-tinyusb.c
+++ b/cores/esp32/esp32-hal-tinyusb.c
@@ -136,7 +136,11 @@ esp_err_t init_usb_hal(bool external_phy) {
     .target = USB_PHY_TARGET_INT,
     .otg_mode = USB_OTG_MODE_DEVICE,
 #if CONFIG_IDF_TARGET_ESP32P4
+#if ARDUINO_USB_DEVICE_PORT == 0
+    .otg_speed = USB_PHY_SPEED_FULL,
+#else
     .otg_speed = USB_PHY_SPEED_HIGH,
+#endif
 #else
     .otg_speed = USB_PHY_SPEED_FULL,
 #endif
@@ -181,8 +185,12 @@ esp_err_t tinyusb_driver_install(const tinyusb_config_t *config) {
   memset(&tinit, 0, sizeof(tusb_rhport_init_t));
   tinit.role = TUSB_ROLE_DEVICE;
 #if CONFIG_IDF_TARGET_ESP32P4
+#if ARDUINO_USB_DEVICE_PORT == 0
+  tinit.speed = TUSB_SPEED_FULL;
+#else
   tinit.speed = TUSB_SPEED_HIGH;
-  if (!tusb_init(1, &tinit)) {
+#endif
+  if (!tusb_init(ARDUINO_USB_DEVICE_PORT, &tinit)) {
 #else
   tinit.speed = TUSB_SPEED_FULL;
   if (!tusb_init(0, &tinit)) {

--- a/cores/esp32/esp32-hal-tinyusb.h
+++ b/cores/esp32/esp32-hal-tinyusb.h
@@ -20,6 +20,15 @@
 
 #if CONFIG_TINYUSB_ENABLED
 
+#if CONFIG_IDF_TARGET_ESP32P4
+#ifndef ARDUINO_USB_DEVICE_PORT
+#define ARDUINO_USB_DEVICE_PORT 1
+#endif
+#if ARDUINO_USB_DEVICE_PORT != 0 && ARDUINO_USB_DEVICE_PORT != 1
+#error "ARDUINO_USB_DEVICE_PORT must be 0 or 1"
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,19 +40,23 @@ extern "C" {
 #define USB_ESPRESSIF_VID                0x303A
 #define USB_STRING_DESCRIPTOR_ARRAY_SIZE 10
 
-#ifndef CFG_TUD_ENDPOINT_SIZE
 #if CONFIG_IDF_TARGET_ESP32P4
-#define CFG_TUD_ENDPOINT_SIZE 512
+#if ARDUINO_USB_DEVICE_PORT == 0
+#define ARDUINO_USB_ENDPOINT_SIZE 64
+#define CFG_TUD_NUM_EPS          6
+#define CFG_TUD_NUM_IN_EPS       5
 #else
+#define ARDUINO_USB_ENDPOINT_SIZE CFG_TUD_ENDPOINT_SIZE
+#define CFG_TUD_NUM_EPS          15
+#define CFG_TUD_NUM_IN_EPS       8
+#endif
+#else
+#ifndef CFG_TUD_ENDPOINT_SIZE
 #define CFG_TUD_ENDPOINT_SIZE 64
 #endif
-#endif
-#if CONFIG_IDF_TARGET_ESP32P4
-#define CFG_TUD_NUM_EPS    15
-#define CFG_TUD_NUM_IN_EPS 8
-#else
-#define CFG_TUD_NUM_EPS    6
-#define CFG_TUD_NUM_IN_EPS 5
+#define ARDUINO_USB_ENDPOINT_SIZE CFG_TUD_ENDPOINT_SIZE
+#define CFG_TUD_NUM_EPS          6
+#define CFG_TUD_NUM_IN_EPS       5
 #endif
 
 typedef struct {

--- a/libraries/USB/src/USBHID.cpp
+++ b/libraries/USB/src/USBHID.cpp
@@ -207,7 +207,7 @@ extern "C" uint16_t tusb_hid_load_descriptor(uint8_t *dst, uint8_t *itf) {
     // HID Input & Output descriptor
     // Interface number, string index, protocol, report descriptor len, EP OUT & IN address, size & polling interval
     TUD_HID_INOUT_DESCRIPTOR(
-      *itf, str_index, tinyusb_interface_protocol, tinyusb_hid_device_descriptor_len, ep_out, (uint8_t)(0x80 | ep_in), CFG_TUD_ENDPOINT_SIZE, 1
+      *itf, str_index, tinyusb_interface_protocol, tinyusb_hid_device_descriptor_len, ep_out, (uint8_t)(0x80 | ep_in), ARDUINO_USB_ENDPOINT_SIZE, 1
     )
   };
   *itf += 1;

--- a/libraries/USB/src/USBMIDI.cpp
+++ b/libraries/USB/src/USBMIDI.cpp
@@ -31,7 +31,7 @@ extern "C" uint16_t tusb_midi_load_descriptor(uint8_t *dst, uint8_t *itf) {
   uint8_t ep_out = tinyusb_get_free_out_endpoint();
   TU_VERIFY(ep_out != 0);
   uint8_t descriptor[TUD_MIDI_DESC_LEN] = {
-    TUD_MIDI_DESCRIPTOR(*itf, str_index, ep_out, (uint8_t)(0x80 | ep_in), CFG_TUD_ENDPOINT_SIZE),
+    TUD_MIDI_DESCRIPTOR(*itf, str_index, ep_out, (uint8_t)(0x80 | ep_in), ARDUINO_USB_ENDPOINT_SIZE),
   };
   *itf += 2;
   memcpy(dst, descriptor, TUD_MIDI_DESC_LEN);

--- a/libraries/USB/src/USBVendor.cpp
+++ b/libraries/USB/src/USBVendor.cpp
@@ -24,7 +24,7 @@ esp_err_t arduino_usb_event_handler_register_with(esp_event_base_t event_base, i
 
 static USBVendor *_Vendor = NULL;
 static QueueHandle_t rx_queue = NULL;
-static uint16_t USB_VENDOR_ENDPOINT_SIZE = CFG_TUD_ENDPOINT_SIZE;
+static uint16_t USB_VENDOR_ENDPOINT_SIZE = ARDUINO_USB_ENDPOINT_SIZE;
 
 uint16_t tusb_vendor_load_descriptor(uint8_t *dst, uint8_t *itf) {
   uint8_t str_index = tinyusb_add_string_descriptor("TinyUSB Vendor");
@@ -72,9 +72,9 @@ USBVendor::USBVendor(uint16_t endpoint_size) : itf(0), cb(NULL) {
   if (!_Vendor) {
     _Vendor = this;
     if (endpoint_size == 0) {
-      endpoint_size = CFG_TUD_ENDPOINT_SIZE;
+      endpoint_size = ARDUINO_USB_ENDPOINT_SIZE;
     }
-    if (endpoint_size <= CFG_TUD_ENDPOINT_SIZE) {
+    if (endpoint_size <= ARDUINO_USB_ENDPOINT_SIZE) {
       USB_VENDOR_ENDPOINT_SIZE = endpoint_size;
     }
     tinyusb_enable_interface(USB_INTERFACE_VENDOR, TUD_VENDOR_DESC_LEN, tusb_vendor_load_descriptor);


### PR DESCRIPTION
## Description of Change

This PR allows selecting the USB device controller on ESP32-P4 at build time using `ARDUINO_USB_DEVICE_PORT`.

The default remains port 1 to preserve the existing high-speed USB behavior.

- `ARDUINO_USB_DEVICE_PORT=0`
  - Uses the full-speed USB controller
  - Configures the USB PHY and TinyUSB for full speed
  - Uses a maximum endpoint size of 64 bytes
  - Uses the endpoint limits of the full-speed controller

- `ARDUINO_USB_DEVICE_PORT=1`
  - Preserves the existing high-speed USB behavior
  - Uses the existing TinyUSB endpoint size
  - Uses the endpoint limits of the high-speed controller

Values other than `0` or `1` produce a compile-time error.

A separate `ARDUINO_USB_ENDPOINT_SIZE` macro is used for descriptors generated by the Arduino USB implementations. This keeps TinyUSB's compile-time `CFG_TUD_ENDPOINT_SIZE` configuration unchanged across translation units.

Existing ESP32-P4 builds are unaffected unless `ARDUINO_USB_DEVICE_PORT` is explicitly defined.

Example using `build_opt.h`:

```text
-DARDUINO_USB_DEVICE_PORT=0
```

No board menu option is added by this PR to keep the change limited to the USB implementation.

## Test Scenarios

Tested using:

- ESP32-P4 development board
- `ESP32P4 Dev Module` board configuration
- Arduino-ESP32 built from this PR branch
- ESP32-P4 Arduino libraries/toolchain version 3.3.10

The following configurations were compiled:

- Default configuration (`ARDUINO_USB_DEVICE_PORT=1`)
- Full-speed controller (`ARDUINO_USB_DEVICE_PORT=0`)
- Invalid controller value (`ARDUINO_USB_DEVICE_PORT=2`), confirming that compilation fails as expected

The affected CDC, MSC, HID, MIDI, Vendor, and TinyUSB HAL source files were compiled for both port 0 and port 1.

Hardware testing was performed with:

```text
-DARDUINO_USB_DEVICE_PORT=0
```

A USB HID keyboard sketch enumerated and operated successfully through the ESP32-P4 full-speed USB device port.

## Related links

N/A