### PR TITLE
feat(board): Add Waveshare ESP32-S3 RGB Matrix

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -45173,6 +45173,150 @@ ws_esp32_s3_matrix.menu.EraseFlash.all.upload.erase_cmd=-e
 
 ##############################################################
 
+waveshare_esp32_s3_rgb_matrix.name=Waveshare ESP32-S3-RGB-Matrix
+
+waveshare_esp32_s3_rgb_matrix.bootloader.tool=esptool_py
+waveshare_esp32_s3_rgb_matrix.bootloader.tool.default=esptool_py
+
+waveshare_esp32_s3_rgb_matrix.upload.tool=esptool_py
+waveshare_esp32_s3_rgb_matrix.upload.tool.default=esptool_py
+waveshare_esp32_s3_rgb_matrix.upload.tool.network=esp_ota
+
+waveshare_esp32_s3_rgb_matrix.upload.maximum_size=4718592
+waveshare_esp32_s3_rgb_matrix.upload.maximum_data_size=327680
+waveshare_esp32_s3_rgb_matrix.upload.flags=
+waveshare_esp32_s3_rgb_matrix.upload.erase_cmd=
+waveshare_esp32_s3_rgb_matrix.upload.extra_flags=
+waveshare_esp32_s3_rgb_matrix.upload.use_1200bps_touch=false
+waveshare_esp32_s3_rgb_matrix.upload.wait_for_upload_port=false
+
+waveshare_esp32_s3_rgb_matrix.serial.disableDTR=false
+waveshare_esp32_s3_rgb_matrix.serial.disableRTS=false
+
+waveshare_esp32_s3_rgb_matrix.build.tarch=xtensa
+waveshare_esp32_s3_rgb_matrix.build.bootloader_addr=0x0
+waveshare_esp32_s3_rgb_matrix.build.target=esp32s3
+waveshare_esp32_s3_rgb_matrix.build.mcu=esp32s3
+waveshare_esp32_s3_rgb_matrix.build.core=esp32
+waveshare_esp32_s3_rgb_matrix.build.variant=waveshare_esp32_s3_rgb_matrix
+waveshare_esp32_s3_rgb_matrix.build.board=WAVESHARE_ESP32_S3_RGB_MATRIX
+
+waveshare_esp32_s3_rgb_matrix.build.usb_mode=1
+waveshare_esp32_s3_rgb_matrix.build.cdc_on_boot=1
+waveshare_esp32_s3_rgb_matrix.build.msc_on_boot=0
+waveshare_esp32_s3_rgb_matrix.build.dfu_on_boot=0
+waveshare_esp32_s3_rgb_matrix.build.f_cpu=240000000L
+waveshare_esp32_s3_rgb_matrix.build.flash_size=32MB
+waveshare_esp32_s3_rgb_matrix.build.flash_freq=80m
+waveshare_esp32_s3_rgb_matrix.build.flash_mode=dio
+waveshare_esp32_s3_rgb_matrix.build.boot=qio
+waveshare_esp32_s3_rgb_matrix.build.boot_freq=80m
+waveshare_esp32_s3_rgb_matrix.build.partitions=large_fat_32MB
+waveshare_esp32_s3_rgb_matrix.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_rgb_matrix.build.loop_core=
+waveshare_esp32_s3_rgb_matrix.build.event_core=
+waveshare_esp32_s3_rgb_matrix.build.psram_type=opi
+waveshare_esp32_s3_rgb_matrix.build.memory_type={build.boot}_{build.psram_type}
+
+waveshare_esp32_s3_rgb_matrix.menu.PSRAM.opi=OPI PSRAM
+waveshare_esp32_s3_rgb_matrix.menu.PSRAM.opi.build.defines=-DBOARD_HAS_PSRAM
+waveshare_esp32_s3_rgb_matrix.menu.PSRAM.opi.build.psram_type=opi
+waveshare_esp32_s3_rgb_matrix.menu.PSRAM.disabled=Disabled
+waveshare_esp32_s3_rgb_matrix.menu.PSRAM.disabled.build.defines=
+waveshare_esp32_s3_rgb_matrix.menu.PSRAM.disabled.build.psram_type=qspi
+
+waveshare_esp32_s3_rgb_matrix.menu.FlashMode.qio=QIO 80MHz
+waveshare_esp32_s3_rgb_matrix.menu.FlashMode.qio.build.flash_mode=dio
+waveshare_esp32_s3_rgb_matrix.menu.FlashMode.qio.build.boot=qio
+waveshare_esp32_s3_rgb_matrix.menu.FlashMode.qio.build.boot_freq=80m
+waveshare_esp32_s3_rgb_matrix.menu.FlashMode.qio.build.flash_freq=80m
+
+waveshare_esp32_s3_rgb_matrix.menu.FlashSize.32M=32MB (256Mb)
+waveshare_esp32_s3_rgb_matrix.menu.FlashSize.32M.build.flash_size=32MB
+
+waveshare_esp32_s3_rgb_matrix.menu.LoopCore.1=Core 1
+waveshare_esp32_s3_rgb_matrix.menu.LoopCore.1.build.loop_core=-DARDUINO_RUNNING_CORE=1
+waveshare_esp32_s3_rgb_matrix.menu.LoopCore.0=Core 0
+waveshare_esp32_s3_rgb_matrix.menu.LoopCore.0.build.loop_core=-DARDUINO_RUNNING_CORE=0
+
+waveshare_esp32_s3_rgb_matrix.menu.EventsCore.1=Core 1
+waveshare_esp32_s3_rgb_matrix.menu.EventsCore.1.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=1
+waveshare_esp32_s3_rgb_matrix.menu.EventsCore.0=Core 0
+waveshare_esp32_s3_rgb_matrix.menu.EventsCore.0.build.event_core=-DARDUINO_EVENT_RUNNING_CORE=0
+
+waveshare_esp32_s3_rgb_matrix.menu.USBMode.hwcdc=Hardware CDC and JTAG
+waveshare_esp32_s3_rgb_matrix.menu.USBMode.hwcdc.build.usb_mode=1
+waveshare_esp32_s3_rgb_matrix.menu.USBMode.default=USB-OTG (TinyUSB)
+waveshare_esp32_s3_rgb_matrix.menu.USBMode.default.build.usb_mode=0
+
+waveshare_esp32_s3_rgb_matrix.menu.CDCOnBoot.cdc=Enabled
+waveshare_esp32_s3_rgb_matrix.menu.CDCOnBoot.cdc.build.cdc_on_boot=1
+waveshare_esp32_s3_rgb_matrix.menu.CDCOnBoot.default=Disabled
+waveshare_esp32_s3_rgb_matrix.menu.CDCOnBoot.default.build.cdc_on_boot=0
+
+waveshare_esp32_s3_rgb_matrix.menu.MSCOnBoot.default=Disabled
+waveshare_esp32_s3_rgb_matrix.menu.MSCOnBoot.default.build.msc_on_boot=0
+waveshare_esp32_s3_rgb_matrix.menu.MSCOnBoot.msc=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_rgb_matrix.menu.MSCOnBoot.msc.build.msc_on_boot=1
+
+waveshare_esp32_s3_rgb_matrix.menu.DFUOnBoot.default=Disabled
+waveshare_esp32_s3_rgb_matrix.menu.DFUOnBoot.default.build.dfu_on_boot=0
+waveshare_esp32_s3_rgb_matrix.menu.DFUOnBoot.dfu=Enabled (Requires USB-OTG Mode)
+waveshare_esp32_s3_rgb_matrix.menu.DFUOnBoot.dfu.build.dfu_on_boot=1
+
+waveshare_esp32_s3_rgb_matrix.menu.UploadMode.default=UART0 / Hardware CDC
+waveshare_esp32_s3_rgb_matrix.menu.UploadMode.default.upload.use_1200bps_touch=false
+waveshare_esp32_s3_rgb_matrix.menu.UploadMode.default.upload.wait_for_upload_port=false
+waveshare_esp32_s3_rgb_matrix.menu.UploadMode.cdc=USB-OTG CDC (TinyUSB)
+waveshare_esp32_s3_rgb_matrix.menu.UploadMode.cdc.upload.use_1200bps_touch=true
+waveshare_esp32_s3_rgb_matrix.menu.UploadMode.cdc.upload.wait_for_upload_port=true
+
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app5M_fat24M_32MB=32M Flash (4.8MB APP/22MB FATFS)
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app5M_fat24M_32MB.build.partitions=large_fat_32MB
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app5M_fat24M_32MB.upload.maximum_size=4718592
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app5M_little24M_32MB=32M Flash (4.8MB APP/22MB LittleFS)
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app5M_little24M_32MB.build.partitions=large_littlefs_32MB
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app5M_little24M_32MB.upload.maximum_size=4718592
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app13M_data7M_32MB=32M Flash (13MB APP/6.75MB SPIFFS)
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app13M_data7M_32MB.build.partitions=default_32MB
+waveshare_esp32_s3_rgb_matrix.menu.PartitionScheme.app13M_data7M_32MB.upload.maximum_size=13107200
+
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.240=240MHz (WiFi)
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.240.build.f_cpu=240000000L
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.160=160MHz (WiFi)
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.160.build.f_cpu=160000000L
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.80=80MHz (WiFi)
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.80.build.f_cpu=80000000L
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.40=40MHz
+waveshare_esp32_s3_rgb_matrix.menu.CPUFreq.40.build.f_cpu=40000000L
+
+waveshare_esp32_s3_rgb_matrix.menu.UploadSpeed.921600=921600
+waveshare_esp32_s3_rgb_matrix.menu.UploadSpeed.921600.upload.speed=921600
+waveshare_esp32_s3_rgb_matrix.menu.UploadSpeed.115200=115200
+waveshare_esp32_s3_rgb_matrix.menu.UploadSpeed.115200.upload.speed=115200
+waveshare_esp32_s3_rgb_matrix.menu.UploadSpeed.460800.linux=460800
+waveshare_esp32_s3_rgb_matrix.menu.UploadSpeed.460800.macosx=460800
+waveshare_esp32_s3_rgb_matrix.menu.UploadSpeed.460800.upload.speed=460800
+
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.none=None
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.none.build.code_debug=0
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.error=Error
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.error.build.code_debug=1
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.warn=Warn
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.warn.build.code_debug=2
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.info=Info
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.info.build.code_debug=3
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.debug=Debug
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.debug.build.code_debug=4
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.verbose=Verbose
+waveshare_esp32_s3_rgb_matrix.menu.DebugLevel.verbose.build.code_debug=5
+
+waveshare_esp32_s3_rgb_matrix.menu.EraseFlash.none=Disabled
+waveshare_esp32_s3_rgb_matrix.menu.EraseFlash.all=Enabled
+waveshare_esp32_s3_rgb_matrix.menu.EraseFlash.all.upload.erase_cmd=-e
+
+##############################################################
+
 waveshare_esp32_s3_touch_lcd_169.name=Waveshare ESP32-S3-Touch-LCD-1.69
 waveshare_esp32_s3_touch_lcd_169.vid.0=0x303a
 waveshare_esp32_s3_touch_lcd_169.pid.0=0x821E

