### PR TITLE
feat(Matter): add MatterWaterHeater endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ set(ARDUINO_LIBRARY_Matter_SRCS
   libraries/Matter/src/MatterEndpoints/MatterContactSensor.cpp
   libraries/Matter/src/MatterEndpoints/MatterWaterLeakDetector.cpp
   libraries/Matter/src/MatterEndpoints/MatterWaterFreezeDetector.cpp
+  libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
   libraries/Matter/src/MatterEndpoints/MatterRainSensor.cpp
   libraries/Matter/src/MatterEndpoints/MatterPressureSensor.cpp
   libraries/Matter/src/MatterEndpoints/MatterOccupancySensor.cpp

--- a/libraries/Matter/examples/MatterWaterHeater/MatterWaterHeater.ino
+++ b/libraries/Matter/examples/MatterWaterHeater/MatterWaterHeater.ino
@@ -1,0 +1,170 @@
+/*
+ * Matter Water Heater example for Arduino-ESP32.
+ *
+ * Creates a Matter 1.4 Water Heater endpoint (0x050F).
+ */
+
+#include <Matter.h>
+#include <MatterEndpoints/MatterWaterHeater.h>
+
+MatterWaterHeater waterHeater;
+
+constexpr float COLD_WATER_TEMP = 20.0f;
+constexpr float INITIAL_WATER_TEMP = 20.0f;
+
+constexpr float TANK_VOLUME_LITERS = 100.0f;
+
+unsigned long lastUpdate = 0;
+
+void updateTankPercentage()
+{
+  const float current = waterHeater.getLocalTemperature();
+  const float target = waterHeater.getHeatingSetpoint();
+
+  if (target <= COLD_WATER_TEMP) {
+    waterHeater.setTankPercentage(0);
+    return;
+  }
+
+  float percentage =
+    ((current - COLD_WATER_TEMP) /
+     (target - COLD_WATER_TEMP)) * 100.0f;
+
+  percentage = constrain(percentage, 0.0f, 100.0f);
+
+  waterHeater.setTankPercentage(
+    static_cast<uint8_t>(percentage)
+  );
+}
+
+void setup()
+{
+  Serial.begin(115200);
+
+  delay(1000);
+
+  Serial.println();
+  Serial.println("Matter Water Heater");
+  Serial.println("-------------------");
+
+  if (!waterHeater.begin()) {
+    Serial.println(
+      "Failed to create Matter Water Heater endpoint"
+    );
+
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  /*
+   * Describe the physical water heater.
+   */
+  waterHeater.setHeaterTypes(
+    MatterWaterHeater::IMMERSION_ELEMENT_1
+  );
+
+  waterHeater.setTankVolume(
+    static_cast<uint16_t>(TANK_VOLUME_LITERS)
+  );
+
+  waterHeater.setLocalTemperature(
+    INITIAL_WATER_TEMP
+  );
+
+  waterHeater.setHeatingSetpoint(48.0f);
+
+  waterHeater.setSystemMode(
+    MatterWaterHeater::SYSTEM_MODE_HEAT
+  );
+
+  waterHeater.setWaterHeaterMode(
+    MatterWaterHeater::WATER_HEATER_MODE_MANUAL
+  );
+
+  waterHeater.setTankPercentage(0);
+
+  /*
+   * Start Matter only after the endpoint has been created.
+   */
+  Matter.begin();
+
+  Serial.println(
+    "Matter Water Heater endpoint created."
+  );
+
+  if (!Matter.isDeviceCommissioned()) {
+
+    Serial.println();
+    Serial.println(
+      "Device is not commissioned."
+    );
+
+    Serial.printf(
+      "Manual pairing code: %s\n",
+      Matter.getManualPairingCode().c_str()
+    );
+
+    Serial.printf(
+      "QR code URL: %s\n",
+      Matter.getOnboardingQRCodeUrl().c_str()
+    );
+  }
+}
+
+void loop()
+{
+  /*
+   * Simulate heating.
+   *
+   * This is only an example. In a real implementation,
+   * local temperature would come from a physical sensor.
+   */
+  if (millis() - lastUpdate < 5000) {
+    return;
+  }
+
+  lastUpdate = millis();
+
+  float temperature =
+    waterHeater.getLocalTemperature();
+
+  float setpoint =
+    waterHeater.getHeatingSetpoint();
+
+  if (waterHeater.getSystemMode() ==
+      MatterWaterHeater::SYSTEM_MODE_HEAT) {
+
+    if (temperature < setpoint) {
+      temperature += 0.5f;
+
+      if (temperature > setpoint) {
+        temperature = setpoint;
+      }
+
+      waterHeater.setLocalTemperature(
+        temperature
+      );
+
+      waterHeater.setHeatDemand(100);
+    } else {
+      waterHeater.setHeatDemand(0);
+    }
+  }
+
+  updateTankPercentage();
+
+  Serial.printf(
+    "Temperature: %.1f C | "
+    "Setpoint: %.1f C | "
+    "Tank: %u %% | "
+    "Demand: %u %% | "
+    "Boost: %u\n",
+
+    waterHeater.getLocalTemperature(),
+    waterHeater.getHeatingSetpoint(),
+    waterHeater.getTankPercentage(),
+    waterHeater.getHeatDemand(),
+    waterHeater.getBoostState()
+  );
+}

--- a/libraries/Matter/examples/MatterWaterHeater/README.md
+++ b/libraries/Matter/examples/MatterWaterHeater/README.md
@@ -1,0 +1,196 @@
+# Matter Water Heater
+
+This example demonstrates how to create and control a Matter Water Heater endpoint using the Arduino-ESP32 Matter library.
+
+The example exposes a Matter Water Heater device and demonstrates:
+
+* Local water temperature
+* Heating setpoint
+* Heating system mode
+* Water heater operating mode
+* Heater type
+* Heat demand
+* Tank volume
+* Tank percentage
+* Boost state
+
+## Hardware
+
+This example requires an ESP32 board supported by the Arduino-ESP32 Matter library.
+
+No additional hardware is required to run the example. The water temperature and tank state are simulated by the sketch.
+
+For a real water heater implementation, the simulated values should be replaced by readings from the appropriate sensors and the Matter attributes should be updated accordingly.
+
+## Matter Device Type
+
+The endpoint implements the Matter Water Heater device type:
+
+```text
+Water Heater
+Device Type ID: 0x050F
+```
+
+The endpoint uses the following Matter clusters:
+
+* Descriptor
+* Water Heater Management
+* Water Heater Mode
+* Thermostat
+
+## Running the example
+
+Open the example from the Arduino IDE:
+
+```text
+File
+  → Examples
+    → Matter
+      → MatterWaterHeater
+```
+
+Select an ESP32 board and compile/upload the example.
+
+After startup, the device prints its Matter commissioning information to the serial console.
+
+Open the Serial Monitor at:
+
+```text
+115200 baud
+```
+
+If the device has not yet been commissioned, the sketch prints the manual pairing code and QR-code URL.
+
+## Commissioning
+
+Use a Matter controller such as:
+
+* Google Home
+* Apple Home
+* Amazon Alexa
+* Home Assistant
+
+to commission the device.
+
+Once commissioned, the Water Heater endpoint can be controlled through the Matter controller.
+
+## Simulated water heater
+
+The example simulates a heating cycle.
+
+The default configuration is:
+
+| Parameter           |             Value |
+| ------------------- | ----------------: |
+| Tank volume         |             100 L |
+| Initial temperature |             20 °C |
+| Heating setpoint    |             48 °C |
+| Heater type         | Immersion element |
+| System mode         |              Heat |
+| Water heater mode   |            Manual |
+| Tank percentage     |               0 % |
+
+Every few seconds the example increases the simulated water temperature until the configured heating setpoint is reached.
+
+The tank percentage is calculated from the simulated water temperature.
+
+## API
+
+The `MatterWaterHeater` class provides APIs for reading and updating the main Water Heater attributes.
+
+### Temperature
+
+```cpp
+waterHeater.setLocalTemperature(45.0f);
+
+float temperature =
+    waterHeater.getLocalTemperature();
+```
+
+### Heating setpoint
+
+```cpp
+waterHeater.setHeatingSetpoint(48.0f);
+
+float setpoint =
+    waterHeater.getHeatingSetpoint();
+```
+
+### System mode
+
+```cpp
+waterHeater.setSystemMode(
+    MatterWaterHeater::SYSTEM_MODE_HEAT
+);
+```
+
+### Heater type
+
+```cpp
+waterHeater.setHeaterTypes(
+    MatterWaterHeater::IMMERSION_ELEMENT_1
+);
+```
+
+### Tank volume
+
+```cpp
+waterHeater.setTankVolume(100);
+```
+
+### Tank percentage
+
+```cpp
+waterHeater.setTankPercentage(75);
+```
+
+### Water Heater mode
+
+```cpp
+waterHeater.setWaterHeaterMode(
+    MatterWaterHeater::WATER_HEATER_MODE_MANUAL
+);
+```
+
+### Heat demand
+
+```cpp
+waterHeater.setHeatDemand(100);
+```
+
+### Boost
+
+```cpp
+waterHeater.setBoostState(
+    MatterWaterHeater::BOOST_ACTIVE
+);
+```
+
+## Implementation notes
+
+The Water Heater endpoint is implemented using the `esp-matter` data model provided by Arduino-ESP32.
+
+The Arduino API is intentionally kept at a higher level than the underlying Matter data model. Applications should normally use `MatterWaterHeater` rather than manipulating the Matter clusters directly.
+
+The example is intended as a starting point for applications implementing a physical water heater, boiler, heat-pump water heater, or similar appliance.
+
+## Limitations
+
+This example uses simulated values and does not control physical heating hardware.
+
+In a production implementation:
+
+1. Read the actual tank temperature from a sensor.
+2. Update the Matter local temperature attribute.
+3. Apply the Matter heating setpoint to the physical controller.
+4. Update the tank percentage from the actual tank state.
+5. Report the actual heat demand.
+6. Implement the appropriate safety limits and hardware interlocks.
+
+Never use the Matter endpoint as the only safety mechanism for controlling a real heating element.
+
+## Related Matter specification
+
+The implementation follows the Matter Water Heater device model and its associated Water Heater Management, Water Heater Mode and Thermostat clusters.
+
+For additional information, refer to the Matter specification and the Arduino-ESP32 Matter documentation.

--- a/libraries/Matter/examples/MatterWaterHeater/ci.yml
+++ b/libraries/Matter/examples/MatterWaterHeater/ci.yml
@@ -1,0 +1,4 @@
+fqbn_append: PartitionScheme=huge_app
+
+requires:
+  - CONFIG_ESP_MATTER_ENABLE_DATA_MODEL=y

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -35,6 +35,7 @@
 #include <MatterEndpoints/MatterWaterLeakDetector.h>
 #include <MatterEndpoints/MatterWaterFreezeDetector.h>
 #include <MatterEndpoints/MatterWaterHeater.h>
+#include <MatterEndpoints/MatterWaterHeater.h>
 #include <MatterEndpoints/MatterRainSensor.h>
 #include <MatterEndpoints/MatterPressureSensor.h>
 #include <MatterEndpoints/MatterOccupancySensor.h>
@@ -223,6 +224,7 @@ public:
   friend class MatterContactSensor;
   friend class MatterWaterLeakDetector;
   friend class MatterWaterFreezeDetector;
+  friend class MatterWaterHeater;
   friend class MatterRainSensor;
   friend class MatterPressureSensor;
   friend class MatterOccupancySensor;

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -35,7 +35,6 @@
 #include <MatterEndpoints/MatterWaterLeakDetector.h>
 #include <MatterEndpoints/MatterWaterFreezeDetector.h>
 #include <MatterEndpoints/MatterWaterHeater.h>
-#include <MatterEndpoints/MatterWaterHeater.h>
 #include <MatterEndpoints/MatterRainSensor.h>
 #include <MatterEndpoints/MatterPressureSensor.h>
 #include <MatterEndpoints/MatterOccupancySensor.h>

--- a/libraries/Matter/src/Matter.h
+++ b/libraries/Matter/src/Matter.h
@@ -34,6 +34,7 @@
 #include <MatterEndpoints/MatterContactSensor.h>
 #include <MatterEndpoints/MatterWaterLeakDetector.h>
 #include <MatterEndpoints/MatterWaterFreezeDetector.h>
+#include <MatterEndpoints/MatterWaterHeater.h>
 #include <MatterEndpoints/MatterRainSensor.h>
 #include <MatterEndpoints/MatterPressureSensor.h>
 #include <MatterEndpoints/MatterOccupancySensor.h>

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
@@ -12,8 +12,6 @@
 
 using namespace esp_matter;
 using namespace esp_matter::endpoint;
-using namespace esp_matter::cluster;
-
 using namespace chip::app::Clusters;
 
 namespace {
@@ -23,35 +21,23 @@ constexpr int16_t DEFAULT_HEATING_SETPOINT = 4800;
 
 constexpr int16_t ABS_MIN_HEATING_SETPOINT = 2000;
 constexpr int16_t MIN_HEATING_SETPOINT = 2000;
-
 constexpr int16_t ABS_MAX_HEATING_SETPOINT = 8500;
 constexpr int16_t MAX_HEATING_SETPOINT = 8500;
 
 constexpr uint8_t DEFAULT_SYSTEM_MODE =
   static_cast<uint8_t>(Thermostat::SystemModeEnum::kHeat);
 
-constexpr uint8_t DEFAULT_HEATER_TYPES = 0x01;
+constexpr uint8_t DEFAULT_HEATER_TYPES =
+  MatterWaterHeater::IMMERSION_ELEMENT_1;
+
 constexpr uint8_t DEFAULT_HEAT_DEMAND = 0;
 constexpr uint16_t DEFAULT_TANK_VOLUME = 100;
 constexpr uint8_t DEFAULT_TANK_PERCENTAGE = 100;
-constexpr uint8_t DEFAULT_BOOST_STATE = 0;
+constexpr uint8_t DEFAULT_BOOST_STATE =
+  MatterWaterHeater::BOOST_INACTIVE;
 
-constexpr uint8_t DEFAULT_WATER_HEATER_MODE = 1;
-
-/*
- * Matter Water Heater device type:
- *
- *   0x050F
- *
- * esp-matter's generated implementation creates:
- *
- *   Descriptor
- *   WaterHeaterManagement
- *   WaterHeaterMode
- *   Thermostat
- *
- * automatically.
- */
+constexpr uint8_t DEFAULT_WATER_HEATER_MODE =
+  MatterWaterHeater::WATER_HEATER_MODE_MANUAL;
 
 }  // namespace
 
@@ -67,67 +53,47 @@ MatterWaterHeater::~MatterWaterHeater()
 bool MatterWaterHeater::begin()
 {
   if (initialized) {
-    log_e("Matter Water Heater has already been initialized.");
     return false;
   }
 
-  /*
-   * Make sure the Arduino Matter node exists.
-   *
-   * This is the same lifecycle used by the other Arduino-ESP32
-   * Matter endpoints.
-   */
   ArduinoMatter::_init();
 
   if (getEndPointId() != 0) {
-    log_e(
-      "Matter Water Heater with Endpoint Id %u already exists.",
-      getEndPointId()
-    );
     return false;
   }
 
   /*
    * Water Heater Management
    */
-  water_heater_management::config_t management_config;
+  esp_matter::cluster::water_heater_management::config_t
+    management_config;
 
   management_config.heater_types = DEFAULT_HEATER_TYPES;
   management_config.heat_demand = DEFAULT_HEAT_DEMAND;
   management_config.boost_state = DEFAULT_BOOST_STATE;
 
   /*
-   * Enable the Energy Management feature.
-   */
-  management_config.features.energy_management.tank_volume =
-    DEFAULT_TANK_VOLUME;
-
-  /*
-   * Enable TankPercent feature.
-   */
-  management_config.features.tank_percent.tank_percentage =
-    DEFAULT_TANK_PERCENTAGE;
-
-  /*
    * Water Heater Mode
    */
-  water_heater_mode::config_t mode_config;
+  esp_matter::cluster::water_heater_mode::config_t
+    mode_config;
 
   /*
    * Thermostat
+   *
+   * This is the endpoint thermostat configuration, not the cluster
+   * namespace. Use the fully-qualified namespace to avoid the
+   * endpoint::thermostat / cluster::thermostat ambiguity.
    */
-  thermostat::config_t thermostat_config;
+  esp_matter::endpoint::thermostat::config_t thermostat_config;
 
-  thermostat_config.local_temperature =
-    DEFAULT_LOCAL_TEMPERATURE;
+  thermostat_config.local_temperature = DEFAULT_LOCAL_TEMPERATURE;
 
   thermostat_config.control_sequence_of_operation =
     static_cast<uint8_t>(
-      Thermostat::ControlSequenceOfOperationEnum::kHeatingOnly
-    );
+      Thermostat::ControlSequenceOfOperationEnum::kHeatingOnly);
 
-  thermostat_config.system_mode =
-    DEFAULT_SYSTEM_MODE;
+  thermostat_config.system_mode = DEFAULT_SYSTEM_MODE;
 
   thermostat_config.features.heating.occupied_heating_setpoint =
     DEFAULT_HEATING_SETPOINT;
@@ -136,42 +102,70 @@ bool MatterWaterHeater::begin()
     DEFAULT_HEATING_SETPOINT;
 
   thermostat_config.feature_flags |=
-    thermostat::feature::heating::get_id();
+    esp_matter::cluster::thermostat::feature::heating::get_id();
 
   /*
-   * Device type configuration.
+   * Water Heater device type 0x050F.
+   *
+   * The generated device type creates:
+   *
+   *   - Water Heater Management
+   *   - Water Heater Mode
+   *   - Thermostat
+   *
+   * on the same endpoint.
    */
-  water_heater::config_t water_heater_config;
+  esp_matter::endpoint::water_heater::config_t water_heater_config;
 
-  water_heater_config.water_heater_management =
-    management_config;
+  water_heater_config.water_heater_management = management_config;
+  water_heater_config.water_heater_mode = mode_config;
+  water_heater_config.thermostat = thermostat_config;
 
-  water_heater_config.water_heater_mode =
-    mode_config;
-
-  water_heater_config.thermostat =
-    thermostat_config;
-
-  /*
-   * Create the Water Heater endpoint.
-   */
   endpoint_t *endpoint =
-    water_heater::create(
+    esp_matter::endpoint::water_heater::create(
       node::get(),
       &water_heater_config,
       ENDPOINT_FLAG_NONE,
-      this
-    );
+      this);
 
   if (endpoint == nullptr) {
-    log_e("Failed to create Matter Water Heater endpoint.");
     return false;
   }
 
-  setEndPointId(endpoint::get_id(endpoint));
+  /*
+   * Enable the optional Water Heater Management features.
+   *
+   * These features are no longer configured through
+   * management_config.features.* in current esp-matter.
+   */
+  cluster_t *management_cluster =
+    cluster::get(
+      endpoint,
+      WaterHeaterManagement::Id);
+
+  if (management_cluster == nullptr) {
+    return false;
+  }
+
+  if (esp_matter::cluster::water_heater_management::
+        feature::energy_management::add(management_cluster) != ESP_OK) {
+    return false;
+  }
+
+  if (esp_matter::cluster::water_heater_management::
+        feature::tank_percentage::add(management_cluster) != ESP_OK) {
+    return false;
+  }
 
   /*
-   * Cache the initial values.
+   * Store the endpoint ID in MatterEndPoint.
+   */
+  setEndPointId(endpoint::get_id(endpoint));
+
+  initialized = true;
+
+  /*
+   * Initialize the local cache from the values configured above.
    */
   localTemperature = DEFAULT_LOCAL_TEMPERATURE;
   heatingSetpoint = DEFAULT_HEATING_SETPOINT;
@@ -195,156 +189,36 @@ bool MatterWaterHeater::begin()
   tankVolume = DEFAULT_TANK_VOLUME;
   tankPercentage = DEFAULT_TANK_PERCENTAGE;
   boostState = DEFAULT_BOOST_STATE;
+  waterHeaterMode = DEFAULT_WATER_HEATER_MODE;
 
-  waterHeaterMode =
-    DEFAULT_WATER_HEATER_MODE;
-
-  initialized = true;
+  /*
+   * The generated Water Heater device type creates the mandatory
+   * attributes. The optional management features have just been
+   * added above.
+   *
+   * Push our configured initial values after the attributes exist.
+   */
+  setTankVolume(DEFAULT_TANK_VOLUME);
+  setTankPercentage(DEFAULT_TANK_PERCENTAGE);
 
   return true;
 }
 
 void MatterWaterHeater::end()
 {
-  /*
-   * Arduino-ESP32 Matter endpoints don't currently expose a public
-   * endpoint::destroy() equivalent through MatterEndPoint.
-   *
-   * Keep the object logically stopped, as the existing endpoint
-   * implementations do.
-   */
   initialized = false;
 }
 
 /*
  * --------------------------------------------------------------------------
- * Attribute callback
- * --------------------------------------------------------------------------
- */
-
-bool MatterWaterHeater::attributeChangeCB(
-  uint16_t endpoint_id,
-  uint32_t cluster_id,
-  uint32_t attribute_id,
-  esp_matter_attr_val_t *val
-)
-{
-  if (!initialized || val == nullptr) {
-    return false;
-  }
-
-  if (endpoint_id != getEndPointId()) {
-    return true;
-  }
-
-  /*
-   * Thermostat
-   */
-  if (cluster_id == Thermostat::Id) {
-
-    switch (attribute_id) {
-
-      case Thermostat::Attributes::LocalTemperature::Id:
-        localTemperature = val->val.i16;
-
-        log_v(
-          "Water Heater local temperature: %.2f C",
-          static_cast<float>(localTemperature) / 100.0f
-        );
-        break;
-
-      case Thermostat::Attributes::OccupiedHeatingSetpoint::Id:
-        heatingSetpoint = val->val.i16;
-
-        log_v(
-          "Water Heater heating setpoint: %.2f C",
-          static_cast<float>(heatingSetpoint) / 100.0f
-        );
-        break;
-
-      case Thermostat::Attributes::SystemMode::Id:
-        systemMode = val->val.u8;
-
-        log_v(
-          "Water Heater system mode: %u",
-          systemMode
-        );
-        break;
-
-      default:
-        break;
-    }
-
-    return true;
-  }
-
-  /*
-   * Water Heater Management
-   */
-  if (cluster_id == WaterHeaterManagement::Id) {
-
-    switch (attribute_id) {
-
-      case WaterHeaterManagement::Attributes::HeaterTypes::Id:
-        heaterTypes = val->val.u8;
-        break;
-
-      case WaterHeaterManagement::Attributes::HeatDemand::Id:
-        heatDemand = val->val.u8;
-        break;
-
-      case WaterHeaterManagement::Attributes::TankVolume::Id:
-        tankVolume = val->val.u16;
-        break;
-
-      case WaterHeaterManagement::Attributes::TankPercentage::Id:
-        tankPercentage = val->val.u8;
-        break;
-
-      case WaterHeaterManagement::Attributes::BoostState::Id:
-        boostState = val->val.u8;
-        break;
-
-      default:
-        break;
-    }
-
-    return true;
-  }
-
-  /*
-   * Water Heater Mode
-   */
-  if (cluster_id == WaterHeaterMode::Id) {
-
-    if (attribute_id ==
-        WaterHeaterMode::Attributes::CurrentMode::Id) {
-
-      waterHeaterMode = val->val.u8;
-
-      log_v(
-        "Water Heater operation mode: %u",
-        waterHeaterMode
-      );
-    }
-
-    return true;
-  }
-
-  return true;
-}
-
-/*
- * --------------------------------------------------------------------------
- * Temperature
+ * Thermostat / local temperature
  * --------------------------------------------------------------------------
  */
 
 bool MatterWaterHeater::setLocalTemperature(float temperature)
 {
   return setLocalTemperatureRaw(
-    static_cast<int16_t>(temperature * 100.0f)
-  );
+    static_cast<int16_t>(temperature * 100.0f));
 }
 
 float MatterWaterHeater::getLocalTemperature()
