### PR TITLE
feat(Preferences): Add std::string to the Preferences object.

### DIFF
--- a/docs/en/tutorials/preferences.rst
+++ b/docs/en/tutorials/preferences.rst
@@ -78,9 +78,11 @@ Preferences directly supports the following data types:
    +-------------------+-------------------+---------------+
    | Double            | double_t          | 8             |
    +-------------------+-------------------+---------------+
-   |                   | const char*       | variable      |
-   | String            +-------------------+               |
+   | String            | const char*       | variable      |
+   |                   +-------------------+               |
    |                   | String            |               |
+   |                   +-------------------+               |
+   |                   | std::string       |               |
    +-------------------+-------------------+---------------+
    | Bytes             | uint8_t           | variable      |
    +-------------------+-------------------+---------------+
@@ -618,6 +620,8 @@ With Preferences, the ``getX`` methods listed in Table 2 below will return a def
    | Double           |                 |
    +------------------+-----------------+
    | String (String)  | ""              |
+   |                  |                 |
+   | std::string      |                 |
    +------------------+-----------------+
    | String (* buf)   | \\0             |
    +------------------+-----------------+

--- a/libraries/Preferences/keywords.txt
+++ b/libraries/Preferences/keywords.txt
@@ -31,6 +31,7 @@ putFloat	KEYWORD2
 putDouble	KEYWORD2
 putBool	KEYWORD2
 putString	KEYWORD2
+putStdString	KEYWORD2
 putBytes	KEYWORD2
 
 getChar	KEYWORD2
@@ -47,6 +48,7 @@ getFloat	KEYWORD2
 getDouble	KEYWORD2
 getBool	KEYWORD2
 getString	KEYWORD2
+getStdString	KEYWORD2
 getBytes	KEYWORD2
 
 #######################################

--- a/libraries/Preferences/src/Preferences.cpp
+++ b/libraries/Preferences/src/Preferences.cpp
@@ -282,6 +282,10 @@ size_t Preferences::putString(const char *key, const String value) {
   return putString(key, value.c_str());
 }
 
