### PR TITLE
feat(ethernet): Make W5500 polling period configurable

### DIFF
--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -171,7 +171,7 @@ ETHClass::ETHClass(uint8_t eth_index)
     _pin_mcd(-1), _pin_mdio(-1), _pin_power(-1), _pin_rmii_clock(-1)
 #endif /* CONFIG_ETH_USE_ESP32_EMAC */
     ,
-    _task_stack_size(4096), _eth_connected_event_handle(0) {
+    _task_stack_size(4096), _poll_period_ms(10), _eth_connected_event_handle(0) {
 }
 
 ETHClass::~ETHClass() {}
@@ -187,6 +187,10 @@ bool ETHClass::ethDetachBus(void *bus_pointer) {
 
 void ETHClass::setTaskStackSize(size_t size) {
   _task_stack_size = size;
+}
+
+void ETHClass::setPollPeriod(uint32_t poll_period_ms) {
+  _poll_period_ms = poll_period_ms;
 }
 
 #if CONFIG_ETH_USE_ESP32_EMAC
@@ -717,7 +721,7 @@ bool ETHClass::beginSPI(
     mac_config.int_gpio_num = _pin_irq;
 #if ETH_SPI_SUPPORTS_NO_IRQ
     if (_pin_irq < 0) {
-      mac_config.poll_period_ms = 10;
+      mac_config.poll_period_ms = _poll_period_ms;
     }
 #endif
 #if ETH_SPI_SUPPORTS_CUSTOM

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -208,6 +208,9 @@ public:
   // This function must be called before `begin()`
   void setTaskStackSize(size_t size);
 
+  // Set the polling period (ms) used by the W5500 MAC when no IRQ pin is set. Must be called before `begin()`.
+  void setPollPeriod(uint32_t poll_period_ms);
+
   // ETH Handle APIs
   bool fullDuplex() const;
   bool setFullDuplex(bool on);
@@ -278,6 +281,7 @@ private:
   int8_t _pin_rmii_clock;
 #endif /* CONFIG_ETH_USE_ESP32_EMAC */
   size_t _task_stack_size;
+  uint32_t _poll_period_ms;
   network_event_handle_t _eth_connected_event_handle;
 
   static bool ethDetachBus(void *bus_pointer);


### PR DESCRIPTION
## Description

The W5500 driver currently uses a fixed 10 ms polling period when no IRQ GPIO is configured.

This change makes the polling period configurable through the `ETHClass` API while preserving the existing 10 ms default.

This is useful for applications using a W5500 without access to the INT pin, where a shorter polling interval can significantly reduce packet reception latency and improve the achievable update rate.

For example:

```cpp
ETH.setPollPeriod(5);

ETH.begin(
    ETH_PHY_W5500,
    -1,
    cs,
    -1,
    -1,
    SPI
);
```

## Motivation

With the default 10 ms polling period, applications that continuously stream small packets can effectively be limited to approximately 100 polling cycles per second.

Reducing the polling period allows applications that require lower latency or higher update rates to configure a more appropriate value.

For example:

10 ms → ~100 polling cycles/s
5 ms → ~200 polling cycles/s
1 ms → ~1000 polling cycles/s

The optimal value depends on the application and the available CPU resources.

This is particularly useful for devices with a limited number of available GPIOs that can't use the IRQ pin.

## Backward compatibility

The default polling period remains unchanged at 10 ms, so existing applications do not change behavior unless they explicitly configure a different value.

The polling period only applies when no W5500 IRQ GPIO is configured. When an IRQ GPIO is provided, the interrupt-driven behavior remains unchanged.

## Testing

Tested with ESP32-S3, ESP32-C5, and ESP32-C6 using a W5500 over SPI Ethernet.

<img width="1919" height="1439" alt="image" src="https://github.com/user-attachments/assets/c7072c26-c671-4403-8c72-52e26e72e360" />

A smaller polling period allows the application to exceed the previous ~100 FPS limitation observed with the default 10 ms polling period.

No IRQ GPIO is required for this configuration.


