### PR TITLE
fix(clock): Fix supported CPU frequencies and SPI clock when using XTAL

### DIFF
--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -34,40 +34,52 @@
 #endif
 
 #include "esp_system.h"
+#include "esp_chip_info.h"
 #ifdef ESP_IDF_VERSION_MAJOR  // IDF 4+
-#if CONFIG_IDF_TARGET_ESP32   // ESP32/PICO-D4
+// The tables are indexed by soc_cpu_clk_src_t, whose values are only a dense range starting at
+// zero on some targets: the ESP32-C5 aliases them to soc_module_clk_t, where XTAL is 16. Naming
+// the index keeps every table correct regardless, at the cost of unused holes in a few of them.
+#if CONFIG_IDF_TARGET_ESP32  // ESP32/PICO-D4
 #include "xtensa_timer.h"
 #include "esp32/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "PLL", "8.5M", "APLL"};
+static const char *clock_source_names[] = {
+  [SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_PLL] = "PLL", [SOC_CPU_CLK_SRC_RC_FAST] = "8.5M", [SOC_CPU_CLK_SRC_APLL] = "APLL"
+};
 #elif CONFIG_IDF_TARGET_ESP32S2
 #include "xtensa_timer.h"
 #include "esp32s2/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "PLL", "8.5M", "APLL"};
+static const char *clock_source_names[] = {
+  [SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_PLL] = "PLL", [SOC_CPU_CLK_SRC_RC_FAST] = "8.5M", [SOC_CPU_CLK_SRC_APLL] = "APLL"
+};
 #elif CONFIG_IDF_TARGET_ESP32S3
 #include "xtensa_timer.h"
 #include "esp32s3/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "PLL", "17.5M"};
+static const char *clock_source_names[] = {[SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_PLL] = "PLL", [SOC_CPU_CLK_SRC_RC_FAST] = "17.5M"};
 #elif CONFIG_IDF_TARGET_ESP32C2
 #include "esp32c2/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "PLL", "17.5M"};
+static const char *clock_source_names[] = {[SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_PLL] = "PLL", [SOC_CPU_CLK_SRC_RC_FAST] = "17.5M"};
 #elif CONFIG_IDF_TARGET_ESP32C3
 #include "esp32c3/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "PLL", "17.5M"};
+static const char *clock_source_names[] = {[SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_PLL] = "PLL", [SOC_CPU_CLK_SRC_RC_FAST] = "17.5M"};
 #elif CONFIG_IDF_TARGET_ESP32C6
 #include "esp32c6/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "PLL", "17.5M"};
+static const char *clock_source_names[] = {[SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_PLL] = "PLL", [SOC_CPU_CLK_SRC_RC_FAST] = "17.5M"};
 #elif CONFIG_IDF_TARGET_ESP32H2
 #include "esp32h2/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "PLL", "8.5M", "FLASH_PLL"};
+static const char *clock_source_names[] = {
+  [SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_PLL] = "PLL", [SOC_CPU_CLK_SRC_RC_FAST] = "8.5M", [SOC_CPU_CLK_SRC_FLASH_PLL] = "FLASH_PLL"
+};
 #elif CONFIG_IDF_TARGET_ESP32P4
 #include "esp32p4/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "CPLL", "17.5M"};
+static const char *clock_source_names[] = {[SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_CPLL] = "CPLL", [SOC_CPU_CLK_SRC_RC_FAST] = "17.5M"};
 #elif CONFIG_IDF_TARGET_ESP32C5
 #include "esp32c5/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "17.5M", "PLL_F160M", "PLL_F240M"};
+static const char *clock_source_names[] = {
+  [SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_RC_FAST] = "17.5M", [SOC_CPU_CLK_SRC_PLL_F160M] = "PLL_F160M", [SOC_CPU_CLK_SRC_PLL_F240M] = "PLL_F240M"
+};
 #elif CONFIG_IDF_TARGET_ESP32C61
 #include "esp32c61/rom/rtc.h"
-static const char *clock_source_names[] = {"XTAL", "17.5M", "PLL_F160M"};
+static const char *clock_source_names[] = {[SOC_CPU_CLK_SRC_XTAL] = "XTAL", [SOC_CPU_CLK_SRC_RC_FAST] = "17.5M", [SOC_CPU_CLK_SRC_PLL_F160M] = "PLL_F160M"};
 #else
 #error Target CONFIG_IDF_TARGET is not supported
 #endif
@@ -189,6 +201,12 @@ static uint32_t calculateApb(rtc_cpu_freq_config_t *conf) {
   }
   return (conf->source_freq_mhz * MHZ) / conf->div;
 #else
+  // Switching the CPU to the XTAL takes the bus clocks down with it: the IDF programs the
+  // AHB divider to the CPU divider ("let f_cpu = f_ahb"), so APB_CLK ends up at the CPU
+  // frequency. Only a PLL-derived CPU frequency leaves APB_CLK at its nominal frequency.
+  if (conf->source == SOC_CPU_CLK_SRC_XTAL) {
+    return conf->freq_mhz * MHZ;
+  }
   return APB_CLK_FREQ;
 #endif
 }
@@ -198,71 +216,108 @@ void esp_timer_impl_update_apb_freq(uint32_t apb_ticks_per_us);  //private in ID
 #endif
 
 const char *getClockSourceName(uint8_t source) {
-  if (source < SOC_CPU_CLK_SRC_INVALID) {
+  if (source < sizeof(clock_source_names) / sizeof(clock_source_names[0]) && clock_source_names[source] != NULL) {
     return clock_source_names[source];
   }
 
   return "Invalid";
 }
 
-const char *getSupportedCpuFrequencyMhz(uint8_t xtal) {
-#define SUP_CPU_FREQ_BUF_SIZE 256
-  const size_t buf_size = SUP_CPU_FREQ_BUF_SIZE;
-  static char buf[SUP_CPU_FREQ_BUF_SIZE];
-  int pos = 0;
-
-#if TARGET_CPU_FREQ_MAX_400
-#if CONFIG_IDF_TARGET_ESP32P4 && CONFIG_ESP32P4_REV_MIN_FULL < 300
-  pos += snprintf(buf + pos, buf_size - pos, "360");
-#else
-  pos += snprintf(buf + pos, buf_size - pos, "400");
-#endif
-#elif TARGET_CPU_FREQ_MAX_240
 #if CONFIG_IDF_TARGET_ESP32
-  if (!REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_RATED) || !REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_LOW)) {
-    pos += snprintf(buf + pos, buf_size - pos, "160, 80");
-  } else
+#define REF_TICK_DIV_MIN 10
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define REF_TICK_DIV_MIN 2
 #endif
