### PR TITLE
fix(matter): fix binary sensors for Matter 1.5

### DIFF
--- a/docs/en/matter/ep_contact_sensor.rst
+++ b/docs/en/matter/ep_contact_sensor.rst
@@ -43,15 +43,21 @@ Initialization
 begin
 ^^^^^
 
-Initializes the Matter contact sensor endpoint with an initial contact state.
+Initializes the Matter contact sensor endpoint. Fabric ``StateValue`` starts ``false`` (open). Call ``setContact()`` after ``Matter.begin()`` with the real sensor reading.
 
 .. code-block:: arduino
 
-    bool begin(bool _contactState = false);
-
-* ``_contactState`` - Initial contact state (``true`` = closed, ``false`` = open, default: ``false``)
+    bool begin();
 
 This function will return ``true`` if successful, ``false`` otherwise.
+
+Typical usage:
+
+.. code-block:: arduino
+
+    ContactSensor.begin();
+    Matter.begin();
+    ContactSensor.setContact(digitalRead(contactPin));
 
 end
 ^^^
@@ -68,7 +74,7 @@ Contact State Control
 setContact
 ^^^^^^^^^^
 
-Sets the contact state.
+Sets the contact state. Call after ``Matter.begin()``.
 
 .. code-block:: arduino
 
@@ -114,7 +120,7 @@ Example:
 Assignment operator
 ^^^^^^^^^^^^^^^^^^^
 
-Sets the contact state.
+Sets the contact state. Same as ``setContact()``; call after ``Matter.begin()``.
 
 .. code-block:: arduino
 

--- a/docs/en/matter/ep_rain_sensor.rst
+++ b/docs/en/matter/ep_rain_sensor.rst
@@ -43,15 +43,21 @@ Initialization
 begin
 ^^^^^
 
-Initializes the Matter rain sensor endpoint with an initial rain detection state.
+Initializes the Matter rain sensor endpoint. Fabric ``StateValue`` starts ``false`` (not detected). Call ``setRain()`` after ``Matter.begin()`` with the real sensor reading.
 
 .. code-block:: arduino
 
-    bool begin(bool _rainState = false);
-
-* ``_rainState`` - Initial rain detection state (``true`` = detected, ``false`` = not detected, default: ``false``)
+    bool begin();
 
 This function will return ``true`` if successful, ``false`` otherwise.
+
+Typical usage:
+
+.. code-block:: arduino
+
+    RainSensor.begin();
+    Matter.begin();
+    RainSensor.setRain(digitalRead(rainPin));
 
 end
 ^^^
@@ -68,7 +74,7 @@ Rain Detection State Control
 setRain
 ^^^^^^^
 
-Sets the rain detection state.
+Sets the rain detection state. Call after ``Matter.begin()``.
 
 .. code-block:: arduino
 
@@ -114,7 +120,7 @@ Example:
 Assignment operator
 ^^^^^^^^^^^^^^^^^^^
 
-Sets the rain detection state.
+Sets the rain detection state. Same as ``setRain()``; call after ``Matter.begin()``.
 
 .. code-block:: arduino
 

--- a/docs/en/matter/ep_water_freeze_detector.rst
+++ b/docs/en/matter/ep_water_freeze_detector.rst
@@ -43,15 +43,21 @@ Initialization
 begin
 ^^^^^
 
-Initializes the Matter water freeze detector endpoint with an initial freeze detection state.
+Initializes the Matter water freeze detector endpoint. Fabric ``StateValue`` starts ``false`` (not detected). Call ``setFreeze()`` after ``Matter.begin()`` with the real sensor reading.
 
 .. code-block:: arduino
 
-    bool begin(bool _freezeState = false);
-
-* ``_freezeState`` - Initial water freeze detection state (``true`` = detected, ``false`` = not detected, default: ``false``)
+    bool begin();
 
 This function will return ``true`` if successful, ``false`` otherwise.
+
+Typical usage:
+
+.. code-block:: arduino
+
+    WaterFreezeDetector.begin();
+    Matter.begin();
+    WaterFreezeDetector.setFreeze(digitalRead(freezePin));
 
 end
 ^^^
@@ -68,7 +74,7 @@ Water Freeze Detection State Control
 setFreeze
 ^^^^^^^^^
 
-Sets the water freeze detection state.
+Sets the water freeze detection state. Call after ``Matter.begin()``.
 
 .. code-block:: arduino
 
@@ -114,7 +120,7 @@ Example:
 Assignment operator
 ^^^^^^^^^^^^^^^^^^^
 
-Sets the water freeze detection state.
+Sets the water freeze detection state. Same as ``setFreeze()``; call after ``Matter.begin()``.
 
 .. code-block:: arduino
 

--- a/docs/en/matter/ep_water_leak_detector.rst
+++ b/docs/en/matter/ep_water_leak_detector.rst
@@ -43,15 +43,21 @@ Initialization
 begin
 ^^^^^
 
-Initializes the Matter water leak detector endpoint with an initial leak detection state.
+Initializes the Matter water leak detector endpoint. Fabric ``StateValue`` starts ``false`` (not detected). Call ``setLeak()`` after ``Matter.begin()`` with the real sensor reading.
 
 .. code-block:: arduino
 
-    bool begin(bool _leakState = false);
-
-* ``_leakState`` - Initial water leak detection state (``true`` = detected, ``false`` = not detected, default: ``false``)
+    bool begin();
 
 This function will return ``true`` if successful, ``false`` otherwise.
+
+Typical usage:
+
+.. code-block:: arduino
+
+    WaterLeakDetector.begin();
+    Matter.begin();
+    WaterLeakDetector.setLeak(digitalRead(leakPin));
 
 end
 ^^^
@@ -68,7 +74,7 @@ Water Leak Detection State Control
 setLeak
 ^^^^^^^^
 
-Sets the water leak detection state.
+Sets the water leak detection state. Call after ``Matter.begin()``.
 
 .. code-block:: arduino
 
@@ -114,7 +120,7 @@ Example:
 Assignment operator
 ^^^^^^^^^^^^^^^^^^^
 
-Sets the water leak detection state.
+Sets the water leak detection state. Same as ``setLeak()``; call after ``Matter.begin()``.
 
 .. code-block:: arduino
 

--- a/docs/en/matter/matter.rst
+++ b/docs/en/matter/matter.rst
@@ -263,6 +263,7 @@ Common Issues
   * Check Serial Monitor for error messages (115200 baud)
   * Verify endpoint initialization with ``begin()`` method
   * Ensure ``Matter.begin()`` is called after all endpoints are initialized
+  * For Boolean State sensors (contact, leak, freeze, rain), call the setter after ``Matter.begin()``. ``begin()`` does not take an initial state.
 
 **Callbacks not firing**
   * Verify callback functions are registered before commissioning

--- a/docs/en/matter/matter_ep.rst
+++ b/docs/en/matter/matter_ep.rst
@@ -130,6 +130,8 @@ Updates the value of an attribute from its cluster ID. This is typically used fo
 
 This function will return ``true`` if successful, ``false`` otherwise.
 
+Boolean State ``StateValue`` (contact, leak, freeze, rain) is internally managed in ESP-Matter 1.5+ and cannot be written with ``updateAttributeVal()``. Those endpoints use a cluster setter; call ``setContact()`` / ``setLeak()`` / ``setFreeze()`` / ``setRain()`` after ``Matter.begin()``.
+
 Identify Cluster
 ****************
 

--- a/libraries/Matter/README.md
+++ b/libraries/Matter/README.md
@@ -13,7 +13,7 @@ Each Matter device type is represented by a C++ class under `src/MatterEndpoints
 
 This library is built on ESP-Matter, which uses an Ember-based attribute store. The attribute store is the protocol-level source of truth: when a Matter controller reads an attribute, it reads from this store.
 
-All endpoint setters and getters **must** follow one of the two patterns below.
+Most endpoint setters and getters **must** follow one of the two Ember store patterns below. Boolean State sensors are the exception: their `StateValue` is internally managed in ESP-Matter 1.5+ and cannot be written with `updateAttributeVal()`.
 
 ### Setter Pattern
 
@@ -64,6 +64,29 @@ int MyEndpoint::getValue() {
 
 This is consistent across all endpoints. Since setters only update internal state after the attribute store succeeds, the getter always reflects the last successfully committed value.
 
+### Boolean State Sensors (ESP-Matter 1.5+)
+
+`MatterContactSensor`, `MatterWaterLeakDetector`, `MatterWaterFreezeDetector`, and `MatterRainSensor` use the code-driven Boolean State cluster. `attribute::update()` returns `ESP_ERR_NOT_SUPPORTED` (262) for `StateValue`. Those setters call `MatterEndPoint::setBooleanStateValue()`, which looks up the live cluster and uses `BooleanStateCluster::SetStateValue()`.
+
+```cpp
+bool MatterWaterLeakDetector::setLeak(bool _leakState) {
+  if (leakState == _leakState) {
+    return true;
+  }
+  if (!setBooleanStateValue(_leakState)) {
+    log_e("Failed to update Water Leak Detector Attribute.");
+    return false;
+  }
+  leakState = _leakState;
+  return true;
+}
+```
+
+Key rules:
+- **`begin()` takes no initial state.** The cluster always starts at `false`. Do not write `config.boolean_state.state_value`; CHIP does not apply that config to the live cluster.
+- **Call the setter after `Matter.begin()`.** The cluster instance is not available before the stack starts. Sketches should `begin()` the endpoint, then `Matter.begin()`, then `setLeak()` / `setFreeze()` / `setRain()` / `setContact()` with the real sensor reading.
+- Do not use `updateAttributeVal()` for Boolean State `StateValue`, and do not use CHIP's `BooleanState::FindClusterOnEndpoint()` (ESP-Matter does not link that helper).
+
 ### Controller-Originated Changes (attributeChangeCB)
 
 When a Matter controller changes an attribute (e.g., turning a light on via an app), the flow is:
@@ -93,6 +116,8 @@ bool MyEndpoint::begin(bool initialState, uint8_t brightness) {
   // ...
 }
 ```