--- a/variants/waveshare_esp32_s3_rgb_matrix/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_rgb_matrix/pins_arduino.h
@@ -60,17 +60,17 @@ static const uint8_t SCK = -1;
 // I2S audio shared by the ES8311 codec and ES7210 ADC
 #define BOARD_HAS_ES8311
 #define BOARD_HAS_ES7210
-#define BOARD_I2S_MCLK 12
-#define BOARD_I2S_BCLK 43
-#define BOARD_I2S_LRC  38
-#define BOARD_I2S_DOUT 21
-#define BOARD_I2S_DIN  39
-#define I2S_MCLK       BOARD_I2S_MCLK
-#define I2S_SCLK       BOARD_I2S_BCLK
-#define I2S_BCLK       BOARD_I2S_BCLK
-#define I2S_LRCK       BOARD_I2S_LRC
-#define I2S_DOUT       BOARD_I2S_DOUT
-#define I2S_DIN        BOARD_I2S_DIN
+#define BOARD_I2S_MCLK  12
+#define BOARD_I2S_BCLK  43
+#define BOARD_I2S_LRC   38
+#define BOARD_I2S_DOUT  21
+#define BOARD_I2S_DIN   39
+#define I2S_MCLK        BOARD_I2S_MCLK
+#define I2S_SCLK        BOARD_I2S_BCLK
+#define I2S_BCLK        BOARD_I2S_BCLK
+#define I2S_LRCK        BOARD_I2S_LRC
+#define I2S_DOUT        BOARD_I2S_DOUT
+#define I2S_DIN         BOARD_I2S_DIN
 #define BOARD_PA_ENABLE 11
 #define PA_POWER        BOARD_PA_ENABLE
 

