### PR TITLE
feat(ota): Add support for IPv6 OTA

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -168,7 +168,12 @@ void ArduinoOTAClass::begin() {
     _port = 3232;
   }
 
+#if CONFIG_LWIP_IPV6
+  // Bind dual-stack (::) so IPv4 and IPv6 OTA invites are accepted
+  if (!_udp_ota.begin(IN6ADDR_ANY, _port)) {
+#else
   if (!_udp_ota.begin(_port)) {
+#endif
     log_e("udp bind failed");
     return;
   }

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -270,15 +270,35 @@ bool HTTPClient::beginInternal(String url, const char *expectedProtocol) {
     _base64Authorization = base64::encode(auth);
   }
 
-  // get port
-  index = host.indexOf(':');
+  // Host / port. RFC 3986 IPv6 literals use brackets: [2001:db8::1]:8080
   String the_host;
-  if (index >= 0) {
-    the_host = host.substring(0, index);  // hostname
-    host.remove(0, (index + 1));          // remove hostname + :
-    _port = host.toInt();                 // get port
+  if (host.startsWith("[")) {
+    int closing = host.indexOf(']');
+    if (closing < 0) {
+      log_e("failed to parse IPv6 host (missing ']')");
+      return false;
+    }
+    the_host = host.substring(1, closing);
+    if (the_host.length() == 0) {
+      log_e("failed to parse IPv6 host (empty)");
+      return false;
+    }
+    if ((size_t)(closing + 1) < host.length()) {
+      if (host.charAt(closing + 1) != ':') {
+        log_e("failed to parse IPv6 URL (expected ':' after ']')");
+        return false;
+      }
+      _port = host.substring(closing + 2).toInt();
+    }
   } else {
-    the_host = host;
+    index = host.indexOf(':');
+    if (index >= 0) {
+      the_host = host.substring(0, index);  // hostname
+      host.remove(0, (index + 1));          // remove hostname + :
+      _port = host.toInt();                 // get port
+    } else {
+      the_host = host;
+    }
   }
   if (_host != the_host && connected()) {
     log_d("switching host from '%s' to '%s'. disconnecting first", _host.c_str(), the_host.c_str());
@@ -1142,7 +1162,15 @@ bool HTTPClient::sendHeader(const char *type) {
     header += "1";
   }
 
-  header += String(F("\r\nHost: ")) + _host;
+  // RFC 3986 / RFC 7230: IPv6 literals in Host must be bracketed.
+  header += String(F("\r\nHost: "));
+  if (_host.indexOf(':') >= 0) {
+    header += '[';
+    header += _host;
+    header += ']';
+  } else {
+    header += _host;
+  }
   if (_port != 80 && _port != 443) {
     header += ':';
     header += String(_port);

--- a/libraries/Network/src/NetworkUdp.cpp
+++ b/libraries/Network/src/NetworkUdp.cpp
@@ -67,7 +67,7 @@ uint8_t NetworkUDP::begin(IPAddress address, uint16_t port) {
     struct sockaddr_in6 *tmpaddr = (struct sockaddr_in6 *)&serveraddr;
     ip_addr_t addr;
     address.to_ip_addr_t(&addr);
-    memset((char *)tmpaddr, 0, sizeof(struct sockaddr_in));
+    memset((char *)tmpaddr, 0, sizeof(struct sockaddr_in6));
     tmpaddr->sin6_family = AF_INET6;
     tmpaddr->sin6_port = htons(server_port);
     tmpaddr->sin6_scope_id = addr.u_addr.ip6.zone;

--- a/tests/validation/ota/README.md
+++ b/tests/validation/ota/README.md
@@ -1,16 +1,26 @@
 # OTA (Unsigned) Validation Test
 
-Validates the `Update` API and `HTTPUpdate` library for unsigned OTA workflows: begin/abort, error handling, MD5 verification, and HTTP-based firmware download.
+Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned OTA workflows (IPv4 and IPv6).
 
 ## Test Cases
 
 | Test Function | Description |
 |---|---|
-| `test_update_begin_abort` | `Update.begin` + `abort`, verify update is not running |
+| `test_update_begin_abort` | `Update.begin` + `abort` (local flash; IP-independent) |
 | `test_update_error_no_begin` | `Update.write` without `begin` returns 0 |
 | `test_update_md5_check` | `setMD5` on an active update session |
-| `test_httpupdate_invalid_url` | `HTTPUpdate` to unreachable URL (192.0.2.1) returns error |
-| `test_httpupdate_download` | `HTTPUpdate` download from pytest HTTP server |
+| `test_arduino_ota_begin_end` | `ArduinoOTA.begin` / `getHostname` / `end` |
+| `test_httpupdate_invalid_url` | `HTTPUpdate` to unreachable IPv4 URL (192.0.2.1) |
+| `test_httpupdate_invalid_url_ipv6` | `HTTPUpdate` to unreachable bracketed IPv6 URL (`[2001:db8::1]`) |
+| `test_arduino_ota_upload_no_auth` | Full `espota.py` upload without password (IPv4) |
+| `test_arduino_ota_ipv4_with_ipv6_enabled` | IPv4 upload after STA IPv6 is enabled (dual-stack bind) |
+| `test_arduino_ota_upload_ipv6` | Full `espota.py` upload over global IPv6 (ignored if host/DUT lack it) |
+| `test_arduino_ota_ipv4_after_ipv6` | IPv6 upload then IPv4 upload on a fresh `begin()` |
+| `test_arduino_ota_ipv4_mapped` | Host uses `::ffff:a.b.c.d` literals against dual-stack DUT |
+| `test_arduino_ota_ipv6_with_auth` | IPv6 upload with PBKDF2-HMAC-SHA256 auth |
+| `test_arduino_ota_upload_with_auth` | IPv4 upload with PBKDF2-HMAC-SHA256 auth |
+| `test_httpupdate_download` | `HTTPUpdate` download over IPv4 |
+| `test_httpupdate_download_ipv6` | `HTTPUpdate` download via RFC 3986 IPv6 URL |
 
 ## Requirements
 
@@ -18,17 +28,30 @@ Validates the `Update` API and `HTTPUpdate` library for unsigned OTA workflows: 
 - **Wokwi/QEMU**: Not supported
 - **CI Runner**: `wifi_router`
 - **SoC Config**: `CONFIG_SOC_WIFI_SUPPORTED=y`
+- **IPv6**: Native IPv6 cases need global IPv6 on DUT and host; mapped/dual-stack cases need host AF_INET6; otherwise those cases are ignored (not failed)
 
 ## Serial Protocol
 
 1. DUT prints `OTA_READY`
 2. DUT prints `Send SSID:` → host sends SSID
 3. DUT prints `Send Password:` → host sends password
-4. DUT prints `Send Server URL (or NONE):` → host sends URL or `NONE`
-5. Unity test suite runs
+4. DUT prints `Send Server URL (or NONE):` → host sends IPv4 HTTP base URL or `NONE`
+5. DUT prints `Send IPv6 Mode (NONE|MAPPED|FULL):`
+   - `NONE` — host has no IPv6 sockets
+   - `MAPPED` — AF_INET6 works (IPv4-mapped uploads OK), no global IPv6
+   - `FULL` — host has a global IPv6 address for native IPv6 OTA/HTTP
+6. DUT prints `Send IPv6 Server Host (or NONE):` → bare IPv6 host or `NONE`
+7. DUT prints `Send IPv6 Server Port (or 0):` → TCP port or `0`
+8. Unity test suite runs
+9. During ArduinoOTA upload tests:
+   - `ARDUINO_OTA_BEGIN <ip> <port> <NONE|password>` → host runs `tools/espota.py`
+   - `ARDUINO_OTA_BEGIN_MAPPED <ipv4> <port> NONE` → host runs espota with `::ffff:` mapped addresses
 
 ## Notes
 
-- The pytest script starts a local HTTP server serving the build directory (which contains the firmware `.bin`). The test fails if the server cannot be started, the LAN IP cannot be determined, or the device cannot connect to the server.
-- `httpUpdate.rebootOnUpdate(false)` is set so the DUT does not reboot mid-test.
+- The pytest HTTP server prefers dual-stack (`::` with `IPV6_V6ONLY=0`) and falls back to IPv4-only if IPv6 bind fails.
+- IPv6 `HTTPUpdate` uses bracketed URLs (`http://[addr]:port/...`); `HTTPClient` parses RFC 3986 IPv6 literals.
+- `Update` API tests are transport-agnostic (no network).
+- Host bind address overrides: `OTA_HOST_IP` (IPv4), `OTA_HOST_IPV6` (IPv6).
+- `ArduinoOTA.setRebootOnSuccess(false)` and `httpUpdate.rebootOnUpdate(false)` keep the DUT from rebooting mid-suite.
 - Signed OTA verification is covered by the separate `signed_ota/` test suite.

--- a/tests/validation/ota/ota.ino
+++ b/tests/validation/ota/ota.ino
@@ -2,10 +2,12 @@
  * OTA Validation Test (unsigned workflow)
  *
  * Covers: HTTPUpdate (download, verify success/failure, MD5 check),
- *         Update API (begin, write, end, abort, error handling).
+ *         Update API (begin, write, end, abort, error handling),
+ *         ArduinoOTA (begin/end, hostname, espota upload IPv4/IPv6, with/without auth).
  *
  * WiFi credentials and HTTP server URL are received via serial from pytest.
- * The pytest harness serves firmware binaries over HTTP.
+ * The pytest harness serves firmware binaries over HTTP and drives espota.py
+ * when the DUT prints ARDUINO_OTA_BEGIN.
  *
  * Note: signed_ota/ (separate test) covers RSA-PSS and ECDSA-DER
  * signature verification. This suite covers the unsigned path only.
@@ -18,13 +20,33 @@
 #include <HTTPClient.h>
 #include <HTTPUpdate.h>
 #include <Update.h>
+#include <ArduinoOTA.h>
 #include <unity.h>
 
-#define WIFI_TIMEOUT_MS 15000
+#define WIFI_TIMEOUT_MS        15000
+#define IPV6_WAIT_MS           10000
+#define ARDUINO_OTA_PORT       3232
+#define ARDUINO_OTA_TIMEOUT_MS 120000
 
 static String wifi_ssid;
 static String wifi_pass;
 static String server_url;
+// Host IPv6 capability from pytest: NONE | MAPPED | FULL
+static String host_ipv6_mode;
+static String server_host_v6;  // bare IPv6 host when mode is FULL
+static uint16_t server_port_v6 = 0;
+
+static bool hostSupportsMappedIPv6() {
+  return host_ipv6_mode == "MAPPED" || host_ipv6_mode == "FULL";
+}
+
+static bool hostSupportsGlobalIPv6() {
+  return host_ipv6_mode == "FULL" && server_host_v6.length() > 0 && server_port_v6 != 0;
+}
+
+static volatile bool s_ota_done = false;
+static volatile bool s_ota_ok = false;
+static volatile int s_ota_error = -1;
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -44,6 +66,96 @@ static bool connectWiFi() {
     delay(100);
   }
   return WiFi.STA.status() == WL_CONNECTED;
+}
+
+#if CONFIG_LWIP_IPV6
+static bool ensureIPv6Enabled() {
+  if (!WiFi.enableIPv6()) {
+    return false;
+  }
+  // Link-local is created immediately; global needs RA — wait briefly.
+  unsigned long start = millis();
+  while (!WiFi.STA.hasGlobalIPv6() && (millis() - start) < IPV6_WAIT_MS) {
+    delay(100);
+  }
+  return true;
+}
+
+static bool hasGlobalIPv6() {
+  return WiFi.STA.hasGlobalIPv6();
+}
+#endif
+
+static void resetArduinoOtaFlags() {
+  s_ota_done = false;
+  s_ota_ok = false;
+  s_ota_error = -1;
+}
+
+static void configureArduinoOtaCallbacks() {
+  ArduinoOTA.onStart([]() {
+    Serial.println("ArduinoOTA starting");
+  });
+  ArduinoOTA.onEnd([]() {
+    Serial.println("ArduinoOTA finished");
+    s_ota_ok = true;
+    s_ota_done = true;
+  });
+  ArduinoOTA.onError([](ota_error_t error) {
+    Serial.printf("ArduinoOTA error %u\n", (unsigned)error);
+    s_ota_error = (int)error;
+    s_ota_ok = false;
+    s_ota_done = true;
+  });
+  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+    if (total == 0) {
+      return;
+    }
+    static unsigned last_pct = 0xFFFF;
+    unsigned pct = progress * 100 / total;
+    if (pct != last_pct && (pct % 25 == 0 || pct == 100)) {
+      Serial.printf("ArduinoOTA progress %u%%\n", pct);
+      last_pct = pct;
+    }
+  });
+}
+
+static bool runArduinoOtaUpload(const char *auth, const IPAddress &listen_ip) {
+  resetArduinoOtaFlags();
+
+  ArduinoOTA.setPort(ARDUINO_OTA_PORT);
+  ArduinoOTA.setHostname("ota-validation");
+  ArduinoOTA.setMdnsEnabled(false);
+  ArduinoOTA.setRebootOnSuccess(false);
+  if (auth && auth[0] != '\0') {
+    ArduinoOTA.setPassword(auth);
+  }
+  configureArduinoOtaCallbacks();
+  ArduinoOTA.begin();
+
+  // Pytest watches for this line and runs tools/espota.py.
+  // IPv6 addresses may contain ':' — fields are space-separated.
+  Serial.printf(
+    "ARDUINO_OTA_BEGIN %s %u %s\n", listen_ip.toString().c_str(), ARDUINO_OTA_PORT, (auth && auth[0]) ? auth : "NONE"
+  );
+
+  unsigned long start = millis();
+  while (!s_ota_done && (millis() - start) < ARDUINO_OTA_TIMEOUT_MS) {
+    ArduinoOTA.handle();
+    delay(1);
+  }
+
+  ArduinoOTA.end();
+
+  if (!s_ota_done) {
+    Serial.println("ArduinoOTA timed out waiting for upload");
+    return false;
+  }
+  if (!s_ota_ok) {
+    Serial.printf("ArduinoOTA failed with error %d\n", s_ota_error);
+    return false;
+  }
+  return true;
 }
 
 // ==================== Update API Tests ====================
@@ -67,6 +179,148 @@ void test_update_md5_check(void) {
   Update.abort();
 }
 
+// ==================== ArduinoOTA Tests ====================
+
+void test_arduino_ota_begin_end(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+
+  ArduinoOTA.setPort(ARDUINO_OTA_PORT);
+  ArduinoOTA.setHostname("ota-validation");
+  ArduinoOTA.setMdnsEnabled(false);
+  ArduinoOTA.setRebootOnSuccess(false);
+  ArduinoOTA.begin();
+
+  TEST_ASSERT_EQUAL_STRING("ota-validation", ArduinoOTA.getHostname().c_str());
+
+  ArduinoOTA.end();
+}
+
+void test_arduino_ota_upload_no_auth(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(runArduinoOtaUpload(nullptr, WiFi.localIP()), "ArduinoOTA upload without auth failed");
+}
+
+void test_arduino_ota_upload_with_auth(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(runArduinoOtaUpload("test-ota", WiFi.localIP()), "ArduinoOTA upload with auth failed");
+}
+
+void test_arduino_ota_upload_ipv6(void) {
+#if !CONFIG_LWIP_IPV6
+  TEST_IGNORE_MESSAGE("IPv6 not enabled in this build");
+#else
+  if (!hostSupportsGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("Host has no global IPv6");
+  }
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  if (!ensureIPv6Enabled()) {
+    TEST_IGNORE_MESSAGE("Failed to enable IPv6 on DUT");
+  }
+  if (!hasGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("No global IPv6 address (router RA unavailable)");
+  }
+
+  IPAddress v6 = WiFi.globalIPv6();
+  Serial.printf("Using global IPv6: %s\n", v6.toString().c_str());
+  TEST_ASSERT_TRUE_MESSAGE(runArduinoOtaUpload(nullptr, v6), "ArduinoOTA IPv6 upload failed");
+#endif
+}
+
+// Dual-stack bind (::) must still accept IPv4 invites after IPv6 is enabled on STA.
+void test_arduino_ota_ipv4_with_ipv6_enabled(void) {
+#if !CONFIG_LWIP_IPV6
+  TEST_IGNORE_MESSAGE("IPv6 not enabled in this build");
+#else
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  if (!ensureIPv6Enabled()) {
+    TEST_IGNORE_MESSAGE("Failed to enable IPv6 on DUT");
+  }
+  TEST_ASSERT_TRUE_MESSAGE(
+    runArduinoOtaUpload(nullptr, WiFi.localIP()), "IPv4 ArduinoOTA failed while IPv6 was enabled"
+  );
+#endif
+}
+
+// After a successful IPv6 session, a fresh begin() must still accept IPv4 invites.
+void test_arduino_ota_ipv4_after_ipv6(void) {
+#if !CONFIG_LWIP_IPV6
+  TEST_IGNORE_MESSAGE("IPv6 not enabled in this build");
+#else
+  if (!hostSupportsGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("Host has no global IPv6");
+  }
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  if (!ensureIPv6Enabled()) {
+    TEST_IGNORE_MESSAGE("Failed to enable IPv6 on DUT");
+  }
+  if (!hasGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("No global IPv6 address (router RA unavailable)");
+  }
+
+  IPAddress v6 = WiFi.globalIPv6();
+  TEST_ASSERT_TRUE_MESSAGE(runArduinoOtaUpload(nullptr, v6), "IPv6 upload (setup for v4-after-v6) failed");
+  TEST_ASSERT_TRUE_MESSAGE(
+    runArduinoOtaUpload(nullptr, WiFi.localIP()), "IPv4 ArduinoOTA failed after a prior IPv6 upload"
+  );
+#endif
+}
+
+void test_arduino_ota_ipv6_with_auth(void) {
+#if !CONFIG_LWIP_IPV6
+  TEST_IGNORE_MESSAGE("IPv6 not enabled in this build");
+#else
+  if (!hostSupportsGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("Host has no global IPv6");
+  }
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  if (!ensureIPv6Enabled()) {
+    TEST_IGNORE_MESSAGE("Failed to enable IPv6 on DUT");
+  }
+  if (!hasGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("No global IPv6 address (router RA unavailable)");
+  }
+
+  IPAddress v6 = WiFi.globalIPv6();
+  TEST_ASSERT_TRUE_MESSAGE(runArduinoOtaUpload("test-ota-v6", v6), "ArduinoOTA IPv6 upload with auth failed");
+#endif
+}
+
+// Host uses IPv4-mapped IPv6 literals (::ffff:a.b.c.d) while the DUT listens dual-stack.
+void test_arduino_ota_ipv4_mapped(void) {
+#if !CONFIG_LWIP_IPV6
+  TEST_IGNORE_MESSAGE("IPv6 not enabled in this build");
+#else
+  if (!hostSupportsMappedIPv6()) {
+    TEST_IGNORE_MESSAGE("Host has no IPv6 socket support for mapped addresses");
+  }
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  if (!ensureIPv6Enabled()) {
+    TEST_IGNORE_MESSAGE("Failed to enable IPv6 on DUT");
+  }
+
+  resetArduinoOtaFlags();
+  ArduinoOTA.setPort(ARDUINO_OTA_PORT);
+  ArduinoOTA.setHostname("ota-validation");
+  ArduinoOTA.setMdnsEnabled(false);
+  ArduinoOTA.setRebootOnSuccess(false);
+  configureArduinoOtaCallbacks();
+  ArduinoOTA.begin();
+
+  // Pytest maps both DUT and host IPv4 into ::ffff: form for espota.
+  Serial.printf("ARDUINO_OTA_BEGIN_MAPPED %s %u NONE\n", WiFi.localIP().toString().c_str(), ARDUINO_OTA_PORT);
+
+  unsigned long start = millis();
+  while (!s_ota_done && (millis() - start) < ARDUINO_OTA_TIMEOUT_MS) {
+    ArduinoOTA.handle();
+    delay(1);
+  }
+  ArduinoOTA.end();
+
+  TEST_ASSERT_TRUE_MESSAGE(s_ota_done, "ArduinoOTA IPv4-mapped upload timed out");
+  TEST_ASSERT_TRUE_MESSAGE(s_ota_ok, "ArduinoOTA IPv4-mapped upload failed");
+#endif
+}
+
 // ==================== HTTPUpdate Tests ====================
 
 void test_httpupdate_invalid_url(void) {
@@ -76,6 +330,23 @@ void test_httpupdate_invalid_url(void) {
   httpUpdate.rebootOnUpdate(false);
   HTTPUpdateResult ret = httpUpdate.update(client, "http://192.0.2.1:9999/nonexistent.bin");
   TEST_ASSERT_NOT_EQUAL(HTTP_UPDATE_OK, ret);
+}
+
+void test_httpupdate_invalid_url_ipv6(void) {
+#if !CONFIG_LWIP_IPV6
+  TEST_IGNORE_MESSAGE("IPv6 not enabled in this build");
+#else
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  if (!ensureIPv6Enabled()) {
+    TEST_IGNORE_MESSAGE("Failed to enable IPv6 on DUT");
+  }
+
+  // RFC 3986 bracketed IPv6 URL (documentation address — must not succeed).
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  HTTPUpdateResult ret = httpUpdate.update(client, "http://[2001:db8::1]:9999/nonexistent.bin");
+  TEST_ASSERT_NOT_EQUAL(HTTP_UPDATE_OK, ret);
+#endif
 }
 
 void test_httpupdate_download(void) {
@@ -88,6 +359,31 @@ void test_httpupdate_download(void) {
   HTTPUpdateResult ret = httpUpdate.update(client, url);
 
   TEST_ASSERT_TRUE_MESSAGE(ret == HTTP_UPDATE_OK || ret == HTTP_UPDATE_NO_UPDATES, "HTTPUpdate could not connect to server or download failed");
+}
+
+void test_httpupdate_download_ipv6(void) {
+#if !CONFIG_LWIP_IPV6
+  TEST_IGNORE_MESSAGE("IPv6 not enabled in this build");
+#else
+  if (!hostSupportsGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("Host has no global IPv6 HTTP server");
+  }
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  if (!ensureIPv6Enabled()) {
+    TEST_IGNORE_MESSAGE("Failed to enable IPv6 on DUT");
+  }
+  if (!hasGlobalIPv6()) {
+    TEST_IGNORE_MESSAGE("No global IPv6 address (router RA unavailable)");
+  }
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  String url = "http://[" + server_host_v6 + "]:" + String(server_port_v6) + "/ota.ino.bin";
+  HTTPUpdateResult ret = httpUpdate.update(client, url);
+  TEST_ASSERT_TRUE_MESSAGE(
+    ret == HTTP_UPDATE_OK || ret == HTTP_UPDATE_NO_UPDATES, "HTTPUpdate IPv6 download failed"
+  );
+#endif
 }
 
 // ==================== Setup ====================
@@ -147,6 +443,35 @@ static void readCredentials() {
   if (server_url == "NONE") {
     server_url = "";
   }
+
+  while (Serial.available()) {
+    Serial.read();
+  }
+
+  Serial.println("Send IPv6 Mode (NONE|MAPPED|FULL):");
+  host_ipv6_mode = waitForLine();
+  host_ipv6_mode.toUpperCase();
+  if (host_ipv6_mode != "MAPPED" && host_ipv6_mode != "FULL") {
+    host_ipv6_mode = "NONE";
+  }
+
+  while (Serial.available()) {
+    Serial.read();
+  }
+
+  Serial.println("Send IPv6 Server Host (or NONE):");
+  server_host_v6 = waitForLine();
+  if (server_host_v6 == "NONE") {
+    server_host_v6 = "";
+  }
+
+  while (Serial.available()) {
+    Serial.read();
+  }
+
+  Serial.println("Send IPv6 Server Port (or 0):");
+  String port_line = waitForLine();
+  server_port_v6 = (uint16_t)port_line.toInt();
 }
 
 void setup() {
@@ -162,8 +487,20 @@ void setup() {
   RUN_TEST(test_update_begin_abort);
   RUN_TEST(test_update_error_no_begin);
   RUN_TEST(test_update_md5_check);
+  RUN_TEST(test_arduino_ota_begin_end);
   RUN_TEST(test_httpupdate_invalid_url);
+  RUN_TEST(test_httpupdate_invalid_url_ipv6);
+  // ArduinoOTA uploads before HTTPUpdate download so partition state stays predictable.
+  // Keep all no-auth cases before any setPassword() so leftover hashes cannot force AUTH.
+  RUN_TEST(test_arduino_ota_upload_no_auth);
+  RUN_TEST(test_arduino_ota_ipv4_with_ipv6_enabled);
+  RUN_TEST(test_arduino_ota_upload_ipv6);
+  RUN_TEST(test_arduino_ota_ipv4_after_ipv6);
+  RUN_TEST(test_arduino_ota_ipv4_mapped);
+  RUN_TEST(test_arduino_ota_ipv6_with_auth);
+  RUN_TEST(test_arduino_ota_upload_with_auth);
   RUN_TEST(test_httpupdate_download);
+  RUN_TEST(test_httpupdate_download_ipv6);
 
   UNITY_END();
 }

--- a/tests/validation/ota/test_ota.py
+++ b/tests/validation/ota/test_ota.py
@@ -1,13 +1,52 @@
 import logging
 import os
+import re
 import socket
+import subprocess
 import sys
 import threading
+import time
 from http.server import SimpleHTTPRequestHandler
 from pathlib import Path
 from socketserver import ThreadingTCPServer
 
 import pytest
+from pytest_embedded.unity import UNITY_SUMMARY_LINE_REGEX
+
+ESP32_ROOT = Path(__file__).resolve().parents[3]
+ESPOTA = ESP32_ROOT / "tools" / "espota.py"
+
+# IPv4 or IPv6 (may contain ':'); auth is last space-separated token
+ARDUINO_OTA_BEGIN_RE = re.compile(rb"ARDUINO_OTA_BEGIN (\S+) ([0-9]+) (\S+)")
+ARDUINO_OTA_BEGIN_MAPPED_RE = re.compile(rb"ARDUINO_OTA_BEGIN_MAPPED (\S+) ([0-9]+) (\S+)")
+
+
+def _is_ipv6(addr: str) -> bool:
+    host = addr.strip("[]")
+    if "%" in host:
+        host = host.split("%", 1)[0]
+    try:
+        socket.inet_pton(socket.AF_INET6, host)
+        return True
+    except OSError:
+        return False
+
+
+def _ipv4_mapped(addr: str) -> str:
+    """Convert an IPv4 literal to an IPv4-mapped IPv6 literal (::ffff:a.b.c.d)."""
+    host = addr.strip("[]")
+    socket.inet_pton(socket.AF_INET, host)  # validate
+    return f"::ffff:{host}"
+
+
+def _ipv6_socket_ok() -> bool:
+    """True if the host can create an IPv6 socket (needed for ::ffff: mapped OTA)."""
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        s.close()
+        return True
+    except OSError:
+        return False
 
 
 def _lan_ip() -> str:
@@ -26,6 +65,35 @@ def _lan_ip() -> str:
         candidate = sockaddr[0]
         if candidate and not candidate.startswith("127."):
             return candidate
+    return ""
+
+
+def _lan_ipv6(v4_hint: str | None = None) -> str:
+    """Pick a global host IPv6 address suitable for ArduinoOTA reverse-connect."""
+    override = os.environ.get("OTA_HOST_IPV6")
+    if override:
+        return override
+
+    # Prefer a global address learned via UDP connect (OS picks the right source)
+    s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+    try:
+        s.connect(("2001:4860:4860::8888", 80))
+        addr = s.getsockname()[0]
+        if addr and not addr.startswith("fe80:") and addr != "::1":
+            return addr
+    except OSError:
+        pass
+    finally:
+        s.close()
+
+    # Fallback: scan getaddrinfo results for a global unicast address
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET6, socket.SOCK_DGRAM):
+            candidate = info[4][0]
+            if candidate and not candidate.startswith("fe80:") and not candidate.startswith("::1"):
+                return candidate
+    except socket.gaierror:
+        pass
     return ""
 
 
@@ -57,6 +125,105 @@ def _find_firmware(build_dir: Path) -> Path | None:
     return None
 
 
+def _run_espota(
+    dut_ip: str,
+    dut_port: int,
+    host_ip: str,
+    firmware: Path,
+    password: str | None,
+    logger: logging.Logger,
+) -> None:
+    if not ESPOTA.is_file():
+        pytest.fail(f"espota.py not found at {ESPOTA}")
+
+    cmd = [
+        sys.executable,
+        str(ESPOTA),
+        "-i",
+        dut_ip,
+        "-I",
+        host_ip,
+        "-p",
+        str(dut_port),
+        "-f",
+        str(firmware),
+        "-t",
+        "30",
+    ]
+    if password:
+        cmd.extend(["-a", password])
+
+    logger.info("Running espota: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ESP32_ROOT))
+    if result.stdout:
+        logger.info("espota stdout:\n%s", result.stdout)
+    if result.stderr:
+        logger.info("espota stderr:\n%s", result.stderr)
+    if result.returncode != 0:
+        pytest.fail(f"espota failed (exit {result.returncode}) for {dut_ip}:{dut_port}")
+
+
+def _expect_unity_with_arduino_ota(
+    dut, firmware: Path, host_ip: str, host_ipv6: str, timeout: float = 300
+) -> None:
+    """Expect Unity output while serving ArduinoOTA uploads via espota.py."""
+    logger = logging.getLogger(__name__)
+    deadline = time.time() + timeout
+    log = b""
+
+    while True:
+        remaining = max(1.0, deadline - time.time())
+        match = dut.expect(
+            [ARDUINO_OTA_BEGIN_MAPPED_RE, ARDUINO_OTA_BEGIN_RE, UNITY_SUMMARY_LINE_REGEX],
+            timeout=remaining,
+        )
+        log += dut.pexpect_proc.before
+
+        matched = match.group(0)
+        if isinstance(matched, str):
+            matched = matched.encode()
+
+        mapped = ARDUINO_OTA_BEGIN_MAPPED_RE.search(matched)
+        begin = ARDUINO_OTA_BEGIN_RE.search(matched)
+        if mapped or begin:
+            log += matched
+            m = mapped or begin
+            dut_ip = m.group(1).decode()
+            dut_port = int(m.group(2).decode())
+            auth = m.group(3).decode()
+            password = None if auth == "NONE" else auth
+
+            if mapped:
+                # Dual-stack edge case: talk to the DUT IPv4 via IPv4-mapped IPv6 literals.
+                dut_ip = _ipv4_mapped(dut_ip)
+                bind_ip = _ipv4_mapped(host_ip)
+            elif _is_ipv6(dut_ip):
+                if not host_ipv6:
+                    pytest.fail(
+                        f"DUT requested IPv6 OTA ({dut_ip}) but host reported no global IPv6 "
+                        "(DUT should have ignored this case)"
+                    )
+                bind_ip = host_ipv6
+            else:
+                bind_ip = host_ip
+
+            logger.info("ArduinoOTA requested: ip=%s port=%s auth=%s host=%s", dut_ip, dut_port, auth, bind_ip)
+            # Give the DUT a moment to enter ArduinoOTA.handle() wait loop
+            time.sleep(0.5)
+            _run_espota(dut_ip, dut_port, bind_ip, firmware, password, logger)
+            continue
+
+        # Unity summary reached — parse cases into the junit report
+        log += matched
+        dut.testsuite.add_unity_test_cases(
+            log,
+            additional_attrs={
+                "app_path": dut.app.app_path,
+            },
+        )
+        return
+
+
 def test_ota(dut, wifi_ssid, wifi_pass, request):
     LOGGER = logging.getLogger(__name__)
 
@@ -75,9 +242,32 @@ def test_ota(dut, wifi_ssid, wifi_pass, request):
     if not host_ip:
         pytest.fail("Could not determine host LAN IP")
 
+    host_ipv6 = _lan_ipv6(host_ip)
+    ipv6_socket_ok = _ipv6_socket_ok()
+    if host_ipv6:
+        ipv6_mode = "FULL"
+        LOGGER.info("Host IPv6 for ArduinoOTA: %s", host_ipv6)
+    elif ipv6_socket_ok:
+        ipv6_mode = "MAPPED"
+        LOGGER.info("Host has IPv6 sockets but no global IPv6; native IPv6 cases will be ignored")
+    else:
+        ipv6_mode = "NONE"
+        LOGGER.warning("Host has no IPv6 support; all IPv6 cases will be ignored")
+
     serve_dir = firmware.parent
 
-    class ReusableTCPServer(ThreadingTCPServer):
+    class DualStackHTTPServer(ThreadingTCPServer):
+        """HTTP server reachable over IPv4 and IPv6."""
+
+        address_family = socket.AF_INET6
+        allow_reuse_address = True
+        daemon_threads = True
+
+        def server_bind(self):
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            super().server_bind()
+
+    class IPv4HTTPServer(ThreadingTCPServer):
         allow_reuse_address = True
         daemon_threads = True
 
@@ -93,19 +283,35 @@ def test_ota(dut, wifi_ssid, wifi_pass, request):
 
     port = 8766
     server = None
-    for _ in range(10):
-        try:
-            server = ReusableTCPServer(("0.0.0.0", port), handler_class)
-            break
-        except OSError:
-            port += 1
+    dual_stack = False
+    if ipv6_socket_ok:
+        for _ in range(10):
+            try:
+                server = DualStackHTTPServer(("::", port), handler_class)
+                dual_stack = True
+                break
+            except OSError:
+                port += 1
+    if server is None:
+        port = 8766
+        for _ in range(10):
+            try:
+                server = IPv4HTTPServer(("0.0.0.0", port), handler_class)
+                break
+            except OSError:
+                port += 1
     if server is None:
         pytest.fail("Could not bind HTTP server port")
 
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     base_url = f"http://{host_ip}:{port}"
-    LOGGER.info("HTTP server at %s serving %s", base_url, serve_dir)
+    LOGGER.info(
+        "HTTP server at %s (%s) serving %s",
+        base_url,
+        f"dual-stack :::{port}" if dual_stack else f"IPv4 0.0.0.0:{port}",
+        serve_dir,
+    )
 
     try:
         LOGGER.info("Waiting for device to be ready...")
@@ -120,8 +326,18 @@ def test_ota(dut, wifi_ssid, wifi_pass, request):
         dut.expect_exact("Send Server URL (or NONE):")
         dut.write(f"{base_url}\n")
 
-        LOGGER.info("Running OTA Unity tests")
-        dut.expect_unity_test_output(timeout=120)
+        dut.expect_exact("Send IPv6 Mode (NONE|MAPPED|FULL):")
+        dut.write(f"{ipv6_mode}\n")
+
+        dut.expect_exact("Send IPv6 Server Host (or NONE):")
+        dut.write(f"{host_ipv6 or 'NONE'}\n")
+
+        dut.expect_exact("Send IPv6 Server Port (or 0):")
+        dut.write(f"{port if host_ipv6 else 0}\n")
+
+        LOGGER.info("Running OTA Unity tests (Update/HTTPUpdate/ArduinoOTA)")
+        # Extra ArduinoOTA uploads (IPv4/IPv6 interaction cases) need a longer budget.
+        _expect_unity_with_arduino_ota(dut, firmware, host_ip, host_ipv6, timeout=600)
     finally:
         if server:
             server.shutdown()

--- a/tools/espota.py
+++ b/tools/espota.py
@@ -49,6 +49,10 @@
 # Changes
 # 2025-10-07:
 # - Fixed authentication when images might use old MD5 hashes stored in the firmware
+#
+# Changes
+# 2026-08-03:
+# - Added IPv6 support for invite/auth UDP and TCP listen
 
 
 from __future__ import print_function
@@ -67,6 +71,59 @@ AUTH = 200
 
 # Constants
 PROGRESS_BAR_LENGTH = 60
+
+
+def normalize_ip_literal(addr):
+    """Strip optional brackets from an IP literal (e.g. '[fe80::1]' -> 'fe80::1')."""
+    if not addr:
+        return addr
+    if addr.startswith("[") and "]" in addr:
+        return addr[1 : addr.index("]")]
+    return addr
+
+
+def resolve_endpoint(addr, port, socktype=socket.SOCK_DGRAM):
+    """
+    Resolve addr:port to (family, sockaddr).
+    Supports IPv4, IPv6, and scoped link-local addresses (fe80::1%en0).
+    """
+    host = normalize_ip_literal(addr)
+    try:
+        infos = socket.getaddrinfo(host, int(port), socket.AF_UNSPEC, socktype)
+    except socket.gaierror as e:
+        raise ValueError("Unable to resolve %s:%s (%s)" % (addr, port, e))
+    if not infos:
+        raise ValueError("Unable to resolve %s:%s" % (addr, port))
+    family, _socktype, _proto, _canonname, sockaddr = infos[0]
+    return family, sockaddr
+
+
+def is_unspecified_bind_address(addr):
+    host = normalize_ip_literal(addr)
+    return host in ("0.0.0.0", "::", "")
+
+
+def choose_bind_address(local_addr, remote_family):
+    """
+    Pick a TCP bind address matching the remote address family.
+    Default 0.0.0.0 becomes :: when the target is IPv6.
+    """
+    if not is_unspecified_bind_address(local_addr):
+        return local_addr
+    if remote_family == socket.AF_INET6:
+        return "::"
+    return "0.0.0.0"
+
+
+def create_socket(family, socktype):
+    sock = socket.socket(family, socktype)
+    if family == socket.AF_INET6 and socktype == socket.SOCK_STREAM:
+        # Dual-stack listen when binding :: (platform permitting)
+        try:
+            sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        except (AttributeError, OSError):
+            pass
+    return sock
 
 
 # update_progress(): Displays or updates a console progress bar
@@ -95,12 +152,16 @@ def update_progress(progress):
         sys.stderr.flush()
 
 
-def send_invitation_and_get_auth_challenge(remote_addr, remote_port, message):
+def send_invitation_and_get_auth_challenge(remote_addr, remote_port, message, local_addr=None):
     """
     Send invitation to ESP device and get authentication challenge.
     Returns (success, auth_data, error_message) tuple.
     """
-    remote_address = (remote_addr, int(remote_port))
+    try:
+        family, remote_address = resolve_endpoint(remote_addr, remote_port, socket.SOCK_DGRAM)
+    except ValueError as e:
+        return False, None, str(e)
+
     inv_tries = 0
     data = ""
 
@@ -110,8 +171,13 @@ def send_invitation_and_get_auth_challenge(remote_addr, remote_port, message):
 
     while inv_tries < 10:
         inv_tries += 1
-        sock2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock2 = create_socket(family, socket.SOCK_DGRAM)
         try:
+            # Bind UDP to the same host address used for TCP listen so the DUT
+            # reverse-connects to an address we are actually listening on.
+            if local_addr and not is_unspecified_bind_address(local_addr):
+                _lf, local_sa = resolve_endpoint(local_addr, 0, socket.SOCK_DGRAM)
+                sock2.bind(local_sa)
             sent = sock2.sendto(message.encode(), remote_address)  # noqa: F841
         except:  # noqa: E722
             sys.stderr.write("failed\n")
@@ -141,7 +207,16 @@ def send_invitation_and_get_auth_challenge(remote_addr, remote_port, message):
 
 
 def authenticate(
-    remote_addr, remote_port, password, use_md5_password, use_old_protocol, filename, content_size, file_md5, nonce
+    remote_addr,
+    remote_port,
+    password,
+    use_md5_password,
+    use_old_protocol,
+    filename,
+    content_size,
+    file_md5,
+    nonce,
+    local_addr=None,
 ):
     """
     Perform authentication with the ESP device.
@@ -153,7 +228,10 @@ def authenticate(
     Returns (success, error_message) tuple.
     """
     cnonce_text = "%s%u%s%s" % (filename, content_size, file_md5, remote_addr)
-    remote_address = (remote_addr, int(remote_port))
+    try:
+        family, remote_address = resolve_endpoint(remote_addr, remote_port, socket.SOCK_DGRAM)
+    except ValueError as e:
+        return False, str(e)
 
     if use_old_protocol:
         # Generate client nonce (cnonce)
@@ -174,7 +252,7 @@ def authenticate(
         # New PBKDF2-HMAC-SHA256 challenge/response protocol (3.3.1+)
         # The password can be hashed with either MD5 or SHA256
         if use_md5_password:
-            # Use MD5 for password hash (for devices that stored MD5 hashes)
+            # Use MD5 for password hash (for devices that stored MD5 passwords)
             password_hash = hashlib.md5(password.encode()).hexdigest()
         else:
             # Use SHA256 for password hash (recommended)
@@ -191,8 +269,11 @@ def authenticate(
         expected_response_length = 64
 
     # Send authentication response
-    sock2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock2 = create_socket(family, socket.SOCK_DGRAM)
     try:
+        if local_addr and not is_unspecified_bind_address(local_addr):
+            _lf, local_sa = resolve_endpoint(local_addr, 0, socket.SOCK_DGRAM)
+            sock2.bind(local_sa)
         message = "%d %s %s\n" % (AUTH, cnonce, response)
         sock2.sendto(message.encode(), remote_address)
         sock2.settimeout(10)
@@ -216,15 +297,29 @@ def authenticate(
 def serve(  # noqa: C901
     remote_addr, local_addr, remote_port, local_port, password, md5_target, filename, command=FLASH
 ):
-    # Create a TCP/IP socket
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server_address = (local_addr, local_port)
+    try:
+        remote_family, _remote_sockaddr = resolve_endpoint(remote_addr, remote_port, socket.SOCK_DGRAM)
+    except ValueError as e:
+        logging.error("%s", str(e))
+        return 1
+
+    bind_addr = choose_bind_address(local_addr, remote_family)
+    try:
+        bind_family, server_address = resolve_endpoint(bind_addr, local_port, socket.SOCK_STREAM)
+    except ValueError as e:
+        logging.error("%s", str(e))
+        return 1
+
+    # Create a TCP socket matching the target address family
+    sock = create_socket(bind_family, socket.SOCK_STREAM)
     logging.info("Starting on %s:%s", str(server_address[0]), str(server_address[1]))
     try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind(server_address)
         sock.listen(1)
     except Exception as e:
         logging.error("Listen Failed: %s", str(e))
+        sock.close()
         return 1
 
     content_size = os.path.getsize(filename)
@@ -234,9 +329,12 @@ def serve(  # noqa: C901
     message = "%d %d %d %s\n" % (command, local_port, content_size, file_md5)
 
     # Send invitation and get authentication challenge
-    success, data, error = send_invitation_and_get_auth_challenge(remote_addr, remote_port, message)
+    success, data, error = send_invitation_and_get_auth_challenge(
+        remote_addr, remote_port, message, local_addr=bind_addr
+    )
     if not success:
         logging.error(error)
+        sock.close()
         return 1
 
     if data != "OK":
@@ -263,12 +361,14 @@ def serve(  # noqa: C901
                     content_size=content_size,
                     file_md5=file_md5,
                     nonce=nonce,
+                    local_addr=bind_addr,
                 )
 
                 if not auth_success:
                     sys.stderr.write("FAIL\n")
                     logging.error("Authentication Failed: %s", auth_error)
                     logging.error("Please check your password and try again")
+                    sock.close()
                     return 1
 
                 sys.stderr.write("OK\n")
@@ -296,6 +396,7 @@ def serve(  # noqa: C901
                         content_size=content_size,
                         file_md5=file_md5,
                         nonce=nonce,
+                        local_addr=bind_addr,
                     )
 
                     if auth_success:
@@ -315,6 +416,7 @@ def serve(  # noqa: C901
                         content_size=content_size,
                         file_md5=file_md5,
                         nonce=nonce,
+                        local_addr=bind_addr,
                     )
 
                     # Scenario 3: If SHA256 fails, try MD5 password hash (for devices with stored MD5 passwords)
@@ -325,15 +427,19 @@ def serve(  # noqa: C901
                         sys.stderr.flush()
 
                         # Device is back in OTA_IDLE after auth failure, need to send new invitation
-                        success, data, error = send_invitation_and_get_auth_challenge(remote_addr, remote_port, message)
+                        success, data, error = send_invitation_and_get_auth_challenge(
+                            remote_addr, remote_port, message, local_addr=bind_addr
+                        )
                         if not success:
                             sys.stderr.write("FAIL\n")
                             logging.error("Failed to get new challenge for MD5 retry: %s", error)
+                            sock.close()
                             return 1
 
                         if not data.startswith("AUTH"):
                             sys.stderr.write("FAIL\n")
                             logging.error("Expected AUTH challenge for MD5 retry, got: %s", data)
+                            sock.close()
                             return 1
 
                         # Get new nonce for second attempt
@@ -352,6 +458,7 @@ def serve(  # noqa: C901
                             content_size=content_size,
                             file_md5=file_md5,
                             nonce=nonce,
+                            local_addr=bind_addr,
                         )
 
                         if auth_success:
@@ -370,14 +477,17 @@ def serve(  # noqa: C901
                     sys.stderr.write("FAIL\n")
                     logging.error("Authentication Failed: %s", auth_error)
                     logging.error("Please check your password and try again")
+                    sock.close()
                     return 1
 
                 sys.stderr.write("OK\n")
             else:
                 logging.error("Invalid nonce length: %d (expected 32 or 64)", nonce_length)
+                sock.close()
                 return 1
         else:
             logging.error("Bad Answer: %s", data)
+            sock.close()
             return 1
 
     logging.info("Waiting for device...")
@@ -417,11 +527,13 @@ def serve(  # noqa: C901
                     sys.stderr.write("\n")
                     logging.error("Error Uploading: %s", str(e))
                     connection.close()
+                    sock.close()
                     return 1
 
             if last_response_contained_ok:
                 logging.info("Success")
                 connection.close()
+                sock.close()
                 return 0
 
             sys.stderr.write("\n")
@@ -439,6 +551,7 @@ def serve(  # noqa: C901
                     if "OK" in data:
                         logging.info("Success")
                         connection.close()
+                        sock.close()
                         return 0
                     elif data:  # Got some response but not OK
                         logging.warning("Unexpected response from device: '%s'", data)
@@ -458,16 +571,21 @@ def serve(  # noqa: C901
                 )
                 logging.warning("Device might be rebooting to apply firmware - this is normal.")
                 connection.close()
+                sock.close()
                 return 0  # Consider it successful if we got any response and upload completed
             else:
                 logging.error("No response from device after upload completion")
                 logging.error("This could indicate device reboot (normal) or network issues")
                 connection.close()
+                sock.close()
                 return 1
     except Exception as e:  # noqa: E722
         logging.error("Error: %s", str(e))
     finally:
-        connection.close()
+        try:
+            connection.close()
+        except Exception as e:
+            logging.debug("Error closing device connection: %s", str(e))
 
     sock.close()
     return 1
@@ -477,8 +595,15 @@ def parse_args(unparsed_args):
     parser = argparse.ArgumentParser(description="Transmit image over the air to the ESP32 module with OTA support.")
 
     # destination ip and port
-    parser.add_argument("-i", "--ip", dest="esp_ip", action="store", help="ESP32 IP Address.", default=False)
-    parser.add_argument("-I", "--host_ip", dest="host_ip", action="store", help="Host IP Address.", default="0.0.0.0")
+    parser.add_argument("-i", "--ip", dest="esp_ip", action="store", help="ESP32 IP Address (IPv4 or IPv6).", default=False)
+    parser.add_argument(
+        "-I",
+        "--host_ip",
+        dest="host_ip",
+        action="store",
+        help="Host IP Address (IPv4 or IPv6). Default: 0.0.0.0 (becomes :: for IPv6 targets).",
+        default="0.0.0.0",
+    )
     parser.add_argument("-p", "--port", dest="esp_port", type=int, help="ESP32 OTA Port. Default: 3232", default=3232)
     parser.add_argument(
         "-P",


### PR DESCRIPTION
## Description of Change

This pull request adds comprehensive IPv6 support to OTA (Over-the-Air) update workflows and validation tests for ESP32, covering both the ArduinoOTA and HTTPUpdate libraries. It introduces dual-stack (IPv4/IPv6) OTA support, updates the HTTP client to properly parse and handle IPv6 URLs, and greatly expands the validation test suite to cover a wide range of IPv6 scenarios. The changes also enhance test infrastructure to support IPv6 and ensure robust handling of new network cases.

**Key changes include:**

### Dual-stack and IPv6 OTA Support

* `ArduinoOTAClass::begin()` now binds to the dual-stack address (`::`) when IPv6 is enabled, allowing the device to accept OTA updates over both IPv4 and IPv6.
* `NetworkUDP::begin()` fixes the socket address structure size for IPv6, ensuring correct socket binding.

### HTTP Client and HTTPUpdate IPv6 Support

* `HTTPClient::beginInternal()` and `HTTPClient::sendHeader()` now parse and format IPv6 host literals according to RFC 3986/7230, supporting bracketed IPv6 addresses in URLs and the Host header. [[1]](diffhunk://#diff-fcae154d5d1c4e49f3b9da7384421924fae66a4c6c01c98b3dfafe320e2c818bL273-R302) [[2]](diffhunk://#diff-fcae154d5d1c4e49f3b9da7384421924fae66a4c6c01c98b3dfafe320e2c818bL1145-R1173)
* Validation tests now include HTTPUpdate cases for IPv6, including invalid and valid bracketed IPv6 URLs. (F8cbb75dL332R332, F8cbb75dL361R361)

### OTA Validation Test Suite Enhancements

* The `ota.ino` test suite is refactored and extended to test:
  - ArduinoOTA uploads over IPv4, IPv6, and IPv4-mapped IPv6, with and without authentication.
  - HTTPUpdate downloads and error cases over IPv4 and IPv6.
  - Dual-stack behavior (IPv4 and IPv6 after enabling/disabling).
  - Host and test device IPv6 capability negotiation. [[1]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2L5-R10) [[2]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2R23-R49) [[3]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2R71-R160) [[4]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2R182-R323) [[5]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2R335-R351) [[6]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2R364-R388) [[7]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2R446-R474) [[8]](diffhunk://#diff-b007ca90c0307a9542a2c84be8244802bc27e3abe9d17dd787649ba0ef30c1c2R490-R503)
* The test protocol and README are updated to describe new IPv6 modes, test cases, and host/server negotiation steps.

### Test Infrastructure and Host Support

* The Python test harness (`test_ota.py`) is extended to:
  - Parse new serial protocol lines for OTA upload triggers.
  - Launch `espota.py` for both IPv4 and IPv6 uploads.
  - Detect host IPv6 capabilities and handle IPv4-mapped addresses.

---

These changes ensure robust OTA update workflows on modern networks, including environments with IPv6, and provide thorough automated validation for both libraries and all supported network cases.

## Test Scenarios

Tested locally with ESP32

## Related links

Closes #12797
