### PR TITLE
Fix(WiFi): Unregister WIFI_EVENT handler before destroyNetif in APClass::onDisable

### DIFF
--- a/libraries/WiFi/src/AP.cpp
+++ b/libraries/WiFi/src/AP.cpp
@@ -181,17 +181,19 @@ bool APClass::onEnable() {
 bool APClass::onDisable() {
   Network.removeEvent(_wifi_ap_event_handle);
   _wifi_ap_event_handle = 0;
-  // we just set _esp_netif to NULL here, so destroyNetif() does not try to destroy it.
-  // That would be done by WiFi.enableAP(false) if STA is not enabled, or when it gets disabled
-  _esp_netif = NULL;
-  destroyNetif();
+
   if (_ap_ev_instance != NULL) {
     esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, &_ap_event_cb);
     _ap_ev_instance = NULL;
   }
+
+  // we just set _esp_netif to NULL here, so destroyNetif() does not try to destroy it.
+  // That would be done by WiFi.enableAP(false) if STA is not enabled, or when it gets disabled
+  _esp_netif = NULL;
+  destroyNetif();
+
   return true;
 }
-
 bool APClass::begin() {
   if (!WiFi.enableAP(true)) {
     log_e("AP enable failed!");


### PR DESCRIPTION
### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

## Description of Change
Fixes #12881
Swapped the execution order in `APClass::onDisable()` to unregister the event handler (`esp_event_handler_unregister`) before destroying the netif (`destroyNetif()`). This prevents a Use-After-Free race condition where a Wi-Fi event could be dispatched against a destroyed event group during rapid AP teardown.

## Test Scenarios
Tested on ESP32-S3 using a custom stress-test sketch that rapidly cycles `WiFi.AP.end()` while a station is connected. The modified code successfully eliminates the race window and prevents the core panic.