--- a/variants/waveshare_esp32_s3_rgb_matrix/pins_arduino.h
+++ b/variants/waveshare_esp32_s3_rgb_matrix/pins_arduino.h
@@ -1,0 +1,102 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID          0x303A
+#define USB_PID          0x1001
+#define USB_MANUFACTURER "Waveshare"
+#define USB_PRODUCT      "ESP32-S3-RGB-Matrix"
+#define USB_SERIAL       ""
+
+// The board has no dedicated UART or general-purpose SPI connector.
+// UART0 pins are shared with I2S and SD_MMC; SPI pins must be selected explicitly.
+static const uint8_t TX = -1;
+static const uint8_t RX = -1;
+
+#define BOARD_I2C_SDA 47
+#define BOARD_I2C_SCL 48
+#define I2C_SDA_PIN   BOARD_I2C_SDA
+#define I2C_SCL_PIN   BOARD_I2C_SCL
+
+static const uint8_t SDA = BOARD_I2C_SDA;
+static const uint8_t SCL = BOARD_I2C_SCL;
+
+static const uint8_t SS = -1;
+static const uint8_t MOSI = -1;
+static const uint8_t MISO = -1;
+static const uint8_t SCK = -1;
+
+// HUB75 interface
+#define WS_HUB75_R1_PIN  4
+#define WS_HUB75_G1_PIN  5
+#define WS_HUB75_B1_PIN  6
+#define WS_HUB75_R2_PIN  7
+#define WS_HUB75_G2_PIN  15
+#define WS_HUB75_B2_PIN  16
+#define WS_HUB75_A_PIN   18
+#define WS_HUB75_B_PIN   8
+#define WS_HUB75_C_PIN   3
+#define WS_HUB75_D_PIN   42
+#define WS_HUB75_E_PIN   9
+#define WS_HUB75_LAT_PIN 40
+#define WS_HUB75_OE_PIN  2
+#define WS_HUB75_CLK_PIN 41
+
+// SD_MMC (1-bit). GPIO14 is the card's DAT3/CS signal, not a card-detect input.
+#define BOARD_HAS_SDMMC
+#define BOARD_HAS_1BIT_SDMMC
+#define BOARD_SD_CLK 1
+#define BOARD_SD_CMD 44
+#define BOARD_SD_D0  17
+#define SDMMC_CLK    BOARD_SD_CLK
+#define SDMMC_CMD    BOARD_SD_CMD
+#define SDMMC_D0     BOARD_SD_D0
+#define SDMMC_CS     14
+#define BSP_SD_CLK   BOARD_SD_CLK
+#define BSP_SD_CMD   BOARD_SD_CMD
+#define BSP_SD_D0    BOARD_SD_D0
+
+// I2S audio shared by the ES8311 codec and ES7210 ADC
+#define BOARD_HAS_ES8311
+#define BOARD_HAS_ES7210
+#define BOARD_I2S_MCLK 12
+#define BOARD_I2S_BCLK 43
+#define BOARD_I2S_LRC  38
+#define BOARD_I2S_DOUT 21
+#define BOARD_I2S_DIN  39
+#define I2S_MCLK       BOARD_I2S_MCLK
+#define I2S_SCLK       BOARD_I2S_BCLK
+#define I2S_BCLK       BOARD_I2S_BCLK
+#define I2S_LRCK       BOARD_I2S_LRC
+#define I2S_DOUT       BOARD_I2S_DOUT
+#define I2S_DIN        BOARD_I2S_DIN
+#define BOARD_PA_ENABLE 11
+#define PA_POWER        BOARD_PA_ENABLE
+
+// PCF85063 RTC, QMI8658 IMU, and SHTC3 share the default I2C bus.
+#define RTC_SDA     47
+#define RTC_SCL     48
+#define RTC_ADDRESS 0x51
+#define RTC_INT     10
+
+#define QMI8658_SDA     47
+#define QMI8658_SCL     48
+#define QMI8658_ADDRESS 0x6B
+#define QMI8658_INT1    13
+
+#define SHTC3_SDA 47
+#define SHTC3_SCL 48
+
+// BOOT button, active low
+#define BOARD_BUTTON_PIN 0
+static const uint8_t BUTTON_BUILTIN = BOARD_BUTTON_PIN;
+
+#define USB_DN 19
+#define USB_DP 20
+
+// GPIO45 and GPIO46 are strapping pins routed to the expansion header.
+#define EXPANSION_GPIO_1 45
+#define EXPANSION_GPIO_2 46
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
### Checklist

