### PR TITLE
Add setCiphers like BearSSL on ESP8266

### DIFF
--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
@@ -455,6 +455,16 @@ void NetworkClientSecure::setAlpnProtocols(const char **alpn_protos) {
   _alpn_protos = alpn_protos;
 }
 
+bool NetworkClientSecure::setCiphers(const int *list, size_t count) {
+  sslclient->cipher_list = std::shared_ptr<int>(new (std::nothrow) int[count + 1], std::default_delete<int[]>());
+  if (!sslclient->cipher_list.get()) {
+    return false;
+  }
+  memcpy(sslclient->cipher_list.get(), list, count * sizeof(int));
+  sslclient->cipher_list.get()[count] = 0;
+  return true;
+}
+
 int NetworkClientSecure::fd() const {
   return sslclient->socket;
 }

--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.h
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.h
@@ -79,6 +79,7 @@ public:
   bool verify(const char *fingerprint, const char *domain_name);
   void setHandshakeTimeout(unsigned long handshake_timeout);
   void setAlpnProtocols(const char **alpn_protos);
+  bool setCiphers(const int *list, size_t count);
 
   // Certain protocols start in plain-text; and then have the client
   // give some STARTSSL command to `upgrade' the connection to TLS

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -196,6 +196,10 @@ int start_ssl_client(
       return handle_error(ret);
     }
   }
+  
+  if (ssl_client->cipher_list) {
+    mbedtls_ssl_conf_ciphersuites(&ssl_client->ssl_conf, ssl_client->cipher_list.get());
+  }
 
   // MBEDTLS_SSL_VERIFY_REQUIRED if a CA certificate is defined on Arduino IDE and
   // MBEDTLS_SSL_VERIFY_NONE if not.

--- a/libraries/NetworkClientSecure/src/ssl_client.h
+++ b/libraries/NetworkClientSecure/src/ssl_client.h
@@ -10,6 +10,7 @@
 #include "mbedtls/ssl.h"
 #include "mbedtls/error.h"
 #include "mbedtls/version.h"
+#include <memory>
 
 #if MBEDTLS_VERSION_MAJOR < 4
 #include "mbedtls/entropy.h"
@@ -39,6 +40,8 @@ typedef struct sslclient_context {
 
   int last_error;
   int peek_buf;
+
+  std::shared_ptr<int> cipher_list;
 
 } sslclient_context;
 


### PR DESCRIPTION
## Description of Change
This PR allows setting a subset of cipher suits. This is sometimes necessary, as some providers expect specific suits for specific user agents.

## Test Scenarios
I've tested this on a WROOM32/CYD with DBAPI 

## Related links
This will allow DBAPI to use the mainline core again (https://github.com/ArduinoHannover/DBAPI/commit/229196ff50ff7a407efc3456f302fb65a8c566e1)