-  {
-    pos += snprintf(buf + pos, buf_size - pos, "240, 160, 80");
+
+// rtc_clk_cpu_freq_mhz_to_config() accepts a few frequencies the chip cannot really run, so
+// tell those apart from the rest. Both cases below only concern the XTAL-derived frequencies:
+// the PLL is always divided exactly and keeps APB_CLK at its own frequency.
+static bool cpuFreqIsUsable(const rtc_cpu_freq_config_t *conf) {
+  if (conf->source != SOC_CPU_CLK_SRC_XTAL) {
+    return true;
   }
-#elif TARGET_CPU_FREQ_MAX_160
-  pos += snprintf(buf + pos, buf_size - pos, "160, 120, 80");
-#elif TARGET_CPU_FREQ_MAX_120
-  pos += snprintf(buf + pos, buf_size - pos, "120, 80");
-#elif TARGET_CPU_FREQ_MAX_96
-  pos += snprintf(buf + pos, buf_size - pos, "96, 64, 48");
-#else
-  return "Unknown";
+
+  // The IDF rounds the XTAL divider, so it accepts frequencies it cannot generate exactly
+  if ((conf->source_freq_mhz % conf->freq_mhz) != 0) {
+    return false;
+  }
+
+#ifdef REF_TICK_DIV_MIN
+  // On these targets APB_CLK follows the CPU, and the 1 MHz REF_TICK divided from APB_CLK
+  // clocks the UART at up to 250000 baud among others. Its divider has a minimum, below which
+  // REF_TICK can no longer be 1 MHz, and that is why esp_pm_configure() rejects such a
+  // minimum frequency as well. The IDF keeps that limit in a private esp_pm header.
+  if (conf->freq_mhz < REF_TICK_DIV_MIN * REF_CLK_FREQ / MHZ) {
+    return false;
+  }
 #endif
 
-  // Append xtal and its dividers only if xtal is nonzero
-  if (xtal != 0) {
-    // We'll show as: , <xtal>, <xtal/2>[, <xtal/4>] MHz
-    pos += snprintf(buf + pos, buf_size - pos, ", %u, %u", xtal, (uint8_t)(xtal / 2));
+  return true;
+}
 
+const char *getSupportedCpuFrequencyMhz(void) {
+  // The IDF has no API to enumerate the supported CPU frequencies, so ask
+  // rtc_clk_cpu_freq_mhz_to_config() about every whole MHz value instead. That is the
+  // same check setCpuFrequencyMhz() and esp_pm_configure() use to accept a frequency,
+  // and it only evaluates the XTAL frequency against per-target constants, so it can
+  // be called freely. Keeping the IDF as the only source of truth means this list stays
+  // correct for every target, chip revision and IDF version.
+  // The technical reference manuals document a maximum CPU_CLK per target (400 MHz on
+  // the ESP32-P4, lower on every other target), so the search starts above every
+  // documented maximum. Only the ESP32 and the ESP32-S2 have a documented minimum, which
+  // cpuFreqIsUsable() enforces, hence the search ends at 1 MHz on every other target.
+  const uint32_t highest_freq_mhz = 1000;
+  static char buf[128];
+  rtc_cpu_freq_config_t conf;
+  size_t pos = 0;
+
+  // The result only depends on the chip itself, so it never changes after the first call
+  if (buf[0] != '\0') {
+    return buf;
+  }
+
+  // The IDF does not check the maximum frequency the chip was rated for, so filter it here
 #if CONFIG_IDF_TARGET_ESP32
-    // Only append xtal/4 if it's > 0 and meaningful for higher-frequency chips (e.g., ESP32 40MHz/4=10)
-    if (xtal >= RTC_XTAL_FREQ_40M) {
-      pos += snprintf(buf + pos, buf_size - pos, ", %u", (uint8_t)(xtal / 4));
+  const bool rated_160 = REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_RATED) && REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_LOW);
+#elif CONFIG_IDF_TARGET_ESP32P4
+  esp_chip_info_t chip_info;
+  esp_chip_info(&chip_info);
+  const bool rated_360 = chip_info.revision < 300;  // Only revision 3 and newer are rated for 400 MHz
+#endif
+
+  for (uint32_t freq_mhz = highest_freq_mhz; freq_mhz > 0; freq_mhz--) {
+#if CONFIG_IDF_TARGET_ESP32
+    if (rated_160 && freq_mhz > 160) {
+      continue;
+    }
+#elif CONFIG_IDF_TARGET_ESP32P4
+    if (rated_360 && freq_mhz > 360) {
+      continue;
     }
 #endif
+
+    if (!rtc_clk_cpu_freq_mhz_to_config(freq_mhz, &conf) || conf.freq_mhz != freq_mhz || !cpuFreqIsUsable(&conf)) {
+      continue;
+    }
+
+    int len = snprintf(buf + pos, sizeof(buf) - pos, (pos == 0) ? "%" PRIu32 : ", %" PRIu32, freq_mhz);
+    if (len < 0 || (size_t)len >= sizeof(buf) - pos) {
+      break;
+    }
+    pos += (size_t)len;
   }
 
-  pos += snprintf(buf + pos, buf_size - pos, " MHz");
+  if (pos == 0) {
+    return "Unknown";
+  }
+
+  snprintf(buf + pos, sizeof(buf) - pos, " MHz");
   return buf;
 }
 
 bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz) {
   rtc_cpu_freq_config_t conf, cconf;
   uint32_t capb, apb;
-  [[maybe_unused]]
-  uint8_t xtal = 0;
-
-  // ===== Get XTAL Frequency and validate input =====
-#if TARGET_HAS_XTAL_FREQ
-  xtal = (uint8_t)rtc_clk_xtal_freq_get();
-#endif
 
   // ===== Get current configuration and check if change is needed =====
   rtc_clk_cpu_freq_get_config(&cconf);
@@ -271,8 +326,8 @@ bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz) {
   }
 
   // ===== Get configuration for new frequency =====
