### PR TITLE
fix(cpu): Fix memory leak in getSupportedCpuFrequencyMhz

### DIFF
--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -206,7 +206,7 @@ const char *getClockSourceName(uint8_t source) {
 }
 
 const char *getSupportedCpuFrequencyMhz(uint8_t xtal) {
-  const size_t buf_size = 256;
+  constexpr size_t buf_size = 256;
   static char buf[buf_size];
   int pos = 0;
 

--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -206,8 +206,9 @@ const char *getClockSourceName(uint8_t source) {
 }
 
 const char *getSupportedCpuFrequencyMhz(uint8_t xtal) {
-  constexpr size_t buf_size = 256;
-  static char buf[buf_size];
+  #define SUP_CPU_FREQ_BUF_SIZE 256
+  const size_t buf_size = SUP_CPU_FREQ_BUF_SIZE;
+  static char buf[SUP_CPU_FREQ_BUF_SIZE];
   int pos = 0;
 
 #if TARGET_CPU_FREQ_MAX_400

--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -206,50 +206,50 @@ const char *getClockSourceName(uint8_t source) {
 }
 
 const char *getSupportedCpuFrequencyMhz(uint8_t xtal) {
-  char *supported_frequencies = (char *)calloc(256, sizeof(char));
+  const size_t buf_size = 256;
+  static char buf[buf_size];
   int pos = 0;
 
 #if TARGET_CPU_FREQ_MAX_400
 #if CONFIG_IDF_TARGET_ESP32P4 && CONFIG_ESP32P4_REV_MIN_FULL < 300
-  pos += snprintf(supported_frequencies + pos, 256 - pos, "360");
+  pos += snprintf(buf + pos, buf_size - pos, "360");
 #else
-  pos += snprintf(supported_frequencies + pos, 256 - pos, "400");
+  pos += snprintf(buf + pos, buf_size - pos, "400");
 #endif
 #elif TARGET_CPU_FREQ_MAX_240
 #if CONFIG_IDF_TARGET_ESP32
   if (!REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_RATED) || !REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_LOW)) {
-    pos += snprintf(supported_frequencies + pos, 256 - pos, "160, 80");
+    pos += snprintf(buf + pos, buf_size - pos, "160, 80");
   } else
 #endif
   {
-    pos += snprintf(supported_frequencies + pos, 256 - pos, "240, 160, 80");
+    pos += snprintf(buf + pos, buf_size - pos, "240, 160, 80");
   }
 #elif TARGET_CPU_FREQ_MAX_160
-  pos += snprintf(supported_frequencies + pos, 256 - pos, "160, 120, 80");
+  pos += snprintf(buf + pos, buf_size - pos, "160, 120, 80");
 #elif TARGET_CPU_FREQ_MAX_120
-  pos += snprintf(supported_frequencies + pos, 256 - pos, "120, 80");
+  pos += snprintf(buf + pos, buf_size - pos, "120, 80");
 #elif TARGET_CPU_FREQ_MAX_96
-  pos += snprintf(supported_frequencies + pos, 256 - pos, "96, 64, 48");
+  pos += snprintf(buf + pos, buf_size - pos, "96, 64, 48");
 #else
-  free(supported_frequencies);
   return "Unknown";
 #endif
 
   // Append xtal and its dividers only if xtal is nonzero
   if (xtal != 0) {
     // We'll show as: , <xtal>, <xtal/2>[, <xtal/4>] MHz
-    pos += snprintf(supported_frequencies + pos, 256 - pos, ", %u, %u", xtal, (uint8_t)(xtal / 2));
+    pos += snprintf(buf + pos, buf_size - pos, ", %u, %u", xtal, (uint8_t)(xtal / 2));
 
 #if CONFIG_IDF_TARGET_ESP32
     // Only append xtal/4 if it's > 0 and meaningful for higher-frequency chips (e.g., ESP32 40MHz/4=10)
     if (xtal >= RTC_XTAL_FREQ_40M) {
-      pos += snprintf(supported_frequencies + pos, 256 - pos, ", %u", (uint8_t)(xtal / 4));
+      pos += snprintf(buf + pos, buf_size - pos, ", %u", (uint8_t)(xtal / 4));
     }
 #endif
   }
 
-  pos += snprintf(supported_frequencies + pos, 256 - pos, " MHz");
-  return supported_frequencies;
+  pos += snprintf(buf + pos, buf_size - pos, " MHz");
+  return buf;
 }
 
 bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz) {

--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -206,7 +206,7 @@ const char *getClockSourceName(uint8_t source) {
 }
 
 const char *getSupportedCpuFrequencyMhz(uint8_t xtal) {
-  #define SUP_CPU_FREQ_BUF_SIZE 256
+#define SUP_CPU_FREQ_BUF_SIZE 256
   const size_t buf_size = SUP_CPU_FREQ_BUF_SIZE;
   static char buf[SUP_CPU_FREQ_BUF_SIZE];
   int pos = 0;


### PR DESCRIPTION
## Description of Change
Minor change.
`getSupportedCpuFrequencyMhz()` allocated a 256-byte buffer with `calloc()` on every call and only freed it on the `#else`/"Unknown" branch. Leaking on every other call. The caller (`setCpuFrequencyMhz()`) never frees the result. The function is not referenced anywhere else in the codebase.

 This PR replaces the heap allocation with a `static char buf[256]`, so no allocation or free is needed. The public signature `const char *getSupportedCpuFrequencyMhz(uint8_t xtal)` is unchanged.
 
 Note that this change is not threadsafe. I figure that this is okay given that this is only called in` setCpuFrequencyMhz()` and is only for logging. 

## Test Scenarios
Compiled against ESP-IDF v6.0.2 for the ESP32 target and flashed to a physical ESP32 where the firmware boots and runs successfully.

## Related links
The function was introduced in https://github.com/espressif/arduino-esp32/pull/12019