1. [x] The title specifically describes the board being added.
2. [x] Related official product, hardware, and example links are provided below.
3. [x] The board definition and variant contain the relevant user-facing metadata; no separate documentation index is required by the existing board-addition convention.
4. [x] The contributing guide has been reviewed.
5. [x] "Allow edits and access to secrets by maintainers" is enabled.

---

## Description of Change

Add Arduino board support for the Waveshare ESP32-S3-RGB-Matrix with the board ID `waveshare_esp32_s3_rgb_matrix`.

The definition follows Waveshare's official Arduino settings for the ESP32-S3-WROOM-2-N32R16V module:

- ESP32-S3, 240 MHz
- 32 MB flash, QIO at 80 MHz
- 16 MB OPI PSRAM through the existing `qio_opi` memory configuration
- Hardware CDC/JTAG with USB CDC enabled on boot
- 921600 baud upload
- 32 MB FATFS partition layout with 4.8 MB application slots

The new variant exposes the documented HUB75, I2C, I2S audio, SD_MMC, USB, BOOT button, RTC, IMU, and expansion pins. The matrix connector is parallel HUB75, not a single-wire addressable LED. Consequently, the variant does not define `RGB_BUILTIN`, `LED_BUILTIN`, a fixed pixel count, or a fixed panel geometry.

