### PR TITLE
fix(wifiprov): Make sure BLE is allocated when using WiFiProv

### DIFF
--- a/libraries/WiFiProv/src/WiFiProv.cpp
+++ b/libraries/WiFiProv/src/WiFiProv.cpp
@@ -29,6 +29,7 @@
 #include <esp_wifi.h>
 #include <esp_event.h>
 #include <esp32-hal.h>
+#include <esp32-hal-alloc-ble-mem.h>
 #if __has_include("qrcode.h")
 #include "qrcode.h"
 #endif


### PR DESCRIPTION
## Description of Change

This pull request introduces a small update to the `WiFiProv` library. The main change is the inclusion of a new header file to support BLE memory allocation.

* [`libraries/WiFiProv/src/WiFiProv.h`](diffhunk://#diff-38a25d999ea84f80f5096c0e752b2d07a64d3aff011382339420d9571dbba42eR28): Added `#include "esp32-hal-alloc-ble-mem.h"` to enable BLE memory allocation functionality.

## Test Scenarios

Tested locally

## Related links

Closes #12436
