### PR TITLE
fix(cmake): Add HTTPUpdateServer to Arduino library list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(ARDUINO_ALL_LIBRARIES
   Hash
   HTTPClient
   HTTPUpdate
+  HTTPUpdateServer
   Insights
   LittleFS
   Matter


### PR DESCRIPTION
This adds HTTPUpdateServer to ARDUINO_ALL_LIBRARIES in CMakeLists.txt.

I needed this for a small HTTP firmware upload server in an Arduino app, and the library was not being included by the Arduino library CMake setup.

Release note: Added HTTPUpdateServer to the Arduino CMake library list for HTTP OTA update support.