### PR TITLE
feat(board): add Waveshare ESP32-S3-Touch-LCD-4.3C

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -48336,6 +48336,198 @@ waveshare_esp32_s3_touch_lcd_43B.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+waveshare_esp32_s3_touch_lcd_43C.name=Waveshare ESP32-S3-Touch-LCD-4.3C
+
+waveshare_esp32_s3_touch_lcd_43C.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_43C.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_43C.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_43C.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_43C.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_43C.upload.maximum_size=1310720
+
+waveshare_esp32_s3_touch_lcd_43C.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_43C.upload.flags=
+waveshare_esp32_s3_touch_lcd_43C.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_43C.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_43C.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_43C.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_43C.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_43C.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_43C.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_43C.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_43C.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_43C.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_43C.build.core=esp32
+waveshare_esp32_s3_touch_lcd_43C.build.variant=waveshare_esp32_s3_touch_lcd_43c
+waveshare_esp32_s3_touch_lcd_43C.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_43C
+
+waveshare_esp32_s3_touch_lcd_43C.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_43C.build.cdc_on_boot=1
+waveshare_esp32_s3_touch_lcd_43C.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43C.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_43C.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_43C.build.flash_size=16MB
+waveshare_esp32_s3_touch_lcd_43C.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_43C.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43C.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43C.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_43C.build.partitions=default
+waveshare_esp32_s3_touch_lcd_43C.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_43C.build.loop_core=
+waveshare_esp32_s3_touch_lcd_43C.build.event_core=
+waveshare_esp32_s3_touch_lcd_43C.build.psram_type=opi
+waveshare_esp32_s3_touch_lcd_43C.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_touch_lcd_43C.menu.PSRAM.enabled=Enabled
+waveshare_esp32_s3_touch_lcd_43C.menu.PSRAM.enabled.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_43C.menu.PSRAM.enabled.build.psram_type=opi
+waveshare_esp32_s3_touch_lcd_43C.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_43C.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_43C.menu.PSRAM.disabled.build.psram_type=qspi
+
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio120=QIO 120MHz
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio120.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio120.build.boot=qio
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio120.build.boot_freq=120m
+waveshare_esp32_s3_touch_lcd_43C.menu.FlashMode.qio120.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_43C.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_43C.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_43C.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_43C.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_43C.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_43C.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_43C.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_43C.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_43C.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_43C.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_43C.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_43C.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_43C.menu.CDCOnBoot.default=Enabled
+waveshare_esp32_s3_touch_lcd_43C.menu.CDCOnBoot.default.build.cdc_on_boot=1
+waveshare_esp32_s3_touch_lcd_43C.menu.CDCOnBoot.cdc=Disabled
+waveshare_esp32_s3_touch_lcd_43C.menu.CDCOnBoot.cdc.build.cdc_on_boot=0
+
+waveshare_esp32_s3_touch_lcd_43C.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43C.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_43C.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_43C.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43C.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_43C.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_43C.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_43C.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.app3M_fat9M_16MB=16M Flash (3MB APP/9.9MB FATFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.app3M_fat9M_16MB.build.partitions=app3M_fat9M_16MB
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.app3M_fat9M_16MB.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.default=Default 4MB with spiffs (1.2MB APP/1.5MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.default.build.partitions=default
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.defaultffat=Default 4MB with ffat (1.2MB APP/1.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.defaultffat.build.partitions=default_ffat
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.no_ota=No OTA (2MB APP/2MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.no_ota.build.partitions=no_ota
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.no_ota.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_3g=No OTA (1MB APP/3MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_3g.build.partitions=noota_3g
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_3g.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_ffat=No OTA (2MB APP/2MB FATFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_ffat.build.partitions=noota_ffat
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_ffat.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_3gffat=No OTA (1MB APP/3MB FATFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_3gffat.build.partitions=noota_3gffat
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.noota_3gffat.upload.maximum_size=1048576
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.huge_app=Huge APP (3MB No OTA/1MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.huge_app.build.partitions=huge_app
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.huge_app.upload.maximum_size=3145728
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.min_spiffs=Minimal SPIFFS (1.9MB APP with OTA/128KB SPIFFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.min_spiffs.build.partitions=min_spiffs
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.min_spiffs.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.rainmaker=RainMaker 4MB
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.rainmaker.build.partitions=rainmaker
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.rainmaker.upload.maximum_size=1966080
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.rainmaker_8MB=RainMaker 8MB
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.rainmaker_8MB.build.partitions=rainmaker_8MB
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.rainmaker_8MB.upload.maximum_size=4096000
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.fatflash=16M Flash (2MB APP/12.5MB FATFS)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.fatflash.build.partitions=ffat
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.fatflash.upload.maximum_size=2097152
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.otanofs=OTA no FS (2MB APP with OTA)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.otanofs.build.custom_partitions=partitions_otanofs_4MB
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.otanofs.upload.maximum_size=2031616
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.all_app=Max APP (4MB APP no OTA)
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.all_app.build.custom_partitions=partitions_all_app_4MB
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.all_app.upload.maximum_size=4128768
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_43C.menu.PartitionScheme.custom.upload.maximum_size=16777216
+
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_43C.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_43C.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_43C.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_43C.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_43C.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_43C.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 waveshare_esp32_s3_touch_lcd_7.name=Waveshare ESP32-S3-Touch-LCD-7
 waveshare_esp32_s3_touch_lcd_7.vid.0=0x303a
 waveshare_esp32_s3_touch_lcd_7.pid.0=0x8234

--- a/variants/waveshare_esp32_s3_touch_lcd_43c/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_43c/pins_arduino.h
@@ -1,0 +1,89 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-4.3C"
+#define USB_SERIAL       ""
+
+// Native USB
+#define USB_DN 19
+#define USB_DP 20
+
+// ST7262 RGB display
+#define WS_LCD_B3 14
+#define WS_LCD_B4 38
+#define WS_LCD_B5 18
+#define WS_LCD_B6 17
+#define WS_LCD_B7 10
+
+#define WS_LCD_G2 39
+#define WS_LCD_G3 0
+#define WS_LCD_G4 45
+#define WS_LCD_G5 48
+#define WS_LCD_G6 47
+#define WS_LCD_G7 21
+
+#define WS_LCD_R3 1
+#define WS_LCD_R4 2
+#define WS_LCD_R5 42
+#define WS_LCD_R6 41
+#define WS_LCD_R7 40
+
+#define WS_LCD_VSYNC 3
+#define WS_LCD_HSYNC 46
+#define WS_LCD_PCLK  7
+#define WS_LCD_DE    5
+
+// GT911 touch controller
+#define WS_TP_SDA 8
+#define WS_TP_SCL 9
+#define WS_TP_RST -1
+#define WS_TP_INT 4
+
+// SD card in 1-bit SDMMC mode
+#define BOARD_HAS_SDMMC
+#define BOARD_HAS_1BIT_SDMMC
+#define SDMMC_CMD 11
+#define SDMMC_CLK 12
+#define SDMMC_D0  13
+
+// ES8311 codec and ES7210 ADC
+#define I2S_MCLK 6
+#define I2S_DOUT 15
+#define I2S_LRCK 16
+#define I2S_SDIN 43
+#define I2S_SCLK 44
+
+// I2C IO expander channels. These indexes are not ESP32 GPIO numbers.
+#define WS_IO_EXT_SDA  8
+#define WS_IO_EXT_SCL  9
+#define WS_IO_EXT_ADDR 0x24
+
+#define WS_EXIO_DI0      0
+#define WS_EXIO_TP_RST   1
+#define WS_EXIO_LCD_BL   2
+#define WS_EXIO_PA_EN    3
+#define WS_EXIO_SD_CS    4
+#define WS_EXIO_DI1      5
+#define WS_EXIO_DO0      6
+#define WS_EXIO_DO1      7
+
+// The board exposes native USB but no dedicated UART or SPI pins.
+static const uint8_t TX = -1;
+static const uint8_t RX = -1;
+
+static const uint8_t SDA = 8;
+static const uint8_t SCL = 9;
+
+static const uint8_t SS = -1;
+static const uint8_t MOSI = -1;
+static const uint8_t MISO = -1;
+static const uint8_t SCK = -1;
+
+#endif /* Pins_Arduino_h */

--- a/variants/waveshare_esp32_s3_touch_lcd_43c/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_43c/pins_arduino.h
@@ -65,14 +65,14 @@
 #define WS_IO_EXT_SCL  9
 #define WS_IO_EXT_ADDR 0x24
 
-#define WS_EXIO_DI0      0
-#define WS_EXIO_TP_RST   1
-#define WS_EXIO_LCD_BL   2
-#define WS_EXIO_PA_EN    3
-#define WS_EXIO_SD_CS    4
-#define WS_EXIO_DI1      5
-#define WS_EXIO_DO0      6
-#define WS_EXIO_DO1      7
+#define WS_EXIO_DI0    0
+#define WS_EXIO_TP_RST 1
+#define WS_EXIO_LCD_BL 2
+#define WS_EXIO_PA_EN  3
+#define WS_EXIO_SD_CS  4
+#define WS_EXIO_DI1    5
+#define WS_EXIO_DO0    6
+#define WS_EXIO_DO1    7
 
 // The board exposes native USB but no dedicated UART or SPI pins.
 static const uint8_t TX = -1;


### PR DESCRIPTION
## Description of Change

Adds board support for the Waveshare ESP32-S3-Touch-LCD-4.3C.

- Adds the `waveshare_esp32_s3_touch_lcd_43C` board definition.
- Configures the ESP32-S3-WROOM-1-N16R8 module with 16 MB QIO flash, 8 MB OPI PSRAM, 240 MHz CPU, native USB CDC/JTAG, and CDC on boot enabled by default.
- Uses the 16 MB 3 MB APP / 9.9 MB FATFS partition scheme by default.
- Adds variant definitions for the ST7262 RGB display, GT911 touch controller, 1-bit SDMMC, ES8311/ES7210 audio, native USB, and the 0x24 I/O expander channels.
- Intentionally omits board-specific VID/PID autodetection entries because no unique USB PID is currently allocated for this board.

## Test Scenarios

- `git diff --check`
- `.github/scripts/validate_board.sh waveshare_esp32_s3_touch_lcd_43C`
- Board discovery returned only `espressif:esp32:waveshare_esp32_s3_touch_lcd_43C`.
- Arduino CLI 1.5.1 compiled `CIBoardsTest` with the exact FQBN using the repository's 3.3.11 platform: 305,427 bytes flash and 23,748 bytes RAM.
- A temporary static-assert sketch compiled successfully for all LCD, touch, USB, SDMMC, audio, and I/O-expander pin definitions.

Real-hardware verification is still required for native USB upload/CDC, LCD and touch operation, the EXIO4-gated 1-bit SDMMC path, audio, and isolated I/O.

## Related Links

- [Product page](https://www.waveshare.net/shop/ESP32-S3-Touch-LCD-4.3C.htm)
- [Official documentation](https://docs.waveshare.com/ESP32-S3-Touch-LCD-4.3C)
- [Official source repository](https://github.com/waveshareteam/ESP32-S3-Touch-LCD-4.3C/tree/2abc815238a779a89095d043c4ceb365a3b3c11c)
- [Official schematic](https://github.com/waveshareteam/ESP32-S3-Touch-LCD-4.3C/blob/2abc815238a779a89095d043c4ceb365a3b3c11c/hardware/schematics/ESP32-S3-Touch-LCD-4.3C-Schematics.pdf)

## Checklist

- [x] The title identifies the affected board.
- [x] Official hardware references are included.
- [x] No separate documentation update is required; the board registry and variant are the integration surface.
- [x] The contributing guide was reviewed.
- [x] Maintainer edits are enabled.