### PR TITLE
fix(network): check rx_buffer allocation in NetworkUDP::parsePacket()

### DIFF
--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -357,7 +357,19 @@ int NetworkUDP::parsePacket() {
 #endif  // LWIP_IPV6=1
   if (len > 0) {
     rx_buffer = new (std::nothrow) cbuf(len);
-    rx_buffer->write(buf, len);
+    if (!rx_buffer) {
+      log_e("failed to allocate %d bytes for the receive buffer", len);
+      free(buf);
+      return 0;
+    }
+    if (rx_buffer->write(buf, len) != (size_t)len) {
+      log_e("failed to buffer %d bytes of received UDP data", len);
+      cbuf *b = rx_buffer;
+      rx_buffer = NULL;
+      delete b;
+      free(buf);
+      return 0;
+    }
   }
   free(buf);
   return len;


### PR DESCRIPTION
### Description of change

`NetworkUDP::parsePacket()` allocates the receive buffer like this:

```cpp
if (len > 0) {
    rx_buffer = new (std::nothrow) cbuf(len);
    rx_buffer->write(buf, len);
}
free(buf);
return len;
```

The result of `new (std::nothrow)` is never checked. Every other `new (std::nothrow)` call site in this codebase (`EEPROM.cpp`, `NetworkEvents.cpp`, `Updater.cpp`) null-checks immediately after — this is the one place that doesn't. Two distinct failure modes follow from that:

1. **Outer allocation fails.** If the small `cbuf` object itself can't be allocated, `rx_buffer` is `NULL` and `rx_buffer->write(buf, len)` dereferences it directly, crashing the device.
2. **Inner allocation fails (the realistic one under load).** `cbuf::cbuf(len)` (`cores/esp32/cbuf.cpp:53`) calls `xRingbufferCreate(len, ...)` — a much larger allocation (up to 1460 bytes) that fails under heap fragmentation well before the tiny outer object would. When that happens, `_buf == NULL` inside `cbuf`, and `cbuf::write()` (`cbuf.cpp:259-274`) safely no-ops via `room()` returning 0 — no crash, but the received bytes are silently dropped. `parsePacket()` still returns the original `len`, so a caller doing `if (udp.parsePacket()) { udp.read(buffer, len); }` believes a packet arrived, calls `read()`, and silently gets nothing back. The datagram is lost with no error surfaced anywhere.

Failure mode 2 is not hypothetical — it matches two closed reports from real users hitting this under sustained UDP traffic with a fragmented heap: #4104 ("WiFiUDP::parsePacket() CRASH") and #7845 ("WiFiUDP::parsePacket() SegFault on memory allocation (Stale Issue #4104)"). #7845 was closed as fixed by #7860 ("Rework cbuf to use FreeRTOS Ringbuffer"), which switched `cbuf`'s internal allocation to `xRingbufferCreate` and wrapped the outer `new` in `std::nothrow` — that stopped the original *uncaught C++ exception → abort()* crash, but the result of the `std::nothrow` allocation was never actually checked, so the underlying allocation-failure path is still unhandled today, just in the quieter "silent data loss" form described above instead of a hard crash.

Fix: check `rx_buffer` for `NULL` before using it, and verify `write()` actually buffered the full packet. On either failure, clean up (matching the existing `cbuf *b = rx_buffer; rx_buffer = NULL; delete b;` pattern used elsewhere in this file, e.g. `stop()`) and return `0` — the function's existing "no packet parsed" convention — instead of reporting a successful receive that isn't backed by any real data.

### Tests scenarios

The real `cbuf` can't be compiled on a host machine (it calls ESP-IDF's `xRingbufferCreate`/`xRingbufferSend` FreeRTOS APIs), so I built a mock that mirrors its verified behavior exactly (`_buf == NULL` on ring-buffer-creation failure; `room()`/`write()` return 0 when `_buf == NULL`; matches `cbuf.cpp` lines 53-56 and 155-274) and reproduced both failure modes plus the fix against the real `parsePacket()` control flow:

**1) Baseline (no memory pressure) — both versions match:**
```
normal case: parsePacket()=512, available()=512 (expected: match)
```

**2) BUGGY — inner ring-buffer allocation fails (the #4104/#7845 scenario):**
```
BUGGY fragmented case: parsePacket() returned 512 (claims 512 bytes of UDP data received)
                       but rx_buffer->available() = 0 (actual bytes buffered)
  -> caller code like `if (udp.parsePacket()) { udp.read(buf, len); }` believes it received
     512 bytes, calls read(), and silently gets 0 bytes back. The UDP datagram is lost with
     no error signaled anywhere.
```

**3) FIXED — same scenario, with this PR's checks:**
```
  [FIXED] short/failed write (0 of 512 bytes) -> discarding and returning 0
FIXED fragmented case: parsePacket() returned 0, rx_buffer=(nil) (consistent: no phantom packet)
```

**4) BUGGY — outer `cbuf` allocation itself fails, compiled with ASan:**
```
BUGGY outer-null case: about to call rx_buffer->write() on a NULL rx_buffer...
AddressSanitizer:DEADLYSIGNAL
==...==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 ...
    #0 ... in MockCbuf::room() const
    #1 ... in MockCbuf::write(char const*, unsigned long)
    #2 ... in parsePacket_BUGGY
SUMMARY: AddressSanitizer: SEGV ... in MockCbuf::room() const
```

**5) FIXED — same scenario:**
```
  [FIXED] rx_buffer allocation failed -> returning 0, no crash
FIXED outer-null case: parsePacket() returned 0, no crash
```

All five outcomes match what the current source (buggy) and this PR's patch (fixed) would do, verified independently of the real ESP-IDF ring buffer implementation by mirroring its documented null/failure behavior.

### Disclosure

I used Claude (Anthropic AI assistant) to help audit this file and draft this fix. I reviewed the diff, wrote/ran the reproduction shown above myself, cross-checked the referenced issues/PR (#4104, #7845, #7860) via the GitHub CLI to confirm they're accurately described, and confirmed the root cause and fix before opening this PR.
