### PR TITLE
feat(matter): node identity, live pairing codes, and CASE based isOnline()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(ARDUINO_LIBRARY_Matter_SRCS
   libraries/Matter/src/MatterEndpoints/MatterWindowCovering.cpp
   libraries/Matter/src/MatterEndpoints/MatterLightSensor.cpp
   libraries/Matter/src/Matter.cpp
+  libraries/Matter/src/MatterIdentity.cpp
   libraries/Matter/src/MatterEndPoint.cpp)
 
 set(ARDUINO_LIBRARY_PPP_SRCS libraries/PPP/src/PPP.cpp)

--- a/docs/en/matter/matter.rst
+++ b/docs/en/matter/matter.rst
@@ -107,18 +107,67 @@ The ``Matter`` class is implemented as a singleton, meaning there's only one ins
 The ``Matter`` class provides the following key methods:
 
 * ``begin()``: Initializes the Matter stack
-* ``isDeviceCommissioned()``: Checks if the device is commissioned
+* ``isDeviceCommissioned()``: Checks if the device is commissioned (a fabric exists)
 * ``isWiFiConnected()``: Checks Wi-Fi connection status
 * ``isThreadConnected()``: Checks Thread connection status
-* ``isDeviceConnected()``: Checks overall device connectivity
+* ``isDeviceConnected()``: Checks overall device connectivity (Wi-Fi or Thread)
+* ``isOnline()``: Checks if a controller has an active CASE session with this node. Stays true until CHIP idle-evicts that session, not until the user closes a controller app.
 * ``isWiFiStationEnabled()``: Checks if Wi-Fi Station mode is supported and enabled
 * ``isWiFiAccessPointEnabled()``: Checks if Wi-Fi AP mode is supported and enabled
 * ``isThreadEnabled()``: Checks if Thread network is supported and enabled
 * ``isBLECommissioningEnabled()``: Checks if BLE commissioning is supported and enabled
 * ``decommission()``: Factory resets the device
-* ``getManualPairingCode()``: Gets the manual pairing code for commissioning
-* ``getOnboardingQRCodeUrl()``: Gets the QR code URL for commissioning
+* ``getManualPairingCode()``: Gets the manual pairing code for commissioning (generated after ``begin()``; empty and a warning before ``begin()``)
+* ``getOnboardingQRCodeUrl()``: Gets the QR code URL for commissioning (generated after ``begin()``; empty and a warning before ``begin()``)
 * ``onEvent()``: Sets a callback for Matter events
+
+Device identity
+^^^^^^^^^^^^^^^
+
+Call these setters **before** ``Matter.begin()``. After ``begin()`` they log a warning and have no effect. String setters copy into internal storage; the argument does not need to remain valid. ``setDeviceName()`` writes Basic Information **NodeLabel**. Do not change Vendor ID / Product ID from a sketch unless the DAC matches. SoftwareVersion is compile-time CHIP configuration.
+
+.. code-block:: arduino
+
+    Matter.setVendorName("Espressif");           // max 32
+    Matter.setProductName("KitchenLight");       // max 32
+    Matter.setDeviceName("KitchenHub");          // NodeLabel, max 32
+    Matter.setSerialNumber("KH-000123");         // max 32
+    Matter.setHardwareVersion(7);
+    Matter.setHardwareVersionString("RevA");     // max 64
+    Matter.setSetupDiscriminator(0xF01);         // 0–0xFFF; Arduino test default 0xF00
+    Matter.setSetupPasscode(20202024);           // valid PIN; test default 20202021
+    Light.begin();
+    Matter.begin();
+
+On a single-endpoint node, controllers often use DeviceName as the accessory title. On a composed node it is the parent/node name; child lights are not renamed. Use ``MatterEndPoint::setTagList()`` for switch-style Descriptor tags, not as a light title.
+
+``getManualPairingCode()`` and ``getOnboardingQRCodeUrl()`` are generated from the live discriminator and PIN after ``Matter.begin()``. Before ``begin()`` they log a warning and return an empty string. The 11-digit short manual code uses only the top 4 bits of the discriminator, so ``0xF00`` and ``0xF01`` collide if the PIN is unchanged. Changing the PIN requires a matching SPAKE2+ verifier; the library regenerates it. Test while uncommissioned and erase flash after changing codes. Production belongs in factory NVS with a unique PIN per unit.
+
+Identity and commissioning APIs (all setters must run before ``Matter.begin()``):
+
+* ``setVendorName()``
+* ``setProductName()``
+* ``setDeviceName()``
+* ``setSerialNumber()``
+* ``setHardwareVersion()``
+* ``setHardwareVersionString()``
+* ``setSetupDiscriminator()``
+* ``setSetupPasscode()``
+
+Runtime status
+^^^^^^^^^^^^^^
+
++-----------------------------------+--------------------------------------------------------------+
+| API                               | Meaning                                                      |
++===================================+==============================================================+
+| ``isDeviceCommissioned()``        | A Matter fabric exists                                       |
++-----------------------------------+--------------------------------------------------------------+
+| ``isDeviceConnected()``           | Wi-Fi or Thread is up                                        |
++-----------------------------------+--------------------------------------------------------------+
+| ``isOnline()``                    | A controller has an active CASE session (until idle-evicted) |
++-----------------------------------+--------------------------------------------------------------+
+
+Do not gate physical outputs (LEDs) on ``isOnline()``. Restore last local state after commissioned. Use ``isOnline()`` for hub-discovery logs. A CASE session can remain active after the user leaves the app, until the hub or CHIP tears it down. See the Matter Status example.
 
 MatterEndPoint
 **************
@@ -186,7 +235,8 @@ The Matter library includes a comprehensive set of examples demonstrating variou
 **Basic Examples:**
 
 * **Matter Minimum** - The smallest code required to create a Matter-compatible device. Ideal starting point for understanding Matter basics. `View Matter Minimum code on GitHub <https://github.com/espressif/arduino-esp32/tree/master/libraries/Matter/examples/MatterMinimum>`_
-* **Matter Status** - Demonstrates how to check enabled Matter features and connectivity status. Implements a basic on/off light and periodically reports capability and connection status. `View Matter Status code on GitHub <https://github.com/espressif/arduino-esp32/tree/master/libraries/Matter/examples/MatterStatus>`_
+* **Matter Status** - Demonstrates how to check enabled Matter features and connectivity status, including ``isDeviceCommissioned()``, ``isDeviceConnected()``, and ``isOnline()``. Implements a basic on/off light and periodically reports capability and connection status. `View Matter Status code on GitHub <https://github.com/espressif/arduino-esp32/tree/master/libraries/Matter/examples/MatterStatus>`_
+* **Matter Device Identity** - Sets VendorName, ProductName, DeviceName (NodeLabel), SerialNumber, hardware version, and custom commissioning codes on ``Matter`` before ``begin()``. `View Matter Device Identity code on GitHub <https://github.com/espressif/arduino-esp32/tree/master/libraries/Matter/examples/MatterDeviceIdentity>`_
 * **Matter Events** - Shows how to monitor and handle Matter events. Provides a comprehensive view of all Matter events during device operation. `View Matter Events code on GitHub <https://github.com/espressif/arduino-esp32/tree/master/libraries/Matter/examples/MatterEvents>`_
 * **Matter Commission Test** - Tests Matter commissioning functionality with automatic decommissioning after a 30-second delay for continuous testing cycles. `View Matter Commission Test code on GitHub <https://github.com/espressif/arduino-esp32/tree/master/libraries/Matter/examples/MatterCommissionTest>`_
 

