### PR TITLE
feat(esp32): Add setCiphers to NetworkClientSecure

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -1143,7 +1143,7 @@ The file lists popular Arduino libraries with their names, which examples to tes
   - Push to `master` or `release/v2.x` (docs or workflow file changes)
   - Pull requests modifying `docs/**` or the workflow file
 - `docs_deploy.yml`:
-  - `workflow_run` after **ESP32 Arduino Release**
+  - `workflow_run` after **Release ESP32 Arduino package**
   - Push to `master` or `release/v2.x` when docs change
 
 **Purpose:** Build and deploy Sphinx documentation to the production docs server

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -2,7 +2,7 @@ name: Documentation Build and Production Deploy CI
 
 on:
   workflow_run:
-    workflows: ["ESP32 Arduino Release"]
+    workflows: ["Release ESP32 Arduino package"]
     types:
       - completed
   push:

--- a/.github/workflows/upload-idf-component.yml
+++ b/.github/workflows/upload-idf-component.yml
@@ -10,7 +10,7 @@ on:
         description: 'Git ref with the source to push to the component registry'
         required: true
   workflow_run:
-    workflows: ["ESP32 Arduino Release"]
+    workflows: ["Release ESP32 Arduino package"]
     types:
       - completed
 

--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
@@ -456,19 +456,19 @@ void NetworkClientSecure::setAlpnProtocols(const char **alpn_protos) {
 }
 
 bool NetworkClientSecure::setCiphers(const int *list, size_t count) {
-  if (list == nullptr || count == 0) {
-    log_e("setCiphers: list is null or count is zero");
-    return false;
-  }
-
-  if (connected()) {
+  if (_connected) {
     log_e("setCiphers: cannot change ciphersuites while a connection is active; "
           "call this before connect() or after stop()");
     return false;
   }
 
+  if (list == nullptr || count == 0) {
+    sslclient->cipher_list.reset();
+    return true;
+  }
+
   sslclient->cipher_list = std::shared_ptr<int>(new (std::nothrow) int[count + 1], std::default_delete<int[]>());
-  if (!sslclient->cipher_list.get()) {
+  if (!sslclient->cipher_list) {
     return false;
   }
   memcpy(sslclient->cipher_list.get(), list, count * sizeof(int));

--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
@@ -456,6 +456,17 @@ void NetworkClientSecure::setAlpnProtocols(const char **alpn_protos) {
 }
 
 bool NetworkClientSecure::setCiphers(const int *list, size_t count) {
+  if (list == nullptr || count == 0) {
+    log_e("setCiphers: list is null or count is zero");
+    return false;
+  }
+
+  if (connected()) {
+    log_e("setCiphers: cannot change ciphersuites while a connection is active; "
+          "call this before connect() or after stop()");
+    return false;
+  }
+
   sslclient->cipher_list = std::shared_ptr<int>(new (std::nothrow) int[count + 1], std::default_delete<int[]>());
   if (!sslclient->cipher_list.get()) {
     return false;

--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp
@@ -455,6 +455,16 @@ void NetworkClientSecure::setAlpnProtocols(const char **alpn_protos) {
   _alpn_protos = alpn_protos;
 }
 
+bool NetworkClientSecure::setCiphers(const int *list, size_t count) {
+  sslclient->cipher_list = std::shared_ptr<int>(new (std::nothrow) int[count + 1], std::default_delete<int[]>());
+  if (!sslclient->cipher_list.get()) {
+    return false;
+  }
+  memcpy(sslclient->cipher_list.get(), list, count * sizeof(int));
+  sslclient->cipher_list.get()[count] = 0;
+  return true;
+}
+
 int NetworkClientSecure::fd() const {
   return sslclient->socket;
 }

--- a/libraries/NetworkClientSecure/src/NetworkClientSecure.h
+++ b/libraries/NetworkClientSecure/src/NetworkClientSecure.h
@@ -79,6 +79,7 @@ public:
   bool verify(const char *fingerprint, const char *domain_name);
   void setHandshakeTimeout(unsigned long handshake_timeout);
   void setAlpnProtocols(const char **alpn_protos);
+  bool setCiphers(const int *list, size_t count);
 
   // Certain protocols start in plain-text; and then have the client
   // give some STARTSSL command to `upgrade' the connection to TLS

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -48,8 +48,8 @@ static int _handle_error(int err, const char *function, int line) {
 #define handle_error(e) _handle_error(e, __FUNCTION__, __LINE__)
 
 void ssl_init(sslclient_context *ssl_client) {
-  // reset embedded pointers to zero
-  memset(ssl_client, 0, sizeof(sslclient_context));
+  // reset ssl_client by creating new (empty) context, as shared_ptr is not safe for memset
+  *ssl_client = sslclient_context();
   mbedtls_ssl_init(&ssl_client->ssl_ctx);
   mbedtls_ssl_config_init(&ssl_client->ssl_conf);
 #if MBEDTLS_VERSION_MAJOR < 4

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -409,8 +409,9 @@ void stop_ssl_socket(sslclient_context *ssl_client) {
   int last_err = ssl_client->last_error;
   crt_bundle_attach_cb bundle_attach_cb = ssl_client->bundle_attach_cb;
 
-  // reset embedded pointers to zero
-  memset(ssl_client, 0, sizeof(sslclient_context));
+  
+  // reset ssl_client by creating new (empty) context, as shared_ptr is not safe for memset
+  *ssl_client = sslclient_context();
 
   ssl_client->handshake_timeout = handshake_timeout;
   ssl_client->socket_timeout = socket_timeout;

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -196,6 +196,10 @@ int start_ssl_client(
       return handle_error(ret);
     }
   }
+  
+  if (ssl_client->cipher_list) {
+    mbedtls_ssl_conf_ciphersuites(&ssl_client->ssl_conf, ssl_client->cipher_list.get());
+  }
 
   // MBEDTLS_SSL_VERIFY_REQUIRED if a CA certificate is defined on Arduino IDE and
   // MBEDTLS_SSL_VERIFY_NONE if not.

--- a/libraries/NetworkClientSecure/src/ssl_client.cpp
+++ b/libraries/NetworkClientSecure/src/ssl_client.cpp
@@ -408,6 +408,7 @@ void stop_ssl_socket(sslclient_context *ssl_client) {
   unsigned long socket_timeout = ssl_client->socket_timeout;
   int last_err = ssl_client->last_error;
   crt_bundle_attach_cb bundle_attach_cb = ssl_client->bundle_attach_cb;
+  std::shared_ptr<int> saved_ciphers = ssl_client->cipher_list;
 
   
   // reset ssl_client by creating new (empty) context, as shared_ptr is not safe for memset
@@ -417,6 +418,7 @@ void stop_ssl_socket(sslclient_context *ssl_client) {
   ssl_client->socket_timeout = socket_timeout;
   ssl_client->last_error = last_err;
   ssl_client->bundle_attach_cb = bundle_attach_cb;
+  ssl_client->cipher_list = saved_ciphers;
   ssl_client->peek_buf = -1;
 }
 

--- a/libraries/NetworkClientSecure/src/ssl_client.h
+++ b/libraries/NetworkClientSecure/src/ssl_client.h
@@ -10,6 +10,7 @@
 #include "mbedtls/ssl.h"
 #include "mbedtls/error.h"
 #include "mbedtls/version.h"
+#include <memory>
 
 #if MBEDTLS_VERSION_MAJOR < 4
 #include "mbedtls/entropy.h"
@@ -39,6 +40,8 @@ typedef struct sslclient_context {
 
   int last_error;
   int peek_buf;
+
+  std::shared_ptr<int> cipher_list;
 
 } sslclient_context;
 


### PR DESCRIPTION
## Description of Change
This PR allows setting a subset of cipher suits. This is sometimes necessary, as some providers expect specific suits for specific user agents.

## Test Scenarios
I've tested this on a WROOM32/CYD with DBAPI 

## Related links
This will allow DBAPI to use the mainline core again (https://github.com/ArduinoHannover/DBAPI/commit/229196ff50ff7a407efc3456f302fb65a8c566e1)