### PR TITLE
feat(wifi): add setInactiveTime/getInactiveTime for STA

### DIFF
--- a/libraries/WiFi/keywords.txt
+++ b/libraries/WiFi/keywords.txt
@@ -59,6 +59,8 @@ softAPConfig	KEYWORD2
 printDiag	KEYWORD2
 hostByName	KEYWORD2
 scanNetworks	KEYWORD2
+setInactiveTime	KEYWORD2
+getInactiveTime	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -606,6 +606,50 @@ bool STAClass::getAutoReconnect() {
   return _autoReconnect;
 }
 
+/**
+ * Set STA inactive (beacon timeout) time.
+ * If the station does not receive a beacon from the connected AP within this time,
+ * it disconnects. Default is 6 seconds; minimum is 3 seconds.
+ * Must be called after STA has been started (e.g. after WiFi.begin()).
+ * @param seconds inactive time in seconds (>= 3)
+ * @return true on success
+ */
+bool STAClass::setInactiveTime(uint16_t seconds) {
+  static constexpr uint16_t kMinInactiveTimeSec = 3;
+  if (seconds < kMinInactiveTimeSec) {
+    log_e("Inactive time must be at least %u seconds", kMinInactiveTimeSec);
+    return false;
+  }
+  if (!started()) {
+    log_w("STA has not been started");
+    return false;
+  }
+  esp_err_t err = esp_wifi_set_inactive_time(WIFI_IF_STA, seconds);
+  if (err != ESP_OK) {
+    log_e("esp_wifi_set_inactive_time failed!: 0x%x: %s", err, esp_err_to_name(err));
+  }
+  return err == ESP_OK;
+}
+
+/**
+ * Get STA inactive (beacon timeout) time in seconds.
+ * Must be called after STA has been started.
+ * @return inactive time in seconds, or 0 on failure
+ */
+uint16_t STAClass::getInactiveTime() {
+  if (!started()) {
+    log_w("STA has not been started");
+    return 0;
+  }
+  uint16_t seconds = 0;
+  esp_err_t err = esp_wifi_get_inactive_time(WIFI_IF_STA, &seconds);
+  if (err != ESP_OK) {
+    log_e("esp_wifi_get_inactive_time failed!: 0x%x: %s", err, esp_err_to_name(err));
+    return 0;
+  }
+  return seconds;
+}
+
 void STAClass::setMinSecurity(wifi_auth_mode_t minSecurity) {
   _minSecurity = minSecurity;
 }

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -268,23 +268,6 @@ bool WiFiSTAClass::getAutoReconnect() {
 }
 
 /**
- * Set STA inactive (beacon timeout) time.
- * @param seconds inactive time in seconds (>= 3)
- * @return true on success
- */
-bool WiFiSTAClass::setInactiveTime(uint16_t seconds) {
-  return STA.setInactiveTime(seconds);
-}
-
-/**
- * Get STA inactive (beacon timeout) time in seconds.
- * @return inactive time in seconds, or 0 on failure
- */
-uint16_t WiFiSTAClass::getInactiveTime() {
-  return STA.getInactiveTime();
-}
-
-/**
  * Wait for WiFi connection to reach a result
  * returns the status reached or disconnect if STA is off
  * @return wl_status_t

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -268,6 +268,23 @@ bool WiFiSTAClass::getAutoReconnect() {
 }
 
 /**
+ * Set STA inactive (beacon timeout) time.
+ * @param seconds inactive time in seconds (>= 3)
+ * @return true on success
+ */
+bool WiFiSTAClass::setInactiveTime(uint16_t seconds) {
+  return STA.setInactiveTime(seconds);
+}
+
+/**
+ * Get STA inactive (beacon timeout) time in seconds.
+ * @return inactive time in seconds, or 0 on failure
+ */
+uint16_t WiFiSTAClass::getInactiveTime() {
+  return STA.getInactiveTime();
+}
+
+/**
  * Wait for WiFi connection to reach a result
  * returns the status reached or disconnect if STA is off
  * @return wl_status_t

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -174,9 +174,6 @@ public:
   bool setAutoReconnect(bool autoReconnect);
   bool getAutoReconnect();
 
-  bool setInactiveTime(uint16_t seconds);
-  uint16_t getInactiveTime();
-
   uint8_t waitForConnectResult(unsigned long timeoutLength = 60000);
 
   // Next group functions must be called before WiFi.begin()

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -84,6 +84,9 @@ public:
   bool setAutoReconnect(bool autoReconnect);
   bool getAutoReconnect();
 
+  bool setInactiveTime(uint16_t seconds);
+  uint16_t getInactiveTime();
+
   // Next group functions must be called before WiFi.begin()
   void setMinSecurity(wifi_auth_mode_t minSecurity);  // Default is WIFI_AUTH_WPA2_PSK
   void setScanMethod(wifi_scan_method_t scanMethod);  // Default is WIFI_FAST_SCAN
@@ -170,6 +173,9 @@ public:
 
   bool setAutoReconnect(bool autoReconnect);
   bool getAutoReconnect();
+
+  bool setInactiveTime(uint16_t seconds);
+  uint16_t getInactiveTime();
 
   uint8_t waitForConnectResult(unsigned long timeoutLength = 60000);
 


### PR DESCRIPTION
## Summary
- Adds thin Arduino wrappers `WiFi.setInactiveTime()` / `WiFi.getInactiveTime()` (and `WiFi.STA.*`) around `esp_wifi_set_inactive_time` / `esp_wifi_get_inactive_time` for STA beacon-timeout tuning.
- Placed on `STAClass` with `WiFiSTAClass` forwarding (same pattern as `setAutoReconnect`), including min-3s validation and a `started()` guard.
- Default IDF behavior is unchanged (STA default remains 6s); this only exposes the existing IDF API.

Fixes #12870