@@ -359,15 +233,31 @@ bool MatterWaterHeater::setLocalTemperatureRaw(int16_t temperature)
   }
 
   esp_matter_attr_val_t value =
-    esp_matter_nullable<int16_t>(temperature);
+    esp_matter_invalid(NULL);
 
-  value = esp_matter_attr_val(temperature);
+  if (!getAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::LocalTemperature::Id,
+        &value)) {
+    return false;
+  }
 
-  return updateAttributeVal(
-    Thermostat::Id,
-    Thermostat::Attributes::LocalTemperature::Id,
-    &value
-  );
+  if (value.val.i16 == temperature) {
+    localTemperature = temperature;
+    return true;
+  }
+
+  value.val.i16 = temperature;
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::LocalTemperature::Id,
+        &value)) {
+    return false;
+  }
+
+  localTemperature = temperature;
+  return true;
 }
 
 int16_t MatterWaterHeater::getLocalTemperatureRaw()
@@ -384,8 +274,7 @@ int16_t MatterWaterHeater::getLocalTemperatureRaw()
 bool MatterWaterHeater::setHeatingSetpoint(float temperature)
 {
   return setHeatingSetpointRaw(
-    static_cast<int16_t>(temperature * 100.0f)
-  );
+    static_cast<int16_t>(temperature * 100.0f));
 }
 
 float MatterWaterHeater::getHeatingSetpoint()
