### PR TITLE
feat(board): Add Waveshare ESP32-S3-Touch-LCD-7C-BOX board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -48537,6 +48537,177 @@ waveshare_esp32_s3_touch_lcd_7.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+waveshare_esp32_s3_touch_lcd_7c.name=Waveshare ESP32-S3-Touch-LCD-7C-BOX
+
+waveshare_esp32_s3_touch_lcd_7c.bootloader.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_7c.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_touch_lcd_7c.upload.tool=esptool_py
+waveshare_esp32_s3_touch_lcd_7c.upload.tool.default=esptool_py
+waveshare_esp32_s3_touch_lcd_7c.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_touch_lcd_7c.upload.maximum_size=4718592
+waveshare_esp32_s3_touch_lcd_7c.upload.maximum_data_size=327680
+waveshare_esp32_s3_touch_lcd_7c.upload.flags=
+waveshare_esp32_s3_touch_lcd_7c.upload.erase_cmd=
+waveshare_esp32_s3_touch_lcd_7c.upload.extra_flags=
+waveshare_esp32_s3_touch_lcd_7c.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_7c.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_touch_lcd_7c.serial.disableDTR=false
+waveshare_esp32_s3_touch_lcd_7c.serial.disableRTS=false
+
+waveshare_esp32_s3_touch_lcd_7c.build.tarch=xtensa
+waveshare_esp32_s3_touch_lcd_7c.build.bootloader_addr=0x0
+waveshare_esp32_s3_touch_lcd_7c.build.target=esp32s3
+waveshare_esp32_s3_touch_lcd_7c.build.mcu=esp32s3
+waveshare_esp32_s3_touch_lcd_7c.build.core=esp32
+waveshare_esp32_s3_touch_lcd_7c.build.variant=waveshare_esp32_s3_touch_lcd_7c
+waveshare_esp32_s3_touch_lcd_7c.build.board=WAVESHARE_ESP32_S3_TOUCH_LCD_7C
+
+waveshare_esp32_s3_touch_lcd_7c.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_7c.build.cdc_on_boot=1
+waveshare_esp32_s3_touch_lcd_7c.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_7c.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_7c.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_7c.build.flash_size=32MB
+waveshare_esp32_s3_touch_lcd_7c.build.flash_freq=80m
+waveshare_esp32_s3_touch_lcd_7c.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_7c.build.boot=qio
+waveshare_esp32_s3_touch_lcd_7c.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_7c.build.partitions=large_fat_32MB
+waveshare_esp32_s3_touch_lcd_7c.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_7c.build.loop_core=
+waveshare_esp32_s3_touch_lcd_7c.build.event_core=
+waveshare_esp32_s3_touch_lcd_7c.build.psram_type=opi
+waveshare_esp32_s3_touch_lcd_7c.build.memory_type={build.boot}_{build.psram_type}
+
+## IDE 2.0 Seems to not update the value
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.default=Disabled
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.default.build.copy_jtag_files=0
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.builtin=Integrated USB JTAG
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.builtin.build.openocdscript=esp32s3-builtin.cfg
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.builtin.build.copy_jtag_files=1
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.external=FTDI Adapter
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.external.build.openocdscript=esp32s3-ftdi.cfg
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.external.build.copy_jtag_files=1
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.bridge=ESP USB Bridge
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.bridge.build.openocdscript=esp32s3-bridge.cfg
+waveshare_esp32_s3_touch_lcd_7c.menu.JTAGAdapter.bridge.build.copy_jtag_files=1
+
+waveshare_esp32_s3_touch_lcd_7c.menu.PSRAM.opi=OPI PSRAM
+waveshare_esp32_s3_touch_lcd_7c.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_touch_lcd_7c.menu.PSRAM.opi.build.psram_type=opi
+waveshare_esp32_s3_touch_lcd_7c.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_touch_lcd_7c.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_touch_lcd_7c.menu.PSRAM.disabled.build.psram_type=opi
+
+waveshare_esp32_s3_touch_lcd_7c.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_touch_lcd_7c.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_touch_lcd_7c.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_touch_lcd_7c.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_touch_lcd_7c.menu.FlashMode.qio.build.flash_freq=80m
+
+waveshare_esp32_s3_touch_lcd_7c.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_7c.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_7c.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_7c.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_7c.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_touch_lcd_7c.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_touch_lcd_7c.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_touch_lcd_7c.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_touch_lcd_7c.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_touch_lcd_7c.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_touch_lcd_7c.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_touch_lcd_7c.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_touch_lcd_7c.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_touch_lcd_7c.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+waveshare_esp32_s3_touch_lcd_7c.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_7c.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+waveshare_esp32_s3_touch_lcd_7c.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_7c.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_touch_lcd_7c.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_7c.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_7c.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_touch_lcd_7c.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_touch_lcd_7c.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_touch_lcd_7c.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app5M_little24M_32MB=32M Flash (4.8MB APP/22MB LittleFS)
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app5M_little24M_32MB.build.partitions=large_littlefs_32MB
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app5M_little24M_32MB.upload.maximum_size=4718592
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app13M_data7M_32MB=32M Flash (13MB APP/6.75MB SPIFFS)
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app13M_data7M_32MB.build.partitions=default_32MB
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.app13M_data7M_32MB.upload.maximum_size=13107200
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.max_app_32MB=Max APP 32MB (31.4 MB)
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.max_app_32MB.build.partitions=max_app_32MB
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.max_app_32MB.upload.maximum_size=33423360
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.custom=Custom
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.custom.build.partitions=
+waveshare_esp32_s3_touch_lcd_7c.menu.PartitionScheme.custom.upload.maximum_size=33554432
+
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.40.build.f_cpu=40000000L
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.20=20MHz
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.20.build.f_cpu=20000000L
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.10=10MHz
+waveshare_esp32_s3_touch_lcd_7c.menu.CPUFreq.10.build.f_cpu=10000000L
+
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.256000.windows=256000
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.256000.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.230400.windows.upload.speed=256000
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.230400=230400
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.230400.upload.speed=230400
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.460800.upload.speed=460800
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.512000.windows=512000
+waveshare_esp32_s3_touch_lcd_7c.menu.UploadSpeed.512000.upload.speed=512000
+
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.none=None
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.error=Error
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.info=Info
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_touch_lcd_7c.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_touch_lcd_7c.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_touch_lcd_7c.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_touch_lcd_7c.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 waveshare_esp32_s3_touch_lcd_5.name=Waveshare ESP32-S3-Touch-LCD-5
 waveshare_esp32_s3_touch_lcd_5.vid.0=0x303a
 waveshare_esp32_s3_touch_lcd_5.pid.0=0x8237

