### PR TITLE
ci(p4): Align FQBN with upcoming EV board USB defaults

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -683,7 +683,7 @@ Defines test requirements and platform support:
 - `fqbn: {chip: [full FQBN, ...]}` - Replaces the default FQBN, one build per entry
 
 **FQBN options (`fqbn_append`):**
-Each menu key is kept only once, so a key set in `fqbn_append` replaces the default value for that key rather than being listed twice. This is how a test disables an option that is on by default, such as `PSRAM=disabled` on ESP32. Options are applied lowest priority first: the target default, then `fqbn_append`, then the per-device `fqbn_append` of a multi-device test, then the debug level passed with `-d`.
+Each menu key is kept only once, so a key set in `fqbn_append` replaces the default value for that key rather than being listed twice. This is how a test disables an option that is on by default, such as `PSRAM=disabled` on ESP32. Options are applied lowest priority first: the target default, then `fqbn_append`, then the per-device `fqbn_append` of a multi-device test, then the debug level passed with `-d`. On ESP32-P4, `CDCOnBoot` is then overwritten for the environment (Disabled in CI, Enabled locally), including for full `fqbn:` lists.
 
 Use the map form when the options differ per target. The `default` entry applies to every target and the entry matching the target is merged on top of it, so only the difference has to be spelled out. This is required for menus that do not exist on every target — ESP32-C3, ESP32-C6 and ESP32-H2 have no PSRAM menu, and `arduino-cli` rejects the whole build with `invalid option 'PSRAM'` if they are given `PSRAM=disabled`:
 
@@ -1565,6 +1565,29 @@ bash .github/scripts/check_official_variants.sh \
 - `count` - Count sketches for chunking
 - `check_requirements` - Validate sketch requirements
 - `install_libs` - Install library dependencies
+
+**Default FQBNs:**
+
+When no explicit FQBN is provided via `ci.yml`, the following per-SoC defaults are used:
+
+| SoC | Default FQBN |
+|-----|-------------|
+| ESP32 | `espressif:esp32:esp32:PSRAM=enabled` |
+| ESP32-S2 | `espressif:esp32:esp32s2:PSRAM=enabled` |
+| ESP32-S3 | `espressif:esp32:esp32s3:PSRAM=opi,USBMode=default` |
+| ESP32-C3 | `espressif:esp32:esp32c3` |
+| ESP32-C6 | `espressif:esp32:esp32c6` |
+| ESP32-H2 | `espressif:esp32:esp32h2` |
+| ESP32-P4 | `espressif:esp32:esp32p4:PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3` |
+| ESP32-C5 | `espressif:esp32:esp32c5:PSRAM=enabled` |
+
+> **Note:** `CDCOnBoot` on ESP32-P4 is **not** taken from `ci.yml`. After the FQBN is fully
+> resolved (defaults, `fqbn_append`, explicit `fqbn:`, or `-fqbn`), `apply_cdc_on_boot_opt`
+> overwrites it:
+> - `CI=true`: `CDCOnBoot=default` (Disabled) so `Serial` maps to UART0 for hardware runners
+> - Local: `CDCOnBoot=cdc` (Enabled) so `Serial` maps to `HWCDCSerial` (USB Serial/JTAG)
+>
+> Do not set `CDCOnBoot` in `ci.yml`; the environment overlay always wins.
 
 ### Test Scripts
 

--- a/.github/scripts/sketch_utils.sh
+++ b/.github/scripts/sketch_utils.sh
@@ -82,6 +82,31 @@ function _normalize_fqbn_opts {
     '
 }
 
