### PR TITLE
WebServer: read request body for HTTP QUERY (RFC 10008)

### DIFF
--- a/libraries/WebServer/src/Parsing.cpp
+++ b/libraries/WebServer/src/Parsing.cpp
@@ -266,7 +266,11 @@ bool WebServer::_parseRequest(NetworkClient &client) {
 
   String formData;
   // below is needed only when POST type request
-  if (method == HTTP_POST || method == HTTP_PUT || method == HTTP_PATCH || method == HTTP_DELETE) {
+  if (method == HTTP_POST || method == HTTP_PUT || method == HTTP_PATCH || method == HTTP_DELETE
+#ifdef HTTP_PARSER_HAS_QUERY
+      || method == HTTP_QUERY
+#endif
+  ) {
     String boundaryStr;
     String headerName;
     String headerValue;


### PR DESCRIPTION
## Description

[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html) \`QUERY\` is safe/idempotent and carries a request body. \`WebServer\` already learns method names from IDF \`HTTP_METHOD_MAP\`, but it only drained bodies for POST/PUT/PATCH/DELETE.

This adds \`HTTP_QUERY\` to that gate, compiled in only when the IDF parser defines \`HTTP_PARSER_HAS_QUERY\` ([espressif/esp-idf#19071](https://github.com/espressif/esp-idf/pull/19071)). Current Arduino/IDF trees keep building.

Related: [ESP32Async/ESPAsyncWebServer#474](https://github.com/ESP32Async/ESPAsyncWebServer/pull/474) (independent parser; not required here).

## Testing

- [ ] With an IDF that defines \`HTTP_PARSER_HAS_QUERY\`: \`QUERY / HTTP/1.1\` + \`Content-Length\` reaches \`arg()\` / the upload callback
- [ ] Without that macro: sketch still compiles
- [ ] Existing POST/PUT/PATCH/DELETE body parsing unchanged