-  if (!rtc_clk_cpu_freq_mhz_to_config(cpu_freq_mhz, &conf)) {
-    log_e("CPU clock could not be set to %" PRIu32 " MHz. Supported frequencies: %s", cpu_freq_mhz, getSupportedCpuFrequencyMhz(xtal));
+  if (!rtc_clk_cpu_freq_mhz_to_config(cpu_freq_mhz, &conf) || !cpuFreqIsUsable(&conf)) {
+    log_e("CPU clock could not be set to %" PRIu32 " MHz. Supported frequencies: %s", cpu_freq_mhz, getSupportedCpuFrequencyMhz());
     return false;
   }
 

--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -229,10 +229,34 @@ const char *getClockSourceName(uint8_t source) {
 #define REF_TICK_DIV_MIN 2
 #endif
 
+// The IDF checks the frequency against what the target can generate, but not against what this
+// particular chip was rated for, which is lower on some parts
+static bool cpuFreqIsRated(uint32_t freq_mhz) {
+#if CONFIG_IDF_TARGET_ESP32
+  // Both eFuse bits set means the part is rated for 160 MHz instead of the usual 240 MHz
+  if (freq_mhz > 160) {
+    return !(REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_RATED) && REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_LOW));
+  }
+#elif CONFIG_IDF_TARGET_ESP32P4
+  // Only revision 3 and newer are rated for 400 MHz
+  if (freq_mhz > 360) {
+    esp_chip_info_t chip_info;
+    esp_chip_info(&chip_info);
+    return chip_info.revision >= 300;
+  }
+#endif
+
+  return true;
+}
+
 // rtc_clk_cpu_freq_mhz_to_config() accepts a few frequencies the chip cannot really run, so
