### PR TITLE
fix(ble): off-by-one heap-buffer-overflow in BLEAdvertisedDevice::getFrameType()

### DIFF
--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -792,13 +792,13 @@ uint8_t BLEAdvertisedDevice::getAddressType() {
 ble_frame_type_t BLEAdvertisedDevice::getFrameType() {
   for (int i = 0; i < m_payloadLength; ++i) {
     log_d("check [%d]=0x%02X", i, m_payload[i]);
-    if (m_payload[i] == 0x16 && m_payloadLength >= i + 3 && m_payload[i + 1] == 0xAA && m_payload[i + 2] == 0xFE && m_payload[i + 3] == 0x00) {
+    if (m_payload[i] == 0x16 && m_payloadLength >= i + 4 && m_payload[i + 1] == 0xAA && m_payload[i + 2] == 0xFE && m_payload[i + 3] == 0x00) {
       return BLE_EDDYSTONE_UUID_FRAME;
     }
-    if (m_payload[i] == 0x16 && m_payloadLength >= i + 3 && m_payload[i + 1] == 0xAA && m_payload[i + 2] == 0xFE && m_payload[i + 3] == 0x10) {
+    if (m_payload[i] == 0x16 && m_payloadLength >= i + 4 && m_payload[i + 1] == 0xAA && m_payload[i + 2] == 0xFE && m_payload[i + 3] == 0x10) {
       return BLE_EDDYSTONE_URL_FRAME;
     }
-    if (m_payload[i] == 0x16 && m_payloadLength >= i + 3 && m_payload[i + 1] == 0xAA && m_payload[i + 2] == 0xFE && m_payload[i + 3] == 0x20) {
+    if (m_payload[i] == 0x16 && m_payloadLength >= i + 4 && m_payload[i + 1] == 0xAA && m_payload[i + 2] == 0xFE && m_payload[i + 3] == 0x20) {
       return BLE_EDDYSTONE_TLM_FRAME;
     }
   }


### PR DESCRIPTION
### Description of change

`BLEAdvertisedDevice::getFrameType()` scans the raw advertisement payload looking for an Eddystone "Service Data" AD record (type byte `0x16`, UUID `0xAA 0xFE`, plus a frame-type byte). Before reading the frame-type byte at `m_payload[i + 3]` it checks:

```cpp
if (m_payload[i] == 0x16 && m_payloadLength >= i + 3 && m_payload[i + 1] == 0xAA && m_payload[i + 2] == 0xFE && m_payload[i + 3] == 0x00) {
```

`m_payloadLength >= i + 3` still passes when `m_payloadLength == i + 3`. In that case the valid indices of `m_payload` only go up to `i + 2` (`m_payload` is `malloc`'d to exactly `m_payloadLength` bytes — see `setPayload()` / `parseAdvertisement()` in the same file), so `m_payload[i + 3]` reads one byte past the end of the heap allocation. The same off-by-one is repeated for all three frame-type checks (UUID/URL/TLM).

`m_payload` is a raw copy of the over-the-air advertising data delivered by the ESP-IDF GAP scan callback, so any nearby BLE advertiser can trigger this simply by advertising a 3-byte (or otherwise short) payload ending in `{0x16, 0xAA, 0xFE}` — no cooperation from the scanning application is needed beyond calling `getFrameType()` (done internally whenever frame type is queried, e.g. from the `BLE_EddystoneURL_Beacon_Scanner`/`BLE_EddystoneTLM_Beacon_Scanner` examples).

Fix: the correct guard to safely read `m_payload[i + 3]` is `m_payloadLength >= i + 4`. Applied to all three checks.

### Tests scenarios

Extracted the exact loop body (verbatim, only the `log_d()` call removed since it isn't available standalone) into a host-side C++ program and compiled it with AddressSanitizer against a 3-byte malloc'd buffer `{0x16, 0xAA, 0xFE}` — precisely what a minimal malformed advertisement would produce:

```
$ g++ -std=c++17 -fsanitize=address -g -O0 -o repro repro.cpp && ./repro buggy
m_payloadLength = 3 (malloc'd exactly 3 bytes)
Running BUGGY version of getFrameType()...
=================================================================
==...==ERROR: AddressSanitizer: heap-buffer-overflow ...
READ of size 1 at ... thread T0
    #0 ... in getFrameType_BUGGY repro.cpp:29
0x... is located 0 bytes after 3-byte region [...]
allocated by thread T0 here:
    #0 ... in malloc ...
    #1 ... in main repro.cpp:65
SUMMARY: AddressSanitizer: heap-buffer-overflow ... in getFrameType_BUGGY
```

Re-running the same harness with the `i + 4` bound (matching this PR's fix) against the same input completes cleanly with no ASan report:

```
$ ./repro fixed
m_payloadLength = 3 (malloc'd exactly 3 bytes)
Running FIXED version of getFrameType()...
getFrameType() returned 0 without crashing (result irrelevant; the read of m_payload[3] past the 3-byte allocation is the bug)
```

### Disclosure

I used Claude (Anthropic AI assistant) to help audit this file and draft this fix. I reviewed the diff, wrote/ran the ASan reproduction shown above myself, and confirmed the root cause and fix before opening this PR.