+# Force ESP32-P4 Serial mapping for the environment. Applied last so it wins
+# over target defaults, fqbn_append, full FQBNs from ci.yml, and -fqbn.
+# CI hardware runners talk to UART0, so CDC on boot must be Disabled
+# (CDCOnBoot=default). Local and Wokwi use USB Serial/JTAG, so Enabled
+# (CDCOnBoot=cdc).
+function apply_cdc_on_boot_opt {
+    local fqbn="$1"
+    local board
+    board=$(echo "$fqbn" | cut -d':' -f3)
+    if [ "$board" != "esp32p4" ]; then
+        echo "$fqbn"
+        return 0
+    fi
+
+    local base options cdc_opt
+    base=$(echo "$fqbn" | cut -d':' -f1-3)
+    options=$(echo "$fqbn" | cut -d':' -f4-)
+    if [ "${CI:-false}" = "true" ]; then
+        cdc_opt="CDCOnBoot=default"
+    else
+        cdc_opt="CDCOnBoot=cdc"
+    fi
+    echo "${base}:$(_normalize_fqbn_opts "${options},${cdc_opt}")"
+}
+
 function default_fqbn_for_target {
     local target="$1"
     local options_override="${2:-}"
@@ -104,47 +129,49 @@ function default_fqbn_for_target {
     esp32c3_opts=$(_normalize_fqbn_opts "${overrides}")
     esp32c6_opts=$(_normalize_fqbn_opts "${overrides}")
     esp32h2_opts=$(_normalize_fqbn_opts "${overrides}")
-    esp32p4_opts=$(_normalize_fqbn_opts "PSRAM=enabled,USBMode=default,ChipVariant=postv3,${overrides}")
+    esp32p4_opts=$(_normalize_fqbn_opts "PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3,${overrides}")
     esp32c5_opts=$(_normalize_fqbn_opts "PSRAM=enabled,${overrides}")
 
+    local result=""
     case "$target" in
         esp32)
             [ -n "${options_override:-$esp32_opts}" ] && opt=":${options_override:-$esp32_opts}"
-            echo "${pkg}:esp32${opt}"
+            result="${pkg}:esp32${opt}"
             ;;
         esp32s2)
             [ -n "${options_override:-$esp32s2_opts}" ] && opt=":${options_override:-$esp32s2_opts}"
-            echo "${pkg}:esp32s2${opt}"
+            result="${pkg}:esp32s2${opt}"
             ;;
         esp32c3)
             [ -n "${options_override:-$esp32c3_opts}" ] && opt=":${options_override:-$esp32c3_opts}"
-            echo "${pkg}:esp32c3${opt}"
+            result="${pkg}:esp32c3${opt}"
             ;;
         esp32s3)
             [ -n "${options_override:-$esp32s3_opts}" ] && opt=":${options_override:-$esp32s3_opts}"
-            echo "${pkg}:esp32s3${opt}"
+            result="${pkg}:esp32s3${opt}"
             ;;
         esp32c6)
             [ -n "${options_override:-$esp32c6_opts}" ] && opt=":${options_override:-$esp32c6_opts}"
-            echo "${pkg}:esp32c6${opt}"
+            result="${pkg}:esp32c6${opt}"
             ;;
         esp32h2)
             [ -n "${options_override:-$esp32h2_opts}" ] && opt=":${options_override:-$esp32h2_opts}"
-            echo "${pkg}:esp32h2${opt}"
+            result="${pkg}:esp32h2${opt}"
             ;;
         esp32p4)
             [ -n "${options_override:-$esp32p4_opts}" ] && opt=":${options_override:-$esp32p4_opts}"
-            echo "${pkg}:esp32p4${opt}"
+            result="${pkg}:esp32p4${opt}"
             ;;
         esp32c5)
             [ -n "${options_override:-$esp32c5_opts}" ] && opt=":${options_override:-$esp32c5_opts}"
-            echo "${pkg}:esp32c5${opt}"
+            result="${pkg}:esp32c5${opt}"
             ;;
         *)
             echo "ERROR: Invalid chip: $target" >&2
             return 1
             ;;
     esac
+    apply_cdc_on_boot_opt "$result"
 }
 
 # Read the fqbn_append options a ci.yml requests for one target. The field is