+
+Boolean State sensors (`MatterContactSensor`, `MatterWaterLeakDetector`, `MatterWaterFreezeDetector`, `MatterRainSensor`) are the exception: `begin()` takes no arguments, does not set `config.boolean_state.state_value`, and forces the local cache to `false`. Apply the real sensor with the setter after `Matter.begin()`.
 
 ### updateAttributeVal vs setAttributeVal
 

--- a/libraries/Matter/README.md
+++ b/libraries/Matter/README.md
@@ -83,7 +83,7 @@ bool MatterWaterLeakDetector::setLeak(bool _leakState) {
 ```
 
 Key rules:
-- **`begin()` takes no initial state.** The cluster always starts at `false`. Do not write `config.boolean_state.state_value`; CHIP does not apply that config to the live cluster.
+- **`begin()` takes no initial state.** Value-initialize the config and set `config.boolean_state.state_value = false` so Ember `create()` gets a deterministic default. CHIP's live `BooleanStateCluster` ignores that field and always starts at `false`. A real sensor that is not false must be applied with the setter after `Matter.begin()`.
 - **Call the setter after `Matter.begin()`.** The cluster instance is not available before the stack starts. Sketches should `begin()` the endpoint, then `Matter.begin()`, then `setLeak()` / `setFreeze()` / `setRain()` / `setContact()` with the real sensor reading.
 - Do not use `updateAttributeVal()` for Boolean State `StateValue`, and do not use CHIP's `BooleanState::FindClusterOnEndpoint()` (ESP-Matter does not link that helper).
 
@@ -117,7 +117,7 @@ bool MyEndpoint::begin(bool initialState, uint8_t brightness) {
 }
 ```
 
-Boolean State sensors (`MatterContactSensor`, `MatterWaterLeakDetector`, `MatterWaterFreezeDetector`, `MatterRainSensor`) are the exception: `begin()` takes no arguments, does not set `config.boolean_state.state_value`, and forces the local cache to `false`. Apply the real sensor with the setter after `Matter.begin()`.
+Boolean State sensors (`MatterContactSensor`, `MatterWaterLeakDetector`, `MatterWaterFreezeDetector`, `MatterRainSensor`) are the exception: `begin()` takes no arguments, value-initializes the config, sets `config.boolean_state.state_value = false` (Ember create only; the live cluster ignores this field and starts at `false`), and forces the local cache to `false`. Apply the real sensor with the setter after `Matter.begin()`.
 
 ### updateAttributeVal vs setAttributeVal
 

--- a/libraries/Matter/examples/MatterContactSensor/MatterContactSensor.ino
+++ b/libraries/Matter/examples/MatterContactSensor/MatterContactSensor.ino
@@ -19,9 +19,10 @@
  * Turning DEBUG Level ON may be useful to following Matter Accessory and Controller messages.
  *
  * The example will create a Matter Contact Sensor Device.
- * The Contact Sensor state can be toggled by pressing the onboard button.
+ * begin() creates the endpoint with StateValue open. Call setContact() after
+ * Matter.begin() with the real or simulated sensor reading.
  * The Contact Sensor state will be indicated by the onboard LED.
- * The Contact Sensor state will be simulated to change every 20 seconds.
+ * The Contact Sensor state will be simulated to change every simulatedSensorInterval.
  *
  * The onboard button can be kept pressed for 5 seconds to decommission the Matter Node.
  * The example will also show the manual commissioning code and QR code to be used in the Matter environment.
@@ -56,18 +57,19 @@ const uint8_t ledPin = 2;  // Set your pin here if your board has not defined LE
 #warning "Do not forget to set the RGB LED pin"
 #endif
 
-// set your board USER BUTTON pin here - decommissioning and Manual Contact Sensor toggle button
+// set your board USER BUTTON pin here - decommissioning only
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
 
 // Button control
 uint32_t button_time_stamp = 0;                // debouncing control
 bool button_state = false;                     // false = released | true = pressed
-const uint32_t debouceTime = 250;              // button debouncing time (ms)
 const uint32_t decommissioningTimeout = 5000;  // keep the button pressed for 5s, or longer, to decommission
+
+// Simulated hardware toggles every 20 seconds. Replace simulatedHWContactSensor() with a real probe read.
+const uint32_t simulatedSensorInterval = 20000;
 
 void setup() {
   // Initialize the USER BUTTON (Boot button) that will be used to decommission the Matter Node
-  // The button will also be used to manually toggle the Contact Sensor state
   pinMode(buttonPin, INPUT_PULLUP);
   // Initialize the LED (light) GPIO and Matter End Point
   pinMode(ledPin, OUTPUT);
@@ -86,7 +88,7 @@ void setup() {
   Serial.println();
 #endif
 
-  // set initial contact sensor state as false (default)
+  // Create the endpoint. Fabric StateValue starts false (open); call setContact() after Matter.begin().
   ContactSensor.begin();
   digitalWrite(ledPin, LOW);  // LED OFF
 
@@ -114,12 +116,11 @@ void setup() {
 }
 
 bool simulatedHWContactSensor() {
-  // Simulated Contact Sensor
+  // Simulated Contact Sensor. Replace this body with a real sensor, e.g. return digitalRead(contactPin);
   static bool contactState = false;
-  static uint32_t lastTime = 0;
+  static uint32_t lastTime = millis();
 
-  // Simulate a Contact Sensor state change every 20 seconds
-  if (millis() - lastTime > 20000) {
+  if (millis() - lastTime > simulatedSensorInterval) {
     contactState = !contactState;
     lastTime = millis();
   }
@@ -134,29 +135,25 @@ void loop() {
     button_state = true;           // pressed.
   }
 
-  uint32_t time_diff = millis() - button_time_stamp;
-  if (button_state && time_diff > debouceTime && digitalRead(buttonPin) == HIGH) {
+  if (button_state && digitalRead(buttonPin) == HIGH) {
     button_state = false;  // released
-    // button is released - toggle Contact State (Open/Closed)
-    ContactSensor.setContact(!ContactSensor.getContact());  // same as ContactSensor = !ContactSensor;
-    Serial.printf("User button released. Setting the Contact Sensor to %s.\r\n", ContactSensor ? "Closed" : "Open");
-    // LED will indicate the Contact Sensor state
-    if (ContactSensor) {
-      digitalWrite(ledPin, HIGH);  // LED ON
-    } else {
-      digitalWrite(ledPin, LOW);  // LED OFF
-    }
   }
 
   // Onboard User Button is kept pressed for longer than 5 seconds in order to decommission matter node
+  uint32_t time_diff = millis() - button_time_stamp;
   if (button_state && time_diff > decommissioningTimeout) {
     Serial.println("Decommissioning Contact Sensor Matter Accessory. It shall be commissioned again.");
     Matter.decommission();
-    button_time_stamp = millis();  // avoid running decommissining again, reboot takes a second or so
+    button_time_stamp = millis();  // avoid running decommissioning again, reboot takes a second or so
   }
 
-  // Simulated Contact Sensor
+  // Report simulated (or real) hardware to Matter. First call after Matter.begin() applies the current reading.
+  bool previous = ContactSensor.getContact();
   ContactSensor.setContact(simulatedHWContactSensor());
+  if (ContactSensor.getContact() != previous) {
+    Serial.printf("Contact Sensor is %s.\r\n", ContactSensor ? "Closed" : "Open");
+  }
+  digitalWrite(ledPin, ContactSensor ? HIGH : LOW);
 
   delay(50);
 }

--- a/libraries/Matter/examples/MatterContactSensor/README.md
+++ b/libraries/Matter/examples/MatterContactSensor/README.md
@@ -1,7 +1,7 @@
 # Matter Contact Sensor Example
 
 This example demonstrates how to create a Matter-compatible contact sensor device using an ESP32 SoC microcontroller.\
-The application showcases Matter commissioning, device control via smart home ecosystems, manual control using a physical button, and automatic simulation of contact state changes.
+The application showcases Matter commissioning, sensor data reporting to smart home ecosystems, and automatic simulation of contact state changes.
 
 ## Supported Targets
 
@@ -26,17 +26,18 @@ The application showcases Matter commissioning, device control via smart home ec
 - Matter protocol implementation for a contact sensor device
 - Support for both Wi-Fi and Thread(*) connectivity
 - Contact state indication using LED (ON = Closed, OFF = Open)
-- Automatic simulation of contact state changes every 20 seconds
-- Button control for toggling contact state and factory reset
+- Automatic simulation of contact state changes every `simulatedSensorInterval` (20 seconds)
+- Button control for factory reset (decommission)
 - Matter commissioning via QR code or manual pairing code
 - Integration with Apple HomeKit, Amazon Alexa, and Google Home
+- `begin()` creates the endpoint (Open). Call `setContact()` after `Matter.begin()` with the real or simulated sensor reading.
 (*) It is necessary to compile the project using Arduino as IDF Component.
 
 ## Hardware Requirements
 
 - ESP32 compatible development board (see supported targets table)
 - LED connected to GPIO pins (or using built-in LED) to indicate contact state
-- User button for manual control (uses BOOT button by default)
+- User button for factory reset (uses BOOT button by default)
 
 ## Pin Configuration
 
@@ -69,9 +70,15 @@ Before uploading the sketch, configure the following:
    ```
 
 3. **Button pin configuration** (optional):
-   By default, the `BOOT` button (GPIO 0) is used for the Contact Sensor state toggle and factory reset. You can change this to a different pin if needed.
+   By default, the `BOOT` button (GPIO 0) is used for factory reset. You can change this to a different pin if needed.
    ```cpp
    const uint8_t buttonPin = BOOT_PIN;  // Set your button pin here
+   ```
+
+4. **Simulated sensor interval** (optional):
+   Change how often the simulated hardware toggles. Replace `simulatedHWContactSensor()` with a real probe read when you have hardware.
+   ```cpp
+   const uint32_t simulatedSensorInterval = 20000;  // 20 seconds
    ```
 
 ## Building and Flashing
@@ -104,24 +111,33 @@ Matter Node not commissioned yet. Waiting for commissioning.
 Matter Node not commissioned yet. Waiting for commissioning.
 ...
 Matter Node is commissioned and connected to the network. Ready for use.
-User button released. Setting the Contact Sensor to Closed.
-User button released. Setting the Contact Sensor to Open.
+Contact Sensor is Closed.
+Contact Sensor is Open.
 ```
+
+After commissioning, the simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default), `setContact()` reports that reading to Matter, and the LED follows `getContact()`.
 
 ## Using the Device
 
 ### Manual Control
 
-The user button (BOOT button by default) provides manual control:
+The user button (BOOT button by default) provides factory reset functionality:
 
-- **Short press of the button**: Toggle contact sensor state (Open/Closed)
 - **Long press (>5 seconds)**: Factory reset the device (decommission)
 
-### Automatic Simulation
+### Sensor Simulation
 
-The contact sensor state automatically toggles every 20 seconds to simulate a real contact sensor (such as a door or window sensor). The LED will reflect the current state:
+The example includes a simulated contact sensor that:
+
+- Starts in the open state (`false`)
+- Toggles every `simulatedSensorInterval` (20 seconds by default)
+- Is the only writer to Matter: `loop()` calls `setContact(simulatedHWContactSensor())`
+- Drives the LED from the reported Matter state (`getContact()`)
+
 - **LED ON**: Contact sensor is Closed
 - **LED OFF**: Contact sensor is Open
+
+To use a real sensor, replace the body of `simulatedHWContactSensor()` with your probe read (for example `return digitalRead(contactPin);`).
 
 ### Smart Home Integration
 
@@ -159,15 +175,15 @@ Use a Matter-compatible hub (like an Apple HomePod, Google Nest Hub, or Amazon E
 
 The MatterContactSensor example consists of the following main components:
 
-1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), sets up the Matter Contact Sensor endpoint with initial state (Open), and waits for Matter commissioning.
-2. **`loop()`**: Handles button input for toggling contact state and factory reset, and automatically simulates contact state changes every 20 seconds.
-3. **`simulatedHWContactSensor()`**: Simulates a hardware contact sensor by toggling the contact state every 20 seconds.
+1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), creates the Matter Contact Sensor endpoint with `begin()` (fabric state starts Open), starts Matter with `Matter.begin()`, and waits for commissioning.
+2. **`loop()`**: Handles the button for factory reset only, reports the simulated (or real) sensor with `setContact()` after `Matter.begin()`, and updates the LED from `getContact()`.
+3. **`simulatedHWContactSensor()`**: Simulates a hardware contact sensor by toggling every `simulatedSensorInterval`. Replace this function with a real sensor read.
 
 ## Troubleshooting
 
 - **Device not visible during commissioning**: Ensure Wi-Fi or Thread connectivity is properly configured
 - **LED not responding**: Verify pin configurations and connections
-- **Contact sensor state not updating**: Check Serial Monitor output to verify state changes are being processed
+- **Contact sensor state not updating**: `setContact()` must be called after `Matter.begin()`. `begin()` only creates the endpoint and does not take an initial state. The simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default). Check Serial Monitor output to verify state changes are being processed.
 - **Failed to commission**: Try factory resetting the device by long-pressing the button. Other option would be to erase the SoC Flash Memory by using `Arduino IDE Menu` -> `Tools` -> `Erase All Flash Before Sketch Upload: "Enabled"` or directly with `esptool.py --port <PORT> erase_flash`
 - **No serial output**: Check baudrate (115200) and USB connection
 

--- a/libraries/Matter/examples/MatterRainSensor/MatterRainSensor.ino
+++ b/libraries/Matter/examples/MatterRainSensor/MatterRainSensor.ino
@@ -19,9 +19,10 @@
  * Turning DEBUG Level ON may be useful to following Matter Accessory and Controller messages.
  *
  * The example will create a Matter Rain Sensor Device.
- * The Rain Sensor state can be toggled by pressing the onboard button.
+ * begin() creates the endpoint with StateValue not detected. Call setRain() after
+ * Matter.begin() with the real or simulated sensor reading.
  * The Rain Sensor state will be indicated by the onboard LED.
- * The Rain Sensor state will be simulated to change every 20 seconds.
+ * The Rain Sensor state will be simulated to change every simulatedSensorInterval.
  *
  * The onboard button can be kept pressed for 5 seconds to decommission the Matter Node.
  * The example will also show the manual commissioning code and QR code to be used in the Matter environment.
@@ -56,18 +57,19 @@ const uint8_t ledPin = 2;  // Set your pin here if your board has not defined LE
 #warning "Do not forget to set the RGB LED pin"
 #endif
 
-// set your board USER BUTTON pin here - decommissioning and Manual Rain Sensor toggle button
+// set your board USER BUTTON pin here - decommissioning only
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
 
 // Button control
 uint32_t button_time_stamp = 0;                // debouncing control
 bool button_state = false;                     // false = released | true = pressed
-const uint32_t debouceTime = 250;              // button debouncing time (ms)
 const uint32_t decommissioningTimeout = 5000;  // keep the button pressed for 5s, or longer, to decommission
+
+// Simulated hardware toggles every 20 seconds. Replace simulatedHWRainSensor() with a real probe read.
+const uint32_t simulatedSensorInterval = 20000;
 
 void setup() {
   // Initialize the USER BUTTON (Boot button) that will be used to decommission the Matter Node
-  // The button will also be used to manually toggle the Rain Sensor state
   pinMode(buttonPin, INPUT_PULLUP);
   // Initialize the LED (light) GPIO and Matter End Point
   pinMode(ledPin, OUTPUT);
@@ -86,7 +88,7 @@ void setup() {
   Serial.println();
 #endif
 
-  // set initial rain sensor state as false (default)
+  // Create the endpoint. Fabric StateValue starts false; call setRain() after Matter.begin().
   RainSensor.begin();
   digitalWrite(ledPin, LOW);  // LED OFF
 
@@ -114,12 +116,11 @@ void setup() {
 }
 
 bool simulatedHWRainSensor() {
-  // Simulated Rain Sensor
+  // Simulated Rain Sensor. Replace this body with a real sensor, e.g. return digitalRead(rainPin);
   static bool rainState = false;
-  static uint32_t lastTime = 0;
+  static uint32_t lastTime = millis();
 
-  // Simulate a Rain Sensor state change every 20 seconds
-  if (millis() - lastTime > 20000) {
+  if (millis() - lastTime > simulatedSensorInterval) {
     rainState = !rainState;
     lastTime = millis();
   }
@@ -134,29 +135,25 @@ void loop() {
     button_state = true;           // pressed.
   }
 
-  uint32_t time_diff = millis() - button_time_stamp;
-  if (button_state && time_diff > debouceTime && digitalRead(buttonPin) == HIGH) {
+  if (button_state && digitalRead(buttonPin) == HIGH) {
     button_state = false;  // released
-    // button is released - toggle Rain State (Not Detected/Detected)
-    RainSensor.setRain(!RainSensor.getRain());  // same as RainSensor = !RainSensor;
-    Serial.printf("User button released. Setting the Rain Sensor to %s.\r\n", RainSensor ? "Detected" : "Not Detected");
-    // LED will indicate the Rain Sensor state
-    if (RainSensor) {
-      digitalWrite(ledPin, HIGH);  // LED ON
-    } else {
-      digitalWrite(ledPin, LOW);  // LED OFF
-    }
   }
 
   // Onboard User Button is kept pressed for longer than 5 seconds in order to decommission matter node
+  uint32_t time_diff = millis() - button_time_stamp;
   if (button_state && time_diff > decommissioningTimeout) {
     Serial.println("Decommissioning Rain Sensor Matter Accessory. It shall be commissioned again.");
     Matter.decommission();
-    button_time_stamp = millis();  // avoid running decommissining again, reboot takes a second or so
+    button_time_stamp = millis();  // avoid running decommissioning again, reboot takes a second or so
   }
 
-  // Simulated Rain Sensor
+  // Report simulated (or real) hardware to Matter. First call after Matter.begin() applies the current reading.
+  bool previous = RainSensor.getRain();
   RainSensor.setRain(simulatedHWRainSensor());
+  if (RainSensor.getRain() != previous) {
+    Serial.printf("Rain Sensor is %s.\r\n", RainSensor ? "Detected" : "Not Detected");
+  }
+  digitalWrite(ledPin, RainSensor ? HIGH : LOW);
 
   delay(50);
 }

--- a/libraries/Matter/examples/MatterRainSensor/README.md
+++ b/libraries/Matter/examples/MatterRainSensor/README.md
@@ -1,7 +1,7 @@
 # Matter Rain Sensor Example
 
 This example demonstrates how to create a Matter-compatible rain sensor device using an ESP32 SoC microcontroller.\
-The application showcases Matter commissioning, device control via smart home ecosystems, manual control using a physical button, and automatic simulation of rain detection state changes.
+The application showcases Matter commissioning, sensor data reporting to smart home ecosystems, and automatic simulation of rain detection state changes.
 
 ## Supported Targets
 
@@ -26,17 +26,18 @@ The application showcases Matter commissioning, device control via smart home ec
 - Matter protocol implementation for a rain sensor device
 - Support for both Wi-Fi and Thread(*) connectivity
 - Rain detection state indication using LED (ON = Detected, OFF = Not Detected)
-- Automatic simulation of rain detection state changes every 20 seconds
-- Button control for toggling rain detection state and factory reset
+- Automatic simulation of rain detection state changes every `simulatedSensorInterval` (20 seconds)
+- Button control for factory reset (decommission)
 - Matter commissioning via QR code or manual pairing code
 - Integration with Apple HomeKit, Amazon Alexa, and Google Home
+- `begin()` creates the endpoint (Not Detected). Call `setRain()` after `Matter.begin()` with the real or simulated sensor reading.
 (*) It is necessary to compile the project using Arduino as IDF Component.
 
 ## Hardware Requirements
 
 - ESP32 compatible development board (see supported targets table)
 - LED connected to GPIO pins (or using built-in LED) to indicate rain detection state
-- User button for manual control (uses BOOT button by default)
+- User button for factory reset (uses BOOT button by default)
 
 ## Pin Configuration
 
@@ -69,9 +70,15 @@ Before uploading the sketch, configure the following:
    ```
 
 3. **Button pin configuration** (optional):
-   By default, the `BOOT` button (GPIO 0) is used for the Rain Sensor state toggle and factory reset. You can change this to a different pin if needed.
+   By default, the `BOOT` button (GPIO 0) is used for factory reset. You can change this to a different pin if needed.
    ```cpp
    const uint8_t buttonPin = BOOT_PIN;  // Set your button pin here
+   ```
+
+4. **Simulated sensor interval** (optional):
+   Change how often the simulated hardware toggles. Replace `simulatedHWRainSensor()` with a real probe read when you have hardware.
+   ```cpp
+   const uint32_t simulatedSensorInterval = 20000;  // 20 seconds
    ```
 
 ## Building and Flashing
@@ -104,24 +111,33 @@ Matter Node not commissioned yet. Waiting for commissioning.
 Matter Node not commissioned yet. Waiting for commissioning.
 ...
 Matter Node is commissioned and connected to the network. Ready for use.
-User button released. Setting the Rain Sensor to Detected.
-User button released. Setting the Rain Sensor to Not Detected.
+Rain Sensor is Detected.
+Rain Sensor is Not Detected.
 ```
+
+After commissioning, the simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default), `setRain()` reports that reading to Matter, and the LED follows `getRain()`.
 
 ## Using the Device
 
 ### Manual Control
 
-The user button (BOOT button by default) provides manual control:
+The user button (BOOT button by default) provides factory reset functionality:
 
-- **Short press of the button**: Toggle rain sensor state (Not Detected/Detected)
 - **Long press (>5 seconds)**: Factory reset the device (decommission)
 
-### Automatic Simulation
+### Sensor Simulation
 
-The rain sensor state automatically toggles every 20 seconds to simulate a real rain sensor. The LED will reflect the current state:
+The example includes a simulated rain sensor that:
+
+- Starts in the not-detected state (`false`)
+- Toggles every `simulatedSensorInterval` (20 seconds by default)
+- Is the only writer to Matter: `loop()` calls `setRain(simulatedHWRainSensor())`
+- Drives the LED from the reported Matter state (`getRain()`)
+
 - **LED ON**: Rain is Detected
 - **LED OFF**: Rain is Not Detected
+
+To use a real sensor, replace the body of `simulatedHWRainSensor()` with your probe read (for example `return digitalRead(rainPin);`).
 
 ### Smart Home Integration
 
@@ -162,15 +178,15 @@ You can also try the Home Assistant Matter feature in order to test it.
 
 The MatterRainSensor example consists of the following main components:
 
-1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), sets up the Matter Rain Sensor endpoint with initial state (Not Detected), and waits for Matter commissioning.
-2. **`loop()`**: Handles button input for toggling rain detection state and factory reset, and automatically simulates rain detection state changes every 20 seconds.
-3. **`simulatedHWRainSensor()`**: Simulates a hardware rain sensor by toggling the rain detection state every 20 seconds.
+1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), creates the Matter Rain Sensor endpoint with `begin()` (fabric state starts Not Detected), starts Matter with `Matter.begin()`, and waits for commissioning.
+2. **`loop()`**: Handles the button for factory reset only, reports the simulated (or real) sensor with `setRain()` after `Matter.begin()`, and updates the LED from `getRain()`.
+3. **`simulatedHWRainSensor()`**: Simulates a hardware rain sensor by toggling every `simulatedSensorInterval`. Replace this function with a real sensor read.
 
 ## Troubleshooting
 
 - **Device not visible during commissioning**: Ensure Wi-Fi or Thread connectivity is properly configured
 - **LED not responding**: Verify pin configurations and connections
-- **Rain sensor state not updating**: Check Serial Monitor output to verify state changes are being processed
+- **Rain sensor state not updating**: `setRain()` must be called after `Matter.begin()`. `begin()` only creates the endpoint and does not take an initial state. The simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default). Check Serial Monitor output to verify state changes are being processed.
 - **Failed to commission**: Try factory resetting the device by long-pressing the button. Other option would be to erase the SoC Flash Memory by using `Arduino IDE Menu` -> `Tools` -> `Erase All Flash Before Sketch Upload: "Enabled"` or directly with `esptool.py --port <PORT> erase_flash`
 - **No serial output**: Check baudrate (115200) and USB connection
 

--- a/libraries/Matter/examples/MatterWaterFreezeDetector/MatterWaterFreezeDetector.ino
+++ b/libraries/Matter/examples/MatterWaterFreezeDetector/MatterWaterFreezeDetector.ino
@@ -19,9 +19,10 @@
  * Turning DEBUG Level ON may be useful to following Matter Accessory and Controller messages.
  *
  * The example will create a Matter Water Freeze Detector Device.
- * The Water Freeze Detector state can be toggled by pressing the onboard button.
+ * begin() creates the endpoint with StateValue not detected. Call setFreeze() after
+ * Matter.begin() with the real or simulated sensor reading.
  * The Water Freeze Detector state will be indicated by the onboard LED.
- * The Water Freeze Detector state will be simulated to change every 20 seconds.
+ * The Water Freeze Detector state will be simulated to change every simulatedSensorInterval.
  *
  * The onboard button can be kept pressed for 5 seconds to decommission the Matter Node.
  * The example will also show the manual commissioning code and QR code to be used in the Matter environment.
@@ -56,18 +57,19 @@ const uint8_t ledPin = 2;  // Set your pin here if your board has not defined LE
 #warning "Do not forget to set the RGB LED pin"
 #endif
 
-// set your board USER BUTTON pin here - decommissioning and Manual Water Freeze Detector toggle button
+// set your board USER BUTTON pin here - decommissioning only
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
 
 // Button control
 uint32_t button_time_stamp = 0;                // debouncing control
 bool button_state = false;                     // false = released | true = pressed
-const uint32_t debouceTime = 250;              // button debouncing time (ms)
 const uint32_t decommissioningTimeout = 5000;  // keep the button pressed for 5s, or longer, to decommission
+
+// Simulated hardware toggles every 20 seconds. Replace simulatedHWWaterFreezeDetector() with a real probe read.
+const uint32_t simulatedSensorInterval = 20000;
 
 void setup() {
   // Initialize the USER BUTTON (Boot button) that will be used to decommission the Matter Node
-  // The button will also be used to manually toggle the Water Freeze Detector state
   pinMode(buttonPin, INPUT_PULLUP);
   // Initialize the LED (light) GPIO and Matter End Point
   pinMode(ledPin, OUTPUT);
@@ -86,7 +88,7 @@ void setup() {
   Serial.println();
 #endif
 
-  // set initial water freeze detector state as false (default)
+  // Create the endpoint. Fabric StateValue starts false; call setFreeze() after Matter.begin().
   WaterFreezeDetector.begin();
   digitalWrite(ledPin, LOW);  // LED OFF
 
@@ -114,12 +116,11 @@ void setup() {
 }
 
 bool simulatedHWWaterFreezeDetector() {
-  // Simulated Water Freeze Detector
+  // Simulated Water Freeze Detector. Replace this body with a real sensor, e.g. return digitalRead(freezePin);
   static bool freezeState = false;
-  static uint32_t lastTime = 0;
+  static uint32_t lastTime = millis();
 
-  // Simulate a Water Freeze Detector state change every 20 seconds
-  if (millis() - lastTime > 20000) {
+  if (millis() - lastTime > simulatedSensorInterval) {
     freezeState = !freezeState;
     lastTime = millis();
   }
@@ -134,29 +135,25 @@ void loop() {
     button_state = true;           // pressed.
   }
 
-  uint32_t time_diff = millis() - button_time_stamp;
-  if (button_state && time_diff > debouceTime && digitalRead(buttonPin) == HIGH) {
+  if (button_state && digitalRead(buttonPin) == HIGH) {
     button_state = false;  // released
-    // button is released - toggle Freeze State (Not Detected/Detected)
-    WaterFreezeDetector.setFreeze(!WaterFreezeDetector.getFreeze());  // same as WaterFreezeDetector = !WaterFreezeDetector;
-    Serial.printf("User button released. Setting the Water Freeze Detector to %s.\r\n", WaterFreezeDetector ? "Detected" : "Not Detected");
-    // LED will indicate the Water Freeze Detector state
-    if (WaterFreezeDetector) {
-      digitalWrite(ledPin, HIGH);  // LED ON
-    } else {
-      digitalWrite(ledPin, LOW);  // LED OFF
-    }
   }
 
   // Onboard User Button is kept pressed for longer than 5 seconds in order to decommission matter node
+  uint32_t time_diff = millis() - button_time_stamp;
   if (button_state && time_diff > decommissioningTimeout) {
     Serial.println("Decommissioning Water Freeze Detector Matter Accessory. It shall be commissioned again.");
     Matter.decommission();
-    button_time_stamp = millis();  // avoid running decommissining again, reboot takes a second or so
+    button_time_stamp = millis();  // avoid running decommissioning again, reboot takes a second or so
   }
 
-  // Simulated Water Freeze Detector
+  // Report simulated (or real) hardware to Matter. First call after Matter.begin() applies the current reading.
+  bool previous = WaterFreezeDetector.getFreeze();
   WaterFreezeDetector.setFreeze(simulatedHWWaterFreezeDetector());
+  if (WaterFreezeDetector.getFreeze() != previous) {
+    Serial.printf("Water Freeze Detector is %s.\r\n", WaterFreezeDetector ? "Detected" : "Not Detected");
+  }
+  digitalWrite(ledPin, WaterFreezeDetector ? HIGH : LOW);
 
   delay(50);
 }

--- a/libraries/Matter/examples/MatterWaterFreezeDetector/README.md
+++ b/libraries/Matter/examples/MatterWaterFreezeDetector/README.md
@@ -1,7 +1,7 @@
 # Matter Water Freeze Detector Example
 
 This example demonstrates how to create a Matter-compatible water freeze detector device using an ESP32 SoC microcontroller.\
-The application showcases Matter commissioning, device control via smart home ecosystems, manual control using a physical button, and automatic simulation of water freeze detection state changes.
+The application showcases Matter commissioning, sensor data reporting to smart home ecosystems, and automatic simulation of water freeze detection state changes.
 
 ## Supported Targets
 
@@ -26,17 +26,18 @@ The application showcases Matter commissioning, device control via smart home ec
 - Matter protocol implementation for a water freeze detector device
 - Support for both Wi-Fi and Thread(*) connectivity
 - Water freeze detection state indication using LED (ON = Detected, OFF = Not Detected)
-- Automatic simulation of water freeze detection state changes every 20 seconds
-- Button control for toggling water freeze detection state and factory reset
+- Automatic simulation of water freeze detection state changes every `simulatedSensorInterval` (20 seconds)
+- Button control for factory reset (decommission)
 - Matter commissioning via QR code or manual pairing code
 - Integration with Apple HomeKit, Amazon Alexa, and Google Home
+- `begin()` creates the endpoint (Not Detected). Call `setFreeze()` after `Matter.begin()` with the real or simulated sensor reading.
 (*) It is necessary to compile the project using Arduino as IDF Component.
 
 ## Hardware Requirements
 
 - ESP32 compatible development board (see supported targets table)
 - LED connected to GPIO pins (or using built-in LED) to indicate water freeze detection state
-- User button for manual control (uses BOOT button by default)
+- User button for factory reset (uses BOOT button by default)
 
 ## Pin Configuration
 
@@ -69,9 +70,15 @@ Before uploading the sketch, configure the following:
    ```
 
 3. **Button pin configuration** (optional):
-   By default, the `BOOT` button (GPIO 0) is used for the Water Freeze Detector state toggle and factory reset. You can change this to a different pin if needed.
+   By default, the `BOOT` button (GPIO 0) is used for factory reset. You can change this to a different pin if needed.
    ```cpp
    const uint8_t buttonPin = BOOT_PIN;  // Set your button pin here
+   ```
+
+4. **Simulated sensor interval** (optional):
+   Change how often the simulated hardware toggles. Replace `simulatedHWWaterFreezeDetector()` with a real probe read when you have hardware.
+   ```cpp
+   const uint32_t simulatedSensorInterval = 20000;  // 20 seconds
    ```
 
 ## Building and Flashing
@@ -104,24 +111,33 @@ Matter Node not commissioned yet. Waiting for commissioning.
 Matter Node not commissioned yet. Waiting for commissioning.
 ...
 Matter Node is commissioned and connected to the network. Ready for use.
-User button released. Setting the Water Freeze Detector to Detected.
-User button released. Setting the Water Freeze Detector to Not Detected.
+Water Freeze Detector is Detected.
+Water Freeze Detector is Not Detected.
 ```
+
+After commissioning, the simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default), `setFreeze()` reports that reading to Matter, and the LED follows `getFreeze()`.
 
 ## Using the Device
 
 ### Manual Control
 
-The user button (BOOT button by default) provides manual control:
+The user button (BOOT button by default) provides factory reset functionality:
 
-- **Short press of the button**: Toggle water freeze detector state (Not Detected/Detected)
 - **Long press (>5 seconds)**: Factory reset the device (decommission)
 
-### Automatic Simulation
+### Sensor Simulation
 
-The water freeze detector state automatically toggles every 20 seconds to simulate a real water freeze detector. The LED will reflect the current state:
+The example includes a simulated water freeze detector that:
+
+- Starts in the not-detected state (`false`)
+- Toggles every `simulatedSensorInterval` (20 seconds by default)
+- Is the only writer to Matter: `loop()` calls `setFreeze(simulatedHWWaterFreezeDetector())`
+- Drives the LED from the reported Matter state (`getFreeze()`)
+
 - **LED ON**: Water freeze is Detected
 - **LED OFF**: Water freeze is Not Detected
+
+To use a real sensor, replace the body of `simulatedHWWaterFreezeDetector()` with your probe read (for example `return digitalRead(freezePin);`).
 
 ### Smart Home Integration
 
@@ -162,15 +178,15 @@ You can also try the Home Assistant Matter feature in order to test it.
 
 The MatterWaterFreezeDetector example consists of the following main components:
 
-1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), sets up the Matter Water Freeze Detector endpoint with initial state (Not Detected), and waits for Matter commissioning.
-2. **`loop()`**: Handles button input for toggling water freeze detection state and factory reset, and automatically simulates water freeze detection state changes every 20 seconds.
-3. **`simulatedHWWaterFreezeDetector()`**: Simulates a hardware water freeze detector by toggling the water freeze detection state every 20 seconds.
+1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), creates the Matter Water Freeze Detector endpoint with `begin()` (fabric state starts Not Detected), starts Matter with `Matter.begin()`, and waits for commissioning.
+2. **`loop()`**: Handles the button for factory reset only, reports the simulated (or real) sensor with `setFreeze()` after `Matter.begin()`, and updates the LED from `getFreeze()`.
+3. **`simulatedHWWaterFreezeDetector()`**: Simulates a hardware water freeze detector by toggling every `simulatedSensorInterval`. Replace this function with a real sensor read.
 
 ## Troubleshooting
 
 - **Device not visible during commissioning**: Ensure Wi-Fi or Thread connectivity is properly configured
 - **LED not responding**: Verify pin configurations and connections
-- **Water freeze detector state not updating**: Check Serial Monitor output to verify state changes are being processed
+- **Water freeze detector state not updating**: `setFreeze()` must be called after `Matter.begin()`. `begin()` only creates the endpoint and does not take an initial state. The simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default). Check Serial Monitor output to verify state changes are being processed.
 - **Failed to commission**: Try factory resetting the device by long-pressing the button. Other option would be to erase the SoC Flash Memory by using `Arduino IDE Menu` -> `Tools` -> `Erase All Flash Before Sketch Upload: "Enabled"` or directly with `esptool.py --port <PORT> erase_flash`
 - **No serial output**: Check baudrate (115200) and USB connection
 

--- a/libraries/Matter/examples/MatterWaterLeakDetector/MatterWaterLeakDetector.ino
+++ b/libraries/Matter/examples/MatterWaterLeakDetector/MatterWaterLeakDetector.ino
@@ -19,9 +19,10 @@
  * Turning DEBUG Level ON may be useful to following Matter Accessory and Controller messages.
  *
  * The example will create a Matter Water Leak Detector Device.
- * The Water Leak Detector state can be toggled by pressing the onboard button.
+ * begin() creates the endpoint with StateValue not detected. Call setLeak() after
+ * Matter.begin() with the real or simulated sensor reading.
  * The Water Leak Detector state will be indicated by the onboard LED.
- * The Water Leak Detector state will be simulated to change every 20 seconds.
+ * The Water Leak Detector state will be simulated to change every simulatedSensorInterval.
  *
  * The onboard button can be kept pressed for 5 seconds to decommission the Matter Node.
  * The example will also show the manual commissioning code and QR code to be used in the Matter environment.
@@ -56,18 +57,19 @@ const uint8_t ledPin = 2;  // Set your pin here if your board has not defined LE
 #warning "Do not forget to set the RGB LED pin"
 #endif
 
-// set your board USER BUTTON pin here - decommissioning and Manual Water Leak Detector toggle button
+// set your board USER BUTTON pin here - decommissioning only
 const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
 
 // Button control
 uint32_t button_time_stamp = 0;                // debouncing control
 bool button_state = false;                     // false = released | true = pressed
-const uint32_t debounceTime = 250;             // button debouncing time (ms)
 const uint32_t decommissioningTimeout = 5000;  // keep the button pressed for 5s, or longer, to decommission
+
+// Simulated hardware toggles every 20 seconds. Replace simulatedHWWaterLeakDetector() with a real probe read.
+const uint32_t simulatedSensorInterval = 20000;
 
 void setup() {
   // Initialize the USER BUTTON (Boot button) that will be used to decommission the Matter Node
-  // The button will also be used to manually toggle the Water Leak Detector state
   pinMode(buttonPin, INPUT_PULLUP);
   // Initialize the LED (light) GPIO and Matter End Point
   pinMode(ledPin, OUTPUT);
@@ -86,7 +88,7 @@ void setup() {
   Serial.println();
 #endif
 
-  // set initial water leak detector state as false (default)
+  // Create the endpoint. Fabric StateValue starts false; call setLeak() after Matter.begin().
   WaterLeakDetector.begin();
   digitalWrite(ledPin, LOW);  // LED OFF
 
@@ -114,12 +116,11 @@ void setup() {
 }
 
 bool simulatedHWWaterLeakDetector() {
-  // Simulated Water Leak Detector
+  // Simulated Water Leak Detector. Replace this body with a real sensor, e.g. return digitalRead(leakPin);
   static bool leakState = false;
-  static uint32_t lastTime = 0;
+  static uint32_t lastTime = millis();
 
-  // Simulate a Water Leak Detector state change every 20 seconds
-  if (millis() - lastTime > 20000) {
+  if (millis() - lastTime > simulatedSensorInterval) {
     leakState = !leakState;
     lastTime = millis();
   }
@@ -134,29 +135,25 @@ void loop() {
     button_state = true;           // pressed.
   }
 
-  uint32_t time_diff = millis() - button_time_stamp;
-  if (button_state && time_diff > debounceTime && digitalRead(buttonPin) == HIGH) {
+  if (button_state && digitalRead(buttonPin) == HIGH) {
     button_state = false;  // released
-    // button is released - toggle Leak State (Not Detected/Detected)
-    WaterLeakDetector.setLeak(!WaterLeakDetector.getLeak());  // same as WaterLeakDetector = !WaterLeakDetector;
-    Serial.printf("User button released. Setting the Water Leak Detector to %s.\r\n", WaterLeakDetector ? "Detected" : "Not Detected");
-    // LED will indicate the Water Leak Detector state
-    if (WaterLeakDetector) {
-      digitalWrite(ledPin, HIGH);  // LED ON
-    } else {
-      digitalWrite(ledPin, LOW);  // LED OFF
-    }
   }
 
   // Onboard User Button is kept pressed for longer than 5 seconds in order to decommission matter node
+  uint32_t time_diff = millis() - button_time_stamp;
   if (button_state && time_diff > decommissioningTimeout) {
     Serial.println("Decommissioning Water Leak Detector Matter Accessory. It shall be commissioned again.");
     Matter.decommission();
     button_time_stamp = millis();  // avoid running decommissioning again, reboot takes a second or so
   }
 
-  // Simulated Water Leak Detector
+  // Report simulated (or real) hardware to Matter. First call after Matter.begin() applies the current reading.
+  bool previous = WaterLeakDetector.getLeak();
   WaterLeakDetector.setLeak(simulatedHWWaterLeakDetector());
+  if (WaterLeakDetector.getLeak() != previous) {
+    Serial.printf("Water Leak Detector is %s.\r\n", WaterLeakDetector ? "Detected" : "Not Detected");
+  }
+  digitalWrite(ledPin, WaterLeakDetector ? HIGH : LOW);
 
   delay(50);
 }

--- a/libraries/Matter/examples/MatterWaterLeakDetector/README.md
+++ b/libraries/Matter/examples/MatterWaterLeakDetector/README.md
@@ -1,7 +1,7 @@
 # Matter Water Leak Detector Example
 
 This example demonstrates how to create a Matter-compatible water leak detector device using an ESP32 SoC microcontroller.\
-The application showcases Matter commissioning, device control via smart home ecosystems, manual control using a physical button, and automatic simulation of water leak detection state changes.
+The application showcases Matter commissioning, sensor data reporting to smart home ecosystems, and automatic simulation of water leak detection state changes.
 
 ## Supported Targets
 
@@ -26,17 +26,18 @@ The application showcases Matter commissioning, device control via smart home ec
 - Matter protocol implementation for a water leak detector device
 - Support for both Wi-Fi and Thread(*) connectivity
 - Water leak detection state indication using LED (ON = Detected, OFF = Not Detected)
-- Automatic simulation of water leak detection state changes every 20 seconds
-- Button control for toggling water leak detection state and factory reset
+- Automatic simulation of water leak detection state changes every `simulatedSensorInterval` (20 seconds)
+- Button control for factory reset (decommission)
 - Matter commissioning via QR code or manual pairing code
 - Integration with Apple HomeKit, Amazon Alexa, and Google Home
+- `begin()` creates the endpoint (Not Detected). Call `setLeak()` after `Matter.begin()` with the real or simulated sensor reading.
 (*) It is necessary to compile the project using Arduino as IDF Component.
 
 ## Hardware Requirements
 
 - ESP32 compatible development board (see supported targets table)
 - LED connected to GPIO pins (or using built-in LED) to indicate water leak detection state
-- User button for manual control (uses BOOT button by default)
+- User button for factory reset (uses BOOT button by default)
 
 ## Pin Configuration
 
@@ -69,9 +70,15 @@ Before uploading the sketch, configure the following:
    ```
 
 3. **Button pin configuration** (optional):
-   By default, the `BOOT` button (GPIO 0) is used for the Water Leak Detector state toggle and factory reset. You can change this to a different pin if needed.
+   By default, the `BOOT` button (GPIO 0) is used for factory reset. You can change this to a different pin if needed.
    ```cpp
    const uint8_t buttonPin = BOOT_PIN;  // Set your button pin here
+   ```
+
+4. **Simulated sensor interval** (optional):
+   Change how often the simulated hardware toggles. Replace `simulatedHWWaterLeakDetector()` with a real probe read when you have hardware.
+   ```cpp
+   const uint32_t simulatedSensorInterval = 20000;  // 20 seconds
    ```
 
 ## Building and Flashing
@@ -104,24 +111,33 @@ Matter Node not commissioned yet. Waiting for commissioning.
 Matter Node not commissioned yet. Waiting for commissioning.
 ...
 Matter Node is commissioned and connected to the network. Ready for use.
-User button released. Setting the Water Leak Detector to Detected.
-User button released. Setting the Water Leak Detector to Not Detected.
+Water Leak Detector is Detected.
+Water Leak Detector is Not Detected.
 ```
+
+After commissioning, the simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default), `setLeak()` reports that reading to Matter, and the LED follows `getLeak()`.
 
 ## Using the Device
 
 ### Manual Control
 
-The user button (BOOT button by default) provides manual control:
+The user button (BOOT button by default) provides factory reset functionality:
 
-- **Short press of the button**: Toggle water leak detector state (Not Detected/Detected)
 - **Long press (>5 seconds)**: Factory reset the device (decommission)
 
-### Automatic Simulation
+### Sensor Simulation
 
-The water leak detector state automatically toggles every 20 seconds to simulate a real water leak detector. The LED will reflect the current state:
+The example includes a simulated water leak detector that:
+
+- Starts in the not-detected state (`false`)
+- Toggles every `simulatedSensorInterval` (20 seconds by default)
+- Is the only writer to Matter: `loop()` calls `setLeak(simulatedHWWaterLeakDetector())`
+- Drives the LED from the reported Matter state (`getLeak()`)
+
 - **LED ON**: Water leak is Detected
 - **LED OFF**: Water leak is Not Detected
+
+To use a real sensor, replace the body of `simulatedHWWaterLeakDetector()` with your probe read (for example `return digitalRead(leakPin);`).
 
 ### Smart Home Integration
 
@@ -162,15 +178,15 @@ You can also try the Home Assistant Matter feature in order to test it.
 
 The MatterWaterLeakDetector example consists of the following main components:
 
-1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), sets up the Matter Water Leak Detector endpoint with initial state (Not Detected), and waits for Matter commissioning.
-2. **`loop()`**: Handles button input for toggling water leak detection state and factory reset, and automatically simulates water leak detection state changes every 20 seconds.
-3. **`simulatedHWWaterLeakDetector()`**: Simulates a hardware water leak detector by toggling the water leak detection state every 20 seconds.
+1. **`setup()`**: Initializes hardware (button, LED), configures Wi-Fi (if needed), creates the Matter Water Leak Detector endpoint with `begin()` (fabric state starts Not Detected), starts Matter with `Matter.begin()`, and waits for commissioning.
+2. **`loop()`**: Handles the button for factory reset only, reports the simulated (or real) sensor with `setLeak()` after `Matter.begin()`, and updates the LED from `getLeak()`.
+3. **`simulatedHWWaterLeakDetector()`**: Simulates a hardware water leak detector by toggling every `simulatedSensorInterval`. Replace this function with a real sensor read.
 
 ## Troubleshooting
 
 - **Device not visible during commissioning**: Ensure Wi-Fi or Thread connectivity is properly configured
 - **LED not responding**: Verify pin configurations and connections
-- **Water leak detector state not updating**: Check Serial Monitor output to verify state changes are being processed
+- **Water leak detector state not updating**: `setLeak()` must be called after `Matter.begin()`. `begin()` only creates the endpoint and does not take an initial state. The simulated sensor toggles every `simulatedSensorInterval` (20 seconds by default). Check Serial Monitor output to verify state changes are being processed.
 - **Failed to commission**: Try factory resetting the device by long-pressing the button. Other option would be to erase the SoC Flash Memory by using `Arduino IDE Menu` -> `Tools` -> `Erase All Flash Before Sketch Upload: "Enabled"` or directly with `esptool.py --port <PORT> erase_flash`
 - **No serial output**: Check baudrate (115200) and USB connection
 

--- a/libraries/Matter/src/MatterEndPoint.cpp
+++ b/libraries/Matter/src/MatterEndPoint.cpp
@@ -16,6 +16,10 @@
 #ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
 
 #include <MatterEndPoint.h>
+#include <app/clusters/boolean-state-server/boolean-state-cluster.h>
+#include <data_model_provider/esp_matter_data_model_provider.h>
+
+using namespace chip::app::Clusters;
 
 uint16_t MatterEndPoint::secondary_network_endpoint_id = 0;
 
@@ -128,6 +132,23 @@ bool MatterEndPoint::updateAttributeVal(uint32_t cluster_id, uint32_t attribute_
   }
   log_e("Update FAILED! for cluster %" PRIu32 ", attribute %" PRIu32 " with value %" PRIu32, cluster_id, attribute_id, attrVal->val.u32);
   return false;
+}
+
+static BooleanStateCluster *getBooleanStateCluster(uint16_t endpoint_id) {
+  chip::app::ServerClusterInterface *iface =
+    esp_matter::data_model::provider::get_instance().registry().Get(chip::app::ConcreteClusterPath(endpoint_id, BooleanState::Id));
+  return static_cast<BooleanStateCluster *>(iface);
+}
+
+bool MatterEndPoint::setBooleanStateValue(bool value) {
+  BooleanStateCluster *cluster = getBooleanStateCluster(endpoint_id);
+  if (cluster == nullptr) {
+    log_e("BooleanState cluster not found on endpoint %u. Call Matter.begin() first.", endpoint_id);
+    return false;
+  }
+  lock::ScopedChipStackLock lock(portMAX_DELAY);
+  cluster->SetStateValue(value);
+  return true;
 }
 
 // This callback is invoked when clients interact with the Identify Cluster of an specific endpoint.

--- a/libraries/Matter/src/MatterEndPoint.h
+++ b/libraries/Matter/src/MatterEndPoint.h
@@ -73,5 +73,9 @@ protected:
   // main endpoint ID
   uint16_t endpoint_id = 0;
   EndPointIdentifyCB _onEndPointIdentifyCB = nullptr;
+
+  // BooleanState::StateValue is internally managed in ESP Matter 1.5+ (code-driven cluster).
+  // attribute::update() returns ESP_ERR_NOT_SUPPORTED (262); use the cluster setter instead.
+  bool setBooleanStateValue(bool value);
 };
 #endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterEndpoints/MatterContactSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterContactSensor.cpp
@@ -51,8 +51,10 @@ bool MatterContactSensor::begin() {
     return false;
   }
 
-  contact_sensor::config_t contact_sensor_config;
-  // BooleanStateCluster always starts at false; apply the real sensor with setContact() after Matter.begin().
+  contact_sensor::config_t contact_sensor_config{};
+  contact_sensor_config.boolean_state.state_value = false;
+  // CHIP BooleanStateCluster still starts at false regardless of this field;
+  // apply the real sensor with setContact() after Matter.begin().
 
   endpoint_t *endpoint = contact_sensor::create(node::get(), &contact_sensor_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {

--- a/libraries/Matter/src/MatterEndpoints/MatterContactSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterContactSensor.cpp
@@ -43,7 +43,7 @@ MatterContactSensor::~MatterContactSensor() {
   end();
 }
 
-bool MatterContactSensor::begin(bool _contactState) {
+bool MatterContactSensor::begin() {
   ArduinoMatter::_init();
 
   if (getEndPointId() != 0) {
@@ -52,15 +52,14 @@ bool MatterContactSensor::begin(bool _contactState) {
   }
 
   contact_sensor::config_t contact_sensor_config;
-  contact_sensor_config.boolean_state.state_value = _contactState;
+  // BooleanStateCluster always starts at false; apply the real sensor with setContact() after Matter.begin().
 
-  // endpoint handles can be used to add/modify clusters.
   endpoint_t *endpoint = contact_sensor::create(node::get(), &contact_sensor_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {
     log_e("Failed to create Contact Sensor endpoint");
     return false;
   }
-  contactState = _contactState;
+  contactState = false;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Contact Sensor created with endpoint_id %u", getEndPointId());
 
@@ -78,27 +77,15 @@ bool MatterContactSensor::setContact(bool _contactState) {
     return false;
   }
 
-  // avoid processing if there was no change
   if (contactState == _contactState) {
     return true;
   }
 
-  esp_matter_attr_val_t contactVal = esp_matter_invalid(NULL);
-
-  if (!getAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &contactVal)) {
-    log_e("Failed to get Contact Sensor Attribute.");
+  if (!setBooleanStateValue(_contactState)) {
+    log_e("Failed to update Contact Sensor Attribute.");
     return false;
   }
-  if (contactVal.val.u8 != _contactState) {
-    contactVal.val.u8 = _contactState;
-    bool ret;
-    ret = updateAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &contactVal);
-    if (!ret) {
-      log_e("Failed to update Contact Sensor Attribute.");
-      return false;
-    }
-    contactState = _contactState;
-  }
+  contactState = _contactState;
   log_v("Contact Sensor set to %s", _contactState ? "Closed" : "Open");
 
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterContactSensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterContactSensor.h
@@ -23,12 +23,12 @@ class MatterContactSensor : public MatterEndPoint {
 public:
   MatterContactSensor();
   ~MatterContactSensor();
-  // begin Matter Contact Sensor endpoint with initial contact state
-  bool begin(bool _contactState = false);
+  // begin Matter Contact Sensor endpoint. Fabric StateValue starts false (open).
+  bool begin();
   // this will just stop processing Contact Sensor Matter events
   void end();
 
-  // set the contact state
+  // set the contact state. Call after Matter.begin() with the real sensor reading.
   bool setContact(bool _contactState);
   // returns the contact state
   bool getContact() {

--- a/libraries/Matter/src/MatterEndpoints/MatterRainSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterRainSensor.cpp
@@ -43,7 +43,7 @@ MatterRainSensor::~MatterRainSensor() {
   end();
 }
 
-bool MatterRainSensor::begin(bool _rainState) {
+bool MatterRainSensor::begin() {
   ArduinoMatter::_init();
 
   if (getEndPointId() != 0) {
@@ -52,15 +52,14 @@ bool MatterRainSensor::begin(bool _rainState) {
   }
 
   rain_sensor::config_t rain_sensor_config;
-  rain_sensor_config.boolean_state.state_value = _rainState;
+  // BooleanStateCluster always starts at false; apply the real sensor with setRain() after Matter.begin().
 
-  // endpoint handles can be used to add/modify clusters.
   endpoint_t *endpoint = rain_sensor::create(node::get(), &rain_sensor_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {
     log_e("Failed to create Rain Sensor endpoint");
     return false;
   }
-  rainState = _rainState;
+  rainState = false;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Rain Sensor created with endpoint_id %u", getEndPointId());
 
@@ -78,27 +77,15 @@ bool MatterRainSensor::setRain(bool _rainState) {
     return false;
   }
 
-  // avoid processing if there was no change
   if (rainState == _rainState) {
     return true;
   }
 
-  esp_matter_attr_val_t rainVal = esp_matter_invalid(NULL);
-
-  if (!getAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &rainVal)) {
-    log_e("Failed to get Rain Sensor Attribute.");
+  if (!setBooleanStateValue(_rainState)) {
+    log_e("Failed to update Rain Sensor Attribute.");
     return false;
   }
-  if (rainVal.val.u8 != _rainState) {
-    rainVal.val.u8 = _rainState;
-    bool ret;
-    ret = updateAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &rainVal);
-    if (!ret) {
-      log_e("Failed to update Rain Sensor Attribute.");
-      return false;
-    }
-    rainState = _rainState;
-  }
+  rainState = _rainState;
   log_v("Rain Sensor set to %s", _rainState ? "Detected" : "Not Detected");
 
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterRainSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterRainSensor.cpp
@@ -51,8 +51,10 @@ bool MatterRainSensor::begin() {
     return false;
   }
 
-  rain_sensor::config_t rain_sensor_config;
-  // BooleanStateCluster always starts at false; apply the real sensor with setRain() after Matter.begin().
+  rain_sensor::config_t rain_sensor_config{};
+  rain_sensor_config.boolean_state.state_value = false;
+  // CHIP BooleanStateCluster still starts at false regardless of this field;
+  // apply the real sensor with setRain() after Matter.begin().
 
   endpoint_t *endpoint = rain_sensor::create(node::get(), &rain_sensor_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {

--- a/libraries/Matter/src/MatterEndpoints/MatterRainSensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterRainSensor.h
@@ -23,12 +23,12 @@ class MatterRainSensor : public MatterEndPoint {
 public:
   MatterRainSensor();
   ~MatterRainSensor();
-  // begin Matter Rain Sensor endpoint with initial rain state
-  bool begin(bool _rainState = false);
+  // begin Matter Rain Sensor endpoint. Fabric StateValue starts false.
+  bool begin();
   // this will just stop processing Rain Sensor Matter events
   void end();
 
-  // set the rain state
+  // set the rain state. Call after Matter.begin() with the real sensor reading.
   bool setRain(bool _rainState);
   // returns the rain state
   bool getRain() {

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterFreezeDetector.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterFreezeDetector.cpp
@@ -43,7 +43,7 @@ MatterWaterFreezeDetector::~MatterWaterFreezeDetector() {
   end();
 }
 
-bool MatterWaterFreezeDetector::begin(bool _freezeState) {
+bool MatterWaterFreezeDetector::begin() {
   ArduinoMatter::_init();
 
   if (getEndPointId() != 0) {
@@ -52,15 +52,14 @@ bool MatterWaterFreezeDetector::begin(bool _freezeState) {
   }
 
   water_freeze_detector::config_t water_freeze_detector_config;
-  water_freeze_detector_config.boolean_state.state_value = _freezeState;
+  // BooleanStateCluster always starts at false; apply the real sensor with setFreeze() after Matter.begin().
 
-  // endpoint handles can be used to add/modify clusters.
   endpoint_t *endpoint = water_freeze_detector::create(node::get(), &water_freeze_detector_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {
     log_e("Failed to create Water Freeze Detector endpoint");
     return false;
   }
-  freezeState = _freezeState;
+  freezeState = false;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Water Freeze Detector created with endpoint_id %u", getEndPointId());
 
@@ -78,27 +77,15 @@ bool MatterWaterFreezeDetector::setFreeze(bool _freezeState) {
     return false;
   }
 
-  // avoid processing if there was no change
   if (freezeState == _freezeState) {
     return true;
   }
 
-  esp_matter_attr_val_t freezeVal = esp_matter_invalid(NULL);
-
-  if (!getAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &freezeVal)) {
-    log_e("Failed to get Water Freeze Detector Attribute.");
+  if (!setBooleanStateValue(_freezeState)) {
+    log_e("Failed to update Water Freeze Detector Attribute.");
     return false;
   }
-  if (freezeVal.val.u8 != _freezeState) {
-    freezeVal.val.u8 = _freezeState;
-    bool ret;
-    ret = updateAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &freezeVal);
-    if (!ret) {
-      log_e("Failed to update Water Freeze Detector Attribute.");
-      return false;
-    }
-    freezeState = _freezeState;
-  }
+  freezeState = _freezeState;
   log_v("Water Freeze Detector set to %s", _freezeState ? "Detected" : "Not Detected");
 
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterFreezeDetector.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterFreezeDetector.cpp
@@ -51,8 +51,10 @@ bool MatterWaterFreezeDetector::begin() {
     return false;
   }
 
-  water_freeze_detector::config_t water_freeze_detector_config;
-  // BooleanStateCluster always starts at false; apply the real sensor with setFreeze() after Matter.begin().
+  water_freeze_detector::config_t water_freeze_detector_config{};
+  water_freeze_detector_config.boolean_state.state_value = false;
+  // CHIP BooleanStateCluster still starts at false regardless of this field;
+  // apply the real sensor with setFreeze() after Matter.begin().
 
   endpoint_t *endpoint = water_freeze_detector::create(node::get(), &water_freeze_detector_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterFreezeDetector.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterFreezeDetector.h
@@ -23,12 +23,12 @@ class MatterWaterFreezeDetector : public MatterEndPoint {
 public:
   MatterWaterFreezeDetector();
   ~MatterWaterFreezeDetector();
-  // begin Matter Water Freeze Detector endpoint with initial freeze state
-  bool begin(bool _freezeState = false);
+  // begin Matter Water Freeze Detector endpoint. Fabric StateValue starts false.
+  bool begin();
   // this will just stop processing Water Freeze Detector Matter events
   void end();
 
-  // set the freeze state
+  // set the freeze state. Call after Matter.begin() with the real sensor reading.
   bool setFreeze(bool _freezeState);
   // returns the freeze state
   bool getFreeze() {

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterLeakDetector.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterLeakDetector.cpp
@@ -43,7 +43,7 @@ MatterWaterLeakDetector::~MatterWaterLeakDetector() {
   end();
 }
 
-bool MatterWaterLeakDetector::begin(bool _leakState) {
+bool MatterWaterLeakDetector::begin() {
   ArduinoMatter::_init();
 
   if (getEndPointId() != 0) {
@@ -52,15 +52,14 @@ bool MatterWaterLeakDetector::begin(bool _leakState) {
   }
 
   water_leak_detector::config_t water_leak_detector_config;
-  water_leak_detector_config.boolean_state.state_value = _leakState;
+  // BooleanStateCluster always starts at false; apply the real sensor with setLeak() after Matter.begin().
 
-  // endpoint handles can be used to add/modify clusters.
   endpoint_t *endpoint = water_leak_detector::create(node::get(), &water_leak_detector_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {
     log_e("Failed to create Water Leak Detector endpoint");
     return false;
   }
-  leakState = _leakState;
+  leakState = false;
   setEndPointId(endpoint::get_id(endpoint));
   log_i("Water Leak Detector created with endpoint_id %u", getEndPointId());
 
@@ -78,27 +77,15 @@ bool MatterWaterLeakDetector::setLeak(bool _leakState) {
     return false;
   }
 
-  // avoid processing if there was no change
   if (leakState == _leakState) {
     return true;
   }
 
-  esp_matter_attr_val_t leakVal = esp_matter_invalid(NULL);
-
-  if (!getAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &leakVal)) {
-    log_e("Failed to get Water Leak Detector Attribute.");
+  if (!setBooleanStateValue(_leakState)) {
+    log_e("Failed to update Water Leak Detector Attribute.");
     return false;
   }
-  if (leakVal.val.u8 != _leakState) {
-    leakVal.val.u8 = _leakState;
-    bool ret;
-    ret = updateAttributeVal(BooleanState::Id, BooleanState::Attributes::StateValue::Id, &leakVal);
-    if (!ret) {
-      log_e("Failed to update Water Leak Detector Attribute.");
-      return false;
-    }
-    leakState = _leakState;
-  }
+  leakState = _leakState;
   log_v("Water Leak Detector set to %s", _leakState ? "Detected" : "Not Detected");
 
   return true;

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterLeakDetector.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterLeakDetector.cpp
@@ -51,8 +51,10 @@ bool MatterWaterLeakDetector::begin() {
     return false;
   }
 
-  water_leak_detector::config_t water_leak_detector_config;
-  // BooleanStateCluster always starts at false; apply the real sensor with setLeak() after Matter.begin().
+  water_leak_detector::config_t water_leak_detector_config{};
+  water_leak_detector_config.boolean_state.state_value = false;
+  // CHIP BooleanStateCluster still starts at false regardless of this field;
+  // apply the real sensor with setLeak() after Matter.begin().
 
   endpoint_t *endpoint = water_leak_detector::create(node::get(), &water_leak_detector_config, ENDPOINT_FLAG_NONE, (void *)this);
   if (endpoint == nullptr) {

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterLeakDetector.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterLeakDetector.h
@@ -23,12 +23,12 @@ class MatterWaterLeakDetector : public MatterEndPoint {
 public:
   MatterWaterLeakDetector();
   ~MatterWaterLeakDetector();
-  // begin Matter Water Leak Detector endpoint with initial leak state
-  bool begin(bool _leakState = false);
+  // begin Matter Water Leak Detector endpoint. Fabric StateValue starts false.
+  bool begin();
   // this will just stop processing Water Leak Detector Matter events
   void end();
 
-  // set the leak state
+  // set the leak state. Call after Matter.begin() with the real sensor reading.
   bool setLeak(bool _leakState);
   // returns the leak state
   bool getLeak() {


### PR DESCRIPTION
## Description of Change

This pull request updates the documentation and example code for Boolean State Matter endpoints (contact, leak, freeze, rain sensors) to reflect changes in ESP-Matter 1.5+. The main focus is clarifying that these endpoints' `begin()` methods no longer accept an initial state, and that their state must be set using the appropriate setter method after calling `Matter.begin()`. The example code and documentation are updated for accuracy and to guide users through the correct initialization and usage patterns.

**Documentation updates for Boolean State endpoints:**

* Updated `docs/en/matter/ep_contact_sensor.rst`, `ep_rain_sensor.rst`, `ep_water_freeze_detector.rst`, and `ep_water_leak_detector.rst` to state that `begin()` takes no arguments and always starts with `StateValue` as `false`. Added instructions and code samples showing that the setter (e.g., `setContact()`) must be called after `Matter.begin()` with the real sensor value. [[1]](diffhunk://#diff-a1fe350bdf32865d98c5a8f2f0e7d644409133c05dcfd26af55fafaaad415c97L46-R61) [[2]](diffhunk://#diff-df59b6035350864bf7cf759768c2b3a1bf0834515f049214ec4edc99b317e530L46-R61) [[3]](diffhunk://#diff-b2c6f34d97aeffd3961f07c6f17006ed6a127ccda8a7d6b7bc5cce44d3809804L46-R61) [[4]](diffhunk://#diff-0bf77e1093c7e134ee92833800e398f4664f8c455c8d404278553791ce926402L46-R61)
* Clarified in the same files that the state setter should be called after `Matter.begin()`, and updated the assignment operator and state control sections accordingly. [[1]](diffhunk://#diff-a1fe350bdf32865d98c5a8f2f0e7d644409133c05dcfd26af55fafaaad415c97L71-R77) [[2]](diffhunk://#diff-a1fe350bdf32865d98c5a8f2f0e7d644409133c05dcfd26af55fafaaad415c97L117-R123) [[3]](diffhunk://#diff-df59b6035350864bf7cf759768c2b3a1bf0834515f049214ec4edc99b317e530L71-R77) [[4]](diffhunk://#diff-df59b6035350864bf7cf759768c2b3a1bf0834515f049214ec4edc99b317e530L117-R123) [[5]](diffhunk://#diff-b2c6f34d97aeffd3961f07c6f17006ed6a127ccda8a7d6b7bc5cce44d3809804L71-R77) [[6]](diffhunk://#diff-b2c6f34d97aeffd3961f07c6f17006ed6a127ccda8a7d6b7bc5cce44d3809804L117-R123) [[7]](diffhunk://#diff-0bf77e1093c7e134ee92833800e398f4664f8c455c8d404278553791ce926402L71-R77) [[8]](diffhunk://#diff-0bf77e1093c7e134ee92833800e398f4664f8c455c8d404278553791ce926402L117-R123)

**General documentation and usage guidance:**

* Added notes in `docs/en/matter/matter.rst` and `docs/en/matter/matter_ep.rst` about the new Boolean State sensor behavior: `begin()` does not accept an initial state, and `updateAttributeVal()` cannot be used for these sensors. Users must use the dedicated setter after `Matter.begin()`. [[1]](diffhunk://#diff-205cd7fca823e583476e6aa6daade105f3ff33bedf71c5371c5745f00e00c192R266) [[2]](diffhunk://#diff-97dd5276ace16b843c0e038be465ad9cb449cee924174dcf294658088df719cdR133-R134)
* Updated `libraries/Matter/README.md` to explain the new pattern for Boolean State sensors, including example code, rules, and exceptions to the standard attribute store usage. [[1]](diffhunk://#diff-aeb2fd008e8660e6448b85bdce9842fd1090639f54cb94c415546e19af255ef3L16-R16) [[2]](diffhunk://#diff-aeb2fd008e8660e6448b85bdce9842fd1090639f54cb94c415546e19af255ef3R67-R89) [[3]](diffhunk://#diff-aeb2fd008e8660e6448b85bdce9842fd1090639f54cb94c415546e19af255ef3R120-R121)

**Example code improvements:**

* Refactored `MatterContactSensor.ino` to remove manual state toggling via the button, clarify initialization order, and simulate sensor state changes using a configurable interval. Added comments and improved the loop to demonstrate correct usage of the setter after `Matter.begin()`. [[1]](diffhunk://#diff-007022595be14911ad123a19d0bc1ff98f80a407e8d0a157b354b45346898718L22-R25) [[2]](diffhunk://#diff-007022595be14911ad123a19d0bc1ff98f80a407e8d0a157b354b45346898718L59-L70) [[3]](diffhunk://#diff-007022595be14911ad123a19d0bc1ff98f80a407e8d0a157b354b45346898718L89-R91) [[4]](diffhunk://#diff-007022595be14911ad123a19d0bc1ff98f80a407e8d0a157b354b45346898718L117-R123) [[5]](diffhunk://#diff-007022595be14911ad123a19d0bc1ff98f80a407e8d0a157b354b45346898718L137-R156)
* Updated the example's README to match the new usage, removing references to manual toggling and emphasizing the correct initialization sequence and configuration options. [[1]](diffhunk://#diff-21f755db22b7a256c5540c69f2ab84b533f214b3dba29d8fd1dbeb398e356908L4-R4) [[2]](diffhunk://#diff-21f755db22b7a256c5540c69f2ab84b533f214b3dba29d8fd1dbeb398e356908L29-R40) [[3]](diffhunk://#diff-21f755db22b7a256c5540c69f2ab84b533f214b3dba29d8fd1dbeb398e356908L72-R83)

## Test Scenarios
Tested using the examples with ESP32-S3, ESP32-C6 and ESP32-C3

## Related links
Close  #12839 