-// tell those apart from the rest. Both cases below only concern the XTAL-derived frequencies:
-// the PLL is always divided exactly and keeps APB_CLK at its own frequency.
+// tell those apart from the rest. Both XTAL cases below only concern the XTAL-derived
+// frequencies: the PLL is always divided exactly and keeps APB_CLK at its own frequency.
 static bool cpuFreqIsUsable(const rtc_cpu_freq_config_t *conf) {
+  if (!cpuFreqIsRated(conf->freq_mhz)) {
+    return false;
+  }
+
   if (conf->source != SOC_CPU_CLK_SRC_XTAL) {
     return true;
   }
@@ -276,26 +300,7 @@ const char *getSupportedCpuFrequencyMhz(void) {
     return buf;
   }
 
-  // The IDF does not check the maximum frequency the chip was rated for, so filter it here
-#if CONFIG_IDF_TARGET_ESP32
-  const bool rated_160 = REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_RATED) && REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_LOW);
-#elif CONFIG_IDF_TARGET_ESP32P4
-  esp_chip_info_t chip_info;
-  esp_chip_info(&chip_info);
-  const bool rated_360 = chip_info.revision < 300;  // Only revision 3 and newer are rated for 400 MHz
-#endif
-
   for (uint32_t freq_mhz = highest_freq_mhz; freq_mhz > 0; freq_mhz--) {
-#if CONFIG_IDF_TARGET_ESP32
-    if (rated_160 && freq_mhz > 160) {
-      continue;
-    }
-#elif CONFIG_IDF_TARGET_ESP32P4
-    if (rated_360 && freq_mhz > 360) {
-      continue;
-    }
-#endif
-
     if (!rtc_clk_cpu_freq_mhz_to_config(freq_mhz, &conf) || conf.freq_mhz != freq_mhz || !cpuFreqIsUsable(&conf)) {
       continue;
     }

--- a/cores/esp32/esp32-hal-cpu.h
+++ b/cores/esp32/esp32-hal-cpu.h
@@ -28,13 +28,6 @@ extern "C" {
 
 // When adding a new target, update the appropriate group(s) below
 
-// Targets that support XTAL frequency queries via rtc_clk_xtal_freq_get()
-#if (!defined(CONFIG_IDF_TARGET_ESP32C5) && !defined(CONFIG_IDF_TARGET_ESP32P4))
-#define TARGET_HAS_XTAL_FREQ 1
-#else
-#define TARGET_HAS_XTAL_FREQ 0
-#endif
-
 // Targets that need dynamic APB frequency updates via rtc_clk_apb_freq_update()
 #if (defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3))
 #define TARGET_HAS_DYNAMIC_APB 1
@@ -57,38 +50,6 @@ extern "C" {
 #define TARGET_HAS_APLL 0
 #endif
 
-// Targets grouped by maximum CPU frequency support
-
-#if (defined(CONFIG_IDF_TARGET_ESP32P4))
-#define TARGET_CPU_FREQ_MAX_400 1
-#else
-#define TARGET_CPU_FREQ_MAX_400 0
-#endif
-
-#if (defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3))
-#define TARGET_CPU_FREQ_MAX_240 1
-#else
-#define TARGET_CPU_FREQ_MAX_240 0
-#endif
-
-#if (defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32C61))
-#define TARGET_CPU_FREQ_MAX_160 1
-#else
-#define TARGET_CPU_FREQ_MAX_160 0
-#endif
-
-#if (defined(CONFIG_IDF_TARGET_ESP32C2))
-#define TARGET_CPU_FREQ_MAX_120 1
-#else
-#define TARGET_CPU_FREQ_MAX_120 0
-#endif
-
-#if (defined(CONFIG_IDF_TARGET_ESP32H2))
-#define TARGET_CPU_FREQ_MAX_96 1
-#else
-#define TARGET_CPU_FREQ_MAX_96 0
-#endif
-
 typedef enum {
   APB_BEFORE_CHANGE,
   APB_AFTER_CHANGE
@@ -99,14 +60,14 @@ typedef void (*apb_change_cb_t)(void *arg, apb_change_ev_t ev_type, uint32_t old
 bool addApbChangeCallback(void *arg, apb_change_cb_t cb);
 bool removeApbChangeCallback(void *arg, apb_change_cb_t cb);
 
-//function takes the following frequencies as valid values:
-//  240, 160, 80    <<< For all XTAL types
-//  40, 20, 10      <<< For 40MHz XTAL
-//  26, 13          <<< For 26MHz XTAL
-//  24, 12          <<< For 24MHz XTAL
+// Valid values depend on the target, its revision and the XTAL frequency.
+// They are either derived from the PLL (e.g. 240, 160, 80 MHz on the ESP32)
+// or from the XTAL divided by an integer (e.g. 40, 20, 10 MHz for a 40 MHz XTAL).
+// Use getSupportedCpuFrequencyMhz() to list the frequencies accepted by the running chip.
 bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz);
 
-const char *getSupportedCpuFrequencyMhz(uint8_t xtal);
+// Returns a pointer to a shared static buffer. Not thread-safe.
+const char *getSupportedCpuFrequencyMhz(void);
 const char *getClockSourceName(uint8_t source);
 uint32_t getCpuFrequencyMhz();   // In MHz
 uint32_t getXtalFrequencyMhz();  // In MHz

--- a/cores/esp32/esp32-hal-cpu.h
+++ b/cores/esp32/esp32-hal-cpu.h
@@ -66,7 +66,7 @@ bool removeApbChangeCallback(void *arg, apb_change_cb_t cb);
 // Use getSupportedCpuFrequencyMhz() to list the frequencies accepted by the running chip.
 bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz);
 
-// Returns a pointer to a shared static buffer. Not thread-safe.
+// Returns a string with static storage duration, which must not be freed. Not thread-safe.
 const char *getSupportedCpuFrequencyMhz(void);
 const char *getClockSourceName(uint8_t source);
 uint32_t getCpuFrequencyMhz();   // In MHz

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -30,6 +30,7 @@
 #include "hal/clk_gate_ll.h"
 #endif
 #include "esp32-hal-periman.h"
+#include "esp_clk_tree.h"
 #include "esp_private/periph_ctrl.h"
 #if !CONFIG_IDF_TARGET_ESP32 && !CONFIG_IDF_TARGET_ESP32S2
 #include "hal/spi_ll.h"
@@ -78,6 +79,18 @@
 #include "esp32c61/rom/gpio.h"
 #else
 #error Target CONFIG_IDF_TARGET is not supported
+#endif
+
+// APB_CLK is only a valid SPI clock source on the ESP32, S2, S3 and C3. The other targets have
+// their own source mux, in which the XTAL is the option that is always available and, unlike the
+// PLL taps, is neither gated nor rescaled by a CPU frequency change. The ESP32-P4 is left out
+// because it picks between the XTAL and the SPLL on its own, see spiFrequencyToClockDiv().
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3
+#define ARDUINO_SPI_CLK_SRC         SPI_CLK_SRC_APB
+#define ARDUINO_SPI_CLK_FOLLOWS_APB 1
+#elif !defined(CONFIG_IDF_TARGET_ESP32P4)
+#define ARDUINO_SPI_CLK_SRC         SPI_CLK_SRC_XTAL
+#define ARDUINO_SPI_CLK_FOLLOWS_APB 0
 #endif
 
 struct spi_struct_t {
@@ -687,8 +700,25 @@ void spiSetBitOrder(spi_t *spi, uint8_t bitOrder) {
   SPI_MUTEX_UNLOCK();
 }
 
+#ifdef ARDUINO_SPI_CLK_SRC
+// Frequency of the clock source the peripheral is configured with, which is what the divider
+// math has to be based on. Asking the IDF keeps this right for every target: it resolves to the
+// current APB_CLK frequency where the source is APB_CLK, and to the measured crystal frequency
+// where it is the XTAL.
+static uint32_t spiSourceFrequency(void) {
+  uint32_t freq_hz = 0;
+  if (esp_clk_tree_src_get_freq_hz((soc_module_clk_t)ARDUINO_SPI_CLK_SRC, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &freq_hz) != ESP_OK || freq_hz == 0) {
+    log_e("Could not read the SPI source clock frequency");
+    return getApbFrequency();
+  }
+  return freq_hz;
+}
+#endif
+
 static void _on_apb_change(void *arg, apb_change_ev_t ev_type, uint32_t old_apb, uint32_t new_apb) {
   spi_t *spi = (spi_t *)arg;
+  (void)old_apb;
+  (void)new_apb;
   if (ev_type == APB_BEFORE_CHANGE) {
     SPI_MUTEX_LOCK();
     while (spi->dev->cmd.usr);
@@ -701,7 +731,12 @@ static void _on_apb_change(void *arg, apb_change_ev_t ev_type, uint32_t old_apb,
     // Use _spiSetClockDivInternal to ensure clock source is updated if needed
     _spiSetClockDivInternal(spi, new_clockDiv);
 #else
+#if ARDUINO_SPI_CLK_FOLLOWS_APB
+    // The source moved with APB_CLK, so rescale the divider to keep the frequency the user asked
+    // for. Where the peripheral runs from the XTAL instead, its clock is unaffected by the change
+    // and touching the divider would only walk it away from that frequency.
     spi->dev->clock.val = spiFrequencyToClockDiv(spi, old_apb / ((spi->dev->clock.clkdiv_pre + 1) * (spi->dev->clock.clkcnt_n + 1)));
+#endif
 #endif
     SPI_MUTEX_UNLOCK();
   }
@@ -881,6 +916,12 @@ spi_t *spiStartBus(uint8_t spi_num, uint32_t clockDiv, uint8_t dataMode, uint8_t
   spi->dev->dma_conf.rx_seg_trans_clr_en = 1;
   spi->dev->dma_conf.dma_seg_trans_en = 0;
 #endif
+#endif
+#if defined(ARDUINO_SPI_CLK_SRC) && !CONFIG_IDF_TARGET_ESP32 && !CONFIG_IDF_TARGET_ESP32S2
+  // Pin the peripheral to the source spiSourceFrequency() reports instead of relying on the
+  // reset value of the mux. The bus is idle here, so the switch cannot disturb a transfer.
+  // The ESP32 and the S2 have no mux to begin with and are always clocked from APB_CLK.
+  spi_ll_set_clk_source((spi_dev_t *)spi->dev, ARDUINO_SPI_CLK_SRC);
 #endif
   spi->dev->user.usr_mosi = 1;
   spi->dev->user.usr_miso = 1;
@@ -1752,22 +1793,23 @@ typedef union {
   };
 } spiClk_t;
 
-#define ClkRegToFreq(reg) (apb_freq / (((reg)->clkdiv_pre + 1) * ((reg)->clkcnt_n + 1)))
+#define ClkRegToFreq(reg) (src_freq / (((reg)->clkdiv_pre + 1) * ((reg)->clkcnt_n + 1)))
 
 uint32_t spiClockDivToFrequency(spi_t *spi, uint32_t clockDiv) {
-  uint32_t apb_freq = getApbFrequency();
 #if defined(CONFIG_IDF_TARGET_ESP32P4)
   // ESP32P4: Use the actual clock source being used by this SPI instance
+  uint32_t src_freq;
   if (spi && spi->clk_src == 1) {
     // SPLL is being used
-    apb_freq = SPI_P4_SPLL_FREQ_HZ;
+    src_freq = SPI_P4_SPLL_FREQ_HZ;
   } else {
     // XTAL is being used (default or if spi is NULL)
-    apb_freq = getXtalFrequencyMhz() * 1000000;
+    src_freq = getXtalFrequencyMhz() * 1000000;
   }
 #else
-  // For non-ESP32P4 targets, ignore spi parameter; always use system APB frequency.
+  // For non-ESP32P4 targets, ignore spi parameter; the whole bus shares one source.
   (void)spi;
+  uint32_t src_freq = spiSourceFrequency();
 #endif
   spiClk_t reg = {clockDiv};
   return ClkRegToFreq(&reg);
@@ -1899,9 +1941,9 @@ uint32_t spiFrequencyToClockDiv(spi_t *spi, uint32_t freq) {
   // Return divider for the clock source that gives closest match
   return best_div;
 #else
-  // Non-ESP32P4: Only use APB clock, spi parameter unused.
+  // Non-ESP32P4: the peripheral stays on the source picked at bus init, spi parameter unused.
   (void)spi;  // Suppress unused parameter warning
-  return _spiFrequencyToClockDivWithSource(freq, getApbFrequency());
+  return _spiFrequencyToClockDivWithSource(freq, spiSourceFrequency());
 #endif
 }
 

--- a/cores/esp32/esp32-hal-spi.c
+++ b/cores/esp32/esp32-hal-spi.c
@@ -709,7 +709,13 @@ static uint32_t spiSourceFrequency(void) {
   uint32_t freq_hz = 0;
   if (esp_clk_tree_src_get_freq_hz((soc_module_clk_t)ARDUINO_SPI_CLK_SRC, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &freq_hz) != ESP_OK || freq_hz == 0) {
     log_e("Could not read the SPI source clock frequency");
+    // Fall back to the source the peripheral was pinned to, since guessing the other one would
+    // put the divider math right back where it was before this frequency was read from the IDF
+#if ARDUINO_SPI_CLK_FOLLOWS_APB
     return getApbFrequency();
+#else
+    return getXtalFrequencyMhz() * 1000000;
+#endif
   }
   return freq_hz;
 }

--- a/tests/validation/clock/README.md
+++ b/tests/validation/clock/README.md
@@ -1,0 +1,30 @@
+# Clock Validation Test
+
+Validates the CPU and bus clock API: the list of supported CPU frequencies, that every listed frequency can be applied exactly and every unlisted one is refused, the clock source names, the reported APB frequency, and that a configured SPI bit rate survives a CPU frequency change.
+
+## Test Cases
+
+| Test Function | Description |
+|---|---|
+| `test_supported_frequency_list` | List is non-empty, descending, and contains the frequency the chip booted at |
+| `test_every_supported_frequency_applies` | Every listed frequency is accepted and `getCpuFrequencyMhz()` returns it exactly |
+| `test_unsupported_frequencies_are_refused` | 0 MHz, 1000 MHz and frequencies missing from the list are refused, and leave the CPU frequency untouched |
+| `test_clock_source_names` | Every clock source the chip selects across the list has a name; invalid input returns `Invalid` |
+| `test_apb_frequency_matches_hardware` | `getApbFrequency()` equals the APB frequency the HAL derives from the dividers in hardware |
+| `test_spi_bitrate_matches_request` | A timed 2 KB transfer confirms the bus really runs at the 1 MHz that was requested |
+| `test_spi_frequency_survives_cpu_change` | A 1 MHz SPI bit rate stays within 10% across every CPU frequency |
+
+## Requirements
+
+- **Hardware**: Any ESP32 variant
+- **Wokwi**: Not supported (the clock tree is not modeled)
+- **QEMU**: Not supported (the clock tree is not modeled)
+
+## Notes
+
+- The list of supported frequencies is read from `getSupportedCpuFrequencyMhz()` rather than hardcoded per target, so the same test covers every variant and follows whatever the chip and IDF version support.
+- The console prints at every frequency under test, so a frequency that breaks the UART shows up as garbled or missing output instead of as a passing test.
+- `test_unsupported_frequencies_are_refused` checks at most eight unlisted frequencies, which is enough to cover the gaps between the crystal dividers on every target.
+- The APB comparison uses `clk_hal_apb_get_freq_hz()`, which reads the dividers the IDF programmed, so the assertion does not simply restate the core's own arithmetic.
+- `test_spi_bitrate_matches_request` is a timed measurement because a divider computed from the wrong source frequency is self-consistent, and therefore invisible to `spiClockDivToFrequency()`. It only runs at the frequency the chip booted at, since feeding the FIFO in software distorts the measurement once the CPU is slow.
+- No SPI wiring is needed: the test measures how long the peripheral takes to shift the bytes out, so MOSI can be left unconnected.

--- a/tests/validation/clock/ci.yml
+++ b/tests/validation/clock/ci.yml
@@ -1,0 +1,3 @@
+platforms:
+  wokwi: false
+  qemu: false

--- a/tests/validation/clock/clock.ino
+++ b/tests/validation/clock/clock.ino
@@ -57,8 +57,9 @@ static void parseSupportedFrequencies(void) {
       continue;
     }
     TEST_ASSERT_LESS_THAN_MESSAGE(MAX_SUPPORTED_FREQS, supported_count, "More frequencies reported than this test can hold");
-    supported[supported_count++] = strtoul(p, (char **)&p, 10);
-    p--;  // strtoul leaves p on the first character it did not consume
+    char *end = NULL;
+    supported[supported_count++] = strtoul(p, &end, 10);
+    p = end - 1;  // end is the first character strtoul did not consume, which the loop steps over
   }
 }
 

--- a/tests/validation/clock/clock.ino
+++ b/tests/validation/clock/clock.ino
@@ -1,0 +1,214 @@
+/*
+ * Clock Validation Test (hardware only)
+ *
+ * Neither Wokwi nor QEMU model the clock tree, so the whole suite runs on hardware.
+ *
+ * Covers:
+ *   getSupportedCpuFrequencyMhz(): shape of the list, and that it agrees with setCpuFrequencyMhz()
+ *   setCpuFrequencyMhz(): every advertised frequency is applied exactly, everything else refused
+ *   getClockSourceName(): names every clock source the chip can select, rejects invalid input
+ *   getApbFrequency(): matches the frequency the HAL derives from the dividers in hardware
+ *   SPI: the configured bit rate does not drift when the CPU frequency changes
+ *
+ * The console runs at every frequency under test, so a frequency that breaks the UART shows up
+ * as garbled or missing output rather than as a passing test.
+ */
+
+#include <Arduino.h>
+#include <unity.h>
+#include <SPI.h>
+#include "soc/rtc.h"
+#include "hal/clk_tree_hal.h"
+
+// Enough room for the longest list any target can report, plus a couple of spare slots
+#define MAX_SUPPORTED_FREQS 32
+
+#define SPI_TEST_FREQ_HZ 1000000
+#define SPI_TOLERANCE_HZ (SPI_TEST_FREQ_HZ / 10)
+#define SPI_TEST_BYTES   2048  // 16 ms at 1 MHz, long enough for the software overhead to vanish
+
+static uint32_t supported[MAX_SUPPORTED_FREQS];
+static size_t supported_count = 0;
+static uint32_t initial_freq_mhz = 0;
+
+void setUp(void) {}
+
+void tearDown(void) {
+  setCpuFrequencyMhz(initial_freq_mhz);
+}
+
+static bool isSupported(uint32_t freq_mhz) {
+  for (size_t i = 0; i < supported_count; i++) {
+    if (supported[i] == freq_mhz) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Turns "240, 160, 80 MHz" into the supported[] array
+static void parseSupportedFrequencies(void) {
+  const char *list = getSupportedCpuFrequencyMhz();
+  TEST_ASSERT_NOT_NULL(list);
+
+  supported_count = 0;
+  for (const char *p = list; *p != '\0'; p++) {
+    if (*p < '0' || *p > '9') {
+      continue;
+    }
+    TEST_ASSERT_LESS_THAN_MESSAGE(MAX_SUPPORTED_FREQS, supported_count, "More frequencies reported than this test can hold");
+    supported[supported_count++] = strtoul(p, (char **)&p, 10);
+    p--;  // strtoul leaves p on the first character it did not consume
+  }
+}
+
+// ==================== Supported frequency list ====================
+
+void test_supported_frequency_list(void) {
+  Serial.printf("Supported: %s\n", getSupportedCpuFrequencyMhz());
+  TEST_ASSERT_GREATER_THAN_MESSAGE(0, supported_count, "No supported CPU frequency reported");
+
+  for (size_t i = 0; i < supported_count; i++) {
+    TEST_ASSERT_GREATER_THAN_MESSAGE(0, supported[i], "Reported a frequency of 0 MHz");
+    if (i > 0) {
+      TEST_ASSERT_GREATER_THAN_MESSAGE(supported[i], supported[i - 1], "List is not in descending order");
+    }
+  }
+
+  // The frequency the chip is running at has to be one the list offers
+  TEST_ASSERT_TRUE_MESSAGE(isSupported(initial_freq_mhz), "The current CPU frequency is missing from the list");
+}
+
+// ==================== setCpuFrequencyMhz ====================
+
+void test_every_supported_frequency_applies(void) {
+  for (size_t i = 0; i < supported_count; i++) {
+    TEST_ASSERT_TRUE_MESSAGE(setCpuFrequencyMhz(supported[i]), "A frequency from the list was refused");
+    TEST_ASSERT_EQUAL_MESSAGE(supported[i], getCpuFrequencyMhz(), "The applied frequency differs from the requested one");
+    Serial.printf("  %3" PRIu32 " MHz ok\n", supported[i]);
+    Serial.flush();
+  }
+}
+
+void test_unsupported_frequencies_are_refused(void) {
+  TEST_ASSERT_FALSE_MESSAGE(setCpuFrequencyMhz(0), "0 MHz was accepted");
+
+  // Well above the maximum of every target, including the 400 MHz ESP32-P4
+  TEST_ASSERT_FALSE_MESSAGE(setCpuFrequencyMhz(1000), "1000 MHz was accepted");
+
+  // Anything the list leaves out has to be refused, otherwise the list is not the contract
+  size_t checked = 0;
+  for (uint32_t freq_mhz = supported[0]; freq_mhz > 0 && checked < 8; freq_mhz--) {
+    if (isSupported(freq_mhz)) {
+      continue;
+    }
+    TEST_ASSERT_FALSE_MESSAGE(setCpuFrequencyMhz(freq_mhz), "A frequency missing from the list was accepted");
+    TEST_ASSERT_EQUAL_MESSAGE(initial_freq_mhz, getCpuFrequencyMhz(), "A refused frequency still changed the CPU frequency");
+    checked++;
+  }
+}
+
+// ==================== getClockSourceName ====================
+
+void test_clock_source_names(void) {
+  rtc_cpu_freq_config_t conf;
+
+  // Every frequency in the list, so that each selectable clock source gets named at least once
+  for (size_t i = 0; i < supported_count; i++) {
+    TEST_ASSERT_TRUE(setCpuFrequencyMhz(supported[i]));
+    rtc_clk_cpu_freq_get_config(&conf);
+
+    const char *name = getClockSourceName(conf.source);
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_GREATER_THAN_MESSAGE(0, strlen(name), "Clock source name is empty");
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(0, strcmp(name, "Invalid"), "Clock source in use has no name");
+    Serial.printf("  %3" PRIu32 " MHz from %s\n", supported[i], name);
+    Serial.flush();
+  }
+
+  // Out of range input must not be indexed into whatever table backs the names
+  TEST_ASSERT_EQUAL_STRING("Invalid", getClockSourceName(SOC_CPU_CLK_SRC_INVALID));
+  TEST_ASSERT_EQUAL_STRING("Invalid", getClockSourceName(UINT8_MAX));
+}
+
+// ==================== getApbFrequency ====================
+
+void test_apb_frequency_matches_hardware(void) {
+  for (size_t i = 0; i < supported_count; i++) {
+    TEST_ASSERT_TRUE(setCpuFrequencyMhz(supported[i]));
+
+    // clk_hal_apb_get_freq_hz() derives APB_CLK from the dividers the IDF programmed, so it is
+    // an independent view of what the bus is really running at
+    const uint32_t expected = clk_hal_apb_get_freq_hz();
+    Serial.printf("  %3" PRIu32 " MHz cpu -> %" PRIu32 " Hz apb\n", supported[i], expected);
+    Serial.flush();
+    TEST_ASSERT_EQUAL_MESSAGE(expected, getApbFrequency(), "getApbFrequency() disagrees with the hardware dividers");
+  }
+}
+
+// ==================== SPI ====================
+
+// A divider is only as good as the source frequency it was computed from, and a wrong source is
+// invisible to the core's own arithmetic, so time a transfer and compare it with the request. Only
+// at the frequency the chip booted at: at low CPU frequencies the software cost of refilling the
+// FIFO dominates the measurement.
+void test_spi_bitrate_matches_request(void) {
+  static uint8_t data[SPI_TEST_BYTES];
+  memset(data, 0xA5, sizeof(data));
+
+  SPI.begin();
+  SPI.setFrequency(SPI_TEST_FREQ_HZ);
+
+  const uint32_t start = micros();
+  SPI.writeBytes(data, sizeof(data));
+  const uint32_t elapsed_us = micros() - start;
+  SPI.end();
+
+  TEST_ASSERT_GREATER_THAN_MESSAGE(0, elapsed_us, "Transfer took no measurable time");
+  const uint32_t measured = (uint32_t)((uint64_t)sizeof(data) * 8 * 1000000 / elapsed_us);
+  Serial.printf("  requested %u Hz, measured %" PRIu32 " bit/s over %" PRIu32 " us\n", SPI_TEST_FREQ_HZ, measured, elapsed_us);
+  Serial.flush();
+  TEST_ASSERT_UINT32_WITHIN_MESSAGE(SPI_TOLERANCE_HZ, SPI_TEST_FREQ_HZ, measured, "Measured SPI bit rate does not match the requested frequency");
+}
+
+void test_spi_frequency_survives_cpu_change(void) {
+  SPI.begin();
+  SPI.setFrequency(SPI_TEST_FREQ_HZ);
+
+  const uint32_t configured = spiClockDivToFrequency(SPI.bus(), spiGetClockDiv(SPI.bus()));
+  TEST_ASSERT_UINT32_WITHIN_MESSAGE(SPI_TOLERANCE_HZ, SPI_TEST_FREQ_HZ, configured, "SPI did not start at the requested frequency");
+
+  for (size_t i = 0; i < supported_count; i++) {
+    TEST_ASSERT_TRUE(setCpuFrequencyMhz(supported[i]));
+
+    const uint32_t freq = spiClockDivToFrequency(SPI.bus(), spiGetClockDiv(SPI.bus()));
+    Serial.printf("  %3" PRIu32 " MHz cpu -> %" PRIu32 " Hz spi\n", supported[i], freq);
+    Serial.flush();
+    TEST_ASSERT_UINT32_WITHIN_MESSAGE(SPI_TOLERANCE_HZ, SPI_TEST_FREQ_HZ, freq, "SPI frequency drifted with the CPU frequency");
+  }
+
+  SPI.end();
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    delay(10);
+  }
+
+  initial_freq_mhz = getCpuFrequencyMhz();
+  Serial.printf("Booted at %" PRIu32 " MHz, XTAL %" PRIu32 " MHz\n", initial_freq_mhz, getXtalFrequencyMhz());
+
+  UNITY_BEGIN();
+  parseSupportedFrequencies();
+  RUN_TEST(test_supported_frequency_list);
+  RUN_TEST(test_every_supported_frequency_applies);
+  RUN_TEST(test_unsupported_frequencies_are_refused);
+  RUN_TEST(test_clock_source_names);
+  RUN_TEST(test_apb_frequency_matches_hardware);
+  RUN_TEST(test_spi_bitrate_matches_request);
+  RUN_TEST(test_spi_frequency_survives_cpu_change);
+  UNITY_END();
+}
+
+void loop() {}

--- a/tests/validation/clock/test_clock.py
+++ b/tests/validation/clock/test_clock.py
@@ -1,0 +1,2 @@
+def test_clock(dut):
+    dut.expect_unity_test_output(timeout=180)


### PR DESCRIPTION
## Description of Change

This pull request significantly improves the handling and reporting of CPU and peripheral clock frequencies across all ESP32 targets. The main focus is on making the supported CPU frequencies dynamically discoverable and accurate for each chip and revision, ensuring robust clock source naming, and improving SPI peripheral clock handling. It also introduces comprehensive validation tests for these features.

**Dynamic CPU Frequency Handling and Reporting:**

* Refactored `getSupportedCpuFrequencyMhz()` to dynamically enumerate valid CPU frequencies for the running chip and revision, removing hardcoded lists and making frequency selection robust to IDF and hardware changes. The function now checks each possible frequency using the IDF's own validation logic and chip-specific constraints. [[1]](diffhunk://#diff-148dc0a05cfb442a25f8653a18647250c2fe811144f2a424149f127c7eb0f488L201-L265) [[2]](diffhunk://#diff-d4185962cb19f2ffc5d315903248e752977ce2c9c00adc52046f94a6933cc197L102-R70)
* Updated error reporting in `setCpuFrequencyMhz()` to use the new dynamic frequency list, ensuring users see only truly supported values for their chip.
* Removed legacy macros and logic for grouping targets by maximum CPU frequency, since the new approach no longer requires hardcoded frequency groups.

**Clock Source Naming Improvements:**

* Switched all `clock_source_names` tables to use designated initializers by enum value, making clock source name lookups robust to changes in enum ordering or value gaps across targets.
* Improved `getClockSourceName()` to safely handle invalid or out-of-range source values.

**Peripheral Clock and SPI Handling:**

* Added logic to dynamically determine the SPI peripheral's clock source frequency using the IDF's clock tree APIs, ensuring SPI divider calculations are always correct regardless of CPU frequency changes or target. [[1]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR84-R95) [[2]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR703-R721) [[3]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL1755-R1812) [[4]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL1902-R1946)
* Ensured SPI peripherals are pinned to the correct clock source at bus initialization, and that SPI bit rates remain stable across CPU frequency changes where required. [[1]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR919-R924) [[2]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR734-R739)

**Validation and Documentation:**

* Added a comprehensive validation test suite (`tests/validation/clock`) to verify supported frequency lists, frequency application, clock source naming, APB frequency reporting, and SPI bit rate stability. The test is designed to be target- and IDF-version agnostic. [[1]](diffhunk://#diff-6755272dbaa8d75180ff16027bdc75d92f81026aa909771c029523b12c09956dR1-R30) [[2]](diffhunk://#diff-3b869ee814cee7d4ba00bf26120571666a5636c53c05456d2b0a2614dca9047eR1-R3)

**Minor Cleanups:**

* Removed unused macros and clarified documentation in header files. [[1]](diffhunk://#diff-d4185962cb19f2ffc5d315903248e752977ce2c9c00adc52046f94a6933cc197L31-L37) [[2]](diffhunk://#diff-d4185962cb19f2ffc5d315903248e752977ce2c9c00adc52046f94a6933cc197L60-L91) [[3]](diffhunk://#diff-d4185962cb19f2ffc5d315903248e752977ce2c9c00adc52046f94a6933cc197L102-R70)

These changes make the clock and frequency APIs more robust, future-proof, and easier to use and validate across the entire ESP32 family.

---

**References:**  
[[1]](diffhunk://#diff-148dc0a05cfb442a25f8653a18647250c2fe811144f2a424149f127c7eb0f488L201-L265) [[2]](diffhunk://#diff-d4185962cb19f2ffc5d315903248e752977ce2c9c00adc52046f94a6933cc197L102-R70) [[3]](diffhunk://#diff-148dc0a05cfb442a25f8653a18647250c2fe811144f2a424149f127c7eb0f488L274-R330) [[4]](diffhunk://#diff-d4185962cb19f2ffc5d315903248e752977ce2c9c00adc52046f94a6933cc197L60-L91) [[5]](diffhunk://#diff-148dc0a05cfb442a25f8653a18647250c2fe811144f2a424149f127c7eb0f488R37-R82) [[6]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR84-R95) [[7]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR703-R721) [[8]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL1755-R1812) [[9]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bL1902-R1946) [[10]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR919-R924) [[11]](diffhunk://#diff-85528bb2cb9850d44fbbf4f4e4fbd25bf2f8198d543dce40413502878719c92bR734-R739) [[12]](diffhunk://#diff-6755272dbaa8d75180ff16027bdc75d92f81026aa909771c029523b12c09956dR1-R30) [[13]](diffhunk://#diff-3b869ee814cee7d4ba00bf26120571666a5636c53c05456d2b0a2614dca9047eR1-R3) [[14]](diffhunk://#diff-d4185962cb19f2ffc5d315903248e752977ce2c9c00adc52046f94a6933cc197L31-L37)

## Test Scenarios

Tested locally

## Related links

Fixes #12833