@@ -373,6 +400,7 @@ function build_sketch { # build_sketch <ide_path> <user_path> <path-to-ino> [ext
         mkdir -p "$build_dir"
 
         currfqbn=$(echo "$fqbn" | jq -r --argjson i "$i" '.[$i]')
+        currfqbn=$(apply_cdc_on_boot_opt "$currfqbn")
 
         if [ "${use_arduino_cli:-0}" -eq 1 ] && [ -f "$ide_path/arduino-cli" ]; then
             echo "Building $sketchname with arduino-cli and FQBN=$currfqbn"

--- a/.github/scripts/tests_run.sh
+++ b/.github/scripts/tests_run.sh
@@ -351,6 +351,9 @@ function run_test {
             if [[ -f "$sketchdir/diagram.$target.json" ]]; then
                 extra_args+=("--wokwi-diagram" "$sketchdir/diagram.$target.json")
             fi
+            if [[ "$target" == "esp32p4" ]] && [[ "${CI:-false}" != "true" ]]; then
+                extra_args+=("--wokwi-usb-serial-jtag" "true")
+            fi
             generate_wokwi_toml "$sketchdir" "$build_dir" "$sketchname"
         elif [ $platform == "qemu" ]; then
             PATH=$HOME/qemu/bin:$PATH

--- a/docs/en/contributing.rst
+++ b/docs/en/contributing.rst
@@ -174,7 +174,8 @@ Currently, the default FQBNs are:
 * ``espressif:esp32:esp32c3``
 * ``espressif:esp32:esp32c6``
 * ``espressif:esp32:esp32h2``
-* ``espressif:esp32:esp32p4:USBMode=default,ChipVariant=postv3``
+* ``espressif:esp32:esp32p4:PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3`` (``CDCOnBoot`` is forced last: ``cdc`` locally, ``default`` / Disabled in CI)
+* ``espressif:esp32:esp32c5:PSRAM=enabled``
 
 There are two ways to alter the FQBNs used to compile the sketches: by using the ``fqbn`` or ``fqbn_append`` fields in the ``ci.yml`` file.
 
@@ -190,6 +191,10 @@ This makes it possible to turn off an option that is enabled by default, such as
 .. code-block:: yaml
 
     fqbn_append: PSRAM=disabled
+
+On ESP32-P4, ``CDCOnBoot`` is an exception: after the FQBN is fully resolved (including a full ``fqbn:`` list),
+the scripts force ``CDCOnBoot=cdc`` (Enabled) for local runs and ``CDCOnBoot=default`` (Disabled) when ``CI=true``.
+Do not set ``CDCOnBoot`` in ``ci.yml``.
 
 When the options differ per target, ``fqbn_append`` can be a dictionary instead. The ``default`` entry is applied to every target and the entry
 matching the target is merged on top of it, so only the difference has to be spelled out. This is needed for options that do not exist on every

--- a/libraries/ESP_SR/examples/Basic/ci.yml
+++ b/libraries/ESP_SR/examples/Basic/ci.yml
@@ -2,7 +2,7 @@ fqbn:
   esp32s3:
     - espressif:esp32:esp32s3:USBMode=default,PartitionScheme=esp_sr_16,FlashSize=16M,FlashMode=dio
   esp32p4:
-    - espressif:esp32:esp32p4:USBMode=default,ChipVariant=postv3,PartitionScheme=esp_sr_16,FlashSize=16M,FlashMode=qio
+    - espressif:esp32:esp32p4:USBMode=hwcdc,ChipVariant=postv3,PartitionScheme=esp_sr_16,FlashSize=16M,FlashMode=qio
 
 requires:
   - CONFIG_MODEL_IN_FLASH=y

--- a/tests/validation/nvs/ci.yml
+++ b/tests/validation/nvs/ci.yml
@@ -23,10 +23,10 @@ fqbn:
     - espressif:esp32:esp32s3:PSRAM=opi,USBMode=default,PartitionScheme=huge_app,FlashMode=qio120
     - espressif:esp32:esp32s3:PSRAM=opi,USBMode=default,PartitionScheme=huge_app,FlashMode=dio
   esp32p4:
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=dio
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=dio,FlashFreq=40
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=qio
-    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=default,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=qio,FlashFreq=40
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=dio
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=dio,FlashFreq=40
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=qio
+    - espressif:esp32:esp32p4:PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3,PartitionScheme=huge_app,FlashMode=qio,FlashFreq=40
 
 platforms:
   qemu: false

--- a/tests/validation/uart/uart.ino
+++ b/tests/validation/uart/uart.ino
@@ -220,7 +220,7 @@ extern "C" int8_t uart_get_TxPin(uint8_t uart_num);
 
 // This task is used to send a message after a delay to test the auto baudrate detection
 void task_delayed_msg(void *pvParameters) {
-  HardwareSerial &selected_serial = uart_test_configs.size() == 1 ? Serial : Serial1;
+  HardwareSerial &selected_serial = uart_test_configs.size() == 1 ? Serial0 : Serial1;
   delay(1500);
   selected_serial.println("Hello to detect baudrate");
   selected_serial.flush();
@@ -1219,8 +1219,8 @@ void setup() {
   uart_test_configs = {
 #if SOC_UART_HP_NUM >= 2 && defined(RX1) && defined(TX1)
 #if CONFIG_IDF_TARGET_ESP32P4
-    // Using a real ESP32-P4 board requires the broken-out pins of the EV board
-    new UARTTestConfig(1, Serial1, 2, 3),  // RX1 = 2, TX1 = 3; ESP32-P4 only: TAB5 (ECO-2) = OK || EV board (ECO5) = OK
+    // Using an ESP32-P4X-Function-EV-Board requires the broken-out pins on J1
+    new UARTTestConfig(1, Serial1, 2, 3),  // RX1 = 2, TX1 = 3; ESP32-P4 only: TAB5 (ECO-2) = OK || P4X EV board = OK
 #else
     // Non-ESP32-P4 targets should use the regular UART1 pins
     new UARTTestConfig(1, Serial1, RX1, TX1),


### PR DESCRIPTION
## Description of Change

This pull request introduces improvements to how the ESP32-P4 board's serial interface is configured and documented in CI and local development environments. The main focus is on reliably setting the `CDCOnBoot` option for ESP32-P4 builds, ensuring consistent serial port behavior between CI (hardware runners) and local/Wokwi emulation. Documentation and test configurations have also been updated for clarity and correctness.

**ESP32-P4 Serial Configuration and Documentation:**

* Scripts now force the `CDCOnBoot` FQBN option for ESP32-P4: it is set to `default` (Disabled) in CI to use UART0, and to `cdc` (Enabled) locally to use USB Serial/JTAG, regardless of what is set in `ci.yml` or other build options. (`.github/scripts/sketch_utils.sh`, `.github/CI_README.md`, `docs/en/contributing.rst`) [[1]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5R85-R109) [[2]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L107-R174) [[3]](diffhunk://#diff-b4656400ea337249663ea596b1bc55dcd79f9837df94ca6d5c39e187709cdde6L686-R686) [[4]](diffhunk://#diff-b4656400ea337249663ea596b1bc55dcd79f9837df94ca6d5c39e187709cdde6R1569-R1591) [[5]](diffhunk://#diff-cf0d42bff30b139cd50ea103c575c0adcb3c2f0f2e0594fbd9caab7fd545f95bL177-R178) [[6]](diffhunk://#diff-cf0d42bff30b139cd50ea103c575c0adcb3c2f0f2e0594fbd9caab7fd545f95bR195-R198)

* Default FQBNs for all ESP32 SoCs are now clearly documented, with ESP32-P4 defaulting to `PSRAM=enabled,USBMode=hwcdc,ChipVariant=postv3`. (`.github/CI_README.md`, `docs/en/contributing.rst`) [[1]](diffhunk://#diff-b4656400ea337249663ea596b1bc55dcd79f9837df94ca6d5c39e187709cdde6R1569-R1591) [[2]](diffhunk://#diff-cf0d42bff30b139cd50ea103c575c0adcb3c2f0f2e0594fbd9caab7fd545f95bL177-R178)

**Test and Build System Updates:**

* All explicit ESP32-P4 FQBNs in test configurations have been updated to use `USBMode=hwcdc` instead of `USBMode=default` for consistency with new defaults. (`libraries/ESP_SR/examples/Basic/ci.yml`, `tests/validation/nvs/ci.yml`) [[1]](diffhunk://#diff-9b6af6e467d16593b993916d65d52b61c90e27c4a0a5e240fb22d4e4461504cdL5-R5) [[2]](diffhunk://#diff-f6e999ebde65e4dce85e37631c90309e557c30c610b132875b33e4094d4ad249L26-R29)

* The build and test scripts now always apply the correct `CDCOnBoot` option for ESP32-P4, regardless of how the FQBN is specified. Additionally, Wokwi emulation for ESP32-P4 enables USB Serial/JTAG when running locally. (`.github/scripts/sketch_utils.sh`, `.github/scripts/tests_run.sh`) [[1]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5L107-R174) [[2]](diffhunk://#diff-48044c26e61c8ff0772ed3f803ba9c5ddbbef7007aa155f9eb377d88da44caf5R403) [[3]](diffhunk://#diff-a79d5ef8d7e3ab662a0d9905060081ad57b8a9f3364c515b80a085558ac19492R354-R356)

**Test Code and Documentation Improvements:**

* Minor corrections and clarifications were made in the UART validation test code and comments to accurately describe ESP32-P4 hardware usage. (`tests/validation/uart/uart.ino`) [[1]](diffhunk://#diff-5719d8ae1f3eb20d24edff4612789d7a42ff2b415a13196ecc821def54752000L223-R223) [[2]](diffhunk://#diff-5719d8ae1f3eb20d24edff4612789d7a42ff2b415a13196ecc821def54752000L1222-R1223)

These changes ensure that serial port mapping for ESP32-P4 is always correct and predictable, improving both developer experience and CI reliability.

## Related links

- Split from #12619
- pytest-embedded USB Serial/JTAG: https://github.com/espressif/pytest-embedded/pull/421 (already merged)