@@ -393,9 +282,7 @@ float MatterWaterHeater::getHeatingSetpoint()
   return static_cast<float>(heatingSetpoint) / 100.0f;
 }
 
-bool MatterWaterHeater::setHeatingSetpointRaw(
-  int16_t temperature
-)
+bool MatterWaterHeater::setHeatingSetpointRaw(int16_t temperature)
 {
   if (!initialized) {
     return false;
@@ -403,30 +290,34 @@ bool MatterWaterHeater::setHeatingSetpointRaw(
 
   if (temperature < minimumHeatingSetpoint ||
       temperature > maximumHeatingSetpoint) {
-    log_e(
-      "Heating setpoint %.2f C is outside [%0.2f, %0.2f] C.",
-      static_cast<float>(temperature) / 100.0f,
-      static_cast<float>(minimumHeatingSetpoint) / 100.0f,
-      static_cast<float>(maximumHeatingSetpoint) / 100.0f
-    );
-
     return false;
   }
 
-    esp_matter_attr_val_t val = esp_matter_invalid(NULL);
+  esp_matter_attr_val_t value =
+    esp_matter_invalid(NULL);
 
-    val.type = ESP_MATTER_VAL_TYPE_INT16;
-    val.val.i16 = temperature;
-
-    if (!updateAttributeVal(
-            Thermostat::Id,
-            Thermostat::Attributes::OccupiedHeatingSetpoint::Id,
-            &val)) {
+  if (!getAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::OccupiedHeatingSetpoint::Id,
+        &value)) {
     return false;
-    }
+  }
+
+  if (value.val.i16 == temperature) {
+    heatingSetpoint = temperature;
+    return true;
+  }
+
+  value.val.i16 = temperature;
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::OccupiedHeatingSetpoint::Id,
+        &value)) {
+    return false;
+  }
 
   heatingSetpoint = temperature;
