### PR TITLE
fix(webserver): Harden security and fix hangs

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -662,8 +662,25 @@ Defines test requirements and platform support:
 - `soc_tags: {chip: [tag1]}` - Per-SoC hardware runner tags (see below)
 - `multi_device: {device0: sketchA, device1: sketchB}` - Multi-DUT test mapping
 - `requires: [CONFIG_X=y]` - Required sdkconfig settings
-- `requires_or: [CONFIG_A=y, CONFIG_B=y]` - Alternative requirements
+- `requires_any: [CONFIG_A=y, CONFIG_B=y]` - Alternative requirements (at least one must match)
 - `libs: [Library1, Library2]` - Required libraries
+- `fqbn_append: Menu=value,...` - Menu options added to the default FQBN of every target
+- `fqbn_append: {default: ..., chip: ...}` - Same, when the options differ per target
+- `fqbn: {chip: [full FQBN, ...]}` - Replaces the default FQBN, one build per entry
+
+**FQBN options (`fqbn_append`):**
+Each menu key is kept only once, so a key set in `fqbn_append` replaces the default value for that key rather than being listed twice. This is how a test disables an option that is on by default, such as `PSRAM=disabled` on ESP32. Options are applied lowest priority first: the target default, then `fqbn_append`, then the per-device `fqbn_append` of a multi-device test, then the debug level passed with `-d`.
+
+Use the map form when the options differ per target. The `default` entry applies to every target and the entry matching the target is merged on top of it, so only the difference has to be spelled out. This is required for menus that do not exist on every target — ESP32-C3, ESP32-C6 and ESP32-H2 have no PSRAM menu, and `arduino-cli` rejects the whole build with `invalid option 'PSRAM'` if they are given `PSRAM=disabled`:
+
+```yaml
+fqbn_append:
+  default: PartitionScheme=huge_app
+  esp32: PSRAM=disabled
+  esp32s3: PSRAM=disabled
+```
+
+Use `fqbn` instead only when a test needs several builds per target (for example with and without PSRAM); it lists complete FQBNs and ignores `fqbn_append`.
 
 Example:
 ```yaml
@@ -790,7 +807,7 @@ Each device entry can be either:
 - A **scalar** (just the sketch directory name): `device0: sender`
 - A **map** with `sketch` (required) and `fqbn_append` (optional): useful when devices need different compile-time options (e.g., different Zigbee roles or partition schemes)
 
-When `fqbn_append` is specified per device, it overrides the parent `ci.yml`'s `fqbn_append` for that device's build only.
+A per-device `fqbn_append` is merged on top of the test's top-level `fqbn_append` for that device's build only, so a device adds to the options shared by the whole test and overrides only the menu keys it sets itself. It takes the same forms as the top-level field, including the per-target map.
 
 **How it works:**
 - `tests_build.sh` builds each device sketch separately and stores artifacts under `~/.arduino/tests/<target>/<test>/<sketch>/build.tmp`.

--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -54,8 +54,32 @@ function check_requirements { # check_requirements <sketchdir> <sdkconfig_path>
     echo "$has_requirements"
 }
 
+# Join FQBN menu options, dropping empty entries and keeping only the last value
+# given for each menu key. Callers list options lowest priority first, so a test
+# can override a per-target default instead of emitting the same key twice, which
+# arduino-cli does not resolve predictably. Each key keeps the position of its
+# first appearance, so the resulting FQBN stays stable.
 function _normalize_fqbn_opts {
-    echo "$1" | sed 's/^,*//;s/,*$//;s/,\{2,\}/,/g'
+    echo "$1" | tr ',' '\n' | awk '
+        {
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+            if ($0 == "") {
+                next
+            }
+            eq = index($0, "=")
+            key = (eq ? substr($0, 1, eq - 1) : $0)
+            if (!(key in value)) {
+                order[++count] = key
+            }
+            value[key] = $0
+        }
+        END {
+            for (i = 1; i <= count; i++) {
+                printf "%s%s", (i > 1 ? "," : ""), value[order[i]]
+            }
+            printf "\n"
+        }
+    '
 }
 
 function default_fqbn_for_target {
@@ -67,18 +91,21 @@ function default_fqbn_for_target {
     local fqbn_append="${6:-}"
 
     local opt=""
-    local merged
-    merged=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
+
+    # Lowest priority first: per-target defaults, then the test's fqbn_append,
+    # then options the caller asked for, then the debug level from the command
+    # line. Duplicate menu keys are resolved by _normalize_fqbn_opts.
+    local overrides="${fqbn_append},${extra_opts},${debug_level}"
 
     local esp32_opts esp32s2_opts esp32s3_opts esp32c3_opts esp32c6_opts esp32h2_opts esp32p4_opts esp32c5_opts
-    esp32_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${debug_level},${fqbn_append},${extra_opts}")
-    esp32s2_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${debug_level},${fqbn_append},${extra_opts}")
-    esp32s3_opts=$(_normalize_fqbn_opts "PSRAM=opi,USBMode=default,${debug_level},${fqbn_append},${extra_opts}")
-    esp32c3_opts=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
-    esp32c6_opts=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
-    esp32h2_opts=$(_normalize_fqbn_opts "${debug_level},${fqbn_append},${extra_opts}")
-    esp32p4_opts=$(_normalize_fqbn_opts "PSRAM=enabled,USBMode=default,ChipVariant=postv3,${debug_level},${fqbn_append},${extra_opts}")
-    esp32c5_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${debug_level},${fqbn_append},${extra_opts}")
+    esp32_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${overrides}")
+    esp32s2_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${overrides}")
+    esp32s3_opts=$(_normalize_fqbn_opts "PSRAM=opi,USBMode=default,${overrides}")
+    esp32c3_opts=$(_normalize_fqbn_opts "${overrides}")
+    esp32c6_opts=$(_normalize_fqbn_opts "${overrides}")
+    esp32h2_opts=$(_normalize_fqbn_opts "${overrides}")
+    esp32p4_opts=$(_normalize_fqbn_opts "PSRAM=enabled,USBMode=default,ChipVariant=postv3,${overrides}")
+    esp32c5_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${overrides}")
 
     case "$target" in
         esp32)
@@ -118,6 +145,34 @@ function default_fqbn_for_target {
             return 1
             ;;
     esac
+}
+
+# Read the fqbn_append options a ci.yml requests for one target. The field is
+# either a string applied to every target, or a map of per-target entries with an
+# optional "default" entry. Map entries are merged with "default", the per-target
+# entry winning, so a test only has to spell out what differs on that target.
+# The field defaults to the top level fqbn_append, but any path can be given so
+# that the per-device fields of a multi-device test resolve the same way.
+function fqbn_append_for_target { # fqbn_append_for_target <ci_yml> <target> [yq_path]
+    local ci_yml="$1"
+    local target="$2"
+    local path="${3:-.fqbn_append}"
+
+    if [ ! -f "$ci_yml" ]; then
+        return 0
+    fi
+
+    local value
+    if [ "$(yq eval "${path} | type" "$ci_yml" 2>/dev/null)" == "!!map" ]; then
+        local common specific
+        common=$(yq eval "${path}.default // \"\"" "$ci_yml" 2>/dev/null)
+        specific=$(yq eval "${path}.\"${target}\" // \"\"" "$ci_yml" 2>/dev/null)
+        value="${common},${specific}"
+    else
+        value=$(yq eval "${path} // \"\"" "$ci_yml" 2>/dev/null)
+    fi
+
+    _normalize_fqbn_opts "$value"
 }
 
 function default_upload_test_fqbn {
@@ -240,13 +295,14 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
 
             len=1
 
+            # Options passed with -fa are merged on top of the ones the ci.yml
+            # asks for, so a single device of a multi-device test can add to or
+            # override them without losing the ones shared by the whole test.
+            if [ -n "$ci_yml_for_build" ]; then
+                fqbn_append=$(fqbn_append_for_target "$ci_yml_for_build" "$target")
+            fi
             if [ -n "${fqbn_append_override:-}" ]; then
-                fqbn_append="$fqbn_append_override"
-            elif [ -n "$ci_yml_for_build" ]; then
-                fqbn_append=$(yq eval '.fqbn_append' "$ci_yml_for_build" 2>/dev/null)
-                if [ "$fqbn_append" == "null" ]; then
-                    fqbn_append=""
-                fi
+                fqbn_append=$(_normalize_fqbn_opts "${fqbn_append},${fqbn_append_override}")
             fi
 
             fqbn=$(default_fqbn_for_target "$target" "$options" "${debug_level:-}" "" "espressif:esp32" "$fqbn_append") || exit 1
@@ -804,6 +860,7 @@ Available commands:
     check_requirements: Check if target meets sketch requirements.
     install_libs: Install libraries from ci.yml file.
     default_upload_test_fqbn: Print default mock-upload FQBN for a SoC (target [pkg_prefix]).
+    fqbn_append: Print the fqbn_append options a ci.yml sets for a target (ci_yml target [yq_path]).
 "
 
 cmd=$1
@@ -826,6 +883,8 @@ case "$cmd" in
     "install_libs") install_libs "$@"
     ;;
     "default_upload_test_fqbn") default_upload_test_fqbn "$@"
+    ;;
+    "fqbn_append") fqbn_append_for_target "$@"
     ;;
     *)
         echo "ERROR: Unrecognized command"

--- a/.github/scripts/tests_build.sh
+++ b/.github/scripts/tests_build.sh
@@ -118,7 +118,7 @@ function build_multi_device_test {
 
         if [ "$device_type" == "!!map" ]; then
             sketch_name=$(yq eval ".multi_device.$device.sketch" "$test_dir/ci.yml" 2>/dev/null)
-            device_fqbn_append=$(yq eval ".multi_device.$device.fqbn_append // \"\"" "$test_dir/ci.yml" 2>/dev/null)
+            device_fqbn_append=$(${SKETCH_UTILS} fqbn_append "$test_dir/ci.yml" "$target" ".multi_device.$device.fqbn_append")
         else
             sketch_name=$(yq eval ".multi_device.$device" "$test_dir/ci.yml" 2>/dev/null)
             device_fqbn_append=""

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -184,7 +184,26 @@ If you just want to append a string to the default FQBNs, you can use the ``fqbn
 
     fqbn_append: DebugLevel=debug
 
-If you want to override the default FQBNs, you can use the ``fqbn`` field. It is a dictionary where the key is the target name and the value is a list of FQBNs.
+Each menu option is kept only once, so a key set in ``fqbn_append`` replaces the default value for that key instead of being listed twice.
+This makes it possible to turn off an option that is enabled by default, such as compiling for ESP32 with ``espressif:esp32:esp32:PSRAM=disabled``:
+
+.. code-block:: yaml
+
+    fqbn_append: PSRAM=disabled
+
+When the options differ per target, ``fqbn_append`` can be a dictionary instead. The ``default`` entry is applied to every target and the entry
+matching the target is merged on top of it, so only the difference has to be spelled out. This is needed for options that do not exist on every
+target: ESP32-C3, ESP32-C6 and ESP32-H2 have no PSRAM menu and would fail to compile if they were given ``PSRAM=disabled``.
+
+.. code-block:: yaml
+
+    fqbn_append:
+      default: PartitionScheme=huge_app
+      esp32: PSRAM=disabled
+      esp32s3: PSRAM=disabled
+
+The options are applied lowest priority first: the default FQBN for the target, then ``fqbn_append``, then the debug level passed on the
+command line. If you want to override the default FQBNs entirely, you can use the ``fqbn`` field. It is a dictionary where the key is the target name and the value is a list of FQBNs.
 The FQBNs in the list will be used in sequence to compile the sketch. For example, to compile a sketch for ESP32-S2 with and without PSRAM enabled, you would use:
 
 .. code-block:: yaml

--- a/docs/en/migration_guides/webserver_hardening.rst
+++ b/docs/en/migration_guides/webserver_hardening.rst
@@ -1,0 +1,240 @@
+###########################
+WebServer Request Hardening
+###########################
+
+Introduction
+------------
+
+The ``WebServer`` library was hardened against malformed and hostile requests. Requests that were previously parsed without any bound on
+length, argument count or loop iterations are now rejected, and a few code paths that could dereference a null pointer or leak state between
+requests were fixed.
+
+This guide lists every change that is visible to a sketch, so an application that relied on the previous behavior can be adjusted. Requests
+produced by browsers and by common HTTP clients are unaffected: every limit below is well above what normal traffic uses, and all of them can
+be raised from the build.
+
+New Request Limits
+------------------
+
+All limits are plain macros with ``#ifndef`` guards, so they can be overridden from the build without editing the library, for example with
+``-DWEBSERVER_MAX_URI_LEN=8192`` in ``build_opt.h`` or in the platform build flags.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 34 12 54
+
+    * - Macro
+      - Default
+      - Effect when exceeded
+    * - ``WEBSERVER_MAX_URI_LEN``
+      - 2048
+      - The request is answered with ``414 URI Too Long`` and the connection is closed. Set to ``0`` to disable the check.
+    * - ``WEBSERVER_MAX_LINE_LEN``
+      - 4096
+      - A single protocol line (request line, header, or multipart part header) is refused. See `Request Line and Headers`_.
+    * - ``WEBSERVER_MAX_POST_ARG_LEN``
+      - 16384
+      - One line of a non-file multipart field value is refused and the request is aborted.
+    * - ``WEBSERVER_MAX_LINE_WAIT``
+      - 5000 ms
+      - A protocol line that has not arrived complete in time is answered with ``408 Request Timeout``. Set to ``0`` to disable.
+    * - ``WEBSERVER_MAX_HEADER_WAIT``
+      - 10000 ms
+      - The request line and headers together took too long; answered with ``408 Request Timeout``. Set to ``0`` to disable.
+    * - ``WEBSERVER_MAX_QUERY_ARGS``
+      - 256
+      - Further arguments are dropped, but the request is still handled. See `Query and Form Arguments`_.
+    * - ``WEBSERVER_MAX_MULTIPART_SKIP_LINES``
+      - 64
+      - The multipart body is treated as malformed and the upload is aborted. See `Multipart Bodies`_.
+    * - ``WEBSERVER_MAX_REGEX_URI_LEN``
+      - 2048
+      - The request-target is not matched against ``UriRegex`` routes. See `Regular Expression Routes`_.
+    * - ``WEBSERVER_MAX_BACKREF_REGEX_URI_LEN``
+      - 64
+      - Same, for patterns that contain a back-reference. See `Regular Expression Routes`_.
+
+Three response codes that the library never produced before can now be sent: ``408 Request Timeout``, ``414 URI Too Long`` and
+``431 Request Header Fields Too Large``.
+
+Behavior Changes
+----------------
+
+Authentication
+**************
+
+``authenticate(username, password)`` now only accepts the ``Basic`` and ``Digest`` schemes. Previously any ``Authorization`` header whose
+value matched the configured user name was accepted, including a bare ``Authorization: <username>`` with no scheme and no password.
+
+Sketches that pass their own callback to ``authenticate()`` are unaffected: the callback still receives every scheme, including
+``OTHER_AUTH``, and decides on its own.
+
+serveStatic()
+*************
+
+A request path containing a ``.`` or ``..`` segment is refused, both in its literal and in its percent-encoded form, and the resolved path
+must stay under the configured filesystem root. Applications that depended on ``..`` being resolved by the filesystem must now request the
+canonical path.
+
+A related bug was fixed at the same time: ``serveStatic("/", fs, "/")`` used to answer every request with ``404``. Mapping a handler to the
+filesystem root now works.
+
+Request Line and Headers
+************************
+
+The request line and every header are read with a bounded reader instead of ``Stream::readStringUntil()``. A peer that never sends a line
+terminator can no longer grow the heap until the device runs out of memory.
+
+* A request line longer than ``WEBSERVER_MAX_LINE_LEN`` is answered with ``414 URI Too Long``.
+* A header line longer than ``WEBSERVER_MAX_LINE_LEN`` is answered with ``431 Request Header Fields Too Large``.
+
+In both cases the already-received part of the request is drained before the connection is closed, so the status reaches the client instead of
+being lost to a connection reset.
+
+Reading is also bounded in time, which fixes `issue #12788 <https://github.com/espressif/arduino-esp32/issues/12788>`_. The stream timeout
+alone only requires that *some* byte arrive every few seconds, so a client sending one byte at a time could keep ``handleClient()`` from
+returning indefinitely and eventually trip the task watchdog. Two deadlines now apply, and both answer ``408 Request Timeout``:
+
+* ``WEBSERVER_MAX_LINE_WAIT`` bounds how long one line may take to arrive complete.
+* ``WEBSERVER_MAX_HEADER_WAIT`` bounds the request line and all headers together. This is the one that catches a client sending an endless
+  stream of complete but tiny headers, since every completed line restarts the per-line deadline.
+
+The header deadline deliberately does not cover the request body, so uploads that legitimately take minutes are unaffected. A client on a link
+so slow that it cannot deliver its headers within ``WEBSERVER_MAX_HEADER_WAIT`` is now dropped, where previously it would be served.
+
+Query and Form Arguments
+************************
+
+The argument array is sized from the number of ``key=value`` pairs the parser will actually accept, instead of from the number of ``&``
+separators. This has two visible consequences:
+
+* A body or query string made only of separators, such as ``&&&&``, now yields zero arguments. It previously yielded one empty argument per
+  separator.
+* Arguments past ``WEBSERVER_MAX_QUERY_ARGS`` are dropped with a warning in the log. The request is still routed and handled, and the
+  arguments below the limit are still available.
+
+Argument arrays are also allocated with ``std::nothrow``. When the allocation fails, ``args()`` reports ``0`` and ``arg()`` returns an empty
+string, where the previous code aborted.
+
+Multipart Bodies
+****************
+
+* A preamble or epilogue around the parts is skipped, as required by :rfc:`2046`, but only up to ``WEBSERVER_MAX_MULTIPART_SKIP_LINES``
+  lines. Beyond that, and when no data arrives for ``HTTP_MAX_POST_WAIT``, the upload is aborted instead of looping.
+* A body truncated right after the boundary aborts the upload instead of spinning the server task forever.
+* Exceeding ``WEBSERVER_MAX_POST_ARGS`` now calls the upload callback with ``UPLOAD_FILE_ABORTED`` before failing. It previously failed
+  without notifying the callback, so a handler could be left holding an open file.
+* A non-file field value is read with the same bounded reader as the rest of the protocol, capped per line by ``WEBSERVER_MAX_POST_ARG_LEN``
+  and by ``WEBSERVER_MAX_LINE_WAIT``. A field value line longer than the cap, or a client that stalls part-way through one, aborts the
+  request. The cap is separate from ``WEBSERVER_MAX_LINE_LEN`` and much larger, because a long field value is legitimate.
+
+Per-Request State
+*****************
+
+Upload state, raw-body state and collected form fields are reset at the start of every request. On a keep-alive connection, a field from an
+earlier request can no longer be returned by ``arg()`` or ``hasArg()``, and an aborted multipart request can no longer leave fields visible to
+the request that follows.
+
+Sketches that read ``upload()`` or ``arg()`` outside the handler for the request they belong to will now see empty state.
+
+upload() and raw()
+******************
+
+A handler registered with an upload callback also receives raw, non-multipart bodies. ``upload()`` and ``raw()`` could therefore be called
+with no corresponding object allocated, dereferencing a null pointer.
+
+Both now return a reference to an inactive object whose ``status`` is ``UPLOAD_FILE_ABORTED`` or ``RAW_ABORTED`` instead. Two accessors were
+added to tell the two contexts apart:
+
+.. code-block:: arduino
+
+    server.on(
+      "/data", HTTP_POST, []() { server.send(200); },
+      []() {
+        if (server.hasUpload()) {
+          HTTPUpload &upload = server.upload();
+          // multipart upload
+        } else if (server.hasRaw()) {
+          HTTPRaw &raw = server.raw();
+          // raw body
+        }
+      }
+    );
+
+Regular Expression Routes
+*************************
+
+``UriRegex`` now compiles its pattern with the bounded matcher provided by the standard library instead of the default recursive one. The
+recursive matcher consumed task stack in proportion to the length of the request-target, and took exponential time on patterns with nested
+quantifiers, both of which an unauthenticated request could trigger. Measured on an ESP32:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 46 27 27
+
+    * - Case
+      - Recursive matcher
+      - Bounded matcher
+    * - Stack, 160-character target
+      - 21.9 KB
+      - 2.5 KB
+    * - Stack, 2000-character target
+      - Overflows the task stack
+      - 2.5 KB
+    * - ``^(a+)+$`` against 22 characters
+      - 13.8 s
+      - 1.4 ms
+    * - Matching a 160-character target
+      - 0.3 ms
+      - 4.7 ms (about 26 us per character)
+
+Stack use no longer depends on the length of the request-target, which is why ``WEBSERVER_MAX_REGEX_URI_LEN`` defaults to 2048 rather than to
+a value derived from the stack of the task that calls ``handleClient()``.
+
+The trade-offs of the bounded matcher are:
+
+* **Back-references are not supported.** A pattern containing ``\1`` to ``\9`` keeps the recursive matcher, and with it the much smaller
+  ``WEBSERVER_MAX_BACKREF_REGEX_URI_LEN`` limit. Route patterns essentially never use back-references, since a back-reference in a route
+  means one path segment has to repeat another.
+* **Matching is slower.** A short path costs roughly 0.6 ms instead of 0.1 ms, and a long one grows linearly at about 26 us per character. The
+  cost is paid once per registered ``UriRegex`` route per request, so an application with many regex routes and long request-targets may want
+  to lower ``WEBSERVER_MAX_REGEX_URI_LEN``.
+* **Pending states are held on the heap** rather than on the stack, at roughly 3 bytes per character of request-target. A failure to allocate
+  is reported as "route does not match", so the client receives a ``404`` instead of the device restarting.
+
+Everything else behaves as before. Anchors, character classes, greedy and lazy quantifiers, counted repetition, alternation, capture groups,
+lookahead, word boundaries and the ``icase`` flag were all compared between the two matchers and produce identical captures.
+
+.. note::
+
+    The bounded matcher is a libstdc++ extension. It is selected only when the standard library provides it, and the library falls back to the
+    previous matcher otherwise, so no configuration is required.
+
+A request-target longer than the applicable limit is not matched against regex routes, and an error is logged naming the limit that was
+exceeded. Plain string routes registered for the same path are unaffected, since they are matched first.
+
+New APIs
+--------
+
+* ``bool WebServer::hasUpload() const`` - true when a multipart upload is in progress.
+* ``bool WebServer::hasRaw() const`` - true when a raw request body is in progress.
+
+Restoring the Previous Limits
+-----------------------------
+
+Every limit can be raised, and the request-target check can be disabled entirely, from the build. For example, in ``build_opt.h``:
+
+.. code-block:: none
+
+    -DWEBSERVER_MAX_URI_LEN=0
+    -DWEBSERVER_MAX_LINE_LEN=16384
+    -DWEBSERVER_MAX_QUERY_ARGS=1024
+    -DWEBSERVER_MAX_HEADER_WAIT=30000
+
+.. warning::
+
+    Raising these limits restores the memory-exhaustion behavior they were added to prevent. Prefer raising a single limit to the value the
+    application actually needs.
+
+The dot-segment rejection in ``serveStatic()``, the authentication scheme check and the per-request state reset are not configurable, because
+each of them fixes a security issue rather than imposing a limit.