--- a/variants/waveshare_esp32_s3_touch_lcd_7c/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_touch_lcd_7c/pins_arduino.h
@@ -1,0 +1,97 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+#include "soc/soc_caps.h"
+
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-Touch-LCD-7C-BOX"
+#define USB_SERIAL       ""
+
+// RGB display
+#define WS_LCD_B3 14
+#define WS_LCD_B4 38
+#define WS_LCD_B5 18
+#define WS_LCD_B6 17
+#define WS_LCD_B7 10
+
+#define WS_LCD_G2 39
+#define WS_LCD_G3 0
+#define WS_LCD_G4 45
+#define WS_LCD_G5 9
+#define WS_LCD_G6 8
+#define WS_LCD_G7 21
+
+#define WS_LCD_R3 1
+#define WS_LCD_R4 2
+#define WS_LCD_R5 42
+#define WS_LCD_R6 41
+#define WS_LCD_R7 40
+
+#define WS_LCD_VSYNC 3
+#define WS_LCD_HSYNC 46
+#define WS_LCD_PCLK  7
+#define WS_LCD_DE    5
+#define WS_LCD_RST   -1
+#define WS_LCD_BL    -1
+
+// GT911 touch controller
+#define WS_TP_SDA 47
+#define WS_TP_SCL 48
+#define WS_TP_RST -1
+#define WS_TP_INT 4
+
+// CH32V006 I2C IO expander channels; these are not ESP32 GPIO numbers.
+#define WS_IO_EXPANDER_ADDR 0x24
+#define WS_EXIO_LCD_RST     0
+#define WS_EXIO_TP_RST      1
+#define WS_EXIO_LCD_BL      2
+#define WS_EXIO_PA_CTRL     3
+#define WS_EXIO_SD_CS       4
+#define WS_EXIO_LCD_VDD_EN  5
+#define WS_EXIO_STATUS_LED  6
+
+// P1 expansion header
+#define WS_EXIO_DI0     7
+#define WS_EXIO_DI1     8
+#define WS_EXIO_DI2     9
+#define WS_EXIO_DI3     10
+#define WS_EXIO_DO0     11
+#define WS_EXIO_DO1     12
+#define WS_EXIO_DO2     13
+#define WS_EXIO_DO3     14
+#define WS_EXIO_RTC_INT 15
+
+// UART0 pins are shared with the I2S audio interface.
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// Shared I2C bus for touch, IO expander, RTC, fuel gauge, and audio codecs.
+static const uint8_t SDA = 47;
+static const uint8_t SCL = 48;
+
+// The SD card CS signal is WS_EXIO_SD_CS, not an ESP32 GPIO.
+static const int8_t SS = -1;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 13;
+static const uint8_t SCK = 12;
+
+// 1-bit SDMMC shares the card's SPI nets. Drive EXIO4 high, then pass these
+// pins to SD_MMC.setPins() and enable one-bit mode when mounting the card.
+#define SDMMC_CMD 11
+#define SDMMC_CLK 12
+#define SDMMC_D0  13
+
+// ES8389 and ES7210 audio interface
+#define I2S_MCLK  6
+#define I2S_BCLK  44
+#define I2S_LRCLK 16
+#define I2S_DOUT  15
+#define I2S_DIN   43
+
+// Native USB; the boot button is shared with LCD G3.
+#define USB_DN 19
+#define USB_DP 20
+static const uint8_t BOOT_BTN = 0;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
### Checklist

