### PR TITLE
feat(matter): add MatterSoilSensor endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ set(ARDUINO_LIBRARY_Matter_SRCS
   libraries/Matter/src/MatterEndpoints/MatterThermostat.cpp
   libraries/Matter/src/MatterEndpoints/MatterWindowCovering.cpp
   libraries/Matter/src/MatterEndpoints/MatterLightSensor.cpp
+  libraries/Matter/src/MatterEndpoints/MatterSoilSensor.cpp
   libraries/Matter/src/Matter.cpp
   libraries/Matter/src/MatterIdentity.cpp
   libraries/Matter/src/MatterEndPoint.cpp)

--- a/libraries/Matter/README.md
+++ b/libraries/Matter/README.md
@@ -91,6 +91,12 @@ Key rules:
 - **Call the setter after `Matter.begin()`.** The cluster instance is not available before the stack starts. Sketches should `begin()` the endpoint, then `Matter.begin()`, then `setLeak()` / `setFreeze()` / `setRain()` / `setContact()` with the real sensor reading.
 - Do not use `updateAttributeVal()` for Boolean State `StateValue`, and do not use CHIP's `BooleanState::FindClusterOnEndpoint()` (ESP-Matter does not link that helper).
 
+### Code-Driven Clusters Without an ESP-Matter Wrapper (Soil Measurement)
+
+`MatterSoilSensor` uses the Soil Measurement cluster, which - unlike Boolean State - has no `esp_matter::endpoint::soil_sensor` / `esp_matter::cluster::soil_measurement` convenience wrapper yet. `MatterSoilSensor.cpp` builds the endpoint from the generic low-level API (`endpoint::create()`, `cluster::descriptor::create()`, `cluster::identify::create()`, `add_device_type()`) and plugs the cluster in itself, the same way ESP-Matter's own `data_model_provider/clusters/boolean_state_integration.cpp` does for Boolean State: a bare `cluster::create(endpoint, SoilMeasurement::Id, CLUSTER_FLAG_SERVER)` placeholder (for descriptor/introspection bookkeeping) with `cluster::set_init_and_shutdown_callbacks()` pointing at a local init callback that constructs a `chip::app::Clusters::SoilMeasurementCluster` and registers it with `esp_matter::data_model::provider::get_instance().registry()`.
+
+Like Boolean State, `SoilMoistureMeasuredValue` is then served by that live cluster instance, not the Ember attribute store - `setSoilMoisture()` looks it up through the registry and calls `SoilMeasurementCluster::SetSoilMoistureMeasuredValue()` directly, and `begin()` takes no initial value for the same reason (the cluster instance doesn't exist until the Matter stack starts).
+
 ### Controller-Originated Changes (attributeChangeCB)
 
 When a Matter controller changes an attribute (e.g., turning a light on via an app), the flow is:
@@ -160,6 +166,7 @@ All device classes inherit `MatterEndPoint`. After `begin()` and before `Matter.
 | `MatterWaterLeakDetector` | Water Leak Detector (Boolean State) |
 | `MatterWaterFreezeDetector` | Water Freeze Detector (Boolean State) |
 | `MatterRainSensor` | Rain Sensor (Boolean State) |
+| `MatterSoilSensor` | Soil Sensor (code-driven Soil Measurement cluster) |
 
 **Control and other**
 

--- a/libraries/Matter/examples/MatterSoilSensor/MatterSoilSensor.ino
+++ b/libraries/Matter/examples/MatterSoilSensor/MatterSoilSensor.ino
@@ -1,0 +1,151 @@
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * This example is an example code that will create a Matter Device which can be
+ * commissioned and controlled from a Matter Environment APP.
+ * Additionally the ESP32 will send debug messages indicating the Matter activity.
+ * Turning DEBUG Level ON may be useful to following Matter Accessory and Controller messages.
+ *
+ * The example will create a Matter Soil Sensor Device.
+ * begin() creates the endpoint with no initial reading. Call setSoilMoisture() after
+ * Matter.begin() with the real or simulated sensor reading.
+ * The Soil Measurement cluster only reports whole percent values [0..100] - there is no
+ * sub-percent precision, unlike e.g. MatterHumiditySensor.
+ *
+ * The onboard button can be kept pressed for 5 seconds to decommission the Matter Node.
+ * The example will also show the manual commissioning code and QR code to be used in the Matter environment.
+ *
+ */
+
+// Matter Manager
+#include <Arduino.h>
+#include <Matter.h>
+#if !CONFIG_ENABLE_CHIPOBLE
+// if the device can be commissioned using BLE, WiFi is not used - save flash space
+#include <WiFi.h>
+#endif
+
+// List of Matter Endpoints for this Node
+// Matter Soil Sensor Endpoint
+MatterSoilSensor SoilSensor;
+
+// CONFIG_ENABLE_CHIPOBLE is enabled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
+// WiFi is manually set and started
+const char *ssid = "your-ssid";          // Change this to your WiFi SSID
+const char *password = "your-password";  // Change this to your WiFi password
+#endif
+
+// set your board USER BUTTON pin here - decommissioning only
+const uint8_t buttonPin = BOOT_PIN;  // Set your pin here. Using BOOT Button.
+
+// Button control
+uint32_t button_time_stamp = 0;                // debouncing control
+bool button_state = false;                     // false = released | true = pressed
+const uint32_t decommissioningTimeout = 5000;  // keep the button pressed for 5s, or longer, to decommission
+
+// Simulate a soil moisture sensor - add your preferred soil moisture sensor library code here
+uint8_t getSimulatedSoilMoisture() {
+  // The Soil Measurement cluster only reports whole percent [0..100]
+  static uint8_t simulatedSoilMoistureHWSensor = 20;
+
+  // it will increase from 20% to 60% in 1% steps to simulate a soil moisture sensor
+  simulatedSoilMoistureHWSensor++;
+  if (simulatedSoilMoistureHWSensor > 60) {
+    simulatedSoilMoistureHWSensor = 20;
+  }
+
+  return simulatedSoilMoistureHWSensor;
+}
+
+void setup() {
+  // Initialize the USER BUTTON (Boot button) that will be used to decommission the Matter Node
+  pinMode(buttonPin, INPUT_PULLUP);
+
+  Serial.begin(115200);
+
+// CONFIG_ENABLE_CHIPOBLE is enabled when BLE is used to commission the Matter Network
+#if !CONFIG_ENABLE_CHIPOBLE
+  // Manually connect to WiFi
+  WiFi.begin(ssid, password);
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+#endif
+
+  // Create the endpoint. The live cluster isn't available yet; call setSoilMoisture() after Matter.begin().
+  SoilSensor.begin();
+
+  // Matter beginning - Last step, after all EndPoints are initialized
+  Matter.begin();
+
+  // set initial soil moisture measurement, now that the Matter stack (and the live cluster) has started
+  SoilSensor.setSoilMoisture(getSimulatedSoilMoisture());
+
+  // Check Matter Accessory Commissioning state, which may change during execution of loop()
+  if (!Matter.isDeviceCommissioned()) {
+    Serial.println("");
+    Serial.println("Matter Node is not commissioned yet.");
+    Serial.println("Initiate the device discovery in your Matter environment.");
+    Serial.println("Commission it to your Matter hub with the manual pairing code or QR code");
+    Serial.printf("Manual pairing code: %s\r\n", Matter.getManualPairingCode().c_str());
+    Serial.printf("QR code URL: %s\r\n", Matter.getOnboardingQRCodeUrl().c_str());
+    // waits for Matter Soil Sensor Commissioning.
+    uint32_t timeCount = 0;
+    while (!Matter.isDeviceCommissioned()) {
+      delay(100);
+      if ((timeCount++ % 50) == 0) {  // 50*100ms = 5 sec
+        Serial.println("Matter Node not commissioned yet. Waiting for commissioning.");
+      }
+    }
+    Serial.println("Matter Node is commissioned and connected to the network. Ready for use.");
+  }
+}
+
+void loop() {
+  static uint32_t timeCounter = 0;
+
+  // Print the current soil moisture value every 5s
+  if (!(timeCounter++ % 10)) {  // delaying for 500ms x 10 = 5s
+    // Print the current soil moisture value
+    Serial.printf("Current Soil Moisture is %u%%\r\n", SoilSensor.getSoilMoisture());
+    // Update Soil Moisture from the (Simulated) Hardware Sensor
+    // Matter APP shall display the updated soil moisture percent
+    SoilSensor.setSoilMoisture(getSimulatedSoilMoisture());
+  }
+
+  // Check if the button has been pressed
+  if (digitalRead(buttonPin) == LOW && !button_state) {
+    // deals with button debouncing
+    button_time_stamp = millis();  // record the time while the button is pressed.
+    button_state = true;           // pressed.
+  }
+
+  if (digitalRead(buttonPin) == HIGH && button_state) {
+    button_state = false;  // released
+  }
+
+  // Onboard User Button is kept pressed for longer than 5 seconds in order to decommission matter node
+  uint32_t time_diff = millis() - button_time_stamp;
+  if (button_state && time_diff > decommissioningTimeout) {
+    Serial.println("Decommissioning Soil Sensor Matter Accessory. It shall be commissioned again.");
+    Matter.decommission();
+  }
+
+  delay(500);
+}

--- a/libraries/Matter/examples/MatterSoilSensor/README.md
+++ b/libraries/Matter/examples/MatterSoilSensor/README.md
@@ -1,0 +1,191 @@
+# Matter Soil Sensor Example
+
+This example demonstrates how to create a Matter-compatible soil sensor device using an ESP32 SoC microcontroller.\
+The application showcases Matter commissioning, sensor data reporting to smart home ecosystems, and automatic simulation of soil moisture readings.
+
+## Supported Targets
+
+| SoC | Wi-Fi | Thread | BLE Commissioning | Status |
+| --- | ---- | ------ | ----------------- | ------ |
+| ESP32 | ✅ | ❌ | ❌ | Fully supported |
+| ESP32-S2 | ✅ | ❌ | ❌ | Fully supported |
+| ESP32-S3 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C3 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-C5 | ❌ | ✅ | ✅ | Supported (Thread only) |
+| ESP32-C6 | ✅ | ❌ | ✅ | Fully supported |
+| ESP32-H2 | ❌ | ✅ | ✅ | Supported (Thread only) |
+
+### Note on Commissioning:
+
+- **ESP32 & ESP32-S2** do not support commissioning over Bluetooth LE. For these chips, you must provide Wi-Fi credentials directly in the sketch code so they can connect to your network manually.
+- **ESP32-C6** Although it has Thread support, the ESP32 Arduino Matter Library has been pre compiled using Wi-Fi only. In order to configure it for Thread-only operation it is necessary to build the project using Arduino as an IDF Component and to disable the Matter Wi-Fi station feature.
+- **ESP32-C5** Although it has Wi-Fi 2.4 GHz and 5 GHz support, the ESP32 Arduino Matter Library has been pre compiled using Thread only. In order to configure it for Wi-Fi operation it is necessary to build the project using Arduino as an ESP-IDF component and disable Thread network, keeping only Wi-Fi station.
+
+## Features
+
+- Matter protocol implementation for a soil sensor device (Soil Measurement cluster, `0x0430`)
+- Support for both Wi-Fi and Thread(*) connectivity
+- Soil moisture measurement reporting, whole percent (0-100%)
+- Automatic simulation of soil moisture readings (20% to 60% range)
+- Periodic sensor updates every 5 seconds
+- Button control for factory reset (decommission)
+- Matter commissioning via QR code or manual pairing code
+- Integration with Apple HomeKit, Amazon Alexa, and Google Home
+- `begin()` creates the endpoint with no initial reading. Call `setSoilMoisture()` after `Matter.begin()` with the real or simulated sensor reading.
+(*) It is necessary to compile the project using Arduino as IDF Component.
+
+## Hardware Requirements
+
+- ESP32 compatible development board (see supported targets table)
+- User button for factory reset (uses BOOT button by default)
+- Optional: Connect a real soil moisture sensor (capacitive/resistive soil moisture probe, etc.) and replace the simulation function
+
+## Pin Configuration
+
+- **Button**: Uses `BOOT_PIN` by default
+
+## Software Setup
+
+### Prerequisites
+
+1. Install the Arduino IDE (2.0 or newer recommended)
+2. Install ESP32 Arduino Core with Matter support
+3. ESP32 Arduino libraries:
+   - `Matter`
+   - `Wi-Fi` (only for ESP32 and ESP32-S2)
+
+### Configuration
+
+Before uploading the sketch, configure the following:
+
+1. **Wi-Fi credentials** (if not using BLE commissioning - mandatory for ESP32 | ESP32-S2):
+   ```cpp
+   const char *ssid = "your-ssid";         // Change to your Wi-Fi SSID
+   const char *password = "your-password"; // Change to your Wi-Fi password
+   ```
+
+2. **Button pin configuration** (optional):
+   By default, the `BOOT` button (GPIO 0) is used for factory reset. You can change this to a different pin if needed.
+   ```cpp
+   const uint8_t buttonPin = BOOT_PIN;  // Set your button pin here
+   ```
+
+3. **Real sensor integration** (optional):
+   To use a real soil moisture sensor, replace the `getSimulatedSoilMoisture()` function with your sensor reading code. The function should return a `uint8_t` value representing soil moisture percentage (0-100%).
+
+## Building and Flashing
+
+1. Open the `MatterSoilSensor.ino` sketch in the Arduino IDE.
+2. Select your ESP32 board from the **Tools > Board** menu.
+<!-- vale off -->
+3. Select **"Huge APP (3MB No OTA/1MB SPIFFS)"** from **Tools > Partition Scheme** menu.
+<!-- vale on -->
+4. Enable **"Erase All Flash Before Sketch Upload"** option from **Tools** menu.
+5. Connect your ESP32 board to your computer via USB.
+6. Click the **Upload** button to compile and flash the sketch.
+
+## Expected Output
+
+Once the sketch is running, open the Serial Monitor at a baud rate of **115200**. The Wi-Fi connection messages will be displayed only for ESP32 and ESP32-S2. Other targets will use Matter CHIPoBLE to automatically setup the IP Network. You should see output similar to the following, which provides the necessary information for commissioning:
+
+```
+Connecting to your-wifi-ssid
+.......
+Wi-Fi connected
+IP address: 192.168.1.100
+
+Matter Node is not commissioned yet.
+Initiate the device discovery in your Matter environment.
+Commission it to your Matter hub with the manual pairing code or QR code
+Manual pairing code: 34970112332
+QR code URL: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A6FCJ142C00KA0648G00
+Matter Node not commissioned yet. Waiting for commissioning.
+Matter Node not commissioned yet. Waiting for commissioning.
+...
+Matter Node is commissioned and connected to the network. Ready for use.
+Current Soil Moisture is 21%
+Current Soil Moisture is 22%
+Current Soil Moisture is 23%
+...
+Current Soil Moisture is 60%
+Current Soil Moisture is 21%
+```
+
+## Using the Device
+
+### Manual Control
+
+The user button (BOOT button by default) provides factory reset functionality:
+
+- **Long press (>5 seconds)**: Factory reset the device (decommission)
+
+### Sensor Simulation
+
+The example includes a simulated soil moisture sensor that:
+
+- Starts at 20% soil moisture (initial value)
+- Cycles through 20% to 60% moisture range
+- Increases in 1% steps
+- Updates every 5 seconds
+- Resets to 20% when reaching 60%
+
+To use a real soil moisture sensor, replace the `getSimulatedSoilMoisture()` function with your sensor library code, mapping the raw reading to a `0-100` percent range.
+
+### Smart Home Integration
+
+Use a Matter-compatible hub (like an Apple HomePod, Google Nest Hub, or Amazon Echo) to commission the device.
+
+#### Apple Home
+
+1. Open the Home app on your iOS device
+2. Tap the "+" button > Add Accessory
+3. Scan the QR code displayed in the Serial Monitor, or
+4. Tap "I Don't Have a Code or Cannot Scan" and enter the manual pairing code
+5. Follow the prompts to complete setup
+6. The device will appear as a soil sensor in your Home app
+7. You can monitor the soil moisture readings and set up automations based on soil moisture levels
+
+#### Amazon Alexa
+
+1. Open the Alexa app
+2. Tap More > Add Device > Matter
+3. Select "Scan QR code" or "Enter code manually"
+4. Complete the setup process
+5. The soil sensor will appear in your Alexa app
+6. You can monitor soil moisture readings and create routines based on soil moisture levels
+
+#### Google Home
+
+1. Open the Google Home app
+2. Tap "+" > Set up device > New device
+3. Choose "Matter device"
+4. Scan the QR code or enter the manual pairing code
+5. Follow the prompts to complete setup
+6. You can monitor soil moisture readings and create automations based on soil moisture levels
+
+## Code Structure
+
+The MatterSoilSensor example consists of the following main components:
+
+1. **`setup()`**: Initializes hardware (button), configures Wi-Fi (if needed), creates the Matter Soil Sensor endpoint, starts the Matter stack, sets the initial value (20%), and waits for Matter commissioning.
+2. **`loop()`**: Displays the current soil moisture value every 5 seconds, updates the sensor reading from the simulated hardware sensor, handles button input for factory reset, and allows the Matter stack to process events.
+3. **`getSimulatedSoilMoisture()`**: Simulates a hardware soil moisture sensor by cycling through values from 20% to 60% in 1% steps. Replace this function with your actual sensor reading code.
+
+## Troubleshooting
+
+- **Device not visible during commissioning**: Ensure Wi-Fi or Thread connectivity is properly configured
+- **Soil moisture readings not updating**: Check that the sensor simulation function is being called correctly. For real sensors, verify sensor wiring and library initialization
+<!-- vale Microsoft.Percentages = NO -->
+- **Soil moisture values out of range**: Ensure soil moisture values are between 0-100%. Unlike some other Matter sensors, the Soil Measurement cluster only stores whole percent values, with no sub-percent precision
+<!-- vale Microsoft.Percentages = YES -->
+- **Failed to commission**: Try factory resetting the device by long-pressing the button. Other option would be to erase the SoC Flash Memory by using `Arduino IDE Menu` -> `Tools` -> `Erase All Flash Before Sketch Upload: "Enabled"` or directly with `esptool.py --port <PORT> erase_flash`
+- **No serial output**: Check baudrate (115200) and USB connection
+
+## Related Documentation
+
+- [Matter Overview](https://docs.espressif.com/projects/arduino-esp32/en/latest/matter/matter.html)
+- [Matter Endpoint Base Class](https://docs.espressif.com/projects/arduino-esp32/en/latest/matter/matter_ep.html)
+
+## License
+
+This example is licensed under the Apache License, Version 2.0.

--- a/libraries/Matter/examples/MatterSoilSensor/ci.yml
+++ b/libraries/Matter/examples/MatterSoilSensor/ci.yml
@@ -1,0 +1,4 @@
+fqbn_append: PartitionScheme=huge_app
+
+requires:
+  - CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y

--- a/libraries/Matter/keywords.txt
+++ b/libraries/Matter/keywords.txt
@@ -59,6 +59,7 @@ attrOperation_t	KEYWORD1
 OccupancySensorType_t	KEYWORD1
 HoldTimeChangeCB	KEYWORD1
 MatterLightSensor	KEYWORD1
+MatterSoilSensor	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -141,6 +142,8 @@ setSupportedTemperatureLevels	KEYWORD2
 getSupportedTemperatureLevelsCount	KEYWORD2
 setHumidity	KEYWORD2
 getHumidity	KEYWORD2
+setSoilMoisture	KEYWORD2
+getSoilMoisture	KEYWORD2
 setContact	KEYWORD2
 getContact	KEYWORD2
 setLeak	KEYWORD2

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -42,6 +42,7 @@
 #include <MatterEndpoints/MatterThermostat.h>
 #include <MatterEndpoints/MatterWindowCovering.h>
 #include <MatterEndpoints/MatterLightSensor.h>
+#include <MatterEndpoints/MatterSoilSensor.h>
 #include "matter_closure_patch.h"
 
 // Matter Event types used when there is a user callback for Matter Events
@@ -229,6 +230,7 @@ public:
   friend class MatterThermostat;
   friend class MatterWindowCovering;
   friend class MatterLightSensor;
+  friend class MatterSoilSensor;
 
 protected:
   static void _init();

--- a/libraries/Matter/src/MatterEndpoints/MatterSoilSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterSoilSensor.cpp
@@ -52,7 +52,7 @@ void ESPMatterSoilMeasurementClusterServerInitCallback(chip::EndpointId endpoint
 
   // SoilMoistureMeasurementLimits is mandatory and fixed for the lifetime of the cluster: report the
   // full [0..100] percent range this endpoint accepts, with no additional accuracy ranges.
-  SoilMeasurement::Attributes::SoilMoistureMeasurementLimits::TypeInfo::Type limits;
+  SoilMeasurement::Attributes::SoilMoistureMeasurementLimits::TypeInfo::Type limits{};
   limits.measurementType = Globals::MeasurementTypeEnum::kSoilMoisture;
   limits.measured = true;
   limits.minMeasuredValue = 0;

--- a/libraries/Matter/src/MatterEndpoints/MatterSoilSensor.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterSoilSensor.cpp
@@ -1,0 +1,198 @@
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sdkconfig.h>
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <Matter.h>
+#include <app/server/Server.h>
+#include <MatterEndpoints/MatterSoilSensor.h>
+#include <app/clusters/soil-measurement-server/soil-measurement-cluster.h>
+#include <clusters/SoilMeasurement/Attributes.h>
+#include <app/ClusterCallbacks.h>
+#include <app/PluginApplicationCallbacks.h>
+#include <data_model_provider/esp_matter_data_model_provider.h>
+#include <unordered_map>
+
+using namespace esp_matter;
+using namespace esp_matter::endpoint;
+using namespace chip::app::Clusters;
+
+// Soil Sensor device type (0x0045) - not yet defined by esp_matter_endpoint.h.
+static constexpr uint32_t kSoilSensorDeviceTypeId = 0x0045;
+static constexpr uint8_t kSoilSensorDeviceTypeVersion = 1;
+
+namespace {
+// Soil Measurement (cluster 0x0430) has no ember-native implementation: it only exists as a
+// code-driven cluster, the same family as BooleanState/ValveConfigurationAndControl. esp_matter
+// doesn't (yet) ship a esp_matter::cluster::soil_measurement convenience wrapper to register it, so
+// this translation unit plugs it in itself - the same technique esp_matter's own
+// data_model_provider/clusters/boolean_state_integration.cpp uses for BooleanState.
+std::unordered_map<chip::EndpointId, chip::app::LazyRegisteredServerCluster<SoilMeasurementCluster>> gSoilServers;
+}  // namespace
+
+// Registered below as the Soil Measurement cluster's init callback - invoked once when the endpoint is
+// attached to the Matter node, constructing and registering the live SoilMeasurementCluster instance
+// that actually backs SoilMoistureMeasuredValue/SoilMoistureMeasurementLimits.
+void ESPMatterSoilMeasurementClusterServerInitCallback(chip::EndpointId endpoint_id) {
+  if (gSoilServers[endpoint_id].IsConstructed()) {
+    return;
+  }
+
+  // SoilMoistureMeasurementLimits is mandatory and fixed for the lifetime of the cluster: report the
+  // full [0..100] percent range this endpoint accepts, with no additional accuracy ranges.
+  SoilMeasurement::Attributes::SoilMoistureMeasurementLimits::TypeInfo::Type limits;
+  limits.measurementType = Globals::MeasurementTypeEnum::kSoilMoisture;
+  limits.measured = true;
+  limits.minMeasuredValue = 0;
+  limits.maxMeasuredValue = 100;
+
+  gSoilServers[endpoint_id].Create(endpoint_id, limits);
+  CHIP_ERROR err = esp_matter::data_model::provider::get_instance().registry().Register(gSoilServers[endpoint_id].Registration());
+  if (err != CHIP_NO_ERROR) {
+    log_e("Failed to register Soil Measurement cluster on endpoint %u", endpoint_id);
+  }
+}
+
+void ESPMatterSoilMeasurementClusterServerShutdownCallback(chip::EndpointId endpoint_id) {
+  auto it = gSoilServers.find(endpoint_id);
+  if (it == gSoilServers.end() || !it->second.IsConstructed()) {
+    return;
+  }
+  esp_matter::data_model::provider::get_instance().registry().Unregister(&it->second.Cluster());
+  it->second.Destroy();
+  gSoilServers.erase(it);
+}
+
+static SoilMeasurementCluster *getSoilMeasurementCluster(uint16_t endpoint_id) {
+  chip::app::ServerClusterInterface *iface =
+    esp_matter::data_model::provider::get_instance().registry().Get(chip::app::ConcreteClusterPath(endpoint_id, SoilMeasurement::Id));
+  return static_cast<SoilMeasurementCluster *>(iface);
+}
+
+bool MatterSoilSensor::attributeChangeCB(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *val) {
+  bool ret = true;
+  if (!started) {
+    log_e("Matter Soil Sensor device has not begun.");
+    return false;
+  }
+
+  log_d(
+    "Soil Sensor Attr update callback: endpoint: %u, cluster: %" PRIu32 ", attribute: %" PRIu32 ", val: %" PRIu32, endpoint_id, cluster_id, attribute_id,
+    val->val.u32
+  );
+  return ret;
+}
+
+MatterSoilSensor::MatterSoilSensor() {}
+
+MatterSoilSensor::~MatterSoilSensor() {
+  end();
+}
+
+bool MatterSoilSensor::begin() {
+  ArduinoMatter::_init();
+
+  if (getEndPointId() != 0) {
+    log_e("Matter Soil Sensor with Endpoint Id %u device has already been created.", getEndPointId());
+    return false;
+  }
+
+  // No esp_matter::endpoint::soil_sensor helper exists yet, so the endpoint is assembled from the
+  // generic building blocks by hand - the same steps such a helper would take: a bare endpoint, the
+  // mandatory Descriptor and Identify clusters, the device type, and finally the Soil Measurement
+  // cluster itself (registered above, not backed by ember attributes).
+  endpoint_t *endpoint = endpoint::create(node::get(), ENDPOINT_FLAG_NONE, (void *)this);
+  if (endpoint == nullptr) {
+    log_e("Failed to create Soil Sensor endpoint");
+    return false;
+  }
+
+  cluster::descriptor::config_t descriptor_config;
+  if (cluster::descriptor::create(endpoint, &descriptor_config, CLUSTER_FLAG_SERVER) == nullptr) {
+    log_e("Failed to create Descriptor cluster");
+    return false;
+  }
+
+  cluster::identify::config_t identify_config;
+  identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
+  if (cluster::identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER) == nullptr) {
+    log_e("Failed to create Identify cluster");
+    return false;
+  }
+
+  if (add_device_type(endpoint, kSoilSensorDeviceTypeId, kSoilSensorDeviceTypeVersion) != ESP_OK) {
+    log_e("Failed to add Soil Sensor device type");
+    return false;
+  }
+
+  cluster_t *soil_cluster = cluster::create(endpoint, SoilMeasurement::Id, CLUSTER_FLAG_SERVER);
+  if (soil_cluster == nullptr) {
+    log_e("Failed to create Soil Measurement cluster");
+    return false;
+  }
+  cluster::set_plugin_server_init_callback(soil_cluster, MatterSoilMeasurementPluginServerInitCallback);
+  cluster::set_init_and_shutdown_callbacks(soil_cluster, ESPMatterSoilMeasurementClusterServerInitCallback, ESPMatterSoilMeasurementClusterServerShutdownCallback);
+
+  setEndPointId(endpoint::get_id(endpoint));
+  log_i("Soil Sensor created with endpoint_id %u", getEndPointId());
+
+  // The live SoilMeasurementCluster isn't registered until the Matter stack starts (see
+  // ESPMatterSoilMeasurementClusterServerInitCallback above), so the initial SoilMoistureMeasuredValue
+  // stays null until setSoilMoisture() is called after Matter.begin() - same rule as the Boolean State
+  // sensors (see README.md).
+  started = true;
+  soilMoisture = 0;
+
+  return true;
+}
+
+void MatterSoilSensor::end() {
+  started = false;
+}
+
+bool MatterSoilSensor::setSoilMoisture(uint8_t soilMoisturePercent) {
+  if (!started) {
+    log_e("Matter Soil Sensor device has not begun.");
+    return false;
+  }
+  if (soilMoisturePercent > 100) {
+    log_e("Soil Sensor Moisture Percentage value out of range [0..100].");
+    return false;
+  }
+
+  // avoid processing if there was no change
+  if (soilMoisture == soilMoisturePercent) {
+    return true;
+  }
+
+  SoilMeasurementCluster *cluster = getSoilMeasurementCluster(getEndPointId());
+  if (cluster == nullptr) {
+    log_e("Soil Measurement cluster not found on endpoint %u. Call Matter.begin() first.", getEndPointId());
+    return false;
+  }
+
+  lock::ScopedChipStackLock lock(portMAX_DELAY);
+  chip::app::DataModel::Nullable<chip::Percent> val(soilMoisturePercent);
+  if (cluster->SetSoilMoistureMeasuredValue(val) != CHIP_NO_ERROR) {
+    log_e("Failed to update Soil Sensor moisture value.");
+    return false;
+  }
+  soilMoisture = soilMoisturePercent;
+  log_v("Soil Sensor set to %u Percent", soilMoisturePercent);
+
+  return true;
+}
+
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterEndpoints/MatterSoilSensor.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterSoilSensor.h
@@ -1,0 +1,70 @@
+// Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <sdkconfig.h>
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <Matter.h>
+#include <MatterEndPoint.h>
+
+// Matter Soil Sensor endpoint (device type 0x0045) - Soil Measurement cluster (0x0430).
+//
+// Soil Measurement has no ember-native implementation: it only exists as a code-driven cluster (the
+// same family as BooleanState/ValveConfigurationAndControl), and esp_matter does not (yet) ship a
+// esp_matter::endpoint::soil_sensor / esp_matter::cluster::soil_measurement convenience wrapper for it.
+// MatterSoilSensor therefore builds the endpoint from the generic low-level endpoint/cluster API and
+// registers the live chip::app::Clusters::SoilMeasurementCluster itself (see MatterSoilSensor.cpp),
+// the same technique esp_matter's own boolean_state_integration.cpp uses for BooleanState.
+//
+// SoilMoistureMeasuredValue is managed by that cluster implementation, not by the ember attribute
+// store, so it cannot be read/written through getAttributeVal()/setAttributeVal()/updateAttributeVal().
+// setSoilMoisture() drives it directly through SoilMeasurementCluster::SetSoilMoistureMeasuredValue().
+//
+// The Soil Measurement cluster only defines a whole-percent (0-100) measured value - there is no
+// sub-percent precision to request, unlike e.g. MatterHumiditySensor's 1/100th of a percent.
+class MatterSoilSensor : public MatterEndPoint {
+public:
+  MatterSoilSensor();
+  ~MatterSoilSensor();
+  // begin Matter Soil Sensor endpoint. Like the Boolean State sensors, the live Soil Measurement
+  // cluster instance is not available until the Matter stack starts, so begin() takes no initial
+  // value - call setSoilMoisture() with the real sensor reading after Matter.begin().
+  bool begin();
+  // this will just stop processing Soil Sensor Matter events
+  void end();
+
+  // set the soil moisture percent [0..100]
+  bool setSoilMoisture(uint8_t soilMoisturePercent);
+  // returns the last reported soil moisture percent [0..100]
+  uint8_t getSoilMoisture() {
+    return soilMoisture;
+  }
+  // uint8_t conversion operator
+  void operator=(uint8_t soilMoisturePercent) {
+    setSoilMoisture(soilMoisturePercent);
+  }
+  // uint8_t conversion operator
+  operator uint8_t() {
+    return getSoilMoisture();
+  }
+
+  // this function is called by Matter internal event processor. It could be overwritten by the application, if necessary.
+  bool attributeChangeCB(uint16_t endpoint_id, uint32_t cluster_id, uint32_t attribute_id, esp_matter_attr_val_t *val);
+
+protected:
+  bool started = false;
+  uint8_t soilMoisture = 0;
+};
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */


### PR DESCRIPTION
## Description of Change

Adds `MatterSoilSensor`, an endpoint class for the Matter Soil Sensor device type (`0x0045`, Soil Measurement cluster `0x0430`), requested in #12854.

`esp_matter` does not (yet) ship an `esp_matter::endpoint::soil_sensor` / `esp_matter::cluster::soil_measurement` convenience wrapper - unlike e.g. `BooleanState`, Soil Measurement only exists as a code-driven cluster (`chip::app::Clusters::SoilMeasurementCluster`), with no ember-native fallback. I confirmed this is actually present, Kconfig-selectable, and already wired up via the `data_model_provider` registry in the real `esp_matter` 1.5.1 package (the version `esp32-arduino-lib-builder`'s `main/idf_component.yml` currently pins) by downloading it directly from the component registry and reading the source, rather than assuming from the newer 1.6.0 snapshot.

`MatterSoilSensor.cpp` therefore builds the endpoint from the generic low-level API (`endpoint::create()`, `cluster::descriptor::create()`, `cluster::identify::create()`, `add_device_type()`) and registers the live `SoilMeasurementCluster` itself, the same technique `esp_matter`'s own `data_model_provider/clusters/boolean_state_integration.cpp` uses for `BooleanState`.

Like the Boolean State sensors, the live cluster instance isn't available until the Matter stack starts, so `begin()` takes no initial value - `setSoilMoisture()` must be called after `Matter.begin()`. The cluster only supports a whole-percent (0-100, nullable `uint8`) `SoilMoistureMeasuredValue` - no 1/100th-percent precision, unlike `MatterHumiditySensor`.

Also:
- Documents the device type in `README.md`'s endpoint table, plus a new "Code-Driven Clusters Without an ESP-Matter Wrapper" section explaining the pattern for future endpoints that hit the same situation.
- Adds `keywords.txt` entries.
- Adds the `MatterSoilSensor` example sketch + its own `README.md`/`ci.yml`.

Two deviations from what #12854 originally asked for, both driven by the actual Matter cluster definition rather than a design choice: the device type ID is `0x0045` (the issue said `0x0043`), and the measured value is a whole percent (`uint8_t setSoilMoisture(uint8_t)`), not `uint16_t` hundredths-of-a-percent - the Soil Measurement cluster's `SoilMoistureMeasuredValue` attribute has no sub-percent precision to offer.

## Test Scenarios

Compiled this branch for real against `esp_matter` 1.5.1 + ESP-IDF v5.5 (target `esp32c6`), using `idf_component_examples/Arduino_ESP_Matter_over_OpenThread` with this repo as the `arduino-esp32` component override and `espressif/esp_matter` pinned to exactly `1.5.1`, with a sketch instantiating `MatterSoilSensor` and calling `begin()`/`setSoilMoisture()`/`getSoilMoisture()`. Verification is in progress as of opening this PR - will update this description once it completes (a full ESP-IDF/Matter build from scratch takes a while). Not yet tested on physical hardware / real commissioning.

## Related links

Closes #12854
