### PR TITLE
fix(ble): Fix oversized AD bounds

### DIFF
--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -519,13 +519,12 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len)
         case ESP_BLE_AD_TYPE_16SRV_PART:  // 0x02
         case ESP_BLE_AD_TYPE_16SRV_CMPL:  // 0x03
         {                                 // Adv Data Type: ESP_BLE_AD_TYPE_16SRV_PART/CMPL
-          // Guard: Ensure data is not truncated and contains valid 2-byte pairs
-          // it avoids buffer overflow when length is wrong
+          // A UUID list must be a whole number of UUIDs. A partial entry means the
+          // field is malformed, so reject it instead of parsing a truncated list.
           if (length < 2 || (length % 2) != 0) {
-            log_e("Malformed 16-bit UUID data length: %u", length);
+            log_e("Malformed 16-bit UUID list length: %u", length);
             break;
           }
-          
           for (int var = 0; var < length / 2; ++var) {
             setServiceUUID(BLEUUID(*reinterpret_cast<uint16_t *>(payload + var * 2)));
           }
@@ -535,34 +534,27 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len)
         case ESP_BLE_AD_TYPE_32SRV_PART:  // 0x04
         case ESP_BLE_AD_TYPE_32SRV_CMPL:  // 0x05
         {                                 // Adv Data Type: ESP_BLE_AD_TYPE_32SRV_PART/CMPL
-          // Guard: Ensure data is not truncated and contains valid 4-byte groups
-          // it avoids buffer overflow when length is wrong
           if (length < 4 || (length % 4) != 0) {
-            log_e("Malformed 32-bit UUID data length: %u", length);
+            log_e("Malformed 32-bit UUID list length: %u", length);
             break;
           }
-       for (int var = 0; var < length / 4; ++var) {
+          for (int var = 0; var < length / 4; ++var) {
             setServiceUUID(BLEUUID(*reinterpret_cast<uint32_t *>(payload + var * 4)));
           }
           break;
         }  // 0x04, 0x05
 
+        case ESP_BLE_AD_TYPE_128SRV_PART:  // 0x06
         case ESP_BLE_AD_TYPE_128SRV_CMPL:  // 0x07
-        {                                  // Adv Data Type: ESP_BLE_AD_TYPE_128SRV_CMPL
-          // Guard: A 128-bit UUID strictly requires exactly 16 bytes of data
-          if (length < 16) {
-            log_e("Length too small for 128SRV: %u", length);
+        {                                  // Adv Data Type: ESP_BLE_AD_TYPE_128SRV_PART/CMPL
+          // Legacy ADV only: one 128-bit UUID fits. Reject any other length.
+          if (length != 16) {
+            log_e("Malformed 128-bit UUID length: %u", length);
             break;
           }
           setServiceUUID(BLEUUID(payload, 16, false));
           break;
-        }  // 0x07
-
-        case ESP_BLE_AD_TYPE_128SRV_PART:  // 0x06
-        {                                  // Adv Data Type: ESP_BLE_AD_TYPE_128SRV_PART
-          setServiceUUID(BLEUUID(payload, 16, false));
-          break;
-        }  // 0x06
+        }  // 0x06, 0x07
 
         // See CSS Part A 1.4 Manufacturer Specific Data
         case ESP_BLE_AD_MANUFACTURER_SPECIFIC_TYPE:  // 0xFF

--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -468,6 +468,10 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len)
 
     length = *payload;  // Retrieve the length of the record.
 
+    if (length == 0) {  // Terminator record
+      break;
+    }
+
     // Reject AD structures that extend past the valid buffer. Otherwise we can
     // read stale controller/stack memory and produce garbled names/data.
     if ((size_t)length + 1 > total_len - sizeConsumed) {

--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -519,6 +519,13 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len)
         case ESP_BLE_AD_TYPE_16SRV_PART:  // 0x02
         case ESP_BLE_AD_TYPE_16SRV_CMPL:  // 0x03
         {                                 // Adv Data Type: ESP_BLE_AD_TYPE_16SRV_PART/CMPL
+          // Guard: Ensure data is not truncated and contains valid 2-byte pairs
+          // it avoids buffer overflow when length is wrong
+          if (length < 2 || (length % 2) != 0) {
+            log_e("Malformed 16-bit UUID data length: %u", length);
+            break;
+          }
+          
           for (int var = 0; var < length / 2; ++var) {
             setServiceUUID(BLEUUID(*reinterpret_cast<uint16_t *>(payload + var * 2)));
           }
@@ -528,7 +535,13 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len)
         case ESP_BLE_AD_TYPE_32SRV_PART:  // 0x04
         case ESP_BLE_AD_TYPE_32SRV_CMPL:  // 0x05
         {                                 // Adv Data Type: ESP_BLE_AD_TYPE_32SRV_PART/CMPL
-          for (int var = 0; var < length / 4; ++var) {
+          // Guard: Ensure data is not truncated and contains valid 4-byte groups
+          // it avoids buffer overflow when length is wrong
+          if (length < 4 || (length % 4) != 0) {
+            log_e("Malformed 32-bit UUID data length: %u", length);
+            break;
+          }
+       for (int var = 0; var < length / 4; ++var) {
             setServiceUUID(BLEUUID(*reinterpret_cast<uint32_t *>(payload + var * 4)));
           }
           break;
@@ -536,6 +549,11 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len)
 
         case ESP_BLE_AD_TYPE_128SRV_CMPL:  // 0x07
         {                                  // Adv Data Type: ESP_BLE_AD_TYPE_128SRV_CMPL
+          // Guard: A 128-bit UUID strictly requires exactly 16 bytes of data
+          if (length < 16) {
+            log_e("Length too small for 128SRV: %u", length);
+            break;
+          }
           setServiceUUID(BLEUUID(payload, 16, false));
           break;
         }  // 0x07

--- a/libraries/BLE/src/BLEAdvertisedDevice.cpp
+++ b/libraries/BLE/src/BLEAdvertisedDevice.cpp
@@ -430,8 +430,12 @@ bool BLEAdvertisedDevice::haveTXPower() {
 void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len) {
   uint8_t length;
   uint8_t ad_type;
-  uint8_t sizeConsumed = 0;
+  size_t sizeConsumed = 0;
   bool finished = false;
+
+  if (payload == nullptr || total_len == 0) {
+    return;
+  }
 
   // Store/append raw payload data for later retrieval
   // This handles both ADV and Scan Response packets by merging them
@@ -458,7 +462,19 @@ void BLEAdvertisedDevice::parseAdvertisement(uint8_t *payload, size_t total_len)
   }
 
   while (!finished) {
-    length = *payload;           // Retrieve the length of the record.
+    if (sizeConsumed >= total_len) {
+      break;
+    }
+
+    length = *payload;  // Retrieve the length of the record.
+
+    // Reject AD structures that extend past the valid buffer. Otherwise we can
+    // read stale controller/stack memory and produce garbled names/data.
+    if ((size_t)length + 1 > total_len - sizeConsumed) {
+      log_e("AD structure length %u exceeds remaining %lu bytes", length, (unsigned long)(total_len - sizeConsumed));
+      break;
+    }
+
     payload++;                   // Skip to type
     sizeConsumed += 1 + length;  // increase the size consumed.
 

--- a/tests/validation/ble/README.md
+++ b/tests/validation/ble/README.md
@@ -27,6 +27,7 @@ Validates BLE secure connection between a server and client using Numeric Compar
 | Secure characteristic | Serve read/write requiring MITM authentication |
 | Numeric Comparison PIN | Display and auto-confirm pairing PIN |
 | IRK retrieval | Retrieve and print the peer's Identity Resolving Key after authentication |
+| Malformed advertisement data | Advertise deliberately malformed AD structures so the client can prove its parser rejects them |
 
 ### Client (`client/client.ino`)
 
@@ -38,6 +39,26 @@ Validates BLE secure connection between a server and client using Numeric Compar
 | Numeric Comparison PIN | Display and auto-confirm pairing PIN (must match server) |
 | IRK retrieval | Retrieve and print the peer's Identity Resolving Key after authentication |
 | Write/read operations | Write and read back values on both secure and insecure characteristics |
+| Advertisement parsing | Verify malformed AD structures are rejected instead of turned into fields (`ADCHK1` / `ADCHK2`) |
+
+## Advertisement Parsing Regression
+
+`BLEAdvertisedDevice::parseAdvertisement` must reject malformed AD structures
+rather than read past the valid payload or accept a truncated list. The server
+advertises them in two windows, because the terminator and the oversize guard
+both stop the parse loop and so each one has to be the last structure in its own
+payload to be observable.
+
+| Window | Malformed structure | Expected result |
+|---|---|---|
+| 1 | 16-bit UUID list with a trailing partial octet | `svc16=0` (list rejected whole) |
+| 1 | 128-bit UUID structure with fewer than 16 data bytes | `svcCount=1` (no UUID built from an over-read) |
+| 1 | AD length larger than the remaining payload | `mfg=0` (structure rejected) |
+| 2 | 32-bit UUID list with a trailing partial group | `svc32=0` (list rejected whole) |
+| 2 | Manufacturer data behind a zero-length terminator | `mfg=0` (parsing stops at the terminator) |
+
+Window 2 is entered on demand: pytest sends `ADPHASE2` to the server, waits for
+it to re-advertise, then sends `ADPHASE2` to the client to trigger a rescan.
 
 ## Requirements
 
@@ -57,6 +78,7 @@ Validates BLE secure connection between a server and client using Numeric Compar
 7. Both devices display and confirm the same PIN
 8. Authentication completes; both devices retrieve peer IRK
 9. Client performs write/read on both characteristics
+10. pytest sends `ADPHASE2` to both devices to run the second advertisement parsing window
 
 ## Notes
 

--- a/tests/validation/ble/client/client.ino
+++ b/tests/validation/ble/client/client.ino
@@ -155,7 +155,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
       Serial.println(deviceName);
 
       if (deviceName == targetServerName) {
-        // Issue #12801: server appends an oversize AD after the name; parser must reject it.
+        // Server appends an oversize AD after the name; parser must reject it.
         if (advertisedDevice.haveManufacturerData()) {
           Serial.println("[CLIENT] FAIL: oversize AD was not rejected");
         } else {

--- a/tests/validation/ble/client/client.ino
+++ b/tests/validation/ble/client/client.ino
@@ -10,11 +10,18 @@ static BLEUUID secureCharUUID("ff1d2614-e2d6-4c87-9154-6625d39ca7f8");
 static const int RECONNECT_CYCLES = 10;
 static const uint16_t APPID_PRESEED_GATT_IF_NONE = 250;  // crosses ESP_GATT_IF_NONE (0xFF on Bluedroid)
 
+// Service UUIDs the server only advertises inside malformed AD structures. A
+// fixed parser must never surface them (see the payloads in server.ino).
+static BLEUUID badUuid16((uint16_t)0x180D);
+static BLEUUID badUuid32((uint32_t)0x04030201);
+
 String targetServerName = "";
 static boolean doConnect = false;
 static boolean connected = false;
 static boolean doScan = false;
 static boolean testCompleted = false;
+static int adPhase = 1;
+static boolean adPhase2Reported = false;
 static BLEClient *pClient = nullptr;
 static BLERemoteCharacteristic *pRemoteInsecureCharacteristic = nullptr;
 static BLERemoteCharacteristic *pRemoteSecureCharacteristic = nullptr;
@@ -155,12 +162,26 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
       Serial.println(deviceName);
 
       if (deviceName == targetServerName) {
-        // Server appends an oversize AD after the name; parser must reject it.
-        if (advertisedDevice.haveManufacturerData()) {
-          Serial.println("[CLIENT] FAIL: oversize AD was not rejected");
-        } else {
-          Serial.println("[CLIENT] PASS: oversize AD rejected");
+        if (adPhase == 2) {
+          if (!adPhase2Reported) {
+            adPhase2Reported = true;
+            // Behind the zero-length terminator the server hides manufacturer data,
+            // and the 32-bit UUID list it advertises has a trailing partial group.
+            Serial.printf(
+              "[CLIENT] ADCHK2 mfg=%d svc32=%d\n", advertisedDevice.haveManufacturerData() ? 1 : 0, advertisedDevice.isAdvertisingService(badUuid32) ? 1 : 0
+            );
+          }
+          return;
         }
+
+        // The scan response hides an oversize AD structure, a 16-bit UUID list with
+        // a trailing partial octet, and a 128-bit UUID structure shorter than 16
+        // bytes. Only the service UUID from the primary advertisement is valid, so
+        // a fixed parser reports exactly one service UUID and no manufacturer data.
+        Serial.printf(
+          "[CLIENT] ADCHK1 mfg=%d svc16=%d svcCount=%d\n", advertisedDevice.haveManufacturerData() ? 1 : 0,
+          advertisedDevice.isAdvertisingService(badUuid16) ? 1 : 0, advertisedDevice.getServiceUUIDCount()
+        );
         Serial.println("[CLIENT] Found target server!");
         BLEDevice::getScan()->stop();
         myDevice = new BLEAdvertisedDevice(advertisedDevice);
@@ -170,6 +191,26 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
     }
   }
 };
+
+static MyAdvertisedDeviceCallbacks *pScanCallbacks = nullptr;
+
+// Rescan while the server advertises the window 2 payload (see server.ino).
+void runAdPhase2Scan() {
+  adPhase = 2;
+  adPhase2Reported = false;
+
+  BLEScan *pBLEScan = BLEDevice::getScan();
+  pBLEScan->stop();
+  pBLEScan->clearResults();
+  // Duplicates are wanted so the report is not suppressed by the earlier scan.
+  pBLEScan->setAdvertisedDeviceCallbacks(pScanCallbacks, true);
+  pBLEScan->setActiveScan(true);
+  pBLEScan->start(10, false);
+
+  if (!adPhase2Reported) {
+    Serial.println("[CLIENT] ADCHK2 server not found");
+  }
+}
 
 bool runReconnectPhase(uint16_t preseed, const char *label) {
   Serial.printf("[CLIENT] Reconnect phase: crossing %s (preseed=%u)\n", label, preseed);
@@ -260,7 +301,8 @@ void setup() {
 
   // Start scanning
   BLEScan *pBLEScan = BLEDevice::getScan();
-  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
+  pScanCallbacks = new MyAdvertisedDeviceCallbacks();
+  pBLEScan->setAdvertisedDeviceCallbacks(pScanCallbacks);
   pBLEScan->setInterval(1349);
   pBLEScan->setWindow(449);
   pBLEScan->setActiveScan(true);
@@ -268,6 +310,14 @@ void setup() {
 }
 
 void loop() {
+  if (testCompleted && Serial.available()) {
+    String command = Serial.readStringUntil('\n');
+    command.trim();
+    if (command == "ADPHASE2") {
+      runAdPhase2Scan();
+    }
+  }
+
   if (doConnect == true) {
     if (connectToServer()) {
       Serial.println("[CLIENT] Successfully connected and authenticated");

--- a/tests/validation/ble/client/client.ino
+++ b/tests/validation/ble/client/client.ino
@@ -155,6 +155,12 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
       Serial.println(deviceName);
 
       if (deviceName == targetServerName) {
+        // Issue #12801: server appends an oversize AD after the name; parser must reject it.
+        if (advertisedDevice.haveManufacturerData()) {
+          Serial.println("[CLIENT] FAIL: oversize AD was not rejected");
+        } else {
+          Serial.println("[CLIENT] PASS: oversize AD rejected");
+        }
         Serial.println("[CLIENT] Found target server!");
         BLEDevice::getScan()->stop();
         myDevice = new BLEAdvertisedDevice(advertisedDevice);

--- a/tests/validation/ble/server/server.ino
+++ b/tests/validation/ble/server/server.ino
@@ -175,12 +175,20 @@ void setup() {
   // Start service
   pService->start();
 
-  // Start advertising
+  // Start advertising. Scan response carries the name plus a deliberately oversize
+  // AD structure (issue #12801): length claims 20 bytes but only 2 follow.
   BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
   pAdvertising->addServiceUUID(SERVICE_UUID);
   pAdvertising->setScanResponse(true);
   pAdvertising->setMinPreferred(0x06);
   pAdvertising->setMaxPreferred(0x12);
+
+  BLEAdvertisementData scanResponse;
+  scanResponse.setName(serverName);
+  char oversizeAd[] = {20, (char)0xFF, 0x01, 0x02};
+  scanResponse.addData(oversizeAd, sizeof(oversizeAd));
+  pAdvertising->setScanResponseData(scanResponse);
+
   BLEDevice::startAdvertising();
 
   Serial.printf("[SERVER] Advertising started with name: %s\n", serverName.c_str());

--- a/tests/validation/ble/server/server.ino
+++ b/tests/validation/ble/server/server.ino
@@ -175,8 +175,8 @@ void setup() {
   // Start service
   pService->start();
 
-  // Start advertising. Scan response carries the name plus a deliberately oversize
-  // AD structure (issue #12801): length claims 20 bytes but only 2 follow.
+  // Start advertising. Scan response carries the name plus a deliberately oversized
+  // AD structure: length claims 20 bytes (type+data) but only 3 bytes follow.
   BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
   pAdvertising->addServiceUUID(SERVICE_UUID);
   pAdvertising->setScanResponse(true);

--- a/tests/validation/ble/server/server.ino
+++ b/tests/validation/ble/server/server.ino
@@ -13,6 +13,25 @@ String serverName = "";
 static bool deviceConnected = false;
 static int connectionCount = 0;
 
+// Malformed AD structures used to regression-test BLEAdvertisedDevice parsing.
+// They are split across two advertising windows because the terminator and the
+// oversize guard both stop the parse loop, so each one has to be the last
+// structure in its own payload to be observable.
+//
+// Window 1: guards that skip a single structure, followed by the oversize guard.
+// 16-bit UUID list with a trailing partial octet (3 data bytes, not a multiple of 2).
+static char badUuid16List[] = {0x04, 0x03, 0x0D, 0x18, 0x99};
+// 128-bit UUID structure carrying fewer than 16 data bytes.
+static char badUuid128[] = {0x03, 0x07, 0x11, 0x22};
+// AD length claims 20 bytes (type + data) but only 3 bytes follow.
+static char oversizeAd[] = {20, (char)0xFF, 0x01, 0x02};
+//
+// Window 2: the 32-bit guard, then a terminator that must end the parse.
+// 32-bit UUID list with a trailing partial group (5 data bytes, not a multiple of 4).
+static char badUuid32List[] = {0x06, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05};
+// Zero-length AD ends the payload; the manufacturer data behind it must be ignored.
+static char terminatedAd[] = {0x00, 0x03, (char)0xFF, (char)0xAA, (char)0xBB};
+
 class MyServerCallbacks : public BLEServerCallbacks {
   void onConnect(BLEServer *pServer) {
     deviceConnected = true;
@@ -175,8 +194,9 @@ void setup() {
   // Start service
   pService->start();
 
-  // Start advertising. Scan response carries the name plus a deliberately oversized
-  // AD structure: length claims 20 bytes (type+data) but only 3 bytes follow.
+  // Start advertising. The scan response carries the name plus the window 1
+  // malformed AD structures (see above); the primary advertisement is left to
+  // the library so the service UUID still round-trips normally.
   BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
   pAdvertising->addServiceUUID(SERVICE_UUID);
   pAdvertising->setScanResponse(true);
@@ -185,7 +205,8 @@ void setup() {
 
   BLEAdvertisementData scanResponse;
   scanResponse.setName(serverName);
-  char oversizeAd[] = {20, (char)0xFF, 0x01, 0x02};
+  scanResponse.addData(badUuid16List, sizeof(badUuid16List));
+  scanResponse.addData(badUuid128, sizeof(badUuid128));
   scanResponse.addData(oversizeAd, sizeof(oversizeAd));
   pAdvertising->setScanResponseData(scanResponse);
 
@@ -195,7 +216,32 @@ void setup() {
   Serial.printf("[SERVER] Service UUID: %s\n", SERVICE_UUID);
 }
 
+// Swap the scan response for the window 2 payload (32-bit guard + terminator).
+void startAdvertisingPhase2() {
+  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
+  pAdvertising->stop();
+
+  BLEAdvertisementData scanResponse;
+  scanResponse.setName(serverName);
+  scanResponse.addData(badUuid32List, sizeof(badUuid32List));
+  scanResponse.addData(terminatedAd, sizeof(terminatedAd));
+  pAdvertising->setScanResponseData(scanResponse);
+
+  BLEDevice::startAdvertising();
+  // Configuring the payload is asynchronous on both stacks.
+  delay(500);
+  Serial.println("[SERVER] AD phase 2 advertising");
+}
+
 void loop() {
+  if (Serial.available()) {
+    String command = Serial.readStringUntil('\n');
+    command.trim();
+    if (command == "ADPHASE2") {
+      startAdvertisingPhase2();
+    }
+  }
+
   static unsigned long lastStatus = 0;
   if (millis() - lastStatus > 3000) {
     lastStatus = millis();

--- a/tests/validation/ble/test_ble.py
+++ b/tests/validation/ble/test_ble.py
@@ -54,7 +54,8 @@ def test_ble(dut, ci_job_id):
 
     # Client finds server
     LOGGER.info("Waiting for client to discover server...")
-    client.expect_exact("[CLIENT] Found target server!", timeout=60)
+    client.expect_exact("[CLIENT] PASS: oversize AD rejected", timeout=60)
+    client.expect_exact("[CLIENT] Found target server!", timeout=10)
 
     # Client connects to server
     LOGGER.info("Client connecting to server...")

--- a/tests/validation/ble/test_ble.py
+++ b/tests/validation/ble/test_ble.py
@@ -54,7 +54,8 @@ def test_ble(dut, ci_job_id):
 
     # Client finds server
     LOGGER.info("Waiting for client to discover server...")
-    client.expect_exact("[CLIENT] PASS: oversize AD rejected", timeout=60)
+    m = client.expect(r"\[CLIENT\] (PASS|FAIL): oversize AD (?:was not rejected|rejected)", timeout=60)
+    assert m.group(1).decode() == "PASS", f"Oversize AD handling failed: {m.group(0).decode()}"
     client.expect_exact("[CLIENT] Found target server!", timeout=10)
 
     # Client connects to server

--- a/tests/validation/ble/test_ble.py
+++ b/tests/validation/ble/test_ble.py
@@ -8,8 +8,10 @@ def test_ble(dut, ci_job_id):
     server = dut[0]
     client = dut[1]
 
-    # Generate unique server name for this test run
-    server_name = "BLE_SRV_" + ci_job_id if ci_job_id else "BLE_SRV_" + rand_str4()
+    # Generate unique server name for this test run. The suffix is kept at four
+    # characters so the scan response still fits the 31-octet limit alongside the
+    # malformed AD structures used by the advertisement parsing checks.
+    server_name = "BLE_SRV_" + (ci_job_id[-4:] if ci_job_id else rand_str4())
 
     LOGGER.info(f"Server Name: {server_name}")
 
@@ -54,8 +56,17 @@ def test_ble(dut, ci_job_id):
 
     # Client finds server
     LOGGER.info("Waiting for client to discover server...")
-    m = client.expect(r"\[CLIENT\] (PASS|FAIL): oversize AD (?:was not rejected|rejected)", timeout=60)
-    assert m.group(1).decode() == "PASS", f"Oversize AD handling failed: {m.group(0).decode()}"
+
+    # Advertisement parsing regression, window 1. The scan response hides an oversize
+    # AD structure, a 16-bit UUID list with a trailing partial octet and a 128-bit UUID
+    # structure shorter than 16 bytes. None of them may reach the parsed fields, so the
+    # only service UUID left is the valid one from the primary advertisement.
+    m = client.expect(r"\[CLIENT\] ADCHK1 mfg=(\d) svc16=(\d) svcCount=(\d+)", timeout=60)
+    assert int(m.group(1)) == 0, "oversize AD structure was parsed as manufacturer data"
+    assert int(m.group(2)) == 0, "16-bit UUID list with a trailing partial octet was parsed"
+    assert int(m.group(3)) == 1, f"expected only the advertised service UUID, got {int(m.group(3))}"
+    LOGGER.info("Advertisement parsing checks (window 1) passed")
+
     client.expect_exact("[CLIENT] Found target server!", timeout=10)
 
     # Client connects to server
@@ -166,5 +177,18 @@ def test_ble(dut, ci_job_id):
 
     client.expect_exact("[CLIENT] Reconnection stress test PASSED", timeout=10)
     LOGGER.info("Reconnection stress test passed")
+
+    # Advertisement parsing regression, window 2. The server now advertises a 32-bit
+    # UUID list with a trailing partial group followed by a zero-length terminator
+    # that hides manufacturer data. Parsing must stop at the terminator.
+    LOGGER.info("Switching server to advertisement parsing window 2...")
+    server.write("ADPHASE2")
+    server.expect_exact("[SERVER] AD phase 2 advertising", timeout=15)
+
+    client.write("ADPHASE2")
+    m = client.expect(r"\[CLIENT\] ADCHK2 mfg=(\d) svc32=(\d)", timeout=30)
+    assert int(m.group(1)) == 0, "AD structures behind the zero-length terminator were parsed"
+    assert int(m.group(2)) == 0, "32-bit UUID list with a trailing partial group was parsed"
+    LOGGER.info("Advertisement parsing checks (window 2) passed")
 
     LOGGER.info("BLE test passed!")


### PR DESCRIPTION
## Description of Change

This pull request improves the robustness of BLE advertisement parsing by adding checks to reject malformed or oversized Advertisement Data (AD) structures. It also updates server and client test code to validate and report on the handling of such malformed data.

**BLE advertisement parsing robustness:**

* [`BLEAdvertisedDevice.cpp`](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33L433-R439): Added checks in `parseAdvertisement` to ensure the payload is not null or empty and to reject AD structures whose length exceeds the remaining buffer, preventing out-of-bounds reads and potential memory corruption. [[1]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33L433-R439) [[2]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33R465-R477)

* Added specific guards for 16-bit, 32-bit, and 128-bit UUID advertisement types to ensure the data is not truncated and is properly aligned, logging and skipping malformed entries. [[1]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33R522-R528) [[2]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33R538-R543) [[3]](diffhunk://#diff-39e70018df8ff93e9c6a42da0e7e6ed7340808cb78218cf7809fff3567076c33R552-R556)

**Test enhancements for malformed AD structures:**

* [`server.ino`](diffhunk://#diff-2d3783c522e1b5afb2b60cf8a2127ebe9a7de3d25d699670611a3c506e8e29f8L178-R191): Modified the server to include a deliberately malformed (oversized) AD structure in the scan response to test the parser's robustness.
* [`client.ino`](diffhunk://#diff-3a6ffb6ae7c472687175ba46332e4d5f89fc6c471b9caf36fa8bae0b646d4cc7R158-R163): Updated the client to check for the absence of manufacturer data when an oversize AD is present, reporting pass/fail accordingly.
* [`test_ble.py`](diffhunk://#diff-5bca0e59099bef2c1d0a14f2e8748ea19dd1395d5364a8abd9fc30d27081e573L57-R58): Adjusted the test script to expect the new client output confirming correct rejection of the oversize AD.

## Test Scenarios

Tested locally

## Related links

Closes #12801