1. [x] The PR title identifies the board support being added.
2. [x] Related official product, source, schematic, and module documentation links are included below.
3. [x] No separate documentation index update is required for a focused board definition; the change follows the existing `boards.txt` and variant layout.
4. [x] The contributing guide was reviewed.
5. [x] "Allow edits and access to secrets by maintainers" is enabled.

---

## Description of Change

Adds Arduino-ESP32 board support for the **Waveshare ESP32-S3-Touch-LCD-7C-BOX** with board ID `waveshare_esp32_s3_touch_lcd_7c`.

The board definition configures:

- ESP32-S3-WROOM-2-N32R16V
- 32 MB Octal Flash and 16 MB Octal PSRAM at 80 MHz
- QIO-configured boot with ESP-IDF runtime Octal Flash auto-detection and `qio_opi` memory libraries
- Hardware USB CDC/JTAG with CDC enabled on boot
- 32 MB partition schemes, defaulting to the large FATFS layout
- RGB LCD, GT911 touch, CH32V006 IO-expander channels, P1 expansion IO, Wire, SD/SDMMC, I2S audio, USB, and BOOT pin mappings

The pin definitions distinguish ESP GPIO numbers from CH32V006 EXIO channel numbers. SD mounting remains explicit because the card CS/DAT3 signal is controlled through EXIO4.

This is intentionally separate from the existing `waveshare_esp32_s3_touch_lcd_7` definition. That board uses 8 MB QIO flash and a CH422G expander, while the 7C-BOX uses a 32 MB Octal Flash module with runtime mode detection, CH32V006, audio codecs, and a different expansion/interface layout.

## Test Scenarios

Validated from the source checkout with FQBN `espressif:esp32:waveshare_esp32_s3_touch_lcd_7c`:

- `.github/scripts/validate_board.sh waveshare_esp32_s3_touch_lcd_7c`: all validation rules passed
- `git diff --check upstream/master...HEAD`
- GitHub Boards Test: board discovery and `libraries/ESP32/examples/CI/CIBoardsTest` compilation passed
- GitHub mock upload tests passed on Ubuntu, Windows, and macOS
- Local `CIBoardsTest` compile passed (67/67 build steps), covering the default Wire and SPI mappings
- Local `SDMMC_Test` compile passed (72/72 build steps)
- Both local builds generated complete 32 MB merged images

The resolved compile configuration selects the ESP32-S3 target, `qio_opi` libraries, a 32 MB DIO image header with QIO 80 MHz boot configuration, Hardware USB CDC/JTAG, and the QIO bootloader. The ESP-IDF configuration automatically switches to OPI STR when Octal Flash is detected.

No physical board was available. Display, touch, audio, SD, USB, RTC, fuel gauge, CH32V006, and expansion IO behavior still require hardware validation.

## Related links

- Product: https://www.waveshare.net/shop/ESP32-S3-Touch-LCD-7C-BOX.htm
- Wiki: https://docs.waveshare.com/ESP32-S3-Touch-LCD-7C-BOX
- Official Arduino settings: https://docs.waveshare.com/ESP32-S3-Touch-LCD-7C-BOX/Development-Environment-Setup-Arduino
- Official source and schematic: https://github.com/waveshareteam/ESP32-S3-Touch-LCD-7C
- ESP32-S3-WROOM-2 datasheet: https://documentation.espressif.com/esp32-s3-wroom-2_datasheet_en.pdf
- ESP-IDF Flash auto-detection behavior: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/kconfig-reference.html#config-esptoolpy-flash-mode-auto-detect