The generic UART and SPI defaults are left unassigned because UART0 GPIO43/GPIO44 are shared with audio and SD, and the board has no dedicated general-purpose SPI connector. SD_MMC defaults to the officially supported 1-bit pin set.

As with existing ESP32-S3 QIO board entries, `build.flash_mode=dio` is retained for the generated image and upload arguments while `build.boot=qio` selects the QIO boot and `qio_opi` library configuration.

## Test Scenarios

Validated with Arduino-ESP32 3.3.11, ESP-IDF libraries 5.5.5, Xtensa GCC 14.2.0, and esptool 5.3.1:

- `.github/scripts/validate_board.sh waveshare_esp32_s3_rgb_matrix`
- `.github/scripts/find_boards.sh all --output-format=array`
- Minimal sketch compiled with `espressif:esp32:waveshare_esp32_s3_rgb_matrix`
- Compile-only sketch referencing every new board macro
- Dependency-free HUB75 GPIO pin exercise sketch
- `libraries/ESP32/examples/CI/CIBoardsTest`
- All builds used `-Wall -Werror=all -Wextra`
- `git diff --check`

The generated images were confirmed as ESP32-S3, 32 MB flash, 80 MHz, with the `qio_opi` library configuration and the expected USB and partition defines.

No physical-board test was performed. External panel scan type, driver IC, color order, brightness/current behavior, and the onboard sensor, audio, and SD peripherals still require hardware validation.

## Related links

- Product page: https://www.waveshare.net/shop/ESP32-S3-RGB-Matrix.htm
- Wiki: https://docs.waveshare.net/ESP32-S3-RGB-Matrix/
- Arduino setup: https://docs.waveshare.net/ESP32-S3-RGB-Matrix/Development-Environment-Setup-Arduino/
- Official repository: https://github.com/waveshareteam/ESP32-S3-RGB-Matrix
- Schematic: https://github.com/waveshareteam/ESP32-S3-RGB-Matrix/blob/main/hardware/schematics/ESP32-S3-RGB-Matrix-Schematics.pdf
- BSP pin configuration: https://github.com/waveshareteam/ESP32-S3-RGB-Matrix/blob/4047e4e7e13b043ae9ddd4daaeff5582de044c80/example/idf_v5.5.2/components/bsp/esp32_s3_matrix/include/bsp/config.h
- Arduino HUB75 pins: https://github.com/waveshareteam/ESP32-S3-RGB-Matrix/blob/4047e4e7e13b043ae9ddd4daaeff5582de044c80/example/arduino_v3.3.7/08_Sensor_Test/platforms/esp32s3/esp32s3-default-pins.hpp
