### PR TITLE
fix(platform): Ensure partition file is updated in output folder

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -112,14 +112,16 @@ build.chip_variant={build.mcu}
 build.opt.name=build_opt.h
 build.opt.path={build.path}/{build.opt.name}
 
-# Check if custom partitions exist: source > variant > build.partitions
-recipe.hooks.prebuild.1.pattern=/usr/bin/env bash -c "[ ! -f "{build.source.path}"/partitions.csv ] || cp -f "{build.source.path}"/partitions.csv "{build.path}"/partitions.csv"
-recipe.hooks.prebuild.2.pattern=/usr/bin/env bash -c "[ -f "{build.path}"/partitions.csv ] || [ ! -f "{build.variant.path}"/{build.custom_partitions}.csv ] || cp "{build.variant.path}"/{build.custom_partitions}.csv "{build.path}"/partitions.csv"
-recipe.hooks.prebuild.3.pattern=/usr/bin/env bash -c "[ -f "{build.path}"/partitions.csv ] || cp "{runtime.platform.path}"/tools/partitions/{build.partitions}.csv "{build.path}"/partitions.csv"
+# Copy the partition table into the build dir, always overwriting so option changes
+# (e.g. PartitionScheme) take effect on incremental builds. Lowest priority is copied
+# first and higher priority overwrites it: build.partitions < variant < source.
+recipe.hooks.prebuild.1.pattern=/usr/bin/env bash -c "[ ! -f "{runtime.platform.path}"/tools/partitions/{build.partitions}.csv ] || cp -f "{runtime.platform.path}"/tools/partitions/{build.partitions}.csv "{build.path}"/partitions.csv"
+recipe.hooks.prebuild.2.pattern=/usr/bin/env bash -c "[ ! -f "{build.variant.path}"/{build.custom_partitions}.csv ] || cp -f "{build.variant.path}"/{build.custom_partitions}.csv "{build.path}"/partitions.csv"
+recipe.hooks.prebuild.3.pattern=/usr/bin/env bash -c "[ ! -f "{build.source.path}"/partitions.csv ] || cp -f "{build.source.path}"/partitions.csv "{build.path}"/partitions.csv"
 
-recipe.hooks.prebuild.1.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" COPY /y "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
-recipe.hooks.prebuild.2.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" if exist "{build.variant.path}\{build.custom_partitions}.csv" COPY "{build.variant.path}\{build.custom_partitions}.csv" "{build.path}\partitions.csv"
-recipe.hooks.prebuild.3.pattern.windows=cmd /c if not exist "{build.path}\partitions.csv" COPY "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
+recipe.hooks.prebuild.1.pattern.windows=cmd /c if exist "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" COPY /y "{runtime.platform.path}\tools\partitions\{build.partitions}.csv" "{build.path}\partitions.csv"
+recipe.hooks.prebuild.2.pattern.windows=cmd /c if exist "{build.variant.path}\{build.custom_partitions}.csv" COPY /y "{build.variant.path}\{build.custom_partitions}.csv" "{build.path}\partitions.csv"
+recipe.hooks.prebuild.3.pattern.windows=cmd /c if exist "{build.source.path}\partitions.csv" COPY /y "{build.source.path}\partitions.csv" "{build.path}\partitions.csv"
 
 # Check if custom bootloader exist: source > variant > build.boot
 recipe.hooks.prebuild.4.pattern_args=--chip {build.mcu} elf2image --flash-mode {build.flash_mode} --flash-freq {build.img_freq} --flash-size {build.flash_size} -o


### PR DESCRIPTION
## Description of Change

This pull request updates the logic for copying partition table files during the build process in `platform.txt`. The new approach always overwrites the partition table file in the build directory, ensuring that changes (such as to the PartitionScheme) are properly reflected in incremental builds. The copy order has been adjusted so that files with higher priority overwrite those with lower priority.

Partition table copy logic improvements:

* Changed the prebuild hooks to always copy (and overwrite) the partition table file into the build directory, ensuring that option changes are respected in incremental builds. The copy order is now: default partition (`build.partitions`) < variant custom partition < source custom partition, with each subsequent file overwriting the previous if it exists.
* Updated both Unix and Windows command patterns to match the new logic, using forced overwrites where supported.

## Test Scenarios

Tested locally
