### PR TITLE
fix(ble): BLEUUID::to128() truncates 32-bit UUID values to 16 bits

### DIFF
--- a/libraries/BLE/src/BLEUUID.cpp
+++ b/libraries/BLE/src/BLEUUID.cpp
@@ -226,7 +226,7 @@ BLEUUID BLEUUID::to128() {
     UUID_VAL_128(m_uuid)[13] = (temp >> 8) & 0xff;
     UUID_VAL_128(m_uuid)[12] = temp & 0xff;
   } else if (UUID_LEN(m_uuid) == BLE_UUID_32_BITS) {
-    uint16_t temp = UUID_VAL_32(m_uuid);
+    uint32_t temp = UUID_VAL_32(m_uuid);
     UUID_VAL_128(m_uuid)[15] = (temp >> 24) & 0xff;
     UUID_VAL_128(m_uuid)[14] = (temp >> 16) & 0xff;
     UUID_VAL_128(m_uuid)[13] = (temp >> 8) & 0xff;


### PR DESCRIPTION
### Description of change

`BLEUUID::to128()` converts a 16/32-bit UUID into its 128-bit form. In the 32-bit branch it copies the UUID value into a `uint16_t` local before splitting it into the last 4 bytes of the 128-bit array:

```cpp
} else if (UUID_LEN(m_uuid) == BLE_UUID_32_BITS) {
    uint16_t temp = UUID_VAL_32(m_uuid);
    UUID_VAL_128(m_uuid)[15] = (temp >> 24) & 0xff;
    UUID_VAL_128(m_uuid)[14] = (temp >> 16) & 0xff;
    UUID_VAL_128(m_uuid)[13] = (temp >> 8) & 0xff;
    UUID_VAL_128(m_uuid)[12] = temp & 0xff;
```

`UUID_VAL_32(m_uuid)` is a genuine `uint32_t` in both backends (`esp_bt_uuid_t::uuid.uuid32` in Bluedroid's `esp_gatt_defs.h`, and `ble_uuid32_t::value` in NimBLE's `host/ble_uuid.h`). Storing it into a `uint16_t temp` silently drops the upper 16 bits, so `(temp >> 24) & 0xff` and `(temp >> 16) & 0xff` are always `0` regardless of the real value. Any 32-bit UUID whose value exceeds `0xFFFF` is corrupted when converted to a 128-bit UUID via `to128()` (e.g. used when comparing/constructing vendor UUIDs). This looks like a copy/paste of the 16-bit branch immediately above it (which correctly uses `uint16_t` since a 16-bit UUID has no upper bits to lose) that was never widened for the 32-bit case.

Fix: widen the local to `uint32_t` so the full value survives the shift/mask sequence. One-line change, no other logic touched.

### Tests scenarios

Not reproducible with the example sketches (there isn't an existing example that constructs a 32-bit UUID > 0xFFFF and calls `to128()`), so I extracted the exact macro/union layout used by `BLEUUID.h` (`esp_bt_uuid_t`-equivalent struct) and the verbatim buggy code block into a standalone host-side C++ program, compared against the same code with only `uint16_t` → `uint32_t` changed:

```
input 32-bit UUID value = 0x12345678

BUGGY to128() bytes[12..15] (should encode 0x12345678):
  00 00 56 78

FIXED to128() bytes[12..15] (should encode 0x12345678):
  12 34 56 78

Result: buggy output drops the upper 16 bits (0x1234 lost)?  YES - BUG CONFIRMED
Result: fixed output reproduces the full 32-bit value?      YES - FIX CONFIRMED
```

This matches the fix applied to `libraries/BLE/src/BLEUUID.cpp` in this PR (only the type of `temp` changed).

### Disclosure

I used Claude (Anthropic AI assistant) to help audit this file and draft this fix. I reviewed the diff, wrote/ran the standalone reproduction shown above myself, and confirmed the root cause and fix before opening this PR.
