### PR TITLE
feat(httpupdate): add optional checksum sidecar URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ set(ARDUINO_LIBRARY_Hash_SRCS
 
 set(ARDUINO_LIBRARY_HTTPClient_SRCS libraries/HTTPClient/src/HTTPClient.cpp)
 
-set(ARDUINO_LIBRARY_HTTPUpdate_SRCS libraries/HTTPUpdate/src/HTTPUpdate.cpp)
+set(ARDUINO_LIBRARY_HTTPUpdate_SRCS libraries/HTTPUpdate/src/HTTPUpdate.cpp libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp)
 
 set(ARDUINO_LIBRARY_Insights_SRCS libraries/Insights/src/Insights.cpp)
 

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -926,7 +926,7 @@ NetworkClient *HTTPClient::getClient(void) {
   // Reapply transport settings on every retrieval. Deprecated begin() calls can
   // replace the traits while retaining the lazily allocated client.
   if (_tcpDeprecated && !_transportTraits->verify(*_client, _host.c_str())) {
-    log_d("transport level verify failed");
+    log_e("transport level verify failed");
     _client->stop();
     _client = nullptr;
     _tcpDeprecated.reset(nullptr);

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -913,6 +913,27 @@ NetworkClient *HTTPClient::getStreamPtr(void) {
   return nullptr;
 }
 
+NetworkClient *HTTPClient::getClient(void) {
+#ifdef HTTPCLIENT_1_1_COMPATIBLE
+  if (_transportTraits && !_client) {
+    _tcpDeprecated = _transportTraits->create();
+    if (!_tcpDeprecated) {
+      log_e("could not create client");
+      return nullptr;
+    }
+    _client = _tcpDeprecated.get();
+    if (!_transportTraits->verify(*_client, _host.c_str())) {
+      log_d("transport level verify failed");
+      _client->stop();
+      _client = nullptr;
+      _tcpDeprecated.reset(nullptr);
+      return nullptr;
+    }
+  }
+#endif
+  return _client;
+}
+
 /**
  * write all  message body / payload to Stream
  * @param stream Stream *
@@ -1141,28 +1162,10 @@ bool HTTPClient::connect(void) {
     return true;
   }
 
-#ifdef HTTPCLIENT_1_1_COMPATIBLE
-  if (_transportTraits && !_client) {
-    _tcpDeprecated = _transportTraits->create();
-    if (!_tcpDeprecated) {
-      log_e("failed to create client");
-      return false;
-    }
-    _client = _tcpDeprecated.get();
-  }
-#endif
-
-  if (!_client) {
+  if (!getClient()) {
     log_d("HTTPClient::begin was not called or returned error");
     return false;
   }
-#ifdef HTTPCLIENT_1_1_COMPATIBLE
-  if (_tcpDeprecated && !_transportTraits->verify(*_client, _host.c_str())) {
-    log_d("transport level verify failed");
-    _client->stop();
-    return false;
-  }
-#endif
   if (!_client->connect(_host.c_str(), _port, _connectTimeout)) {
     log_d("failed connect to %s:%u", _host.c_str(), _port);
     return false;

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -922,13 +922,15 @@ NetworkClient *HTTPClient::getClient(void) {
       return nullptr;
     }
     _client = _tcpDeprecated.get();
-    if (!_transportTraits->verify(*_client, _host.c_str())) {
-      log_d("transport level verify failed");
-      _client->stop();
-      _client = nullptr;
-      _tcpDeprecated.reset(nullptr);
-      return nullptr;
-    }
+  }
+  // Reapply transport settings on every retrieval. Deprecated begin() calls can
+  // replace the traits while retaining the lazily allocated client.
+  if (_tcpDeprecated && !_transportTraits->verify(*_client, _host.c_str())) {
+    log_d("transport level verify failed");
+    _client->stop();
+    _client = nullptr;
+    _tcpDeprecated.reset(nullptr);
+    return nullptr;
   }
 #endif
   return _client;

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -170,6 +170,8 @@ typedef struct {
 } Cookie;
 typedef std::vector<Cookie> CookieJar;
 
+class HTTPUpdate;
+
 class HTTPClient {
 public:
   HTTPClient();
@@ -251,14 +253,6 @@ public:
 
   NetworkClient &getStream(void);
   NetworkClient *getStreamPtr(void);
-  /**
-   * @brief Return the NetworkClient set by begin(), even before connect().
-   *
-   * Unlike getStreamPtr(), this does not require an active TCP connection.
-   */
-  NetworkClient *getClient(void) {
-    return _client;
-  }
   int writeToStream(Stream *stream);
   String getString(void);
 
@@ -268,6 +262,10 @@ public:
   void setCookieJar(CookieJar *cookieJar);
   void resetCookieJar();
   void clearAllCookies();
+
+private:
+  friend class HTTPUpdate;
+  NetworkClient *getClient(void);
 
 protected:
   struct RequestArgument {

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -251,6 +251,14 @@ public:
 
   NetworkClient &getStream(void);
   NetworkClient *getStreamPtr(void);
+  /**
+   * @brief Return the NetworkClient set by begin(), even before connect().
+   *
+   * Unlike getStreamPtr(), this does not require an active TCP connection.
+   */
+  NetworkClient *getClient(void) {
+    return _client;
+  }
   int writeToStream(Stream *stream);
   String getString(void);
 

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -170,8 +170,6 @@ typedef struct {
 } Cookie;
 typedef std::vector<Cookie> CookieJar;
 
-class HTTPUpdate;
-
 class HTTPClient {
 public:
   HTTPClient();
@@ -221,6 +219,9 @@ public:
   // Redirections
   void setFollowRedirects(followRedirects_t follow);
   void setRedirectLimit(uint16_t limit);  // max redirects to follow for a single request
+  uint16_t getRedirectLimit(void) const {
+    return _redirectLimit;
+  }
 
   bool setURL(const String &url);
   void useHTTP10(bool usehttp10 = true);
@@ -253,6 +254,7 @@ public:
 
   NetworkClient &getStream(void);
   NetworkClient *getStreamPtr(void);
+  NetworkClient *getClient(void);
   int writeToStream(Stream *stream);
   String getString(void);
 
@@ -262,10 +264,6 @@ public:
   void setCookieJar(CookieJar *cookieJar);
   void resetCookieJar();
   void clearAllCookies();
-
-private:
-  friend class HTTPUpdate;
-  NetworkClient *getClient(void);
 
 protected:
   struct RequestArgument {

--- a/libraries/HTTPUpdate/keywords.txt
+++ b/libraries/HTTPUpdate/keywords.txt
@@ -24,6 +24,8 @@ update	KEYWORD2
 updateSpiffs	KEYWORD2
 setMD5sum	KEYWORD2
 setSHA256sum	KEYWORD2
+setMD5sumUrl	KEYWORD2
+setSHA256sumUrl	KEYWORD2
 getLastError	KEYWORD2
 getLastErrorString	KEYWORD2
 

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -38,10 +38,7 @@
 HTTPUpdate::HTTPUpdate(int httpClientTimeout, UpdateClass *updater)
   : _httpClientTimeout(httpClientTimeout), _updater(updater), _followRedirects(HTTPC_DISABLE_FOLLOW_REDIRECTS) {}
 
-HTTPUpdate::~HTTPUpdate(void) {
-  delete _md5SumUrl;
-  delete _sha256SumUrl;
-}
+HTTPUpdate::~HTTPUpdate(void) {}
 
 HTTPUpdateResult HTTPUpdate::update(NetworkClient &client, const String &url, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
   HTTPClient http;
@@ -204,11 +201,9 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
   String sha256;
   uint8_t sidecarFailures = 0;
   if (_checksumSidecarFetch) {
-    uint8_t requested = (_md5SumUrlSet && !_md5Sum.length() ? HTTPUPDATE_SIDECAR_MD5_FAILED : 0)
-                        | (_sha256SumUrlSet && !_sha256Sum.length() ? HTTPUPDATE_SIDECAR_SHA256_FAILED : 0);
-    sidecarFailures = _checksumSidecarFetch(
-      http.getClient(), _md5SumUrl, _sha256SumUrl, requested, md5, sha256, _httpClientTimeout, _followRedirects, _user, _password, _auth, requestCB
-    );
+    uint8_t requested =
+      (!_md5SumUrl.isEmpty() && _md5Sum.isEmpty() ? SIDECAR_MD5_FAILED : 0) | (!_sha256SumUrl.isEmpty() && _sha256Sum.isEmpty() ? SIDECAR_SHA256_FAILED : 0);
+    sidecarFailures = _checksumSidecarFetch(http.getClient(), _md5SumUrl, _sha256SumUrl, requested, md5, sha256, _httpClientTimeout, _followRedirects);
   }
 
   // use HTTP/1.0 for update since the update handler not support any transfer Encoding
@@ -289,7 +284,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
     md5 = _md5Sum;
   } else if (http.hasHeader("x-MD5")) {
     md5 = http.header("x-MD5");
-  } else if ((sidecarFailures & HTTPUPDATE_SIDECAR_MD5_FAILED) && code == HTTP_CODE_OK && len > 0) {
+  } else if ((sidecarFailures & SIDECAR_MD5_FAILED) && code == HTTP_CODE_OK && len > 0) {
     _setLastError(HTTP_UE_SERVER_FAULTY_MD5);
     http.end();
     return HTTP_UPDATE_FAILED;
@@ -302,7 +297,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
     sha256 = _sha256Sum;
   } else if (http.hasHeader("x-SHA256")) {
     sha256 = http.header("x-SHA256");
-  } else if ((sidecarFailures & HTTPUPDATE_SIDECAR_SHA256_FAILED) && code == HTTP_CODE_OK && len > 0) {
+  } else if ((sidecarFailures & SIDECAR_SHA256_FAILED) && code == HTTP_CODE_OK && len > 0) {
     _setLastError(HTTP_UE_SERVER_FAULTY_SHA256);
     http.end();
     return HTTP_UPDATE_FAILED;

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -203,7 +203,8 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
   if (_checksumSidecarFetch) {
     uint8_t requested =
       (!_md5SumUrl.isEmpty() && _md5Sum.isEmpty() ? SIDECAR_MD5_FAILED : 0) | (!_sha256SumUrl.isEmpty() && _sha256Sum.isEmpty() ? SIDECAR_SHA256_FAILED : 0);
-    sidecarFailures = _checksumSidecarFetch(http.getClient(), _md5SumUrl, _sha256SumUrl, requested, md5, sha256, _httpClientTimeout, _followRedirects);
+    sidecarFailures =
+      _checksumSidecarFetch(http.getClient(), _md5SumUrl, _sha256SumUrl, requested, md5, sha256, _httpClientTimeout, _followRedirects, http._redirectLimit);
   }
 
   // use HTTP/1.0 for update since the update handler not support any transfer Encoding

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -285,7 +285,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
   } else if (http.hasHeader("x-MD5")) {
     md5 = http.header("x-MD5");
   } else if ((sidecarFailures & SIDECAR_MD5_FAILED) && code == HTTP_CODE_OK && len > 0) {
-    _setLastError(HTTP_UE_SERVER_FAULTY_MD5);
+    _lastError = HTTP_UE_SERVER_FAULTY_MD5;
     http.end();
     return HTTP_UPDATE_FAILED;
   }
@@ -298,7 +298,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
   } else if (http.hasHeader("x-SHA256")) {
     sha256 = http.header("x-SHA256");
   } else if ((sidecarFailures & SIDECAR_SHA256_FAILED) && code == HTTP_CODE_OK && len > 0) {
-    _setLastError(HTTP_UE_SERVER_FAULTY_SHA256);
+    _lastError = HTTP_UE_SERVER_FAULTY_SHA256;
     http.end();
     return HTTP_UPDATE_FAILED;
   }

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -38,7 +38,10 @@
 HTTPUpdate::HTTPUpdate(int httpClientTimeout, UpdateClass *updater)
   : _httpClientTimeout(httpClientTimeout), _updater(updater), _followRedirects(HTTPC_DISABLE_FOLLOW_REDIRECTS) {}
 
-HTTPUpdate::~HTTPUpdate(void) {}
+HTTPUpdate::~HTTPUpdate(void) {
+  delete _md5SumUrl;
+  delete _sha256SumUrl;
+}
 
 HTTPUpdateResult HTTPUpdate::update(NetworkClient &client, const String &url, const String &currentVersion, HTTPUpdateRequestCB requestCB) {
   HTTPClient http;
@@ -195,6 +198,19 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
 
   HTTPUpdateResult ret = HTTP_UPDATE_FAILED;
 
+  // Prefetch checksum sidecars before the firmware GET when an explicit digest is
+  // not already set. Response headers can still override a successful prefetch.
+  String md5;
+  String sha256;
+  uint8_t sidecarFailures = 0;
+  if (_checksumSidecarFetch) {
+    uint8_t requested = (_md5SumUrlSet && !_md5Sum.length() ? HTTPUPDATE_SIDECAR_MD5_FAILED : 0)
+                        | (_sha256SumUrlSet && !_sha256Sum.length() ? HTTPUPDATE_SIDECAR_SHA256_FAILED : 0);
+    sidecarFailures = _checksumSidecarFetch(
+      http.getClient(), _md5SumUrl, _sha256SumUrl, requested, md5, sha256, _httpClientTimeout, _followRedirects, _user, _password, _auth, requestCB
+    );
+  }
+
   // use HTTP/1.0 for update since the update handler not support any transfer Encoding
   http.useHTTP10(true);
   http.setTimeout(_httpClientTimeout);
@@ -268,21 +284,28 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
   log_d(" - code: %d\n", code);
   log_d(" - len: %d\n", len);
 
-  String md5;
+  // Precedence: setMD5sum()/setSHA256sum() > response header > sidecar URL
   if (_md5Sum.length()) {
     md5 = _md5Sum;
   } else if (http.hasHeader("x-MD5")) {
     md5 = http.header("x-MD5");
+  } else if ((sidecarFailures & HTTPUPDATE_SIDECAR_MD5_FAILED) && code == HTTP_CODE_OK && len > 0) {
+    _setLastError(HTTP_UE_SERVER_FAULTY_MD5);
+    http.end();
+    return HTTP_UPDATE_FAILED;
   }
   if (md5.length()) {
     log_d(" - MD5: %s\n", md5.c_str());
   }
 
-  String sha256;
   if (_sha256Sum.length()) {
     sha256 = _sha256Sum;
   } else if (http.hasHeader("x-SHA256")) {
     sha256 = http.header("x-SHA256");
+  } else if ((sidecarFailures & HTTPUPDATE_SIDECAR_SHA256_FAILED) && code == HTTP_CODE_OK && len > 0) {
+    _setLastError(HTTP_UE_SERVER_FAULTY_SHA256);
+    http.end();
+    return HTTP_UPDATE_FAILED;
   }
   if (sha256.length()) {
     log_d(" - SHA256: %s\n", sha256.c_str());

--- a/libraries/HTTPUpdate/src/HTTPUpdate.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.cpp
@@ -204,7 +204,7 @@ HTTPUpdateResult HTTPUpdate::handleUpdate(HTTPClient &http, const String &curren
     uint8_t requested =
       (!_md5SumUrl.isEmpty() && _md5Sum.isEmpty() ? SIDECAR_MD5_FAILED : 0) | (!_sha256SumUrl.isEmpty() && _sha256Sum.isEmpty() ? SIDECAR_SHA256_FAILED : 0);
     sidecarFailures =
-      _checksumSidecarFetch(http.getClient(), _md5SumUrl, _sha256SumUrl, requested, md5, sha256, _httpClientTimeout, _followRedirects, http._redirectLimit);
+      _checksumSidecarFetch(http.getClient(), _md5SumUrl, _sha256SumUrl, requested, md5, sha256, _httpClientTimeout, _followRedirects, http.getRedirectLimit());
   }
 
   // use HTTP/1.0 for update since the update handler not support any transfer Encoding

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -57,17 +57,6 @@ using HTTPUpdateEndCB = std::function<void()>;
 using HTTPUpdateErrorCB = std::function<void(int)>;
 using HTTPUpdateProgressCB = std::function<void(int, int)>;
 
-enum HTTPUpdateSidecarResult : uint8_t {
-  HTTPUPDATE_SIDECAR_MD5_FAILED = 0x01,
-  HTTPUPDATE_SIDECAR_SHA256_FAILED = 0x02,
-};
-
-// Implemented in HTTPUpdateChecksum.cpp; referenced only when setMD5sumUrl/setSHA256sumUrl is used.
-uint8_t httpUpdateFetchChecksumSidecars(
-  NetworkClient *client, const String *md5Url, const String *sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
-  const String &user, const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
-);
-
 class HTTPUpdate {
 public:
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_UPDATE)
@@ -178,14 +167,16 @@ protected:
       _cbError(err);
     }
   }
-  int _lastError;
+  int _lastError = 0;
   bool _rebootOnUpdate = true;
 
 private:
   using ChecksumSidecarFetchFn = uint8_t (*)(
-    NetworkClient *client, const String *md5Url, const String *sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
-    const String &user, const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
+    NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow
   );
+
+  static constexpr uint8_t SIDECAR_MD5_FAILED = 0x01;
+  static constexpr uint8_t SIDECAR_SHA256_FAILED = 0x02;
 
   int _httpClientTimeout;
   UpdateClass *_updater;
@@ -195,10 +186,8 @@ private:
   String _auth;
   String _md5Sum;
   String _sha256Sum;
-  String *_md5SumUrl = nullptr;
-  String *_sha256SumUrl = nullptr;
-  bool _md5SumUrlSet = false;
-  bool _sha256SumUrlSet = false;
+  String _md5SumUrl;
+  String _sha256SumUrl;
   ChecksumSidecarFetchFn _checksumSidecarFetch = nullptr;
 
   // Callbacks
@@ -208,7 +197,7 @@ private:
   HTTPUpdateProgressCB _cbProgress;
 
   int _ledPin{-1};
-  uint8_t _ledOn;
+  uint8_t _ledOn = HIGH;
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_HTTPUPDATE)

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -107,6 +107,10 @@ public:
    */
   void setSHA256sumUrl(const String &url);
 
+  // Bitmask values returned by the sidecar fetch helper.
+  static constexpr uint8_t SIDECAR_MD5_FAILED = 0x01;
+  static constexpr uint8_t SIDECAR_SHA256_FAILED = 0x02;
+
   void setAuthorization(const String &user, const String &password) {
     _user = user;
     _password = password;
@@ -175,9 +179,6 @@ private:
     NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
     uint16_t redirectLimit
   );
-
-  static constexpr uint8_t SIDECAR_MD5_FAILED = 0x01;
-  static constexpr uint8_t SIDECAR_SHA256_FAILED = 0x02;
 
   int _httpClientTimeout;
   UpdateClass *_updater;

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -57,6 +57,17 @@ using HTTPUpdateEndCB = std::function<void()>;
 using HTTPUpdateErrorCB = std::function<void(int)>;
 using HTTPUpdateProgressCB = std::function<void(int, int)>;
 
+enum HTTPUpdateSidecarResult : uint8_t {
+  HTTPUPDATE_SIDECAR_MD5_FAILED = 0x01,
+  HTTPUPDATE_SIDECAR_SHA256_FAILED = 0x02,
+};
+
+// Implemented in HTTPUpdateChecksum.cpp; referenced only when setMD5sumUrl/setSHA256sumUrl is used.
+uint8_t httpUpdateFetchChecksumSidecars(
+  NetworkClient *client, const String *md5Url, const String *sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
+  const String &user, const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
+);
+
 class HTTPUpdate {
 public:
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_UPDATE)
@@ -92,6 +103,20 @@ public:
   void setSHA256sum(const String &sha256Sum) {
     _sha256Sum = sha256Sum;
   }
+
+  /**
+   * Optional URL of a small checksum sidecar (e.g. firmware.bin.md5).
+   * Used only when setMD5sum() is empty; response header x-MD5 still wins.
+   * Calling this pulls in the sidecar fetch code (flash cost only when used).
+   */
+  void setMD5sumUrl(const String &url);
+
+  /**
+   * Optional URL of a small checksum sidecar (e.g. firmware.bin.sha256).
+   * Used only when setSHA256sum() is empty; response header x-SHA256 still wins.
+   * Calling this pulls in the sidecar fetch code (flash cost only when used).
+   */
+  void setSHA256sumUrl(const String &url);
 
   void setAuthorization(const String &user, const String &password) {
     _user = user;
@@ -157,6 +182,11 @@ protected:
   bool _rebootOnUpdate = true;
 
 private:
+  using ChecksumSidecarFetchFn = uint8_t (*)(
+    NetworkClient *client, const String *md5Url, const String *sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
+    const String &user, const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
+  );
+
   int _httpClientTimeout;
   UpdateClass *_updater;
   followRedirects_t _followRedirects;
@@ -165,6 +195,11 @@ private:
   String _auth;
   String _md5Sum;
   String _sha256Sum;
+  String *_md5SumUrl = nullptr;
+  String *_sha256SumUrl = nullptr;
+  bool _md5SumUrlSet = false;
+  bool _sha256SumUrlSet = false;
+  ChecksumSidecarFetchFn _checksumSidecarFetch = nullptr;
 
   // Callbacks
   HTTPUpdateStartCB _cbStart;

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -172,7 +172,8 @@ protected:
 
 private:
   using ChecksumSidecarFetchFn = uint8_t (*)(
-    NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow
+    NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
+    uint16_t redirectLimit
   );
 
   static constexpr uint8_t SIDECAR_MD5_FAILED = 0x01;

--- a/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
@@ -40,47 +40,180 @@ static bool httpUpdateIsHexDigit(int c) {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
 }
 
-/**
- * Read the first hex token of exactly expectedLen characters from stream.
- * Longer or shorter hex runs are skipped. Uses only a stack buffer.
- */
-static bool httpUpdateParseFirstHexToken(NetworkClient &stream, size_t expectedLen, int contentLength, char *out) {
-  if (!out || (expectedLen != 32 && expectedLen != 64)) {
-    return false;
+class HTTPUpdateChecksumParser {
+public:
+  explicit HTTPUpdateChecksumParser(size_t expectedLen) : _expectedLen(expectedLen) {}
+
+  bool push(uint8_t byte) {
+    if (_scanned >= HTTPUPDATE_SIDECAR_MAX_SCAN) {
+      // One byte beyond the scan window may only confirm that an exact-length
+      // token ending at the boundary is properly delimited.
+      if (_tokenLength == _expectedLen && !httpUpdateIsHexDigit(byte)) {
+        _token[_expectedLen] = '\0';
+        _found = true;
+        return true;
+      }
+      _failed = true;
+      return false;
+    }
+
+    _scanned++;
+    if (httpUpdateIsHexDigit(byte)) {
+      if (_tokenLength < _expectedLen) {
+        _token[_tokenLength] = (char)byte;
+      }
+      _tokenLength++;
+    } else {
+      if (_tokenLength == _expectedLen) {
+        _token[_expectedLen] = '\0';
+        _found = true;
+      } else {
+        _tokenLength = 0;
+      }
+    }
+    return !_failed;
   }
 
-  const size_t maxScan = contentLength >= 0 && contentLength < (int)HTTPUPDATE_SIDECAR_MAX_SCAN ? contentLength : HTTPUPDATE_SIDECAR_MAX_SCAN;
-  size_t scanned = 0;
-  size_t tokenLength = 0;
+  bool finish() {
+    if (!_failed && !_found && _tokenLength == _expectedLen) {
+      _token[_expectedLen] = '\0';
+      _found = true;
+    }
+    return _found && !_failed;
+  }
 
-  while (scanned < maxScan) {
+  const char *token() const {
+    return _token;
+  }
+
+  bool found() const {
+    return _found;
+  }
+
+private:
+  size_t _expectedLen;
+  size_t _scanned = 0;
+  size_t _tokenLength = 0;
+  bool _found = false;
+  bool _failed = false;
+  char _token[65] = {};
+};
+
+enum HTTPUpdateReadResult {
+  HTTPUPDATE_READ_OK,
+  HTTPUPDATE_READ_EOF,
+  HTTPUPDATE_READ_TIMEOUT,
+};
+
+static HTTPUpdateReadResult httpUpdateReadByte(NetworkClient &stream, uint32_t startedAt, uint32_t timeout, uint8_t &out) {
+  while (!stream.available()) {
+    if ((uint32_t)(millis() - startedAt) >= timeout) {
+      return HTTPUPDATE_READ_TIMEOUT;
+    }
+    if (!stream.connected()) {
+      return HTTPUPDATE_READ_EOF;
+    }
+    delay(1);
+  }
+
+  int value = stream.read();
+  if (value < 0) {
+    return stream.connected() ? HTTPUPDATE_READ_TIMEOUT : HTTPUPDATE_READ_EOF;
+  }
+  out = (uint8_t)value;
+  return HTTPUPDATE_READ_OK;
+}
+
+static bool httpUpdateReadChunkSize(NetworkClient &stream, uint32_t startedAt, uint32_t timeout, size_t &chunkSize) {
+  char line[32];
+  size_t length = 0;
+  while (true) {
     uint8_t byte;
-    if (stream.readBytes(&byte, 1) != 1) {
+    if (httpUpdateReadByte(stream, startedAt, timeout, byte) != HTTPUPDATE_READ_OK) {
+      return false;
+    }
+    if (byte == '\n') {
       break;
     }
-    int c = byte;
-    scanned++;
-
-    if (httpUpdateIsHexDigit(c)) {
-      if (tokenLength < expectedLen) {
-        out[tokenLength] = (char)c;
+    if (byte != '\r') {
+      if (length + 1 >= sizeof(line)) {
+        return false;
       }
-      tokenLength++;
-      continue;
+      line[length++] = (char)byte;
     }
+  }
+  line[length] = '\0';
 
-    if (tokenLength == expectedLen) {
-      out[expectedLen] = '\0';
+  chunkSize = 0;
+  bool hasDigit = false;
+  for (size_t i = 0; i < length && line[i] != ';'; i++) {
+    int digit;
+    if (line[i] >= '0' && line[i] <= '9') {
+      digit = line[i] - '0';
+    } else if (line[i] >= 'a' && line[i] <= 'f') {
+      digit = line[i] - 'a' + 10;
+    } else if (line[i] >= 'A' && line[i] <= 'F') {
+      digit = line[i] - 'A' + 10;
+    } else {
+      return false;
+    }
+    if (chunkSize > (SIZE_MAX - (size_t)digit) / 16) {
+      return false;
+    }
+    chunkSize = chunkSize * 16 + (size_t)digit;
+    hasDigit = true;
+  }
+  return hasDigit;
+}
+
+static bool httpUpdateParseIdentityBody(NetworkClient &stream, int contentLength, HTTPUpdateChecksumParser &parser, uint32_t startedAt, uint32_t timeout) {
+  size_t remaining = contentLength >= 0 ? (size_t)contentLength : SIZE_MAX;
+  while (remaining) {
+    uint8_t byte;
+    HTTPUpdateReadResult result = httpUpdateReadByte(stream, startedAt, timeout, byte);
+    if (result != HTTPUPDATE_READ_OK) {
+      return result == HTTPUPDATE_READ_EOF && contentLength < 0 && parser.finish();
+    }
+    if (!parser.push(byte)) {
+      return false;
+    }
+    if (parser.found()) {
       return true;
     }
-    tokenLength = 0;
+    if (contentLength >= 0) {
+      remaining--;
+    }
   }
+  return parser.finish();
+}
 
-  if (tokenLength == expectedLen) {
-    out[expectedLen] = '\0';
-    return true;
+static bool httpUpdateParseChunkedBody(NetworkClient &stream, HTTPUpdateChecksumParser &parser, uint32_t startedAt, uint32_t timeout) {
+  while (true) {
+    size_t chunkSize;
+    if (!httpUpdateReadChunkSize(stream, startedAt, timeout, chunkSize)) {
+      return false;
+    }
+    if (chunkSize == 0) {
+      return parser.finish();
+    }
+
+    for (size_t i = 0; i < chunkSize; i++) {
+      uint8_t byte;
+      if (httpUpdateReadByte(stream, startedAt, timeout, byte) != HTTPUPDATE_READ_OK || !parser.push(byte)) {
+        return false;
+      }
+      if (parser.found()) {
+        return true;
+      }
+    }
+
+    uint8_t cr;
+    uint8_t lf;
+    if (httpUpdateReadByte(stream, startedAt, timeout, cr) != HTTPUPDATE_READ_OK || httpUpdateReadByte(stream, startedAt, timeout, lf) != HTTPUPDATE_READ_OK
+        || cr != '\r' || lf != '\n') {
+      return false;
+    }
   }
-  return false;
 }
 
 void HTTPUpdate::setMD5sumUrl(const String &url) {
@@ -101,6 +234,10 @@ static bool
     return false;
   }
 
+  // A new HTTPClient cannot determine which origin an existing socket belongs
+  // to. Close it so the sidecar request always connects to its own URL.
+  client.stop();
+
   HTTPClient http;
   if (!http.begin(client, url)) {
     return false;
@@ -111,20 +248,20 @@ static bool
   http.setTimeout(timeout);
   http.setFollowRedirects(follow);
   http.setUserAgent("ESP32-http-Update");
+  const char *headerKeys[] = {"Transfer-Encoding"};
+  http.collectHeaders(headerKeys, 1);
 
   // Firmware authorization and request callbacks are intentionally not applied:
   // a sidecar URL or redirect target may belong to a different origin.
+  uint32_t timeoutMs = timeout > 0 ? (uint32_t)timeout : 1;
+  uint32_t startedAt = millis();
   int code = http.GET();
-  if (code != HTTP_CODE_OK) {
+  if (code != HTTP_CODE_OK || (uint32_t)(millis() - startedAt) >= timeoutMs) {
     http.end();
     return false;
   }
 
   int contentLength = http.getSize();
-  if (contentLength > (int)HTTPUPDATE_SIDECAR_MAX_SCAN) {
-    http.end();
-    return false;
-  }
 
   NetworkClient *stream = http.getStreamPtr();
   if (!stream) {
@@ -132,15 +269,17 @@ static bool
     return false;
   }
 
-  char token[65];
-  bool ok = httpUpdateParseFirstHexToken(*stream, digestLen, contentLength, token);
+  HTTPUpdateChecksumParser parser(digestLen);
+  bool chunked = http.header("Transfer-Encoding").equalsIgnoreCase("chunked");
+  bool ok = chunked ? httpUpdateParseChunkedBody(*stream, parser, startedAt, timeoutMs)
+                    : httpUpdateParseIdentityBody(*stream, contentLength, parser, startedAt, timeoutMs);
   http.end();
 
   if (!ok) {
     return false;
   }
 
-  outDigest = token;
+  outDigest = parser.token();
   return true;
 }
 

--- a/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
@@ -26,10 +26,15 @@
  */
 
 #include "HTTPUpdate.h"
-#include <new>
 
 // Cap sidecar body scan so a hostile/oversized response cannot grow heap.
 static const size_t HTTPUPDATE_SIDECAR_MAX_SCAN = 512;
+static const uint8_t HTTPUPDATE_SIDECAR_MD5_FAILED = 0x01;
+static const uint8_t HTTPUPDATE_SIDECAR_SHA256_FAILED = 0x02;
+
+static uint8_t httpUpdateFetchChecksumSidecars(
+  NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow
+);
 
 static bool httpUpdateIsHexDigit(int c) {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
@@ -78,35 +83,18 @@ static bool httpUpdateParseFirstHexToken(NetworkClient &stream, size_t expectedL
   return false;
 }
 
-static void httpUpdateSetChecksumUrl(String *&target, bool &configured, const String &url) {
-  configured = !url.isEmpty();
-  if (url.isEmpty()) {
-    delete target;
-    target = nullptr;
-  } else {
-    if (!target) {
-      target = new (std::nothrow) String();
-    }
-    if (target) {
-      *target = url;
-    }
-  }
-}
-
 void HTTPUpdate::setMD5sumUrl(const String &url) {
-  httpUpdateSetChecksumUrl(_md5SumUrl, _md5SumUrlSet, url);
-  _checksumSidecarFetch = (_md5SumUrlSet || _sha256SumUrlSet) ? httpUpdateFetchChecksumSidecars : nullptr;
+  _md5SumUrl = url;
+  _checksumSidecarFetch = (!_md5SumUrl.isEmpty() || !_sha256SumUrl.isEmpty()) ? httpUpdateFetchChecksumSidecars : nullptr;
 }
 
 void HTTPUpdate::setSHA256sumUrl(const String &url) {
-  httpUpdateSetChecksumUrl(_sha256SumUrl, _sha256SumUrlSet, url);
-  _checksumSidecarFetch = (_md5SumUrlSet || _sha256SumUrlSet) ? httpUpdateFetchChecksumSidecars : nullptr;
+  _sha256SumUrl = url;
+  _checksumSidecarFetch = (!_md5SumUrl.isEmpty() || !_sha256SumUrl.isEmpty()) ? httpUpdateFetchChecksumSidecars : nullptr;
 }
 
-static bool httpUpdateFetchChecksumSidecar(
-  NetworkClient &client, const String &url, size_t digestLen, String &outDigest, int timeout, followRedirects_t follow, const String &user,
-  const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
-) {
+static bool
+  httpUpdateFetchChecksumSidecar(NetworkClient &client, const String &url, size_t digestLen, String &outDigest, int timeout, followRedirects_t follow) {
   outDigest = String();
 
   if (url.isEmpty() || (digestLen != 32 && digestLen != 64)) {
@@ -124,17 +112,8 @@ static bool httpUpdateFetchChecksumSidecar(
   http.setFollowRedirects(follow);
   http.setUserAgent("ESP32-http-Update");
 
-  if (requestCB) {
-    requestCB(&http);
-  }
-
-  if (!user.isEmpty() && !password.isEmpty()) {
-    http.setAuthorization(user.c_str(), password.c_str());
-  }
-  if (!auth.isEmpty()) {
-    http.setAuthorization(auth.c_str());
-  }
-
+  // Firmware authorization and request callbacks are intentionally not applied:
+  // a sidecar URL or redirect target may belong to a different origin.
   int code = http.GET();
   if (code != HTTP_CODE_OK) {
     http.end();
@@ -165,17 +144,14 @@ static bool httpUpdateFetchChecksumSidecar(
   return true;
 }
 
-uint8_t httpUpdateFetchChecksumSidecars(
-  NetworkClient *client, const String *md5Url, const String *sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
-  const String &user, const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
+static uint8_t httpUpdateFetchChecksumSidecars(
+  NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow
 ) {
   uint8_t failures = 0;
-  if ((requested & HTTPUPDATE_SIDECAR_MD5_FAILED)
-      && (!client || !md5Url || !httpUpdateFetchChecksumSidecar(*client, *md5Url, 32, md5, timeout, follow, user, password, auth, requestCB))) {
+  if ((requested & HTTPUPDATE_SIDECAR_MD5_FAILED) && (!client || !httpUpdateFetchChecksumSidecar(*client, md5Url, 32, md5, timeout, follow))) {
     failures |= HTTPUPDATE_SIDECAR_MD5_FAILED;
   }
-  if ((requested & HTTPUPDATE_SIDECAR_SHA256_FAILED)
-      && (!client || !sha256Url || !httpUpdateFetchChecksumSidecar(*client, *sha256Url, 64, sha256, timeout, follow, user, password, auth, requestCB))) {
+  if ((requested & HTTPUPDATE_SIDECAR_SHA256_FAILED) && (!client || !httpUpdateFetchChecksumSidecar(*client, sha256Url, 64, sha256, timeout, follow))) {
     failures |= HTTPUPDATE_SIDECAR_SHA256_FAILED;
   }
   return failures;

--- a/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
@@ -247,7 +247,6 @@ static bool
   http.useHTTP10(true);
   http.setTimeout(timeout);
   http.setFollowRedirects(follow);
-  http.setUserAgent("ESP32-http-Update");
   const char *headerKeys[] = {"Transfer-Encoding"};
   http.collectHeaders(headerKeys, 1);
 

--- a/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
@@ -1,0 +1,182 @@
+/**
+ *
+ * @file HTTPUpdateChecksum.cpp
+ * @brief Optional MD5/SHA-256 checksum sidecar fetch for HTTPUpdate.
+ *
+ * Linked only when a sketch calls setMD5sumUrl() / setSHA256sumUrl()
+ * (referenced via a function pointer assigned in those setters).
+ *
+ * Copyright (c) 2026. All rights reserved.
+ * This file is part of the ESP32 Http Updater.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "HTTPUpdate.h"
+#include <new>
+
+// Cap sidecar body scan so a hostile/oversized response cannot grow heap.
+static const size_t HTTPUPDATE_SIDECAR_MAX_SCAN = 512;
+
+static bool httpUpdateIsHexDigit(int c) {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+/**
+ * Read the first hex token of exactly expectedLen characters from stream.
+ * Longer or shorter hex runs are skipped. Uses only a stack buffer.
+ */
+static bool httpUpdateParseFirstHexToken(NetworkClient &stream, size_t expectedLen, int contentLength, char *out) {
+  if (!out || (expectedLen != 32 && expectedLen != 64)) {
+    return false;
+  }
+
+  const size_t maxScan = contentLength >= 0 && contentLength < (int)HTTPUPDATE_SIDECAR_MAX_SCAN ? contentLength : HTTPUPDATE_SIDECAR_MAX_SCAN;
+  size_t scanned = 0;
+  size_t tokenLength = 0;
+
+  while (scanned < maxScan) {
+    uint8_t byte;
+    if (stream.readBytes(&byte, 1) != 1) {
+      break;
+    }
+    int c = byte;
+    scanned++;
+
+    if (httpUpdateIsHexDigit(c)) {
+      if (tokenLength < expectedLen) {
+        out[tokenLength] = (char)c;
+      }
+      tokenLength++;
+      continue;
+    }
+
+    if (tokenLength == expectedLen) {
+      out[expectedLen] = '\0';
+      return true;
+    }
+    tokenLength = 0;
+  }
+
+  if (tokenLength == expectedLen) {
+    out[expectedLen] = '\0';
+    return true;
+  }
+  return false;
+}
+
+static void httpUpdateSetChecksumUrl(String *&target, bool &configured, const String &url) {
+  configured = !url.isEmpty();
+  if (url.isEmpty()) {
+    delete target;
+    target = nullptr;
+  } else {
+    if (!target) {
+      target = new (std::nothrow) String();
+    }
+    if (target) {
+      *target = url;
+    }
+  }
+}
+
+void HTTPUpdate::setMD5sumUrl(const String &url) {
+  httpUpdateSetChecksumUrl(_md5SumUrl, _md5SumUrlSet, url);
+  _checksumSidecarFetch = (_md5SumUrlSet || _sha256SumUrlSet) ? httpUpdateFetchChecksumSidecars : nullptr;
+}
+
+void HTTPUpdate::setSHA256sumUrl(const String &url) {
+  httpUpdateSetChecksumUrl(_sha256SumUrl, _sha256SumUrlSet, url);
+  _checksumSidecarFetch = (_md5SumUrlSet || _sha256SumUrlSet) ? httpUpdateFetchChecksumSidecars : nullptr;
+}
+
+static bool httpUpdateFetchChecksumSidecar(
+  NetworkClient &client, const String &url, size_t digestLen, String &outDigest, int timeout, followRedirects_t follow, const String &user,
+  const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
+) {
+  outDigest = String();
+
+  if (url.isEmpty() || (digestLen != 32 && digestLen != 64)) {
+    return false;
+  }
+
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    return false;
+  }
+
+  // HTTP/1.0 disables keep-alive so the shared NetworkClient is free for the firmware GET.
+  http.useHTTP10(true);
+  http.setTimeout(timeout);
+  http.setFollowRedirects(follow);
+  http.setUserAgent("ESP32-http-Update");
+
+  if (requestCB) {
+    requestCB(&http);
+  }
+
+  if (!user.isEmpty() && !password.isEmpty()) {
+    http.setAuthorization(user.c_str(), password.c_str());
+  }
+  if (!auth.isEmpty()) {
+    http.setAuthorization(auth.c_str());
+  }
+
+  int code = http.GET();
+  if (code != HTTP_CODE_OK) {
+    http.end();
+    return false;
+  }
+
+  int contentLength = http.getSize();
+  if (contentLength > (int)HTTPUPDATE_SIDECAR_MAX_SCAN) {
+    http.end();
+    return false;
+  }
+
+  NetworkClient *stream = http.getStreamPtr();
+  if (!stream) {
+    http.end();
+    return false;
+  }
+
+  char token[65];
+  bool ok = httpUpdateParseFirstHexToken(*stream, digestLen, contentLength, token);
+  http.end();
+
+  if (!ok) {
+    return false;
+  }
+
+  outDigest = token;
+  return true;
+}
+
+uint8_t httpUpdateFetchChecksumSidecars(
+  NetworkClient *client, const String *md5Url, const String *sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
+  const String &user, const String &password, const String &auth, const HTTPUpdateRequestCB &requestCB
+) {
+  uint8_t failures = 0;
+  if ((requested & HTTPUPDATE_SIDECAR_MD5_FAILED)
+      && (!client || !md5Url || !httpUpdateFetchChecksumSidecar(*client, *md5Url, 32, md5, timeout, follow, user, password, auth, requestCB))) {
+    failures |= HTTPUPDATE_SIDECAR_MD5_FAILED;
+  }
+  if ((requested & HTTPUPDATE_SIDECAR_SHA256_FAILED)
+      && (!client || !sha256Url || !httpUpdateFetchChecksumSidecar(*client, *sha256Url, 64, sha256, timeout, follow, user, password, auth, requestCB))) {
+    failures |= HTTPUPDATE_SIDECAR_SHA256_FAILED;
+  }
+  return failures;
+}

--- a/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
@@ -29,8 +29,6 @@
 
 // Cap sidecar body scan so a hostile/oversized response cannot grow heap.
 static const size_t HTTPUPDATE_SIDECAR_MAX_SCAN = 512;
-static const uint8_t HTTPUPDATE_SIDECAR_MD5_FAILED = 0x01;
-static const uint8_t HTTPUPDATE_SIDECAR_SHA256_FAILED = 0x02;
 
 static uint8_t httpUpdateFetchChecksumSidecars(
   NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
@@ -233,6 +231,7 @@ static bool httpUpdateFetchChecksumSidecar(
   outDigest = String();
 
   if (url.isEmpty() || (digestLen != 32 && digestLen != 64)) {
+    log_e("invalid sidecar URL or digest length %u", (unsigned)digestLen);
     return false;
   }
 
@@ -242,6 +241,7 @@ static bool httpUpdateFetchChecksumSidecar(
 
   HTTPClient http;
   if (!http.begin(client, url)) {
+    log_e("sidecar begin failed: %s", url.c_str());
     return false;
   }
 
@@ -258,7 +258,13 @@ static bool httpUpdateFetchChecksumSidecar(
   uint32_t timeoutMs = timeout > 0 ? (uint32_t)timeout : 1;
   uint32_t startedAt = millis();
   int code = http.GET();
-  if (code != HTTP_CODE_OK || (uint32_t)(millis() - startedAt) >= timeoutMs) {
+  if (code != HTTP_CODE_OK) {
+    log_e("sidecar GET failed: %s code=%d", url.c_str(), code);
+    http.end();
+    return false;
+  }
+  if ((uint32_t)(millis() - startedAt) >= timeoutMs) {
+    log_e("sidecar GET timed out: %s", url.c_str());
     http.end();
     return false;
   }
@@ -267,6 +273,7 @@ static bool httpUpdateFetchChecksumSidecar(
 
   NetworkClient *stream = http.getStreamPtr();
   if (!stream) {
+    log_e("sidecar stream missing: %s", url.c_str());
     http.end();
     return false;
   }
@@ -278,11 +285,16 @@ static bool httpUpdateFetchChecksumSidecar(
   http.end();
 
   if (!ok) {
+    log_e("sidecar parse failed: %s chunked=%d", url.c_str(), chunked ? 1 : 0);
     return false;
   }
 
   outDigest = parser.token();
-  return outDigest.length() == digestLen;
+  if (outDigest.length() != digestLen) {
+    log_e("sidecar digest copy failed: %s len=%u expected=%u", url.c_str(), (unsigned)outDigest.length(), (unsigned)digestLen);
+    return false;
+  }
+  return true;
 }
 
 static uint8_t httpUpdateFetchChecksumSidecars(
@@ -290,12 +302,15 @@ static uint8_t httpUpdateFetchChecksumSidecars(
   uint16_t redirectLimit
 ) {
   uint8_t failures = 0;
-  if ((requested & HTTPUPDATE_SIDECAR_MD5_FAILED) && (!client || !httpUpdateFetchChecksumSidecar(*client, md5Url, 32, md5, timeout, follow, redirectLimit))) {
-    failures |= HTTPUPDATE_SIDECAR_MD5_FAILED;
+  if (!client && requested) {
+    log_e("sidecar fetch has no client");
   }
-  if ((requested & HTTPUPDATE_SIDECAR_SHA256_FAILED)
+  if ((requested & HTTPUpdate::SIDECAR_MD5_FAILED) && (!client || !httpUpdateFetchChecksumSidecar(*client, md5Url, 32, md5, timeout, follow, redirectLimit))) {
+    failures |= HTTPUpdate::SIDECAR_MD5_FAILED;
+  }
+  if ((requested & HTTPUpdate::SIDECAR_SHA256_FAILED)
       && (!client || !httpUpdateFetchChecksumSidecar(*client, sha256Url, 64, sha256, timeout, follow, redirectLimit))) {
-    failures |= HTTPUPDATE_SIDECAR_SHA256_FAILED;
+    failures |= HTTPUpdate::SIDECAR_SHA256_FAILED;
   }
   return failures;
 }

--- a/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
+++ b/libraries/HTTPUpdate/src/HTTPUpdateChecksum.cpp
@@ -33,7 +33,8 @@ static const uint8_t HTTPUPDATE_SIDECAR_MD5_FAILED = 0x01;
 static const uint8_t HTTPUPDATE_SIDECAR_SHA256_FAILED = 0x02;
 
 static uint8_t httpUpdateFetchChecksumSidecars(
-  NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow
+  NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
+  uint16_t redirectLimit
 );
 
 static bool httpUpdateIsHexDigit(int c) {
@@ -226,8 +227,9 @@ void HTTPUpdate::setSHA256sumUrl(const String &url) {
   _checksumSidecarFetch = (!_md5SumUrl.isEmpty() || !_sha256SumUrl.isEmpty()) ? httpUpdateFetchChecksumSidecars : nullptr;
 }
 
-static bool
-  httpUpdateFetchChecksumSidecar(NetworkClient &client, const String &url, size_t digestLen, String &outDigest, int timeout, followRedirects_t follow) {
+static bool httpUpdateFetchChecksumSidecar(
+  NetworkClient &client, const String &url, size_t digestLen, String &outDigest, int timeout, followRedirects_t follow, uint16_t redirectLimit
+) {
   outDigest = String();
 
   if (url.isEmpty() || (digestLen != 32 && digestLen != 64)) {
@@ -247,6 +249,7 @@ static bool
   http.useHTTP10(true);
   http.setTimeout(timeout);
   http.setFollowRedirects(follow);
+  http.setRedirectLimit(redirectLimit);
   const char *headerKeys[] = {"Transfer-Encoding"};
   http.collectHeaders(headerKeys, 1);
 
@@ -279,17 +282,19 @@ static bool
   }
 
   outDigest = parser.token();
-  return true;
+  return outDigest.length() == digestLen;
 }
 
 static uint8_t httpUpdateFetchChecksumSidecars(
-  NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow
+  NetworkClient *client, const String &md5Url, const String &sha256Url, uint8_t requested, String &md5, String &sha256, int timeout, followRedirects_t follow,
+  uint16_t redirectLimit
 ) {
   uint8_t failures = 0;
-  if ((requested & HTTPUPDATE_SIDECAR_MD5_FAILED) && (!client || !httpUpdateFetchChecksumSidecar(*client, md5Url, 32, md5, timeout, follow))) {
+  if ((requested & HTTPUPDATE_SIDECAR_MD5_FAILED) && (!client || !httpUpdateFetchChecksumSidecar(*client, md5Url, 32, md5, timeout, follow, redirectLimit))) {
     failures |= HTTPUPDATE_SIDECAR_MD5_FAILED;
   }
-  if ((requested & HTTPUPDATE_SIDECAR_SHA256_FAILED) && (!client || !httpUpdateFetchChecksumSidecar(*client, sha256Url, 64, sha256, timeout, follow))) {
+  if ((requested & HTTPUPDATE_SIDECAR_SHA256_FAILED)
+      && (!client || !httpUpdateFetchChecksumSidecar(*client, sha256Url, 64, sha256, timeout, follow, redirectLimit))) {
     failures |= HTTPUPDATE_SIDECAR_SHA256_FAILED;
   }
   return failures;

--- a/libraries/Update/README.md
+++ b/libraries/Update/README.md
@@ -12,6 +12,7 @@ The Update library provides functionality for Over-The-Air (OTA) firmware update
 - **MD5 Verification**: Optional MD5 checksum verification
 - **SHA-256 Verification**: Optional SHA-256 checksum verification of the downloaded payload (enabled only when `setSHA256()` / `HTTPUpdate::setSHA256sum()` / `x-SHA256` is used)
 - **Checksum Sidecar URLs**: `HTTPUpdate::setMD5sumUrl()` / `setSHA256sumUrl()` can fetch a small sidecar file (first 32/64 hex token) when no explicit digest or response header is available. This is integrity checking only, not code signing. The fetch code is linked only when those setters are used.
+  Sidecar requests reuse the firmware client's transport and redirect mode, but not firmware authorization or the firmware request callback.
 
 ## Quick Start
 

--- a/libraries/Update/README.md
+++ b/libraries/Update/README.md
@@ -12,7 +12,7 @@ The Update library provides functionality for Over-The-Air (OTA) firmware update
 - **MD5 Verification**: Optional MD5 checksum verification
 - **SHA-256 Verification**: Optional SHA-256 checksum verification of the downloaded payload (enabled only when `setSHA256()` / `HTTPUpdate::setSHA256sum()` / `x-SHA256` is used)
 - **Checksum Sidecar URLs**: `HTTPUpdate::setMD5sumUrl()` / `setSHA256sumUrl()` can fetch a small sidecar file (first 32/64 hex token) when no explicit digest or response header is available. This is integrity checking only, not code signing. The fetch code is linked only when those setters are used.
-  Sidecar requests reuse the firmware client's transport and redirect mode, but not firmware authorization or the firmware request callback.
+  Sidecars are prefetched before the firmware response headers are known; those headers still take precedence. Sidecar requests reuse the firmware client's transport (including its TLS configuration) and redirect mode, but not firmware HTTP authorization or the firmware request callback. Keep sidecar URLs within the same transport trust boundary as the firmware URL.
 
 ## Quick Start
 

--- a/libraries/Update/README.md
+++ b/libraries/Update/README.md
@@ -11,6 +11,7 @@ The Update library provides functionality for Over-The-Air (OTA) firmware update
 - **Progress Callbacks**: Monitor update progress
 - **MD5 Verification**: Optional MD5 checksum verification
 - **SHA-256 Verification**: Optional SHA-256 checksum verification of the downloaded payload (enabled only when `setSHA256()` / `HTTPUpdate::setSHA256sum()` / `x-SHA256` is used)
+- **Checksum Sidecar URLs**: `HTTPUpdate::setMD5sumUrl()` / `setSHA256sumUrl()` can fetch a small sidecar file (first 32/64 hex token) when no explicit digest or response header is available. This is integrity checking only, not code signing. The fetch code is linked only when those setters are used.
 
 ## Quick Start
 
@@ -241,9 +242,13 @@ Sets expected SHA-256 hash for verification of the entire downloaded payload
 
 Call after `begin()` and before writing any payload bytes. The SHA-256 streaming
 context is allocated only when this succeeds, so sketches that never call
-`setSHA256()` (or never receive an `x-SHA256` header via `HTTPUpdate`) avoid the
+`setSHA256()` (or never receive an `x-SHA256` header / sidecar via `HTTPUpdate`) avoid the
 extra hashing work and keep the smaller static footprint on the global `Update`
 object.
+
+`HTTPUpdate` digest precedence is: `setMD5sum()` / `setSHA256sum()` >
+response headers `x-MD5` / `x-SHA256` > `setMD5sumUrl()` / `setSHA256sumUrl()`
+sidecar fetch (first hex token of length 32 / 64).
 
 **Parameters:**
 - `expected_sha256`: SHA-256 hash as hex string (64 characters)

--- a/tests/validation/ota/README.md
+++ b/tests/validation/ota/README.md
@@ -34,6 +34,9 @@ Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned 
 | `test_httpupdate_sidecar_slow_fragmented` | Slowly fragmented SHA-256 sidecar is read with timeout handling |
 | `test_httpupdate_sidecar_unknown_length` | SHA-256 sidecar without `Content-Length` is accepted |
 | `test_httpupdate_sidecar_httpclient_overload` | Sidecar works with the preconfigured `HTTPClient` overload |
+| `test_httpupdate_sidecar_httpclient_compatible_overload` | Sidecar works when compatibility `HTTPClient::begin(url)` creates its client lazily |
+| `test_httpupdate_sidecar_copy_is_independent` | Copying `HTTPUpdate` keeps independently owned sidecar URL state |
+| `test_httpupdate_sidecar_does_not_receive_firmware_credentials` | Firmware authorization and request callback data are not sent to the sidecar |
 | `test_httpupdate_sidecar_md5` | MD5 sidecar verifies firmware without header |
 | `test_httpupdate_both_sidecars` | MD5 and SHA-256 sidecars are fetched and verified together |
 | `test_httpupdate_sidecar_uppercase` | Uppercase hex sidecar is accepted |

--- a/tests/validation/ota/README.md
+++ b/tests/validation/ota/README.md
@@ -45,6 +45,7 @@ Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned 
 | `test_httpupdate_both_sidecars` | MD5 and SHA-256 sidecars are fetched and verified together |
 | `test_httpupdate_sidecar_uppercase` | Uppercase hex sidecar is accepted |
 | `test_httpupdate_sidecar_redirect` | Sidecar URL follows HTTP redirect when enabled |
+| `test_httpupdate_sidecar_redirect_limit` | Sidecar request honors the firmware client's configured redirect limit |
 | `test_httpupdate_sidecar_failure_does_not_mask_not_modified` | A failed sidecar prefetch does not replace HTTP 304 / no-update result |
 | `test_httpupdate_download` | `HTTPUpdate` download and SHA-256 verification over IPv4 |
 | `test_httpupdate_download_ipv6` | `HTTPUpdate` download and SHA-256 verification via RFC 3986 IPv6 URL |

--- a/tests/validation/ota/README.md
+++ b/tests/validation/ota/README.md
@@ -33,7 +33,11 @@ Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned 
 | `test_httpupdate_sidecar_sha256` | SHA-256 sidecar (GNU `sha256sum` format) verifies firmware without header |
 | `test_httpupdate_sidecar_slow_fragmented` | Slowly fragmented SHA-256 sidecar is read with timeout handling |
 | `test_httpupdate_sidecar_unknown_length` | SHA-256 sidecar without `Content-Length` is accepted |
-| `test_httpupdate_sidecar_httpclient_overload` | Sidecar works with the preconfigured `HTTPClient` overload |
+| `test_httpupdate_sidecar_chunked` | Chunked SHA-256 sidecar split inside the digest is decoded and accepted |
+| `test_httpupdate_sidecar_large_body` | A digest near the start of a sidecar larger than the scan window is accepted |
+| `test_httpupdate_sidecar_scan_boundary` | A digest ending exactly at the 512-byte scan boundary is validated with delimiter lookahead |
+| `test_httpupdate_sidecar_body_timeout` | A stalled sidecar body is aborted within the configured response timeout |
+| `test_httpupdate_sidecar_httpclient_overload` | Sidecar works with a preconfigured `HTTPClient` that already has an open firmware response |
 | `test_httpupdate_sidecar_httpclient_compatible_overload` | Sidecar works when compatibility `HTTPClient::begin(url)` creates its client lazily |
 | `test_httpupdate_sidecar_copy_is_independent` | Copying `HTTPUpdate` keeps independently owned sidecar URL state |
 | `test_httpupdate_sidecar_does_not_receive_firmware_credentials` | Firmware authorization and request callback data are not sent to the sidecar |
@@ -73,7 +77,7 @@ Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned 
 ## Notes
 
 - The pytest HTTP server serves the firmware with its SHA-256 digest in an `x-SHA256` response header for `/ota.ino.bin`, prefers dual-stack (`::` with `IPV6_V6ONLY=0`), and falls back to IPv4-only if IPv6 bind fails.
-- Sidecar checksum tests use `/firmware-noheader.bin` (same bytes, no digest header), static checksum artifacts, delayed/unknown-length responses, and `/redirect-sha256` (302).
+- Sidecar checksum tests use `/firmware-noheader.bin` (same bytes, no digest header), static checksum artifacts, delayed/unknown-length/chunked responses, and `/redirect-sha256` (302).
 - Digest precedence in `HTTPUpdate` is: explicit setter > response header > sidecar URL.
 - IPv6 `HTTPUpdate` uses bracketed URLs (`http://[addr]:port/...`); `HTTPClient` parses RFC 3986 IPv6 literals.
 - `Update` API tests are transport-agnostic (no network).

--- a/tests/validation/ota/README.md
+++ b/tests/validation/ota/README.md
@@ -16,6 +16,11 @@ Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned 
 | `test_httpupdate_invalid_url_ipv6` | `HTTPUpdate` to unreachable bracketed IPv6 URL (`[2001:db8::1]`) |
 | `test_httpupdate_invalid_checksums_abort` | Invalid MD5/SHA-256 values abort the update session |
 | `test_httpupdate_wrong_sha256_has_no_digest` | A SHA-256 mismatch fails without exposing a digest |
+| `test_httpupdate_sidecar_missing` | Missing sidecar URL fails with `HTTP_UE_SERVER_FAULTY_SHA256` |
+| `test_httpupdate_sidecar_md5_missing` | Missing MD5 sidecar URL fails with `HTTP_UE_SERVER_FAULTY_MD5` |
+| `test_httpupdate_sidecar_invalid` | Sidecar without a valid hex token fails with `HTTP_UE_SERVER_FAULTY_SHA256` |
+| `test_httpupdate_sidecar_wrong_sha256` | Sidecar with wrong digest fails the firmware verify |
+| `test_httpupdate_sidecar_wrong_md5` | MD5 sidecar with wrong digest fails the firmware verify |
 | `test_arduino_ota_upload_no_auth` | Full `espota.py` upload without password (IPv4) |
 | `test_arduino_ota_ipv4_with_ipv6_enabled` | IPv4 upload after STA IPv6 is enabled (dual-stack bind) |
 | `test_arduino_ota_upload_ipv6` | Full `espota.py` upload over global IPv6 (ignored if host/DUT lack it) |
@@ -23,6 +28,17 @@ Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned 
 | `test_arduino_ota_ipv4_mapped` | Host uses `::ffff:a.b.c.d` literals against dual-stack DUT |
 | `test_arduino_ota_ipv6_with_auth` | IPv6 upload with PBKDF2-HMAC-SHA256 auth |
 | `test_arduino_ota_upload_with_auth` | IPv4 upload with PBKDF2-HMAC-SHA256 auth |
+| `test_httpupdate_header_overrides_sidecar` | Correct `x-SHA256` header wins over a wrong sidecar URL |
+| `test_httpupdate_setter_overrides_sidecar` | Explicit `setSHA256sum()` wins over a wrong sidecar URL |
+| `test_httpupdate_sidecar_sha256` | SHA-256 sidecar (GNU `sha256sum` format) verifies firmware without header |
+| `test_httpupdate_sidecar_slow_fragmented` | Slowly fragmented SHA-256 sidecar is read with timeout handling |
+| `test_httpupdate_sidecar_unknown_length` | SHA-256 sidecar without `Content-Length` is accepted |
+| `test_httpupdate_sidecar_httpclient_overload` | Sidecar works with the preconfigured `HTTPClient` overload |
+| `test_httpupdate_sidecar_md5` | MD5 sidecar verifies firmware without header |
+| `test_httpupdate_both_sidecars` | MD5 and SHA-256 sidecars are fetched and verified together |
+| `test_httpupdate_sidecar_uppercase` | Uppercase hex sidecar is accepted |
+| `test_httpupdate_sidecar_redirect` | Sidecar URL follows HTTP redirect when enabled |
+| `test_httpupdate_sidecar_failure_does_not_mask_not_modified` | A failed sidecar prefetch does not replace HTTP 304 / no-update result |
 | `test_httpupdate_download` | `HTTPUpdate` download and SHA-256 verification over IPv4 |
 | `test_httpupdate_download_ipv6` | `HTTPUpdate` download and SHA-256 verification via RFC 3986 IPv6 URL |
 
@@ -53,7 +69,9 @@ Validates the `Update` API, `HTTPUpdate` library, and `ArduinoOTA` for unsigned 
 
 ## Notes
 
-- The pytest HTTP server serves the firmware with its SHA-256 digest in an `x-SHA256` response header, prefers dual-stack (`::` with `IPV6_V6ONLY=0`), and falls back to IPv4-only if IPv6 bind fails.
+- The pytest HTTP server serves the firmware with its SHA-256 digest in an `x-SHA256` response header for `/ota.ino.bin`, prefers dual-stack (`::` with `IPV6_V6ONLY=0`), and falls back to IPv4-only if IPv6 bind fails.
+- Sidecar checksum tests use `/firmware-noheader.bin` (same bytes, no digest header), static checksum artifacts, delayed/unknown-length responses, and `/redirect-sha256` (302).
+- Digest precedence in `HTTPUpdate` is: explicit setter > response header > sidecar URL.
 - IPv6 `HTTPUpdate` uses bracketed URLs (`http://[addr]:port/...`); `HTTPClient` parses RFC 3986 IPv6 literals.
 - `Update` API tests are transport-agnostic (no network).
 - Host bind address overrides: `OTA_HOST_IP` (IPv4), `OTA_HOST_IPV6` (IPv6).

--- a/tests/validation/ota/ota.ino
+++ b/tests/validation/ota/ota.ino
@@ -717,6 +717,22 @@ void test_httpupdate_sidecar_redirect(void) {
   TEST_ASSERT_EQUAL(64, Update.sha256String().length());
 }
 
+void test_httpupdate_sidecar_redirect_limit(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  HTTPClient http;
+  TEST_ASSERT_TRUE(http.begin(client, server_url + "/firmware-noheader.bin"));
+  http.setRedirectLimit(0);
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+  httpUpdate.setSHA256sumUrl(server_url + "/redirect-sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_FAILED, httpUpdate.update(http));
+  TEST_ASSERT_EQUAL(HTTP_UE_SERVER_FAULTY_SHA256, httpUpdate.getLastError());
+  TEST_ASSERT_FALSE(Update.isRunning());
+}
+
 void test_httpupdate_sidecar_failure_does_not_mask_not_modified(void) {
   TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
   TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
@@ -902,6 +918,7 @@ void setup() {
   RUN_TEST(test_httpupdate_both_sidecars);
   RUN_TEST(test_httpupdate_sidecar_uppercase);
   RUN_TEST(test_httpupdate_sidecar_redirect);
+  RUN_TEST(test_httpupdate_sidecar_redirect_limit);
   RUN_TEST(test_httpupdate_sidecar_failure_does_not_mask_not_modified);
   RUN_TEST(test_httpupdate_download);
   RUN_TEST(test_httpupdate_download_ipv6);

--- a/tests/validation/ota/ota.ino
+++ b/tests/validation/ota/ota.ino
@@ -556,6 +556,53 @@ void test_httpupdate_sidecar_unknown_length(void) {
   TEST_ASSERT_EQUAL(64, Update.sha256String().length());
 }
 
+void test_httpupdate_sidecar_chunked(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/chunked.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_large_body(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/large.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_scan_boundary(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/boundary.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_body_timeout(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  HTTPUpdate fastUpdate(200);
+  fastUpdate.rebootOnUpdate(false);
+  fastUpdate.setSHA256sumUrl(server_url + "/stalled.sha256");
+  NetworkClient client;
+  uint32_t startedAt = millis();
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_FAILED, fastUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(HTTP_UE_SERVER_FAULTY_SHA256, fastUpdate.getLastError());
+  TEST_ASSERT_LESS_THAN_UINT32(1000, millis() - startedAt);
+}
+
 void test_httpupdate_sidecar_httpclient_overload(void) {
   TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
   TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
@@ -563,6 +610,9 @@ void test_httpupdate_sidecar_httpclient_overload(void) {
   NetworkClient client;
   HTTPClient http;
   TEST_ASSERT_TRUE(http.begin(client, server_url + "/firmware-noheader.bin"));
+  // Leave a firmware response open. Sidecar fetching must close this socket
+  // instead of reusing it for a potentially different origin.
+  TEST_ASSERT_EQUAL(HTTP_CODE_OK, http.GET());
   httpUpdate.rebootOnUpdate(false);
   httpUpdate.setSHA256sumUrl(server_url + "/ota.ino.bin.sha256");
   TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(http));
@@ -840,6 +890,10 @@ void setup() {
   RUN_TEST(test_httpupdate_sidecar_sha256);
   RUN_TEST(test_httpupdate_sidecar_slow_fragmented);
   RUN_TEST(test_httpupdate_sidecar_unknown_length);
+  RUN_TEST(test_httpupdate_sidecar_chunked);
+  RUN_TEST(test_httpupdate_sidecar_large_body);
+  RUN_TEST(test_httpupdate_sidecar_scan_boundary);
+  RUN_TEST(test_httpupdate_sidecar_body_timeout);
   RUN_TEST(test_httpupdate_sidecar_httpclient_overload);
   RUN_TEST(test_httpupdate_sidecar_httpclient_compatible_overload);
   RUN_TEST(test_httpupdate_sidecar_copy_is_independent);

--- a/tests/validation/ota/ota.ino
+++ b/tests/validation/ota/ota.ino
@@ -52,6 +52,9 @@ void setUp(void) {}
 void tearDown(void) {
   httpUpdate.setMD5sum("");
   httpUpdate.setSHA256sum("");
+  httpUpdate.setMD5sumUrl("");
+  httpUpdate.setSHA256sumUrl("");
+  httpUpdate.setFollowRedirects(HTTPC_DISABLE_FOLLOW_REDIRECTS);
   if (Update.isRunning()) {
     Update.abort();
   }
@@ -426,6 +429,201 @@ void test_httpupdate_wrong_sha256_has_no_digest(void) {
   httpUpdate.setSHA256sum("");
 }
 
+void test_httpupdate_sidecar_missing(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/missing.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_FAILED, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(HTTP_UE_SERVER_FAULTY_SHA256, httpUpdate.getLastError());
+  TEST_ASSERT_FALSE(Update.isRunning());
+}
+
+void test_httpupdate_sidecar_md5_missing(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setMD5sumUrl(server_url + "/missing.md5");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_FAILED, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(HTTP_UE_SERVER_FAULTY_MD5, httpUpdate.getLastError());
+  TEST_ASSERT_FALSE(Update.isRunning());
+}
+
+void test_httpupdate_sidecar_invalid(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/bad.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_FAILED, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(HTTP_UE_SERVER_FAULTY_SHA256, httpUpdate.getLastError());
+  TEST_ASSERT_FALSE(Update.isRunning());
+}
+
+void test_httpupdate_sidecar_wrong_sha256(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/wrong.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_FAILED, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(UPDATE_ERROR_SHA256, httpUpdate.getLastError());
+  TEST_ASSERT_FALSE(Update.isRunning());
+  TEST_ASSERT_TRUE(Update.sha256String().isEmpty());
+}
+
+void test_httpupdate_sidecar_wrong_md5(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setMD5sumUrl(server_url + "/wrong.md5");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_FAILED, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(UPDATE_ERROR_MD5, httpUpdate.getLastError());
+  TEST_ASSERT_FALSE(Update.isRunning());
+}
+
+void test_httpupdate_header_overrides_sidecar(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  // ota.ino.bin sends a correct x-SHA256 header; wrong sidecar must be ignored.
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/wrong.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/ota.ino.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_setter_overrides_sidecar(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  // Fetch the correct digest via sidecar first, then reuse it as an explicit setter
+  // while pointing the URL at a wrong sidecar — setter must win.
+  httpUpdate.setSHA256sumUrl(server_url + "/ota.ino.bin.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  String correct = Update.sha256String();
+  TEST_ASSERT_EQUAL(64, correct.length());
+
+  httpUpdate.setSHA256sum(correct);
+  httpUpdate.setSHA256sumUrl(server_url + "/wrong.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_TRUE(correct.equalsIgnoreCase(Update.sha256String()));
+}
+
+void test_httpupdate_sidecar_sha256(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/ota.ino.bin.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_slow_fragmented(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/slow.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_unknown_length(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/unknown-length.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_httpclient_overload(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  HTTPClient http;
+  TEST_ASSERT_TRUE(http.begin(client, server_url + "/firmware-noheader.bin"));
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/ota.ino.bin.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(http));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_md5(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setMD5sumUrl(server_url + "/ota.ino.bin.md5");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(32, Update.md5String().length());
+}
+
+void test_httpupdate_both_sidecars(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setMD5sumUrl(server_url + "/ota.ino.bin.md5");
+  httpUpdate.setSHA256sumUrl(server_url + "/ota.ino.bin.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(32, Update.md5String().length());
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_uppercase(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/upper.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_redirect(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+  httpUpdate.setSHA256sumUrl(server_url + "/redirect-sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_failure_does_not_mask_not_modified(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/missing.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_NO_UPDATES, httpUpdate.update(client, server_url + "/not-modified.bin", "1.0.0"));
+}
+
 void test_httpupdate_download(void) {
   TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
   TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
@@ -570,6 +768,11 @@ void setup() {
   RUN_TEST(test_httpupdate_invalid_url_ipv6);
   RUN_TEST(test_httpupdate_invalid_checksums_abort);
   RUN_TEST(test_httpupdate_wrong_sha256_has_no_digest);
+  RUN_TEST(test_httpupdate_sidecar_missing);
+  RUN_TEST(test_httpupdate_sidecar_md5_missing);
+  RUN_TEST(test_httpupdate_sidecar_invalid);
+  RUN_TEST(test_httpupdate_sidecar_wrong_sha256);
+  RUN_TEST(test_httpupdate_sidecar_wrong_md5);
   // ArduinoOTA uploads before HTTPUpdate download so partition state stays predictable.
   // Keep all no-auth cases before any setPassword() so leftover hashes cannot force AUTH.
   RUN_TEST(test_arduino_ota_upload_no_auth);
@@ -579,6 +782,17 @@ void setup() {
   RUN_TEST(test_arduino_ota_ipv4_mapped);
   RUN_TEST(test_arduino_ota_ipv6_with_auth);
   RUN_TEST(test_arduino_ota_upload_with_auth);
+  RUN_TEST(test_httpupdate_header_overrides_sidecar);
+  RUN_TEST(test_httpupdate_setter_overrides_sidecar);
+  RUN_TEST(test_httpupdate_sidecar_sha256);
+  RUN_TEST(test_httpupdate_sidecar_slow_fragmented);
+  RUN_TEST(test_httpupdate_sidecar_unknown_length);
+  RUN_TEST(test_httpupdate_sidecar_httpclient_overload);
+  RUN_TEST(test_httpupdate_sidecar_md5);
+  RUN_TEST(test_httpupdate_both_sidecars);
+  RUN_TEST(test_httpupdate_sidecar_uppercase);
+  RUN_TEST(test_httpupdate_sidecar_redirect);
+  RUN_TEST(test_httpupdate_sidecar_failure_does_not_mask_not_modified);
   RUN_TEST(test_httpupdate_download);
   RUN_TEST(test_httpupdate_download_ipv6);
 

--- a/tests/validation/ota/ota.ino
+++ b/tests/validation/ota/ota.ino
@@ -55,6 +55,8 @@ void tearDown(void) {
   httpUpdate.setMD5sumUrl("");
   httpUpdate.setSHA256sumUrl("");
   httpUpdate.setFollowRedirects(HTTPC_DISABLE_FOLLOW_REDIRECTS);
+  httpUpdate.setAuthorization("", "");
+  httpUpdate.setAuthorization("");
   if (Update.isRunning()) {
     Update.abort();
   }
@@ -567,6 +569,57 @@ void test_httpupdate_sidecar_httpclient_overload(void) {
   TEST_ASSERT_EQUAL(64, Update.sha256String().length());
 }
 
+void test_httpupdate_sidecar_httpclient_compatible_overload(void) {
+#ifndef HTTPCLIENT_1_1_COMPATIBLE
+  TEST_IGNORE_MESSAGE("HTTPClient compatibility API is disabled");
+#else
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  HTTPClient http;
+  TEST_ASSERT_TRUE(http.begin(server_url + "/firmware-noheader.bin"));
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setSHA256sumUrl(server_url + "/ota.ino.bin.sha256");
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(http));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+#endif
+}
+
+void test_httpupdate_sidecar_copy_is_independent(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  HTTPUpdate source;
+  source.setSHA256sumUrl(server_url + "/ota.ino.bin.sha256");
+  HTTPUpdate copied = source;
+  HTTPUpdate assigned;
+  assigned = copied;
+  source.setSHA256sumUrl("");
+  copied.setSHA256sumUrl("");
+  assigned.rebootOnUpdate(false);
+  NetworkClient client;
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, assigned.update(client, server_url + "/firmware-noheader.bin"));
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
+void test_httpupdate_sidecar_does_not_receive_firmware_credentials(void) {
+  TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
+  TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
+
+  NetworkClient client;
+  int callbackCalls = 0;
+  httpUpdate.rebootOnUpdate(false);
+  httpUpdate.setAuthorization("firmware-user", "firmware-password");
+  httpUpdate.setSHA256sumUrl(server_url + "/no-firmware-credentials.sha256");
+  HTTPUpdateRequestCB requestCB = [&callbackCalls](HTTPClient *http) {
+    callbackCalls++;
+    http->addHeader("X-Firmware-Only", "true");
+  };
+  TEST_ASSERT_EQUAL(HTTP_UPDATE_OK, httpUpdate.update(client, server_url + "/firmware-noheader.bin", "", requestCB));
+  TEST_ASSERT_EQUAL(1, callbackCalls);
+  TEST_ASSERT_EQUAL(64, Update.sha256String().length());
+}
+
 void test_httpupdate_sidecar_md5(void) {
   TEST_ASSERT_TRUE_MESSAGE(connectWiFi(), "WiFi connect failed");
   TEST_ASSERT_TRUE_MESSAGE(server_url.length() > 0, "No server URL provided");
@@ -788,6 +841,9 @@ void setup() {
   RUN_TEST(test_httpupdate_sidecar_slow_fragmented);
   RUN_TEST(test_httpupdate_sidecar_unknown_length);
   RUN_TEST(test_httpupdate_sidecar_httpclient_overload);
+  RUN_TEST(test_httpupdate_sidecar_httpclient_compatible_overload);
+  RUN_TEST(test_httpupdate_sidecar_copy_is_independent);
+  RUN_TEST(test_httpupdate_sidecar_does_not_receive_firmware_credentials);
   RUN_TEST(test_httpupdate_sidecar_md5);
   RUN_TEST(test_httpupdate_both_sidecars);
   RUN_TEST(test_httpupdate_sidecar_uppercase);

--- a/tests/validation/ota/test_ota.py
+++ b/tests/validation/ota/test_ota.py
@@ -301,6 +301,44 @@ def _http_handler(serve_dir: Path, firmware_sha256: str):
                 self.wfile.write(body)
                 self.close_connection = True
                 return
+            if path == "/chunked.sha256":
+                body = f"{firmware_sha256}  ota.ino.bin\n".encode()
+                chunks = (body[:17], body[17:49], body[49:])
+                self.send_response(200)
+                self.send_header("Transfer-Encoding", "chunked")
+                self.end_headers()
+                for chunk in chunks:
+                    self.wfile.write(f"{len(chunk):X}\r\n".encode())
+                    self.wfile.write(chunk + b"\r\n")
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+                return
+            if path == "/large.sha256":
+                body = f"{firmware_sha256}\n".encode() + b"x" * 600
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if path == "/boundary.sha256":
+                body = b"g" * (512 - len(firmware_sha256)) + firmware_sha256.encode() + b"\n"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if path == "/stalled.sha256":
+                body = f"{firmware_sha256}\n".encode()
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.flush()
+                time.sleep(1)
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+                return
             if path == "/no-firmware-credentials.sha256":
                 if self.headers.get("Authorization") or self.headers.get("X-Firmware-Only"):
                     self.send_response(400)

--- a/tests/validation/ota/test_ota.py
+++ b/tests/validation/ota/test_ota.py
@@ -301,6 +301,17 @@ def _http_handler(serve_dir: Path, firmware_sha256: str):
                 self.wfile.write(body)
                 self.close_connection = True
                 return
+            if path == "/no-firmware-credentials.sha256":
+                if self.headers.get("Authorization") or self.headers.get("X-Firmware-Only"):
+                    self.send_response(400)
+                    self.end_headers()
+                    return
+                body = f"{firmware_sha256}\n".encode()
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
             if path == "/not-modified.bin":
                 self.send_response(304)
                 self.end_headers()

--- a/tests/validation/ota/test_ota.py
+++ b/tests/validation/ota/test_ota.py
@@ -234,6 +234,101 @@ def _expect_unity_with_arduino_ota(dut, firmware: Path, host_ip: str, host_ipv6:
         return
 
 
+SIDECAR_ARTIFACTS = (
+    "ota.ino.bin.sha256",
+    "ota.ino.bin.md5",
+    "upper.sha256",
+    "bad.sha256",
+    "wrong.sha256",
+    "wrong.md5",
+)
+
+
+def _remove_sidecar_artifacts(serve_dir: Path) -> None:
+    for artifact in SIDECAR_ARTIFACTS:
+        (serve_dir / artifact).unlink(missing_ok=True)
+
+
+class DualStackHTTPServer(ThreadingTCPServer):
+    """HTTP server reachable over IPv4 and IPv6."""
+
+    address_family = socket.AF_INET6
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def server_bind(self):
+        # Prefer dual-stack; if the sockopt is unsupported, still bind IPv6.
+        try:
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        except (AttributeError, OSError) as e:
+            LOGGER.debug("IPV6_V6ONLY=0 not applied (%s); continuing with IPv6 bind", e)
+        super().server_bind()
+
+
+class IPv4HTTPServer(ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def _http_handler(serve_dir: Path, firmware_sha256: str):
+    class Handler(SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            self._omit_digest_header = False
+            super().__init__(*args, directory=str(serve_dir), **kwargs)
+
+        def do_GET(self):
+            path = self.path.split("?", 1)[0]
+            if path == "/redirect-sha256":
+                self.send_response(302)
+                self.send_header("Location", "/ota.ino.bin.sha256")
+                self.end_headers()
+                return
+            if path == "/slow.sha256":
+                body = f"{firmware_sha256}  ota.ino.bin\n".encode()
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                for byte in body:
+                    self.wfile.write(bytes((byte,)))
+                    self.wfile.flush()
+                    time.sleep(0.002)
+                return
+            if path == "/unknown-length.sha256":
+                body = f"{firmware_sha256}\n".encode()
+                self.send_response(200)
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(body)
+                self.close_connection = True
+                return
+            if path == "/not-modified.bin":
+                self.send_response(304)
+                self.end_headers()
+                return
+            if path == "/firmware-noheader.bin":
+                # Same binary as ota.ino.bin, but without x-SHA256 (sidecar-only path).
+                self.path = "/ota.ino.bin"
+                self._omit_digest_header = True
+                try:
+                    return SimpleHTTPRequestHandler.do_GET(self)
+                finally:
+                    self._omit_digest_header = False
+            self._omit_digest_header = False
+            return SimpleHTTPRequestHandler.do_GET(self)
+
+        def end_headers(self):
+            path = self.path.split("?", 1)[0]
+            if path.endswith("/ota.ino.bin") or path == "/ota.ino.bin":
+                if not self._omit_digest_header:
+                    self.send_header("x-SHA256", firmware_sha256)
+            super().end_headers()
+
+        def log_message(self, format, *args):
+            LOGGER.debug("HTTP %s - %s", self.address_string(), format % args)
+
+    return Handler
+
+
 def test_ota(dut, wifi_ssid, wifi_pass, request):
     if not wifi_ssid:
         pytest.fail("WiFi SSID is required but not provided. Use --wifi-ssid argument.")
@@ -263,34 +358,19 @@ def test_ota(dut, wifi_ssid, wifi_pass, request):
         LOGGER.warning("Host has no IPv6 support; all IPv6 cases will be ignored")
 
     serve_dir = firmware.parent
-    firmware_sha256 = hashlib.sha256(firmware.read_bytes()).hexdigest()
+    firmware_bytes = firmware.read_bytes()
+    firmware_sha256 = hashlib.sha256(firmware_bytes).hexdigest()
+    firmware_md5 = hashlib.md5(firmware_bytes).hexdigest()
 
-    class DualStackHTTPServer(ThreadingTCPServer):
-        """HTTP server reachable over IPv4 and IPv6."""
-
-        address_family = socket.AF_INET6
-        allow_reuse_address = True
-        daemon_threads = True
-
-        def server_bind(self):
-            # Prefer dual-stack; if the sockopt is unsupported, still bind IPv6.
-            try:
-                self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-            except (AttributeError, OSError) as e:
-                LOGGER.debug("IPV6_V6ONLY=0 not applied (%s); continuing with IPv6 bind", e)
-            super().server_bind()
-
-    class IPv4HTTPServer(ThreadingTCPServer):
-        allow_reuse_address = True
-        daemon_threads = True
-
-    class Handler(SimpleHTTPRequestHandler):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, directory=str(serve_dir), **kwargs)
-
-        def end_headers(self):
-            self.send_header("x-SHA256", firmware_sha256)
-            super().end_headers()
+    # Sidecar artifacts for HTTPUpdate checksum URL tests (#12826)
+    request.addfinalizer(lambda: _remove_sidecar_artifacts(serve_dir))
+    (serve_dir / "ota.ino.bin.sha256").write_text(f"{firmware_sha256}  ota.ino.bin\n", encoding="ascii")
+    (serve_dir / "ota.ino.bin.md5").write_text(f"{firmware_md5}  ota.ino.bin\n", encoding="ascii")
+    (serve_dir / "upper.sha256").write_text(f"{firmware_sha256.upper()}\n", encoding="ascii")
+    (serve_dir / "bad.sha256").write_text("not-a-valid-digest\n", encoding="ascii")
+    (serve_dir / "wrong.sha256").write_text("0" * 64 + "\n", encoding="ascii")
+    (serve_dir / "wrong.md5").write_text("0" * 32 + "\n", encoding="ascii")
+    Handler = _http_handler(serve_dir, firmware_sha256)
 
     port = 8766
     server = None


### PR DESCRIPTION
## Description of Change

Adds optional checksum sidecar URLs to `HTTPUpdate` for firmware hosts that cannot provide `x-MD5` or `x-SHA256` response headers.

- Adds `HTTPUpdate.setMD5sumUrl()` and `setSHA256sumUrl()`
- Accepts the first exact 32/64-character hexadecimal token
- Supports fixed-length, unknown-length, and chunked responses
- Reuses the firmware client transport and redirect configuration
- Keeps firmware HTTP authorization and request callbacks isolated from sidecar requests
- Preserves digest precedence: explicit setter > response header > sidecar
- Bounds checksum scanning and sidecar body wait time
- Supports existing `HTTPClient` overloads, including lazy compatibility clients
- Links the sidecar fetch implementation only when a sidecar setter is used

This provides generic support for common files such as:

- `firmware.bin` + `firmware.md5`
- `firmware.bin` + `firmware.sha256`

Sidecar checks provide integrity verification only; they are not code signing.

Fixes #12826

Related: #12824, #7629

## Test plan

- [x] Pre-commit hooks pass
- [x] CMake source-list validation passes
- [x] OTA validation sketch builds successfully for ESP32
- [x] Added coverage for MD5 and SHA-256 sidecars
- [x] Added precedence tests for explicit setters and response headers
- [x] Added malformed, missing, wrong, uppercase, redirect, and combined sidecar cases
- [x] Added fixed-length, unknown-length, chunked, stalled, large-body, and scan-boundary cases
- [x] Added compatibility-client, open-socket, copy-safety, and credential-isolation cases
- [x] Hardware OTA validation runs in CI