### PR TITLE
feat(doc):  include Home Assistant as Matter environment

### DIFF
--- a/docs/en/matter/matter.rst
+++ b/docs/en/matter/matter.rst
@@ -11,7 +11,7 @@ The Matter library provides support for creating Matter-compatible devices inclu
 * Matter commissioning via QR code or manual pairing code
 * Multiple endpoint types for various device categories
 * Event monitoring and callback support
-* Integration with Apple HomeKit, Amazon Alexa, and Google Home
+* Integration with Home Assistand, Apple HomeKit, Amazon Alexa, and Google Home
 * Smart home ecosystem compatibility
 
 The Matter library is built on top of `ESP Matter SDK <https://github.com/espressif/esp-matter>`_ and provides a high-level Arduino-style interface for creating Matter devices.

--- a/docs/en/matter/matter.rst
+++ b/docs/en/matter/matter.rst
@@ -11,7 +11,7 @@ The Matter library provides support for creating Matter-compatible devices inclu
 * Matter commissioning via QR code or manual pairing code
 * Multiple endpoint types for various device categories
 * Event monitoring and callback support
-* Integration with Home Assistand, Apple HomeKit, Amazon Alexa, and Google Home
+* Integration with Home Assistant, Apple HomeKit, Amazon Alexa, and Google Home
 * Smart home ecosystem compatibility
 
 The Matter library is built on top of `ESP Matter SDK <https://github.com/espressif/esp-matter>`_ and provides a high-level Arduino-style interface for creating Matter devices.


### PR DESCRIPTION

## Description of Change

This pull request makes a minor update to the documentation for the Matter library, correcting and expanding the list of supported smart home integrations.

- Documentation update:
  * Added "Home Assistand" to the list of supported smart home integrations in the Matter library documentation.

## Test Scenarios
DOC CI only.

## Related links
None