### PR TITLE
Fix rgbLedWrite typo in MiniMain ESP32-S2 variant comment

### DIFF
--- a/variants/department_of_alchemy_minimain_esp32s2/pins_arduino.h
+++ b/variants/department_of_alchemy_minimain_esp32s2/pins_arduino.h
@@ -16,7 +16,7 @@
 
 // RGB LED
 #define PIN_RGB_LED 33
-// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWritee() for blinking
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite() for blinking
 #define RGB_BUILTIN    (PIN_RGB_LED + SOC_GPIO_PIN_COUNT)
 #define RGB_BRIGHTNESS 64
 


### PR DESCRIPTION
## What changed

Corrected `rgbLedWritee()` to `rgbLedWrite()` in the MiniMain ESP32-S2 board variant comment.

## Why

The comment referenced a non-existent API name because of an extra `e`. This could confuse users looking for the documented RGB LED helper.

## Impact

Documentation-only change; runtime behavior is unchanged.

## Validation

- Ran `git diff --check`.
- Searched the repository to confirm no remaining `rgbLedWritee` occurrences.
