### PR TITLE
feat(board): add Waveshare ESP32-C5-Zero

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -46265,6 +46265,182 @@ waveshare_esp32_c3_zero.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr
 
 ##############################################################
 
+waveshare_esp32_c5_zero.name=Waveshare ESP32-C5-Zero
+
+waveshare_esp32_c5_zero.bootloader.tool=esptool_py
+waveshare_esp32_c5_zero.bootloader.tool.default=esptool_py
+
+waveshare_esp32_c5_zero.upload.tool=esptool_py
+waveshare_esp32_c5_zero.upload.tool.default=esptool_py
+waveshare_esp32_c5_zero.upload.tool.network=esp_ota
+
+waveshare_esp32_c5_zero.upload.maximum_size=1310720
+waveshare_esp32_c5_zero.upload.maximum_data_size=327680
+waveshare_esp32_c5_zero.upload.flags=
+waveshare_esp32_c5_zero.upload.erase_cmd=
+waveshare_esp32_c5_zero.upload.extra_flags=
+waveshare_esp32_c5_zero.upload.use_1200bps_touch=false
+waveshare_esp32_c5_zero.upload.wait_for_upload_port=false
+
+waveshare_esp32_c5_zero.serial.disableDTR=false
+waveshare_esp32_c5_zero.serial.disableRTS=false
+
+waveshare_esp32_c5_zero.build.tarch=riscv32
+waveshare_esp32_c5_zero.build.target=esp
+waveshare_esp32_c5_zero.build.mcu=esp32c5
+waveshare_esp32_c5_zero.build.core=esp32
+waveshare_esp32_c5_zero.build.variant=waveshare_esp32_c5_zero
+waveshare_esp32_c5_zero.build.board=WAVESHARE_ESP32_C5_ZERO
+waveshare_esp32_c5_zero.build.bootloader_addr=0x2000
+
+waveshare_esp32_c5_zero.build.cdc_on_boot=1
+waveshare_esp32_c5_zero.build.f_cpu=240000000L
+waveshare_esp32_c5_zero.build.flash_size=4MB
+waveshare_esp32_c5_zero.build.flash_freq=80m
+waveshare_esp32_c5_zero.build.flash_mode=qio
+waveshare_esp32_c5_zero.build.boot=qio
+waveshare_esp32_c5_zero.build.partitions=default
+waveshare_esp32_c5_zero.build.defines=
+
+## IDE 2.0 Seems to not update the value
+waveshare_esp32_c5_zero.menu.JTAGAdapter.default=Disabled
+waveshare_esp32_c5_zero.menu.JTAGAdapter.default.build.copy_jtag_files=0
+waveshare_esp32_c5_zero.menu.JTAGAdapter.builtin=Integrated USB JTAG
+waveshare_esp32_c5_zero.menu.JTAGAdapter.builtin.build.openocdscript=esp32c5-builtin.cfg
+waveshare_esp32_c5_zero.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+waveshare_esp32_c5_zero.menu.JTAGAdapter.external=FTDI Adapter
+waveshare_esp32_c5_zero.menu.JTAGAdapter.external.build.openocdscript=esp32c5-ftdi.cfg
+waveshare_esp32_c5_zero.menu.JTAGAdapter.external.build.copy_jtag_files=1
+waveshare_esp32_c5_zero.menu.JTAGAdapter.bridge=ESP USB Bridge
+waveshare_esp32_c5_zero.menu.JTAGAdapter.bridge.build.openocdscript=esp32c5-bridge.cfg
+waveshare_esp32_c5_zero.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+waveshare_esp32_c5_zero.menu.CDCOnBoot.default=Enabled
+waveshare_esp32_c5_zero.menu.CDCOnBoot.default.build.cdc_on_boot=1
+waveshare_esp32_c5_zero.menu.CDCOnBoot.cdc=Disabled
+waveshare_esp32_c5_zero.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+waveshare_esp32_c5_zero.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_c5_zero.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_c5_zero.menu.PartitionScheme.minimal=Minimal (1.3MB APP/700KB SPIFFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.minimal.build.partitions=minimal
+waveshare_esp32_c5_zero.menu.PartitionScheme.no_fs=No FS 4MB (2MB APP x2)
+waveshare_esp32_c5_zero.menu.PartitionScheme.no_fs.build.partitions=no_fs
+waveshare_esp32_c5_zero.menu.PartitionScheme.no_fs.upload.maximum_size=2031616
+waveshare_esp32_c5_zero.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_c5_zero.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_c5_zero.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_c5_zero.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_c5_zero.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_c5_zero.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
+waveshare_esp32_c5_zero.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_c5_zero.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_c5_zero.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_c5_zero.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_c5_zero.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_c5_zero.menu.PartitionScheme.rainmaker_4MB=RainMaker 4MB No OTA
+waveshare_esp32_c5_zero.menu.PartitionScheme.rainmaker_4MB.build.partitions=rainmaker_4MB_no_ota
+waveshare_esp32_c5_zero.menu.PartitionScheme.rainmaker_4MB.upload.maximum_size=4038656
+waveshare_esp32_c5_zero.menu.PartitionScheme.zigbee=Zigbee 4MB with spiffs
+waveshare_esp32_c5_zero.menu.PartitionScheme.zigbee.build.partitions=zigbee
+waveshare_esp32_c5_zero.menu.PartitionScheme.zigbee.upload.maximum_size=1310720
+waveshare_esp32_c5_zero.menu.PartitionScheme.zigbee_zczr=Zigbee ZCZR 4MB with spiffs
+waveshare_esp32_c5_zero.menu.PartitionScheme.zigbee_zczr.build.partitions=zigbee_zczr
+waveshare_esp32_c5_zero.menu.PartitionScheme.zigbee_zczr.upload.maximum_size=1310720
+waveshare_esp32_c5_zero.menu.PartitionScheme.custom=Custom
+waveshare_esp32_c5_zero.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_c5_zero.menu.PartitionScheme.custom.upload.maximum_size=4194304
+
+waveshare_esp32_c5_zero.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_c5_zero.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_c5_zero.menu.CPUFreq.120=120MHz (WiFi)
+waveshare_esp32_c5_zero.menu.CPUFreq.120.build.f_cpu=120000000L
+waveshare_esp32_c5_zero.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_c5_zero.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_c5_zero.menu.CPUFreq.40=40MHz
+waveshare_esp32_c5_zero.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_c5_zero.menu.CPUFreq.20=20MHz
+waveshare_esp32_c5_zero.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_c5_zero.menu.CPUFreq.10=10MHz
+waveshare_esp32_c5_zero.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_c5_zero.menu.FlashMode.qio=QIO
+waveshare_esp32_c5_zero.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_c5_zero.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_c5_zero.menu.FlashMode.dio=DIO
+waveshare_esp32_c5_zero.menu.FlashMode.dio.build.flash_mode=dio
+waveshare_esp32_c5_zero.menu.FlashMode.dio.build.boot=dio
+
+waveshare_esp32_c5_zero.menu.FlashFreq.80=80MHz
+waveshare_esp32_c5_zero.menu.FlashFreq.80.build.flash_freq=80m
+waveshare_esp32_c5_zero.menu.FlashFreq.40=40MHz
+waveshare_esp32_c5_zero.menu.FlashFreq.40.build.flash_freq=40m
+
+waveshare_esp32_c5_zero.menu.FlashSize.4M=4MB (32Mb)
+waveshare_esp32_c5_zero.menu.FlashSize.4M.build.flash_size=4MB
+
+waveshare_esp32_c5_zero.menu.UploadSpeed.921600=921600
+waveshare_esp32_c5_zero.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_c5_zero.menu.UploadSpeed.115200=115200
+waveshare_esp32_c5_zero.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_c5_zero.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_c5_zero.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_c5_zero.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_c5_zero.menu.UploadSpeed.230400=230400
+waveshare_esp32_c5_zero.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_c5_zero.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_c5_zero.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_c5_zero.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_c5_zero.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_c5_zero.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_c5_zero.menu.DebugLevel.none=None
+waveshare_esp32_c5_zero.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_c5_zero.menu.DebugLevel.error=Error
+waveshare_esp32_c5_zero.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_c5_zero.menu.DebugLevel.warn=Warn
+waveshare_esp32_c5_zero.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_c5_zero.menu.DebugLevel.info=Info
+waveshare_esp32_c5_zero.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_c5_zero.menu.DebugLevel.debug=Debug
+waveshare_esp32_c5_zero.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_c5_zero.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_c5_zero.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_c5_zero.menu.EraseFlash.none=Disabled
+waveshare_esp32_c5_zero.menu.EraseFlash.all=Enabled
+waveshare_esp32_c5_zero.menu.EraseFlash.all.upload.erase_cmd=-e
+
+waveshare_esp32_c5_zero.menu.ZigbeeMode.default=Disabled
+waveshare_esp32_c5_zero.menu.ZigbeeMode.default.build.zigbee_mode=
+waveshare_esp32_c5_zero.menu.ZigbeeMode.default.build.zigbee_libs=
+waveshare_esp32_c5_zero.menu.ZigbeeMode.ed=Zigbee ED (end device)
+waveshare_esp32_c5_zero.menu.ZigbeeMode.ed.build.zigbee_mode=-DZIGBEE_MODE_ED
+waveshare_esp32_c5_zero.menu.ZigbeeMode.ed.build.zigbee_libs=-lesp_zb_api.ed -lzboss_stack.ed -lzboss_port.native
+waveshare_esp32_c5_zero.menu.ZigbeeMode.zczr=Zigbee ZCZR (coordinator/router)
+waveshare_esp32_c5_zero.menu.ZigbeeMode.zczr.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+waveshare_esp32_c5_zero.menu.ZigbeeMode.zczr.build.zigbee_libs=-lesp_zb_api.zczr -lzboss_stack.zczr -lzboss_port.native
+waveshare_esp32_c5_zero.menu.ZigbeeMode.ed_debug=Zigbee ED (end device) - Debug
+waveshare_esp32_c5_zero.menu.ZigbeeMode.ed_debug.build.zigbee_mode=-DZIGBEE_MODE_ED
+waveshare_esp32_c5_zero.menu.ZigbeeMode.ed_debug.build.zigbee_libs=-lesp_zb_api.ed.debug -lzboss_stack.ed.debug -lzboss_port.native.debug
+waveshare_esp32_c5_zero.menu.ZigbeeMode.zczr_debug=Zigbee ZCZR (coordinator/router) - Debug
+waveshare_esp32_c5_zero.menu.ZigbeeMode.zczr_debug.build.zigbee_mode=-DZIGBEE_MODE_ZCZR
+waveshare_esp32_c5_zero.menu.ZigbeeMode.zczr_debug.build.zigbee_libs=-lesp_zb_api.zczr.debug -lzboss_stack.zczr.debug -lzboss_port.native.debug
+
+##############################################################
+
 waveshare_esp32_c6_zero.name=Waveshare ESP32-C6-Zero
 
 waveshare_esp32_c6_zero.bootloader.tool=esptool_py

--- a/variants/waveshare_esp32_c5_zero/pins_arduino.h
+++ b/variants/waveshare_esp32_c5_zero/pins_arduino.h
@@ -20,8 +20,8 @@ static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
 #define BUILTIN_LED LED_BUILTIN  // backward compatibility
 #define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
 // RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
-#define RGB_BUILTIN    LED_BUILTIN
-#define RGB_BRIGHTNESS 64
+#define RGB_BUILTIN                 LED_BUILTIN
+#define RGB_BRIGHTNESS              64
 #define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB
 
 static const uint8_t TX = 11;

--- a/variants/waveshare_esp32_c5_zero/pins_arduino.h
+++ b/variants/waveshare_esp32_c5_zero/pins_arduino.h
@@ -1,0 +1,59 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+/*
+  Exposed GPIOs:
+  - Headers: GPIO0-GPIO14 (GPIO11/12 are UART0, GPIO13/14 are USB D-/D+)
+  - Test pads: GPIO23, GPIO24, GPIO25, GPIO28 (BOOT)
+  - Onboard: GPIO26 antenna select, GPIO27 WS2812 RGB LED
+*/
+
+// LOW selects the onboard antenna; HIGH selects the IPEX-1 antenna.
+#define ANT_SELECT 26
+
+#define PIN_RGB_LED 27
+// BUILTIN_LED can be used in new Arduino API digitalWrite() like in Blink.ino
+static const uint8_t LED_BUILTIN = SOC_GPIO_PIN_COUNT + PIN_RGB_LED;
+#define BUILTIN_LED LED_BUILTIN  // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+// RGB_BUILTIN and RGB_BRIGHTNESS can be used in new Arduino API rgbLedWrite()
+#define RGB_BUILTIN    LED_BUILTIN
+#define RGB_BRIGHTNESS 64
+#define RGB_BUILTIN_LED_COLOR_ORDER LED_COLOR_ORDER_RGB
+
+static const uint8_t TX = 11;
+static const uint8_t RX = 12;
+
+static const uint8_t USB_DM = 13;
+static const uint8_t USB_DP = 14;
+
+static const uint8_t SDA = 0;
+static const uint8_t SCL = 1;
+
+static const uint8_t SS = 6;
+static const uint8_t MOSI = 8;
+static const uint8_t MISO = 9;
+static const uint8_t SCK = 10;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+
+// LP I2C pins are fixed on ESP32-C5.
+static const uint8_t LP_SDA = 2;
+static const uint8_t LP_SCL = 3;
+#define WIRE1_PIN_DEFINED
+#define SDA1 LP_SDA
+#define SCL1 LP_SCL
+
+// LP UART pins are fixed on ESP32-C5.
+static const uint8_t LP_RX = 4;
+static const uint8_t LP_TX = 5;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
## Description of Change

Adds Arduino board support for the Waveshare ESP32-C5-Zero.

- Adds `waveshare_esp32_c5_zero` to `boards.txt`
- Configures ESP32-C5 at 240 MHz with 4 MB QIO Flash at 80 MHz, native USB CDC enabled by default, and no PSRAM
- Adds a dedicated variant with GPIO26 antenna selection and GPIO27 WS2812 support
- Defines schematic-backed UART0 and native USB pins
- Adds the applicable ESP32-C5 JTAG, partition, CPU, Flash, upload, debug, erase, and Zigbee menus

The hardware configuration is based on the ESP32-C5HF4 specification and the Waveshare schematic. The ESP32-C5HF4 includes 4 MB Quad SPI Flash and does not include PSRAM.

## Test Scenarios

Software-only validation on Windows; no physical board was attached.

- `git diff --check`
- `.github/scripts/validate_board.sh waveshare_esp32_c5_zero` (all six rules passed)
- `.github/scripts/ci_testing/test_find_boards.py` (12/12 passed)
- Confirmed FQBN discovery: `espressif:esp32:waveshare_esp32_c5_zero`
- Compiled a minimal sketch for the FQBN with `--warnings all --no-object-cache` (65/65 build targets completed)
- Compile-time assertions verified GPIO26, GPIO27, UART0, and native USB pins

Hardware validation remains pending for native USB enumeration/download, manual BOOT download mode, RGB LED behavior, and antenna switching.

## Related links

- https://www.waveshare.net/shop/ESP32-C5-Zero.htm
- https://docs.waveshare.com/ESP32-C5-Zero
- https://docs.waveshare.com/ESP32-C5-Zero/Resources-And-Documents
- https://github.com/waveshareteam/ESP32-C5-Zero
- https://github.com/waveshareteam/ESP32-C5-Zero/blob/main/hardware/schematics/ESP32-C5-Zero.pdf
- https://documentation.espressif.com/esp32-c5_datasheet_en.pdf