--- a/docs/en/migration_guides/webserver_hardening.rst
+++ b/docs/en/migration_guides/webserver_hardening.rst
@@ -72,9 +72,13 @@ Sketches that pass their own callback to ``authenticate()`` are unaffected: the 
 serveStatic()
 *************
 
+.. vale off
+
 A request path containing a ``.`` or ``..`` segment is refused, both in its literal and in its percent-encoded form, and the resolved path
 must stay under the configured filesystem root. Applications that depended on ``..`` being resolved by the filesystem must now request the
 canonical path.
+
+.. vale on
 
 A related bug was fixed at the same time: ``serveStatic("/", fs, "/")`` used to answer every request with ``404``. Mapping a handler to the
 filesystem root now works.

--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -21,6 +21,7 @@
 
 #include <Arduino.h>
 #include <esp32-hal-log.h>
+#include <new>
 #include "NetworkServer.h"
 #include "NetworkClient.h"
 #include "WebServer.h"
@@ -73,10 +74,126 @@ static char *readBytesWithTimeout(NetworkClient &client, size_t maxLength, size_
   return buf;
 }
 
+// Answer a request that is being dropped part-way through. The peer is usually
+// still sending, and closing a connection with unread input resets it, which
+// discards the response we just queued. Drain what already arrived first so the
+// status actually reaches the client. The drain is bounded: a peer that keeps
+// streaming is cut off.
+static void sendErrorResponse(NetworkClient &client, const char *status) {
+  client.printf("HTTP/1.1 %s\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", status);
+
+  const size_t maxDrain = 2 * WEBSERVER_MAX_LINE_LEN;
+  uint8_t discard[64];
+  size_t drained = 0;
+  unsigned long lastData = millis();
+  while (drained < maxDrain && millis() - lastData < 50) {
+    int available = client.available();
+    if (available <= 0) {
+      yield();
+      continue;
+    }
+    size_t wanted = (size_t)available < sizeof(discard) ? (size_t)available : sizeof(discard);
+    int read = client.read(discard, wanted);
+    if (read <= 0) {
+      break;
+    }
+    drained += (size_t)read;
+    lastData = millis();
+  }
+}
+
+enum class LineStatus {
+  Ok,
+  TooLong,   // reached maxLength before any line terminator
+  TimedOut,  // took longer than the per-line or the caller's phase budget
+};
+
+// Read one CRLF-terminated protocol line, consuming the terminator.
+//
+// Stream::readStringUntil() bounds neither the length of the line nor the total
+// time it may take: it only requires that another byte arrive within the stream
+// timeout. A peer that never sends a terminator therefore grows the String until
+// the heap is gone, and a peer that sends one byte just inside every timeout
+// keeps the read alive for as long as it likes. Both keep handleClient() from
+// returning.
+//
+// This bounds all three: the length of the line, the time one line may take, and
+// (through phaseBudget) the time the caller's whole parse phase may take. The
+// phase budget is what catches a peer that keeps sending complete but tiny lines,
+// since each of those restarts the per-line budget.
+static LineStatus readLineWithLimit(NetworkClient &client, String &line, size_t maxLength, unsigned long phaseStart = 0, unsigned long phaseBudget = 0) {
+  line = "";
+  const unsigned long idleTimeout = client.getTimeout();
+  const unsigned long lineStart = millis();
+  unsigned long lastActivity = lineStart;
+
+  while (millis() - lastActivity < idleTimeout) {
+#if WEBSERVER_MAX_LINE_WAIT > 0
+    if (millis() - lineStart >= WEBSERVER_MAX_LINE_WAIT) {
+      log_e("Protocol line still incomplete after %u ms", (unsigned)WEBSERVER_MAX_LINE_WAIT);
+      return LineStatus::TimedOut;
+    }
+#endif
+    if (phaseBudget && millis() - phaseStart >= phaseBudget) {
+      log_e("Request headers still incomplete after %u ms", (unsigned)phaseBudget);
+      return LineStatus::TimedOut;
+    }
+
+    int c = client.read();
+    if (c < 0) {
+      yield();
+      continue;
+    }
+    lastActivity = millis();
+    if (c == '\r') {
+      // Consume the paired LF, waiting for it as readStringUntil('\n') would.
+      while (millis() - lastActivity < idleTimeout) {
+        int next = client.peek();
+        if (next < 0) {
+          yield();
+          continue;
+        }
+        if (next == '\n') {
+          client.read();
+        }
+        break;
+      }
+      return LineStatus::Ok;
+    }
+    if (line.length() >= maxLength) {
+      log_e("Protocol line longer than %u bytes", (unsigned)maxLength);
+      return LineStatus::TooLong;
+    }
+    line += (char)c;
+  }
+  // The peer stopped sending part-way through a line, so there is no complete
+  // request to act on.
+  return LineStatus::TimedOut;
+}
+
 bool WebServer::_parseRequest(NetworkClient &client) {
+  // Upload, raw and multipart field state all belong to a single request. Drop
+  // anything left over from an earlier request on this connection so it cannot
+  // poison arg()/hasArg() lookups or be reported as an active upload.
+  if (_postArgs) {
+    delete[] _postArgs;
+    _postArgs = nullptr;
+    _postArgsLen = 0;
+  }
+  _currentUpload.reset();
+  _currentRaw.reset();
+
+  // The request line and the headers share one deadline. Only the body is
+  // allowed to take longer, so a slow upload is not affected.
+  const unsigned long headerPhaseStart = millis();
+
   // Read the first line of HTTP request
-  String req = client.readStringUntil('\r');
-  client.readStringUntil('\n');
+  String req;
+  switch (readLineWithLimit(client, req, WEBSERVER_MAX_LINE_LEN, headerPhaseStart, WEBSERVER_MAX_HEADER_WAIT)) {
+    case LineStatus::TooLong:  sendErrorResponse(client, "414 URI Too Long"); return false;
+    case LineStatus::TimedOut: sendErrorResponse(client, "408 Request Timeout"); return false;
+    case LineStatus::Ok:       break;
+  }
   //reset header value
   if (_collectAllHeaders) {
     // clear previous headers
@@ -110,6 +227,17 @@ bool WebServer::_parseRequest(NetworkClient &client) {
   _currentUri = url;
   _chunked = false;
   _clientContentLength = 0;  // not known yet, or invalid
+
+  // Bound the request-target before it reaches route matching and argument
+  // parsing. Answer with 414 so the peer sees why it was refused instead of
+  // just having the connection dropped.
+#if WEBSERVER_MAX_URI_LEN > 0
+  if (url.length() + searchStr.length() > WEBSERVER_MAX_URI_LEN) {
+    log_e("Request-target too long (%u bytes, max %u)", (unsigned)(url.length() + searchStr.length()), (unsigned)WEBSERVER_MAX_URI_LEN);
+    sendErrorResponse(client, "414 URI Too Long");
+    return false;
+  }
+#endif
 
   HTTPMethod method = HTTP_ANY;
   size_t num_methods = sizeof(_http_method_str) / sizeof(const char *);
@@ -146,8 +274,11 @@ bool WebServer::_parseRequest(NetworkClient &client) {
     bool isEncoded = false;
     //parse headers
     while (1) {
-      req = client.readStringUntil('\r');
-      client.readStringUntil('\n');
+      switch (readLineWithLimit(client, req, WEBSERVER_MAX_LINE_LEN, headerPhaseStart, WEBSERVER_MAX_HEADER_WAIT)) {
+        case LineStatus::TooLong:  sendErrorResponse(client, "431 Request Header Fields Too Large"); return false;
+        case LineStatus::TimedOut: sendErrorResponse(client, "408 Request Timeout"); return false;
+        case LineStatus::Ok:       break;
+      }
       if (req == "") {
         break;  //no moar headers
       }
@@ -223,7 +354,7 @@ bool WebServer::_parseRequest(NetworkClient &client) {
           searchStr += plainBuf;
         }
         _parseArguments(searchStr);
-        if (!isEncoded) {
+        if (!isEncoded && _currentArgs) {
           //plain post json or other data
           RequestArgument &arg = _currentArgs[_currentArgCount++];
           arg.key = F("plain");
@@ -248,8 +379,11 @@ bool WebServer::_parseRequest(NetworkClient &client) {
     String headerValue;
     //parse headers
     while (1) {
-      req = client.readStringUntil('\r');
-      client.readStringUntil('\n');
+      switch (readLineWithLimit(client, req, WEBSERVER_MAX_LINE_LEN, headerPhaseStart, WEBSERVER_MAX_HEADER_WAIT)) {
+        case LineStatus::TooLong:  sendErrorResponse(client, "431 Request Header Fields Too Large"); return false;
+        case LineStatus::TimedOut: sendErrorResponse(client, "408 Request Timeout"); return false;
+        case LineStatus::Ok:       break;
+      }
       if (req == "") {
         break;  //no moar headers
       }
@@ -308,24 +442,40 @@ void WebServer::_parseArguments(const String &data) {
     delete[] _currentArgs;
   }
   _currentArgs = 0;
+  _currentArgCount = 0;
   if (data.length() == 0) {
-    _currentArgCount = 0;
-    _currentArgs = new RequestArgument[1];
+    _currentArgs = new (std::nothrow) RequestArgument[1];
     return;
   }
-  _currentArgCount = 1;
 
-  for (int i = 0; i < (int)data.length();) {
-    i = data.indexOf('&', i);
-    if (i == -1) {
+  // Size the allocation from the number of arguments the parse loop below will
+  // actually accept, not from the number of separators. Counting separators
+  // lets a body of bare '&'s request an arbitrarily large allocation while
+  // yielding no arguments at all.
+  for (int pos = 0; pos <= (int)data.length();) {
+    int next_arg_index = data.indexOf('&', pos);
+    int equal_sign_index = data.indexOf('=', pos);
+    if (equal_sign_index != -1 && (next_arg_index == -1 || equal_sign_index < next_arg_index)) {
+      ++_currentArgCount;
+      if (_currentArgCount >= WEBSERVER_MAX_QUERY_ARGS) {
+        log_w("Argument count capped at %u, ignoring the rest", (unsigned)WEBSERVER_MAX_QUERY_ARGS);
+        break;
+      }
+    }
+    if (next_arg_index == -1) {
       break;
     }
-    ++i;
-    ++_currentArgCount;
+    pos = next_arg_index + 1;
   }
   log_v("args count: %d", _currentArgCount);
 
-  _currentArgs = new RequestArgument[_currentArgCount + 1];
+  _currentArgs = new (std::nothrow) RequestArgument[_currentArgCount + 1];
+  if (!_currentArgs) {
+    log_e("Failed to allocate %d request arguments", _currentArgCount);
+    _currentArgCount = 0;
+    _currentArgs = new (std::nothrow) RequestArgument[1];
+    return;
+  }
   int pos = 0;
   int iarg;
   for (iarg = 0; iarg < _currentArgCount;) {
@@ -415,18 +565,26 @@ bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32
   String line;
   int retry = 0;
   do {
-    line = client.readStringUntil('\r');
+    if (readLineWithLimit(client, line, WEBSERVER_MAX_LINE_LEN) != LineStatus::Ok) {
+      return false;
+    }
     ++retry;
   } while (line.length() == 0 && retry < 3);
 
-  client.readStringUntil('\n');
   //start reading the form
   if (line == ("--" + boundary)) {
     if (_postArgs) {
       delete[] _postArgs;
     }
-    _postArgs = new RequestArgument[WEBSERVER_MAX_POST_ARGS];
+    _postArgs = new (std::nothrow) RequestArgument[WEBSERVER_MAX_POST_ARGS];
+    if (!_postArgs) {
+      log_e("Failed to allocate post arguments");
+      return false;
+    }
     _postArgsLen = 0;
+    size_t skippedLines = 0;
+    bool inEmptyRun = false;
+    uint32_t emptyRunStart = 0;
     while (1) {
       String argName;
       String argValue;
@@ -434,9 +592,36 @@ bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32
       String argFilename;
       bool argIsFile = false;
 
-      line = client.readStringUntil('\r');
-      client.readStringUntil('\n');
+      // Exit when the client is gone or timed out instead of spinning forever
+      // on empty reads after a truncated multipart body.
+      if (!client.connected() && !client.available()) {
+        log_e("Multipart parse aborted: client disconnected");
+        return _parseFormUploadAborted();
+      }
+
+      if (readLineWithLimit(client, line, WEBSERVER_MAX_LINE_LEN) != LineStatus::Ok) {
+        return _parseFormUploadAborted();
+      }
+      if (line.length() == 0) {
+        // A bare CRLF is tolerated, but an unbroken run of empty reads means the
+        // body was truncated or the peer stalled. Reads block for the client
+        // timeout, so bound the run by time as well as by count.
+        if (!inEmptyRun) {
+          inEmptyRun = true;
+          emptyRunStart = millis();
+        } else if (millis() - emptyRunStart > HTTP_MAX_POST_WAIT) {
+          log_e("Multipart parse aborted: no data for %u ms", (unsigned)HTTP_MAX_POST_WAIT);
+          return _parseFormUploadAborted();
+        }
+        if (++skippedLines > WEBSERVER_MAX_MULTIPART_SKIP_LINES) {
+          log_e("Multipart parse aborted: %u blank lines without a part", (unsigned)skippedLines);
+          return _parseFormUploadAborted();
+        }
+        continue;
+      }
+      inEmptyRun = false;
       if (line.length() > (size_t)19 && line.substring(0, 19).equalsIgnoreCase(F("Content-Disposition"))) {
+        skippedLines = 0;
         int nameStart = line.indexOf('=');
         if (nameStart != -1) {
           argName = line.substring(nameStart + 2);
@@ -456,23 +641,33 @@ bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32
           log_v("PostArg Name: %s", argName.c_str());
           using namespace mime;
           argType = FPSTR(mimeTable[txt].mimeType);
-          line = client.readStringUntil('\r');
-          client.readStringUntil('\n');
+          if (readLineWithLimit(client, line, WEBSERVER_MAX_LINE_LEN) != LineStatus::Ok) {
+            return _parseFormUploadAborted();
+          }
           while (line.length() > 0) {
             if (line.length() > (size_t)12 && line.substring(0, 12).equalsIgnoreCase(FPSTR(Content_Type))) {
               argType = line.substring(line.indexOf(':') + 2);
             }
             //skip over any other headers
-            line = client.readStringUntil('\r');
-            client.readStringUntil('\n');
+            if (readLineWithLimit(client, line, WEBSERVER_MAX_LINE_LEN) != LineStatus::Ok) {
+              return _parseFormUploadAborted();
+            }
           }
           log_v("PostArg Type: %s", argType.c_str());
           if (!argIsFile) {
             while (1) {
-              line = client.readStringUntil('\r');
-              client.readStringUntil('\n');
+              // Field values are the one place a long line is legitimate, so the
+              // cap is its own, more generous limit. The time bound still applies.
+              if (readLineWithLimit(client, line, WEBSERVER_MAX_POST_ARG_LEN) != LineStatus::Ok) {
+                log_e("Multipart parse aborted: field value too long or too slow");
+                return _parseFormUploadAborted();
+              }
               if (line.startsWith("--" + boundary)) {
                 break;
+              }
+              if (!client.connected() && !client.available() && line.length() == 0) {
+                log_e("Multipart parse aborted: truncated field value");
+                return _parseFormUploadAborted();
               }
               if (argValue.length() > (size_t)0) {
                 argValue += "\n";
@@ -490,7 +685,7 @@ bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32
               break;
             } else if (_postArgsLen >= WEBSERVER_MAX_POST_ARGS) {
               log_e("Too many PostArgs (max: %u) in request.", WEBSERVER_MAX_POST_ARGS);
-              return false;
+              return _parseFormUploadAborted();
             }
           } else {
             _currentUpload.reset(new HTTPUpload());
@@ -552,8 +747,9 @@ bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32
             if (!client.connected()) {
               return _parseFormUploadAborted();
             }
-            line = client.readStringUntil('\r');
-            client.readStringUntil('\n');
+            if (readLineWithLimit(client, line, WEBSERVER_MAX_LINE_LEN) != LineStatus::Ok) {
+              return _parseFormUploadAborted();
+            }
             if (line == "--") {  // extra two dashes mean we reached the end of all form fields
               log_v("Done Parsing POST");
               break;
@@ -561,6 +757,13 @@ bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32
             continue;
           }
         }
+      } else if (line == ("--" + boundary + "--")) {
+        break;
+      } else if (++skippedLines > WEBSERVER_MAX_MULTIPART_SKIP_LINES) {
+        // A preamble or epilogue around the parts is legal (RFC 2046), so
+        // unrecognized lines are skipped -- but not indefinitely.
+        log_e("Multipart parse aborted: %u lines without a part", (unsigned)skippedLines);
+        return _parseFormUploadAborted();
       }
     }
 
@@ -574,7 +777,10 @@ bool WebServer::_parseForm(NetworkClient &client, const String &boundary, uint32
     if (_currentArgs) {
       delete[] _currentArgs;
     }
-    _currentArgs = new RequestArgument[_postArgsLen];
+    _currentArgs = new (std::nothrow) RequestArgument[_postArgsLen ? _postArgsLen : 1];
+    if (!_currentArgs) {
+      return _parseFormUploadAborted();
+    }
     for (iarg = 0; iarg < _postArgsLen; iarg++) {
       RequestArgument &arg = _currentArgs[iarg];
       arg.key = _postArgs[iarg].key;
@@ -618,9 +824,18 @@ String WebServer::urlDecode(const String &text) {
 }
 
 bool WebServer::_parseFormUploadAborted() {
-  _currentUpload->status = UPLOAD_FILE_ABORTED;
-  if (_currentHandler && _currentHandler->canUpload(*this, _currentUri)) {
-    _currentHandler->upload(*this, _currentUri, *_currentUpload);
+  if (_currentUpload) {
+    _currentUpload->status = UPLOAD_FILE_ABORTED;
+    if (_currentHandler && _currentHandler->canUpload(*this, _currentUri)) {
+      _currentHandler->upload(*this, _currentUri, *_currentUpload);
+    }
+  }
+  // Drop any fields collected before the abort so they cannot shadow later
+  // requests via arg()/hasArg().
+  if (_postArgs) {
+    delete[] _postArgs;
+    _postArgs = nullptr;
+    _postArgsLen = 0;
   }
   return false;
 }

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -143,8 +143,12 @@ bool WebServer::authenticateBasicSHA1(const char *_username, const char *_sha1Ba
 
 bool WebServer::authenticate(const char *_username, const char *_password) {
   return WebServer::authenticate([_username, _password](HTTPAuthMethod mode, String username, String params[]) -> String * {
-    (void)mode;
     (void)params;
+    // Plaintext-password auth only applies to Basic/Digest. A bare or unknown
+    // Authorization scheme must not be treated as a successful username match.
+    if (mode != BASIC_AUTH && mode != DIGEST_AUTH) {
+      return NULL;
+    }
     return username.equalsConstantTime(_username) ? new String(_password) : NULL;
   });
 }

--- a/libraries/WebServer/src/WebServer.h
+++ b/libraries/WebServer/src/WebServer.h
@@ -69,6 +69,40 @@ enum HTTPAuthMethod {
 #define HTTP_MAX_CLOSE_WAIT     5000  //ms to wait for the client to close the connection
 #define HTTP_MAX_BASIC_AUTH_LEN 256   // maximum length of a basic Auth base64 encoded username:password string
 
+// Request limits. All of these can be overridden from the build (e.g. with
+// -DWEBSERVER_MAX_URI_LEN=8192) to trade robustness against memory use.
+
+#ifndef WEBSERVER_MAX_URI_LEN
+#define WEBSERVER_MAX_URI_LEN 2048  // max request-target length; longer requests get 414. 0 disables the check
+#endif
+
+#ifndef WEBSERVER_MAX_QUERY_ARGS
+#define WEBSERVER_MAX_QUERY_ARGS 256  // max key=value args taken from a query string or urlencoded body
+#endif
+
+#ifndef WEBSERVER_MAX_MULTIPART_SKIP_LINES
+#define WEBSERVER_MAX_MULTIPART_SKIP_LINES 64  // unrecognized multipart lines tolerated before giving up
+#endif
+
+#ifndef WEBSERVER_MAX_LINE_LEN
+#define WEBSERVER_MAX_LINE_LEN 4096  // max length of a single protocol line (request line, header, multipart header)
+#endif
+
+#ifndef WEBSERVER_MAX_POST_ARG_LEN
+#define WEBSERVER_MAX_POST_ARG_LEN 16384  // max length of one line of a non-file multipart field value
+#endif
+
+// Time limits on receiving a request. Without them a peer that trickles one byte
+// per stream timeout keeps handleClient() from returning for as long as it likes.
+
+#ifndef WEBSERVER_MAX_LINE_WAIT
+#define WEBSERVER_MAX_LINE_WAIT 5000  // ms for a single protocol line to arrive complete. 0 disables the check
+#endif
+
+#ifndef WEBSERVER_MAX_HEADER_WAIT
+#define WEBSERVER_MAX_HEADER_WAIT 10000  // ms for the request line and all headers together. 0 disables the check
+#endif
+
 #define CONTENT_LENGTH_UNKNOWN ((size_t) - 1)
 #define CONTENT_LENGTH_NOT_SET ((size_t) - 2)
 
@@ -176,11 +210,30 @@ public:
   virtual NetworkClient &client() {
     return _currentClient;
   }
+  // A handler registered with an upload callback also receives raw
+  // (non-multipart) bodies, so upload() may be reached with no upload in
+  // progress and vice versa. Report an inactive object rather than
+  // dereferencing null; use hasUpload()/hasRaw() to tell the contexts apart.
   HTTPUpload &upload() {
+    if (!_currentUpload) {
+      _currentUpload.reset(new HTTPUpload());
+      _currentUpload->status = UPLOAD_FILE_ABORTED;
+    }
     return *_currentUpload;
   }
   HTTPRaw &raw() {
+    if (!_currentRaw) {
+      _currentRaw.reset(new HTTPRaw());
+      _currentRaw->status = RAW_ABORTED;
+    }
     return *_currentRaw;
+  }
+
+  bool hasUpload() const {
+    return static_cast<bool>(_currentUpload);
+  }
+  bool hasRaw() const {
+    return static_cast<bool>(_currentRaw);
   }
 
   String pathArg(unsigned int i) const;                                         // get request path argument by number

--- a/libraries/WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/WebServer/src/detail/RequestHandlersImpl.h
@@ -154,6 +154,28 @@ public:
     _baseUriLength = _uri.length();
   }
 
+  // True if path contains a "." or ".." segment (slash-delimited), including a
+  // trailing "/.." or leading "../".
+  static bool containsDotSegment(const String &path) {
+    size_t start = 0;
+    while (start <= path.length()) {
+      int slash = path.indexOf('/', start);
+      size_t end = (slash < 0) ? path.length() : (size_t)slash;
+      size_t len = end - start;
+      if (len == 1 && path.charAt(start) == '.') {
+        return true;
+      }
+      if (len == 2 && path.charAt(start) == '.' && path.charAt(start + 1) == '.') {
+        return true;
+      }
+      if (slash < 0) {
+        break;
+      }
+      start = (size_t)slash + 1;
+    }
+    return false;
+  }
+
   bool canHandle(HTTPMethod requestMethod, const String &requestUri) override {
     if (requestMethod != HTTP_GET) {
       return false;
@@ -199,7 +221,30 @@ public:
       }
 
       // Append whatever follows this URI in request to get the file path.
-      path += requestUri.substring(_baseUriLength);
+      // Reject path traversal: literal and percent-encoded dot-segments must not
+      // escape the configured filesystem root.
+      String relative = requestUri.substring(_baseUriLength);
+      String decoded = WebServer::urlDecode(relative);
+      if (containsDotSegment(relative) || containsDotSegment(decoded)) {
+        log_e("StaticRequestHandler: rejecting path traversal in %s", requestUri.c_str());
+        return false;
+      }
+      path += relative;
+
+      // Final path must still sit under the configured root once duplicate
+      // slashes are collapsed. Note the root may itself be "/".
+      String normalizedPath = path;
+      while (normalizedPath.indexOf("//") >= 0) {
+        normalizedPath.replace("//", "/");
+      }
+      String rootPrefix = _path;
+      if (!rootPrefix.endsWith("/")) {
+        rootPrefix += "/";
+      }
+      if (normalizedPath != rootPrefix && !normalizedPath.startsWith(rootPrefix)) {
+        log_e("StaticRequestHandler: path %s escapes root %s", path.c_str(), _path.c_str());
+        return false;
+      }
     }
     log_v("StaticRequestHandler::handle: path=%s, isFile=%d\r\n", path.c_str(), _isFile);
 

--- a/libraries/WebServer/src/uri/UriRegex.h
+++ b/libraries/WebServer/src/uri/UriRegex.h
@@ -2,7 +2,34 @@
 #define URI_REGEX_H
 
 #include "Uri.h"
+#include <esp32-hal-log.h>
 #include <regex>
+
+// libstdc++ ships two regex executors. The default one is a recursive
+// backtracker: matching a repeating group costs about 128 bytes of task stack
+// per character of request-target, and a pattern such as "^(a+)+$" takes
+// exponential time (measured on ESP32: 0.9 s for 18 characters, 13.8 s for 22).
+// Both are reachable from an unauthenticated request.
+//
+// The __polynomial extension selects a breadth-first executor that keeps its
+// state on the heap instead. Stack use is then flat (~2.5 KB regardless of
+// request-target length) and matching is linear in the length, at roughly
+// 26 us per character. Capture semantics are unchanged.
+//
+// That executor cannot handle back-references, so patterns using them keep the
+// recursive one and the much smaller length limit that comes with it.
+
+#ifndef WEBSERVER_MAX_REGEX_URI_LEN
+#define WEBSERVER_MAX_REGEX_URI_LEN 2048  // matches WEBSERVER_MAX_URI_LEN; 0 disables the check
+#endif
+
+// Only used for patterns containing back-references. Budget ~128 bytes of stack
+// per character in the task that calls handleClient(), on top of everything else
+// that task does (CONFIG_ARDUINO_LOOP_STACK_SIZE for the Arduino loop task, or
+// the stack passed to xTaskCreate for a dedicated task).
+#ifndef WEBSERVER_MAX_BACKREF_REGEX_URI_LEN
+#define WEBSERVER_MAX_BACKREF_REGEX_URI_LEN 64
+#endif
 
 class UriRegex : public Uri {
 
@@ -15,7 +42,7 @@ public:
   };
 
   void initPathArgs(std::vector<String> &pathArgs) override final {
-    std::regex rgx((_uri + "|").c_str());
+    std::regex rgx = compile(_uri + "|");
     std::smatch matches;
     std::string s{""};
     std::regex_search(s, matches, rgx);
@@ -27,19 +54,87 @@ public:
       return true;
     }
 
+    if (!_compiled) {
+      _rgx = compile(_uri);
+      _compiled = true;
+    }
+
+    const size_t maxLen = _boundedStack ? WEBSERVER_MAX_REGEX_URI_LEN : WEBSERVER_MAX_BACKREF_REGEX_URI_LEN;
+    if (maxLen && requestUri.length() > maxLen) {
+      log_e(
+        "Request-target of %u bytes exceeds %s (%u); not matched against %s", (unsigned)requestUri.length(),
+        _boundedStack ? "WEBSERVER_MAX_REGEX_URI_LEN" : "WEBSERVER_MAX_BACKREF_REGEX_URI_LEN", (unsigned)maxLen, _uri.c_str()
+      );
+      return false;
+    }
+
     unsigned int pathArgIndex = 0;
-    std::regex rgx(_uri.c_str());
     std::smatch matches;
     std::string s(requestUri.c_str());
-    if (std::regex_search(s, matches, rgx)) {
-      for (size_t i = 1; i < matches.size(); ++i) {  // skip first
-        pathArgs[pathArgIndex] = String(matches[i].str().c_str());
-        pathArgIndex++;
+    // The bounded executor holds its pending states on the heap, so a request
+    // arriving under memory pressure can fail to allocate. Treat that as "route
+    // does not match" (the client gets a 404) rather than letting it reach the
+    // top of the task.
+#ifdef CONFIG_CXX_EXCEPTIONS
+    try {
+#endif
+      if (std::regex_search(s, matches, _rgx)) {
+        for (size_t i = 1; i < matches.size(); ++i) {  // skip first
+          pathArgs[pathArgIndex] = String(matches[i].str().c_str());
+          pathArgIndex++;
+        }
+        return true;
       }
-      return true;
+#ifdef CONFIG_CXX_EXCEPTIONS
+    } catch (const std::exception &e) {
+      log_e("Matching %s against %s failed: %s", requestUri.c_str(), _uri.c_str(), e.what());
+    }
+#endif
+    return false;
+  }
+
+private:
+  // A back-reference is a backslash followed by a non-zero digit. Skipping the
+  // character after a backslash keeps "\\1" (escaped backslash, literal 1) from
+  // being mistaken for one. Octal escapes inside a character class are reported
+  // as back-references, which only costs the stricter length limit.
+  static bool hasBackreference(const String &pattern) {
+    for (size_t i = 0; i + 1 < pattern.length(); ++i) {
+      if (pattern[i] != '\\') {
+        continue;
+      }
+      if (pattern[i + 1] >= '1' && pattern[i + 1] <= '9') {
+        return true;
+      }
+      ++i;
     }
     return false;
   }
+
+  std::regex compile(const String &pattern) {
+    if (!hasBackreference(pattern)) {
+      constexpr auto boundedFlags = std::regex::ECMAScript | std::regex_constants::__polynomial;
+#ifdef CONFIG_CXX_EXCEPTIONS
+      try {
+        std::regex rgx(pattern.c_str(), boundedFlags);
+        _boundedStack = true;
+        return rgx;
+      } catch (const std::regex_error &) {
+        // The bounded executor rejected something in the pattern; fall back to
+        // the recursive one rather than refusing to serve the route.
+      }
+#else
+      _boundedStack = true;
+      return std::regex(pattern.c_str(), boundedFlags);
+#endif
+    }
+    _boundedStack = false;
+    return std::regex(pattern.c_str());
+  }
+
+  std::regex _rgx;
+  bool _compiled = false;
+  bool _boundedStack = false;
 };
 
 #endif

--- a/tests/validation/democfg/ci.yml
+++ b/tests/validation/democfg/ci.yml
@@ -39,7 +39,19 @@
 # FQBN append
 # -----------
 # This is the setting that will be appended to the default FQBNs.
+# A menu key given here replaces the default for that key, so this can also be
+# used to turn off options that are enabled by default (for example PSRAM).
 fqbn_append: DebugLevel=verbose
+
+# It can also be a dictionary when the options differ per target. The "default"
+# entry applies to every target and the per-target entry is merged on top of it,
+# so only the difference has to be spelled out. Targets without a PSRAM menu must
+# not receive PSRAM=disabled, which is what the example below avoids:
+#
+# fqbn_append:
+#   default: PartitionScheme=huge_app
+#   esp32: PSRAM=disabled
+#   esp32s3: PSRAM=disabled
 
 # FQBN list
 # ---------

--- a/tests/validation/webserver/README.md
+++ b/tests/validation/webserver/README.md
@@ -1,6 +1,6 @@
 # WebServer Validation Test
 
-Validates the `WebServer::send(code, content_type, Stream&)` overload by running a softAP-based HTTP server on one device and an HTTP client on another. This is a **multi-DUT** test that verifies stream-based response sending with text, binary, and empty payloads.
+Validates the `WebServer::send(code, content_type, Stream&)` overload and a set of HTTP request-parsing robustness properties by running a softAP-based HTTP server on one device and an HTTP client on another. This is a **multi-DUT** test: the server exposes endpoints configured the same way as the upstream `WebServer` examples, and the client crafts both well-formed and malformed raw HTTP requests to exercise the server's parser.
 
 ## Architecture
 
@@ -18,6 +18,8 @@ Validates the `WebServer::send(code, content_type, Stream&)` overload by running
 
 ## Test Cases
 
+### `send(Stream&)` overload
+
 | Test Function | Description |
 |---|---|
 | `stream_text` | Stream text data via `send(200, "text/plain", stream)`, verify Content-Length and body |
@@ -25,6 +27,38 @@ Validates the `WebServer::send(code, content_type, Stream&)` overload by running
 | `stream_explicit_len` | Stream with explicit content length parameter, verify Content-Length header |
 | `stream_empty` | Stream empty data, verify server returns HTTP 204 with empty body |
 | `string` | Regression test for `send(200, "text/plain", "OK")` string overload |
+
+### Request-parsing robustness (security regression checks)
+
+Each case first confirms the endpoint behaves correctly for a well-formed request, then sends a malformed/hostile request and verifies the server neither leaks data, bypasses a check, nor stops responding. After the destructive checks the client re-probes `/alive` to confirm the server task survived.
+
+| Test Function | Property verified |
+|---|---|
+| `auth_bypass` | A bare `Authorization: <username>` header must not bypass the configured plaintext password (only `Basic`/`Digest` are accepted). |
+| `path_traversal` | `serveStatic()` must not serve files outside its configured root via `..` dot segments. |
+| `arg_poison` | A completed field from an aborted, unauthenticated multipart request must not shadow a later request's named arguments. |
+| `arg_flood` | An oversized query string (many `&` separators) must not trigger an unbounded allocation that resets the device. |
+| `upload_null_deref` | A non-multipart POST to an upload route must not dereference a null upload object. |
+| `regex_stack` | A long path against a `UriRegex` route with unbounded repetition must not exhaust the task stack. |
+| `regex_backtrack` | A short, non-matching path against a `UriRegex` route with nested quantifiers (`(a+)+`) must not block the server task in exponential backtracking. |
+| `multipart_eof` | A multipart body truncated right after the initial boundary must not spin the parser in an unbounded loop. |
+| `long_line` | A request line or header with no CRLF must be refused (`414`/`431`) instead of being accumulated until the heap is exhausted, while long-but-legal headers are still accepted. |
+| `slow_line` | A client trickling bytes into a header line it never terminates must be dropped on a deadline (`408`), not kept alive one byte at a time ([#12788](https://github.com/espressif/arduino-esp32/issues/12788)). |
+| `slow_headers` | A client sending an endless stream of complete but tiny headers must be dropped by the header-phase deadline, which per-line deadlines cannot catch. |
+
+### Compatibility (limits must not refuse legitimate requests)
+
+The checks above introduce bounds on request size and shape. These cases pin down the request shapes that must keep working, so a future tightening cannot silently break applications.
+
+| Test Function | Property verified |
+|---|---|
+| `static_root` | `serveStatic()` whose filesystem root is `/` still serves files (the mapping used by the `WebServer` example). |
+| `raw_body` | A non-multipart body on a route registered with an upload-style callback still streams to that callback via `server.raw()`. |
+| `many_args` | A urlencoded form with 100 fields is parsed in full, not silently reduced to zero arguments. |
+| `long_uri` | A ~900 byte query string is served normally, while an over-long request-target is answered with `414` instead of a dropped connection. |
+| `regex_route` | A `UriRegex` route still matches a normal-length path, including one with nested quantifiers. |
+
+The limits are compile-time configurable: `WEBSERVER_MAX_URI_LEN`, `WEBSERVER_MAX_QUERY_ARGS`, `WEBSERVER_MAX_LINE_LEN`, `WEBSERVER_MAX_POST_ARG_LEN`, `WEBSERVER_MAX_MULTIPART_SKIP_LINES`, `WEBSERVER_MAX_LINE_WAIT`, `WEBSERVER_MAX_HEADER_WAIT`, `WEBSERVER_MAX_REGEX_URI_LEN` and `WEBSERVER_MAX_BACKREF_REGEX_URI_LEN`.
 
 ## Requirements
 

--- a/tests/validation/webserver/ci.yml
+++ b/tests/validation/webserver/ci.yml
@@ -12,6 +12,19 @@ platforms:
   hardware:
     esp32p4: false # No two_duts runners using ESP-Hosted
 
+# huge_app is required because the server pulls in WebServer + LittleFS + regex.
+# PSRAM must stay disabled so the query-argument allocation regression matches
+# classic SRAM limits (with SPIRAM, oversized new[] quietly succeeds in external
+# RAM). PSRAM is only overridden on the targets that have the menu; the others
+# have no PSRAM to begin with.
+fqbn_append:
+  default: PartitionScheme=huge_app
+  esp32: PSRAM=disabled
+  esp32s2: PSRAM=disabled
+  esp32s3: PSRAM=disabled
+  esp32c5: PSRAM=disabled
+  esp32p4: PSRAM=disabled
+
 requires_any:
   - CONFIG_SOC_WIFI_SUPPORTED=y
   - CONFIG_ESP_HOSTED_ENABLED=y

--- a/tests/validation/webserver/client/client.ino
+++ b/tests/validation/webserver/client/client.ino
@@ -1,8 +1,11 @@
 /*
   client.ino - HTTP client device for multi-DUT WebServer validation test.
 
-  Connects to the server's WiFi AP, then makes HTTP requests to test
-  WebServer::send(code, content_type, Stream&) overload.
+  Connects to the server's WiFi AP, then makes HTTP requests to test the
+  WebServer::send(code, content_type, Stream&) overload and a set of
+  request-parsing robustness properties (see server.ino). Malicious/malformed
+  requests are crafted as raw bytes over WiFiClient so the server's parser is
+  exercised directly.
 
   Communicates with the Python test runner via serial protocol.
 */
@@ -13,6 +16,11 @@
 
 #define SERVER_PORT  80
 #define TEST_TIMEOUT 5000
+// Time to let the server task settle / recover after each robustness probe.
+#define SETTLE_MS 1000
+
+// Basic auth header value for admin:SuperSecurePassword (see server.ino).
+static const char *VALID_BASIC_AUTH = "Basic YWRtaW46U3VwZXJTZWN1cmVQYXNzd29yZA==";
 
 // Test data (must match server)
 static const char test_body[] = "Hello from Stream!";
@@ -94,6 +102,50 @@ String http_get(const char *path) {
   return response;
 }
 
+// Send an arbitrary raw request (already fully formed) and return the raw
+// response. If close_early is true, the socket is closed right after writing
+// without waiting for a full response (used to simulate a client that
+// disconnects mid-request).
+String http_raw(const String &request, unsigned long timeout_ms, bool close_early) {
+  WiFiClient client;
+  if (!client.connect(serverIP.c_str(), SERVER_PORT)) {
+    return "";
+  }
+  // Write in chunks: a single large print can be truncated, which would silently
+  // weaken the requests that depend on their full length reaching the parser.
+  size_t written = 0;
+  while (written < request.length()) {
+    size_t chunk = min((size_t)512, request.length() - written);
+    size_t n = client.write((const uint8_t *)request.c_str() + written, chunk);
+    if (n == 0) {
+      break;
+    }
+    written += n;
+  }
+  client.flush();
+
+  if (close_early) {
+    delay(50);
+    client.stop();
+    return "";
+  }
+
+  String response;
+  unsigned long start = millis();
+  while (millis() - start < timeout_ms) {
+    if (client.available()) {
+      response += (char)client.read();
+      start = millis();
+    } else if (!client.connected()) {
+      break;
+    } else {
+      delay(1);
+    }
+  }
+  client.stop();
+  return response;
+}
+
 // Extract body from HTTP response (after \r\n\r\n)
 String get_body(const String &response) {
   int idx = response.indexOf("\r\n\r\n");
@@ -123,9 +175,81 @@ int get_content_length(const String &response) {
   return val.toInt();
 }
 
-void runTests() {
-  bool all_passed = true;
+static bool all_passed = true;
 
+void report(const char *name, bool ok, const char *detail = nullptr) {
+  if (ok) {
+    Serial.printf("[CLIENT] PASS %s\n", name);
+  } else {
+    if (detail) {
+      Serial.printf("[CLIENT] FAIL %s: %s\n", name, detail);
+    } else {
+      Serial.printf("[CLIENT] FAIL %s\n", name);
+    }
+    all_passed = false;
+  }
+}
+
+// Return the server's current boot id, or "" if it is unreachable. Retries to
+// tolerate the AP briefly disappearing while the server finishes a connection
+// or (on a vulnerable build) reboots and recovers.
+// SoftAP disappearances (server crash/recover) drop the client's STA association.
+// Rejoin before probing so post-crash survival checks remain meaningful.
+void ensureWifi() {
+  if (WiFi.STA.status() == WL_CONNECTED) {
+    return;
+  }
+  Serial.println("[CLIENT] Reconnecting to AP");
+  WiFi.STA.disconnect();
+  WiFi.STA.connect(ssid, password);
+  for (int i = 0; i < 50 && WiFi.STA.status() != WL_CONNECTED; i++) {
+    delay(200);
+  }
+  if (WiFi.STA.status() == WL_CONNECTED) {
+    Serial.printf("[CLIENT] Reconnected IP=%s\n", WiFi.STA.localIP().toString().c_str());
+  } else {
+    Serial.println("[CLIENT] Reconnect failed");
+  }
+}
+
+String get_boot_id(int max_attempts) {
+  // SoftAP disappearances (server crash/recover) drop the client's STA association.
+  // Rejoin before probing so post-crash survival checks remain meaningful.
+  for (int i = 0; i < max_attempts; i++) {
+    ensureWifi();
+    String body = get_body(http_get("/alive"));
+    if (body.startsWith("ALIVE ")) {
+      return body.substring(6);
+    }
+    delay(SETTLE_MS);
+  }
+  return "";
+}
+
+// Run a destructive attack and confirm the server task survived it unchanged:
+// same boot id (did not reset) and still responsive (did not hang).
+void survivalTest(const char *name, void (*attack)()) {
+  String before = get_boot_id(30);
+  if (before.length() == 0) {
+    report(name, false, "server not responsive before attack");
+    return;
+  }
+  attack();
+  // After the attack use a shorter probe window so a hung server is detected
+  // before the pytest case timeout elapses.
+  String after = get_boot_id(8);
+  if (after.length() == 0) {
+    report(name, false, "server unresponsive after attack (hang or down)");
+  } else if (after != before) {
+    report(name, false, "server reset (boot id changed)");
+  } else {
+    report(name, true);
+  }
+}
+
+// ------------------------- stream send() overload tests -------------------------
+
+void runStreamTests() {
   // Test 1: Stream with text data
   {
     Serial.println("[CLIENT] Testing /stream_text");
@@ -133,16 +257,13 @@ void runTests() {
     int cl = get_content_length(response);
     String body = get_body(response);
     if (response.length() == 0) {
-      Serial.println("[CLIENT] FAIL stream_text: no response");
-      all_passed = false;
+      report("stream_text", false, "no response");
     } else if (cl != (int)strlen(test_body)) {
-      Serial.printf("[CLIENT] FAIL stream_text: Content-Length=%d expected=%d\n", cl, (int)strlen(test_body));
-      all_passed = false;
+      report("stream_text", false, "content-length mismatch");
     } else if (!body.equals(test_body)) {
-      Serial.println("[CLIENT] FAIL stream_text: body mismatch");
-      all_passed = false;
+      report("stream_text", false, "body mismatch");
     } else {
-      Serial.println("[CLIENT] PASS stream_text");
+      report("stream_text", true);
     }
   }
 
@@ -153,16 +274,13 @@ void runTests() {
     int cl = get_content_length(response);
     String body = get_body(response);
     if (response.length() == 0) {
-      Serial.println("[CLIENT] FAIL stream_binary: no response");
-      all_passed = false;
+      report("stream_binary", false, "no response");
     } else if (cl != 4) {
-      Serial.printf("[CLIENT] FAIL stream_binary: Content-Length=%d expected=4\n", cl);
-      all_passed = false;
+      report("stream_binary", false, "content-length mismatch");
     } else if (body.length() != 4 || (uint8_t)body[0] != 0xDE || (uint8_t)body[1] != 0xAD || (uint8_t)body[2] != 0xBE || (uint8_t)body[3] != 0xEF) {
-      Serial.println("[CLIENT] FAIL stream_binary: body mismatch");
-      all_passed = false;
+      report("stream_binary", false, "body mismatch");
     } else {
-      Serial.println("[CLIENT] PASS stream_binary");
+      report("stream_binary", true);
     }
   }
 
@@ -172,13 +290,11 @@ void runTests() {
     String response = http_get("/stream_explicit_len");
     int cl = get_content_length(response);
     if (response.length() == 0) {
-      Serial.println("[CLIENT] FAIL stream_explicit_len: no response");
-      all_passed = false;
+      report("stream_explicit_len", false, "no response");
     } else if (cl != (int)strlen(test_body)) {
-      Serial.printf("[CLIENT] FAIL stream_explicit_len: Content-Length=%d expected=%d\n", cl, (int)strlen(test_body));
-      all_passed = false;
+      report("stream_explicit_len", false, "content-length mismatch");
     } else {
-      Serial.println("[CLIENT] PASS stream_explicit_len");
+      report("stream_explicit_len", true);
     }
   }
 
@@ -189,16 +305,13 @@ void runTests() {
     int status = get_status_code(response);
     String body = get_body(response);
     if (response.length() == 0) {
-      Serial.println("[CLIENT] FAIL stream_empty: no response");
-      all_passed = false;
+      report("stream_empty", false, "no response");
     } else if (status != 204) {
-      Serial.printf("[CLIENT] FAIL stream_empty: status=%d expected=204\n", status);
-      all_passed = false;
+      report("stream_empty", false, "status mismatch");
     } else if (body.length() != 0) {
-      Serial.println("[CLIENT] FAIL stream_empty: body should be empty");
-      all_passed = false;
+      report("stream_empty", false, "body should be empty");
     } else {
-      Serial.println("[CLIENT] PASS stream_empty");
+      report("stream_empty", true);
     }
   }
 
@@ -208,15 +321,414 @@ void runTests() {
     String response = http_get("/string");
     String body = get_body(response);
     if (response.length() == 0) {
-      Serial.println("[CLIENT] FAIL string: no response");
-      all_passed = false;
+      report("string", false, "no response");
     } else if (!body.equals("OK")) {
-      Serial.println("[CLIENT] FAIL string: body mismatch");
-      all_passed = false;
+      report("string", false, "body mismatch");
     } else {
-      Serial.println("[CLIENT] PASS string");
+      report("string", true);
     }
   }
+}
+
+// ------------------------- request-parsing robustness tests -------------------------
+
+// Report 2: a bare "Authorization: <username>" header must not bypass the
+// configured plaintext password.
+void testAuthBypass() {
+  Serial.println("[CLIENT] Testing auth_bypass");
+
+  // Control: no credentials must be rejected.
+  String control = http_raw("GET /secure HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  if (get_status_code(control) != 401) {
+    report("auth_bypass", false, "control not 401");
+    return;
+  }
+
+  // Valid Basic credentials must be accepted (endpoint is functioning).
+  String ok = http_raw(String("GET /secure HTTP/1.1\r\nHost: x\r\nAuthorization: ") + VALID_BASIC_AUTH + "\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  if (get_status_code(ok) != 200) {
+    report("auth_bypass", false, "valid basic auth rejected");
+    return;
+  }
+
+  // Attack: a bare header whose value equals the username must NOT authenticate.
+  String attack = http_raw("GET /secure HTTP/1.1\r\nHost: x\r\nAuthorization: admin\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  int status = get_status_code(attack);
+  report("auth_bypass", status == 401, status == 200 ? "bare username authenticated" : "unexpected status");
+}
+
+// Report 6: serveStatic() must not allow escaping the configured static root
+// via dot segments.
+void testPathTraversal() {
+  Serial.println("[CLIENT] Testing path_traversal");
+
+  // Sanity: the public file inside the root is served.
+  String pub = http_raw("GET /static/public.txt HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  if (get_body(pub).indexOf("PUBLIC_FILE_OK") < 0) {
+    report("path_traversal", false, "public file not served");
+    return;
+  }
+
+  // Attack: traversal to a file outside the root must not disclose it.
+  String attack = http_raw("GET /static/../secret.txt HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  bool leaked = get_body(attack).indexOf("TOP_SECRET_OUTSIDE_ROOT") >= 0;
+  report("path_traversal", !leaked, leaked ? "secret disclosed via traversal" : nullptr);
+}
+
+// Report 8: a completed field from an aborted, unauthenticated multipart
+// request must not shadow a later request's arguments.
+void testArgPoison() {
+  Serial.println("[CLIENT] Testing arg_poison");
+
+  // Baseline authenticated request selects its own "path" argument.
+  String baseline = http_raw(
+    String("GET /secure?path=/legit HTTP/1.1\r\nHost: x\r\nAuthorization: ") + VALID_BASIC_AUTH + "\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false
+  );
+  if (get_body(baseline).indexOf("PATH=/legit") < 0) {
+    report("arg_poison", false, "baseline path not selected");
+    return;
+  }
+
+  // Poison: unauthenticated multipart to an unregistered route with a completed
+  // "path" field, followed by a truncated file part; then disconnect.
+  String boundary = "BND1";
+  String body = "--" + boundary + "\r\n";
+  body += "Content-Disposition: form-data; name=\"path\"\r\n\r\n";
+  body += "/post-poison\r\n";
+  body += "--" + boundary + "\r\n";
+  body += "Content-Disposition: form-data; name=\"file\"; filename=\"f.txt\"\r\n";
+  body += "Content-Type: text/plain\r\n\r\n";
+  body += "truncated";  // no closing boundary -> aborted
+
+  String req = "POST /missing HTTP/1.1\r\nHost: x\r\n";
+  req += "Content-Type: multipart/form-data; boundary=" + boundary + "\r\n";
+  req += "Content-Length: 100000\r\n";  // claim more than we send
+  req += "Connection: close\r\n\r\n";
+  req += body;
+  http_raw(req, TEST_TIMEOUT, true);
+
+  delay(SETTLE_MS);
+
+  // Repeat the authenticated request; it must still select its own argument.
+  String after = http_raw(
+    String("GET /secure?path=/legit HTTP/1.1\r\nHost: x\r\nAuthorization: ") + VALID_BASIC_AUTH + "\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false
+  );
+  String after_body = get_body(after);
+  bool poisoned = after_body.indexOf("/post-poison") >= 0;
+  report("arg_poison", !poisoned, poisoned ? "later request poisoned" : nullptr);
+}
+
+// ------------------------- compatibility regression tests -------------------------
+// These cover request shapes that the robustness limits above must not refuse.
+
+// A serveStatic() route whose filesystem root is "/" must still serve files.
+void testStaticRootMapping() {
+  Serial.println("[CLIENT] Testing static_root");
+  String resp = http_raw("GET /root/root_ok.txt HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  bool ok = get_body(resp).indexOf("ROOT_FILE_OK") >= 0;
+  report("static_root", ok, ok ? nullptr : "file not served from root-mapped serveStatic");
+}
+
+// A non-multipart body on a route registered with an upload-style callback must
+// still be streamed to that callback.
+void testRawBody() {
+  Serial.println("[CLIENT] Testing raw_body");
+  const int payload_len = 3000;
+  String payload;
+  payload.reserve(payload_len);
+  for (int i = 0; i < payload_len; i++) {
+    payload += 'A';
+  }
+  String req = "PUT /raw HTTP/1.1\r\nHost: x\r\nContent-Type: application/octet-stream\r\n";
+  req += "Content-Length: " + String(payload_len) + "\r\nConnection: close\r\n\r\n";
+  req += payload;
+
+  String body = get_body(http_raw(req, TEST_TIMEOUT, false));
+  bool ok = body.equals("RAW=" + String(payload_len));
+  report("raw_body", ok, ok ? nullptr : body.c_str());
+}
+
+// A form with more fields than a conservative cap would allow must still be
+// parsed in full rather than silently yielding no arguments.
+void testManyArgs() {
+  Serial.println("[CLIENT] Testing many_args");
+  const int n = 100;
+  String body;
+  for (int i = 0; i < n; i++) {
+    if (i > 0) {
+      body += '&';
+    }
+    body += "k" + String(i) + "=v" + String(i);
+  }
+  String req = "POST /args HTTP/1.1\r\nHost: x\r\nContent-Type: application/x-www-form-urlencoded\r\n";
+  req += "Content-Length: " + String(body.length()) + "\r\nConnection: close\r\n\r\n";
+  req += body;
+
+  String got = get_body(http_raw(req, TEST_TIMEOUT, false));
+  bool ok = got.toInt() == n;
+  report("many_args", ok, ok ? nullptr : got.c_str());
+}
+
+// A long-but-reasonable query string must be served; an over-long request-target
+// must be refused with 414 rather than a silently dropped connection.
+void testLongUri() {
+  Serial.println("[CLIENT] Testing long_uri");
+  String value;
+  for (int i = 0; i < 900; i++) {
+    value += 'a';
+  }
+  String resp = http_raw("GET /args?x=" + value + " HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  if (get_status_code(resp) != 200 || get_body(resp).toInt() != 1) {
+    report("long_uri", false, "long query string rejected");
+    return;
+  }
+
+  String oversized;
+  for (int i = 0; i < 4096; i++) {
+    oversized += 'a';
+  }
+  String big = http_raw("GET /args?x=" + oversized + " HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false);
+  int status = get_status_code(big);
+  report("long_uri", status == 414, status < 0 ? "no response to over-long target" : "unexpected status");
+}
+
+// A protocol line that never terminates must not be buffered without bound: the
+// server must refuse it outright while still accepting long-but-legal headers.
+void testLongLine() {
+  Serial.println("[CLIENT] Testing long_line");
+
+  // A long but legitimate header (a fat cookie) must still be accepted.
+  String cookie;
+  for (int i = 0; i < 1000; i++) {
+    cookie += 'c';
+  }
+  String legal = "GET /string HTTP/1.1\r\nHost: x\r\nCookie: " + cookie + "\r\nConnection: close\r\n\r\n";
+  if (get_status_code(http_raw(legal, TEST_TIMEOUT, false)) != 200) {
+    report("long_line", false, "long header rejected");
+    return;
+  }
+
+  // Request line with no CRLF at all: must be answered 414, not accumulated
+  // until the read times out.
+  String unterminated = "GET /";
+  for (int i = 0; i < 8000; i++) {
+    unterminated += 'a';
+  }
+  int status = get_status_code(http_raw(unterminated, 12000, false));
+  if (status != 414) {
+    report("long_line", false, status < 0 ? "no response to unterminated request line" : "unexpected status for request line");
+    return;
+  }
+
+  // Oversized header line: must be answered 431.
+  String bigHeader = "GET /string HTTP/1.1\r\nHost: x\r\nX-Pad: ";
+  for (int i = 0; i < 8000; i++) {
+    bigHeader += 'p';
+  }
+  bigHeader += "\r\nConnection: close\r\n\r\n";
+  int header_status = get_status_code(http_raw(bigHeader, 12000, false));
+  report("long_line", header_status == 431, header_status < 0 ? "no response to oversized header" : "unexpected status for header");
+}
+
+// Drip-feed a request that is never completed, then report how long the server
+// took to answer and what it answered. Returns the status code, or -1 if the
+// server never replied while it was being fed.
+static int dripAttack(const String &prologue, const String &drip, unsigned long dripIntervalMs, unsigned long giveUpMs, unsigned long *elapsedMs) {
+  WiFiClient client;
+  if (!client.connect(serverIP.c_str(), SERVER_PORT)) {
+    return -2;
+  }
+  client.print(prologue);
+  client.flush();
+
+  String response;
+  unsigned long start = millis();
+  unsigned long lastDrip = millis();
+  while (millis() - start < giveUpMs) {
+    if (client.available()) {
+      while (client.available()) {
+        response += (char)client.read();
+      }
+      break;  // the server answered instead of staying blocked
+    }
+    if (!client.connected()) {
+      break;
+    }
+    if (millis() - lastDrip >= dripIntervalMs) {
+      client.print(drip);
+      client.flush();
+      lastDrip = millis();
+    }
+    delay(10);
+  }
+  *elapsedMs = millis() - start;
+  client.stop();
+  return response.length() ? get_status_code(response) : -1;
+}
+
+// A client that trickles bytes into a header line it never terminates must be
+// dropped on a deadline, not kept alive one byte at a time. On a vulnerable
+// build handleClient() stays inside the parser and nothing is answered.
+// See https://github.com/espressif/arduino-esp32/issues/12788
+void testSlowLine() {
+  Serial.println("[CLIENT] Testing slow_line");
+  unsigned long elapsed = 0;
+  int status = dripAttack("GET /string HTTP/1.1\r\nHost: x\r\nUser-Agent: slow", "x", 1000, 20000, &elapsed);
+  Serial.printf("[CLIENT] slow_line answered %d after %lu ms\n", status, elapsed);
+  if (status < 0) {
+    report("slow_line", false, "server never answered a stalled request line");
+    return;
+  }
+  // The per-line deadline is 5 s; allow generous slack for scheduling.
+  report("slow_line", elapsed < 15000, "answered but took too long");
+}
+
+// A client that keeps sending complete but tiny headers restarts the per-line
+// deadline every time, so only a deadline covering the whole header phase stops
+// it. The request is never completed, so the server must give up on its own.
+void testSlowHeaders() {
+  Serial.println("[CLIENT] Testing slow_headers");
+  unsigned long elapsed = 0;
+  int status = dripAttack("GET /string HTTP/1.1\r\nHost: x\r\n", "X-Pad: 1\r\n", 1000, 30000, &elapsed);
+  Serial.printf("[CLIENT] slow_headers answered %d after %lu ms\n", status, elapsed);
+  if (status < 0) {
+    report("slow_headers", false, "server never answered a drip-fed header stream");
+    return;
+  }
+  // The header-phase deadline is 10 s.
+  report("slow_headers", elapsed < 25000, "answered but took too long");
+}
+
+// A regex route must still match a normal-length path.
+void testRegexRoute() {
+  Serial.println("[CLIENT] Testing regex_route");
+  String body = get_body(http_raw("GET /users/12345 HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false));
+  if (!body.equals("USER=12345")) {
+    report("regex_route", false, body.c_str());
+    return;
+  }
+
+  // Nested quantifiers must still match and capture normally.
+  String nested = get_body(http_raw("GET /nested/aaa HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", TEST_TIMEOUT, false));
+  bool ok = nested.equals("NESTED=aaa");
+  report("regex_route", ok, ok ? nullptr : nested.c_str());
+}
+
+// Report 3: many separators must not crash the device via unbounded allocation.
+// Written in chunks so the payload is not lost to a single giant String write.
+void attackArgFlood() {
+  WiFiClient client;
+  if (!client.connect(serverIP.c_str(), SERVER_PORT)) {
+    return;
+  }
+  const int n = 20000;
+  client.print("POST /args HTTP/1.1\r\nHost: x\r\n");
+  client.print("Content-Type: application/x-www-form-urlencoded\r\n");
+  client.printf("Content-Length: %d\r\n", n);
+  client.print("Connection: close\r\n\r\n");
+  for (int i = 0; i < n; i++) {
+    client.write('&');
+  }
+  client.flush();
+  unsigned long start = millis();
+  while (client.connected() && millis() - start < TEST_TIMEOUT) {
+    if (client.available()) {
+      while (client.available()) {
+        client.read();
+      }
+      break;
+    }
+    delay(1);
+  }
+  client.stop();
+}
+
+// Report 4: a non-multipart POST to an upload route must not dereference a null
+// upload object.
+void attackUploadNullDeref() {
+  String req = "POST /edit HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+  http_raw(req, TEST_TIMEOUT, false);
+}
+
+// Report 7: a long path against a regex route with unbounded repetition must
+// not exhaust the task stack.
+void attackRegexStack() {
+  String req = "GET /users/";
+  for (int i = 0; i < 2000; i++) {
+    req += '9';
+  }
+  req += " HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n";
+  http_raw(req, TEST_TIMEOUT, false);
+}
+
+// Report 7, second vector: a nested quantifier against a short input that
+// cannot match. A recursive backtracking engine explores 2^30 paths here, which
+// blocks the server task for roughly an hour; a bounded engine answers in
+// milliseconds. The length limits do not help because the request is tiny.
+void attackRegexBacktrack() {
+  String req = "GET /nested/";
+  for (int i = 0; i < 30; i++) {
+    req += 'a';
+  }
+  req += "b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n";
+  http_raw(req, TEST_TIMEOUT, false);
+}
+
+// Report 1: a multipart body that ends immediately after the initial boundary
+// must not spin the parser in an unbounded loop.
+void attackMultipartEof() {
+  String boundary = "AaB03x";
+  String req = "POST /edit HTTP/1.1\r\nHost: x\r\n";
+  req += "Content-Type: multipart/form-data; boundary=" + boundary + "\r\n";
+  req += "Content-Length: 100000\r\n";
+  req += "Connection: close\r\n\r\n";
+  req += "--" + boundary + "\r\n";  // initial boundary, then EOF
+  http_raw(req, TEST_TIMEOUT, true);
+}
+
+void runTests() {
+  runStreamTests();
+
+  // Non-destructive robustness checks first (server stays responsive).
+  testAuthBypass();
+  testPathTraversal();
+
+  // Compatibility checks: request shapes the robustness limits must still accept.
+  testStaticRootMapping();
+  testRawBody();
+  testManyArgs();
+  testLongUri();
+  testLongLine();
+  testRegexRoute();
+
+  // Slow-client checks. A vulnerable build stays inside the parser for as long
+  // as the attack runs, but recovers once the connection closes, so these are
+  // safe to run before the destructive cases.
+  testSlowLine();
+  testSlowHeaders();
+
+  // upload_null_deref must run before any multipart request: a prior multipart
+  // parse can leave _currentUpload allocated and mask the null dereference.
+  Serial.println("[CLIENT] Testing upload_null_deref");
+  survivalTest("upload_null_deref", attackUploadNullDeref);
+
+  testArgPoison();
+
+  // Checks that, on a vulnerable build, crash or hang the server task. Each one
+  // re-baselines the server boot id first, so they are independently meaningful
+  // even if a previous attack reset (and auto-recovered) the server.
+  Serial.println("[CLIENT] Testing arg_flood");
+  survivalTest("arg_flood", attackArgFlood);
+  Serial.println("[CLIENT] Testing regex_stack");
+  survivalTest("regex_stack", attackRegexStack);
+  // regex_backtrack before multipart_eof: on a vulnerable build it blocks the
+  // server task for hours, so nothing after it can baseline against /alive.
+  Serial.println("[CLIENT] Testing regex_backtrack");
+  survivalTest("regex_backtrack", attackRegexBacktrack);
+  // multipart_eof last: a vulnerable build hangs the server task permanently,
+  // so no later case can baseline against /alive.
+  Serial.println("[CLIENT] Testing multipart_eof");
+  survivalTest("multipart_eof", attackMultipartEof);
 
   if (all_passed) {
     Serial.println("[CLIENT] All tests passed");

--- a/tests/validation/webserver/server/server.ino
+++ b/tests/validation/webserver/server/server.ino
@@ -1,8 +1,12 @@
 /*
   server.ino - WebServer device for multi-DUT validation test.
 
-  Runs a WiFi softAP and WebServer with test endpoints for
-  WebServer::send(code, content_type, Stream&) overload.
+  Runs a WiFi softAP and WebServer with test endpoints for the
+  WebServer::send(code, content_type, Stream&) overload, plus a set of
+  endpoints configured the same way as the upstream WebServer examples so the
+  client device can exercise request-parsing robustness properties: malformed
+  multipart bodies, oversized query strings, authentication headers,
+  static-file path traversal, regex routes and cross-request argument state.
 
   Communicates with the Python test runner via serial protocol.
 */
@@ -10,10 +14,37 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <WebServer.h>
+#include <LittleFS.h>
+#include <Preferences.h>
+#include <uri/UriRegex.h>
+#include "esp_system.h"
 
 #define SERVER_PORT 80
 
 static WebServer server(SERVER_PORT);
+static Preferences prefs;
+
+// Per-boot identifier reported by /alive. The client uses it to detect whether
+// a request caused the server to reset (the id changes) versus hang (no reply).
+static String bootId;
+
+// Credentials for the authentication-protected endpoint.
+static const char *www_username = "admin";
+static const char *www_password = "SuperSecurePassword";
+
+// Files used by the serveStatic() traversal check. The public file lives inside
+// the configured static root; the secret file deliberately lives outside of it.
+static const char *STATIC_ROOT = "/www/";
+static const char *PUBLIC_PATH = "/www/public.txt";
+static const char *PUBLIC_BODY = "PUBLIC_FILE_OK";
+static const char *SECRET_PATH = "/secret.txt";
+static const char *SECRET_BODY = "TOP_SECRET_OUTSIDE_ROOT";
+
+// File served through a serveStatic() route whose filesystem root is "/", the
+// mapping used by the WebServer example. Kept separate from the traversal check
+// above so that check keeps a root it must not escape.
+static const char *ROOT_FILE_PATH = "/root_ok.txt";
+static const char *ROOT_FILE_BODY = "ROOT_FILE_OK";
 
 // In-memory stream for testing (simulates a File)
 class TestStream : public Stream {
@@ -54,6 +85,33 @@ static const uint8_t test_data[] = {0xDE, 0xAD, 0xBE, 0xEF};
 String ssid = "";
 String password = "";
 
+// Dummy upload/raw body sink. Mirrors the upstream FSBrowser upload-callback
+// pattern: the callback reads server.upload() on every invocation. Used by the
+// multipart and non-multipart upload robustness checks.
+void handleUpload() {
+  // Touch members through server.upload() the same way application callbacks do.
+  // A bare (void)upload.status can be optimized away and hide a null dereference.
+  HTTPUpload &upload = server.upload();
+  Serial.printf("[SERVER] upload status=%d name=%s\n", (int)upload.status, upload.name.c_str());
+}
+
+// Raw (non-multipart) body sink, registered in the same callback slot as an
+// upload handler. Mirrors the upstream UploadHugeFile example.
+static size_t rawTotalSize = 0;
+static bool rawSawStart = false;
+
+void handleRawBody() {
+  HTTPRaw &raw = server.raw();
+  if (raw.status == RAW_START) {
+    rawTotalSize = 0;
+    rawSawStart = true;
+  } else if (raw.status == RAW_WRITE) {
+    rawTotalSize += raw.currentSize;
+  } else if (raw.status == RAW_END) {
+    Serial.printf("[SERVER] raw end total=%u\n", (unsigned)rawTotalSize);
+  }
+}
+
 void readWiFiCredentials() {
   Serial.println("[SERVER] Send SSID:");
   while (ssid.length() == 0) {
@@ -79,27 +137,40 @@ void readWiFiCredentials() {
   Serial.printf("[SERVER] Password: %s\n", password.c_str());
 }
 
-void setup() {
-  Serial.begin(115200);
-  while (!Serial) {
-    delay(100);
-  }
-
-  Serial.println("[SERVER] Device ready for WiFi credentials");
-  readWiFiCredentials();
-
-  // Start WiFi softAP
-  WiFi.AP.begin();
-  bool ok = WiFi.AP.create(ssid, password);
-  if (!ok) {
-    Serial.println("[SERVER] Failed to start AP");
+void setupFilesystem() {
+  if (!LittleFS.begin(true)) {
+    Serial.println("[SERVER] LittleFS mount failed");
     return;
   }
+  LittleFS.mkdir("/www");
+  File pub = LittleFS.open(PUBLIC_PATH, "w");
+  if (pub) {
+    pub.print(PUBLIC_BODY);
+    pub.close();
+    Serial.println("[SERVER] Wrote public file");
+  } else {
+    Serial.println("[SERVER] Failed to write public file");
+  }
+  File secret = LittleFS.open(SECRET_PATH, "w");
+  if (secret) {
+    secret.print(SECRET_BODY);
+    secret.close();
+    Serial.println("[SERVER] Wrote secret file");
+  } else {
+    Serial.println("[SERVER] Failed to write secret file");
+  }
+  File rootFile = LittleFS.open(ROOT_FILE_PATH, "w");
+  if (rootFile) {
+    rootFile.print(ROOT_FILE_BODY);
+    rootFile.close();
+    Serial.println("[SERVER] Wrote root file");
+  } else {
+    Serial.println("[SERVER] Failed to write root file");
+  }
+}
 
-  IPAddress ip = WiFi.AP.localIP();
-  Serial.printf("[SERVER] AP started IP=%s\n", ip.toString().c_str());
-
-  // Register test endpoints
+void registerEndpoints() {
+  // --- Stream send() overload endpoints (existing coverage) ---
   server.on("/stream_text", HTTP_GET, []() {
     TestStream stream((const uint8_t *)test_body, strlen(test_body));
     server.send(200, "text/plain", stream);
@@ -129,6 +200,130 @@ void setup() {
     server.send(200, "text/plain", "OK");
     Serial.println("[SERVER] Served /string");
   });
+
+  // --- Liveness probe: used to confirm the server task survives each attack ---
+  // The boot id lets the client distinguish "still alive" from "reset and
+  // recovered" (id changes) and from "hung" (no response).
+  server.on("/alive", HTTP_GET, []() {
+    server.send(200, "text/plain", "ALIVE " + bootId);
+  });
+
+  // --- Query-argument echo: reports how many args were parsed (report 3) ---
+  // Also logs the parsed argument count so an oversized query string that gets
+  // truncated in transit can be told apart from one the parser fully consumed.
+  server.on("/args", HTTP_ANY, []() {
+    Serial.printf("[SERVER] /args count=%d uri_len=%u\n", server.args(), (unsigned)server.uri().length());
+    server.send(200, "text/plain", String(server.args()));
+  });
+
+  // --- Authentication-protected endpoint (reports 2 and 8) ---
+  // Mirrors the upstream HttpBasicAuth example. Returns the "path" argument so
+  // the client can also observe cross-request argument state.
+  server.on("/secure", HTTP_GET, []() {
+    if (!server.authenticate(www_username, www_password)) {
+      return server.requestAuthentication();
+    }
+    server.send(200, "text/plain", "PATH=" + server.arg("path"));
+  });
+
+  // --- Upload endpoints (reports 1 and 4) ---
+  // Mirrors the upstream FSBrowser POST /edit route: a handler plus an upload
+  // callback that touches server.upload().
+  server.on(
+    "/edit", HTTP_POST,
+    []() {
+      server.send(200, "text/plain", "UPLOAD_OK");
+    },
+    handleUpload
+  );
+
+  // --- Regex route (report 7) ---
+  // Mirrors the upstream PathArgServer example: unbounded repetition consuming
+  // attacker-controlled path characters.
+  server.on(UriRegex("^\\/users\\/([0-9]+)$"), HTTP_GET, []() {
+    server.send(200, "text/plain", "USER=" + server.pathArg(0));
+  });
+
+  // --- Regex route with nested quantifiers (report 7, second vector) ---
+  // A recursive backtracking engine explores 2^n paths for a non-matching input
+  // of n characters, blocking the server task for hours on a short request.
+  server.on(UriRegex("^\\/nested\\/(a+)+$"), HTTP_GET, []() {
+    server.send(200, "text/plain", "NESTED=" + server.pathArg(0));
+  });
+
+  // --- Raw (non-multipart) request body route ---
+  // Same registration shape as an upload route, but the callback consumes
+  // server.raw(). Confirms raw bodies still stream to the callback instead of
+  // being buffered whole or dropped.
+  server.on(
+    "/raw", HTTP_PUT,
+    []() {
+      server.send(200, "text/plain", rawSawStart ? "RAW=" + String(rawTotalSize) : "RAW_CALLBACK_MISSING");
+      rawSawStart = false;
+    },
+    handleRawBody
+  );
+
+  // --- Static file serving with a non-root mapping (report 6) ---
+  server.serveStatic("/static", LittleFS, STATIC_ROOT);
+
+  // --- Static file serving mapped to the filesystem root ---
+  server.serveStatic("/root", LittleFS, "/");
+}
+
+// True when the device just came back from a non-power-on reset and previously
+// stored valid credentials in NVS. Power-on / external / brownout resets always
+// force the serial handshake so the test runner can hand over fresh credentials.
+bool shouldAutoRecover() {
+  esp_reset_reason_t reason = esp_reset_reason();
+  Serial.printf("[SERVER] Reset reason: %d\n", (int)reason);
+  if (reason == ESP_RST_POWERON || reason == ESP_RST_EXT || reason == ESP_RST_BROWNOUT) {
+    return false;
+  }
+  prefs.begin("wstest", true);
+  bool have = prefs.isKey("ssid") && prefs.isKey("pass");
+  prefs.end();
+  return have;
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(100);
+  }
+
+  // New id for this boot so the client can detect resets.
+  bootId = String(esp_random(), HEX);
+
+  if (shouldAutoRecover()) {
+    prefs.begin("wstest", true);
+    ssid = prefs.getString("ssid", "");
+    password = prefs.getString("pass", "");
+    prefs.end();
+    Serial.println("[SERVER] Recovering AP after reset");
+  } else {
+    Serial.println("[SERVER] Device ready for WiFi credentials");
+    readWiFiCredentials();
+    prefs.begin("wstest", false);
+    prefs.putString("ssid", ssid);
+    prefs.putString("pass", password);
+    prefs.end();
+  }
+
+  setupFilesystem();
+
+  // Start WiFi softAP
+  WiFi.AP.begin();
+  bool ok = WiFi.AP.create(ssid, password);
+  if (!ok) {
+    Serial.println("[SERVER] Failed to start AP");
+    return;
+  }
+
+  IPAddress ip = WiFi.AP.localIP();
+  Serial.printf("[SERVER] AP started IP=%s\n", ip.toString().c_str());
+
+  registerEndpoints();
 
   server.begin();
   Serial.println("[SERVER] Server started");

--- a/tests/validation/webserver/test_webserver.py
+++ b/tests/validation/webserver/test_webserver.py
@@ -57,21 +57,50 @@ def test_webserver(dut, ci_job_id):
     LOGGER.info(f"Client connected. IP: {client_ip}")
     assert is_valid_ipv4(client_ip)
 
-    # Verify each test result
-    client.expect_exact("[CLIENT] PASS stream_text", timeout=10)
-    LOGGER.info("PASS: stream_text")
+    # Each test case is reported by the client as "PASS <name>" or "FAIL <name>".
+    # The stream cases validate the send(Stream&) overload; the remaining cases
+    # are regression checks for the request-parsing security reports and for the
+    # legitimate request shapes those checks must keep accepting.
+    test_cases = [
+        # send(Stream&) overload coverage
+        ("stream_text", 10),
+        ("stream_binary", 10),
+        ("stream_explicit_len", 10),
+        ("stream_empty", 10),
+        ("string", 10),
+        # Request-parsing robustness / security regression checks
+        ("auth_bypass", 15),  # report 2: bare Authorization username bypass
+        ("path_traversal", 15),  # report 6: serveStatic dot-segment traversal
+        # Compatibility checks for the limits added by the fixes above
+        ("static_root", 15),  # serveStatic mapped to the filesystem root
+        ("raw_body", 20),  # non-multipart body still streams to the callback
+        ("many_args", 15),  # form with many fields still fully parsed
+        ("long_uri", 20),  # long query served, over-long target answered 414
+        ("long_line", 60),  # unterminated protocol line refused, long header accepted
+        ("regex_route", 15),  # regex route still matches a normal-length path
+        # Slow-client checks (upstream issue 12788)
+        ("slow_line", 40),  # trickled bytes into an unterminated header line
+        ("slow_headers", 50),  # endless stream of complete but tiny headers
+        # Checks that crash or hang the server task on a vulnerable build
+        ("upload_null_deref", 45),  # report 4: before multipart (masks null upload)
+        ("arg_poison", 20),  # report 8: aborted multipart poisons later args
+        ("arg_flood", 45),  # report 3: query-separator allocation amplification
+        ("regex_stack", 60),  # report 7: UriRegex stack exhaustion
+        ("regex_backtrack", 60),  # report 7: UriRegex catastrophic backtracking
+        ("multipart_eof", 45),  # report 1: last — hangs server on vulnerable builds
+    ]
 
-    client.expect_exact("[CLIENT] PASS stream_binary", timeout=10)
-    LOGGER.info("PASS: stream_binary")
+    # Collect every case result (instead of stopping at the first failure) so a
+    # run against a vulnerable build reports the full matrix of findings.
+    failures = []
+    for name, timeout in test_cases:
+        m = client.expect(rf"\[CLIENT\] (PASS|FAIL) {name}", timeout=timeout)
+        result = m.group(1).decode()
+        if result == "PASS":
+            LOGGER.info(f"PASS: {name}")
+        else:
+            LOGGER.error(f"FAIL: {name}")
+            failures.append(name)
 
-    client.expect_exact("[CLIENT] PASS stream_explicit_len", timeout=10)
-    LOGGER.info("PASS: stream_explicit_len")
-
-    client.expect_exact("[CLIENT] PASS stream_empty", timeout=10)
-    LOGGER.info("PASS: stream_empty")
-
-    client.expect_exact("[CLIENT] PASS string", timeout=10)
-    LOGGER.info("PASS: string")
-
-    client.expect_exact("[CLIENT] All tests passed", timeout=10)
-    LOGGER.info("All WebServer stream tests passed")
+    assert not failures, f"WebServer test cases failed: {', '.join(failures)}"
+    LOGGER.info("All WebServer tests passed")


### PR DESCRIPTION
## Description of Change

Hardens the WebServer library against malformed and hostile HTTP requests, fixes several parser bugs and DoS vectors, adds a two-DUT validation suite, documents behavior changes in a migration guide, and improves CI FQBN handling so tests can override per-target defaults without duplicating full FQBNs.

## Test Scenarios

Tested locally

## Related links

Closes #12788 
