### PR TITLE
fix(httpclient): Fix socket reuse for HTTP 1 and test chain

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -1155,13 +1155,17 @@ bool HTTPClient::connect(void) {
   if (connected()) {
     if (_reuse) {
       log_d("already connected, reusing connection");
-    } else {
-      log_d("already connected, try reuse!");
+      while (_client->available() > 0) {
+        _client->read();
+      }
+      return true;
     }
-    while (_client->available() > 0) {
-      _client->read();
-    }
-    return true;
+    // HTTP/1.0 and Connection: close cannot reuse the socket. The previous
+    // response (including a 302 with no body) may still look "connected"
+    // because the peer FIN has not been observed yet. Sending the next
+    // request on that socket — typical after a redirect — fails.
+    log_d("already connected, closing because reuse is disabled");
+    _client->stop();
   }
 
   if (!getClient()) {

--- a/tests/validation/tls_http/test_tls_http.py
+++ b/tests/validation/tls_http/test_tls_http.py
@@ -1,26 +1,94 @@
 import logging
+import os
+import re
+import ssl
+import socket
+import subprocess
+import tempfile
 import pytest
+
+
+def _name_key(name):
+    return tuple(tuple(rdn) for rdn in name)
+
+
+def _decode_pem_cert(pem):
+    """Decode a PEM certificate into the dict shape used by SSLSocket.getpeercert()."""
+    if isinstance(pem, str):
+        pem = pem.encode()
+    fd, path = tempfile.mkstemp(suffix=".pem")
+    try:
+        os.write(fd, pem if pem.endswith(b"\n") else pem + b"\n")
+        os.close(fd)
+        fd = None
+        return ssl._ssl._test_decode_cert(path)
+    finally:
+        if fd is not None:
+            os.close(fd)
+        os.unlink(path)
+
+
+def _root_der_from_presented_chain(ctx, pem_blocks):
+    """Map a presented chain onto a trust-anchor CA from the default store.
+
+    Prefer a presented certificate that is already a trust anchor (same choice
+    as SSLSocket.get_verified_chain()[-1]). Otherwise use the issuer of the
+    last extra cert, which is typically a cross-signing root.
+    """
+    store = {_name_key(info["subject"]): der for info, der in zip(ctx.get_ca_certs(), ctx.get_ca_certs(binary_form=True))}
+    if not store:
+        raise RuntimeError("Default CA store is empty")
+
+    for pem in reversed(pem_blocks):
+        info = _decode_pem_cert(pem)
+        subject = _name_key(info["subject"])
+        issuer = _name_key(info["issuer"])
+        if subject in store:
+            return store[subject]
+        if issuer in store:
+            return store[issuer]
+    raise RuntimeError("Could not map server chain to a trust-anchor CA")
+
+
+def _openssl_showcerts(hostname, port):
+    proc = subprocess.run(
+        ["openssl", "s_client", "-connect", f"{hostname}:{port}", "-servername", hostname, "-showcerts"],
+        input=b"",
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+    pems = re.findall(rb"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----", proc.stdout, re.S)
+    if not pems:
+        err = proc.stderr.decode("utf-8", "replace")[:300]
+        raise RuntimeError(f"openssl s_client did not return certificates: {err}")
+    return pems
+
+
+def _der_to_pem(der):
+    import base64
+
+    b64 = base64.encodebytes(der).decode()
+    return f"-----BEGIN CERTIFICATE-----\n{b64}-----END CERTIFICATE-----\n"
 
 
 def _get_server_ca_cert(hostname="postman-echo.com", port=443):
     """Fetch the root CA certificate for a given host at test time."""
-    import ssl
-    import socket
-    import base64
-
     ctx = ssl.create_default_context()
     with ctx.wrap_socket(socket.socket(), server_hostname=hostname) as s:
         s.settimeout(10)
         s.connect((hostname, port))
-        chain = s.get_verified_chain()
+        get_chain = getattr(s, "get_verified_chain", None)
+        if callable(get_chain):
+            chain = get_chain()
+            if not chain:
+                raise RuntimeError("Could not retrieve certificate chain")
+            return _der_to_pem(chain[-1])
 
-    if not chain:
-        raise RuntimeError("Could not retrieve certificate chain")
-
-    # The last certificate in the verified chain is the root CA
-    root_der = chain[-1]
-    b64 = base64.encodebytes(root_der).decode()
-    return f"-----BEGIN CERTIFICATE-----\n{b64}-----END CERTIFICATE-----\n"
+    # Python < 3.13 has no SSLSocket.get_verified_chain(). Reconstruct the
+    # trust anchor from the server-presented chain plus the default CA store.
+    pems = _openssl_showcerts(hostname, port)
+    return _der_to_pem(_root_der_from_presented_chain(ctx, pems))
 
 
 def test_tls_http(dut, wifi_ssid, wifi_pass):


### PR DESCRIPTION
## Description of Change

This pull request improves the reliability and compatibility of TLS certificate validation in the test suite, and fixes connection reuse logic in the HTTP client. The most significant changes include a robust method for fetching the server's root CA certificate that works across Python versions, and an update to the HTTP client to properly handle non-reusable connections.

**TLS Certificate Validation Improvements:**

* Added new helper functions in `test_tls_http.py` to fetch and decode the server's root CA certificate, supporting both Python ≥3.13 (using `SSLSocket.get_verified_chain()`) and earlier versions (by reconstructing the trust anchor from the server's presented chain and the system CA store). This ensures the test suite works reliably across different Python environments.
* Added logic to invoke `openssl s_client` as a fallback for retrieving the server's certificate chain when the Python standard library lacks the necessary API, improving compatibility and robustness.

**HTTP Client Connection Handling:**

* Updated the `HTTPClient::connect()` method to explicitly close the connection if reuse is disabled, preventing issues where a socket appears connected but cannot be reused (e.g., after redirects with HTTP/1.0 or `Connection: close`). This fixes potential failures in subsequent HTTP requests.

## Test Scenarios

Tested locally
