### PR TITLE
fix(preferences): return 1 from putString for empty success

### DIFF
--- a/docs/en/api/preferences.rst
+++ b/docs/en/api/preferences.rst
@@ -375,7 +375,8 @@ Arduino-esp32 Preferences API
          - if ``String``, a valid Arduino String type.
 
    **Returns**
-      * if successful: the number of bytes stored; ``0`` otherwise.
+      * if successful: the number of bytes stored; for an empty string ``1`` is returned
+        so success is distinguishable from failure; ``0`` otherwise.
 
    **Notes**
       * Attempting to store a value without a namespace being open in read-write mode will fail.

--- a/libraries/Preferences/src/Preferences.cpp
+++ b/libraries/Preferences/src/Preferences.cpp
@@ -275,7 +275,10 @@ size_t Preferences::putString(const char *key, const char *value) {
     log_e("nvs_commit fail: %s %s", key, nvs_error(err));
     return 0;
   }
-  return strlen(value);
+  // Empty string stores successfully but strlen is 0; return 1 so callers
+  // treating 0 as failure still see success.
+  const size_t len = strlen(value);
+  return len > 0 ? len : 1;
 }
 
 size_t Preferences::putString(const char *key, const String value) {

--- a/tests/validation/nvs/nvs.ino
+++ b/tests/validation/nvs/nvs.ino
@@ -2,7 +2,7 @@
  * NVS/Preferences Validation Test
  *
  * Covers: all typed put/get (Char, UChar, Short, UShort, Int, UInt, Long,
- * ULong, Long64, ULong64, Float, Double, Bool), String (String + char*),
+ * ULong, Long64, ULong64, Float, Double, Bool), String (String + char* + empty),
  * Bytes/struct, isKey, getType, freeEntries, remove, clear,
  * multi-namespace isolation, and persistence across reboots.
  *
@@ -142,6 +142,14 @@ void test_string_cstr(void) {
   size_t len = prefs.getString("sc", buf, sizeof(buf));
   TEST_ASSERT_GREATER_THAN(0, len);
   TEST_ASSERT_EQUAL_STRING(val, buf);
+  prefs.end();
+}
+
+void test_string_empty(void) {
+  prefs.begin("test-str", false);
+  TEST_ASSERT_GREATER_OR_EQUAL(1, prefs.putString("se", ""));
+  TEST_ASSERT_TRUE(prefs.isKey("se"));
+  TEST_ASSERT_EQUAL_STRING("", prefs.getString("se", "default").c_str());
   prefs.end();
 }
 
@@ -333,6 +341,7 @@ void setup() {
     RUN_TEST(test_bool);
     RUN_TEST(test_string_object);
     RUN_TEST(test_string_cstr);
+    RUN_TEST(test_string_empty);
     RUN_TEST(test_bytes);
     RUN_TEST(test_struct);
     RUN_TEST(test_is_key);


### PR DESCRIPTION
## Summary
- `Preferences::putString("")` stores successfully but previously returned `0` (`strlen`), indistinguishable from failure.
- On empty-string success, return `1` so callers treating `0` as error still see success; non-empty returns unchanged.
- Document the return value and add `test_string_empty` to the NVS validation suite.

Fixes #12869