-
   return true;
 }
 
@@ -437,127 +328,188 @@ int16_t MatterWaterHeater::getHeatingSetpointRaw()
 
 /*
  * --------------------------------------------------------------------------
- * Heating limits
+ * Heating setpoint limits
  * --------------------------------------------------------------------------
  */
 
 bool MatterWaterHeater::setAbsoluteMinimumHeatingSetpoint(
-  float temperature
-)
+  float temperature)
 {
+  const int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
   if (!initialized) {
     return false;
   }
 
-  int16_t value =
-    static_cast<int16_t>(temperature * 100.0f);
-
-  if (value > absoluteMinimumHeatingSetpoint) {
-    /*
-     * The absolute minimum can only be lowered by hardware
-     * configuration; don't allow an invalid Matter state.
-     */
+  if (value < ABS_MIN_HEATING_SETPOINT ||
+      value > ABS_MAX_HEATING_SETPOINT) {
+    return false;
   }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(value);
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::
+          AbsMinHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.i16 = value;
 
   if (!updateAttributeVal(
         Thermostat::Id,
-        Thermostat::Attributes::AbsMinHeatSetpointLimit::Id,
+        Thermostat::Attributes::
+          AbsMinHeatSetpointLimit::Id,
         &attr)) {
     return false;
   }
 
   absoluteMinimumHeatingSetpoint = value;
 
+  if (minimumHeatingSetpoint < value) {
+    setMinimumHeatingSetpoint(
+      static_cast<float>(value) / 100.0f);
+  }
+
   return true;
 }
 
 bool MatterWaterHeater::setMinimumHeatingSetpoint(
-  float temperature
-)
+  float temperature)
 {
+  const int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
   if (!initialized) {
     return false;
   }
 
-  int16_t value =
-    static_cast<int16_t>(temperature * 100.0f);
-
   if (value < absoluteMinimumHeatingSetpoint ||
-      value > absoluteMaximumHeatingSetpoint) {
+      value > maximumHeatingSetpoint) {
     return false;
   }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(value);
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::
+          MinHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.i16 = value;
 
   if (!updateAttributeVal(
         Thermostat::Id,
-        Thermostat::Attributes::MinHeatSetpointLimit::Id,
+        Thermostat::Attributes::
+          MinHeatSetpointLimit::Id,
         &attr)) {
     return false;
   }
 
   minimumHeatingSetpoint = value;
 
+  if (heatingSetpoint < value) {
+    setHeatingSetpointRaw(value);
+  }
+
   return true;
 }
 
 bool MatterWaterHeater::setAbsoluteMaximumHeatingSetpoint(
-  float temperature
-)
+  float temperature)
 {
+  const int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
   if (!initialized) {
     return false;
   }
 
-  int16_t value =
-    static_cast<int16_t>(temperature * 100.0f);
+  if (value < ABS_MIN_HEATING_SETPOINT ||
+      value > ABS_MAX_HEATING_SETPOINT) {
+    return false;
+  }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(value);
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::
+          AbsMaxHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.i16 = value;
 
   if (!updateAttributeVal(
         Thermostat::Id,
-        Thermostat::Attributes::AbsMaxHeatSetpointLimit::Id,
+        Thermostat::Attributes::
+          AbsMaxHeatSetpointLimit::Id,
         &attr)) {
     return false;
   }
 
   absoluteMaximumHeatingSetpoint = value;
 
+  if (maximumHeatingSetpoint > value) {
+    setMaximumHeatingSetpoint(
+      static_cast<float>(value) / 100.0f);
+  }
+
   return true;
 }
 
 bool MatterWaterHeater::setMaximumHeatingSetpoint(
-  float temperature
-)
+  float temperature)
 {
+  const int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
   if (!initialized) {
     return false;
   }
 
-  int16_t value =
-    static_cast<int16_t>(temperature * 100.0f);
-
-  if (value < absoluteMinimumHeatingSetpoint ||
+  if (value < minimumHeatingSetpoint ||
       value > absoluteMaximumHeatingSetpoint) {
     return false;
   }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(value);
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::
+          MaxHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.i16 = value;
 
   if (!updateAttributeVal(
         Thermostat::Id,
-        Thermostat::Attributes::MaxHeatSetpointLimit::Id,
+        Thermostat::Attributes::
+          MaxHeatSetpointLimit::Id,
         &attr)) {
     return false;
   }
 
   maximumHeatingSetpoint = value;
+
+  if (heatingSetpoint > value) {
+    setHeatingSetpointRaw(value);
+  }
 
   return true;
 }
@@ -565,40 +517,35 @@ bool MatterWaterHeater::setMaximumHeatingSetpoint(
 float MatterWaterHeater::getAbsoluteMinimumHeatingSetpoint()
 {
   return static_cast<float>(
-    absoluteMinimumHeatingSetpoint
-  ) / 100.0f;
+    absoluteMinimumHeatingSetpoint) / 100.0f;
 }
 
 float MatterWaterHeater::getMinimumHeatingSetpoint()
 {
   return static_cast<float>(
-    minimumHeatingSetpoint
-  ) / 100.0f;
+    minimumHeatingSetpoint) / 100.0f;
 }
 
 float MatterWaterHeater::getAbsoluteMaximumHeatingSetpoint()
 {
   return static_cast<float>(
-    absoluteMaximumHeatingSetpoint
-  ) / 100.0f;
+    absoluteMaximumHeatingSetpoint) / 100.0f;
 }
 
 float MatterWaterHeater::getMaximumHeatingSetpoint()
 {
   return static_cast<float>(
-    maximumHeatingSetpoint
-  ) / 100.0f;
+    maximumHeatingSetpoint) / 100.0f;
 }
 
 /*
  * --------------------------------------------------------------------------
- * System mode
+ * Thermostat system mode
  * --------------------------------------------------------------------------
  */
 
 bool MatterWaterHeater::setSystemMode(
-  SystemMode_t mode
-)
+  SystemMode_t mode)
 {
   if (!initialized) {
     return false;
@@ -610,9 +557,16 @@ bool MatterWaterHeater::setSystemMode(
   }
 
   esp_matter_attr_val_t value =
-    esp_matter_attr_val(
-      static_cast<uint8_t>(mode)
-    );
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::SystemMode::Id,
+        &value)) {
+    return false;
+  }
+
+  value.val.u8 = static_cast<uint8_t>(mode);
 
   if (!updateAttributeVal(
         Thermostat::Id,
@@ -621,8 +575,7 @@ bool MatterWaterHeater::setSystemMode(
     return false;
   }
 
-  systemMode = mode;
-
+  systemMode = static_cast<uint8_t>(mode);
   return true;
 }
 
@@ -639,28 +592,34 @@ MatterWaterHeater::getSystemMode()
  */
 
 bool MatterWaterHeater::setHeaterTypes(
-  uint8_t value
-)
+  uint8_t value)
 {
   if (!initialized) {
     return false;
   }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(
-      value,
-      esp_matter_attr_val::uint_sub_type::k_bitmap
-    );
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::
+          HeaterTypes::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.u8 = value;
 
   if (!updateAttributeVal(
         WaterHeaterManagement::Id,
-        WaterHeaterManagement::Attributes::HeaterTypes::Id,
+        WaterHeaterManagement::Attributes::
+          HeaterTypes::Id,
         &attr)) {
     return false;
   }
 
   heaterTypes = value;
-
   return true;
 }
 
