### PR TITLE
fix(hosted): Pin version for lower hosted RAM usage

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -120,7 +120,7 @@ dependencies:
       - if: "target in [esp32s3, esp32p4]"
       - if: idf_version < 6.0
   espressif/esp_hosted:
-    version: "^2.9.2"
+    version: "2.12.3"
     rules:
       - if: "target == esp32p4"
   espressif/esp_wifi_remote:


### PR DESCRIPTION
This pull request updates the version constraint for the `espressif/esp_hosted` dependency in the `idf_component.yml` file. The new version ensures compatibility with recent changes and bug fixes.

Dependency updates:

* Updated the `espressif/esp_hosted` dependency version from `^2.9.2` to `2.12.3` in `idf_component.yml` to use the latest stable release.