+size_t Preferences::putStdString(const char *key, const std::string value) {
+  return putString(key, value.c_str());
+}
+
 size_t Preferences::putBytes(const char *key, const void *value, size_t len) {
   if (!_started || !key || !value || !len || _readOnly) {
     return 0;
@@ -514,6 +518,27 @@ String Preferences::getString(const char *key, const String defaultValue) {
     return String(defaultValue);
   }
   return String(buf);
+}
+
+std::string Preferences::getStdString(const char *key, const std::string defaultValue) {
+  char *value = NULL;
+  size_t len = 0;
+  if (!_started || !key) {
+    return std::string(defaultValue);
+  }
+  esp_err_t err = nvs_get_str(_handle, key, value, &len);
+  if (err) {
+    log_e("nvs_get_str len fail: %s %s", key, nvs_error(err));
+    return std::string(defaultValue);
+  }
+  char buf[len];
+  value = buf;
+  err = nvs_get_str(_handle, key, value, &len);
+  if (err) {
+    log_e("nvs_get_str fail: %s %s", key, nvs_error(err));
+    return std::tring(defaultValue);
+  }
+  return std::string(buf);
 }
 
 size_t Preferences::getStringLength(const char *key) {

--- a/libraries/Preferences/src/Preferences.cpp
+++ b/libraries/Preferences/src/Preferences.cpp
@@ -282,9 +282,11 @@ size_t Preferences::putString(const char *key, const String value) {
   return putString(key, value.c_str());
 }
 
+#ifdef USE_STD_STRING
 size_t Preferences::putStdString(const char *key, const std::string value) {
   return putString(key, value.c_str());
 }
+#endif
 
 size_t Preferences::putBytes(const char *key, const void *value, size_t len) {
   if (!_started || !key || !value || !len || _readOnly) {
@@ -520,6 +522,7 @@ String Preferences::getString(const char *key, const String defaultValue) {
   return String(buf);
 }
 
+#ifdef USE_STD_STRING
 std::string Preferences::getStdString(const char *key, const std::string defaultValue) {
   char *value = NULL;
   size_t len = 0;
@@ -540,6 +543,7 @@ std::string Preferences::getStdString(const char *key, const std::string default
   }
   return std::string(buf);
 }
+#endif
 
 size_t Preferences::getStringLength(const char *key) {
   size_t len = 0;

--- a/libraries/Preferences/src/Preferences.h
+++ b/libraries/Preferences/src/Preferences.h
@@ -61,6 +61,8 @@ public:
   size_t putBool(const char *key, bool value);
   size_t putString(const char *key, const char *value);
   size_t putString(const char *key, String value);
+  size_t putStdString(const char *key, std::string value);
+  
   size_t putBytes(const char *key, const void *value, size_t len);
 
   bool isKey(const char *key);
@@ -80,6 +82,7 @@ public:
   bool getBool(const char *key, bool defaultValue = false);
   size_t getString(const char *key, char *value, size_t maxLen);
   String getString(const char *key, String defaultValue = String());
+  std::string getStdString(const char *key, std::string defaultValue = std::string());
   size_t getStringLength(const char *key);
   size_t getBytesLength(const char *key);
   size_t getBytes(const char *key, void *buf, size_t maxLen);

--- a/libraries/Preferences/src/Preferences.h
+++ b/libraries/Preferences/src/Preferences.h
@@ -16,6 +16,10 @@
 
 #include "Arduino.h"
 
+#ifdef __has_include(<string>) 
+  #define USE_STD_STRING 1
+#endif
+
 typedef enum {
   PT_I8,
   PT_U8,
@@ -61,8 +65,9 @@ public:
   size_t putBool(const char *key, bool value);
   size_t putString(const char *key, const char *value);
   size_t putString(const char *key, String value);
+#ifdef USE_STD_STRING
   size_t putStdString(const char *key, std::string value);
-  
+#endif
   size_t putBytes(const char *key, const void *value, size_t len);
 
   bool isKey(const char *key);
@@ -82,7 +87,9 @@ public:
   bool getBool(const char *key, bool defaultValue = false);
   size_t getString(const char *key, char *value, size_t maxLen);
   String getString(const char *key, String defaultValue = String());
+#ifdef USE_STD_STRING
   std::string getStdString(const char *key, std::string defaultValue = std::string());
+#endif
   size_t getStringLength(const char *key);
   size_t getBytesLength(const char *key);
   size_t getBytes(const char *key, void *buf, size_t maxLen);

--- a/libraries/Preferences/src/Preferences.h
+++ b/libraries/Preferences/src/Preferences.h
@@ -16,7 +16,7 @@
 
 #include "Arduino.h"
 
-#ifdef __has_include(<string>) 
+#if __has_include(<string>) 
   #define USE_STD_STRING 1
 #endif
 


### PR DESCRIPTION
*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
In my firmware i use only the std::string as string storage's.
When i want to use the Preferences object i found out that only the Arduino String variable is offered.
This PR add this option. It is basically a copy of the `putString()` and `getString()` but returning `std::string` instead.

## Test Scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.
I have tested my Pull Request on Arduino-esp32 core v3.3.10 with an ESP32-S3.
(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)
```cpp
std::string current_name = "";

void load() {
  Preferences prefs;
  prefs.begin("testing", true);
  current_name = prefs.getStdString("name", current_name);
  prefs.end();
}

void load() {
  Preferences prefs;
  prefs.begin("testing");
  prefs.putStdString("name", current_name);
  prefs.end();
}
```

## Related links
Please provide links to related issue, PRs etc.
https://github.com/espressif/arduino-esp32/issues/12831
https://github.com/espressif/arduino-esp32/discussions/12820
(*eg. Closes #number of issue*)
