### PR TITLE
fix(zigbee): Check proper return of readAttribute and configure

### DIFF
--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -147,12 +147,10 @@ bool ZigbeeEP::readClusterAttribute(esp_zb_zcl_read_attr_cmd_t *read_req) {
     log_w("Cannot read attribute: failed to acquire Zigbee lock");
     return false;
   }
-  esp_err_t ret = esp_zb_zcl_read_attr_cmd_req(read_req);
+  // Returns transaction sequence number (queued), not esp_err_t
+  uint8_t tsn = esp_zb_zcl_read_attr_cmd_req(read_req);
   esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to read attribute: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
+  log_v("Read-attribute request queued, TSN: 0x%02x", tsn);
   return true;
 }
 
@@ -191,12 +189,10 @@ bool ZigbeeEP::configureClusterReporting(esp_zb_zcl_config_report_cmd_t *report_
     log_w("Cannot configure cluster reporting: failed to acquire Zigbee lock");
     return false;
   }
-  esp_err_t ret = esp_zb_zcl_config_report_cmd_req(report_cmd);
+  // Returns transaction sequence number (queued), not esp_err_t
+  uint8_t tsn = esp_zb_zcl_config_report_cmd_req(report_cmd);
   esp_zb_lock_release();
-  if (ret != ESP_OK) {
-    log_e("Failed to configure cluster reporting: 0x%x: %s", ret, esp_err_to_name(ret));
-    return false;
-  }
+  log_v("Configure-report request queued, TSN: 0x%02x", tsn);
   return true;
 }
 

--- a/libraries/Zigbee/src/ZigbeeEP.cpp
+++ b/libraries/Zigbee/src/ZigbeeEP.cpp
@@ -147,10 +147,9 @@ bool ZigbeeEP::readClusterAttribute(esp_zb_zcl_read_attr_cmd_t *read_req) {
     log_w("Cannot read attribute: failed to acquire Zigbee lock");
     return false;
   }
-  // Returns transaction sequence number (queued), not esp_err_t
-  uint8_t tsn = esp_zb_zcl_read_attr_cmd_req(read_req);
+  // Returns transaction sequence number (queued), not esp_err_t — ignore it
+  esp_zb_zcl_read_attr_cmd_req(read_req);
   esp_zb_lock_release();
-  log_v("Read-attribute request queued, TSN: 0x%02x", tsn);
   return true;
 }
 
@@ -189,10 +188,9 @@ bool ZigbeeEP::configureClusterReporting(esp_zb_zcl_config_report_cmd_t *report_
     log_w("Cannot configure cluster reporting: failed to acquire Zigbee lock");
     return false;
   }
-  // Returns transaction sequence number (queued), not esp_err_t
-  uint8_t tsn = esp_zb_zcl_config_report_cmd_req(report_cmd);
+  // Returns transaction sequence number (queued), not esp_err_t — ignore it
+  esp_zb_zcl_config_report_cmd_req(report_cmd);
   esp_zb_lock_release();
-  log_v("Configure-report request queued, TSN: 0x%02x", tsn);
   return true;
 }
 


### PR DESCRIPTION
## Description of Change
This pull request updates how Zigbee cluster attribute reads and reporting configuration requests are handled in `ZigbeeEP.cpp`. The main change is to correctly handle the return value from the Zigbee stack API, which returns a transaction sequence number (TSN) instead of an error code.

**Zigbee attribute read and reporting request handling:**

* Updated `readClusterAttribute` to use the transaction sequence number returned by `esp_zb_zcl_read_attr_cmd_req` and remove error checking based on `esp_err_t`.
* Updated `configureClusterReporting` to use the transaction sequence number returned by `esp_zb_zcl_config_report_cmd_req` and remove error checking based on `esp_err_t`.

## Test Scenarios

## Related links
Closes #12798
Closes #12676