@@ -670,28 +629,34 @@ uint8_t MatterWaterHeater::getHeaterTypes()
 }
 
 bool MatterWaterHeater::setHeatDemand(
-  uint8_t value
-)
+  uint8_t value)
 {
   if (!initialized) {
     return false;
   }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(
-      value,
-      esp_matter_attr_val::uint_sub_type::k_bitmap
-    );
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::
+          HeatDemand::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.u8 = value;
 
   if (!updateAttributeVal(
         WaterHeaterManagement::Id,
-        WaterHeaterManagement::Attributes::HeatDemand::Id,
+        WaterHeaterManagement::Attributes::
+          HeatDemand::Id,
         &attr)) {
     return false;
   }
 
   heatDemand = value;
-
   return true;
 }
 
@@ -701,25 +666,34 @@ uint8_t MatterWaterHeater::getHeatDemand()
 }
 
 bool MatterWaterHeater::setTankVolume(
-  uint16_t value
-)
+  uint16_t value)
 {
   if (!initialized) {
     return false;
   }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(value);
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::
+          TankVolume::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.u16 = value;
 
   if (!updateAttributeVal(
         WaterHeaterManagement::Id,
-        WaterHeaterManagement::Attributes::TankVolume::Id,
+        WaterHeaterManagement::Attributes::
+          TankVolume::Id,
         &attr)) {
     return false;
   }
 
   tankVolume = value;
-
   return true;
 }
 
@@ -729,25 +703,34 @@ uint16_t MatterWaterHeater::getTankVolume()
 }
 
 bool MatterWaterHeater::setTankPercentage(
-  uint8_t value
-)
+  uint8_t value)
 {
   if (!initialized || value > 100) {
     return false;
   }
 
   esp_matter_attr_val_t attr =
-    esp_matter_attr_val(value);
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::
+          TankPercentage::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.u8 = value;
 
   if (!updateAttributeVal(
         WaterHeaterManagement::Id,
-        WaterHeaterManagement::Attributes::TankPercentage::Id,
+        WaterHeaterManagement::Attributes::
+          TankPercentage::Id,
         &attr)) {
     return false;
   }
 
   tankPercentage = value;
-
   return true;
 }
 
@@ -757,28 +740,39 @@ uint8_t MatterWaterHeater::getTankPercentage()
 }
 
 bool MatterWaterHeater::setBoostState(
-  BoostState_t state
-)
+  BoostState_t state)
 {
   if (!initialized) {
     return false;
   }
 
-  esp_matter_attr_val_t attr =
-    esp_matter_attr_val(
-      static_cast<uint8_t>(state),
-      esp_matter_attr_val::uint_sub_type::k_enum
-    );
+  if (state != BOOST_INACTIVE &&
+      state != BOOST_ACTIVE) {
+    return false;
+  }
 
-  if (!updateAttributeVal(
+  esp_matter_attr_val_t attr =
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
         WaterHeaterManagement::Id,
-        WaterHeaterManagement::Attributes::BoostState::Id,
+        WaterHeaterManagement::Attributes::
+          BoostState::Id,
         &attr)) {
     return false;
   }
 
-  boostState = state;
+  attr.val.u8 = static_cast<uint8_t>(state);
 
+  if (!updateAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::
+          BoostState::Id,
+        &attr)) {
+    return false;
+  }
+
+  boostState = static_cast<uint8_t>(state);
   return true;
 }
 
@@ -795,31 +789,40 @@ MatterWaterHeater::getBoostState()
  */
 
 bool MatterWaterHeater::setWaterHeaterMode(
-  WaterHeaterMode_t mode
-)
+  WaterHeaterMode_t mode)
 {
   if (!initialized) {
     return false;
   }
 
-  if (mode > WATER_HEATER_MODE_ECO) {
+  if (mode != WATER_HEATER_MODE_OFF &&
+      mode != WATER_HEATER_MODE_MANUAL &&
+      mode != WATER_HEATER_MODE_ECO) {
     return false;
   }
 
-  esp_matter_attr_val_t value =
-    esp_matter_attr_val(
-      static_cast<uint8_t>(mode)
-    );
+  esp_matter_attr_val_t attr =
+    esp_matter_invalid(NULL);
+
+  if (!getAttributeVal(
+        WaterHeaterMode::Id,
+        WaterHeaterMode::Attributes::
+          CurrentMode::Id,
+        &attr)) {
+    return false;
+  }
+
+  attr.val.u8 = static_cast<uint8_t>(mode);
 
   if (!updateAttributeVal(
         WaterHeaterMode::Id,
-        WaterHeaterMode::Attributes::CurrentMode::Id,
-        &value)) {
+        WaterHeaterMode::Attributes::
+          CurrentMode::Id,
+        &attr)) {
     return false;
   }
 
-  waterHeaterMode = mode;
-
+  waterHeaterMode = static_cast<uint8_t>(mode);
   return true;
 }
 
