### PR TITLE
docs(compatibility): Add notes on ESP8266 compatibility

### DIFF
--- a/docs/en/api/espnow.rst
+++ b/docs/en/api/espnow.rst
@@ -9,7 +9,10 @@ ESP-NOW is a communication protocol designed for low-power, low-latency, and hig
 It is ideal for scenarios where devices need to communicate directly with each other in a local network.
 ESP-NOW can be used for smart lights, remote control devices, sensors and many other applications.
 
-This library provides an easy-to-use interface for setting up ESP-NOW communication, adding and removing peers, and sending and receiving data packets. This library is only tested on the ESP32 family of chips. We cannot guarantee that it will be compatible with ESP8266 or other ESP32-like chips.
+This library provides an easy-to-use interface for setting up ESP-NOW communication, adding and removing peers, and sending and receiving data packets.
+
+.. note::
+   This library is only tested on the ESP32 family of chips. Interoperability with ESP8266 or other non-ESP32 platforms is not guaranteed.
 
 Arduino-ESP32 ESP-NOW API
 -------------------------

--- a/docs/en/api/espnow.rst
+++ b/docs/en/api/espnow.rst
@@ -9,7 +9,7 @@ ESP-NOW is a communication protocol designed for low-power, low-latency, and hig
 It is ideal for scenarios where devices need to communicate directly with each other in a local network.
 ESP-NOW can be used for smart lights, remote control devices, sensors and many other applications.
 
-This library provides an easy-to-use interface for setting up ESP-NOW communication, adding and removing peers, and sending and receiving data packets.
+This library provides an easy-to-use interface for setting up ESP-NOW communication, adding and removing peers, and sending and receiving data packets. This library is only tested on the ESP32 family of chips. We cannot guarantee that it will be compatible with ESP8266 or other ESP32-like chips.
 
 Arduino-ESP32 ESP-NOW API
 -------------------------

--- a/docs/en/getting_started.rst
+++ b/docs/en/getting_started.rst
@@ -52,6 +52,9 @@ ESP32-S3   Yes    Yes         `ESP32-S3`_
     For more information, see the `Arduino as an ESP-IDF component documentation <esp-idf_component.html>`_ or the
     `Lib Builder documentation <lib_builder.html>`_, respectively.
 
+.. note::
+    This core and its libraries are only tested on the ESP32 family of chips listed above. We cannot guarantee that the libraries will be compatible with ESP8266 or other ESP32-like chips.
+
 See `Boards <boards/boards.html>`_ for more details about ESP32 development boards.
 
 Arduino Core Reference

--- a/docs/en/getting_started.rst
+++ b/docs/en/getting_started.rst
@@ -53,7 +53,7 @@ ESP32-S3   Yes    Yes         `ESP32-S3`_
     `Lib Builder documentation <lib_builder.html>`_, respectively.
 
 .. note::
-    This core and its libraries are only tested on the ESP32 family of chips listed above. We cannot guarantee that the libraries will be compatible with ESP8266 or other ESP32-like chips.
+    This core and its libraries are only tested on the ESP32 family of chips listed above. Interoperability with ESP8266 or other non-ESP32 platforms is not guaranteed.
 
 See `Boards <boards/boards.html>`_ for more details about ESP32 development boards.
 


### PR DESCRIPTION
## Description of Change

This pull request updates the documentation to clarify hardware compatibility for the ESP-NOW library and the Arduino core. The main focus is to set expectations about support for ESP32 and related chips.

Documentation updates for hardware compatibility:

* [`docs/en/api/espnow.rst`](diffhunk://#diff-1a7200b6db4158ceb3d3e1ce5c66d5595d0b2ef8f0ed191d36e0b72b241697abL12-R12): Added a note that the ESP-NOW library is only tested on the ESP32 family of chips and compatibility with ESP8266 or other ESP32-like chips is not guaranteed.
* [`docs/en/getting_started.rst`](diffhunk://#diff-008b36887a9ddd62b52cb57f5045a43bfbdb8342f21444fbb1b25bbe0c61319fR55-R57): Added a note stating that the core and its libraries are only tested on the listed ESP32 family chips, with no guarantee of compatibility with ESP8266 or other ESP32-like chips.

## Related links

Closes #12796 