--- a/libraries/Matter/README.md
+++ b/libraries/Matter/README.md
@@ -131,33 +131,80 @@ Boolean State sensors (`MatterContactSensor`, `MatterWaterLeakDetector`, `Matter
 | `setAttributeVal()` | `attribute::set_val()` | No | No | Fallback for nullable attributes, syncing related attributes inside callbacks, avoiding re-entrancy |
 | Color HSV `report()` | `attribute::report()` | No | Yes | `setColorHSV()` / `setColorRGB()`: notify subscribers without re-entering `attributeChangeCB` |
 
+## Shared endpoint API
+
+All device classes inherit `MatterEndPoint`. After `begin()` and before `Matter.begin()`, sketches can call `setTagList()` with `MatterTags` presets (Number, Location, Position, Switches) to set the Descriptor TagList. At most 3 tags per endpoint. See `MatterSmartButtonsTagList`. TagList does not set a light's display name.
+
 ## Endpoint Classes
+
+**Lighting**
 
 | Class | Device Type |
 |-------|-------------|
 | `MatterOnOffLight` | On/Off Light |
 | `MatterDimmableLight` | Dimmable Light |
-| `MatterColorLight` | Extended Color Light (HSV/XY, no color temperature) |
 | `MatterColorTemperatureLight` | Color Temperature Light |
+| `MatterColorLight` | Color Light (HSV/XY, no color temperature) |
 | `MatterEnhancedColorLight` | Extended Color Light (HSV/XY + color temperature) |
+
+**Sensors**
+
+| Class | Device Type |
+|-------|-------------|
+| `MatterTemperatureSensor` | Temperature Sensor |
+| `MatterHumiditySensor` | Humidity Sensor |
+| `MatterPressureSensor` | Pressure Sensor |
+| `MatterLightSensor` | Light / Illuminance Sensor |
+| `MatterOccupancySensor` | Occupancy Sensor (optional HoldTime) |
+| `MatterContactSensor` | Contact Sensor (Boolean State) |
+| `MatterWaterLeakDetector` | Water Leak Detector (Boolean State) |
+| `MatterWaterFreezeDetector` | Water Freeze Detector (Boolean State) |
+| `MatterRainSensor` | Rain Sensor (Boolean State) |
+
+**Control and other**
+
+| Class | Device Type |
+|-------|-------------|
 | `MatterOnOffPlugin` | On/Off Plug-in Unit |
 | `MatterDimmablePlugin` | Dimmable Plug-in Unit |
 | `MatterFan` | Fan |
 | `MatterGenericSwitch` | Generic Switch (smart button — short click, long press, multi-press) |
-| `MatterTemperatureSensor` | Temperature Sensor |
-| `MatterHumiditySensor` | Humidity Sensor |
-| `MatterPressureSensor` | Pressure Sensor |
-| `MatterContactSensor` | Contact Sensor |
-| `MatterOccupancySensor` | Occupancy Sensor |
-| `MatterWaterLeakDetector` | Water Leak Detector |
-| `MatterWaterFreezeDetector` | Water Freeze Detector |
-| `MatterRainSensor` | Rain Sensor |
 | `MatterThermostat` | Thermostat |
 | `MatterWindowCovering` | Window Covering |
 | `MatterTemperatureControlledCabinet` | Temperature Controlled Cabinet |
 
+## Node identity and commissioning
+
+Call these on the `Matter` singleton **before** `Matter.begin()`. After `begin()` they log a warning and do nothing. String setters **copy** into internal storage (stack or `String` temporaries are safe). `setDeviceName()` writes Basic Information NodeLabel (not a per-light name). Do not change Vendor ID / Product ID unless the DAC matches. SoftwareVersion is compile-time CHIP config.
+
+```cpp
+Matter.setVendorName("Espressif");            // max 32
+Matter.setProductName("KitchenLight");        // max 32
+Matter.setDeviceName("KitchenHub");           // NodeLabel, max 32
+Matter.setSerialNumber("KH-000123");          // max 32
+Matter.setHardwareVersion(7);
+Matter.setHardwareVersionString("RevA");      // max 64
+Matter.setSetupDiscriminator(0xF01);          // 0–0xFFF
+Matter.setSetupPasscode(20202024);            // valid Matter PIN
+Light.begin();
+Matter.begin();
+Serial.println(Matter.getManualPairingCode());     // live code after begin()
+Serial.println(Matter.getOnboardingQRCodeUrl());   // live QR URL after begin()
+```
+
+If the sketch never calls `setSetupPasscode()` / `setSetupDiscriminator()`, Arduino Matter uses the CHIP test pair **PIN `20202021`**, discriminator **`0xF00`**, manual code **`34970112332`** (same as On/Off Light and the other examples). Before `begin()` the pairing getters log a warning and return empty.
+
+| API | Meaning |
+|-----|---------|
+| `isDeviceCommissioned()` | A Matter fabric exists |
+| `isDeviceConnected()` | Wi-Fi or Thread is up |
+| `isOnline()` | A controller has an active CASE session (until CHIP idle-evicts it) |
+
+Do not gate LEDs on `isOnline()`. A session can stay up after the user leaves the app. See examples `MatterDeviceIdentity` and `MatterStatus`.
+
 ## Further Reading
 
-- [ESP-Matter Programming Guide](https://docs.espressif.com/projects/esp-matter/en/latest/)
 - [Arduino-ESP32 Matter Documentation](https://docs.espressif.com/projects/arduino-esp32/en/latest/matter/index.html)
+- [ESP-Matter Programming Guide](https://docs.espressif.com/projects/esp-matter/en/latest/)
 - [Matter Specification (CSA)](https://csa-iot.org/developer-resource/specifications-download-request/)
+- Examples: `MatterDeviceIdentity`, `MatterStatus`, `MatterSmartButtonsTagList`

--- a/libraries/Matter/examples/MatterDeviceIdentity/MatterDeviceIdentity.ino
+++ b/libraries/Matter/examples/MatterDeviceIdentity/MatterDeviceIdentity.ino
@@ -1,0 +1,188 @@
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/License-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing terms and
+// limitations under the License.
+
+// Matter node identity and commissioning codes on the Matter singleton.
+// Call setters before Matter.begin(). Pairing codes printed after begin() are generated.
+
+#include <Arduino.h>
+#include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+#include <WiFi.h>
+#endif
+#include <Preferences.h>
+
+MatterOnOffLight OnOffLight;
+
+#if !CONFIG_ENABLE_CHIPOBLE
+const char *ssid = "your-ssid";
+const char *password = "your-password";
+#endif
+
+Preferences matterPref;
+const char *onOffPrefKey = "OnOff";
+
+#ifdef LED_BUILTIN
+const uint8_t ledPin = LED_BUILTIN;
+#else
+const uint8_t ledPin = 2;
+#warning "Do not forget to set the LED pin"
+#endif
+
+const uint8_t buttonPin = BOOT_PIN;
+
+uint32_t button_time_stamp = 0;
+bool button_state = false;
+const uint32_t debouceTime = 250;
+const uint32_t decommissioningTimeout = 5000;
+
+bool setLightOnOff(bool state) {
+  Serial.printf("User Callback :: New Light State = %s\r\n", state ? "ON" : "OFF");
+  digitalWrite(ledPin, state ? HIGH : LOW);
+  matterPref.putBool(onOffPrefKey, state);
+  return true;
+}
+
+static const char *kVendorName = "Espressif";
+static const char *kProductName = "KitchenLight";
+static const char *kDeviceName = "KitchenHub";
+static const char *kSerialNumber = "KH-000123";
+static const char *kHardwareVersionString = "RevA";
+static const uint16_t kHardwareVersion = 7;
+static const uint16_t kSetupDiscriminator = 0xF01;
+static const uint32_t kSetupPasscode = 20202024;
+
+void printIdentity() {
+  Serial.println("Applied Matter identity (Basic Information / commissioning):");
+  Serial.printf("  VendorName:  %s\r\n", kVendorName);
+  Serial.printf("  ProductName: %s\r\n", kProductName);
+  Serial.printf("  DeviceName:  %s (NodeLabel)\r\n", kDeviceName);
+  Serial.printf("  SerialNumber: %s\r\n", kSerialNumber);
+  Serial.printf("  HardwareVersion: %u\r\n", kHardwareVersion);
+  Serial.printf("  HardwareVersionString: %s\r\n", kHardwareVersionString);
+  Serial.printf("  Setup discriminator: 0x%03X\r\n", kSetupDiscriminator);
+  Serial.printf("  Setup passcode: %lu\r\n", static_cast<unsigned long>(kSetupPasscode));
+  Serial.printf("  Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
+  Serial.printf("  QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
+}
+
+// Log CASE session up/down without blocking loop() (button / decommission stay live).
+// Sample every 2.5 s — isOnline() takes the CHIP stack lock.
+void pollControllerOnline() {
+  static bool announced = false;
+  static uint32_t lastPollMs = 0;
+  const uint32_t now = millis();
+  if (lastPollMs != 0 && (now - lastPollMs) < 2500) {
+    return;
+  }
+  lastPollMs = now;
+  if (!Matter.isDeviceCommissioned()) {
+    announced = false;
+    return;
+  }
+  const bool online = Matter.isOnline();
+  if (online && !announced) {
+    Serial.println("Matter controller has an active CASE session. Node is online.");
+    announced = true;
+  } else if (!online && announced) {
+    Serial.println("Matter controller CASE session ended.");
+    announced = false;
+  }
+}
+
+void setup() {
+  pinMode(buttonPin, INPUT_PULLUP);
+  pinMode(ledPin, OUTPUT);
+  Serial.begin(115200);
+
+#if !CONFIG_ENABLE_CHIPOBLE
+  Serial.print("Connecting to ");
+  Serial.println(ssid);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("\r\nWi-Fi connected");
+  Serial.println("IP address: ");
+  Serial.println(WiFi.localIP());
+  delay(500);
+#endif
+
+  // Must be called before Matter.begin(). Late calls log a warning and are ignored.
+  Matter.setVendorName(kVendorName);
+  Matter.setProductName(kProductName);
+  Matter.setDeviceName(kDeviceName);
+  Matter.setSerialNumber(kSerialNumber);
+  Matter.setHardwareVersion(kHardwareVersion);
+  Matter.setHardwareVersionString(kHardwareVersionString);
+  // Not the Arduino test pair 0xF00 / 20202021. Use the generated pairing codes below.
+  Matter.setSetupDiscriminator(kSetupDiscriminator);
+  Matter.setSetupPasscode(kSetupPasscode);
+
+  matterPref.begin("MatterPrefs", false);
+  bool lastOnOffState = matterPref.getBool(onOffPrefKey, true);
+  OnOffLight.begin(lastOnOffState);
+  OnOffLight.onChange(setLightOnOff);
+
+  Matter.begin();
+  printIdentity();
+
+  if (Matter.isDeviceCommissioned()) {
+    Serial.printf("Initial state: %s\r\n", OnOffLight.getOnOff() ? "ON" : "OFF");
+    OnOffLight.updateAccessory();
+    Serial.println("Matter Node is commissioned. Light restored from local state.");
+  }
+}
+
+void loop() {
+  if (!Matter.isDeviceCommissioned()) {
+    Serial.println("");
+    Serial.println("Matter Node is not commissioned yet.");
+    Serial.println("Initiate the device discovery in your Matter environment.");
+    Serial.println("Commission it using the generated manual pairing code or QR code");
+    Serial.printf("Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
+    Serial.printf("QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
+    uint32_t timeCount = 0;
+    while (!Matter.isDeviceCommissioned()) {
+      delay(100);
+      if ((timeCount++ % 50) == 0) {
+        Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
+      }
+    }
+    Serial.printf("Initial state: %s\r\n", OnOffLight.getOnOff() ? "ON" : "OFF");
+    OnOffLight.updateAccessory();
+    Serial.println("Matter Node is commissioned. Applying last local light state.");
+  }
+
+  pollControllerOnline();
+
+  if (digitalRead(buttonPin) == LOW && !button_state) {
+    button_time_stamp = millis();
+    button_state = true;
+  }
+
+  uint32_t time_diff = millis() - button_time_stamp;
+  if (button_state && time_diff > debouceTime && digitalRead(buttonPin) == HIGH) {
+    button_state = false;
+    Serial.println("User button released. Toggling Light!");
+    OnOffLight.toggle();
+  }
+
+  if (button_state && time_diff > decommissioningTimeout) {
+    Serial.println("Decommissioning the Light Matter Accessory. It shall be commissioned again.");
+    OnOffLight.setOnOff(false);
+    Matter.decommission();
+    button_time_stamp = millis();
+  }
+}

--- a/libraries/Matter/examples/MatterDeviceIdentity/MatterDeviceIdentity.ino
+++ b/libraries/Matter/examples/MatterDeviceIdentity/MatterDeviceIdentity.ino
@@ -4,12 +4,12 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/License-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing terms and
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 // Matter node identity and commissioning codes on the Matter singleton.

--- a/libraries/Matter/examples/MatterDeviceIdentity/README.md
+++ b/libraries/Matter/examples/MatterDeviceIdentity/README.md
@@ -65,7 +65,7 @@ Do not gate the LED on `isOnline()`. After a power cycle the light restores last
 
 1. Open `MatterDeviceIdentity.ino`.
 2. Board: your ESP32 target.
-3. Partition Scheme: **Huge APP (3MB No OTA/1MB SPIFFS)**.
+3. Partition Scheme: **Huge APP (3 MB No OTA / 1 MB SPIFFS)**.
 4. Enable **Erase All Flash Before Sketch Upload**.
 5. Upload. Serial 115200.
 

--- a/libraries/Matter/examples/MatterDeviceIdentity/README.md
+++ b/libraries/Matter/examples/MatterDeviceIdentity/README.md
@@ -1,0 +1,82 @@
+# Matter Device Identity Example
+
+This example shows how to set node identity and commissioning codes on the `Matter` singleton before `Matter.begin()`. It is an on/off light (same hardware as Matter On/Off Light) plus VendorName, ProductName, DeviceName (NodeLabel), SerialNumber, hardware version, and a non-default discriminator/PIN.
+
+Use the **generated** pairing codes printed after `Matter.begin()`. Before `begin()` the getters log a warning and return empty. Do not use a remembered Arduino test code (`34970112332`) when the PIN or discriminator has been changed.
+
+## Supported Targets
+
+| SoC | Wi-Fi | Thread | BLE Commissioning | LED | Status |
+| --- | ---- | ------ | ----------------- | --- | ------ |
+| ESP32 | ✅ | ❌ | ❌ | Required | Fully supported |
+| ESP32-S2 | ✅ | ❌ | ❌ | Required | Fully supported |
+| ESP32-S3 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C3 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
+| ESP32-C6 | ✅ | ❌ | ✅ | Required | Fully supported |
+| ESP32-H2 | ❌ | ✅ | ✅ | Required | Supported (Thread only) |
+
+### Note on Commissioning
+
+- **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. Set Wi-Fi credentials in the sketch.
+- **ESP32-C6** Arduino Matter is precompiled Wi-Fi only. Thread-only needs Arduino as an IDF component.
+- **ESP32-C5** Arduino Matter is precompiled Thread only.
+
+## Call order
+
+```cpp
+Matter.setVendorName("Espressif");
+Matter.setProductName("KitchenLight");
+Matter.setDeviceName("KitchenHub");   // Basic Information NodeLabel
+Matter.setSerialNumber("KH-000123");
+Matter.setHardwareVersion(7);
+Matter.setHardwareVersionString("RevA");
+Matter.setSetupDiscriminator(0xF01);  // 0–0xFFF; test default is 0xF00
+Matter.setSetupPasscode(20202024);    // valid PIN; test default is 20202021
+
+OnOffLight.begin(lastOnOffState);
+Matter.begin();  // applies identity, regenerates SPAKE2+ if the PIN changed, prints live codes
+```
+
+Setters after `Matter.begin()` log a warning and have no effect. String setters copy the text (literals, stack buffers, and `String` are all safe). Limits: names and serial 32, hardware version string 64.
+
+`setDeviceName()` writes NodeLabel. On a single-endpoint node, controllers often use that as the device title. On a composed node it is the parent/node name; child lights are not renamed (use `MatterEndPoint::setTagList()` for switch-style tags, not light titles).
+
+Do not change Vendor ID / Product ID from a sketch unless the DAC matches. SoftwareVersion is compile-time CHIP config.
+
+Production devices should use a unique random PIN and discriminator per unit (factory NVS). This example stores values in RAM and reapplies them every boot.
+
+## Commissioned, connected, online
+
+After pairing, the sketch drives the LED from local Matter state (`updateAccessory()`). `loop()` keeps the button live and samples `Matter.isOnline()` every 2.5 seconds, logging only when the CASE session goes up or down.
+
+1. `Matter.isDeviceCommissioned()` — fabric exists (pairing wait)
+2. `Matter.isDeviceConnected()` — Wi-Fi or Thread is up
+3. `Matter.isOnline()` — a controller has an active CASE session (stays true until the session is idle-evicted, not when the user closes the app)
+
+Do not gate the LED on `isOnline()`. After a power cycle the light restores last on/off even if the hub is off. See [Matter Status](../MatterStatus) for a periodic print of all three flags.
+
+## Hardware
+
+- LED: `LED_BUILTIN` or pin 2
+- Button: `BOOT_PIN` — short press toggles, hold 5 s decommissions
+
+## Building and Flashing
+
+1. Open `MatterDeviceIdentity.ino`.
+2. Board: your ESP32 target.
+3. Partition Scheme: **Huge APP (3MB No OTA/1MB SPIFFS)**.
+4. Enable **Erase All Flash Before Sketch Upload**.
+5. Upload. Serial 115200.
+
+Erase flash after changing identity or pairing codes. Controllers cache names at commissioning.
+
+## Related Documentation
+
+- [Matter Overview](https://docs.espressif.com/projects/arduino-esp32/en/latest/matter/matter.html)
+- [Matter Status](../MatterStatus) — commissioned / connected / online
+- [Matter Smart Buttons TagList](../MatterSmartButtonsTagList) — Descriptor tags (not light names)
+
+## License
+
+Apache License 2.0.

--- a/libraries/Matter/examples/MatterDeviceIdentity/ci.yml
+++ b/libraries/Matter/examples/MatterDeviceIdentity/ci.yml
@@ -1,0 +1,4 @@
+fqbn_append: PartitionScheme=huge_app
+
+requires:
+  - CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y

--- a/libraries/Matter/examples/MatterStatus/MatterStatus.ino
+++ b/libraries/Matter/examples/MatterStatus/MatterStatus.ino
@@ -1,4 +1,4 @@
-// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,23 +98,59 @@ void setup() {
   Serial.println("Matter started");
   Serial.println();
 
-  // Print commissioning information
   Serial.println("========================================");
-  Serial.println("Matter Node is not commissioned yet.");
-  Serial.println("Initiate the device discovery in your Matter environment.");
-  Serial.println("Commission it to your Matter hub with the manual pairing code or QR code");
+  if (Matter.isDeviceCommissioned()) {
+    Serial.println("Matter Node is already commissioned.");
+  } else {
+    Serial.println("Matter Node is not commissioned yet.");
+    Serial.println("Initiate the device discovery in your Matter environment.");
+    Serial.println("Commission it to your Matter hub with the manual pairing code or QR code");
+  }
   Serial.printf("Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
   Serial.printf("QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
   Serial.println("========================================\n");
 }
 
 void loop() {
-  // Report connection status every 10 seconds
-  Serial.println("=== Connection Status ===");
-  Serial.printf("WiFi Connected: %s\r\n", Matter.isWiFiConnected() ? "YES" : "NO");
-  Serial.printf("Thread Connected: %s\r\n", Matter.isThreadConnected() ? "YES" : "NO");
-  Serial.printf("Device Connected: %s\r\n", Matter.isDeviceConnected() ? "YES" : "NO");
-  Serial.printf("Device Commissioned: %s\r\n", Matter.isDeviceCommissioned() ? "YES" : "NO");
-  Serial.println();
-  delay(10000);
+  static bool lastCommissioned = false;
+  static bool lastConnected = false;
+  static bool lastOnline = false;
+  static uint32_t lastOnlinePollMs = 0;
+  static uint32_t lastStatusPollMs = 0;
+
+  const uint32_t now = millis();
+
+  // CASE session is sampled every 2.5 s. The LED is not gated on isOnline().
+  if (lastOnlinePollMs == 0 || (now - lastOnlinePollMs) >= 2500) {
+    lastOnlinePollMs = now;
+    const bool online = Matter.isOnline();
+    if (online != lastOnline) {
+      Serial.printf("State change: Online=%s\r\n", online ? "YES" : "NO");
+      lastOnline = online;
+    }
+  }
+
+  // Commissioned / connected / radios every 5 s.
+  if (lastStatusPollMs == 0 || (now - lastStatusPollMs) >= 5000) {
+    lastStatusPollMs = now;
+    const bool commissioned = Matter.isDeviceCommissioned();
+    const bool connected = Matter.isDeviceConnected();
+    if (commissioned != lastCommissioned || connected != lastConnected) {
+      Serial.printf(
+        "State change: Commissioned=%s Connected=%s\r\n", commissioned ? "YES" : "NO", connected ? "YES" : "NO"
+      );
+      lastCommissioned = commissioned;
+      lastConnected = connected;
+    }
+
+    Serial.println("=== Connection Status ===");
+    Serial.printf("WiFi Connected: %s\r\n", Matter.isWiFiConnected() ? "YES" : "NO");
+    Serial.printf("Thread Connected: %s\r\n", Matter.isThreadConnected() ? "YES" : "NO");
+    Serial.printf("Device Connected: %s\r\n", connected ? "YES" : "NO");
+    Serial.printf("Device Commissioned: %s\r\n", commissioned ? "YES" : "NO");
+    Serial.printf("Device Online (CASE): %s\r\n", lastOnline ? "YES" : "NO");
+    Serial.println();
+  }
+
+  delay(50);
 }

--- a/libraries/Matter/examples/MatterStatus/MatterStatus.ino
+++ b/libraries/Matter/examples/MatterStatus/MatterStatus.ino
@@ -136,9 +136,7 @@ void loop() {
     const bool commissioned = Matter.isDeviceCommissioned();
     const bool connected = Matter.isDeviceConnected();
     if (commissioned != lastCommissioned || connected != lastConnected) {
-      Serial.printf(
-        "State change: Commissioned=%s Connected=%s\r\n", commissioned ? "YES" : "NO", connected ? "YES" : "NO"
-      );
+      Serial.printf("State change: Commissioned=%s Connected=%s\r\n", commissioned ? "YES" : "NO", connected ? "YES" : "NO");
       lastCommissioned = commissioned;
       lastConnected = connected;
     }

--- a/libraries/Matter/examples/MatterStatus/README.md
+++ b/libraries/Matter/examples/MatterStatus/README.md
@@ -28,11 +28,12 @@ This example demonstrates how to check enabled Matter features and connectivity 
   - `isWiFiAccessPointEnabled()`: Checks if Wi-Fi AP mode is supported and enabled
   - `isThreadEnabled()`: Checks if Thread network is supported and enabled
   - `isBLECommissioningEnabled()`: Checks if BLE commissioning is supported and enabled
-- **Connection status monitoring**: Reports connection status every 10 seconds
+- **Connection status monitoring**: Reports commissioned / connected / radios every 5 seconds. Samples `isOnline()` every 2.5 seconds and prints a line when any of those flags change
   - `isWiFiConnected()`: Checks Wi-Fi connection status (if Wi-Fi Station is enabled)
   - `isThreadConnected()`: Checks Thread connection status (if Thread is enabled)
   - `isDeviceConnected()`: Checks overall device connectivity (Wi-Fi or Thread)
   - `isDeviceCommissioned()`: Checks if the device is commissioned to a Matter fabric
+  - `isOnline()`: Checks if a controller has an active CASE session with this node (not a gate for the LED). Stays true until the session is idle-evicted, not when the user closes the app.
 - Simple on/off light control
 - Matter commissioning via QR code or manual pairing code
 - Integration with Apple HomeKit, Amazon Alexa, and Google Home
@@ -116,14 +117,16 @@ WiFi Connected: YES
 Thread Connected: NO
 Device Connected: YES
 Device Commissioned: NO
+Device Online (CASE): NO
 
 === Connection Status ===
 WiFi Connected: YES
 Thread Connected: NO
 Device Connected: YES
 Device Commissioned: NO
+Device Online (CASE): NO
 
-... (reports every 10 seconds)
+... (reports every 5 seconds)
 
 User Callback :: New Light State = ON
 === Connection Status ===
@@ -131,8 +134,17 @@ WiFi Connected: YES
 Thread Connected: NO
 Device Connected: YES
 Device Commissioned: YES
+Device Online (CASE): NO
 
-... (reports every 10 seconds)
+State change: Commissioned=YES Connected=YES Online=YES
+=== Connection Status ===
+WiFi Connected: YES
+Thread Connected: NO
+Device Connected: YES
+Device Commissioned: YES
+Device Online (CASE): YES
+
+... (reports every 5 seconds)
 ```
 
 ## Usage
@@ -153,12 +165,15 @@ These functions are useful for:
 
 ### Connection Status Monitoring
 
-The example periodically reports connection status every 10 seconds:
+The example reports commissioned / connected / radio status every 5 seconds and samples `isOnline()` every 2.5 seconds:
 
 - **`Matter.isWiFiConnected()`**: Returns `true` if Wi-Fi Station is connected. If Wi-Fi Station is not enabled, always returns `false`.
 - **`Matter.isThreadConnected()`**: Returns `true` if Thread is attached to a network. If Thread is not enabled, always returns `false`.
 - **`Matter.isDeviceConnected()`**: Returns `true` if the device is connected via Wi-Fi or Thread (overall connectivity status)
 - **`Matter.isDeviceCommissioned()`**: Returns `true` if the device has been commissioned to a Matter fabric
+- **`Matter.isOnline()`**: Returns `true` if a Matter controller currently has an active CASE (operational) session. This is not the same as commissioned (fabric exists) or connected (radio/IP is up). It stays true until CHIP or the hub tears that session down (idle-evict), not merely when the user closes an app. The on/off LED is **not** gated on this flag.
+
+Typical first-commission sequence: pairing code → `Commissioned=YES` → `Connected=YES` → `Online=YES`. Online changes can appear on the 2.5 s poll; commissioned / connected changes appear on the 5 s poll.
 
 ### Smart Home Integration
 
@@ -175,7 +190,7 @@ Use a Matter-compatible hub (like an Apple HomePod, Google Nest Hub, or Amazon E
   - Prints commissioning information
 
 - **`loop()`**:
-  - Reports connection status every 10 seconds
+  - Samples `isOnline()` every 2.5 seconds; reports commissioned / connected / radios every 5 seconds
   - All light control is handled via Matter callbacks
 
 - **Callbacks**:
@@ -187,7 +202,7 @@ Use a Matter-compatible hub (like an Apple HomePod, Google Nest Hub, or Amazon E
 
 2. **Capability queries return unexpected values**: These functions check both hardware support and Matter configuration. Verify that the features are enabled in your Matter build configuration.
 
-3. **Connection status not updating**: The status is reported every 10 seconds. Check Serial Monitor output to see the periodic reports.
+3. **Connection status not updating**: Radios and commissioned / connected are reported every 5 seconds; `isOnline()` is sampled every 2.5 seconds. Check Serial Monitor output to see the periodic reports.
 
 4. **LED not responding**: Verify pin configurations and connections.
 

--- a/libraries/Matter/keywords.txt
+++ b/libraries/Matter/keywords.txt
@@ -71,6 +71,15 @@ getOnboardingQRCodeUrl	KEYWORD2
 isBLECommissioningEnabled	KEYWORD2
 isDeviceCommissioned	KEYWORD2
 isDeviceConnected	KEYWORD2
+isOnline	KEYWORD2
+setVendorName	KEYWORD2
+setProductName	KEYWORD2
+setDeviceName	KEYWORD2
+setSerialNumber	KEYWORD2
+setHardwareVersion	KEYWORD2
+setHardwareVersionString	KEYWORD2
+setSetupDiscriminator	KEYWORD2
+setSetupPasscode	KEYWORD2
 isThreadConnected	KEYWORD2
 isThreadEnabled	KEYWORD2
 isWiFiAccessPointEnabled	KEYWORD2

--- a/libraries/Matter/src/Matter.cpp
+++ b/libraries/Matter/src/Matter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,7 +37,11 @@ using namespace chip::app::Clusters;
 
 constexpr auto k_timeout_seconds = 300;
 
-static bool _matter_has_started = false;
+// Two-phase lifecycle. Endpoint begin() creates the node (NodeCreated).
+// Matter.begin() starts the CHIP stack (StackStarted). These are not the same:
+// identity setters are valid after the node exists and invalid after the stack starts.
+enum class MatterLifecycle : uint8_t { Uninitialized, NodeCreated, StackStarted };
+static MatterLifecycle sLifecycle = MatterLifecycle::Uninitialized;
 static node::config_t node_config;
 static node_t *deviceNode = nullptr;
 ArduinoMatter::matterEventCB ArduinoMatter::_matterEventCB = nullptr;
@@ -143,8 +147,12 @@ static void app_event_cb(const ChipDeviceEvent *event, intptr_t arg) {
   }
 }
 
+bool ArduinoMatter::isStackStarted() {
+  return sLifecycle == MatterLifecycle::StackStarted;
+}
+
 void ArduinoMatter::_init() {
-  if (_matter_has_started) {
+  if (sLifecycle != MatterLifecycle::Uninitialized) {
     return;
   }
 
@@ -156,11 +164,14 @@ void ArduinoMatter::_init() {
     return;
   }
 
-  _matter_has_started = true;
+  sLifecycle = MatterLifecycle::NodeCreated;
 }
 
 void ArduinoMatter::begin() {
-  if (!_matter_has_started) {
+  if (sLifecycle == MatterLifecycle::StackStarted) {
+    return;
+  }
+  if (sLifecycle != MatterLifecycle::NodeCreated) {
     log_e("No Matter endpoint has been created. Please create an endpoint first.");
     return;
   }
@@ -184,12 +195,16 @@ void ArduinoMatter::begin() {
   set_openthread_platform_config(&config);
 #endif
 
+  applyIdentityBeforeStart();
+
   /* Matter start */
   esp_err_t err = esp_matter::start(app_event_cb);
   if (err != ESP_OK) {
     log_e("Failed to start Matter, err:%d", err);
-    _matter_has_started = false;
+    return;
   }
+  sLifecycle = MatterLifecycle::StackStarted;
+  applyIdentityAfterStart();
 }
 
 // Network and Commissioning Capability Queries

--- a/libraries/Matter/src/Matter.cpp
+++ b/libraries/Matter/src/Matter.cpp
@@ -40,7 +40,11 @@ constexpr auto k_timeout_seconds = 300;
 // Two-phase lifecycle. Endpoint begin() creates the node (NodeCreated).
 // Matter.begin() starts the CHIP stack (StackStarted). These are not the same:
 // identity setters are valid after the node exists and invalid after the stack starts.
-enum class MatterLifecycle : uint8_t { Uninitialized, NodeCreated, StackStarted };
+enum class MatterLifecycle : uint8_t {
+  Uninitialized,
+  NodeCreated,
+  StackStarted
+};
 static MatterLifecycle sLifecycle = MatterLifecycle::Uninitialized;
 static node::config_t node_config;
 static node_t *deviceNode = nullptr;

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -234,6 +234,7 @@ protected:
   static void _init();
   static bool isStackStarted();  // true only after a successful Matter.begin()
   static bool ensureSetBeforeBegin(const char *apiName);
+  static bool storeIdentityString(char *dst, size_t dstSize, const char *src, const char *apiName);
   static void applyIdentityBeforeStart();
   static void applyIdentityAfterStart();
 };

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -1,4 +1,4 @@
-// Copyright 2025 Espressif Systems (Shanghai) PTE LTD
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -174,15 +174,24 @@ public:
     _matterEventCB = cb;
   }
 
-  static inline String getManualPairingCode() {
-    // return the pairing code for manual pairing
-    return String("34970112332");
-  }
-  static inline String getOnboardingQRCodeUrl() {
-    // return the URL for the QR code for onboarding
-    return String("https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT:Y.K9042C00KA0648G00");
-  }
+  // Generated after Matter.begin() from CommissionableDataProvider.
+  // Before begin() these log a warning and return an empty String.
+  static String getManualPairingCode();
+  static String getOnboardingQRCodeUrl();
   static void begin();
+
+  // Node identity (Basic Information on endpoint 0). Call before Matter.begin().
+  // String setters copy into internal storage; the argument need not outlive the call.
+  static bool setVendorName(const char *name);
+  static bool setProductName(const char *name);
+  static bool setDeviceName(const char *name);  // writes NodeLabel
+  static bool setSerialNumber(const char *value);
+  static bool setHardwareVersion(uint16_t version);
+  static bool setHardwareVersionString(const char *value);
+
+  // Commissioning codes. Call before Matter.begin(). Test defaults are 0xF00 / 20202021.
+  static bool setSetupDiscriminator(uint16_t discriminator);
+  static bool setSetupPasscode(uint32_t passcode);
 
   // Network and Commissioning Capability Queries
   // These methods check both hardware support (SOC capabilities) and Matter configuration
@@ -195,6 +204,7 @@ public:
   static bool isWiFiConnected();
   static bool isThreadConnected();
   static bool isDeviceConnected();
+  static bool isOnline();  // active CASE session with a controller
   static void decommission();
 
   // list of Matter EndPoints Friend Classes
@@ -222,6 +232,10 @@ public:
 
 protected:
   static void _init();
+  static bool isStackStarted();  // true only after a successful Matter.begin()
+  static bool ensureSetBeforeBegin(const char *apiName);
+  static void applyIdentityBeforeStart();
+  static void applyIdentityAfterStart();
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MATTER)

--- a/libraries/Matter/src/MatterIdentity.cpp
+++ b/libraries/Matter/src/MatterIdentity.cpp
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/License-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/libraries/Matter/src/MatterIdentity.cpp
+++ b/libraries/Matter/src/MatterIdentity.cpp
@@ -1,0 +1,376 @@
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/License-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sdkconfig.h>
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <Matter.h>
+#include "MatterIdentity.h"
+
+#include <access/SubjectDescriptor.h>
+#include <app/AttributeValueDecoder.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/clusters/basic-information/BasicInformationCluster.h>
+#include <app/data-model-provider/ActionReturnStatus.h>
+#include <app/data-model-provider/OperationTypes.h>
+#include <app/server/Dnssd.h>
+#include <app/server/Server.h>
+#include <lib/core/TLV.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <setup_payload/OnboardingCodesUtil.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <setup_payload/SetupPayload.h>
+#include <transport/SecureSession.h>
+#include <transport/Session.h>
+#include <transport/SessionManager.h>
+
+using chip::SessionHandle;
+
+using namespace esp_matter;
+using namespace MatterIdentityInternal;
+
+static constexpr size_t kMaxQrCodeLen = chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1;
+static constexpr size_t kMaxQrUrlLen = 768;
+static constexpr size_t kMaxManualCodeLen = chip::kManualSetupLongCodeCharLength + 2;
+
+static OverrideInstanceInfoProvider sInstanceProvider;
+static OverrideCommissionableDataProvider sCommissionableProvider;
+
+static char sVendorName[kMaxIdentityLen + 1] = {};
+static char sProductName[kMaxIdentityLen + 1] = {};
+static char sDeviceName[kMaxIdentityLen + 1] = {};
+static char sHardwareVersionString[kMaxHwStringLen + 1] = {};
+static char sSerialNumber[kMaxSerialLen + 1] = {};
+static char sManualCode[kMaxManualCodeLen] = {};
+static char sQrUrl[kMaxQrUrlLen] = {};
+static uint16_t sHardwareVersion = 0;
+static uint16_t sDiscriminator = 0;
+static uint32_t sPasscode = 0;
+static bool sHasHardwareVersion = false;
+static bool sHasDiscriminator = false;
+static bool sHasPasscode = false;
+static bool sCodesGenerated = false;
+
+bool ArduinoMatter::ensureSetBeforeBegin(const char *apiName) {
+  if (isStackStarted()) {
+    log_w("Matter.%s() has no effect after Matter.begin(); call it before Matter.begin().", apiName);
+    return false;
+  }
+  return true;
+}
+
+static bool storeIdentityString(char *dst, size_t dstSize, const char *src, const char *apiName) {
+  if (!ArduinoMatter::ensureSetBeforeBegin(apiName)) {
+    return false;
+  }
+  if (!copyBounded(dst, dstSize, src)) {
+    log_e("Matter.%s() value is empty or longer than %u characters.", apiName, static_cast<unsigned>(dstSize - 1));
+    return false;
+  }
+  return true;
+}
+
+bool ArduinoMatter::setVendorName(const char *name) {
+  return storeIdentityString(sVendorName, sizeof(sVendorName), name, "setVendorName");
+}
+bool ArduinoMatter::setProductName(const char *name) {
+  return storeIdentityString(sProductName, sizeof(sProductName), name, "setProductName");
+}
+bool ArduinoMatter::setDeviceName(const char *name) {
+  return storeIdentityString(sDeviceName, sizeof(sDeviceName), name, "setDeviceName");
+}
+bool ArduinoMatter::setSerialNumber(const char *value) {
+  return storeIdentityString(sSerialNumber, sizeof(sSerialNumber), value, "setSerialNumber");
+}
+bool ArduinoMatter::setHardwareVersionString(const char *value) {
+  return storeIdentityString(sHardwareVersionString, sizeof(sHardwareVersionString), value, "setHardwareVersionString");
+}
+
+bool ArduinoMatter::setHardwareVersion(uint16_t version) {
+  if (!ensureSetBeforeBegin("setHardwareVersion")) {
+    return false;
+  }
+  sHardwareVersion = version;
+  sHasHardwareVersion = true;
+  return true;
+}
+
+bool ArduinoMatter::setSetupDiscriminator(uint16_t discriminator) {
+  if (!ensureSetBeforeBegin("setSetupDiscriminator")) {
+    return false;
+  }
+  if (discriminator > chip::kMaxDiscriminatorValue) {
+    log_e("Matter.setSetupDiscriminator() must be 0..0xFFF.");
+    return false;
+  }
+  sDiscriminator = discriminator;
+  sHasDiscriminator = true;
+  return true;
+}
+
+bool ArduinoMatter::setSetupPasscode(uint32_t passcode) {
+  if (!ensureSetBeforeBegin("setSetupPasscode")) {
+    return false;
+  }
+  if (!chip::PayloadContents::IsValidSetupPIN(passcode)) {
+    log_e("Matter.setSetupPasscode() is not a valid Matter setup PIN.");
+    return false;
+  }
+  sPasscode = passcode;
+  sHasPasscode = true;
+  return true;
+}
+
+static bool needsOptionalBasicInfoAttrs() {
+  return sSerialNumber[0] != '\0';
+}
+
+static bool needsInstanceInfoWrap() {
+  return sVendorName[0] != '\0' || sProductName[0] != '\0' || sHasHardwareVersion || sHardwareVersionString[0] != '\0' || sSerialNumber[0] != '\0';
+}
+
+static bool ensureBasicInfoAttr(
+  cluster_t *cluster, uint32_t attributeId, attribute_t *(*createFn)(cluster_t *, char *, uint16_t), const char *name
+) {
+  if (attribute::get(cluster, attributeId) != nullptr) {
+    return true;
+  }
+  if (createFn(cluster, nullptr, 0) == nullptr) {
+    log_e("Failed to create %s", name);
+    return false;
+  }
+  return true;
+}
+
+void ArduinoMatter::applyIdentityBeforeStart() {
+  if (!needsOptionalBasicInfoAttrs()) {
+    return;
+  }
+  endpoint_t *ep = endpoint::get(0);
+  cluster_t *cluster = (ep != nullptr) ? cluster::get(ep, chip::app::Clusters::BasicInformation::Id) : nullptr;
+  if (cluster == nullptr) {
+    log_e("Basic Information cluster missing on endpoint 0; optional identity attributes were not created.");
+    return;
+  }
+  using namespace chip::app::Clusters::BasicInformation::Attributes;
+  if (sSerialNumber[0] != '\0') {
+    ensureBasicInfoAttr(cluster, SerialNumber::Id, cluster::basic_information::attribute::create_serial_number, "SerialNumber");
+  }
+}
+
+static bool writeNodeLabel(const char *label) {
+  esp_matter::lock::ScopedChipStackLock lock(portMAX_DELAY);
+
+  uint8_t tlvBuf[64] = {};
+  chip::TLV::TLVWriter writer;
+  writer.Init(tlvBuf);
+  CHIP_ERROR err = writer.PutString(chip::TLV::AnonymousTag(), label);
+  if (err != CHIP_NO_ERROR) {
+    log_e("NodeLabel TLV encode failed: %" CHIP_ERROR_FORMAT, err.Format());
+    return false;
+  }
+
+  chip::TLV::TLVReader reader;
+  reader.Init(tlvBuf, writer.GetLengthWritten());
+  err = reader.Next();
+  if (err != CHIP_NO_ERROR) {
+    log_e("NodeLabel TLV read failed: %" CHIP_ERROR_FORMAT, err.Format());
+    return false;
+  }
+
+  chip::Access::SubjectDescriptor subject{};
+  chip::app::AttributeValueDecoder decoder(reader, subject);
+  chip::app::DataModel::WriteAttributeRequest request;
+  request.path = chip::app::ConcreteDataAttributePath(
+    chip::kRootEndpointId, chip::app::Clusters::BasicInformation::Id, chip::app::Clusters::BasicInformation::Attributes::NodeLabel::Id
+  );
+  request.operationFlags.Set(chip::app::DataModel::OperationFlags::kInternal);
+
+  const chip::app::DataModel::ActionReturnStatus status = chip::app::Clusters::BasicInformationCluster::Instance().WriteAttribute(request, decoder);
+  if (!status.IsSuccess()) {
+    log_e("NodeLabel write failed");
+    return false;
+  }
+  log_i("NodeLabel written: %s", label);
+  return true;
+}
+
+static void refreshOnboardingCodes() {
+  sManualCode[0] = '\0';
+  sQrUrl[0] = '\0';
+  sCodesGenerated = false;
+
+  chip::RendezvousInformationFlags flags(chip::RendezvousInformationFlag::kOnNetwork);
+#if CONFIG_ENABLE_CHIPOBLE
+  flags.Set(chip::RendezvousInformationFlag::kBLE);
+#endif
+
+  char qrBuf[kMaxQrCodeLen] = {};
+  chip::MutableCharSpan qr(qrBuf, sizeof(qrBuf));
+  chip::MutableCharSpan manual(sManualCode, sizeof(sManualCode));
+  CHIP_ERROR qrErr = CHIP_NO_ERROR;
+  CHIP_ERROR manualErr = CHIP_NO_ERROR;
+  {
+    esp_matter::lock::ScopedChipStackLock lock(portMAX_DELAY);
+    qrErr = GetQRCode(qr, flags);
+    if (qrErr == CHIP_NO_ERROR) {
+      manualErr = GetManualPairingCode(manual, flags);
+    }
+  }
+  if (qrErr != CHIP_NO_ERROR) {
+    log_e("GetQRCode failed: %" CHIP_ERROR_FORMAT, qrErr.Format());
+    return;
+  }
+  if (manualErr != CHIP_NO_ERROR) {
+    log_e("GetManualPairingCode failed: %" CHIP_ERROR_FORMAT, manualErr.Format());
+    sManualCode[0] = '\0';
+    return;
+  }
+  sCodesGenerated = true;
+  const CHIP_ERROR urlErr = GetQRCodeUrl(sQrUrl, sizeof(sQrUrl), qr);
+  if (urlErr != CHIP_NO_ERROR) {
+    log_e("GetQRCodeUrl failed: %" CHIP_ERROR_FORMAT, urlErr.Format());
+    sQrUrl[0] = '\0';
+  }
+}
+
+static bool applyCommissionable() {
+  esp_matter::lock::ScopedChipStackLock lock(portMAX_DELAY);
+
+  if (!sCommissionableProvider.bindBase(chip::DeviceLayer::GetCommissionableDataProvider())) {
+    log_e("CommissionableDataProvider is not available.");
+    return false;
+  }
+  if (sHasDiscriminator) {
+    const CHIP_ERROR err = sCommissionableProvider.SetSetupDiscriminator(sDiscriminator);
+    if (err != CHIP_NO_ERROR) {
+      log_e("SetSetupDiscriminator failed: %" CHIP_ERROR_FORMAT, err.Format());
+      return false;
+    }
+  }
+  if (sHasPasscode) {
+    const CHIP_ERROR err = sCommissionableProvider.SetSetupPasscode(sPasscode);
+    if (err != CHIP_NO_ERROR) {
+      log_e("SetSetupPasscode failed: %" CHIP_ERROR_FORMAT, err.Format());
+      return false;
+    }
+    const CHIP_ERROR verifierErr = sCommissionableProvider.ensureVerifier();
+    if (verifierErr != CHIP_NO_ERROR) {
+      log_e("SPAKE2+ verifier generate failed: %" CHIP_ERROR_FORMAT, verifierErr.Format());
+      return false;
+    }
+  }
+
+  sCommissionableProvider.publish();
+
+#if CONFIG_ENABLE_CHIPOBLE
+  CHIP_ERROR bleErr = chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
+  if (bleErr == CHIP_NO_ERROR) {
+    bleErr = chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+  }
+  if (bleErr != CHIP_NO_ERROR) {
+    log_e("BLE advertising restart failed: %" CHIP_ERROR_FORMAT, bleErr.Format());
+  }
+#endif
+  chip::app::DnssdServer::Instance().StartServer();
+  return true;
+}
+
+static bool applyInstanceInfoWrap() {
+  if (sVendorName[0] != '\0') {
+    sInstanceProvider.setVendorName(sVendorName);
+  }
+  if (sProductName[0] != '\0') {
+    sInstanceProvider.setProductName(sProductName);
+  }
+  if (sHasHardwareVersion) {
+    sInstanceProvider.setHardwareVersion(sHardwareVersion);
+  }
+  if (sHardwareVersionString[0] != '\0') {
+    sInstanceProvider.setHardwareVersionString(sHardwareVersionString);
+  }
+  if (sSerialNumber[0] != '\0') {
+    sInstanceProvider.setSerialNumber(sSerialNumber);
+  }
+
+  esp_matter::lock::ScopedChipStackLock lock(portMAX_DELAY);
+  if (!sInstanceProvider.bindBase(chip::DeviceLayer::GetDeviceInstanceInfoProvider())) {
+    log_e("DeviceInstanceInfoProvider is not available.");
+    return false;
+  }
+  sInstanceProvider.publish();
+  return true;
+}
+
+void ArduinoMatter::applyIdentityAfterStart() {
+  if (needsInstanceInfoWrap() && !applyInstanceInfoWrap()) {
+    log_e("Instance identity wrap was not installed.");
+  }
+
+  if (sDeviceName[0] != '\0') {
+    writeNodeLabel(sDeviceName);
+  }
+
+  if (sHasDiscriminator || sHasPasscode) {
+    if (!applyCommissionable()) {
+      log_e("Custom discriminator/passcode were not applied; pairing codes use the factory values.");
+    }
+  }
+
+  refreshOnboardingCodes();
+}
+
+String ArduinoMatter::getManualPairingCode() {
+  if (!isStackStarted()) {
+    log_w("Matter.getManualPairingCode() is not available before Matter.begin(); pairing codes are generated after begin().");
+    return String();
+  }
+  if (sCodesGenerated && sManualCode[0] != '\0') {
+    return String(sManualCode);
+  }
+  log_w("Matter.getManualPairingCode() could not generate a pairing code.");
+  return String();
+}
+
+String ArduinoMatter::getOnboardingQRCodeUrl() {
+  if (!isStackStarted()) {
+    log_w("Matter.getOnboardingQRCodeUrl() is not available before Matter.begin(); pairing codes are generated after begin().");
+    return String();
+  }
+  if (sCodesGenerated && sQrUrl[0] != '\0') {
+    return String(sQrUrl);
+  }
+  log_w("Matter.getOnboardingQRCodeUrl() could not generate a pairing code URL.");
+  return String();
+}
+
+static bool sessionIsActiveCase(void *context, chip::SessionHandle &session) {
+  chip::Transport::SecureSession *secure = session->AsSecureSession();
+  if (secure != nullptr && secure->IsCASESession() && secure->IsActiveSession()) {
+    *static_cast<bool *>(context) = true;
+  }
+  return true;
+}
+
+bool ArduinoMatter::isOnline() {
+  if (!isStackStarted() || !isDeviceCommissioned()) {
+    return false;
+  }
+  bool online = false;
+  esp_matter::lock::ScopedChipStackLock lock(portMAX_DELAY);
+  chip::Server::GetInstance().GetSecureSessionManager().ForEachSessionHandle(&online, sessionIsActiveCase);
+  return online;
+}
+
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterIdentity.cpp
+++ b/libraries/Matter/src/MatterIdentity.cpp
@@ -157,10 +157,10 @@ void ArduinoMatter::applyIdentityBeforeStart() {
   if (!needsOptionalBasicInfoAttrs()) {
     return;
   }
-  endpoint_t *ep = endpoint::get(0);
+  endpoint_t *ep = endpoint::get(node::get(), chip::kRootEndpointId);
   cluster_t *cluster = (ep != nullptr) ? cluster::get(ep, chip::app::Clusters::BasicInformation::Id) : nullptr;
   if (cluster == nullptr) {
-    log_e("Basic Information cluster missing on endpoint 0; optional identity attributes were not created.");
+    log_e("Basic Information cluster missing on the root endpoint; optional identity attributes were not created.");
     return;
   }
   using namespace chip::app::Clusters::BasicInformation::Attributes;

--- a/libraries/Matter/src/MatterIdentity.cpp
+++ b/libraries/Matter/src/MatterIdentity.cpp
@@ -24,7 +24,6 @@
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/OperationTypes.h>
-#include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <lib/core/TLV.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -274,16 +273,24 @@ static bool applyCommissionable() {
 
   sCommissionableProvider.publish();
 
-#if CONFIG_ENABLE_CHIPOBLE
-  CHIP_ERROR bleErr = chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
-  if (bleErr == CHIP_NO_ERROR) {
-    bleErr = chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+  // Server::Init already opened a window and snapshotted the factory SPAKE2+ verifier.
+  // Reopen so AdvertiseAndListenForPASE() copies the wrap. Skip if a fabric exists or
+  // fail-safe is armed (an in-progress PASE already passed SPAKE).
+  if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0) {
+    if (!chip::Server::GetInstance().GetFailSafeContext().IsFailSafeFullyDisarmed()) {
+      log_w("Commissioning already in progress; custom PIN takes effect on the next window.");
+    } else {
+      chip::CommissioningWindowManager &mgr = chip::Server::GetInstance().GetCommissioningWindowManager();
+      if (mgr.IsCommissioningWindowOpen()) {
+        mgr.CloseCommissioningWindow();
+      }
+      const CHIP_ERROR err = mgr.OpenBasicCommissioningWindow();
+      if (err != CHIP_NO_ERROR) {
+        log_e("Failed to reopen commissioning window after custom PIN: %" CHIP_ERROR_FORMAT, err.Format());
+        return false;
+      }
+    }
   }
-  if (bleErr != CHIP_NO_ERROR) {
-    log_e("BLE advertising restart failed: %" CHIP_ERROR_FORMAT, bleErr.Format());
-  }
-#endif
-  chip::app::DnssdServer::Instance().StartServer();
   return true;
 }
 
@@ -314,18 +321,18 @@ static bool applyInstanceInfoWrap() {
 }
 
 void ArduinoMatter::applyIdentityAfterStart() {
+  if (sHasDiscriminator || sHasPasscode) {
+    if (!applyCommissionable()) {
+      log_e("Custom discriminator/passcode were not applied; pairing codes use the factory values.");
+    }
+  }
+
   if (needsInstanceInfoWrap() && !applyInstanceInfoWrap()) {
     log_e("Instance identity wrap was not installed.");
   }
 
   if (sDeviceName[0] != '\0') {
     writeNodeLabel(sDeviceName);
-  }
-
-  if (sHasDiscriminator || sHasPasscode) {
-    if (!applyCommissionable()) {
-      log_e("Custom discriminator/passcode were not applied; pairing codes use the factory values.");
-    }
   }
 
   refreshOnboardingCodes();

--- a/libraries/Matter/src/MatterIdentity.cpp
+++ b/libraries/Matter/src/MatterIdentity.cpp
@@ -70,8 +70,8 @@ bool ArduinoMatter::ensureSetBeforeBegin(const char *apiName) {
   return true;
 }
 
-static bool storeIdentityString(char *dst, size_t dstSize, const char *src, const char *apiName) {
-  if (!ArduinoMatter::ensureSetBeforeBegin(apiName)) {
+bool ArduinoMatter::storeIdentityString(char *dst, size_t dstSize, const char *src, const char *apiName) {
+  if (!ensureSetBeforeBegin(apiName)) {
     return false;
   }
   if (!copyBounded(dst, dstSize, src)) {

--- a/libraries/Matter/src/MatterIdentity.cpp
+++ b/libraries/Matter/src/MatterIdentity.cpp
@@ -273,7 +273,7 @@ static bool applyCommissionable() {
 
   // Server::Init already opened a window and snapshotted the factory SPAKE2+ verifier.
   // Reopen so AdvertiseAndListenForPASE() copies the wrap. Skip if a fabric exists or
-  // fail-safe is armed (an in-progress PASE already passed SPAKE).
+  // fail-safe is armed (an in-progress PASE already passed SPAKE). // codespell:ignore
   if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0) {
     if (!chip::Server::GetInstance().GetFailSafeContext().IsFailSafeFullyDisarmed()) {
       log_w("Commissioning already in progress; custom PIN takes effect on the next window.");

--- a/libraries/Matter/src/MatterIdentity.cpp
+++ b/libraries/Matter/src/MatterIdentity.cpp
@@ -139,9 +139,7 @@ static bool needsInstanceInfoWrap() {
   return sVendorName[0] != '\0' || sProductName[0] != '\0' || sHasHardwareVersion || sHardwareVersionString[0] != '\0' || sSerialNumber[0] != '\0';
 }
 
-static bool ensureBasicInfoAttr(
-  cluster_t *cluster, uint32_t attributeId, attribute_t *(*createFn)(cluster_t *, char *, uint16_t), const char *name
-) {
+static bool ensureBasicInfoAttr(cluster_t *cluster, uint32_t attributeId, attribute_t *(*createFn)(cluster_t *, char *, uint16_t), const char *name) {
   if (attribute::get(cluster, attributeId) != nullptr) {
     return true;
   }

--- a/libraries/Matter/src/MatterIdentity.h
+++ b/libraries/Matter/src/MatterIdentity.h
@@ -1,0 +1,281 @@
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <sdkconfig.h>
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/CommissionableDataProvider.h>
+#include <platform/DeviceInstanceInfoProvider.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <setup_payload/SetupPayload.h>
+
+#include <string.h>
+
+// Internal provider wraps used by ArduinoMatter. Not part of the public API.
+
+namespace MatterIdentityInternal {
+
+static constexpr size_t kMaxIdentityLen = 32;
+static constexpr size_t kMaxHwStringLen = 64;
+static constexpr size_t kMaxSerialLen = 32;
+
+// Copies src into dst (NUL-terminated). src may be a stack/String temporary;
+// after return only dst is used. Rejects empty or overflow.
+inline bool copyBounded(char *dst, size_t dstSize, const char *src) {
+  if (dst == nullptr || src == nullptr || dstSize < 2) {
+    return false;
+  }
+  const size_t n = strlen(src);
+  if (n == 0 || n + 1 > dstSize) {
+    return false;
+  }
+  memcpy(dst, src, n + 1);
+  return true;
+}
+
+class OverrideInstanceInfoProvider : public chip::DeviceLayer::DeviceInstanceInfoProvider {
+public:
+  // Non-owning views of ArduinoMatter file-static buffers only (never sketch/stack pointers).
+  // Bind the current provider, then publish under the CHIP stack lock.
+  bool bindBase(chip::DeviceLayer::DeviceInstanceInfoProvider *current) {
+    if (current == nullptr) {
+      return false;
+    }
+    if (current == this) {
+      return true;
+    }
+    mBase = current;
+    return true;
+  }
+
+  void publish() {
+    chip::DeviceLayer::SetDeviceInstanceInfoProvider(this);
+  }
+
+  void setVendorName(const char *name) {
+    mVendorName = name;
+  }
+  void setProductName(const char *name) {
+    mProductName = name;
+  }
+  void setHardwareVersion(uint16_t version) {
+    mHardwareVersion = version;
+    mHasHardwareVersion = true;
+  }
+  void setHardwareVersionString(const char *value) {
+    mHardwareVersionString = value;
+  }
+  void setSerialNumber(const char *value) {
+    mSerialNumber = value;
+  }
+
+  CHIP_ERROR GetVendorName(char *buf, size_t bufSize) override {
+    return getStringOrBase(buf, bufSize, mVendorName, &chip::DeviceLayer::DeviceInstanceInfoProvider::GetVendorName);
+  }
+  CHIP_ERROR GetVendorId(uint16_t &vendorId) override {
+    return requireBase()->GetVendorId(vendorId);
+  }
+  CHIP_ERROR GetProductName(char *buf, size_t bufSize) override {
+    return getStringOrBase(buf, bufSize, mProductName, &chip::DeviceLayer::DeviceInstanceInfoProvider::GetProductName);
+  }
+  CHIP_ERROR GetProductId(uint16_t &productId) override {
+    return requireBase()->GetProductId(productId);
+  }
+  CHIP_ERROR GetPartNumber(char *buf, size_t bufSize) override {
+    return requireBase()->GetPartNumber(buf, bufSize);
+  }
+  CHIP_ERROR GetProductURL(char *buf, size_t bufSize) override {
+    return requireBase()->GetProductURL(buf, bufSize);
+  }
+  CHIP_ERROR GetProductLabel(char *buf, size_t bufSize) override {
+    return requireBase()->GetProductLabel(buf, bufSize);
+  }
+  CHIP_ERROR GetSerialNumber(char *buf, size_t bufSize) override {
+    return getStringOrBase(buf, bufSize, mSerialNumber, &chip::DeviceLayer::DeviceInstanceInfoProvider::GetSerialNumber);
+  }
+  CHIP_ERROR GetManufacturingDate(uint16_t &year, uint8_t &month, uint8_t &day) override {
+    return requireBase()->GetManufacturingDate(year, month, day);
+  }
+  CHIP_ERROR GetHardwareVersion(uint16_t &hardwareVersion) override {
+    if (mHasHardwareVersion) {
+      hardwareVersion = mHardwareVersion;
+      return CHIP_NO_ERROR;
+    }
+    return requireBase()->GetHardwareVersion(hardwareVersion);
+  }
+  CHIP_ERROR GetHardwareVersionString(char *buf, size_t bufSize) override {
+    return getStringOrBase(buf, bufSize, mHardwareVersionString, &chip::DeviceLayer::DeviceInstanceInfoProvider::GetHardwareVersionString);
+  }
+  CHIP_ERROR GetRotatingDeviceIdUniqueId(chip::MutableByteSpan &uniqueIdSpan) override {
+    return requireBase()->GetRotatingDeviceIdUniqueId(uniqueIdSpan);
+  }
+
+private:
+  using StringGetter = CHIP_ERROR (chip::DeviceLayer::DeviceInstanceInfoProvider::*)(char *, size_t);
+
+  static CHIP_ERROR copyToBuf(char *buf, size_t bufSize, const char *src) {
+    if (buf == nullptr || src == nullptr) {
+      return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    const size_t n = strlen(src);
+    if (n + 1 > bufSize) {
+      return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+    memcpy(buf, src, n + 1);
+    return CHIP_NO_ERROR;
+  }
+
+  CHIP_ERROR getStringOrBase(char *buf, size_t bufSize, const char *overrideVal, StringGetter getter) {
+    if (overrideVal != nullptr && overrideVal[0] != '\0') {
+      return copyToBuf(buf, bufSize, overrideVal);
+    }
+    return (requireBase()->*getter)(buf, bufSize);
+  }
+
+  chip::DeviceLayer::DeviceInstanceInfoProvider *requireBase() {
+    VerifyOrDie(mBase != nullptr);
+    return mBase;
+  }
+
+  chip::DeviceLayer::DeviceInstanceInfoProvider *mBase = nullptr;
+  const char *mVendorName = nullptr;
+  const char *mProductName = nullptr;
+  const char *mHardwareVersionString = nullptr;
+  const char *mSerialNumber = nullptr;
+  uint16_t mHardwareVersion = 0;
+  bool mHasHardwareVersion = false;
+};
+
+class OverrideCommissionableDataProvider : public chip::DeviceLayer::CommissionableDataProvider {
+public:
+  // Bind the current provider so salt/iterations are available, then publish under the CHIP stack lock.
+  bool bindBase(chip::DeviceLayer::CommissionableDataProvider *current) {
+    if (current == nullptr) {
+      return false;
+    }
+    if (current == this) {
+      return true;
+    }
+    mBase = current;
+    return true;
+  }
+
+  void publish() {
+    chip::DeviceLayer::SetCommissionableDataProvider(this);
+  }
+
+  void setDiscriminator(uint16_t discriminator) {
+    mDiscriminator = discriminator;
+    mHasDiscriminator = true;
+  }
+
+  void setPasscode(uint32_t passcode) {
+    mPasscode = passcode;
+    mHasPasscode = true;
+    mHasVerifier = false;
+  }
+
+  CHIP_ERROR ensureVerifier() {
+    if (!mHasPasscode || mHasVerifier) {
+      return CHIP_NO_ERROR;
+    }
+    uint32_t iterationCount = 0;
+    uint8_t saltBytes[chip::Crypto::kSpake2p_Max_PBKDF_Salt_Length] = {};
+    chip::MutableByteSpan salt(saltBytes);
+    ReturnErrorOnFailure(GetSpake2pIterationCount(iterationCount));
+    ReturnErrorOnFailure(GetSpake2pSalt(salt));
+    chip::Crypto::Spake2pVerifier verifier;
+    ReturnErrorOnFailure(verifier.Generate(iterationCount, salt, mPasscode));
+    chip::MutableByteSpan serialized(mVerifier);
+    ReturnErrorOnFailure(verifier.Serialize(serialized));
+    mHasVerifier = true;
+    return CHIP_NO_ERROR;
+  }
+
+  CHIP_ERROR GetSetupDiscriminator(uint16_t &setupDiscriminator) override {
+    if (mHasDiscriminator) {
+      setupDiscriminator = mDiscriminator;
+      return CHIP_NO_ERROR;
+    }
+    return requireBase()->GetSetupDiscriminator(setupDiscriminator);
+  }
+
+  CHIP_ERROR SetSetupDiscriminator(uint16_t setupDiscriminator) override {
+    if (setupDiscriminator > chip::kMaxDiscriminatorValue) {
+      return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    setDiscriminator(setupDiscriminator);
+    return CHIP_NO_ERROR;
+  }
+
+  CHIP_ERROR GetSpake2pIterationCount(uint32_t &iterationCount) override {
+    return requireBase()->GetSpake2pIterationCount(iterationCount);
+  }
+
+  CHIP_ERROR GetSpake2pSalt(chip::MutableByteSpan &saltBuf) override {
+    return requireBase()->GetSpake2pSalt(saltBuf);
+  }
+
+  CHIP_ERROR GetSpake2pVerifier(chip::MutableByteSpan &verifierBuf, size_t &outVerifierLen) override {
+    if (!mHasPasscode) {
+      return requireBase()->GetSpake2pVerifier(verifierBuf, outVerifierLen);
+    }
+    ReturnErrorOnFailure(ensureVerifier());
+    outVerifierLen = chip::Crypto::kSpake2p_VerifierSerialized_Length;
+    VerifyOrReturnError(verifierBuf.size() >= outVerifierLen, CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(verifierBuf.data(), mVerifier, outVerifierLen);
+    verifierBuf.reduce_size(outVerifierLen);
+    return CHIP_NO_ERROR;
+  }
+
+  CHIP_ERROR GetSetupPasscode(uint32_t &setupPasscode) override {
+    if (mHasPasscode) {
+      setupPasscode = mPasscode;
+      return CHIP_NO_ERROR;
+    }
+    return requireBase()->GetSetupPasscode(setupPasscode);
+  }
+
+  CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override {
+    if (!chip::PayloadContents::IsValidSetupPIN(setupPasscode)) {
+      return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    setPasscode(setupPasscode);
+    return CHIP_NO_ERROR;
+  }
+
+private:
+  chip::DeviceLayer::CommissionableDataProvider *requireBase() {
+    VerifyOrDie(mBase != nullptr);
+    return mBase;
+  }
+
+  chip::DeviceLayer::CommissionableDataProvider *mBase = nullptr;
+  uint8_t mVerifier[chip::Crypto::kSpake2p_VerifierSerialized_Length] = {};
+  uint16_t mDiscriminator = 0;
+  uint32_t mPasscode = 0;
+  bool mHasDiscriminator = false;
+  bool mHasPasscode = false;
+  bool mHasVerifier = false;
+};
+
+}  // namespace MatterIdentityInternal
+
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */


### PR DESCRIPTION
## Description of Change

This pull request introduces comprehensive improvements to the Matter library documentation and adds a new example demonstrating Matter node identity and commissioning code configuration. The documentation is enhanced with clearer explanations of the Matter API, device identity, commissioning, and runtime status, and now includes detailed tables and code samples. A new example, `MatterDeviceIdentity`, is added to illustrate setting node identity and custom pairing codes. The README and reference documentation are updated to reflect these changes, and a new source file is included in the build.

**New Example and Build Integration:**

* Added the `MatterDeviceIdentity` example (`MatterDeviceIdentity.ino`, `README.md`, and CI config) to demonstrate how to set VendorName, ProductName, DeviceName, SerialNumber, hardware version, and custom commissioning codes on the `Matter` singleton before `Matter.begin()`. This example shows correct call order, pairing code usage, and session status logging. 
* Included the new `MatterIdentity.cpp` source file in the Matter library build (`CMakeLists.txt`).

**Documentation Improvements:**

* Enhanced the Matter library reference documentation (`matter.rst`) with detailed explanations of device identity, commissioning API, runtime status flags (`isDeviceCommissioned()`, `isDeviceConnected()`, `isOnline()`), and call order. Added code samples and clarified the effect and timing of setters.
* Updated the list of basic examples to include `MatterDeviceIdentity`, and expanded the description of `MatterStatus` to cover new status flags.

**README Organization and Content:**

* Improved the Matter library README with new sections on the shared endpoint API, device identity and commissioning, and class tables for lighting, sensors, and control devices. Added guidance on API usage, pairing code generation, and links to relevant examples and documentation.

**Other:**

* Updated copyright year in `MatterStatus.ino`.

## Test Scenarios
Using examples with ESP32-S3 and ESP32-C6

## Related links
Closes #12293
Closes #12370