### PR TITLE
fix(network): honor the requested bind address in NetworkServer::begin()

### DIFF
--- a/libraries/Network/src/NetworkServer.cpp
+++ b/libraries/Network/src/NetworkServer.cpp
@@ -84,20 +84,27 @@ void NetworkServer::begin(uint16_t port, int enable) {
   }
 #if CONFIG_LWIP_IPV6
   struct sockaddr_in6 server;
+  memset(&server, 0x0, sizeof(server));
   sockfd = socket(AF_INET6, SOCK_STREAM, 0);
   if (sockfd < 0) {
     return;
   }
   setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
   server.sin6_family = AF_INET6;
-  if (_addr.type() == IPv4) {
-    memcpy(server.sin6_addr.s6_addr + 11, (uint8_t *)&_addr[0], 4);
-    server.sin6_addr.s6_addr[10] = 0xFF;
-    server.sin6_addr.s6_addr[11] = 0xFF;
-  } else {
-    memcpy(server.sin6_addr.s6_addr, (uint8_t *)&_addr[0], 16);
+  // Only fill in sin6_addr when an explicit bind address was requested; otherwise leave it
+  // all-zero so the socket binds to the "::" wildcard (listen on every interface), which is
+  // also what a plain `NetworkServer(port)` / `WiFiServer(port)` (no address argument) expects.
+  if (_addr != IPAddress()) {
+    if (_addr.type() == IPv4) {
+      // Build an IPv4-mapped IPv6 address (::ffff:a.b.c.d) per RFC 4291: the 0xFF markers go
+      // in bytes 10-11 and the 4-byte IPv4 payload goes in bytes 12-15.
+      server.sin6_addr.s6_addr[10] = 0xFF;
+      server.sin6_addr.s6_addr[11] = 0xFF;
+      memcpy(server.sin6_addr.s6_addr + 12, (uint8_t *)&_addr[0], 4);
+    } else {
+      memcpy(server.sin6_addr.s6_addr, (uint8_t *)&_addr[0], 16);
+    }
   }
-  memset(server.sin6_addr.s6_addr, 0x0, 16);
   server.sin6_port = htons(_port);
 #else
   struct sockaddr_in server;


### PR DESCRIPTION
### Bug description

`NetworkServer` (and its `WiFiServer`/`EthernetServer` typedefs) has a constructor that lets a caller restrict the listening socket to one local address:

```cpp
NetworkServer(const IPAddress &addr, uint16_t port = 80, uint8_t max_clients = 4);
```

This is exactly the ability requested in #1946 ("bind WiFiServer to only the AP IP address so a server started in `WIFI_AP_STA` mode isn't reachable from the STA/internet side").

However, in `NetworkServer::begin(uint16_t, int)` (`libraries/Network/src/NetworkServer.cpp`), under `#if CONFIG_LWIP_IPV6` — which is the branch that is actually compiled in **every** official arduino-esp32 release since 3.0.0, because that core version requires `CONFIG_LWIP_IPV6=y` to build at all (see #9334, confirmed by @Jason2866: *"Upcoming Arduino 3.0.0 needs IPv6 support enabled"*) — the requested address is built and then immediately wiped out:

```cpp
struct sockaddr_in6 server;
...
server.sin6_family = AF_INET6;
if (_addr.type() == IPv4) {
  memcpy(server.sin6_addr.s6_addr + 11, (uint8_t *)&_addr[0], 4);
  server.sin6_addr.s6_addr[10] = 0xFF;
  server.sin6_addr.s6_addr[11] = 0xFF;
} else {
  memcpy(server.sin6_addr.s6_addr, (uint8_t *)&_addr[0], 16);
}
memset(server.sin6_addr.s6_addr, 0x0, 16);   // <-- wipes the address just built
server.sin6_port = htons(_port);
```

`server.sin6_addr` is unconditionally zeroed right after being filled in, so `bind()` always uses the wildcard address `::`. Every `NetworkServer`/`WiFiServer` constructed with an explicit bind address silently listens on **every** interface instead — the address argument is a complete no-op.

There is also an independent, secondary bug in the same block: RFC 4291 IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) store the marker bytes `0xFF, 0xFF` at `s6_addr[10..11]` and the 4-byte IPv4 payload at `s6_addr[12..15]`. The shipped code does `memcpy(server.sin6_addr.s6_addr + 11, ...)` (one byte too early), and the following line then overwrites `s6_addr[11]` — which is the first IPv4 payload byte it just wrote — with a marker byte. This corruption is currently masked by the full `memset` right after, but would matter on its own once that `memset` is removed.

### Fix

- Zero-initialize `struct sockaddr_in6 server` up front (mirrors what the non-IPv6 branch already does for `sockaddr_in`).
- Only write into `sin6_addr` when the caller passed an explicit (non-default) address; when no address was given — the common `NetworkServer(port)` / `WiFiServer(port)` case — `sin6_addr` is left all-zero, so the socket still binds to the `::` wildcard exactly as before (no behavior change for the default case).
- Fix the off-by-one: the IPv4-mapped payload now goes to `s6_addr[12..15]`, with the `0xFF` markers at `s6_addr[10..11]`.
- Drop the erroneous trailing `memset` that caused the bug.

### Verification

This is host-buildable logic (no lwIP/ESP32-specific behavior involved — `sockaddr_in6` layout is the same POSIX struct on Linux), so I verified it with a standalone C program using **real AF_INET6 TCP sockets** (WSL/Ubuntu 24.04, gcc 13.3), not mocks — same approach used in #12754.

The program builds `sockaddr_in6` exactly as the shipped code does (buggy) and as proposed (fixed), binds a real listening socket, reads back the actually-bound address with `getsockname()`, and attempts real `connect()`s from both `127.0.0.1` and the test machine's LAN-facing IP (`172.28.108.84`) to check whether a loopback-only bind request is actually honored.

```
=== Scenario: NetworkServer(IPAddress(127,0,0,1), port) -- caller wants loopback-only ===

-- BUGGY (shipped) code path, requested bind = 127.0.0.1:15551 --
  [BUGGY] getsockname() reports bound address: :: (port 15551)
  connect to 127.0.0.1:15551      -> ACCEPTED
  connect to 172.28.108.84:15551 -> ACCEPTED (BUG: server reachable from LAN IP!)  (should be refused if loopback-only bind worked)

-- FIXED code path, requested bind = 127.0.0.1:15552 --
  [FIXED] getsockname() reports bound address: ::ffff:127.0.0.1 (port 15552)
  connect to 127.0.0.1:15552      -> ACCEPTED
  connect to 172.28.108.84:15552 -> refused  (expected: refused)

=== Scenario: NetworkServer(port) -- no address given, default IPAddress() (0.0.0.0) ===

-- FIXED code path, default constructor (no address requested) --
  [FIXED/default] getsockname() reports bound address: :: (port 15553)
  connect to 127.0.0.1:15553      -> ACCEPTED
  connect to 172.28.108.84:15553 -> ACCEPTED  (expected: ACCEPTED, no regression for default 'listen on everything')
```

This confirms:
1. The shipped code silently ignores a requested loopback-only bind and ends up reachable from any interface.
2. The fix makes the requested address take effect (`::ffff:127.0.0.1`, LAN connection correctly refused).
3. The common no-address-given case is unaffected — still binds `::` and accepts from any interface, so no regression for existing sketches.

### Duplicate check

Searched `gh pr list --search "NetworkServer"/"sin6_addr"/"WiFiServer bind"` and `gh issue list` for related keywords across this repo; no open or merged PR touches this code, and no `closedByPullRequestsReferences` link exists on the related (2018, pre-refactor) issue #1946. This is a different, independent bug from #12754 (which was in `NetworkClient::connected()`), submitted earlier in the same repo.

### Disclosure

This fix was found and drafted with the assistance of Claude (Anthropic), including the standalone reproduction program above. I reviewed the diagnosis and the diff myself before opening this PR.
