### PR TITLE
fix(network): don't inspect stale errno when recv() reports EOF in connected()

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -575,15 +575,8 @@ uint8_t NetworkClient::connected() {
   if (_connected) {
     uint8_t dummy;
     int res = recv(fd(), &dummy, 1, MSG_DONTWAIT | MSG_PEEK);
-    if (res == 0) {
-      // The peer performed an orderly shutdown (FIN received, e.g. via shutdown(SHUT_WR)).
-      // This is a *successful* recv() call, not an error, so errno is not set by it and
-      // must not be inspected here (it may still hold a stale value from an unrelated,
-      // earlier syscall). A half-closed connection can still be perfectly writable, so
-      // do not tear it down based on leftover errno.
-      _connected = true;
-    } else if (res < 0) {
-      // recv only sets errno if res is < 0
+    // recv only sets errno when it returns -1
+    if (res < 0) {
       switch (errno) {
         case EWOULDBLOCK:
         case ENOENT:  //caused by vfs

--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -575,10 +575,15 @@ uint8_t NetworkClient::connected() {
   if (_connected) {
     uint8_t dummy;
     int res = recv(fd(), &dummy, 1, MSG_DONTWAIT | MSG_PEEK);
-    // avoid unused var warning by gcc
-    (void)res;
-    // recv only sets errno if res is <= 0
-    if (res <= 0) {
+    if (res == 0) {
+      // The peer performed an orderly shutdown (FIN received, e.g. via shutdown(SHUT_WR)).
+      // This is a *successful* recv() call, not an error, so errno is not set by it and
+      // must not be inspected here (it may still hold a stale value from an unrelated,
+      // earlier syscall). A half-closed connection can still be perfectly writable, so
+      // do not tear it down based on leftover errno.
+      _connected = true;
+    } else if (res < 0) {
+      // recv only sets errno if res is < 0
       switch (errno) {
         case EWOULDBLOCK:
         case ENOENT:  //caused by vfs


### PR DESCRIPTION
### Checklist
- [x] Please provide specific title of the PR describing the change, including the component name
- [x] Please provide related links (Issue which will be closed by this Pull Request)
- [x] Please **update relevant Documentation** if applicable (no user-facing API/behavior change requiring docs)
- [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
- [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

-----------
## Description of Change

`NetworkClient::connected()` (`libraries/Network/src/NetworkClient.cpp`) peeks the
socket to detect disconnects:

```cpp
int res = recv(fd(), &dummy, 1, MSG_DONTWAIT | MSG_PEEK);
// recv only sets errno if res is <= 0
if (res <= 0) {
  switch (errno) {
    case ENOTCONN:
    case EPIPE:
    case ECONNRESET:
    case ECONNREFUSED:
    case ECONNABORTED:
      _connected = false;
      ...
```

`recv()` only sets `errno` when it returns **-1** (an actual error). When a stream
peer performs an *orderly* shutdown (e.g. it calls `shutdown(fd, SHUT_WR)` then
closes, as many HTTP clients do to signal "I'm done sending, keep reading my
response"), `recv()` returns **0** — a *successful* call reporting EOF, not an
error. In that case `errno` is left completely untouched and may still hold a
stale value from any unrelated earlier syscall on the same thread.

The existing code runs the `switch (errno)` for `res <= 0`, i.e. for both the
error case (`res < 0`) *and* the EOF case (`res == 0`). So whenever a half-closed
connection is polled and the leftover `errno` happens to coincide with
`ENOTCONN`/`EPIPE`/`ECONNRESET`/`ECONNREFUSED`/`ECONNABORTED`, the still-usable,
half-closed socket gets marked `_connected = false` and torn down — even though
nothing is actually wrong with it.

This exactly matches the symptom in #12751: the reporter's own debug log shows

```
[NetworkClient.cpp:593] connected(): Disconnected: RES: 0, ERR: 128
```

`RES: 0` proves `recv()` succeeded (EOF / orderly shutdown), yet the code
inspected `errno` (128 == `ENOTCONN` on the target's newlib) and incorrectly
closed the connection before the sketch could write its response.

### Fix

Only consult `errno` when `res < 0`. When `res == 0`, treat it deterministically
as "peer is done sending for now" and keep `_connected` as `true`, since a
half-closed connection can still be written to. This removes the dependency on
whatever `errno` happens to be lying around and matches the documented POSIX
`recv()`/`errno` contract that ESP-IDF's lwIP socket layer is built to mirror.

## Test Scenarios

I do not have ESP32 hardware set up for this at the moment, so I could not
verify this end-to-end on target. Instead, I wrote a standalone, hardware-free
C reproduction that exercises the *exact* statement and switch-logic from
`NetworkClient::connected()` against **real loopback TCP sockets** (not a mock)
on Linux, to validate the underlying POSIX semantics the fix relies on:

1. Open a real TCP connection over `127.0.0.1`.
2. The "client" sends a request, then calls `shutdown(SHUT_WR)` — the exact
   half-close pattern from the issue.
3. The "server" reads the request to completion.
4. `errno` is poisoned to `ENOTCONN` via a genuine failing syscall (`recv()`
   on a fresh, never-connected socket) — a stand-in for "some unrelated
   syscall earlier in the same thread left `errno` set", which is exactly
   what happens on real hardware per the reporter's log.
5. The exact statement `recv(fd, &dummy, 1, MSG_DONTWAIT | MSG_PEEK)` is
   called on the half-closed socket: it returns `res == 0`, and `errno`
   is confirmed **unchanged** (still `ENOTCONN`) — i.e. real, unmodified
   kernel behavior, not an assumption.
6. Running the **current** switch-statement logic verbatim on `(res=0,
   errno=ENOTCONN)` produces `_connected = false` — the bug, reproduced.
7. Running the **fixed** logic on the same inputs produces
   `_connected = true` — correct.
8. To prove the connection really is still usable (true half-close, not a
   dead socket): the server calls `send()` on the "disconnected" socket and
   the client genuinely receives the bytes.

Output (abridged):

```
=== Step 5: the exact statement from NetworkClient::connected() ===
recv(server_fd, &dummy, 1, MSG_DONTWAIT|MSG_PEEK) -> res = 0
errno BEFORE this call : 107
errno AFTER  this call : 107  (unchanged by a successful/EOF recv, per POSIX)

=== Step 6: run CURRENT (buggy) connected() logic ===
    [current logic] Disconnected: RES: 0, ERR: 107
    current logic result: _connected = false (WRONG - socket is only half-closed)

=== Step 7: run FIXED connected() logic ===
    fixed logic result:   _connected = true (correct)

=== Step 8: prove the socket is genuinely still writable (true half-close) ===
Server send() on the 'disconnected' socket returned 21 bytes (errno=107)
Client still receives it: 21 bytes: "HTTP/1.0 200 OK

ok"
```

(`errno 107` is `ENOTCONN` on Linux glibc; the reporter's hardware log shows
`128`, which is `ENOTCONN` on ESP32/newlib — same condition, different libc
numbering.)

I'd very much appreciate it if a maintainer (or @P-R-O-C-H-Y / @me-no-dev, who
were involved in the issue thread) could additionally confirm this against
real hardware with the reporter's original sketch, since I could only validate
the socket-layer logic on host.

## Related links

Closes #12751

## Disclosure

This fix was investigated and drafted with AI assistance (Claude), based on
reading the issue thread and the source, and validated with the host-side
reproduction described above. I've reviewed the change and reasoning myself
before opening this PR.
