### PR TITLE
fix(ble): Report failed pairings instead of silently succeeding

### DIFF
--- a/libraries/BLE/examples/Client_secure_static_passkey/Client_secure_static_passkey.ino
+++ b/libraries/BLE/examples/Client_secure_static_passkey/Client_secure_static_passkey.ino
@@ -116,8 +116,8 @@ static void get_peer_irk(BLEAddress peerAddr) {
     Serial.println();
   } else {
     Serial.println("!!! Failed to retrieve peer IRK !!!");
-    Serial.println("This is expected if bonding is disabled or the peer doesn't distribute its Identity Key.");
-    Serial.println("To enable bonding, change setAuthenticationMode to: pSecurity->setAuthenticationMode(true, true, true);\n");
+    Serial.println("Pairing succeeded, so this means the peer chose not to distribute its Identity Key.");
+    Serial.println("Not every device does. Bonding is already enabled in this example, so there is nothing to change here.\n");
   }
 
   Serial.println("=======================================\n");
@@ -149,6 +149,14 @@ class MyClientCallback : public BLEClientCallbacks {
 class MySecurityCallbacks : public BLESecurityCallbacks {
 #if defined(CONFIG_BLUEDROID_ENABLED)
   void onAuthenticationComplete(esp_ble_auth_cmpl_t desc) override {
+    // Bluedroid reports both outcomes here, so the result has to be checked.
+    // Asking for the IRK after a failed pairing would only produce a confusing error.
+    if (!desc.success) {
+      Serial.printf("\n!!! Pairing failed: reason %u (0x%02X) !!!\n", desc.fail_reason, desc.fail_reason);
+      Serial.println("No keys were exchanged, so there is no peer IRK to retrieve.\n");
+      return;
+    }
+
     // desc.bd_addr is the peer's connection address (may be a Resolvable Private Address).
     // getPeerIRK() will also search by the stored identity address as a fallback.
     BLEAddress peerAddr(desc.bd_addr);
@@ -157,6 +165,8 @@ class MySecurityCallbacks : public BLESecurityCallbacks {
 #endif
 
 #if defined(CONFIG_NIMBLE_ENABLED)
+  // Only called once pairing has actually succeeded. Override the (desc, status)
+  // overload instead if you also want to be told why a pairing was rejected.
   void onAuthenticationComplete(ble_gap_conn_desc *desc) override {
     // peer_id_addr is always the resolved identity address in NimBLE
     BLEAddress peerAddr(desc->peer_id_addr.val, desc->peer_id_addr.type);

--- a/libraries/BLE/examples/Server_secure_static_passkey/Server_secure_static_passkey.ino
+++ b/libraries/BLE/examples/Server_secure_static_passkey/Server_secure_static_passkey.ino
@@ -114,8 +114,8 @@ static void get_peer_irk(BLEAddress peerAddr) {
     Serial.println();
   } else {
     Serial.println("!!! Failed to retrieve peer IRK !!!");
-    Serial.println("This is expected if bonding is disabled or the peer doesn't distribute its Identity Key.");
-    Serial.println("To enable bonding, change setAuthenticationMode to: pSecurity->setAuthenticationMode(true, true, true);\n");
+    Serial.println("Pairing succeeded, so this means the peer chose not to distribute its Identity Key.");
+    Serial.println("Not every device does. Bonding is already enabled in this example, so there is nothing to change here.\n");
   }
 
   Serial.println("=======================================\n");
@@ -125,6 +125,14 @@ static void get_peer_irk(BLEAddress peerAddr) {
 class MySecurityCallbacks : public BLESecurityCallbacks {
 #if defined(CONFIG_BLUEDROID_ENABLED)
   void onAuthenticationComplete(esp_ble_auth_cmpl_t desc) override {
+    // Bluedroid reports both outcomes here, so the result has to be checked.
+    // Asking for the IRK after a failed pairing would only produce a confusing error.
+    if (!desc.success) {
+      Serial.printf("\n!!! Pairing failed: reason %u (0x%02X) !!!\n", desc.fail_reason, desc.fail_reason);
+      Serial.println("No keys were exchanged, so there is no peer IRK to retrieve.\n");
+      return;
+    }
+
     // desc.bd_addr is the peer's connection address (may be a Resolvable Private Address).
     // getPeerIRK() will also search by the stored identity address as a fallback.
     BLEAddress peerAddr(desc.bd_addr);
@@ -133,6 +141,8 @@ class MySecurityCallbacks : public BLESecurityCallbacks {
 #endif
 
 #if defined(CONFIG_NIMBLE_ENABLED)
+  // Only called once pairing has actually succeeded. Override the (desc, status)
+  // overload instead if you also want to be told why a pairing was rejected.
   void onAuthenticationComplete(ble_gap_conn_desc *desc) override {
     // peer_id_addr is always the resolved identity address in NimBLE
     BLEAddress peerAddr(desc->peer_id_addr.val, desc->peer_id_addr.type);

--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -1293,22 +1293,57 @@ int BLEClient::handleGAPEvent(struct ble_gap_event *event, void *arg) {
         return 0;
       }
 
-      if (event->enc_change.status == 0 || event->enc_change.status == (BLE_HS_ERR_HCI_BASE + BLE_ERR_PINKEY_MISSING)) {
-        struct ble_gap_conn_desc desc;
-        rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
-        assert(rc == 0);
+      struct ble_gap_conn_desc desc;
+      bool descFound = ble_gap_conn_find(event->enc_change.conn_handle, &desc) == 0;
 
-        if (event->enc_change.status == (BLE_HS_ERR_HCI_BASE + BLE_ERR_PINKEY_MISSING)) {
-          // Key is missing, try deleting.
-          ble_store_util_delete_peer(&desc.peer_id_addr);
-        } else if (BLEDevice::m_securityCallbacks != nullptr) {
-          BLEDevice::m_securityCallbacks->onAuthenticationComplete(&desc);
+      if (event->enc_change.status == 0) {
+        if (descFound) {
+          log_i(
+            "Encryption enabled: handle=%u, encrypted=%d, authenticated=%d, bonded=%d", event->enc_change.conn_handle, desc.sec_state.encrypted,
+            desc.sec_state.authenticated, desc.sec_state.bonded
+          );
         }
+      } else if (event->enc_change.status == (BLE_HS_ERR_HCI_BASE + BLE_ERR_PINKEY_MISSING)) {
+        // The peer no longer has the key we bonded with; drop the stale bond so the next attempt can pair again.
+        log_w("Peer is missing the bonding key. Deleting the stale bond.");
+        if (descFound) {
+          ble_store_util_delete_peer(&desc.peer_id_addr);
+        }
+      } else {
+        log_e(
+          "Encryption failed: handle=%u, rc=%d (0x%04x), %s", event->enc_change.conn_handle, event->enc_change.status, event->enc_change.status,
+          BLEUtils::returnCodeToString(event->enc_change.status)
+        );
+      }
+
+      // Reported for both outcomes so a failed pairing cannot look like a successful one.
+      if (descFound && BLEDevice::m_securityCallbacks != nullptr) {
+        BLEDevice::m_securityCallbacks->onAuthenticationComplete(&desc, event->enc_change.status);
       }
 
       rc = event->enc_change.status;
       break;
     }  //BLE_GAP_EVENT_ENC_CHANGE
+
+    case BLE_GAP_EVENT_PARING_COMPLETE:  // Name is misspelled in NimBLE
+    {
+      if (client->m_conn_id != event->pairing_complete.conn_handle) {
+        return 0;
+      }
+
+      // Reported before the keys are persisted, and carries the SMP reason code that
+      // BLE_GAP_EVENT_ENC_CHANGE does not.
+      if (event->pairing_complete.status == 0) {
+        log_i("Pairing complete: handle=%u", event->pairing_complete.conn_handle);
+      } else {
+        log_e(
+          "Pairing failed: handle=%u, SMP reason=%u, %s", event->pairing_complete.conn_handle, event->pairing_complete.status,
+          BLEUtils::smErrorToString(event->pairing_complete.status)
+        );
+      }
+
+      return 0;
+    }  // BLE_GAP_EVENT_PARING_COMPLETE
 
     case BLE_GAP_EVENT_MTU:
     {

--- a/libraries/BLE/src/BLEDevice.cpp
+++ b/libraries/BLE/src/BLEDevice.cpp
@@ -1391,6 +1391,21 @@ void BLEDevice::gapEventHandler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_par
     {
       log_i("ESP_GAP_BLE_AUTH_CMPL_EVT");
 #ifdef CONFIG_BLE_SMP_ENABLE  // Check that BLE SMP (security) is configured in make menuconfig
+      // Report the outcome so a failed pairing is not mistaken for a successful one.
+      // fail_reason carries the SMP reason code and is the only way to tell why pairing was rejected.
+      if (param->ble_security.auth_cmpl.success) {
+        log_i(
+          "Authentication complete: addr=%s, auth_mode=0x%02x", BLEAddress(param->ble_security.auth_cmpl.bd_addr).toString().c_str(),
+          param->ble_security.auth_cmpl.auth_mode
+        );
+      } else {
+        log_e(
+          "Authentication failed: addr=%s, reason=%u (0x%02x), %s", BLEAddress(param->ble_security.auth_cmpl.bd_addr).toString().c_str(),
+          param->ble_security.auth_cmpl.fail_reason, param->ble_security.auth_cmpl.fail_reason,
+          BLEUtils::authFailReasonToString(param->ble_security.auth_cmpl.fail_reason)
+        );
+      }
+
       // Call user callback BEFORE signaling completion.
       // This ensures callback output (e.g., "Authentication complete") appears before
       // any waiting GATT operations are unblocked and produce their own output.

--- a/libraries/BLE/src/BLESecurity.cpp
+++ b/libraries/BLE/src/BLESecurity.cpp
@@ -319,9 +319,9 @@ void BLESecurity::waitForAuthenticationComplete(uint32_t timeoutMs) {
     return;
   }
 
-  // Semaphore should have been created in startSecurity()
-  if (m_authCompleteSemaphore == nullptr) {
-    log_e("Authentication semaphore not initialized");
+  // The semaphore is created by startSecurity(). If security was never started there is
+  // nothing to wait for, which is the normal path when forced authentication is disabled.
+  if (!m_securityStarted || m_authCompleteSemaphore == nullptr) {
     return;
   }
 
@@ -463,10 +463,21 @@ bool BLESecurity::startSecurity(uint16_t connHandle, int *rcPtr) {
   return m_securityStarted;
 }
 
-// This function is called when authentication is complete for NimBLE.
+// This function is called when authentication completed successfully for NimBLE.
 void BLESecurityCallbacks::onAuthenticationComplete(ble_gap_conn_desc *desc) {
-  bool success = desc != nullptr;
-  Serial.printf("Using default onAuthenticationComplete. Authentication %s.\n", success ? "successful" : "failed");
+  Serial.println("Using default onAuthenticationComplete. Authentication successful.");
+}
+
+// This function is called when authentication completes for NimBLE, successfully or not.
+void BLESecurityCallbacks::onAuthenticationComplete(ble_gap_conn_desc *desc, int status) {
+  if (status != 0) {
+    // The reason code is not decoded here because the text tables are only compiled in
+    // when logging is enabled, which is independent of this Serial output.
+    Serial.printf("Using default onAuthenticationComplete. Authentication failed with status %d.\n", status);
+    return;
+  }
+
+  onAuthenticationComplete(desc);
 }
 #endif
 

--- a/libraries/BLE/src/BLESecurity.h
+++ b/libraries/BLE/src/BLESecurity.h
@@ -233,9 +233,15 @@ public:
    ***************************************************************************/
 
 #if defined(CONFIG_NIMBLE_ENABLED)
-  // This callback is called when the authentication is complete.
-  // Status can be checked in the desc parameter.
+  // This callback is called when the authentication completed successfully.
+  // The resulting security state can be checked in the desc parameter.
   virtual void onAuthenticationComplete(ble_gap_conn_desc *desc);
+
+  // This callback is called when the authentication completes, successfully or not.
+  // status is 0 on success, otherwise a BLE_HS_* error code.
+  // The default implementation forwards successful authentications to the overload above,
+  // so overriding only that one keeps the success-only semantics.
+  virtual void onAuthenticationComplete(ble_gap_conn_desc *desc, int status);
 #endif
 
 };  // BLESecurityCallbacks

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -993,12 +993,44 @@ int BLEServer::handleGATTServerEvent(struct ble_gap_event *event, void *arg) {
         return BLE_ATT_ERR_INVALID_HANDLE;
       }
 
+      if (event->enc_change.status == 0) {
+        log_i(
+          "Encryption enabled: handle=%u, encrypted=%d, authenticated=%d, bonded=%d", event->enc_change.conn_handle, desc.sec_state.encrypted,
+          desc.sec_state.authenticated, desc.sec_state.bonded
+        );
+      } else if (event->enc_change.status == (BLE_HS_ERR_HCI_BASE + BLE_ERR_PINKEY_MISSING)) {
+        // The peer no longer has the key we bonded with; drop the stale bond so the next attempt can pair again.
+        log_w("Peer is missing the bonding key. Deleting the stale bond.");
+        ble_store_util_delete_peer(&desc.peer_id_addr);
+      } else {
+        log_e(
+          "Encryption failed: handle=%u, rc=%d (0x%04x), %s", event->enc_change.conn_handle, event->enc_change.status, event->enc_change.status,
+          BLEUtils::returnCodeToString(event->enc_change.status)
+        );
+      }
+
       if (BLEDevice::m_securityCallbacks != nullptr) {
-        BLEDevice::m_securityCallbacks->onAuthenticationComplete(&desc);
+        BLEDevice::m_securityCallbacks->onAuthenticationComplete(&desc, event->enc_change.status);
       }
 
       return 0;
     }  // BLE_GAP_EVENT_ENC_CHANGE
+
+    case BLE_GAP_EVENT_PARING_COMPLETE:  // Name is misspelled in NimBLE
+    {
+      // Reported before the keys are persisted, and carries the SMP reason code that
+      // BLE_GAP_EVENT_ENC_CHANGE does not.
+      if (event->pairing_complete.status == 0) {
+        log_i("Pairing complete: handle=%u", event->pairing_complete.conn_handle);
+      } else {
+        log_e(
+          "Pairing failed: handle=%u, SMP reason=%u, %s", event->pairing_complete.conn_handle, event->pairing_complete.status,
+          BLEUtils::smErrorToString(event->pairing_complete.status)
+        );
+      }
+
+      return 0;
+    }  // BLE_GAP_EVENT_PARING_COMPLETE
 
     case BLE_GAP_EVENT_PASSKEY_ACTION:
     {

--- a/libraries/BLE/src/BLEUtils.cpp
+++ b/libraries/BLE/src/BLEUtils.cpp
@@ -869,6 +869,48 @@ String BLEUtils::adFlagsToString(uint8_t adFlags) {
   return res;
 }  // adFlagsToString
 
+/**
+ * @brief Convert a Bluedroid authentication failure reason to a string representation.
+ *
+ * The table is only compiled in when the error log level is enabled, since that is the
+ * only place these strings are consumed.
+ *
+ * @param [in] reason The reason reported in esp_ble_auth_cmpl_t::fail_reason.
+ * @return A string representation of the failure reason.
+ */
+const char *BLEUtils::authFailReasonToString(esp_ble_auth_fail_rsn_t reason) {
+  switch (reason) {
+#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_ERROR
+    case ESP_AUTH_SMP_PASSKEY_FAIL:            return "Passkey entry failed or was canceled by the user";
+    case ESP_AUTH_SMP_OOB_FAIL:                return "OOB data is not available";
+    case ESP_AUTH_SMP_PAIR_AUTH_FAIL:          return "Authentication requirements cannot be met with these IO capabilities";
+    case ESP_AUTH_SMP_CONFIRM_VALUE_FAIL:      return "Confirm value does not match the calculated compare value";
+    case ESP_AUTH_SMP_PAIR_NOT_SUPPORT:        return "Pairing is not supported by the peer";
+    case ESP_AUTH_SMP_ENC_KEY_SIZE:            return "Resultant encryption key size is insufficient";
+    case ESP_AUTH_SMP_INVALID_CMD:             return "SMP command is not supported by the peer";
+    case ESP_AUTH_SMP_UNKNOWN_ERR:             return "Pairing failed for an unspecified reason";
+    case ESP_AUTH_SMP_REPEATED_ATTEMPT:        return "Too little time has elapsed since the last pairing or security request";
+    case ESP_AUTH_SMP_INVALID_PARAMETERS:      return "Command length is invalid or a parameter is out of range";
+    case ESP_AUTH_SMP_DHKEY_CHK_FAIL:          return "DHKey check value does not match the one calculated locally";
+    case ESP_AUTH_SMP_NUM_COMP_FAIL:           return "Numeric comparison values do not match";
+    case ESP_AUTH_SMP_BR_PARING_IN_PROGR:      return "Pairing over BR/EDR is already in progress";
+    case ESP_AUTH_SMP_XTRANS_DERIVE_NOT_ALLOW: return "BR/EDR link key cannot be used to derive LE transport keys";
+    case ESP_AUTH_SMP_INTERNAL_ERR:            return "Internal error in the pairing procedure";
+    case ESP_AUTH_SMP_UNKNOWN_IO:              return "Unknown IO capability, unable to decide the association model";
+    case ESP_AUTH_SMP_INIT_FAIL:               return "SMP pairing initiation failed";
+    case ESP_AUTH_SMP_CONFIRM_FAIL:            return "Confirm value does not match";
+    case ESP_AUTH_SMP_BUSY:                    return "A security request is already in progress";
+    case ESP_AUTH_SMP_ENC_FAIL:                return "The controller failed to start encryption";
+    case ESP_AUTH_SMP_STARTED:                 return "SMP pairing process started";
+    case ESP_AUTH_SMP_RSP_TIMEOUT:             return "Timed out waiting for an SMP command";
+    case ESP_AUTH_SMP_DIV_NOT_AVAIL:           return "Encrypted Diversifier value not available";
+    case ESP_AUTH_SMP_UNSPEC_ERR:              return "Unspecified failure reason";
+    case ESP_AUTH_SMP_CONN_TOUT:               return "Pairing failed due to a connection timeout";
+#endif
+    default: return "Unknown";
+  }
+}  // authFailReasonToString
+
 esp_gatt_id_t BLEUtils::buildGattId(esp_bt_uuid_t uuid, uint8_t inst_id) {
   esp_gatt_id_t retGattId;
   retGattId.uuid = uuid;
@@ -2119,6 +2161,41 @@ const char *BLEUtils::returnCodeToString(int rc) {
 }
 
 /**
+ * @brief Converts a raw SMP pairing failure reason to a text string.
+ *
+ * BLE_GAP_EVENT_PARING_COMPLETE reports the reason as a bare SMP code, unlike most
+ * NimBLE status values which are namespaced BLE_HS_* codes handled by returnCodeToString().
+ *
+ * The table is only compiled in when the error log level is enabled, since that is the
+ * only place these strings are consumed.
+ *
+ * @param [in] smErr The SMP reason code (Core spec Vol 3, Part H, 3.5.5).
+ * @return A string representation of the reason code.
+ */
+const char *BLEUtils::smErrorToString(uint8_t smErr) {
+  switch (smErr) {
+#if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_ERROR
+    case 0:                           return "Success";
+    case BLE_SM_ERR_PASSKEY:          return "Passkey entry failed or was canceled by the user";
+    case BLE_SM_ERR_OOB:              return "OOB data is not available";
+    case BLE_SM_ERR_AUTHREQ:          return "Authentication requirements cannot be met with these IO capabilities";
+    case BLE_SM_ERR_CONFIRM_MISMATCH: return "Confirm value does not match the calculated compare value";
+    case BLE_SM_ERR_PAIR_NOT_SUPP:    return "Pairing is not supported by the peer";
+    case BLE_SM_ERR_ENC_KEY_SZ:       return "Resultant encryption key size is insufficient";
+    case BLE_SM_ERR_CMD_NOT_SUPP:     return "SMP command is not supported by the peer";
+    case BLE_SM_ERR_UNSPECIFIED:      return "Pairing failed for an unspecified reason";
+    case BLE_SM_ERR_REPEATED:         return "Too little time has elapsed since the last pairing or security request";
+    case BLE_SM_ERR_INVAL:            return "Command length is invalid or a parameter is out of range";
+    case BLE_SM_ERR_DHKEY:            return "DHKey check value does not match the one calculated locally";
+    case BLE_SM_ERR_NUMCMP:           return "Numeric comparison values do not match";
+    case BLE_SM_ERR_ALREADY:          return "Pairing over BR/EDR is already in progress";
+    case BLE_SM_ERR_CROSS_TRANS:      return "BR/EDR link key cannot be used to derive LE transport keys";
+#endif
+    default: return "Unknown";
+  }
+}
+
+/**
  * @brief Utility function to log the gap event info.
  * @param [in] event A pointer to the gap event structure.
  * @param [in] arg Unused.
@@ -2209,6 +2286,19 @@ const char *BLEUtils::gapEventToString(uint8_t eventType) {
     case BLE_GAP_EVENT_SCAN_REQ_RCVD:  //23
       return "BLE_GAP_EVENT_SCAN_REQ_RCVD";
 #endif
+
+    case BLE_GAP_EVENT_PARING_COMPLETE:  //27, name is misspelled in NimBLE
+      return "BLE_GAP_EVENT_PAIRING_COMPLETE";
+
+    case BLE_GAP_EVENT_SUBRATE_CHANGE:  //28
+      return "BLE_GAP_EVENT_SUBRATE_CHANGE";
+
+    case BLE_GAP_EVENT_DATA_LEN_CHG:  //34
+      return "BLE_GAP_EVENT_DATA_LEN_CHG";
+
+    case BLE_GAP_EVENT_LINK_ESTAB:  //38
+      return "BLE_GAP_EVENT_LINK_ESTAB";
+
     default: log_d("gapEventToString: Unknown event type %d 0x%02x", eventType, eventType); return "Unknown event type";
   }
 #else   // #if defined(CONFIG_NIMBLE_ENABLE_GAP_EVENT_CODE_TEXT)

--- a/libraries/BLE/src/BLEUtils.h
+++ b/libraries/BLE/src/BLEUtils.h
@@ -127,6 +127,7 @@ public:
 #if defined(CONFIG_BLUEDROID_ENABLED)
   static const char *addressTypeToString(esp_ble_addr_type_t type);
   static String adFlagsToString(uint8_t adFlags);
+  static const char *authFailReasonToString(esp_ble_auth_fail_rsn_t reason);
   static const char *devTypeToString(esp_bt_dev_type_t type);
   static esp_gatt_id_t buildGattId(esp_bt_uuid_t uuid, uint8_t inst_id = 0);
   static esp_gatt_srvc_id_t buildGattSrvcId(esp_gatt_id_t gattId, bool is_primary = true);
@@ -160,6 +161,7 @@ public:
   static void dumpGapEvent(ble_gap_event *event, void *arg);
   static const char *gapEventToString(uint8_t eventType);
   static const char *returnCodeToString(int rc);
+  static const char *smErrorToString(uint8_t smErr);
   static int checkConnParams(ble_gap_conn_params *params);
   static bool taskWait(const BLETaskData &taskData, uint32_t timeout);
   static void taskRelease(const BLETaskData &taskData, int rc = 0);

--- a/tests/validation/ble/README.md
+++ b/tests/validation/ble/README.md
@@ -1,6 +1,6 @@
 # BLE Validation Test
 
-Validates BLE secure connection between a server and client using Numeric Comparison pairing, characteristic read/write operations, and IRK (Identity Resolving Key) retrieval. This is a **multi-DUT** test supporting both Bluedroid and NimBLE stacks.
+Validates BLE secure connection between a server and client using both MITM pairing methods (Numeric Comparison and Passkey Entry), characteristic read/write operations, and IRK (Identity Resolving Key) retrieval. This is a **multi-DUT** test supporting both Bluedroid and NimBLE stacks.
 
 ## Architecture
 
@@ -28,6 +28,8 @@ Validates BLE secure connection between a server and client using Numeric Compar
 | Write-NR characteristic | Serve Write / Write-Without-Response; capture burst payloads in `onWrite()` (issue #12815) |
 | Heap integrity | `heap_caps_check_integrity_all()` before and after `BLEDevice::init()` (issue #12821) |
 | Numeric Comparison PIN | Display and auto-confirm pairing PIN |
+| Passkey Entry | Switch to DisplayOnly with a static passkey and report it through `onPassKeyNotify()` (issue #12860) |
+| Authentication result | Report success and failure separately, so a rejected pairing cannot look like a successful one |
 | IRK retrieval | Retrieve and print the peer's Identity Resolving Key after authentication |
 | Malformed advertisement data | Advertise deliberately malformed AD structures so the client can prove its parser rejects them |
 
@@ -39,6 +41,8 @@ Validates BLE secure connection between a server and client using Numeric Compar
 | Insecure characteristic read | Read unprotected characteristic value without authentication |
 | Secure characteristic read | Read protected characteristic, triggering on-demand authentication |
 | Numeric Comparison PIN | Display and auto-confirm pairing PIN (must match server) |
+| Passkey Entry, correct passkey | Switch to KeyboardOnly, pair with `123456`; must succeed and produce a bond (issue #12860) |
+| Passkey Entry, wrong passkey | Pair with `654321` against the server's `123456`; must be rejected *and* reported as a failure |
 | IRK retrieval | Retrieve and print the peer's Identity Resolving Key after authentication |
 | Write/read operations | Write and read back values on both secure and insecure characteristics |
 | Write-NR burst | Three back-to-back Write-Without-Response packets (`AA`, `BB`, `CC`) with no delay (issue #12815) |
@@ -64,6 +68,34 @@ payload to be observable.
 Window 2 is entered on demand: pytest sends `ADPHASE2` to the server, waits for
 it to re-advertise, then sends `ADPHASE2` to the client to trigger a rescan.
 
+## Pairing Method Coverage
+
+Both MITM pairing methods are exercised against the same pair of devices. The
+capabilities are switched at runtime, so no second sketch is needed.
+
+| Phase | Server capability | Client capability | Method selected |
+|---|---|---|---|
+| Main test | DisplayYesNo | DisplayYesNo | Numeric Comparison |
+| `PSKPHASE` | DisplayOnly | KeyboardOnly | Passkey Entry |
+
+Passkey Entry is the method used by the `Server_secure_static_passkey` and
+`Client_secure_static_passkey` examples, and the one reported in issue #12860.
+Each side drops its bonds before an attempt, otherwise the link would simply be
+re-encrypted with the stored LTK and the pairing method would never run again.
+
+The wrong-passkey attempt is what pins down the regression behind #12860. The
+NimBLE path used to invoke `onAuthenticationComplete()` from
+`BLE_GAP_EVENT_ENC_CHANGE` without inspecting `enc_change.status`, so a rejected
+pairing produced exactly the same callback as a successful one. The failure only
+surfaced later as an unexplained missing IRK or a read that returned nothing. The
+test asserts that both sides report the failure, while the correct-passkey attempt
+that runs first stops a stack that simply reports failure for everything from
+passing.
+
+The correct passkey is tried first on purpose: a peer that has just rejected a
+pairing answers the next attempt with `Repeated Attempts` (SMP reason 9) instead
+of running Passkey Entry again, which would mask the real result.
+
 ## Requirements
 
 - **Hardware**: Two boards with BLE support (e.g. ESP32, ESP32-S3)
@@ -84,10 +116,12 @@ it to re-advertise, then sends `ADPHASE2` to the client to trigger a rescan.
 9. Client performs write/read on both characteristics
 10. Client sends a 3-packet Write-Without-Response burst; server must report `AA AA AA`, `BB BB BB`, `CC CC CC`
 11. Heap integrity is checked around `BLEDevice::init()` on both devices (and again on the server after the burst)
-12. pytest sends `ADPHASE2` to both devices to run the second advertisement parsing window
+12. pytest sends `PSKPHASE` to both devices to switch capabilities and run the two Passkey Entry attempts
+13. pytest sends `ADPHASE2` to both devices to run the second advertisement parsing window
 
 ## Notes
 
 - NVS is erased at startup to ensure fresh pairing on every run.
 - Authentication is triggered on-demand (when reading the secure characteristic) rather than on connect, ensuring consistent ordering across Bluedroid and NimBLE.
 - The test verifies PIN match between server and client via assertion.
+- ESP32-P4 over ESP-Hosted is excluded in `ci.yml` because there are no `two_duts` runners for it. Note that LE Secure Connections pairing currently fails on that target for a reason outside this repository (the DHKey check fails regardless of the pairing method, while legacy pairing succeeds), so this test would not pass there today.

--- a/tests/validation/ble/client/client.ino
+++ b/tests/validation/ble/client/client.ino
@@ -199,11 +199,26 @@ bool connectToServer() {
   pRemoteSecureCharacteristic->setAuth(ESP_GATT_AUTH_REQ_MITM);
 
   // Read secure characteristic (triggers on-demand authentication for both stacks)
+  authResult = AUTH_PENDING;
   if (pRemoteSecureCharacteristic->canRead()) {
     Serial.println("[CLIENT] Reading secure characteristic...");
     String value = pRemoteSecureCharacteristic->readValue();
     Serial.print("[CLIENT] Secure characteristic value: ");
     Serial.println(value.c_str());
+  }
+
+  // The read above only triggers pairing; the outcome arrives asynchronously through
+  // the security callbacks. Reporting success without checking it is exactly what made
+  // the failure in issue #12860 look like a working pairing.
+  unsigned long authStart = millis();
+  while (authResult == AUTH_PENDING && (millis() - authStart) < 10000) {
+    delay(50);
+  }
+
+  if (authResult != AUTH_SUCCESS) {
+    Serial.println("[CLIENT] ERROR: Authentication did not complete successfully");
+    pClient->disconnect();
+    return false;
   }
 
   connected = true;

--- a/tests/validation/ble/client/client.ino
+++ b/tests/validation/ble/client/client.ino
@@ -27,6 +27,19 @@ static boolean doConnect = false;
 static boolean connected = false;
 static boolean doScan = false;
 static boolean testCompleted = false;
+
+// Static passkeys for the Passkey Entry phase. The wrong one must be rejected.
+static const uint32_t PASSKEY_CORRECT = 123456;
+static const uint32_t PASSKEY_WRONG = 654321;
+
+// Outcome of the most recent pairing attempt, written from the security callbacks.
+enum AuthResult {
+  AUTH_PENDING,
+  AUTH_SUCCESS,
+  AUTH_FAILURE
+};
+static volatile AuthResult authResult = AUTH_PENDING;
+
 static int adPhase = 1;
 static boolean adPhase2Reported = false;
 static BLEClient *pClient = nullptr;
@@ -60,8 +73,26 @@ class MySecurityCallbacks : public BLESecurityCallbacks {
     return true;
   }
 
+  // Passkey Entry phase only. With KeyboardOnly capability the stack asks us for the
+  // passkey the peer displays. A static passkey is configured, so this only runs if
+  // that lookup ever fails.
+  uint32_t onPassKeyRequest() override {
+    uint32_t passkey = BLESecurity::getPassKey();
+    Serial.printf("[CLIENT] Passkey request, injecting: %06lu\n", (unsigned long)passkey);
+    return passkey;
+  }
+
 #if defined(CONFIG_BLUEDROID_ENABLED)
   void onAuthenticationComplete(esp_ble_auth_cmpl_t desc) override {
+    // Bluedroid reports both outcomes through this callback, so the result has to be
+    // checked here. Without it a rejected pairing looks exactly like a successful one.
+    if (!desc.success) {
+      authResult = AUTH_FAILURE;
+      Serial.printf("[CLIENT] Authentication failed: reason=%u (0x%02X)\n", desc.fail_reason, desc.fail_reason);
+      return;
+    }
+
+    authResult = AUTH_SUCCESS;
     BLEAddress peerAddr(desc.bd_addr);
     Serial.println("[CLIENT] Authentication complete");
 
@@ -83,7 +114,16 @@ class MySecurityCallbacks : public BLESecurityCallbacks {
 #endif
 
 #if defined(CONFIG_NIMBLE_ENABLED)
-  void onAuthenticationComplete(ble_gap_conn_desc *desc) override {
+  // The status-aware overload is used so a rejected pairing is reported instead of
+  // silently looking like a successful one.
+  void onAuthenticationComplete(ble_gap_conn_desc *desc, int status) override {
+    if (status != 0) {
+      authResult = AUTH_FAILURE;
+      Serial.printf("[CLIENT] Authentication failed: status=%d\n", status);
+      return;
+    }
+
+    authResult = AUTH_SUCCESS;
     BLEAddress peerAddr(desc->peer_id_addr.val, desc->peer_id_addr.type);
     Serial.println("[CLIENT] Authentication complete");
 
@@ -270,6 +310,95 @@ bool runReconnectPhase(uint16_t preseed, const char *label) {
   return true;
 }
 
+// Drops every bond this device holds. Without this the next attempt would re-encrypt
+// the link with the stored LTK and never run Passkey Entry again.
+static void forgetBonds() {
+#if defined(CONFIG_BLUEDROID_ENABLED)
+  int count = esp_ble_get_bond_device_num();
+  if (count > 0) {
+    esp_ble_bond_dev_t *list = (esp_ble_bond_dev_t *)malloc(sizeof(esp_ble_bond_dev_t) * count);
+    if (list != nullptr) {
+      esp_ble_get_bond_device_list(&count, list);
+      for (int i = 0; i < count; i++) {
+        esp_ble_remove_bond_device(list[i].bd_addr);
+      }
+      free(list);
+    }
+  }
+#elif defined(CONFIG_NIMBLE_ENABLED)
+  ble_store_clear();
+#endif
+}
+
+// One Passkey Entry attempt: connect, discover, then read the secure characteristic
+// to trigger on-demand pairing with the given passkey. Reports whether the peer
+// accepted it. A pairing that never completes is reported as a rejection so the test
+// cannot hang on a stack that goes silent.
+static bool runPasskeyAttempt(const char *label, uint32_t passkey) {
+  forgetBonds();
+  BLESecurity::setPassKey(true, passkey);
+
+  authResult = AUTH_PENDING;
+
+  BLEClient *pPasskeyClient = BLEDevice::createClient();
+  if (pPasskeyClient == nullptr) {
+    Serial.printf("[CLIENT] %s FAILED: createClient returned null\n", label);
+    return false;
+  }
+
+  if (!pPasskeyClient->connect(myDevice->getAddress(), myDevice->getAddressType(), 10000)) {
+    Serial.printf("[CLIENT] %s FAILED: connect failed\n", label);
+    delete pPasskeyClient;
+    return false;
+  }
+
+  bool paired = false;
+  BLERemoteService *pSvc = pPasskeyClient->getService(serviceUUID);
+  if (pSvc == nullptr) {
+    Serial.printf("[CLIENT] %s FAILED: service not found\n", label);
+  } else {
+    BLERemoteCharacteristic *pChr = pSvc->getCharacteristic(secureCharUUID);
+    if (pChr == nullptr) {
+      Serial.printf("[CLIENT] %s FAILED: secure characteristic not found\n", label);
+    } else {
+      pChr->setAuth(ESP_GATT_AUTH_REQ_MITM);
+      Serial.printf("[CLIENT] %s reading secure characteristic\n", label);
+      pChr->readValue();
+
+      unsigned long start = millis();
+      while (authResult == AUTH_PENDING && (millis() - start) < 30000) {
+        delay(50);
+      }
+      paired = (authResult == AUTH_SUCCESS);
+    }
+  }
+
+  pPasskeyClient->disconnect();
+  delete pPasskeyClient;
+  // Give both sides time to tear the link down and restart advertising.
+  delay(2000);
+
+  Serial.printf("[CLIENT] %s result: %s\n", label, paired ? "PAIRED" : "REJECTED");
+  return paired;
+}
+
+// Passkey Entry coverage. The correct passkey runs first: a peer that has just
+// rejected a pairing answers the next attempt with "Repeated Attempts" (SMP reason 9)
+// rather than running Passkey Entry again, which would mask the real result.
+void runPasskeyPhase() {
+  Serial.println("[CLIENT] Starting passkey entry phase");
+  BLESecurity::setCapability(ESP_IO_CAP_IN);
+
+  bool correctPaired = runPasskeyAttempt("Passkey correct", PASSKEY_CORRECT);
+  bool wrongPaired = runPasskeyAttempt("Passkey wrong", PASSKEY_WRONG);
+
+  if (correctPaired && !wrongPaired) {
+    Serial.println("[CLIENT] Passkey entry phase PASSED");
+  } else {
+    Serial.println("[CLIENT] Passkey entry phase FAILED");
+  }
+}
+
 void readServerName() {
   Serial.println("[CLIENT] Waiting for server name...");
   Serial.println("[CLIENT] Send server name:");
@@ -339,6 +468,8 @@ void loop() {
     command.trim();
     if (command == "ADPHASE2") {
       runAdPhase2Scan();
+    } else if (command == "PSKPHASE") {
+      runPasskeyPhase();
     }
   }
 

--- a/tests/validation/ble/server/server.ino
+++ b/tests/validation/ble/server/server.ino
@@ -11,6 +11,9 @@
 #define SECURE_CHARACTERISTIC_UUID   "ff1d2614-e2d6-4c87-9154-6625d39ca7f8"
 #define WRITE_NR_CHARACTERISTIC_UUID "d7c1aa01-36e1-4688-b7f5-ea07361b26a8"
 
+// Static passkey used by the Passkey Entry phase.
+#define PASSKEY_PIN 123456
+
 static const int WRITE_NR_BURST_COUNT = 3;
 static const uint8_t WRITE_NR_EXPECTED[WRITE_NR_BURST_COUNT][3] = {
   {0xAA, 0xAA, 0xAA},
@@ -87,8 +90,22 @@ class MySecurityCallbacks : public BLESecurityCallbacks {
     return true;
   }
 
+  // Passkey Entry phase only. With DisplayOnly capability the stack asks us to show
+  // the passkey the peer has to enter, which is how the test tells the two pairing
+  // methods apart: Numeric Comparison would call onConfirmPIN() instead.
+  void onPassKeyNotify(uint32_t passkey) override {
+    Serial.printf("[SERVER] Passkey notify: %06lu\n", (unsigned long)passkey);
+  }
+
 #if defined(CONFIG_BLUEDROID_ENABLED)
   void onAuthenticationComplete(esp_ble_auth_cmpl_t desc) override {
+    // Bluedroid reports both outcomes through this callback, so the result has to be
+    // checked here. Without it a rejected pairing looks exactly like a successful one.
+    if (!desc.success) {
+      Serial.printf("[SERVER] Authentication failed: reason=%u (0x%02X)\n", desc.fail_reason, desc.fail_reason);
+      return;
+    }
+
     BLEAddress peerAddr(desc.bd_addr);
     Serial.println("[SERVER] Authentication complete");
 
@@ -110,7 +127,14 @@ class MySecurityCallbacks : public BLESecurityCallbacks {
 #endif
 
 #if defined(CONFIG_NIMBLE_ENABLED)
-  void onAuthenticationComplete(ble_gap_conn_desc *desc) override {
+  // The status-aware overload is used so a rejected pairing is reported instead of
+  // silently looking like a successful one.
+  void onAuthenticationComplete(ble_gap_conn_desc *desc, int status) override {
+    if (status != 0) {
+      Serial.printf("[SERVER] Authentication failed: status=%d\n", status);
+      return;
+    }
+
     BLEAddress peerAddr(desc->peer_id_addr.val, desc->peer_id_addr.type);
     Serial.println("[SERVER] Authentication complete");
 
@@ -281,6 +305,37 @@ void setup() {
   Serial.printf("[SERVER] Service UUID: %s\n", SERVICE_UUID);
 }
 
+// Drops every bond this device holds. Without this the next pairing attempt would
+// re-encrypt the link with the stored LTK instead of running the pairing method
+// the test wants to exercise.
+static void forgetBonds() {
+#if defined(CONFIG_BLUEDROID_ENABLED)
+  int count = esp_ble_get_bond_device_num();
+  if (count > 0) {
+    esp_ble_bond_dev_t *list = (esp_ble_bond_dev_t *)malloc(sizeof(esp_ble_bond_dev_t) * count);
+    if (list != nullptr) {
+      esp_ble_get_bond_device_list(&count, list);
+      for (int i = 0; i < count; i++) {
+        esp_ble_remove_bond_device(list[i].bd_addr);
+      }
+      free(list);
+    }
+  }
+#elif defined(CONFIG_NIMBLE_ENABLED)
+  ble_store_clear();
+#endif
+}
+
+// Switch from Numeric Comparison to Passkey Entry. DisplayOnly here against
+// KeyboardOnly on the client selects Passkey Entry, which is the method used by the
+// Server_secure_static_passkey example and the one reported broken in issue #12860.
+static void startPasskeyPhase() {
+  forgetBonds();
+  BLESecurity::setPassKey(true, PASSKEY_PIN);
+  BLESecurity::setCapability(ESP_IO_CAP_OUT);
+  Serial.println("[SERVER] Passkey entry mode ready");
+}
+
 // Swap the scan response for the window 2 payload (32-bit guard + terminator).
 void startAdvertisingPhase2() {
   BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
@@ -323,6 +378,8 @@ void loop() {
     command.trim();
     if (command == "ADPHASE2") {
       startAdvertisingPhase2();
+    } else if (command == "PSKPHASE") {
+      startPasskeyPhase();
     }
   }
 

--- a/tests/validation/ble/test_ble.py
+++ b/tests/validation/ble/test_ble.py
@@ -200,6 +200,46 @@ def test_ble(dut, ci_job_id):
     client.expect_exact("[CLIENT] Reconnection stress test PASSED", timeout=10)
     LOGGER.info("Reconnection stress test passed")
 
+    # --- Passkey Entry pairing (issue #12860) ---
+    # Everything above pairs with Numeric Comparison (DisplayYesNo on both sides).
+    # Both devices now switch to the other MITM method, the one used by the
+    # Server_secure_static_passkey example: DisplayOnly on the server against
+    # KeyboardOnly on the client, with a static passkey.
+    LOGGER.info("Switching both devices to Passkey Entry...")
+    server.write("PSKPHASE")
+    server.expect_exact("[SERVER] Passkey entry mode ready", timeout=15)
+    client.write("PSKPHASE")
+    client.expect_exact("[CLIENT] Starting passkey entry phase", timeout=15)
+
+    # Correct passkey must pair. The server being asked to *display* the passkey is
+    # what proves Passkey Entry was selected rather than Numeric Comparison.
+    LOGGER.info("Pairing with the correct passkey...")
+    client.expect_exact("[CLIENT] Passkey correct reading secure characteristic", timeout=30)
+    m = server.expect(r"\[SERVER\] Passkey notify: (\d{6})", timeout=30)
+    server_passkey = m.group(1).decode()
+    assert server_passkey == "123456", f"server displayed an unexpected passkey: {server_passkey}"
+    LOGGER.info(f"Server displayed passkey: {server_passkey}")
+
+    client.expect_exact("[CLIENT] Authentication complete", timeout=40)
+    server.expect_exact("[SERVER] Authentication complete", timeout=30)
+    m = client.expect(r"\[CLIENT\] Passkey correct result: (PAIRED|REJECTED)", timeout=15)
+    assert m.group(1).decode() == "PAIRED", "pairing failed with the correct passkey"
+    LOGGER.info("Passkey Entry paired as expected")
+
+    # Wrong passkey must be rejected, and the rejection must actually be reported.
+    # Before issue #12860 the NimBLE path invoked onAuthenticationComplete() without
+    # inspecting the status, so a rejected pairing was indistinguishable from success.
+    LOGGER.info("Pairing with the wrong passkey...")
+    client.expect_exact("[CLIENT] Passkey wrong reading secure characteristic", timeout=30)
+    server.expect(r"\[SERVER\] Passkey notify: (\d{6})", timeout=30)
+    client.expect(r"\[CLIENT\] Authentication failed: (status|reason)=", timeout=40)
+    server.expect(r"\[SERVER\] Authentication failed: (status|reason)=", timeout=20)
+    m = client.expect(r"\[CLIENT\] Passkey wrong result: (PAIRED|REJECTED)", timeout=15)
+    assert m.group(1).decode() == "REJECTED", "pairing succeeded with the wrong passkey"
+    LOGGER.info("Passkey Entry rejected the wrong passkey as expected")
+
+    client.expect_exact("[CLIENT] Passkey entry phase PASSED", timeout=10)
+
     # Advertisement parsing regression, window 2. The server now advertises a 32-bit
     # UUID list with a trailing partial group followed by a zero-length terminator
     # that hides manufacturer data. Parsing must stop at the terminator.


### PR DESCRIPTION
## Description of Change

This pull request makes several improvements to BLE security event handling and logging, especially around authentication and pairing outcomes. It clarifies callback semantics, ensures failures are not mistaken for successes, and adds user-friendly error messages. The changes also improve the documentation and output in BLE example sketches.

**Key changes include:**

### Security Event Handling and Callbacks

* Added a new overload `onAuthenticationComplete(ble_gap_conn_desc *desc, int status)` to `BLESecurityCallbacks`, which is called for both successful and failed authentications, ensuring failures are properly reported and not mistaken for successes. The default implementation logs the outcome and forwards successes to the original callback. 
* Updated BLE client and server event handlers to use the new callback, passing the authentication status, and improved logging for encryption and pairing events, including clear output for failures and bond deletion when keys are missing.

### Error Reporting and Logging

* Added human-readable string conversion functions for authentication and SMP pairing failure reasons (`authFailReasonToString`, `smErrorToString`) and integrated them into error logs for better debugging and user feedback.
* Improved the log output in example sketches and core code to clarify when a peer does not distribute its Identity Key, and to distinguish between expected and unexpected authentication failures. 

### Example Sketches and Documentation

* Updated example sketches to clarify when failure to retrieve a peer IRK is expected, and improved comments to help users understand pairing and bonding behaviors.

### Internal Logic Improvements

* Improved the logic in `waitForAuthenticationComplete` to handle cases where security was never started, preventing unnecessary errors.
* Added new GAP event string mappings and improved event code handling for NimBLE.

These changes collectively make BLE authentication and pairing more robust, transparent, and easier to debug for both developers and users.

## Test Scenarios

Tested locally