@@ -827,8 +830,133 @@ MatterWaterHeater::WaterHeaterMode_t
 MatterWaterHeater::getWaterHeaterMode()
 {
   return static_cast<WaterHeaterMode_t>(
-    waterHeaterMode
-  );
+    waterHeaterMode);
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * MatterEndPoint callback
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::attributeChangeCB(
+  uint16_t endpoint_id,
+  uint32_t cluster_id,
+  uint32_t attribute_id,
+  esp_matter_attr_val_t *val)
+{
+  if (!initialized || val == nullptr) {
+    return false;
+  }
+
+  if (endpoint_id != getEndPointId()) {
+    return false;
+  }
+
+  switch (cluster_id) {
+
+    case Thermostat::Id:
+      switch (attribute_id) {
+
+        case Thermostat::Attributes::
+          LocalTemperature::Id:
+          localTemperature = val->val.i16;
+          return true;
+
+        case Thermostat::Attributes::
+          OccupiedHeatingSetpoint::Id:
+          heatingSetpoint = val->val.i16;
+          return true;
+
+        case Thermostat::Attributes::
+          AbsMinHeatSetpointLimit::Id:
+          absoluteMinimumHeatingSetpoint =
+            val->val.i16;
+          return true;
+
+        case Thermostat::Attributes::
+          MinHeatSetpointLimit::Id:
+          minimumHeatingSetpoint =
+            val->val.i16;
+          return true;
+
+        case Thermostat::Attributes::
+          AbsMaxHeatSetpointLimit::Id:
+          absoluteMaximumHeatingSetpoint =
+            val->val.i16;
+          return true;
+
+        case Thermostat::Attributes::
+          MaxHeatSetpointLimit::Id:
+          maximumHeatingSetpoint =
+            val->val.i16;
+          return true;
+
+        case Thermostat::Attributes::
+          SystemMode::Id:
+          systemMode = val->val.u8;
+          return true;
+
+        default:
+          break;
+      }
+      break;
+
+    case WaterHeaterManagement::Id:
+      switch (attribute_id) {
+
+        case WaterHeaterManagement::Attributes::
+          HeaterTypes::Id:
+          heaterTypes = val->val.u8;
+          return true;
+
+        case WaterHeaterManagement::Attributes::
+          HeatDemand::Id:
+          heatDemand = val->val.u8;
+          return true;
+
+        case WaterHeaterManagement::Attributes::
+          BoostState::Id:
+          boostState = val->val.u8;
+          return true;
+
+        /*
+         * TankVolume and TankPercentage are optional features,
+         * but once enabled above they are normal attributes.
+         */
+        case WaterHeaterManagement::Attributes::
+          TankVolume::Id:
+          tankVolume = val->val.u16;
+          return true;
+
+        case WaterHeaterManagement::Attributes::
+          TankPercentage::Id:
+          tankPercentage = val->val.u8;
+          return true;
+
+        default:
+          break;
+      }
+      break;
+
+    case WaterHeaterMode::Id:
+      switch (attribute_id) {
+
+        case WaterHeaterMode::Attributes::
+          CurrentMode::Id:
+          waterHeaterMode = val->val.u8;
+          return true;
+
+        default:
+          break;
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  return true;
 }
 
 #endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
@@ -98,9 +98,6 @@ bool MatterWaterHeater::begin()
   thermostat_config.features.heating.occupied_heating_setpoint =
     DEFAULT_HEATING_SETPOINT;
 
-  thermostat_config.features.heating.unoccupied_heating_setpoint =
-    DEFAULT_HEATING_SETPOINT;
-
   thermostat_config.feature_flags |=
     esp_matter::cluster::thermostat::feature::heating::get_id();
 
@@ -149,11 +146,6 @@ bool MatterWaterHeater::begin()
 
   if (esp_matter::cluster::water_heater_management::
         feature::energy_management::add(management_cluster) != ESP_OK) {
-    return false;
-  }
-
-  if (esp_matter::cluster::water_heater_management::
-        feature::tank_percentage::add(management_cluster) != ESP_OK) {
     return false;
   }
 

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
@@ -115,7 +115,7 @@ bool MatterWaterHeater::begin()
    *
    * on the same endpoint.
    */
-  esp_matter::cluster::thermostat::config_t::config_t water_heater_config;
+  esp_matter::endpoint::water_heater::config_t water_heater_config;
 
   water_heater_config.water_heater_management = management_config;
   water_heater_config.water_heater_mode = mode_config;

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
@@ -1,0 +1,832 @@
+#include <sdkconfig.h>
+
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <Matter.h>
+#include <MatterEndpoints/MatterWaterHeater.h>
+
+#include <esp_matter.h>
+#include <esp_matter_core.h>
+
+#include <app-common/zap-generated/cluster-enums.h>
+
+using namespace esp_matter;
+using namespace esp_matter::endpoint;
+using namespace esp_matter::cluster;
+
+using namespace chip::app::Clusters;
+
+namespace {
+
+constexpr int16_t DEFAULT_LOCAL_TEMPERATURE = 2000;
+constexpr int16_t DEFAULT_HEATING_SETPOINT = 4800;
+
+constexpr int16_t ABS_MIN_HEATING_SETPOINT = 2000;
+constexpr int16_t MIN_HEATING_SETPOINT = 2000;
+
+constexpr int16_t ABS_MAX_HEATING_SETPOINT = 8500;
+constexpr int16_t MAX_HEATING_SETPOINT = 8500;
+
+constexpr uint8_t DEFAULT_SYSTEM_MODE =
+  static_cast<uint8_t>(Thermostat::SystemModeEnum::kHeat);
+
+constexpr uint8_t DEFAULT_HEATER_TYPES = 0x01;
+constexpr uint8_t DEFAULT_HEAT_DEMAND = 0;
+constexpr uint16_t DEFAULT_TANK_VOLUME = 100;
+constexpr uint8_t DEFAULT_TANK_PERCENTAGE = 100;
+constexpr uint8_t DEFAULT_BOOST_STATE = 0;
+
+constexpr uint8_t DEFAULT_WATER_HEATER_MODE = 1;
+
+/*
+ * Matter Water Heater device type:
+ *
+ *   0x050F
+ *
+ * esp-matter's generated implementation creates:
+ *
+ *   Descriptor
+ *   WaterHeaterManagement
+ *   WaterHeaterMode
+ *   Thermostat
+ *
+ * automatically.
+ */
+
+}  // namespace
+
+MatterWaterHeater::MatterWaterHeater()
+{
+}
+
+MatterWaterHeater::~MatterWaterHeater()
+{
+  end();
+}
+
+bool MatterWaterHeater::begin()
+{
+  if (initialized) {
+    log_e("Matter Water Heater has already been initialized.");
+    return false;
+  }
+
+  /*
+   * Make sure the Arduino Matter node exists.
+   *
+   * This is the same lifecycle used by the other Arduino-ESP32
+   * Matter endpoints.
+   */
+  ArduinoMatter::_init();
+
+  if (getEndPointId() != 0) {
+    log_e(
+      "Matter Water Heater with Endpoint Id %u already exists.",
+      getEndPointId()
+    );
+    return false;
+  }
+
+  /*
+   * Water Heater Management
+   */
+  water_heater_management::config_t management_config;
+
+  management_config.heater_types = DEFAULT_HEATER_TYPES;
+  management_config.heat_demand = DEFAULT_HEAT_DEMAND;
+  management_config.boost_state = DEFAULT_BOOST_STATE;
+
+  /*
+   * Enable the Energy Management feature.
+   */
+  management_config.features.energy_management.tank_volume =
+    DEFAULT_TANK_VOLUME;
+
+  /*
+   * Enable TankPercent feature.
+   */
+  management_config.features.tank_percent.tank_percentage =
+    DEFAULT_TANK_PERCENTAGE;
+
+  /*
+   * Water Heater Mode
+   */
+  water_heater_mode::config_t mode_config;
+
+  /*
+   * Thermostat
+   */
+  thermostat::config_t thermostat_config;
+
+  thermostat_config.local_temperature =
+    DEFAULT_LOCAL_TEMPERATURE;
+
+  thermostat_config.control_sequence_of_operation =
+    static_cast<uint8_t>(
+      Thermostat::ControlSequenceOfOperationEnum::kHeatingOnly
+    );
+
+  thermostat_config.system_mode =
+    DEFAULT_SYSTEM_MODE;
+
+  thermostat_config.features.heating.occupied_heating_setpoint =
+    DEFAULT_HEATING_SETPOINT;
+
+  thermostat_config.features.heating.unoccupied_heating_setpoint =
+    DEFAULT_HEATING_SETPOINT;
+
+  thermostat_config.feature_flags |=
+    thermostat::feature::heating::get_id();
+
+  /*
+   * Device type configuration.
+   */
+  water_heater::config_t water_heater_config;
+
+  water_heater_config.water_heater_management =
+    management_config;
+
+  water_heater_config.water_heater_mode =
+    mode_config;
+
+  water_heater_config.thermostat =
+    thermostat_config;
+
+  /*
+   * Create the Water Heater endpoint.
+   */
+  endpoint_t *endpoint =
+    water_heater::create(
+      node::get(),
+      &water_heater_config,
+      ENDPOINT_FLAG_NONE,
+      this
+    );
+
+  if (endpoint == nullptr) {
+    log_e("Failed to create Matter Water Heater endpoint.");
+    return false;
+  }
+
+  setEndPointId(endpoint::get_id(endpoint));
+
+  /*
+   * Cache the initial values.
+   */
+  localTemperature = DEFAULT_LOCAL_TEMPERATURE;
+  heatingSetpoint = DEFAULT_HEATING_SETPOINT;
+
+  absoluteMinimumHeatingSetpoint =
+    ABS_MIN_HEATING_SETPOINT;
+
+  minimumHeatingSetpoint =
+    MIN_HEATING_SETPOINT;
+
+  absoluteMaximumHeatingSetpoint =
+    ABS_MAX_HEATING_SETPOINT;
+
+  maximumHeatingSetpoint =
+    MAX_HEATING_SETPOINT;
+
+  systemMode = DEFAULT_SYSTEM_MODE;
+
+  heaterTypes = DEFAULT_HEATER_TYPES;
+  heatDemand = DEFAULT_HEAT_DEMAND;
+  tankVolume = DEFAULT_TANK_VOLUME;
+  tankPercentage = DEFAULT_TANK_PERCENTAGE;
+  boostState = DEFAULT_BOOST_STATE;
+
+  waterHeaterMode =
+    DEFAULT_WATER_HEATER_MODE;
+
+  initialized = true;
+
+  return true;
+}
+
+void MatterWaterHeater::end()
+{
+  /*
+   * Arduino-ESP32 Matter endpoints don't currently expose a public
+   * endpoint::destroy() equivalent through MatterEndPoint.
+   *
+   * Keep the object logically stopped, as the existing endpoint
+   * implementations do.
+   */
+  initialized = false;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * Attribute callback
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::attributeChangeCB(
+  uint16_t endpoint_id,
+  uint32_t cluster_id,
+  uint32_t attribute_id,
+  esp_matter_attr_val_t *val
+)
+{
+  if (!initialized || val == nullptr) {
+    return false;
+  }
+
+  if (endpoint_id != getEndPointId()) {
+    return true;
+  }
+
+  /*
+   * Thermostat
+   */
+  if (cluster_id == Thermostat::Id) {
+
+    switch (attribute_id) {
+
+      case Thermostat::Attributes::LocalTemperature::Id:
+        localTemperature = val->val.i16;
+
+        log_v(
+          "Water Heater local temperature: %.2f C",
+          static_cast<float>(localTemperature) / 100.0f
+        );
+        break;
+
+      case Thermostat::Attributes::OccupiedHeatingSetpoint::Id:
+        heatingSetpoint = val->val.i16;
+
+        log_v(
+          "Water Heater heating setpoint: %.2f C",
+          static_cast<float>(heatingSetpoint) / 100.0f
+        );
+        break;
+
+      case Thermostat::Attributes::SystemMode::Id:
+        systemMode = val->val.u8;
+
+        log_v(
+          "Water Heater system mode: %u",
+          systemMode
+        );
+        break;
+
+      default:
+        break;
+    }
+
+    return true;
+  }
+
+  /*
+   * Water Heater Management
+   */
+  if (cluster_id == WaterHeaterManagement::Id) {
+
+    switch (attribute_id) {
+
+      case WaterHeaterManagement::Attributes::HeaterTypes::Id:
+        heaterTypes = val->val.u8;
+        break;
+
+      case WaterHeaterManagement::Attributes::HeatDemand::Id:
+        heatDemand = val->val.u8;
+        break;
+
+      case WaterHeaterManagement::Attributes::TankVolume::Id:
+        tankVolume = val->val.u16;
+        break;
+
+      case WaterHeaterManagement::Attributes::TankPercentage::Id:
+        tankPercentage = val->val.u8;
+        break;
+
+      case WaterHeaterManagement::Attributes::BoostState::Id:
+        boostState = val->val.u8;
+        break;
+
+      default:
+        break;
+    }
+
+    return true;
+  }
+
+  /*
+   * Water Heater Mode
+   */
+  if (cluster_id == WaterHeaterMode::Id) {
+
+    if (attribute_id ==
+        WaterHeaterMode::Attributes::CurrentMode::Id) {
+
+      waterHeaterMode = val->val.u8;
+
+      log_v(
+        "Water Heater operation mode: %u",
+        waterHeaterMode
+      );
+    }
+
+    return true;
+  }
+
+  return true;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * Temperature
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::setLocalTemperature(float temperature)
+{
+  return setLocalTemperatureRaw(
+    static_cast<int16_t>(temperature * 100.0f)
+  );
+}
+
+float MatterWaterHeater::getLocalTemperature()
+{
+  return static_cast<float>(localTemperature) / 100.0f;
+}
+
+bool MatterWaterHeater::setLocalTemperatureRaw(int16_t temperature)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  esp_matter_attr_val_t value =
+    esp_matter_nullable<int16_t>(temperature);
+
+  value = esp_matter_attr_val(temperature);
+
+  return updateAttributeVal(
+    Thermostat::Id,
+    Thermostat::Attributes::LocalTemperature::Id,
+    &value
+  );
+}
+
+int16_t MatterWaterHeater::getLocalTemperatureRaw()
+{
+  return localTemperature;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * Heating setpoint
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::setHeatingSetpoint(float temperature)
+{
+  return setHeatingSetpointRaw(
+    static_cast<int16_t>(temperature * 100.0f)
+  );
+}
+
+float MatterWaterHeater::getHeatingSetpoint()
+{
+  return static_cast<float>(heatingSetpoint) / 100.0f;
+}
+
+bool MatterWaterHeater::setHeatingSetpointRaw(
+  int16_t temperature
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  if (temperature < minimumHeatingSetpoint ||
+      temperature > maximumHeatingSetpoint) {
+    log_e(
+      "Heating setpoint %.2f C is outside [%0.2f, %0.2f] C.",
+      static_cast<float>(temperature) / 100.0f,
+      static_cast<float>(minimumHeatingSetpoint) / 100.0f,
+      static_cast<float>(maximumHeatingSetpoint) / 100.0f
+    );
+
+    return false;
+  }
+
+  esp_matter_attr_val_t value =
+    esp_matter_attr_val(temperature);
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::OccupiedHeatingSetpoint::Id,
+        &value)) {
+    return false;
+  }
+
+  heatingSetpoint = temperature;
+
+  return true;
+}
+
+int16_t MatterWaterHeater::getHeatingSetpointRaw()
+{
+  return heatingSetpoint;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * Heating limits
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::setAbsoluteMinimumHeatingSetpoint(
+  float temperature
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
+  if (value > absoluteMinimumHeatingSetpoint) {
+    /*
+     * The absolute minimum can only be lowered by hardware
+     * configuration; don't allow an invalid Matter state.
+     */
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(value);
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::AbsMinHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  absoluteMinimumHeatingSetpoint = value;
+
+  return true;
+}
+
+bool MatterWaterHeater::setMinimumHeatingSetpoint(
+  float temperature
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
+  if (value < absoluteMinimumHeatingSetpoint ||
+      value > absoluteMaximumHeatingSetpoint) {
+    return false;
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(value);
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::MinHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  minimumHeatingSetpoint = value;
+
+  return true;
+}
+
+bool MatterWaterHeater::setAbsoluteMaximumHeatingSetpoint(
+  float temperature
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(value);
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::AbsMaxHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  absoluteMaximumHeatingSetpoint = value;
+
+  return true;
+}
+
+bool MatterWaterHeater::setMaximumHeatingSetpoint(
+  float temperature
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  int16_t value =
+    static_cast<int16_t>(temperature * 100.0f);
+
+  if (value < absoluteMinimumHeatingSetpoint ||
+      value > absoluteMaximumHeatingSetpoint) {
+    return false;
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(value);
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::MaxHeatSetpointLimit::Id,
+        &attr)) {
+    return false;
+  }
+
+  maximumHeatingSetpoint = value;
+
+  return true;
+}
+
+float MatterWaterHeater::getAbsoluteMinimumHeatingSetpoint()
+{
+  return static_cast<float>(
+    absoluteMinimumHeatingSetpoint
+  ) / 100.0f;
+}
+
+float MatterWaterHeater::getMinimumHeatingSetpoint()
+{
+  return static_cast<float>(
+    minimumHeatingSetpoint
+  ) / 100.0f;
+}
+
+float MatterWaterHeater::getAbsoluteMaximumHeatingSetpoint()
+{
+  return static_cast<float>(
+    absoluteMaximumHeatingSetpoint
+  ) / 100.0f;
+}
+
+float MatterWaterHeater::getMaximumHeatingSetpoint()
+{
+  return static_cast<float>(
+    maximumHeatingSetpoint
+  ) / 100.0f;
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * System mode
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::setSystemMode(
+  SystemMode_t mode
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  if (mode != SYSTEM_MODE_OFF &&
+      mode != SYSTEM_MODE_HEAT) {
+    return false;
+  }
+
+  esp_matter_attr_val_t value =
+    esp_matter_attr_val(
+      static_cast<uint8_t>(mode)
+    );
+
+  if (!updateAttributeVal(
+        Thermostat::Id,
+        Thermostat::Attributes::SystemMode::Id,
+        &value)) {
+    return false;
+  }
+
+  systemMode = mode;
+
+  return true;
+}
+
+MatterWaterHeater::SystemMode_t
+MatterWaterHeater::getSystemMode()
+{
+  return static_cast<SystemMode_t>(systemMode);
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * Water Heater Management
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::setHeaterTypes(
+  uint8_t value
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(
+      value,
+      esp_matter_attr_val::uint_sub_type::k_bitmap
+    );
+
+  if (!updateAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::HeaterTypes::Id,
+        &attr)) {
+    return false;
+  }
+
+  heaterTypes = value;
+
+  return true;
+}
+
+uint8_t MatterWaterHeater::getHeaterTypes()
+{
+  return heaterTypes;
+}
+
+bool MatterWaterHeater::setHeatDemand(
+  uint8_t value
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(
+      value,
+      esp_matter_attr_val::uint_sub_type::k_bitmap
+    );
+
+  if (!updateAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::HeatDemand::Id,
+        &attr)) {
+    return false;
+  }
+
+  heatDemand = value;
+
+  return true;
+}
+
+uint8_t MatterWaterHeater::getHeatDemand()
+{
+  return heatDemand;
+}
+
+bool MatterWaterHeater::setTankVolume(
+  uint16_t value
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(value);
+
+  if (!updateAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::TankVolume::Id,
+        &attr)) {
+    return false;
+  }
+
+  tankVolume = value;
+
+  return true;
+}
+
+uint16_t MatterWaterHeater::getTankVolume()
+{
+  return tankVolume;
+}
+
+bool MatterWaterHeater::setTankPercentage(
+  uint8_t value
+)
+{
+  if (!initialized || value > 100) {
+    return false;
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(value);
+
+  if (!updateAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::TankPercentage::Id,
+        &attr)) {
+    return false;
+  }
+
+  tankPercentage = value;
+
+  return true;
+}
+
+uint8_t MatterWaterHeater::getTankPercentage()
+{
+  return tankPercentage;
+}
+
+bool MatterWaterHeater::setBoostState(
+  BoostState_t state
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  esp_matter_attr_val_t attr =
+    esp_matter_attr_val(
+      static_cast<uint8_t>(state),
+      esp_matter_attr_val::uint_sub_type::k_enum
+    );
+
+  if (!updateAttributeVal(
+        WaterHeaterManagement::Id,
+        WaterHeaterManagement::Attributes::BoostState::Id,
+        &attr)) {
+    return false;
+  }
+
+  boostState = state;
+
+  return true;
+}
+
+MatterWaterHeater::BoostState_t
+MatterWaterHeater::getBoostState()
+{
+  return static_cast<BoostState_t>(boostState);
+}
+
+/*
+ * --------------------------------------------------------------------------
+ * Water Heater Mode
+ * --------------------------------------------------------------------------
+ */
+
+bool MatterWaterHeater::setWaterHeaterMode(
+  WaterHeaterMode_t mode
+)
+{
+  if (!initialized) {
+    return false;
+  }
+
+  if (mode > WATER_HEATER_MODE_ECO) {
+    return false;
+  }
+
+  esp_matter_attr_val_t value =
+    esp_matter_attr_val(
+      static_cast<uint8_t>(mode)
+    );
+
+  if (!updateAttributeVal(
+        WaterHeaterMode::Id,
+        WaterHeaterMode::Attributes::CurrentMode::Id,
+        &value)) {
+    return false;
+  }
+
+  waterHeaterMode = mode;
+
+  return true;
+}
+
+MatterWaterHeater::WaterHeaterMode_t
+MatterWaterHeater::getWaterHeaterMode()
+{
+  return static_cast<WaterHeaterMode_t>(
+    waterHeaterMode
+  );
+}
+
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
@@ -144,11 +144,6 @@ bool MatterWaterHeater::begin()
     return false;
   }
 
-  if (esp_matter::cluster::water_heater_management::
-        feature::energy_management::add(management_cluster) != ESP_OK) {
-    return false;
-  }
-
   /*
    * Store the endpoint ID in MatterEndPoint.
    */

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
@@ -413,15 +413,17 @@ bool MatterWaterHeater::setHeatingSetpointRaw(
     return false;
   }
 
-  esp_matter_attr_val_t value =
-    esp_matter_attr_val(temperature);
+    esp_matter_attr_val_t val = esp_matter_invalid(NULL);
 
-  if (!updateAttributeVal(
-        Thermostat::Id,
-        Thermostat::Attributes::OccupiedHeatingSetpoint::Id,
-        &value)) {
+    val.type = ESP_MATTER_VAL_TYPE_INT16;
+    val.val.i16 = temperature;
+
+    if (!updateAttributeVal(
+            Thermostat::Id,
+            Thermostat::Attributes::OccupiedHeatingSetpoint::Id,
+            &val)) {
     return false;
-  }
+    }
 
   heatingSetpoint = temperature;
 

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.cpp
@@ -85,7 +85,7 @@ bool MatterWaterHeater::begin()
    * namespace. Use the fully-qualified namespace to avoid the
    * endpoint::thermostat / cluster::thermostat ambiguity.
    */
-  esp_matter::endpoint::thermostat::config_t thermostat_config;
+  esp_matter::cluster::thermostat::config_t thermostat_config;
 
   thermostat_config.local_temperature = DEFAULT_LOCAL_TEMPERATURE;
 
@@ -115,7 +115,7 @@ bool MatterWaterHeater::begin()
    *
    * on the same endpoint.
    */
-  esp_matter::endpoint::water_heater::config_t water_heater_config;
+  esp_matter::cluster::thermostat::config_t::config_t water_heater_config;
 
   water_heater_config.water_heater_management = management_config;
   water_heater_config.water_heater_mode = mode_config;

--- a/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.h
+++ b/libraries/Matter/src/MatterEndpoints/MatterWaterHeater.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <sdkconfig.h>
+
+#ifdef CONFIG_ESP_MATTER_ENABLE_DATA_MODEL
+
+#include <Matter.h>
+#include <MatterEndPoint.h>
+
+#include <app-common/zap-generated/cluster-enums.h>
+
+class MatterWaterHeater : public MatterEndPoint {
+public:
+  enum WaterHeaterMode_t {
+    WATER_HEATER_MODE_OFF  = 0,
+    WATER_HEATER_MODE_MANUAL = 1,
+    WATER_HEATER_MODE_ECO = 2,
+  };
+
+  enum SystemMode_t {
+    SYSTEM_MODE_OFF  = 0,
+    SYSTEM_MODE_HEAT = 4,
+  };
+
+  enum HeaterType_t {
+    IMMERSION_ELEMENT_1 = 0x01,
+    IMMERSION_ELEMENT_2 = 0x02,
+    HEAT_PUMP           = 0x04,
+    BOILER              = 0x08,
+    OTHER               = 0x10,
+  };
+
+  enum BoostState_t {
+    BOOST_INACTIVE = 0,
+    BOOST_ACTIVE   = 1,
+  };
+
+  MatterWaterHeater();
+  ~MatterWaterHeater();
+
+  bool begin();
+  void end();
+
+  /*
+   * Thermostat / temperature
+   */
+  bool setLocalTemperature(float temperature);
+  float getLocalTemperature();
+
+  bool setLocalTemperatureRaw(int16_t temperature);
+  int16_t getLocalTemperatureRaw();
+
+  bool setHeatingSetpoint(float temperature);
+  float getHeatingSetpoint();
+
+  bool setHeatingSetpointRaw(int16_t temperature);
+  int16_t getHeatingSetpointRaw();
+
+  /*
+   * Heating setpoint limits
+   */
+  bool setAbsoluteMinimumHeatingSetpoint(float temperature);
+  bool setMinimumHeatingSetpoint(float temperature);
+  bool setAbsoluteMaximumHeatingSetpoint(float temperature);
+  bool setMaximumHeatingSetpoint(float temperature);
+
+  float getAbsoluteMinimumHeatingSetpoint();
+  float getMinimumHeatingSetpoint();
+  float getAbsoluteMaximumHeatingSetpoint();
+  float getMaximumHeatingSetpoint();
+
+  /*
+   * Thermostat system mode
+   */
+  bool setSystemMode(SystemMode_t mode);
+  SystemMode_t getSystemMode();
+
+  /*
+   * Water Heater Management
+   */
+  bool setHeaterTypes(uint8_t heaterTypes);
+  uint8_t getHeaterTypes();
+
+  bool setHeatDemand(uint8_t heatDemand);
+  uint8_t getHeatDemand();
+
+  bool setTankVolume(uint16_t tankVolume);
+  uint16_t getTankVolume();
+
+  bool setTankPercentage(uint8_t tankPercentage);
+  uint8_t getTankPercentage();
+
+  bool setBoostState(BoostState_t state);
+  BoostState_t getBoostState();
+
+  /*
+   * Water Heater Mode
+   */
+  bool setWaterHeaterMode(WaterHeaterMode_t mode);
+  WaterHeaterMode_t getWaterHeaterMode();
+
+  /*
+   * MatterEndPoint callback.
+   */
+  bool attributeChangeCB(
+    uint16_t endpoint_id,
+    uint32_t cluster_id,
+    uint32_t attribute_id,
+    esp_matter_attr_val_t *val
+  ) override;
+
+private:
+  bool initialized = false;
+
+  int16_t localTemperature = 2000;
+  int16_t heatingSetpoint = 4800;
+
+  int16_t absoluteMinimumHeatingSetpoint = 2000;
+  int16_t minimumHeatingSetpoint = 2000;
+  int16_t absoluteMaximumHeatingSetpoint = 8500;
+  int16_t maximumHeatingSetpoint = 8500;
+
+  uint8_t systemMode = SYSTEM_MODE_HEAT;
+
+  uint8_t heaterTypes = IMMERSION_ELEMENT_1;
+  uint8_t heatDemand = 0;
+  uint16_t tankVolume = 100;
+  uint8_t tankPercentage = 100;
+  uint8_t boostState = BOOST_INACTIVE;
+
+  uint8_t waterHeaterMode = WATER_HEATER_MODE_MANUAL;
+};
+
+#endif /* CONFIG_ESP_MATTER_ENABLE_DATA_MODEL */


### PR DESCRIPTION
### Checklist
1. [x] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [x] Please **update relevant Documentation** if applicable
4. [x] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [x] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change

Adds support for the Matter Water Heater device type (`0x050F`) to the Arduino-ESP32 Matter library.

This introduces a new `MatterWaterHeater` endpoint based on the Water Heater device type defined by the Matter specification, exposing the Water Heater Management, Water Heater Mode, and Thermostat clusters.

The implementation provides APIs to configure and monitor the water heater, including:

* heater types and heat demand
* tank volume
* local temperature
* heating setpoint and limits
* system and operation modes
* boost state

A Matter Water Heater example is also added to demonstrate endpoint configuration, commissioning, and basic operation.

This brings the Arduino-ESP32 Matter API in line with the Water Heater device type already supported by the underlying `esp-matter` data model.


## Test Scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
