### PR TITLE
ci(upload): Fix upload test gating

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -198,7 +198,8 @@ The checked-out core is installed via `install-arduino-core-esp32.sh` (symlink +
 
 **Logic:**
 - Non-PR (`push`, `workflow_dispatch`): always run
-- PR: `tj-actions/changed-files` with `files_yaml` categories `boards` / `upload` (`**` minus `boards.txt`)
+- PR: `tj-actions/changed-files` with `files_yaml` categories `boards` / `upload`
+  - `upload` matches `on.pull_request.paths` minus `boards.txt` (not `**`, so `variants/` and other companion files do not force a run)
   - run `find_boards.sh official` only when `boards_any_changed`
   - run mock upload if official `CORE_SOCS` boards changed (`FQBNS` non-empty) **or** `upload_any_changed`
 

--- a/.github/workflows/upload-tests.yml
+++ b/.github/workflows/upload-tests.yml
@@ -13,7 +13,6 @@ on:
       - "boards.txt"
       - "tools/flasher.py"
       - "package/package_esp32_index.template.json"
-      - ".github/esp32-mock-bootloader-version"
       - ".github/scripts/arduino_headless.sh"
       - ".github/scripts/find_boards.sh"
       - ".github/scripts/mock_upload_lib.sh"
@@ -51,8 +50,18 @@ jobs:
             boards:
               - boards.txt
             upload:
-              - '**'
-              - '!boards.txt'
+              - platform.txt
+              - programmers.txt
+              - tools/flasher.py
+              - package/package_esp32_index.template.json
+              - .github/scripts/arduino_headless.sh
+              - .github/scripts/find_boards.sh
+              - .github/scripts/mock_upload_lib.sh
+              - .github/scripts/test-mock-upload.sh
+              - .github/scripts/install-arduino-builder.sh
+              - .github/scripts/sketch_utils.sh
+              - .github/scripts/socs_config.sh
+              - .github/workflows/upload-tests.yml
 
       - name: Find changed official boards
         if: github.event_name == 'pull_request' && steps.changed.outputs.boards_any_changed == 'true'
@@ -83,7 +92,7 @@ jobs:
             exit 0
           fi
 
-          echo "Only non-official boards.txt changes; skipping mock upload"
+          echo "No official CORE_SOCS boards or upload-related paths changed; skipping mock upload"
           echo "should_run=false" >> "$GITHUB_OUTPUT"
 
   mock-upload:


### PR DESCRIPTION
## Description of Change

This pull request updates the logic and configuration for when upload tests are triggered in CI, making the process more precise and reducing unnecessary runs. The main changes clarify which files should trigger upload tests and update documentation and workflow files accordingly.

**Workflow logic and configuration updates:**

* Updated the documentation in `.github/CI_README.md` to clarify that the `upload` category now matches specific paths rather than all files except `boards.txt`, so changes to companion files like those in `variants/` no longer force a run.
* Refined the `upload` file list in `.github/workflows/upload-tests.yml` to explicitly include relevant files and exclude the previous broad pattern, ensuring only meaningful changes trigger upload tests.
* Removed `.github/esp32-mock-bootloader-version` from the list of paths that trigger the workflow, further narrowing the scope of upload test triggers.

**Output and messaging improvements:**

* Improved the skip message in the workflow to clarify that mock uploads are skipped when neither official boards nor upload-related paths have changed.
