### PR TITLE
fix(littlefs): zero-init conf to avoid -Werror

### DIFF
--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -60,15 +60,14 @@ bool LittleFSFS::begin(bool formatOnFail, const char *basePath, uint8_t maxOpenF
     return true;
   }
 
-  esp_vfs_littlefs_conf_t conf = {
-    .base_path = basePath,
-    .partition_label = partitionLabel_,
-    .partition = NULL,
-    .format_if_mount_failed = false,
-    .read_only = false,
-    .dont_mount = false,
-    .grow_on_mount = true
-  };
+  esp_vfs_littlefs_conf_t conf = {};
+  conf.base_path = basePath;
+  conf.partition_label = partitionLabel_;
+  conf.partition = NULL;
+  conf.format_if_mount_failed = false;
+  conf.read_only = false;
+  conf.dont_mount = false;
+  conf.grow_on_mount = true;
 
   esp_err_t err = esp_vfs_littlefs_register(&conf);
   if (err == ESP_FAIL && formatOnFail) {


### PR DESCRIPTION
## Description of Change
LittleFS.cpp initializes esp_vfs_littlefs_conf_t with a designated initializer that omits the blockdev member added in newer esp_littlefs versions. When arduino-esp32 is built as an ESP-IDF component against esp_littlefs 1.22.3, this fails with -Werror=missing-field-initializers. 

Replace the designated initializer with value-initialization (= {}) plus explicit member assignment, which initializes all members regardless of the esp_littlefs struct version. 

This preserves existing behavior: = {} zero-initializes every member, and the explicit assignments keep the original field values, so the result is identical regardless of the esp_littlefs struct version.

## Test Scenarios
Built arduino-esp32 as an ESP-IDF component on an ESP32 with ESP-IDF v6.0.2. The build previously failed with `-Werror=missing-field-initializers` at `libraries/LittleFS/src/LittleFS.cpp`; with the fix it compiles cleanly.

## Related links
Related: #9044 (same class of warning for earlier struct members). The fix https://github.com/espressif/arduino-esp32/pull/9046 is a narrow fix that satisfies a specific struct layout. This is the _third time_ this class of warning has been fixed (see #6953 and #9046). This fix should satisfy further struct changes.
