### PR TITLE
fix(core): terminate the working buffer in MacAddress::fromString6/8

### DIFF
--- a/cores/esp32/MacAddress.cpp
+++ b/cores/esp32/MacAddress.cpp
@@ -93,6 +93,7 @@ bool MacAddress::fromString6(const char *buf) {
   int i;
 
   strncpy(cs, buf, sizeof(cs) - 1);  //strtok modifies the buffer: copy to working buffer.
+  cs[sizeof(cs) - 1] = '\0';         //strncpy does not terminate when the input fills the buffer.
 
   for (i = 0; i < 6; i++) {
     token = strtok((i == 0) ? cs : NULL, ":");  //Find first or next token
@@ -112,6 +113,7 @@ bool MacAddress::fromString8(const char *buf) {
   int i;
 
   strncpy(cs, buf, sizeof(cs) - 1);  //strtok modifies the buffer: copy to working buffer.
+  cs[sizeof(cs) - 1] = '\0';         //strncpy does not terminate when the input fills the buffer.
 
   for (i = 0; i < 8; i++) {
     token = strtok((i == 0) ? cs : NULL, ":");  //Find first or next token


### PR DESCRIPTION
## Description of Change

`MacAddress::fromString6()` and `fromString8()` copy the input with `strncpy(cs, buf, sizeof(cs) - 1)` and never terminate `cs`. A valid MAC string is exactly 17 (or 23) characters, which is `sizeof(cs) - 1`, so `strncpy` fills the buffer and leaves `cs[sizeof(cs) - 1]` holding whatever was on the stack. `strtok` then scans past the end of `cs`, and if it finds a `:` in the bytes that follow it writes a NUL over it.

The fix adds one line to each function to terminate the buffer after the copy.

Whether the bug fires depends on the stack contents next to `cs`, so the same input can parse correctly on one boot and corrupt the stack on the next. With the stack protector enabled it aborts:

```
Stack smashing protect failure!
Core  1 register dump:
...
0x4001b3d2: MacAddress::fromString6(char const*) at cores/esp32/MacAddress.cpp:100
```

## Test Scenarios

Observed on an ESP32-P4 Function EV board, arduino-esp32 3.3.9 (pioarduino platform), with MycilaESPConnect 10.6.2, whose captive portal calls `MacAddress::fromString()` on the scanned BSSID before `WiFi.begin()`. The credential test crashed intermittently with the abort above; the same BSSID had parsed fine on earlier boots.

Confirmed the diagnosis on that hardware by removing the BSSID from the portal's scan response so `fromString6` is never called: the crash no longer occurs across repeated portal sessions. The one-line fix itself is by inspection of the code and the `strncpy` contract; I have not rebuilt the prebuilt core libraries to run the patched function on hardware.

## Related links

Found while building a factory-provisioning image that uses MycilaESPConnect on the P4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPjSqu91kvk9YPeEG52dNf